### PR TITLE
[WIP] Implement CayleyEuler

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -198,7 +198,7 @@ module OrdinaryDiffEq
          Kvaerno3, KenCarp3, Cash4, Hairer4, Hairer42, SSPSDIRK2, Kvaerno4,
          Kvaerno5, KenCarp4, KenCarp5, ESDIRK54I8L2SA, SFSDIRK4
 
-  export MagnusMidpoint, LinearExponential, MagnusLeapfrog, LieEuler
+  export MagnusMidpoint, LinearExponential, MagnusLeapfrog, LieEuler, CayleyEuler
 
   export Rosenbrock23, Rosenbrock32, RosShamp4, Veldd4, Velds4, GRK4T, GRK4A,
          Ros4LStab, ROS3P, Rodas3, Rodas4, Rodas42, Rodas4P, Rodas5,

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -49,7 +49,7 @@ isimplicit(alg::CompositeAlgorithm) = any(isimplicit.(alg.algs))
 
 isdtchangeable(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = true
 isdtchangeable(alg::CompositeAlgorithm) = all(isdtchangeable.(alg.algs))
-isdtchangeable(alg::Union{LawsonEuler,NorsettEuler,LieEuler,ETDRK2,ETDRK3,ETDRK4,HochOst4,ETD2}) = false # due to caching
+isdtchangeable(alg::Union{LawsonEuler,NorsettEuler,LieEuler,CayleyEuler,ETDRK2,ETDRK3,ETDRK4,HochOst4,ETD2}) = false # due to caching
 
 ismultistep(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = false
 ismultistep(alg::CompositeAlgorithm) = any(ismultistep.(alg.algs))
@@ -149,6 +149,7 @@ alg_order(alg::Ralston) = 2
 alg_order(alg::LawsonEuler) = 1
 alg_order(alg::NorsettEuler) = 1
 alg_order(alg::LieEuler) = 1
+alg_order(alg::CayleyEuler) = 2
 alg_order(alg::ETDRK2) = 2
 alg_order(alg::ETDRK3) = 3
 alg_order(alg::ETDRK4) = 4

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -662,6 +662,8 @@ struct LinearExponential <: OrdinaryDiffEqExponentialAlgorithm
 end
 LinearExponential(;krylov=:off, m=10, iop=0) = LinearExponential(krylov, m, iop)
 
+struct CayleyEuler <: OrdinaryDiffEqAlgorithm end  
+
 ################################################################################
 
 # FIRK Methods

--- a/src/caches/linear_caches.jl
+++ b/src/caches/linear_caches.jl
@@ -48,6 +48,31 @@ function alg_cache(alg::LieEuler,u,rate_prototype,uEltypeNoUnits,
   LieEulerConstantCache()
 end
 
+@cache struct CayleyEulerCache{uType,rateType,WType} <: OrdinaryDiffEqMutableCache
+  u::uType
+  uprev::uType
+  uprev2::uType
+  tmp::uType
+  fsalfirst::rateType
+  W::WType
+  k::rateType
+end
+
+function alg_cache(alg::CayleyEuler,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
+                   tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{true})
+  W = false .* vec(rate_prototype) .* vec(rate_prototype)' # uEltype?
+  k = zero(rate_prototype); fsalfirst = zero(rate_prototype)
+  CayleyEulerCache(u,uprev,uprev2,similar(u),fsalfirst,W,k)
+end
+
+struct CayleyEulerConstantCache <: OrdinaryDiffEqConstantCache
+end
+
+function alg_cache(alg::CayleyEuler,u,rate_prototype,uEltypeNoUnits,
+                   tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{false})
+  CayleyEulerConstantCache()
+end
+
 @cache struct MagnusLeapfrogCache{uType,rateType,WType} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType

--- a/src/caches/linear_caches.jl
+++ b/src/caches/linear_caches.jl
@@ -53,6 +53,7 @@ end
   uprev::uType
   uprev2::uType
   tmp::uType
+  V::uType
   fsalfirst::rateType
   W::WType
   k::rateType
@@ -62,7 +63,7 @@ function alg_cache(alg::CayleyEuler,u,rate_prototype,uEltypeNoUnits,uBottomEltyp
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{true})
   W = false .* vec(rate_prototype) .* vec(rate_prototype)' # uEltype?
   k = zero(rate_prototype); fsalfirst = zero(rate_prototype)
-  CayleyEulerCache(u,uprev,uprev2,similar(u),fsalfirst,W,k)
+  CayleyEulerCache(u,uprev,uprev2,similar(u),similar(u),fsalfirst,W,k)
 end
 
 struct CayleyEulerConstantCache <: OrdinaryDiffEqConstantCache

--- a/src/caches/linear_caches.jl
+++ b/src/caches/linear_caches.jl
@@ -66,10 +66,8 @@ end
 struct CayleyEulerConstantCache <: OrdinaryDiffEqConstantCache
 end
 
-function alg_cache(alg::CayleyEuler,u,rate_prototype,uEltypeNoUnits,
-                   tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{false})
-  CayleyEulerConstantCache()
-end
+alg_cache(alg::CayleyEuler,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
+  tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{false}) = CayleyEulerConstantCache()
 
 @cache struct MagnusLeapfrogCache{uType,rateType,WType} <: OrdinaryDiffEqMutableCache
   u::uType

--- a/src/caches/linear_caches.jl
+++ b/src/caches/linear_caches.jl
@@ -48,22 +48,19 @@ function alg_cache(alg::LieEuler,u,rate_prototype,uEltypeNoUnits,
   LieEulerConstantCache()
 end
 
-@cache struct CayleyEulerCache{uType,rateType,WType} <: OrdinaryDiffEqMutableCache
+@cache struct CayleyEulerCache{uType,rateType} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
-  uprev2::uType
   tmp::uType
   V::uType
   fsalfirst::rateType
-  W::WType
   k::rateType
 end
 
 function alg_cache(alg::CayleyEuler,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{true})
-  W = false .* vec(rate_prototype) .* vec(rate_prototype)' # uEltype?
   k = zero(rate_prototype); fsalfirst = zero(rate_prototype)
-  CayleyEulerCache(u,uprev,uprev2,similar(u),similar(u),fsalfirst,W,k)
+  CayleyEulerCache(u,uprev,similar(u),similar(u),fsalfirst,k)
 end
 
 struct CayleyEulerConstantCache <: OrdinaryDiffEqConstantCache

--- a/src/perform_step/linear_perform_step.jl
+++ b/src/perform_step/linear_perform_step.jl
@@ -191,14 +191,15 @@ end
 
 function perform_step!(integrator, cache::CayleyEulerCache, repeat_step=false)
   @unpack t,dt,uprev,u,p,alg = integrator
-  @unpack W,k,tmp = cache
+  @unpack W,k,V,tmp = cache
   mass_matrix = integrator.f.mass_matrix
 
   L = integrator.f.f
-  update_coefficients!(L,1/2*(u+uprev),p,t)
+  update_coefficients!(L,uprev,p,t)
 
-  cay!(tmp, L*dt)
-  u .= tmp*uprev*transpose(tmp)
+  cay!(V, L*dt)
+  mul!(tmp, uprev, transpose(V))
+  mul!(u, V, tmp)
 
   # Update integrator state
   integrator.f(integrator.fsallast,u,p,t+dt)

--- a/src/perform_step/linear_perform_step.jl
+++ b/src/perform_step/linear_perform_step.jl
@@ -191,7 +191,7 @@ end
 
 function perform_step!(integrator, cache::CayleyEulerCache, repeat_step=false)
   @unpack t,dt,uprev,u,p,f,alg = integrator
-  @unpack W,k,V,tmp = cache
+  @unpack k,V,tmp = cache
   mass_matrix = integrator.f.mass_matrix
 
   if f isa SplitFunction

--- a/src/perform_step/linear_perform_step.jl
+++ b/src/perform_step/linear_perform_step.jl
@@ -190,11 +190,16 @@ function initialize!(integrator, cache::CayleyEulerCache)
 end
 
 function perform_step!(integrator, cache::CayleyEulerCache, repeat_step=false)
-  @unpack t,dt,uprev,u,p,alg = integrator
+  @unpack t,dt,uprev,u,p,f,alg = integrator
   @unpack W,k,V,tmp = cache
   mass_matrix = integrator.f.mass_matrix
 
-  L = integrator.f.f
+  if f isa SplitFunction
+    L = f.f1.f
+  else  # f isa ODEFunction
+    L = f.f
+  end
+
   update_coefficients!(L,uprev,p,t)
 
   cay!(V, L*dt)

--- a/test/algconvergence/linear_method_tests.jl
+++ b/test/algconvergence/linear_method_tests.jl
@@ -93,7 +93,7 @@ end
 
 η = diagm([1.,2,3,4,5])
 A = DiffEqArrayOperator(Matrix{eltype(η)}(I(size(η,1))), update_func=update_func)
-dts = 1 ./2 .^(10:-1:1)
+dts = 1 ./2 .^(10:-1:2)
 tspan = (0., 20.)
 
 f = SplitFunction(A, (du,u,p,t)->du.=-u*B(u), _func_cache=similar(η))
@@ -106,4 +106,4 @@ eig_err = [norm(eigvals(sol[i])-eigvals(η)) for i in eachindex(sol)]
 test_setup = Dict(:alg=>Vern9(),:reltol=>1e-14,:abstol=>1e-14)
 
 sim = analyticless_test_convergence(dts,prob,CayleyEuler(),test_setup)
-@test sim.𝒪est[:l2] ≈ 2 atol=0.2
+@test sim.𝒪est[:l2] ≈ 1 atol=0.2

--- a/test/algconvergence/linear_method_tests.jl
+++ b/test/algconvergence/linear_method_tests.jl
@@ -96,9 +96,25 @@ A = DiffEqArrayOperator(Matrix{eltype(η)}(I(size(η,1))), update_func=update_fu
 dts = 1 ./2 .^(10:-1:2)
 tspan = (0., 20.)
 
+# IIP
 f = SplitFunction(A, (du,u,p,t)->du.=-u*B(u), _func_cache=similar(η))
 prob = SplitODEProblem(f, η, tspan)
 sol = solve(prob, CayleyEuler(), dt=1/10)
+
+@test sol.retcode == :Success
+eig_err = [norm(eigvals(sol[i])-eigvals(η)) for i in eachindex(sol)]
+@test all(≈(e,0, atol=1e-13) for e in eig_err)
+
+test_setup = Dict(:alg=>Vern9(),:reltol=>1e-14,:abstol=>1e-14)
+
+sim = analyticless_test_convergence(dts,prob,CayleyEuler(),test_setup)
+@test sim.𝒪est[:l2] ≈ 1 atol=0.2
+
+# OOP
+f = SplitFunction(A, (u,p,t)->-u*B(u), _func_cache=similar(η))
+prob = SplitODEProblem(f, η, tspan)
+sol = solve(prob, CayleyEuler(), dt=1/10)
+
 @test sol.retcode == :Success
 eig_err = [norm(eigvals(sol[i])-eigvals(η)) for i in eachindex(sol)]
 @test all(≈(e,0, atol=1e-13) for e in eig_err)

--- a/test/algconvergence/linear_method_tests.jl
+++ b/test/algconvergence/linear_method_tests.jl
@@ -86,20 +86,24 @@ function B(y::AbstractMatrix)
     return b
 end
 
-commutator(A,B) = A*B - B*A
 function update_func(A, u, p, t)
     A .= B(u)
     return nothing
 end
 
-η = diagm([1.,2,3,4])
-A = DiffEqArrayOperator(I(size(η,1)), update_func=update_func)
+η = diagm([1.,2,3,4,5])
+A = DiffEqArrayOperator(Matrix{eltype(η)}(I(size(η,1))), update_func=update_func)
 dts = 1 ./2 .^(10:-1:1)
-tspan = (0., 5.)
+tspan = (0., 20.)
 
-f = SplitFunction(A, (du,u,p,t)->du.=-u*B(u))
+f = SplitFunction(A, (du,u,p,t)->du.=-u*B(u), _func_cache=similar(η))
 prob = SplitODEProblem(f, η, tspan)
+sol = solve(prob, CayleyEuler(), dt=1/10)
+@test sol.retcode == :Success
+eig_err = [norm(eigvals(sol[i])-eigvals(η)) for i in eachindex(sol)]
+@test all(≈(e,0, atol=1e-13) for e in eig_err)
 
-test_setup = Dict(:prob=>prob_ref,:alg=>Vern9(),:reltol=>1e-14,:abstol=>1e-14)
+test_setup = Dict(:alg=>Vern9(),:reltol=>1e-14,:abstol=>1e-14)
+
 sim = analyticless_test_convergence(dts,prob,CayleyEuler(),test_setup)
 @test sim.𝒪est[:l2] ≈ 2 atol=0.2


### PR DESCRIPTION
I have begun implementing the CayleyEuler method form https://github.com/SciML/OrdinaryDiffEq.jl/issues/1068 (more precisely from [1]). I used the LieEuler PR as a model for this one. The method was developed to solve the isospectral flow equation
```
Y'=[B(Y),Y],
```
where Y is a real symmetric matrix (Sn) and B is a function that maps Sn to real skew-symmetric matrices. It has been show that solving the above equation is equivalent to solving
```
Q'=B(Y)Q,   Q(0)=I
```
with `Y(t)=Q(t)*Y0*transpose(Q(t))`, i.e. we solve a linear problem in with different coordinates and impose the orthogonality of Y by construction.
Because of this reason, I implemented the method as solving the linear problem in auxiliary coordinates together with the orthogonality relation for Y.
In order to easily compare methods, I also taken into account the `SplitODEProblem` formulation, but in that case I only look at the linear operator (`f1`). I think this should be more clearly communicated to the user, as this method does not solve a general `SplitODEProblem`.

The method is very similar to the one quoted in [2], but there a modification to the implicit midpoint method is described. The method in [1] is an explicit method.
I have reproduced the error plot in the paper (fig. 1.1), but I'm having trouble with the order estimation. In [1] it says that this scheme "has the same order of accuracy" as the Forward Euler, but in my case the convergence plot looks quite strange:
![image](https://user-images.githubusercontent.com/31181429/79926505-c28f4300-8445-11ea-89c0-7059ac8f54ca.png)

and the order estimate for `:l2` is 1.56.

Regarding the implementation details
- I wanted to ask if it's ok to put the method together with the linear ones. 
- I am not sure where the implementation if the Cayley transformation should live. It would be helpful if the user could give a custom `cay`, since there are some special cases like the SO(3) group, for which the Rodrigues relation can be used to simplify computations.
- Also regarding the Cayley transformation, there are ways to compute it for SO(N) via the Rodrigues formula [3], but I'm not sure if they are computationally efficient. There are also iterative methods, but I did not investigate this. In the current implementation I did not optimize the Cayley transform.
- I think the structure of the cache could be simplified. (I'm not sure if `W` is relevant)
- I still have to implement the out-of-place version
- In [2] there is a discussion about interpolations, but I'm not familiar with the topic yet and I don't know if it's relevant in this case.
_______________
[1] Iserles, Arieh, Hans Z. Munthe-Kaas, Syvert P. Nørsett, and Antonella Zanna. “Lie-Group Methods.” Acta Numerica 9 (January 2000): 215–365. https://doi.org/10.1017/S0962492900002154.

[2] Calvo, Mari, Arieh Iserles, and Antonella Zanna. “Numerical Solution of Isospectral Flows.” Mathematics of Computation 66, no. 220 (1997): 1461–86. https://doi.org/10.1090/S0025-5718-97-00902-2.

[3] Andrica, Dorin, and Oana Liliana Chender. “Rodrigues Formula for the Cayley Transform of Groups SO(n) and SE(n).” Studia Universitatis Babeş-Bolyai Mathematica 60, no. 1 (2015): 31--38. http://www.cs.ubbcluj.ro/~studia-m/2015-1/2015_1/04-andrica-chender-final.pdf.