### PR TITLE
Don't differentiate the step controller

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEq"
 uuid = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "5.34.1"
+version = "5.35.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/integrators/controllers.jl
+++ b/src/integrators/controllers.jl
@@ -17,7 +17,7 @@
     end
     expo = 1/(get_current_adaptive_order(integrator.alg,integrator.cache)+1)
     qtmp = DiffEqBase.fastpow(integrator.EEst,expo)/fac
-    @fastmath q = max(inv(integrator.opts.qmax),min(inv(integrator.opts.qmin),qtmp))
+    @fastmath q = DiffEqBase.value(max(inv(integrator.opts.qmax),min(inv(integrator.opts.qmin),qtmp)))
     integrator.qold = q
   end
   q
@@ -29,7 +29,7 @@ end
     q = inv(integrator.opts.qmax)
   else
     qtmp = DiffEqBase.fastpow(integrator.EEst,1/(get_current_adaptive_order(integrator.alg,integrator.cache)+1))/integrator.opts.gamma
-    @fastmath q = max(inv(integrator.opts.qmax),min(inv(integrator.opts.qmin),qtmp))
+    @fastmath q = DiffEqBase.value(max(inv(integrator.opts.qmax),min(inv(integrator.opts.qmin),qtmp)))
     integrator.qold = integrator.dt/q
   end
   q
@@ -41,10 +41,10 @@ end
   if iszero(EEst)
     q = inv(integrator.opts.qmax)
   else
-    q11 = DiffEqBase.fastpow(EEst,beta1)
+    q11 = DiffEqBase.value(DiffEqBase.fastpow(EEst,beta1))
     q = q11/DiffEqBase.fastpow(qold,beta2)
     integrator.q11 = q11
-    @fastmath q = max(inv(integrator.opts.qmax),min(inv(integrator.opts.qmin),q/integrator.opts.gamma))
+    @fastmath q = DiffEqBase.value(max(inv(integrator.opts.qmax),min(inv(integrator.opts.qmin),q/integrator.opts.gamma)))
   end
   q
 end
@@ -64,12 +64,12 @@ end
     expo = 1/(get_current_adaptive_order(integrator.alg,integrator.cache)+1)
     qgus=(integrator.dtacc/integrator.dt)*DiffEqBase.fastpow((integrator.EEst^2)/integrator.erracc,expo)
     qgus = max(inv(integrator.opts.qmax),min(inv(integrator.opts.qmin),qgus/integrator.opts.gamma))
-    qacc=max(q,qgus)
+    qacc= DiffEqBase.value(max(q,qgus))
   else
-    qacc = q
+    qacc = DiffEqBase.value(q)
   end
   if integrator.opts.qsteady_min <= qacc <= integrator.opts.qsteady_max
-    qacc = one(qacc)
+    qacc = DiffEqBase.value(one(qacc))
   end
   integrator.dtacc = integrator.dt
   integrator.erracc = max(1e-2,integrator.EEst)

--- a/test/integrators/ode_event_tests.jl
+++ b/test/integrators/ode_event_tests.jl
@@ -32,7 +32,7 @@ end
 
 callback = VectorContinuousCallback(condition,affect!,1)
 
-sol = solve(prob,Tsit5(),callback=callback)
+@test_broken sol = solve(prob,Tsit5(),callback=callback)
 
 f = function (du,u,p,t)
   du[1] = - u[1] + sin(t)

--- a/test/integrators/ode_event_tests.jl
+++ b/test/integrators/ode_event_tests.jl
@@ -19,6 +19,7 @@ end
 callback = ContinuousCallback(condition,affect!)
 
 sol = solve(prob,Tsit5(),callback=callback)
+@test length(sol) < 20
 
 condition= function (out, u,t,integrator) # Event when event_f(u,t,k) == 0
   out[1] = - t - 2.95
@@ -32,7 +33,7 @@ end
 
 callback = VectorContinuousCallback(condition,affect!,1)
 
-@test_broken sol = solve(prob,Tsit5(),callback=callback)
+sol = solve(prob,Tsit5(),callback=callback)
 
 f = function (du,u,p,t)
   du[1] = - u[1] + sin(t)

--- a/test/regression/ode_dense_tests.jl
+++ b/test/regression/ode_dense_tests.jl
@@ -30,7 +30,7 @@ const deriv_test_points = range(0, stop=1, length=5)
 #       commands below to get numerical values for `tol_ode_linear` and
 #       `tol_ode_2Dlinear`.
 function regression_test(alg, tol_ode_linear, tol_ode_2Dlinear; test_diff1 = false, nth_der = 1, dertol=1e-6)
-  PRINT_TESTS && println("\n", alg)
+  println("\n", alg)
 
   sol = solve(prob_ode_linear, alg, dt=1//2^(2), dense=true)
   sol(interpolation_results_1d, interpolation_points)


### PR DESCRIPTION
Odd little issue. The PI-controller in the stepper is not actually differentiable, so we need to keep the ties in the differentiation in the dts and t, but when we hit the qold gain on the integral control, we want to drop the AD there since we want to just have the chosen dt there. This fixes a fairly obscured bug that was found in one case of Pumas

>okay, tlag is fixed, and I also fixed the nan-safeness I think, and that also could fix the estimation robustness. Essentially, when differentiating something that also involves differentiating a callback, if a step rejected twice in a row where the error amount was less than qmax, and some of the states being differentiated have a zero derivative w.r.t. one of the parameters. I.e., this is the edge case-iest of edge cases, so it's hard to tell if you ever hit it in the optimization, but now you won't.