### PR TITLE
QNDF Fixes

### DIFF
--- a/src/integrators/controllers.jl
+++ b/src/integrators/controllers.jl
@@ -138,6 +138,7 @@ function stepsize_controller!(integrator, alg::QNDF)
   cnt = integrator.iter
   EEst1 = integrator.cache.EEst1
   EEst2 = integrator.cache.EEst2
+  prev_order = integrator.cache.order
   dttmp = QNDF_stepsize_and_order!(integrator.cache, integrator.EEst, EEst1, EEst2, integrator.dt, integrator.cache.order)
   integrator.cache.nconsteps = min(integrator.cache.nconsteps+1,5+2); #Max-order + 2
   if integrator.EEst > one(integrator.EEst)
@@ -145,11 +146,13 @@ function stepsize_controller!(integrator, alg::QNDF)
     q = integrator.dt/dttmp
     integrator.qold = integrator.dt/q
   else
-    if integrator.cache.nconsteps <= integrator.cache.order + 2
+    if integrator.cache.nconsteps < integrator.cache.order + 2
       q = one(integrator.qold) #quasi-contsant steps
       integrator.qold = integrator.dt/q
     else
-      integrator.cache.nconsteps = 1
+      if (integrator.dt != dttmp || prev_order != integrator.cache.order)
+        integrator.cache.nconsteps = 1
+      end
       q = integrator.dt/dttmp
     end
   end

--- a/src/perform_step/bdf_perform_step.jl
+++ b/src/perform_step/bdf_perform_step.jl
@@ -951,6 +951,17 @@ function perform_step!(integrator,cache::QNDFCache,repeat_step=false)
     # cnt == 1
   end # integrator.opts.adaptive
 
+  if integrator.EEst > one(integrator.EEst)
+    for i = 1:5
+      fill!(D[i], zero(eltype(u)))
+    end
+    for i = 1:6, j = 1:6
+      fill!(D2[i,j], zero(eltype(u)))
+    end
+    fill!(R, zero(t)); fill!(U, zero(t))
+    return
+  end
+
   swap_tmp = udiff[6]
   for i = 6:-1:2
     dts[i] = dts[i-1]

--- a/src/perform_step/bdf_perform_step.jl
+++ b/src/perform_step/bdf_perform_step.jl
@@ -939,15 +939,21 @@ function perform_step!(integrator,cache::QNDFCache,repeat_step=false)
       @.. utilde = (integrator.alg.kappa[k-1]*γₖ[k-1] + inv(k)) * D[k]
       calculate_residuals!(atmp, utilde, uprev, u, integrator.opts.abstol, integrator.opts.reltol, integrator.opts.internalnorm, t)
       cache.EEst1 = integrator.opts.internalnorm(atmp,t)
+    else
+      cache.EEst2 = Inf
     end
     backward_diff!(cache,D,D2,k+1,false)
     @.. tmp = u - uprev
     for i = 1:(k+1)
       @. tmp -= D2[i,1]
     end
+    if k < 5
     @.. utilde = (integrator.alg.kappa[k+1]*γₖ[k+1] + inv(k+2)) * tmp
     calculate_residuals!(atmp, utilde, uprev, u, integrator.opts.abstol, integrator.opts.reltol, integrator.opts.internalnorm, t)
     cache.EEst2 = integrator.opts.internalnorm(atmp,t)
+    else
+      cache.EEst2 = Inf
+    end
     # cnt == 1
   end # integrator.opts.adaptive
 

--- a/src/perform_step/bdf_perform_step.jl
+++ b/src/perform_step/bdf_perform_step.jl
@@ -936,7 +936,7 @@ function perform_step!(integrator,cache::QNDFCache,repeat_step=false)
     end
 
     if k > 1
-      @.. utilde = (κ*γₖ[k-1] + inv(k)) * D[k]
+      @.. utilde = (integrator.alg.kappa[k-1]*γₖ[k-1] + inv(k)) * D[k]
       calculate_residuals!(atmp, utilde, uprev, u, integrator.opts.abstol, integrator.opts.reltol, integrator.opts.internalnorm, t)
       cache.EEst1 = integrator.opts.internalnorm(atmp,t)
     end
@@ -945,7 +945,7 @@ function perform_step!(integrator,cache::QNDFCache,repeat_step=false)
     for i = 1:(k+1)
       @. tmp -= D2[i,1]
     end
-    @.. utilde = (κ*γₖ[k+1] + inv(k+2)) * tmp
+    @.. utilde = (integrator.alg.kappa[k+1]*γₖ[k+1] + inv(k+2)) * tmp
     calculate_residuals!(atmp, utilde, uprev, u, integrator.opts.abstol, integrator.opts.reltol, integrator.opts.internalnorm, t)
     cache.EEst2 = integrator.opts.internalnorm(atmp,t)
     # cnt == 1


### PR DESCRIPTION
In continuation of comments mentioned in #1158 , here are some fixes made in QNDF.
Results:
```
    function test!(du, u, p, t)
        du[1] = -10 * u[1]
        du[2] = -0.01 * u[2]
    end
    u0 = [1.01;1.01]
    tspan = (0.0, 1.0)
    prob = ODEProblem(test!, u0, tspan)
    @time sol = solve(prob, QNDF()) 
```
Before:
```
julia> @time sol = solve(prob, QNDF())
  0.000780 seconds (2.08 k allocations: 101.531 KiB)
julia> sol.destats
DiffEqBase.DEStats
Number of function 1 evaluations:                  361
Number of function 2 evaluations:                  0
Number of W matrix evaluations:                    57
Number of linear solves:                           243
Number of Jacobians created:                       1
Number of nonlinear solver iterations:             243
Number of nonlinear solver convergence failures:   0
Number of rootfind condition calls:                0
Number of accepted steps:                          68
Number of rejected steps:                          46

```
After
```
julia> @time sol = solve(prob, QNDF())
  0.000682 seconds (1.57 k allocations: 81.781 KiB)
julia> sol.destats
DiffEqBase.DEStats
Number of function 1 evaluations:                  247
Number of function 2 evaluations:                  0
Number of W matrix evaluations:                    28
Number of linear solves:                           173
Number of Jacobians created:                       1
Number of nonlinear solver iterations:             173
Number of nonlinear solver convergence failures:   0
Number of rootfind condition calls:                0
Number of accepted steps:                          70
Number of rejected steps:                          11
```
@ChrisRackauckas @kanav99 please review.