### PR TITLE
Fix redundant copies of tdir_t in tstops heap

### DIFF
--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -353,7 +353,10 @@ function handle_tstop!(integrator)
     tdir_t = integrator.tdir * integrator.t
     tdir_ts_top = top(tstops)
     if tdir_t == tdir_ts_top
-      pop!(tstops)
+      while tdir_t == tdir_ts_top #remove all redundant copies in heap == tdir_t
+        pop!(tstops)
+        isempty(tstops) ? break : tdir_ts_top = top(tstops)
+      end
       integrator.just_hit_tstop = true
     elseif tdir_t > tdir_ts_top
       if !integrator.dtchangeable


### PR DESCRIPTION
Fixes https://github.com/SciML/DifferentialEquations.jl/issues/616

MWE:
```
tspan = (0.0, 365.0)
prob = ODEProblem(system, u0, tspan)
integrator = init(prob, Tsit5())
step!(integrator, 365.0, true)
#integrator.t = 365.0
step!(integrator, 365.0, true)
#Warning: dt <= dtmin. Aborting.
```
Cause: `integrator.opts.tstops` has `tspan[end]` pushed into the heap.  A duplicate copy is pushed in heap after `step!(integrator,365.0,true)` for eg. `[365.0,365,0]`. The `handle_stop` removes only the top element when integration has reach `tspan[end]`. And then it pushes another `tstop` into heap which causes `integrator.dt = 0` because top element hasn't changed. Hence we need to remove all similar copies of` tspan[end]` from the heap, hence the change.