### PR TITLE
Use IncrementingODE in LSRK 2N methods

### DIFF
--- a/src/caches/low_storage_rk_caches.jl
+++ b/src/caches/low_storage_rk_caches.jl
@@ -48,7 +48,7 @@ function alg_cache(alg::ORK256,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUn
     k = zero(rate_prototype)
     williamson_condition = false
   else
-    if williamson_condition
+    if williamson_condition || f isa IncrementingODEFunction
       k = tmp
     else
       k = zero(rate_prototype)
@@ -93,7 +93,7 @@ function alg_cache(alg::CarpenterKennedy2N54,u,rate_prototype,uEltypeNoUnits,uBo
     k = zero(rate_prototype)
     williamson_condition = false
   else
-    if williamson_condition
+    if williamson_condition || f isa IncrementingODEFunction
       k = tmp
     else
       k = zero(rate_prototype)
@@ -142,7 +142,7 @@ function alg_cache(alg::HSLDDRK64,u,rate_prototype,uEltypeNoUnits,uBottomEltypeN
     k = zero(rate_prototype)
     williamson_condition = false
   else
-    if williamson_condition
+    if williamson_condition || f isa IncrementingODEFunction
       k = tmp
     else
       k = zero(rate_prototype)
@@ -193,7 +193,7 @@ function alg_cache(alg::DGLDDRK73_C,u,rate_prototype,uEltypeNoUnits,uBottomEltyp
     k = zero(rate_prototype)
     williamson_condition = false
   else
-    if williamson_condition
+    if williamson_condition || f isa IncrementingODEFunction
       k = tmp
     else
       k = zero(rate_prototype)
@@ -247,7 +247,7 @@ function alg_cache(alg::DGLDDRK84_C,u,rate_prototype,uEltypeNoUnits,uBottomEltyp
     k = zero(rate_prototype)
     williamson_condition = false
   else
-    if williamson_condition
+    if williamson_condition || f isa IncrementingODEFunction
       k = tmp
     else
       k = zero(rate_prototype)
@@ -301,7 +301,7 @@ function alg_cache(alg::DGLDDRK84_F,u,rate_prototype,uEltypeNoUnits,uBottomEltyp
     k = zero(rate_prototype)
     williamson_condition = false
   else
-    if williamson_condition
+    if williamson_condition || f isa IncrementingODEFunction
       k = tmp
     else
       k = zero(rate_prototype)
@@ -367,7 +367,7 @@ function alg_cache(alg::NDBLSRK124,u,rate_prototype,uEltypeNoUnits,uBottomEltype
     k = zero(rate_prototype)
     williamson_condition = false
   else
-    if williamson_condition
+    if williamson_condition || f isa IncrementingODEFunction
       k = tmp
     else
       k = zero(rate_prototype)
@@ -436,7 +436,7 @@ function alg_cache(alg::NDBLSRK134,u,rate_prototype,uEltypeNoUnits,uBottomEltype
     k = zero(rate_prototype)
     williamson_condition = false
   else
-    if williamson_condition
+    if williamson_condition || f isa IncrementingODEFunction
       k = tmp
     else
       k = zero(rate_prototype)
@@ -508,7 +508,7 @@ function alg_cache(alg::NDBLSRK144,u,rate_prototype,uEltypeNoUnits,uBottomEltype
     k = zero(rate_prototype)
     williamson_condition = false
   else
-    if williamson_condition
+    if williamson_condition || f isa IncrementingODEFunction
       k = tmp
     else
       k = zero(rate_prototype)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -77,6 +77,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
     end
   elseif !(typeof(prob)<:DiscreteProblem) &&
          !(typeof(prob)<:DiffEqBase.AbstractDAEProblem) &&
+         !(typeof(prob.f)<:IncrementingODEFunction) &&
          !is_mass_matrix_alg(alg) &&
          prob.f.mass_matrix != I
     error("This solver is not able to use mass matrices.")
@@ -99,6 +100,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
   end
 
   isdae = alg isa DAEAlgorithm || (!(typeof(prob)<:DiscreteProblem) &&
+                                  (!prob.f isa IncrementingODEFunction) &&
                                      prob.f.mass_matrix != I &&
                                      !(typeof(prob.f.mass_matrix)<:Tuple) &&
                                      ArrayInterface.issingular(prob.f.mass_matrix))


### PR DESCRIPTION
Test script - 
```julia
       using OrdinaryDiffEq
       function f(du, u, p, t, increment)
           if increment
               @. du += u
           else
               @. du = u
           end
       end
       prob = IncrementingODEProblem(f, [1.0], (0.0, 1.0))
       solve(prob, CarpenterKennedy2N54(;williamson_condition=false); dt=1.0)
```

I don't like the idea of dividing with `dt` in this PR