### PR TITLE
Add sequences for ImplicitEulerExtrapolation

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -71,8 +71,8 @@ function ImplicitEulerExtrapolation(;chunk_size=0,autodiff=true,
       @warn "The `sequence` given to the `ImplicitEulerExtrapolation` algorithm
           is not valid: it must match `:harmonic`, `:romberg` or `:bulirsch`.
           Thus it has been changed
-        :$(sequence) --> :harmonic"
-      sequence = :harmonic
+        :$(sequence) --> :bulirsch"
+      sequence = :bulirsch
     end
     ImplicitEulerExtrapolation{chunk_size,autodiff,typeof(linsolve),typeof(diff_type)}(
       linsolve,max_order,min_order,init_order,threading,diff_type,sequence)

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -68,7 +68,7 @@ function ImplicitEulerExtrapolation(;chunk_size=0,autodiff=true,
 
     # Warn user if sequence has been changed:
     if sequence != :harmonic && sequence != :romberg && sequence != :bulirsch
-      @warn "The `sequence` given to the `ImplicitHairerWannerExtrapolation` algorithm
+      @warn "The `sequence` given to the `ImplicitEulerExtrapolation` algorithm
           is not valid: it must match `:harmonic`, `:romberg` or `:bulirsch`.
           Thus it has been changed
         :$(sequence) --> :harmonic"

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -60,7 +60,7 @@ end
 
 function ImplicitEulerExtrapolation(;chunk_size=0,autodiff=true,
     diff_type=Val{:forward},linsolve=DEFAULT_LINSOLVE,
-    max_order=10,min_order=1,init_order=5,threading=true,sequence = :harmonic)
+    max_order=10,min_order=1,init_order=5,threading=true,sequence = :bulirsch)
     if threading
       @warn "Threading in `ImplicitEulerExtrapolation` is currently disabled. Thus `threading` has been changed from `true` to `false`."
       threading = false

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -55,17 +55,27 @@ struct ImplicitEulerExtrapolation{CS,AD,F,FDT} <: OrdinaryDiffEqImplicitExtrapol
   init_order::Int
   threading::Bool
   diff_type::FDT
+  sequence::Symbol # Name of the subdividing sequence
 end
 
 function ImplicitEulerExtrapolation(;chunk_size=0,autodiff=true,
     diff_type=Val{:forward},linsolve=DEFAULT_LINSOLVE,
-    max_order=10,min_order=1,init_order=5,threading=true)
+    max_order=10,min_order=1,init_order=5,threading=true,sequence = :harmonic)
     if threading
       @warn "Threading in `ImplicitEulerExtrapolation` is currently disabled. Thus `threading` has been changed from `true` to `false`."
       threading = false
     end
+
+    # Warn user if sequence has been changed:
+    if sequence != :harmonic && sequence != :romberg && sequence != :bulirsch
+      @warn "The `sequence` given to the `ImplicitHairerWannerExtrapolation` algorithm
+          is not valid: it must match `:harmonic`, `:romberg` or `:bulirsch`.
+          Thus it has been changed
+        :$(sequence) --> :harmonic"
+      sequence = :harmonic
+    end
     ImplicitEulerExtrapolation{chunk_size,autodiff,typeof(linsolve),typeof(diff_type)}(
-      linsolve,max_order,min_order,init_order,threading,diff_type)
+      linsolve,max_order,min_order,init_order,threading,diff_type,sequence)
 end
 
 struct ExtrapolationMidpointDeuflhard <: OrdinaryDiffEqExtrapolationVarOrderVarStepAlgorithm

--- a/src/caches/extrapolation_caches.jl
+++ b/src/caches/extrapolation_caches.jl
@@ -318,8 +318,6 @@ function generate_sequence(T, alg::ImplicitEulerExtrapolation)
 
   @unpack min_order, init_order, max_order, sequence = alg
 
-  max_order > 15 && error("max_order > 15 not allowed for Float32 or Float64 with this algorithm. That's a bad idea.")
-
   # Initialize subdividing_sequence:
   if sequence == :harmonic
       subdividing_sequence = BigInt.(1:(max_order + 1))
@@ -337,15 +335,13 @@ function generate_sequence(T::Type{<:CompiledFloats}, alg::ImplicitEulerExtrapol
 
   @unpack min_order, init_order, max_order, sequence = alg
 
-  max_order > 15 && error("max_order > 15 not allowed for Float32 or Float64 with this algorithm. That's a bad idea.")
-
   # Initialize subdividing_sequence:
   if sequence == :harmonic
-    subdividing_sequence = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
+    subdividing_sequence = Int.(1:(max_order + 1))
   elseif sequence == :romberg
-    subdividing_sequence = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]
+    subdividing_sequence = Int(2).^(0:max_order)
   else # sequence == :bulirsch
-    subdividing_sequence = [1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64, 96, 128, 192, 256]
+    subdividing_sequence = [n==0 ? Int(1) : (isodd(n) ? Int(2)^((n + 1) ÷ 2) : 3 * Int(2)^(n ÷ 2 - 1)) for n = 0:max_order]
   end
 
   subdividing_sequence

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -1490,6 +1490,7 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationConst
       u_temp1 = T[i+1]
     end
   end
+  @show T
 
   if integrator.opts.adaptive
     # Compute all information relating to an extrapolation order ≦ win_min

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -252,6 +252,10 @@ function perform_step!(integrator,cache::ImplicitEulerExtrapolationCache,repeat_
   @unpack J,W,uf,tf,jac_config = cache
   @unpack u_tmps, k_tmps, linsolve_tmps = cache
 
+  @unpack subdividing_sequence = cache.coefficients
+
+  @show subdividing_sequence
+
   max_order = min(size(T, 1), cur_order + 1)
 
   if !integrator.alg.threading

--- a/test/multithreading/ode_extrapolation_tests.jl
+++ b/test/multithreading/ode_extrapolation_tests.jl
@@ -70,26 +70,26 @@ testTol = 0.2
   end
 end # AitkenNeville
 
+# Define the subdividing sequences
+sequence_array =[:harmonic, :romberg, :bulirsch]
+
 @testset "Testing ImplicitEulerExtrapolation" begin
-  for prob in problem_array
+  for prob in problem_array, seq in sequence_array
     global dts
 
     newTol = 0.35
     #  Convergence test
     for j = 1:4
       sim = test_convergence(dts,prob,ImplicitEulerExtrapolation(max_order = j,
-        min_order = j, init_order = j))
+        min_order = j, init_order = j,sequence = seq))
       @test sim.𝒪est[:final] ≈ j atol=newTol
     end
     # Regression test
     sol = solve(prob,ImplicitEulerExtrapolation(max_order = 9, min_order = 1,
-        init_order = 9),reltol=1e-3)
+        init_order = 9,sequence = seq),reltol=1e-3)
     @test length(sol.u) < 15
   end
 end
-
-# Define the subdividing sequences
-sequence_array =[:harmonic, :romberg, :bulirsch]
 
 @testset "Testing ImplicitDeuflhardExtrapolation" begin
   for prob in problem_array, seq in sequence_array


### PR DESCRIPTION
Hi,

I added a choice of sequences in ImplicitEulerExtrapolation similar to seulex. The default sequence is set to Bulirsch. There we some minor improvements in the method. Comparing with seulex:

```
function test!(du, u, p, t)
     du[1] = -10 * u[1]
     du[2] = -0.01 * u[2]
 end
 u0 = [1.01;1.01]
 tspan = (0.0, 1.0)
 prob = ODEProblem(test!, u0, tspan)
```
```
julia> sol = solve(prob,seulex())
retcode: Success
Interpolation: 1st order linear
t: 12-element Array{Float64,1}:
 0.0
 1.0e-6
 7.957010852370433e-6
 5.6357010852370424e-5
 ⋮
 0.171697546989057
 0.362553477748044
 0.8757951760869469
 1.0
u: 12-element Array{Array{Float64,1},1}:
 [1.01, 1.01]
 [1.0099899000505004, 1.0099999898999994]
 [1.009919637387684, 1.0099999196341929]
 [1.0094309545603295, 1.0099994307943505]
 ⋮
 [0.18151135597475912, 1.0082673426661455]
 [0.02691950277797022, 1.006344839833677]
 [0.00015776855888100059, 1.001193090258896]
 [4.575739308257184e-5, 0.9999503320867008]
```

```
julia> sol = solve(prob,ImplicitEulerExtrapolation(),dt=1e-6)
┌ Warning: Threading in `ImplicitEulerExtrapolation` is currently disabled. Thus `threading` has been changed from `true` to `false`.
└ @ OrdinaryDiffEq C:\Users\Utkarsh\.julia\dev\OrdinaryDiffEq\src\algorithms.jl:65
retcode: Success
Interpolation: 3rd order Hermite
t: 14-element Array{Float64,1}:
 0.0
 1.0e-6
 1.1e-5
 0.00011099999999999999
 ⋮
 0.33900999182564423
 0.5605959154883677
 0.8354148791156211
 1.0
u: 14-element Array{Array{Float64,1},1}:
 [1.01, 1.01]
 [1.0099899000505, 1.0099999899]
 [1.0098889061104441, 1.009999888900006]
 [1.0088795221484086, 1.0099988789006225]
 ⋮
 [0.03404236668264801, 1.006581796382659]
 [0.0037126518729961797, 1.00435382215883]
 [0.00023777180592478287, 1.0015974566391057]
 [4.585389370221542e-5, 0.999950332087402]
```
I will make changes on adaptive step-sizing (which seems to be different from Hairer II for seulex) after this. It would help me compare benchmarks across different sequences.
@ChrisRackauckas please review.