### PR TITLE
Sequence factor option in explicit-extrapolation midpoint methods

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -117,7 +117,7 @@ function ExtrapolationMidpointDeuflhard(;min_order=1,init_order=5, max_order=10,
 
   # Warn user if sequence_factor is not even
   if sequence_factor%2 != 0
-    @warn "An odd number cannot be used as sequence factor. 
+    @warn "A non-even number cannot be used as sequence factor. 
           Thus is has been changed 
           $(sequence_factor) --> 2"
     sequence_factor = 2
@@ -201,7 +201,7 @@ function ExtrapolationMidpointHairerWanner(;min_order=2,init_order=5, max_order=
 
   # Warn user if sequence_factor is not even
   if sequence_factor%2 != 0
-    @warn "A odd number cannot be used as sequence factor. 
+    @warn "A non-even number cannot be used as sequence factor. 
           Thus is has been changed 
           $(sequence_factor) --> 2"
     sequence_factor = 2

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -98,8 +98,9 @@ struct ExtrapolationMidpointDeuflhard <: OrdinaryDiffEqExtrapolationVarOrderVarS
   n_max::Int # Maximal extrapolation order
   sequence::Symbol # Name of the subdividing sequence
   threading::Bool
+  sequence_factor::Int # An even factor by which sequence is scaled for midpoint extrapolation
 end
-function ExtrapolationMidpointDeuflhard(;min_order=1,init_order=5, max_order=10, sequence = :harmonic, threading = true)
+function ExtrapolationMidpointDeuflhard(;min_order=1,init_order=5, max_order=10, sequence = :harmonic, threading = true, sequence_factor = 2)
   # Enforce 1 <=  min_order <= init_order <= max_order:
   n_min = max(1,min_order)
   n_init = max(n_min,init_order)
@@ -114,6 +115,14 @@ function ExtrapolationMidpointDeuflhard(;min_order=1,init_order=5, max_order=10,
       Initial order: " * lpad(init_order,2," ") * " --> "  * lpad(n_init,2," ")
   end
 
+  # Warn user if sequence_factor is not even
+  if sequence_factor%2 != 0
+    @warn "An odd number cannot be used as sequence factor. 
+          Thus is has been changed 
+          $(sequence_factor) --> 2"
+    sequence_factor = 2
+  end
+
   # Warn user if sequence has been changed:
   if sequence != :harmonic && sequence != :romberg && sequence != :bulirsch
     @warn "The `sequence` given to the `ExtrapolationMidpointDeuflhard` algorithm
@@ -124,7 +133,7 @@ function ExtrapolationMidpointDeuflhard(;min_order=1,init_order=5, max_order=10,
   end
 
   # Initialize algorithm
-  ExtrapolationMidpointDeuflhard(n_min,n_init,n_max,sequence,threading)
+  ExtrapolationMidpointDeuflhard(n_min,n_init,n_max,sequence,threading,sequence_factor)
 end
 
 struct ImplicitDeuflhardExtrapolation{CS,AD,F,FDT} <: OrdinaryDiffEqImplicitExtrapolationAlgorithm{CS,AD}
@@ -172,8 +181,9 @@ struct ExtrapolationMidpointHairerWanner <: OrdinaryDiffEqExtrapolationVarOrderV
   n_max::Int # Maximal extrapolation order
   sequence::Symbol # Name of the subdividing sequence
   threading::Bool
+  sequence_factor::Int # An even factor by which sequence is scaled for midpoint extrapolation
 end
-function ExtrapolationMidpointHairerWanner(;min_order=2,init_order=5, max_order=10, sequence = :harmonic, threading = true)
+function ExtrapolationMidpointHairerWanner(;min_order=2,init_order=5, max_order=10, sequence = :harmonic, threading = true, sequence_factor = 2)
   # Enforce 2 <=  min_order
   # and min_order + 1 <= init_order <= max_order - 1:
   n_min = max(2, min_order)
@@ -189,6 +199,14 @@ function ExtrapolationMidpointHairerWanner(;min_order=2,init_order=5, max_order=
       Initial order: " * lpad(init_order,2," ") * " --> "  * lpad(n_init,2," ")
   end
 
+  # Warn user if sequence_factor is not even
+  if sequence_factor%2 != 0
+    @warn "A odd number cannot be used as sequence factor. 
+          Thus is has been changed 
+          $(sequence_factor) --> 2"
+    sequence_factor = 2
+  end
+
   # Warn user if sequence has been changed:
   if sequence != :harmonic && sequence != :romberg && sequence != :bulirsch
     @warn "The `sequence` given to the `ExtrapolationMidpointHairerWanner` algorithm
@@ -199,7 +217,7 @@ function ExtrapolationMidpointHairerWanner(;min_order=2,init_order=5, max_order=
   end
 
   # Initialize algorithm
-  ExtrapolationMidpointHairerWanner(n_min,n_init,n_max,sequence,threading)
+  ExtrapolationMidpointHairerWanner(n_min,n_init,n_max,sequence,threading,sequence_factor)
 end
 
 struct ImplicitHairerWannerExtrapolation{CS,AD,F,FDT} <: OrdinaryDiffEqImplicitExtrapolationAlgorithm{CS,AD}

--- a/src/caches/extrapolation_caches.jl
+++ b/src/caches/extrapolation_caches.jl
@@ -365,6 +365,7 @@ function alg_cache(alg::ExtrapolationMidpointDeuflhard,u,rate_prototype,uEltypeN
     Q = fill(zero(QType),alg.n_max - alg.n_min + 1)
     n_curr = alg.n_init
     n_old = alg.n_init
+    sequence_factor = alg.sequence_factor
 
     coefficients = create_extrapolation_coefficients(constvalue(uBottomEltypeNoUnits),alg)
     stage_number = Vector{Int}(undef, alg.n_max - alg.n_min + 1)
@@ -373,7 +374,7 @@ function alg_cache(alg::ExtrapolationMidpointDeuflhard,u,rate_prototype,uEltypeN
       for i in alg.n_min:(alg.n_min + n)
         s += coefficients.subdividing_sequence[i]
       end
-      stage_number[n] = 2 * Int(s) - alg.n_min - n + 1
+      stage_number[n] = sequence_factor * Int(s) - alg.n_min - n + 1
     end
 
     # Initialize cache
@@ -578,6 +579,7 @@ function alg_cache(alg::ExtrapolationMidpointHairerWanner,u,rate_prototype,uElty
   Q = fill(zero(QType),alg.n_max + 1)
   n_curr = alg.n_init
   n_old = alg.n_init
+  sequence_factor = alg.sequence_factor
 
   coefficients = create_extrapolation_coefficients(constvalue(uBottomEltypeNoUnits),alg)
   stage_number = Vector{Int}(undef, alg.n_max + 1)
@@ -586,7 +588,7 @@ function alg_cache(alg::ExtrapolationMidpointHairerWanner,u,rate_prototype,uElty
     for i in 1:n
       s += coefficients.subdividing_sequence[i]
     end
-    stage_number[n] = 2 * Int(s) - n + 1
+    stage_number[n] = sequence_factor * Int(s) - n + 1
   end
   sigma = 9//10
 

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -522,7 +522,7 @@ function perform_step!(integrator, cache::ExtrapolationMidpointDeuflhardCache, r
   #Compute the internal discretisations
   if !integrator.alg.threading
     for i in 0:n_curr
-      j_int = 2 * subdividing_sequence[i+1]
+      j_int = sequence_factor * subdividing_sequence[i+1]
       dt_int = dt / j_int # Stepsize of the ith internal discretisation
       @.. u_temp2 = uprev
       @.. u_temp1 = u_temp2 + dt_int * fsalfirst # Euler starting step
@@ -547,7 +547,7 @@ function perform_step!(integrator, cache::ExtrapolationMidpointDeuflhardCache, r
           startIndex = (i == 1) ? 0 : n_curr
           endIndex = (i == 1) ? n_curr - 1 : n_curr
           for index = startIndex : endIndex
-            j_int_temp = 2 * subdividing_sequence[index+1]
+            j_int_temp = sequence_factor * subdividing_sequence[index+1]
             dt_int_temp = dt / j_int_temp # Stepsize of the ith internal discretisation
             @.. u_temp4[Threads.threadid()] = uprev
             @.. u_temp3[Threads.threadid()] = u_temp4[Threads.threadid()] + dt_int_temp * fsalfirst # Euler starting step
@@ -567,7 +567,7 @@ function perform_step!(integrator, cache::ExtrapolationMidpointDeuflhardCache, r
         Threads.@threads for i in 0:(n_curr ÷ 2)
           indices = (i, n_curr-i)
           for index in indices
-            j_int_temp = 2 * subdividing_sequence[index+1]
+            j_int_temp = sequence_factor * subdividing_sequence[index+1]
             dt_int_temp = dt / j_int_temp # Stepsize of the ith internal discretisation
             @.. u_temp4[Threads.threadid()] = uprev
             @.. u_temp3[Threads.threadid()] = u_temp4[Threads.threadid()] + dt_int_temp * fsalfirst # Euler starting step
@@ -625,7 +625,7 @@ function perform_step!(integrator, cache::ExtrapolationMidpointDeuflhardCache, r
         cache.n_curr = n_curr
 
         # Update cache.T
-        j_int = 2 * subdividing_sequence[n_curr + 1]
+        j_int = sequence_factor * subdividing_sequence[n_curr + 1]
         dt_int = dt / j_int # Stepsize of the new internal discretisation
         @.. u_temp2 = uprev
         @.. u_temp1 = u_temp2 + dt_int * fsalfirst # Euler starting step
@@ -698,6 +698,7 @@ function perform_step!(integrator,cache::ExtrapolationMidpointDeuflhardConstantC
   # Additional constant information
   @unpack subdividing_sequence = cache.coefficients
   @unpack stage_number = cache
+  @unpack sequence_factor = integrator.alg.sequence_factor
 
   # Create auxiliary variables
   u_temp1, u_temp2 = copy(uprev), copy(uprev) # Auxiliary variables for computing the internal discretisations
@@ -720,7 +721,7 @@ function perform_step!(integrator,cache::ExtrapolationMidpointDeuflhardConstantC
   # Compute the internal discretisations
   if !integrator.alg.threading
     for i = 0:n_curr
-      j_int = 2 * subdividing_sequence[i+1]
+      j_int = sequence_factor * subdividing_sequence[i+1]
       dt_int = dt / j_int # Stepsize of the ith internal discretisation
       u_temp2 = uprev
       u_temp1 = u_temp2 + dt_int*integrator.fsalfirst # Euler starting step
@@ -744,7 +745,7 @@ function perform_step!(integrator,cache::ExtrapolationMidpointDeuflhardConstantC
           startIndex = (i == 1) ? 0 : n_curr
           endIndex = (i == 1) ? n_curr - 1 : n_curr
           for index = startIndex : endIndex
-            j_int_temp = 2 * subdividing_sequence[index+1]
+            j_int_temp = sequence_factor * subdividing_sequence[index+1]
             dt_int_temp = dt / j_int_temp # Stepsize of the ith internal discretisation
             u_temp4 = uprev
             u_temp3 = u_temp4 + dt_int_temp*integrator.fsalfirst # Euler starting step
@@ -763,7 +764,7 @@ function perform_step!(integrator,cache::ExtrapolationMidpointDeuflhardConstantC
         Threads.@threads for i in 0:(n_curr ÷ 2)
           indices = (i, n_curr-i)
           for index in indices
-            j_int_temp = 2 * subdividing_sequence[index+1]
+            j_int_temp = sequence_factor * subdividing_sequence[index+1]
             dt_int_temp = dt / j_int_temp # Stepsize of the ith internal discretisation
             u_temp4 = uprev
             u_temp3 = u_temp4 + dt_int_temp * integrator.fsalfirst # Euler starting step
@@ -806,7 +807,7 @@ function perform_step!(integrator,cache::ExtrapolationMidpointDeuflhardConstantC
         cache.n_curr = n_curr
 
         # Update T
-        j_int = 2 * subdividing_sequence[n_curr + 1]
+        j_int = sequence_factor * subdividing_sequence[n_curr + 1]
         dt_int = dt / j_int # Stepsize of the new internal discretisation
         u_temp2 = uprev
         u_temp1 = u_temp2 + dt_int * integrator.fsalfirst # Euler starting step
@@ -1127,6 +1128,7 @@ function perform_step!(integrator, cache::ExtrapolationMidpointHairerWannerCache
   @unpack extrapolation_weights_2, extrapolation_scalars_2 = cache.coefficients
   # Additional constant information
   @unpack subdividing_sequence = cache.coefficients
+  @unpack sequence_factor = integrator.alg
 
   fill!(cache.Q, zero(eltype(cache.Q)))
 
@@ -1148,7 +1150,7 @@ function perform_step!(integrator, cache::ExtrapolationMidpointHairerWannerCache
   #Compute the internal discretisations
   if !integrator.alg.threading
     for i in 0:n_curr
-      j_int = 2 * subdividing_sequence[i+1]
+      j_int = sequence_factor * subdividing_sequence[i+1]
       dt_int = dt / j_int # Stepsize of the ith internal discretisation
       @.. u_temp2 = uprev
       @.. u_temp1 = u_temp2 + dt_int * fsalfirst # Euler starting step
@@ -1174,7 +1176,7 @@ function perform_step!(integrator, cache::ExtrapolationMidpointHairerWannerCache
           endIndex = (i == 1) ? n_curr - 1 : n_curr
 
           for index in startIndex:endIndex
-            j_int_temp = 2 * subdividing_sequence[index+1]
+            j_int_temp = sequence_factor * subdividing_sequence[index+1]
             dt_int_temp = dt / j_int_temp # Stepsize of the ith internal discretisation
             @.. u_temp4[Threads.threadid()] = uprev
             @.. u_temp3[Threads.threadid()] = u_temp4[Threads.threadid()] + dt_int_temp * fsalfirst # Euler starting step
@@ -1194,7 +1196,7 @@ function perform_step!(integrator, cache::ExtrapolationMidpointHairerWannerCache
         Threads.@threads for i in 0:(n_curr ÷ 2)
           indices = (i, n_curr - i)
           for index in indices
-            j_int_temp = 2 * subdividing_sequence[index+1]
+            j_int_temp = sequence_factor * subdividing_sequence[index+1]
             dt_int_temp = dt / j_int_temp # Stepsize of the ith internal discretisation
             @.. u_temp4[Threads.threadid()] = uprev
             @.. u_temp3[Threads.threadid()] = u_temp4[Threads.threadid()] + dt_int_temp * fsalfirst # Euler starting step
@@ -1248,7 +1250,7 @@ function perform_step!(integrator, cache::ExtrapolationMidpointHairerWannerCache
         cache.n_curr = n_curr
 
         # Update cache.T
-        j_int = 2 * subdividing_sequence[n_curr + 1]
+        j_int = sequence_factor * subdividing_sequence[n_curr + 1]
         dt_int = dt / j_int # Stepsize of the new internal discretisation
         @.. u_temp2 = uprev
         @.. u_temp1 = u_temp2 + dt_int * fsalfirst # Euler starting step
@@ -1345,7 +1347,7 @@ function perform_step!(integrator, cache::ExtrapolationMidpointHairerWannerConst
   #Compute the internal discretisations
   if !integrator.alg.threading
     for i in 0:n_curr
-     j_int = 2 * subdividing_sequence[i+1]
+     j_int = sequence_factor * subdividing_sequence[i+1]
      dt_int = dt / j_int # Stepsize of the ith internal discretisation
      u_temp2 = uprev
      u_temp1 = u_temp2 + dt_int * integrator.fsalfirst # Euler starting step
@@ -1369,7 +1371,7 @@ function perform_step!(integrator, cache::ExtrapolationMidpointHairerWannerConst
           startIndex = (i == 1) ? 0 : n_curr
           endIndex = (i == 1) ? n_curr - 1 : n_curr
           for index in startIndex:endIndex
-            j_int_temp = 2 * subdividing_sequence[index+1]
+            j_int_temp = sequence_factor * subdividing_sequence[index+1]
             dt_int_temp = dt / j_int_temp # Stepsize of the ith internal discretisation
             u_temp4 = uprev
             u_temp3 = u_temp4 + dt_int_temp * integrator.fsalfirst # Euler starting step
@@ -1388,7 +1390,7 @@ function perform_step!(integrator, cache::ExtrapolationMidpointHairerWannerConst
         Threads.@threads for i in 0:(n_curr ÷ 2)
           indices = (i, n_curr - i)
           for index in indices
-            j_int_temp = 2 * subdividing_sequence[index+1]
+            j_int_temp = sequence_factor * subdividing_sequence[index+1]
             dt_int_temp = dt / j_int_temp # Stepsize of the ith internal discretisation
             u_temp4 = uprev
             u_temp3 = u_temp4 + dt_int_temp * integrator.fsalfirst # Euler starting step
@@ -1427,7 +1429,7 @@ function perform_step!(integrator, cache::ExtrapolationMidpointHairerWannerConst
         cache.n_curr = n_curr
 
         # Update T
-        j_int = 2 * subdividing_sequence[n_curr + 1]
+        j_int = sequence_factor * subdividing_sequence[n_curr + 1]
         dt_int = dt / j_int # Stepsize of the new internal discretisation
         u_temp2 = uprev
         u_temp1 = u_temp2 + dt_int * integrator.fsalfirst # Euler starting step

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -1194,7 +1194,7 @@ function perform_step!(integrator, cache::ExtrapolationMidpointHairerWannerCache
       let n_curr=n_curr,subdividing_sequence=subdividing_sequence,uprev=uprev,dt=dt,u_temp3=u_temp3,
           u_temp4=u_temp4,k_tmps=k_tmps,p=p,t=t,T=T
         Threads.@threads for i in 0:(n_curr ÷ 2)
-          indices = 2*i != n_curr ? (i, n_curr - i) : (n_curr-i)
+          indices = i != n_curr - i ? (i, n_curr - i) : (n_curr-i) #Avoid duplicate entry in tuple
           for index in indices
             j_int_temp = sequence_factor * subdividing_sequence[index+1]
             dt_int_temp = dt / j_int_temp # Stepsize of the ith internal discretisation
@@ -1379,7 +1379,6 @@ function perform_step!(integrator, cache::ExtrapolationMidpointHairerWannerConst
             u_temp3 = u_temp4 + dt_int_temp * integrator.fsalfirst # Euler starting step
             for j in 2:j_int_temp
               T[index+1] = u_temp4 + 2 * dt_int_temp * f(u_temp3, p, t + (j - 1) * dt_int_temp) # Explicit Midpoint rule
-              integrator.destats.nf += 1
               u_temp4 = u_temp3
               u_temp3 = T[index+1]
             end
@@ -1390,7 +1389,7 @@ function perform_step!(integrator, cache::ExtrapolationMidpointHairerWannerConst
       let n_curr=n_curr, subdividing_sequence=subdividing_sequence, dt=dt, uprev=uprev,
           integrator=integrator, T=T, p=p, t=t
         Threads.@threads for i in 0:(n_curr ÷ 2)
-          indices = (i, n_curr - i)
+          indices = i != n_curr - i ? (i, n_curr - i) : (n_curr-i) #Avoid duplicate entry in tuple
           for index in indices
             j_int_temp = sequence_factor * subdividing_sequence[index+1]
             dt_int_temp = dt / j_int_temp # Stepsize of the ith internal discretisation
@@ -1398,7 +1397,6 @@ function perform_step!(integrator, cache::ExtrapolationMidpointHairerWannerConst
             u_temp3 = u_temp4 + dt_int_temp * integrator.fsalfirst # Euler starting step
             for j in 2:j_int_temp
               T[index+1] = u_temp4 + 2 * dt_int_temp * f(u_temp3, p, t + (j - 1) * dt_int_temp) # Explicit Midpoint rule
-              integrator.destats.nf += 1
               u_temp4 = u_temp3
               u_temp3 = T[index+1]
             end
@@ -1406,6 +1404,8 @@ function perform_step!(integrator, cache::ExtrapolationMidpointHairerWannerConst
         end
       end
     end
+    nevals = cache.stage_number[n_curr+1] - 1
+    integrator.destats.nf += nevals
   end
   if integrator.opts.adaptive
     # Compute all information relating to an extrapolation order ≦ win_min

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -565,7 +565,7 @@ function perform_step!(integrator, cache::ExtrapolationMidpointDeuflhardCache, r
       let n_curr=n_curr,subdividing_sequence=subdividing_sequence,uprev=uprev,dt=dt,u_temp3=u_temp3,
           u_temp4=u_temp4,k_tmps=k_tmps,p=p,t=t,T=T
         Threads.@threads for i in 0:(n_curr ÷ 2)
-          indices = i != n_curr - i ? (i, n_curr - i) : (n_curr-i) #Avoid duplicate entry in tuple
+          indices = (i, n_curr - i)
           for index in indices
             j_int_temp = sequence_factor * subdividing_sequence[index+1]
             dt_int_temp = dt / j_int_temp # Stepsize of the ith internal discretisation
@@ -752,7 +752,6 @@ function perform_step!(integrator,cache::ExtrapolationMidpointDeuflhardConstantC
             u_temp3 = u_temp4 + dt_int_temp*integrator.fsalfirst # Euler starting step
             for j in 2:j_int_temp
               T[index+1] = u_temp4 + 2 * dt_int_temp * f(u_temp3, p, t + (j-1) * dt_int_temp) # Explicit Midpoint rule
-              integrator.destats.nf += 1
               u_temp4 = u_temp3
               u_temp3 = T[index+1]
             end
@@ -763,7 +762,7 @@ function perform_step!(integrator,cache::ExtrapolationMidpointDeuflhardConstantC
       let n_curr=n_curr, subdividing_sequence=subdividing_sequence, dt=dt, uprev=uprev,
               p=p, t=t, T=T
         Threads.@threads for i in 0:(n_curr ÷ 2)
-          indices = (i, n_curr-i)
+          indices = (i, n_curr - i)
           for index in indices
             j_int_temp = sequence_factor * subdividing_sequence[index+1]
             dt_int_temp = dt / j_int_temp # Stepsize of the ith internal discretisation
@@ -771,7 +770,6 @@ function perform_step!(integrator,cache::ExtrapolationMidpointDeuflhardConstantC
             u_temp3 = u_temp4 + dt_int_temp * integrator.fsalfirst # Euler starting step
             for j in 2:j_int_temp
               T[index+1] = u_temp4 + 2 * dt_int_temp * f(u_temp3, p, t + (j-1) * dt_int_temp) # Explicit Midpoint rule
-              integrator.destats.nf += 1
               u_temp4 = u_temp3
               u_temp3 = T[index+1]
             end
@@ -782,6 +780,8 @@ function perform_step!(integrator,cache::ExtrapolationMidpointDeuflhardConstantC
         end
       end
     end
+    nevals = cache.stage_number[n_curr+1] - 1
+    integrator.destats.nf += nevals
   end
 
 

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -504,6 +504,7 @@ function perform_step!(integrator, cache::ExtrapolationMidpointDeuflhardCache, r
   # Additional constant information
   @unpack subdividing_sequence = cache.coefficients
   @unpack stage_number = cache
+  @unpack sequence_factor = integrator.alg
 
   fill!(cache.Q, zero(eltype(cache.Q)))
   tol = integrator.opts.internalnorm(integrator.opts.reltol, t) # Used by the convergence monitor
@@ -698,7 +699,7 @@ function perform_step!(integrator,cache::ExtrapolationMidpointDeuflhardConstantC
   # Additional constant information
   @unpack subdividing_sequence = cache.coefficients
   @unpack stage_number = cache
-  @unpack sequence_factor = integrator.alg.sequence_factor
+  @unpack sequence_factor = integrator.alg
 
   # Create auxiliary variables
   u_temp1, u_temp2 = copy(uprev), copy(uprev) # Auxiliary variables for computing the internal discretisations
@@ -1322,6 +1323,7 @@ function perform_step!(integrator, cache::ExtrapolationMidpointHairerWannerConst
   @unpack extrapolation_weights_2, extrapolation_scalars_2 = cache.coefficients
   # Additional constant information
   @unpack subdividing_sequence = cache.coefficients
+  @unpack subdividing_sequence = integrator.alg
 
   # Create auxiliary variables
   u_temp1, u_temp2 = copy(uprev), copy(uprev) # Auxiliary variables for computing the internal discretisations


### PR DESCRIPTION
As discussed in #1200 , I have added choice in algorithms to set `sequence_factor`.
I would also be comparing benchmarks across this parameter as your comment had said earlier.
@ChrisRackauckas have a look.