### PR TITLE
Update T calculation in adaptive step-sizing of Implicit Extrapolation Methods

### DIFF
--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -1565,11 +1565,13 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationConst
 
         # Update T
         j_int = 2 * subdividing_sequence[n_curr + 1]
-        dt_int = dt / j_int # Stepsize of the new internal discretisation
+        dt_int = dt / j_int # Stepsize of the ith internal discretisation
+        W = dt_int*J - integrator.f.mass_matrix
+        integrator.destats.nw += 1
         u_temp2 = uprev
-        u_temp1 = u_temp2 + dt_int * integrator.fsalfirst # Euler starting step
+        u_temp1 = u_temp2 + _reshape(W\-_vec(dt_int*integrator.fsalfirst), axes(uprev)) # Euler starting step
         for j in 2:j_int
-          T[n_curr+1] = u_temp2 + 2 * dt_int * f(u_temp1, p, t + (j-1) * dt_int)
+          T[n_curr+1] = 2*u_temp1 - u_temp2 + 2*_reshape(W\-_vec(dt_int * f(u_temp1, p, t + (j-1) * dt_int) - (u_temp1 - u_temp2)),axes(uprev))
           integrator.destats.nf += 1
           u_temp2 = u_temp1
           u_temp1 = T[n_curr+1]

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -1645,7 +1645,7 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationCache
   for i in 0:n_curr
     j_int = 2 * subdividing_sequence[i+1]
     dt_int = dt / j_int # Stepsize of the ith internal discretisation
-    jacobian2W!(W, integrator.f.mass_matrix, dt_t, J, false)
+    jacobian2W!(W, integrator.f.mass_matrix, dt_int, J, false)
     integrator.destats.nw +=1
     @.. u_temp2 = uprev
     @.. linsolve_tmp = dt_int * fsalfirst

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -1097,11 +1097,13 @@ function perform_step!(integrator,cache::ImplicitDeuflhardExtrapolationConstantC
 
         # Update T
         j_int = 2 * subdividing_sequence[n_curr + 1]
-        dt_int = dt / j_int # Stepsize of the new internal discretisation
+        dt_int = dt / j_int # Stepsize of the ith internal discretisation
+        W = dt_int*J - integrator.f.mass_matrix
+        integrator.destats.nw += 1
         u_temp2 = uprev
-        u_temp1 = u_temp2 + dt_int * integrator.fsalfirst # Euler starting step
+        u_temp1 = u_temp2 + _reshape(W\-_vec(dt_int*integrator.fsalfirst), axes(uprev)) # Euler starting step
         for j in 2:j_int
-          T[n_curr+1] = u_temp2 + 2 * dt_int * f(u_temp1, p, t + (j-1) * dt_int)
+          T[n_curr+1] = 2*u_temp1 - u_temp2 + 2 * _reshape(W\-_vec(dt_int*f(u_temp1, p, t + (j-1) * dt_int) - (u_temp1 - u_temp2)),axes(uprev))
           integrator.destats.nf += 1
           u_temp2 = u_temp1
           u_temp1 = T[n_curr+1]

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -954,13 +954,23 @@ function perform_step!(integrator, cache::ImplicitDeuflhardExtrapolationCache, r
 
         # Update cache.T
         j_int = 2 * subdividing_sequence[n_curr + 1]
-        dt_int = dt / j_int # Stepsize of the new internal discretisation
+        dt_int = dt / j_int # Stepsize of the ith internal discretisation
+        jacobian2W!(W, integrator.f.mass_matrix, dt_int, J, false)
+        integrator.destats.nw += 1
         @.. u_temp2 = uprev
-        @.. u_temp1 = u_temp2 + dt_int * fsalfirst # Euler starting step
+        @.. linsolve_tmp = dt_int*fsalfirst
+        cache.linsolve(vec(k), W, vec(linsolve_tmp), !repeat_step)
+        integrator.destats.nsolve += 1
+        @.. k = -k
+        @.. u_temp1 = u_temp2 + k # Euler starting step
         for j in 2:j_int
           f(k, cache.u_temp1, p, t + (j-1) * dt_int)
           integrator.destats.nf += 1
-          @.. T[n_curr+1] = u_temp2 + 2 * dt_int * k
+          @.. linsolve_tmp = dt_int * k - (u_temp1 - u_temp2)
+          cache.linsolve(vec(k), W, vec(linsolve_tmp), !repeat_step)
+          integrator.destats.nsolve += 1
+          @.. k = -k
+          @.. T[n_curr+1] = 2 * u_temp1 - u_temp2 + 2 * k # Explicit Midpoint rule
           @.. u_temp2 = u_temp1
           @.. u_temp1 = T[n_curr+1]
         end

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -954,7 +954,7 @@ function perform_step!(integrator, cache::ImplicitDeuflhardExtrapolationCache, r
 
         # Update cache.T
         j_int = 2 * subdividing_sequence[n_curr + 1]
-        dt_int = dt / j_int # Stepsize of the ith internal discretisation
+        dt_int = dt / j_int # Stepsize of the new internal discretisation
         jacobian2W!(W, integrator.f.mass_matrix, dt_int, J, false)
         integrator.destats.nw += 1
         @.. u_temp2 = uprev
@@ -1097,7 +1097,7 @@ function perform_step!(integrator,cache::ImplicitDeuflhardExtrapolationConstantC
 
         # Update T
         j_int = 2 * subdividing_sequence[n_curr + 1]
-        dt_int = dt / j_int # Stepsize of the ith internal discretisation
+        dt_int = dt / j_int # Stepsize of the new internal discretisation
         W = dt_int*J - integrator.f.mass_matrix
         integrator.destats.nw += 1
         u_temp2 = uprev
@@ -1577,7 +1577,7 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationConst
 
         # Update T
         j_int = 2 * subdividing_sequence[n_curr + 1]
-        dt_int = dt / j_int # Stepsize of the ith internal discretisation
+        dt_int = dt / j_int # Stepsize of the new internal discretisation
         W = dt_int*J - integrator.f.mass_matrix
         integrator.destats.nw += 1
         u_temp2 = uprev
@@ -1718,7 +1718,7 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationCache
 
         # Update cache.T
         j_int = 2 * subdividing_sequence[n_curr+1]
-        dt_int = dt / j_int # Stepsize of the ith internal discretisation
+        dt_int = dt / j_int # Stepsize of the new internal discretisation
         jacobian2W!(W, integrator.f.mass_matrix, dt_int, J, false)
         integrator.destats.nw +=1
         @.. u_temp2 = uprev


### PR DESCRIPTION
Hi, 
It seems to me that while calculating T for higher-order for using in adaptive step-sizing, the calculation was being done using explicit midpoint rule. Since we are using Semi-Implicit Method in Implicit Midpoint, the T update for higher-order must be done using that formula. The changes also reflect the results:
(Prob with Low Tolerance)
```function test!(du, u, p, t)
     du[1] = -10 * u[1]
     du[2] = -0.01 * u[2]
 end
 u0 = [1.01;1.01]
 tspan = (0.0, 1.0)
 prob = ODEProblem(test!, u0, tspan)
```
**Deuflhard adaptivity**

Before:
```
julia> sol = solve(prob2,ImplicitDeuflhardExtrapolation(),abstol=1/10^10,reltol=1/10^10)
retcode: Success
Interpolation: 3rd order Hermite
t: 888-element Array{Float64,1}:
 0.0
 0.017050171615874587
 0.05115051484762376
 0.06772480113669428
 ⋮
 0.9867500091857027
 0.9940131961176869
 0.9972786827976968
 1.0
u: 888-element Array{Array{Float64,1},1}:
 [1.01, 1.01]
 [0.8516740589157609, 1.0098278079466156]
 [0.6055883479052939, 1.0094835119044607]
 [0.5130932479154474, 1.0093162110819989]
 ⋮
 [5.23629936377725e-5, 1.0000828341921708]
 [4.8695694504693576e-5, 1.00001019894432]
 [4.713122586873632e-5, 0.9999775442776444]
 [4.5865930152960936e-5, 0.9999503320869795]

julia> sol.destats
DiffEqBase.DEStats
Number of function 1 evaluations:                  23690
Number of function 2 evaluations:                  0
Number of W matrix evaluations:                    3583
Number of linear solves:                           10914
Number of Jacobians created:                       1775
Number of nonlinear solver iterations:             0
Number of nonlinear solver convergence failures:   0
Number of rootfind condition calls:                0
Number of accepted steps:                          887
Number of rejected steps:                          888
```
After:
```
julia> sol = solve(prob,ImplicitDeuflhardExtrapolation(),abstol=1/10^10,reltol=1/10^10)
retcode: Success
Interpolation: 3rd order Hermite
t: 23-element Array{Float64,1}:
 0.0
 0.07426470725777685
 0.07723529554808793
 0.08226746560099449
 ⋮
 0.943872811790557
 0.953854546431799
 0.980860403378464
 1.0
u: 23-element Array{Array{Float64,1},1}:
 [1.01, 1.01]
 [0.4806111567565677, 1.0092502049077194]
 [0.46654414888144063, 1.0092202246846091]
 [0.44364777756059715, 1.0091694402844846]
 ⋮
 [8.037750923138577e-5, 1.0005117336262639]
 [7.274186326961106e-5, 1.0004118701840938]
 [5.552639423099845e-5, 1.0001417368631054]
 [4.5854003520698434e-5, 0.9999503320866616]

julia> sol.destats
DiffEqBase.DEStats
Number of function 1 evaluations:                  527
Number of function 2 evaluations:                  0
Number of W matrix evaluations:                    113
Number of linear solves:                           578
Number of Jacobians created:                       30
Number of nonlinear solver iterations:             0
Number of nonlinear solver convergence failures:   0
Number of rootfind condition calls:                0
Number of accepted steps:                          22
Number of rejected steps:                          8
```
**HairerWanner Adaptivity**
Before:
```
julia> sol = solve(prob,ImplicitHairerWannerExtrapolation(),abstol=1/10^10,reltol=1/10^10)
retcode: Success
Interpolation: 3rd order Hermite
t: 164-element Array{Float64,1}:
 0.0
 0.018597328040457235
 0.023893516271022718
 0.026376811462331555
 ⋮
 0.9322661429166624
 0.9550863670182133
 0.9763483387938785
 1.0
u: 164-element Array{Array{Float64,1},1}:
 [1.01, 1.01]
 [0.8385987376513978, 1.0098121844516683]
 [0.7953405972534116, 1.0097587043138219]
 [0.7758331585604524, 1.0097336293358183]
 ⋮
 [9.026948329027718e-5, 1.0006278664497013]
 [7.185119271214167e-5, 1.000399546980653]
 [5.8089068333537456e-5, 1.0001868649223309]
 [4.585392861744542e-5, 0.9999503320866869]

julia> sol.destats
DiffEqBase.DEStats
Number of function 1 evaluations:                  4765
Number of function 2 evaluations:                  0
Number of W matrix evaluations:                    983
Number of linear solves:                           3956
Number of Jacobians created:                       326
Number of nonlinear solver iterations:             0
Number of nonlinear solver convergence failures:   0
Number of rootfind condition calls:                0
Number of accepted steps:                          163
Number of rejected steps:                          163
```
After
```
julia> sol = solve(prob,ImplicitHairerWannerExtrapolation(),abstol=1/10^10,reltol=1/10^10)
retcode: Success
Interpolation: 3rd order Hermite
t: 6-element Array{Float64,1}:
 0.0
 0.07426470725777685
 0.22142252720664862
 0.4615506878742195
 0.760831972088764
 1.0
u: 6-element Array{Array{Float64,1},1}:
 [1.01, 1.01]
 [0.4806111567565677, 1.0092502049077194]
 [0.11033049240135955, 1.0077661065595556]
 [0.009996137130707792, 1.0053490794867768]
 [0.0005012681466757007, 1.0023447557826006]
 [4.5853928719958735e-5, 0.9999503320866611]

julia> sol.destats
DiffEqBase.DEStats
Number of function 1 evaluations:                  274
Number of function 2 evaluations:                  0
Number of W matrix evaluations:                    36
Number of linear solves:                           298
Number of Jacobians created:                       5
Number of nonlinear solver iterations:             0
Number of nonlinear solver convergence failures:   0
Number of rootfind condition calls:                0
Number of accepted steps:                          5
Number of rejected steps:                          0
```
@ChrisRackauckas @kanav99 can you have a look if these changes are acceptable?