### PR TITLE
Update Work Calculation in Implicit Extrapolation Methods

### DIFF
--- a/src/caches/extrapolation_caches.jl
+++ b/src/caches/extrapolation_caches.jl
@@ -371,10 +371,10 @@ function alg_cache(alg::ExtrapolationMidpointDeuflhard,u,rate_prototype,uEltypeN
     stage_number = Vector{Int}(undef, alg.n_max - alg.n_min + 1)
     for n in 1:length(stage_number)
       s = zero(eltype(coefficients.subdividing_sequence))
-      for i in alg.n_min:(alg.n_min + n)
+      for i in 1:(alg.n_min + n)
         s += coefficients.subdividing_sequence[i]
       end
-      stage_number[n] = sequence_factor * Int(s) - alg.n_min - n + 1
+      stage_number[n] = sequence_factor * Int(s) - alg.n_min - n + 3 - sequence_factor
     end
 
     # Initialize cache
@@ -602,7 +602,7 @@ function alg_cache(alg::ExtrapolationMidpointHairerWanner,u,rate_prototype,uElty
     for i in 1:n
       s += coefficients.subdividing_sequence[i]
     end
-    stage_number[n] = sequence_factor * Int(s) - n + 1
+    stage_number[n] = sequence_factor * Int(s) - n + 3 - sequence_factor
   end
   sigma = 9//10
 

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -1538,7 +1538,7 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationConst
   #Compute the internal discretisations
   J = calc_J(integrator,cache) # Store the calculated jac as it won't change in internal discretisation
   for i in 0:n_curr
-    j_int = 2 * subdividing_sequence[i+1]
+    j_int = 4 * subdividing_sequence[i+1]
     dt_int = dt / j_int # Stepsize of the ith internal discretisation
     W = dt_int*J - integrator.f.mass_matrix
     integrator.destats.nw += 1
@@ -1576,7 +1576,7 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationConst
         cache.n_curr = n_curr
 
         # Update T
-        j_int = 2 * subdividing_sequence[n_curr + 1]
+        j_int = 4 * subdividing_sequence[n_curr + 1]
         dt_int = dt / j_int # Stepsize of the new internal discretisation
         W = dt_int*J - integrator.f.mass_matrix
         integrator.destats.nw += 1
@@ -1657,7 +1657,7 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationCache
   #Compute the internal discretisations
   calc_J!(J,integrator,cache) # Store the calculated jac as it won't change in internal discretisation
   for i in 0:n_curr
-    j_int = 2 * subdividing_sequence[i+1]
+    j_int = 4 * subdividing_sequence[i+1]
     dt_int = dt / j_int # Stepsize of the ith internal discretisation
     jacobian2W!(W, integrator.f.mass_matrix, dt_int, J, false)
     integrator.destats.nw +=1
@@ -1717,7 +1717,7 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationCache
         cache.n_curr = n_curr
 
         # Update cache.T
-        j_int = 2 * subdividing_sequence[n_curr+1]
+        j_int = 4 * subdividing_sequence[n_curr+1]
         dt_int = dt / j_int # Stepsize of the new internal discretisation
         jacobian2W!(W, integrator.f.mass_matrix, dt_int, J, false)
         integrator.destats.nw +=1

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -894,7 +894,7 @@ function perform_step!(integrator, cache::ImplicitDeuflhardExtrapolationCache, r
   #Compute the internal discretisations
   calc_J!(J,integrator,cache) # Store the calculated jac as it won't change in internal discretisation
   for i in 0:n_curr
-    j_int = 2 * subdividing_sequence[i+1]
+    j_int = 4 * subdividing_sequence[i+1]
     dt_int = dt / j_int # Stepsize of the ith internal discretisation
     jacobian2W!(W, integrator.f.mass_matrix, dt_int, J, false)
     integrator.destats.nw += 1
@@ -953,7 +953,7 @@ function perform_step!(integrator, cache::ImplicitDeuflhardExtrapolationCache, r
         cache.n_curr = n_curr
 
         # Update cache.T
-        j_int = 2 * subdividing_sequence[n_curr + 1]
+        j_int = 4 * subdividing_sequence[n_curr + 1]
         dt_int = dt / j_int # Stepsize of the new internal discretisation
         jacobian2W!(W, integrator.f.mass_matrix, dt_int, J, false)
         integrator.destats.nw += 1
@@ -1058,7 +1058,7 @@ function perform_step!(integrator,cache::ImplicitDeuflhardExtrapolationConstantC
   # Compute the internal discretisations
   J = calc_J(integrator,cache) # Store the calculated jac as it won't change in internal discretisation
   for i in 0:n_curr
-    j_int = 2 * subdividing_sequence[i+1]
+    j_int = 4 * subdividing_sequence[i+1]
     dt_int = dt / j_int # Stepsize of the ith internal discretisation
     W = dt_int*J - integrator.f.mass_matrix
     integrator.destats.nw += 1
@@ -1096,7 +1096,7 @@ function perform_step!(integrator,cache::ImplicitDeuflhardExtrapolationConstantC
         cache.n_curr = n_curr
 
         # Update T
-        j_int = 2 * subdividing_sequence[n_curr + 1]
+        j_int = 4 * subdividing_sequence[n_curr + 1]
         dt_int = dt / j_int # Stepsize of the new internal discretisation
         W = dt_int*J - integrator.f.mass_matrix
         integrator.destats.nw += 1

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -878,7 +878,6 @@ function perform_step!(integrator, cache::ImplicitDeuflhardExtrapolationCache, r
   @unpack J,W,uf,tf,linsolve_tmp,jac_config = cache
 
   fill!(cache.Q, zero(eltype(cache.Q)))
-  tol = integrator.opts.internalnorm(integrator.opts.reltol, t) # Used by the convergence monitor
 
   if integrator.opts.adaptive
     # Set up the order window
@@ -943,6 +942,7 @@ function perform_step!(integrator, cache::ImplicitDeuflhardExtrapolationCache, r
 
     # Check if an approximation of some order in the order window can be accepted
     while n_curr <= win_max
+      tol = integrator.opts.internalnorm(cache.utilde,t)/integrator.EEst # Used by the convergence monitor
       if integrator.EEst <= 1.0
         # Accept current approximation u of order n_curr
         break
@@ -1040,7 +1040,6 @@ function perform_step!(integrator,cache::ImplicitDeuflhardExtrapolationConstantC
   # Create auxiliary variables
   u_temp1, u_temp2 = copy(uprev), copy(uprev) # Auxiliary variables for computing the internal discretisations
   u, utilde = copy(uprev), copy(uprev) # Storage for the latest approximation and its internal counterpart
-  tol = integrator.opts.internalnorm(integrator.opts.reltol, t) # Used by the convergence monitor
   T = fill(zero(uprev), integrator.alg.n_max + 1) # Storage for the internal discretisations obtained by the explicit midpoint rule
   fill!(cache.Q, zero(eltype(cache.Q)))
 
@@ -1086,6 +1085,7 @@ function perform_step!(integrator,cache::ImplicitDeuflhardExtrapolationConstantC
 
     # Check if an approximation of some order in the order window can be accepted
     while n_curr <= win_max
+      tol = integrator.opts.internalnorm(cache.utilde,t)/integrator.EEst # Used by the convergence monitor
       if integrator.EEst <= 1.0
         # Accept current approximation u of order n_curr
         break
@@ -1710,7 +1710,7 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationCache
       if integrator.EEst <= 1.0
         # Accept current approximation u of order n_curr
         break
-    elseif (n_curr < integrator.alg.n_min + 1) || integrator.EEst <= typeof(integrator.EEst)(prod(subdividing_sequence[n_curr+2:win_max+1] .// subdividing_sequence[1]^2))
+    elseif (n_curr < integrator.alg.n_min + 1) || integrator.opts.internalnorm(cache.utilde,t) <= (prod(subdividing_sequence[n_curr+2:win_max+1] .// subdividing_sequence[1]^2))
         # Reject current approximation order but pass convergence monitor
         # Compute approximation of order (n_curr + 1)
         n_curr = n_curr + 1


### PR DESCRIPTION
SODEX and SEULEX have same work calculation, hence referring this:
**Hairer Wanner Adaptivity**
https://github.com/luchr/ODEInterface.jl/blob/master/src/Seulex.jl#L393-L399
**Deuflhard Adaptivity**
https://link.springer.com/article/10.1007/BF01418332
Also, resorting back to `4 * subdiving_sequence` instead to `2 * subdiving_sequence` to avoid maxiters in Stiff ODE Problems.