### PR TITLE
Fix overflow in Implicit Extrapolation methods

### DIFF
--- a/src/caches/extrapolation_caches.jl
+++ b/src/caches/extrapolation_caches.jl
@@ -485,6 +485,9 @@ end
   linsolve::F
   jac_config::JCType
   grad_config::GCType
+  # Values to check overflow in T1 computation
+  diff1::uType
+  diff2::uType  
 end
 
 function alg_cache(alg::ImplicitDeuflhardExtrapolation,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{false})
@@ -568,10 +571,12 @@ function alg_cache(alg::ImplicitDeuflhardExtrapolation,u,rate_prototype,uEltypeN
   linsolve = alg.linsolve(Val{:init},uf,u)
   grad_config = build_grad_config(alg,f,tf,du1,t)
   jac_config = build_jac_config(alg,f,uf,du1,uprev,u,du1,du2)
+  diff1 = zero(u)
+  diff2 = zero(u)
 
 
   ImplicitDeuflhardExtrapolationCache(utilde,u_temp1,u_temp2,u_temp3,u_temp4,tmp,T,res,fsalfirst,k,k_tmps,cc.Q,cc.n_curr,cc.n_old,cc.coefficients,cc.stage_number,
-    du1,du2,J,W,tf,uf,linsolve_tmp,linsolve,jac_config,grad_config)
+    du1,du2,J,W,tf,uf,linsolve_tmp,linsolve,jac_config,grad_config,diff1,diff2)
 end
 
 @cache mutable struct ExtrapolationMidpointHairerWannerConstantCache{QType,extrapolation_coefficients} <: OrdinaryDiffEqConstantCache

--- a/src/caches/extrapolation_caches.jl
+++ b/src/caches/extrapolation_caches.jl
@@ -516,7 +516,7 @@ function alg_cache(alg::ImplicitDeuflhardExtrapolation,u,rate_prototype,uEltypeN
   end
 
   #Update stage_number by the jacobian size
-  jac_dim = size(rate_prototype)[1]
+  jac_dim = typeof(rate_prototype) <: Float64 ? 1 : sum(size(rate_prototype)) 
   stage_number = stage_number .+ jac_dim
 
   tf = TimeDerivativeWrapper(f,u,p)

--- a/src/caches/extrapolation_caches.jl
+++ b/src/caches/extrapolation_caches.jl
@@ -758,6 +758,9 @@ end
   linsolve::F
   jac_config::JCType
   grad_config::GCType
+  # Values to check overflow in T1 computation
+  diff1::uType
+  diff2::uType 
 end
 
 
@@ -805,8 +808,11 @@ function alg_cache(alg::ImplicitHairerWannerExtrapolation,u,rate_prototype,uElty
   grad_config = build_grad_config(alg,f,tf,du1,t)
   jac_config = build_jac_config(alg,f,uf,du1,uprev,u,du1,du2)
 
+  diff1 = zero(u)
+  diff2 = zero(u)
+
   # Initialize the cache
   ImplicitHairerWannerExtrapolationCache(utilde, u_temp1, u_temp2, u_temp3, u_temp4, tmp, T, res, fsalfirst, k, k_tmps,
       cc.Q, cc.n_curr, cc.n_old, cc.coefficients, cc.stage_number, cc.sigma, du1, du2, J, W, tf, uf, linsolve_tmp,
-      linsolve, jac_config, grad_config)
+      linsolve, jac_config, grad_config,diff1,diff2)
 end

--- a/src/caches/extrapolation_caches.jl
+++ b/src/caches/extrapolation_caches.jl
@@ -519,7 +519,7 @@ function alg_cache(alg::ImplicitDeuflhardExtrapolation,u,rate_prototype,uEltypeN
   end
 
   #Update stage_number by the jacobian size
-  jac_dim = typeof(rate_prototype) <: Float64 ? 1 : sum(size(rate_prototype)) 
+  jac_dim = typeof(rate_prototype) <: Union{CompiledFloats,BigFloat} ? 1 : sum(size(rate_prototype)) 
   stage_number = stage_number .+ jac_dim
 
   tf = TimeDerivativeWrapper(f,u,p)

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -592,7 +592,7 @@ function perform_step!(integrator, cache::ExtrapolationMidpointDeuflhardCache, r
         end
       end
     end
-    nevals = cache.stage_number[n_curr+1] - 1
+    nevals = cache.stage_number[n_curr - integrator.alg.n_min + 1] - 1
     integrator.destats.nf += nevals
   end
 
@@ -788,7 +788,7 @@ function perform_step!(integrator,cache::ExtrapolationMidpointDeuflhardConstantC
         end
       end
     end
-    nevals = cache.stage_number[n_curr+1] - 1
+    nevals = cache.stage_number[n_curr - integrator.alg.n_min + 1] - 1
     integrator.destats.nf += nevals
   end
 

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -1626,7 +1626,7 @@ end
 function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationCache, repeat_step = false)
   # Unpack all information needed
   @unpack t, uprev, dt, f, p = integrator
-  @unpack n_curr, u_temp1, u_temp2, utilde, res, T, fsalfirst,k  = cache
+  @unpack n_curr, u_temp1, u_temp2, utilde, res, T, fsalfirst, k, diff1, diff2  = cache
   @unpack u_temp3, u_temp4, k_tmps = cache
   # Coefficients for obtaining u
   @unpack extrapolation_weights, extrapolation_scalars = cache.coefficients
@@ -1667,6 +1667,7 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationCache
     integrator.destats.nsolve += 1
     @.. k = -k
     @.. u_temp1 = u_temp2 + k # Euler starting step
+    @.. diff1 = u_temp1 - u_temp2
     for j in 2:j_int
       f(k, cache.u_temp1, p, t + (j - 1) * dt_int)
       integrator.destats.nf += 1
@@ -1677,6 +1678,15 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationCache
       @.. T[i+1] = 2*u_temp1 - u_temp2 + 2*k # Explicit Midpoint rule
       @.. u_temp2 = u_temp1
       @.. u_temp1 = T[i+1]
+      if(i<=1)
+        # Deuflhard Stability check for initial two sequences 
+        @.. diff2 = u_temp1 - u_temp2
+        if(integrator.opts.internalnorm(diff1,t)<integrator.opts.internalnorm(0.5*(diff2 - diff1),t))
+          # Divergence of iteration, overflow is possible. Force fail and start with smaller step
+          integrator.force_stepfail = true
+          return
+        end
+      end
     end
   end
 
@@ -1710,7 +1720,7 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationCache
       if integrator.EEst <= 1.0
         # Accept current approximation u of order n_curr
         break
-    elseif (n_curr < integrator.alg.n_min + 1) || integrator.opts.internalnorm(cache.utilde,t) <= (prod(subdividing_sequence[n_curr+2:win_max+1] .// subdividing_sequence[1]^2))
+    elseif (n_curr < integrator.alg.n_min + 1) || integrator.EEst <= typeof(integrator.EEst)(prod(subdividing_sequence[n_curr+2:win_max+1] .// subdividing_sequence[1]^2))
         # Reject current approximation order but pass convergence monitor
         # Compute approximation of order (n_curr + 1)
         n_curr = n_curr + 1

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -942,7 +942,7 @@ function perform_step!(integrator, cache::ImplicitDeuflhardExtrapolationCache, r
 
     # Check if an approximation of some order in the order window can be accepted
     while n_curr <= win_max
-      tol = integrator.opts.internalnorm(cache.utilde,t)/integrator.EEst # Used by the convergence monitor
+      tol = integrator.opts.internalnorm(cache.utilde - integrator.u,t)/integrator.EEst # Used by the convergence monitor
       if integrator.EEst <= 1.0
         # Accept current approximation u of order n_curr
         break
@@ -1085,7 +1085,7 @@ function perform_step!(integrator,cache::ImplicitDeuflhardExtrapolationConstantC
 
     # Check if an approximation of some order in the order window can be accepted
     while n_curr <= win_max
-      tol = integrator.opts.internalnorm(cache.utilde,t)/integrator.EEst # Used by the convergence monitor
+      tol = integrator.opts.internalnorm(utilde - u,t)/integrator.EEst # Used by the convergence monitor
       if integrator.EEst <= 1.0
         # Accept current approximation u of order n_curr
         break
@@ -1349,7 +1349,7 @@ function perform_step!(integrator, cache::ExtrapolationMidpointHairerWannerConst
   @unpack extrapolation_weights_2, extrapolation_scalars_2 = cache.coefficients
   # Additional constant information
   @unpack subdividing_sequence = cache.coefficients
-  @unpack subdividing_sequence = integrator.alg
+  @unpack sequence_factor = integrator.alg
 
   # Create auxiliary variables
   u_temp1, u_temp2 = copy(uprev), copy(uprev) # Auxiliary variables for computing the internal discretisations

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -1544,11 +1544,21 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationConst
     integrator.destats.nw += 1
     u_temp2 = uprev
     u_temp1 = u_temp2 + _reshape(W\-_vec(dt_int*integrator.fsalfirst), axes(uprev)) # Euler starting step
+    diff1 = u_temp1 - u_temp2
     for j in 2:j_int
       T[i+1] = 2*u_temp1 - u_temp2 + 2*_reshape(W\-_vec(dt_int * f(u_temp1, p, t + (j-1) * dt_int) - (u_temp1 - u_temp2)),axes(uprev))
       integrator.destats.nf += 1
       u_temp2 = u_temp1
       u_temp1 = T[i+1]
+      if(i<=1)
+        # Deuflhard Stability check for initial two sequences 
+        diff2 = u_temp1 - u_temp2
+        if(integrator.opts.internalnorm(diff1,t)<integrator.opts.internalnorm(0.5*(diff2 - diff1),t))
+          # Divergence of iteration, overflow is possible. Force fail and start with smaller step
+          integrator.force_stepfail = true
+          return
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Hi,
Previously our solvers weren't working well with stiff problems. It was happening because often computing the T Array, the RHS would overflow. Hence According to Hairer II, we need to check the stability of iterations, which is implemented in these solvers. The results are good with fewer step rejections and no need to use BigFloats now on.
![image](https://user-images.githubusercontent.com/37050056/87810497-b6672600-c87a-11ea-9b36-d3402a9489cf.png)
(I have currently implemented part b)
**Deuflhard Adaptivity**
Tested on ROBER ODE:
Before:
```
julia> sol = solve(prob,ImplicitDeuflhardExtrapolation())
┌ Warning: Instability detected. Aborting
└ @ DiffEqBase C:\Users\Utkarsh\.julia\packages\DiffEqBase\uSSHl\src\integrator_interface.jl:349
retcode: Unstable
Interpolation: 3rd order Hermite
t: 1-element Array{Float64,1}:
 0.0
u: 1-element Array{Array{Float64,1},1}:
 [1.0, 0.0, 0.0]
```
After:
```
julia> sol = solve(prob,ImplicitDeuflhardExtrapolation())
retcode: Success
Interpolation: 3rd order Hermite
t: 266-element Array{Float64,1}:
      0.0
      0.0015609382820287144
      0.0032217252350683883
      0.01982959476546512
      ⋮
  98098.71397471431
  98336.37472787502
 100000.0
u: 266-element Array{Array{Float64,1},1}:
 [1.0, 0.0, 0.0]
 [0.9999375686612252, 3.419772436599121e-5, 2.8233614409315348e-5]
 [0.9998711793059183, 3.643895343817835e-5, 9.238244240272467e-5]
 [0.9992097316972253, 3.637778804778818e-5, 0.0007538906470362338]
 ⋮
 [0.016984699279155385, 6.958893419099181e-8, 0.9763523642123009]
 [0.016945267341560107, 6.941164337956342e-8, 0.9763868133849163]
 [0.016692488863459237, 6.836399668715074e-8, 0.9766241235297372]

julia> sol.destats
DiffEqBase.DEStats
Number of function 1 evaluations:                  7099
Number of function 2 evaluations:                  0
Number of W matrix evaluations:                    1465
Number of linear solves:                           8244
Number of Jacobians created:                       914
Number of nonlinear solver iterations:             0
Number of nonlinear solver convergence failures:   0
Number of rootfind condition calls:                0
Number of accepted steps:                          265
Number of rejected steps:                          53
```
**HairerWanner Adaptivity**

Before:
```
julia> sol = solve(prob,ImplicitHairerWannerExtrapolation())
┌ Warning: Instability detected. Aborting
└ @ DiffEqBase C:\Users\Utkarsh\.julia\packages\DiffEqBase\uSSHl\src\integrator_interface.jl:349
retcode: Unstable
Interpolation: 3rd order Hermite
t: 1-element Array{Float64,1}:
 0.0
u: 1-element Array{Array{Float64,1},1}:
 [1.0, 0.0, 0.0]
```
After:
```
julia> sol = solve(prob,ImplicitHairerWannerExtrapolation())
retcode: Success
Interpolation: 3rd order Hermite
t: 747-element Array{Float64,1}:
      0.0
      0.0015609382820287144
      0.005947311862904938
      0.017875507821567417
      ⋮
  99827.4274364894
  99913.71371824469
 100000.0
u: 747-element Array{Array{Float64,1},1}:
 [1.0, 0.0, 0.0]
 [0.9999375686612252, 3.419772436599121e-5, 2.8233614409315348e-5]
 [0.9997623217678924, 3.6481272624923937e-5, 0.0002011974708534907]
 [0.9992873280073079, 3.6392577401366066e-5, 0.0006762799286862737]
 ⋮
 [0.018102928740776507, 7.342822706468105e-8, 0.9869765617695905]
 [0.018088653760709415, 7.331417850048177e-8, 0.9869904796337489]
 [0.018074656738217017, 7.324062302959472e-8, 0.9870043742819968]

julia> sol.destats
DiffEqBase.DEStats
Number of function 1 evaluations:                  22121
Number of function 2 evaluations:                  0
Number of W matrix evaluations:                    4034
Number of linear solves:                           25407
Number of Jacobians created:                       2161
Number of nonlinear solver iterations:             0
Number of nonlinear solver convergence failures:   0
Number of rootfind condition calls:                0
Number of accepted steps:                          746
Number of rejected steps:                          0
```
@ChrisRackauckas @kanav99 