### PR TITLE
Add Gragg's smoothing to Implicit Hairer Wanner Extrapolation

### DIFF
--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -1565,9 +1565,12 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationConst
     u_temp2 = uprev
     u_temp1 = u_temp2 + _reshape(W\-_vec(dt_int*integrator.fsalfirst), axes(uprev)) # Euler starting step
     diff1 = u_temp1 - u_temp2
-    for j in 2:j_int
+    for j in 2:j_int + 1
       T[i+1] = 2*u_temp1 - u_temp2 + 2*_reshape(W\-_vec(dt_int * f(u_temp1, p, t + (j-1) * dt_int) - (u_temp1 - u_temp2)),axes(uprev))
       integrator.destats.nf += 1
+      if(j == j_int + 1)
+        T[i + 1] = 0.5(T[i + 1] + u_temp2)
+      end
       u_temp2 = u_temp1
       u_temp1 = T[i+1]
       if(i<=1)
@@ -1579,6 +1582,7 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationConst
           return
         end
       end
+      diff1 = u_temp1 - u_temp2
     end
   end
 
@@ -1612,9 +1616,12 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationConst
         integrator.destats.nw += 1
         u_temp2 = uprev
         u_temp1 = u_temp2 + _reshape(W\-_vec(dt_int*integrator.fsalfirst), axes(uprev)) # Euler starting step
-        for j in 2:j_int
+        for j in 2:j_int + 1
           T[n_curr+1] = 2*u_temp1 - u_temp2 + 2*_reshape(W\-_vec(dt_int * f(u_temp1, p, t + (j-1) * dt_int) - (u_temp1 - u_temp2)),axes(uprev))
           integrator.destats.nf += 1
+          if(j == j_int + 1)
+            T[n_curr+ 1] = 0.5(T[n_curr + 1] + u_temp2)
+          end
           u_temp2 = u_temp1
           u_temp1 = T[n_curr+1]
         end

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -981,6 +981,9 @@ function perform_step!(integrator, cache::ImplicitDeuflhardExtrapolationCache, r
           integrator.destats.nsolve += 1
           @.. k = -k
           @.. T[n_curr+1] = 2 * u_temp1 - u_temp2 + 2 * k # Explicit Midpoint rule
+          # if(j == j_int + 1)
+          #   @.. T[n_curr + 1] = 0.5(T[n_curr + 1] + u_temp2)
+          # end
           @.. u_temp2 = u_temp1
           @.. u_temp1 = T[n_curr+1]
         end
@@ -1698,7 +1701,7 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationCache
     @.. k = -k
     @.. u_temp1 = u_temp2 + k # Euler starting step
     @.. diff1 = u_temp1 - u_temp2
-    for j in 2:j_int
+    for j in 2:j_int + 1
       f(k, cache.u_temp1, p, t + (j - 1) * dt_int)
       integrator.destats.nf += 1
       @.. linsolve_tmp = dt_int*k - (u_temp1 - u_temp2)
@@ -1706,6 +1709,9 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationCache
       integrator.destats.nsolve += 1
       @.. k = -k
       @.. T[i+1] = 2*u_temp1 - u_temp2 + 2*k # Explicit Midpoint rule
+      if(j == j_int + 1)
+        @.. T[i + 1] = 0.5(T[i + 1] + u_temp2)
+      end
       @.. u_temp2 = u_temp1
       @.. u_temp1 = T[i+1]
       if(i<=1)
@@ -1714,9 +1720,11 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationCache
         if(integrator.opts.internalnorm(diff1,t)<integrator.opts.internalnorm(0.5*(diff2 - diff1),t))
           # Divergence of iteration, overflow is possible. Force fail and start with smaller step
           integrator.force_stepfail = true
+          #integrator.destats.nreject += 1
           return
         end
       end
+      @.. diff1 = u_temp1 - u_temp2
     end
   end
 
@@ -1767,7 +1775,7 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationCache
         integrator.destats.nsolve += 1
         @.. k = -k
         @.. u_temp1 = u_temp2 + k # Euler starting step
-        for j in 2:j_int
+        for j in 2:j_int + 1
           f(k, cache.u_temp1, p, t + (j - 1) * dt_int)
           integrator.destats.nf += 1
           @.. linsolve_tmp = dt_int*k - (u_temp1 - u_temp2)
@@ -1775,6 +1783,9 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationCache
           integrator.destats.nsolve += 1
           @.. k = -k
           @.. T[n_curr+1] = 2*u_temp1 - u_temp2 + 2*k # Explicit Midpoint rule
+          if(j == j_int + 1)
+            @.. T[n_curr+ 1] = 0.5(T[n_curr + 1] + u_temp2)
+          end
           @.. u_temp2 = u_temp1
           @.. u_temp1 = T[n_curr+1]
         end

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -904,7 +904,7 @@ function perform_step!(integrator, cache::ImplicitDeuflhardExtrapolationCache, r
     @.. k = -k
     @.. u_temp1 = u_temp2 + k # Euler starting step
     @.. diff1 = u_temp1 - u_temp2
-    for j in 2:j_int + 1
+    for j in 2:j_int
       f(k, cache.u_temp1, p, t + (j-1) * dt_int)
       integrator.destats.nf += 1
       @.. linsolve_tmp = dt_int * k - (u_temp1 - u_temp2)
@@ -912,9 +912,6 @@ function perform_step!(integrator, cache::ImplicitDeuflhardExtrapolationCache, r
       integrator.destats.nsolve += 1
       @.. k = -k
       @.. T[i+1] = 2 * u_temp1 - u_temp2 + 2 * k # Explicit Midpoint rule
-      if(j == j_int + 1)
-        @.. T[i + 1] = 0.5(T[i + 1] + u_temp2)
-      end
       @.. u_temp2 = u_temp1
       @.. u_temp1 = T[i+1]
       if(i<=1)
@@ -926,7 +923,6 @@ function perform_step!(integrator, cache::ImplicitDeuflhardExtrapolationCache, r
           return
         end
       end
-      @.. diff1 = u_temp1 - u_temp2
     end
   end
 
@@ -977,7 +973,7 @@ function perform_step!(integrator, cache::ImplicitDeuflhardExtrapolationCache, r
         integrator.destats.nsolve += 1
         @.. k = -k
         @.. u_temp1 = u_temp2 + k # Euler starting step
-        for j in 2:j_int + 1
+        for j in 2:j_int
           f(k, cache.u_temp1, p, t + (j-1) * dt_int)
           integrator.destats.nf += 1
           @.. linsolve_tmp = dt_int * k - (u_temp1 - u_temp2)
@@ -985,9 +981,6 @@ function perform_step!(integrator, cache::ImplicitDeuflhardExtrapolationCache, r
           integrator.destats.nsolve += 1
           @.. k = -k
           @.. T[n_curr+1] = 2 * u_temp1 - u_temp2 + 2 * k # Explicit Midpoint rule
-          if(j == j_int + 1)
-            @.. T[n_curr + 1] = 0.5(T[n_curr + 1] + u_temp2)
-          end
           @.. u_temp2 = u_temp1
           @.. u_temp1 = T[n_curr+1]
         end

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -904,7 +904,7 @@ function perform_step!(integrator, cache::ImplicitDeuflhardExtrapolationCache, r
     @.. k = -k
     @.. u_temp1 = u_temp2 + k # Euler starting step
     @.. diff1 = u_temp1 - u_temp2
-    for j in 2:j_int
+    for j in 2:j_int + 1
       f(k, cache.u_temp1, p, t + (j-1) * dt_int)
       integrator.destats.nf += 1
       @.. linsolve_tmp = dt_int * k - (u_temp1 - u_temp2)
@@ -912,6 +912,9 @@ function perform_step!(integrator, cache::ImplicitDeuflhardExtrapolationCache, r
       integrator.destats.nsolve += 1
       @.. k = -k
       @.. T[i+1] = 2 * u_temp1 - u_temp2 + 2 * k # Explicit Midpoint rule
+      if(j == j_int + 1)
+        @.. T[i + 1] = 0.5(T[i + 1] + u_temp2)
+      end
       @.. u_temp2 = u_temp1
       @.. u_temp1 = T[i+1]
       if(i<=1)
@@ -923,6 +926,7 @@ function perform_step!(integrator, cache::ImplicitDeuflhardExtrapolationCache, r
           return
         end
       end
+      @.. diff1 = u_temp1 - u_temp2
     end
   end
 
@@ -973,7 +977,7 @@ function perform_step!(integrator, cache::ImplicitDeuflhardExtrapolationCache, r
         integrator.destats.nsolve += 1
         @.. k = -k
         @.. u_temp1 = u_temp2 + k # Euler starting step
-        for j in 2:j_int
+        for j in 2:j_int + 1
           f(k, cache.u_temp1, p, t + (j-1) * dt_int)
           integrator.destats.nf += 1
           @.. linsolve_tmp = dt_int * k - (u_temp1 - u_temp2)
@@ -981,9 +985,9 @@ function perform_step!(integrator, cache::ImplicitDeuflhardExtrapolationCache, r
           integrator.destats.nsolve += 1
           @.. k = -k
           @.. T[n_curr+1] = 2 * u_temp1 - u_temp2 + 2 * k # Explicit Midpoint rule
-          # if(j == j_int + 1)
-          #   @.. T[n_curr + 1] = 0.5(T[n_curr + 1] + u_temp2)
-          # end
+          if(j == j_int + 1)
+            @.. T[n_curr + 1] = 0.5(T[n_curr + 1] + u_temp2)
+          end
           @.. u_temp2 = u_temp1
           @.. u_temp1 = T[n_curr+1]
         end
@@ -1720,7 +1724,6 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationCache
         if(integrator.opts.internalnorm(diff1,t)<integrator.opts.internalnorm(0.5*(diff2 - diff1),t))
           # Divergence of iteration, overflow is possible. Force fail and start with smaller step
           integrator.force_stepfail = true
-          #integrator.destats.nreject += 1
           return
         end
       end

--- a/test/multithreading/ode_extrapolation_tests.jl
+++ b/test/multithreading/ode_extrapolation_tests.jl
@@ -122,7 +122,7 @@ end
         init_order = j, max_order=j,
         sequence = seq)
       sim = test_convergence(dts,prob,alg)
-      @test sim.𝒪est[:final] ≈ 2*(alg.n_init+1) atol=testTol
+      @test sim.𝒪est[:final] ≈ 2*(alg.n_init+1) - 1 atol=testTol
     end
 
     # TODO: Regression test


### PR DESCRIPTION
Hi, I have added Gragg's Smoothing in Implicit Extrapolation Methods in the in-place version.
![image](https://user-images.githubusercontent.com/37050056/87880914-30321780-ca13-11ea-8798-b905f42abdfc.png)
I have tested on ROBER problem,
The results are better now for especially ImplicitHairerWanner for eg.:
Before:
```
julia> sol = solve(prob,ImplicitHairerWannerExtrapolation())
retcode: Success
Interpolation: 3rd order Hermite
t: 747-element Array{Float64,1}:
      0.0
      0.0015609382820287144
      0.005947311862904938
      0.017875507821567417
      0.21419373297455405
      3.4452645219507922
     14.17595103549799
     45.72140722571571
    136.72463715323127
    360.0337463837034
    791.7377120761394
    842.4930986170706
    902.9450866695021
      ⋮
  98617.40624567194
  98694.73172896286
  98864.85989529881
  98952.72199598706
  99133.22298583384
  99239.38548077142
  99670.94665679023
  99712.07832469145
  99769.90324865252
  99827.4274364894
  99913.71371824469
 100000.0
u: 747-element Array{Array{Float64,1},1}:
 [1.0, 0.0, 0.0]
 [0.9999375686612252, 3.419772436599121e-5, 2.8233614409315348e-5]
 [0.9997623217678924, 3.6481272624923937e-5, 0.0002011974708534907]
 [0.9992873280073079, 3.6392577401366066e-5, 0.0006762799286862737]
 [0.9917821490821827, 3.50291948169626e-5, 0.00818282252912719]
 [0.9142532826118859, 2.3437837422793913e-5, 0.08572175541978577]
 [0.8126877839209197, 1.4130319867668001e-5, 0.18726378652315454]
 [0.7021160977468687, 8.677123330594477e-6, 0.29778174212910896]
 [0.5809830077630976, 5.3393812358882494e-6, 0.41876702297581186]
 [0.4622526802215967, 3.391675819683235e-6, 0.5363477776038761]
 [0.37633002823808775, 2.551157834742878e-6, 0.6334016071005959]
 [0.36809363642017884, 2.4217840521649283e-6, 0.6415694016779914]
 [0.3589617388519237, 2.279226012583151e-6, 0.6506123658686606]
 ⋮
 [0.01827910876881332, 7.417640762370387e-8, 0.9867795201981193]
 [0.018266103109520673, 7.406920272092818e-8, 0.9867922427360799]
 [0.01823448553630541, 7.379547926302563e-8, 0.9868201702124244]
 [0.018220603977110332, 7.381257697774555e-8, 0.9868345502165281]
 [0.018193892307383427, 7.379776987027918e-8, 0.98686402276212]
 [0.018175805890085682, 7.364240824122424e-8, 0.9868813200158614]
 [0.01812850575053794, 7.362446005221851e-8, 0.9869512653567989]
 [0.018121803049209413, 7.357623461065652e-8, 0.9869579215902864]
 [0.018112316518646383, 7.349616427443333e-8, 0.9869672710777913]
 [0.018102928740776507, 7.342822706468105e-8, 0.9869765617695905]
 [0.018088653760709415, 7.331417850048177e-8, 0.9869904796337489]
 [0.018074656738217017, 7.324062302959472e-8, 0.9870043742819968]
julia> sol.destats
DiffEqBase.DEStats
Number of function 1 evaluations:                  22121
Number of function 2 evaluations:                  0
Number of W matrix evaluations:                    4034
Number of linear solves:                           25407
Number of Jacobians created:                       2161
Number of nonlinear solver iterations:             0
Number of nonlinear solver convergence failures:   0
Number of rootfind condition calls:                0
Number of accepted steps:                          746
Number of rejected steps:                          0
```
After:
```
julia> sol = solve(prob,ImplicitHairerWannerExtrapolation())
retcode: Success
Interpolation: 3rd order Hermite
t: 62-element Array{Float64,1}:
      0.0
      0.0015609382820287144
      0.005825835783645151
      0.01567575045726786
      0.16947966893502833
      1.743871372983346
      9.306194996461432
     31.770571909730194
     99.75191412340172
    251.80711169599098
    536.8233987024881
   1047.4098500692314
   1277.3618197236628
      ⋮
  43133.7921812233
  44533.0199685061
  50055.47993946205
  50143.549394361304
  50645.7867089978
  53200.886884522
  67639.73166022974
  67726.34146826199
  68290.34600170281
  71327.41288918354
  88525.6423629744
 100000.0
u: 62-element Array{Array{Float64,1},1}:
 [1.0, 0.0, 0.0]
 [0.9999375686612398, 3.419788713381114e-5, 2.8233451626510687e-5]
 [0.9997671708792938, 3.6480839574421016e-5, 0.0001963617819497166]
 [0.9993747529950145, 3.6408757655733936e-5, 0.0005888518373725846]
 [0.9934418204907772, 3.532707974034257e-5, 0.006522860595101827]
 [0.9473878487210842, 2.7843504922838892e-5, 0.05258355109327624]
 [0.8469989043693693, 1.6688688600730842e-5, 0.152974647487413]
 [0.7387518670436833, 1.0136165147203725e-5, 0.26123561998272277]
 [0.6174763123317458, 6.160142276754425e-6, 0.38247879318679445]
 [0.5076171597118828, 4.028549430990326e-6, 0.4920810102753788]
 [0.4131543327232221, 2.7803011885121084e-6, 0.5858827290916845]
 [0.3290933691209731, 1.940403291877344e-6, 0.6680100908138078]
 [0.3045872886094369, 1.7328634339264573e-6, 0.6916504292086891]
 ⋮
 [0.036616402611313, 1.537768134569056e-7, 0.9519856200593746]
 [0.0356457232493685, 1.495630266061263e-7, 0.9529511700095585]
 [0.0322879960671094, 1.348414844453152e-7, 0.95628613653051]
 [0.03223986774524779, 1.3479187702398253e-7, 0.9563342193567873]
 [0.031969297577572324, 1.336219095630056e-7, 0.9566055821982409]
 [0.030652705785227934, 1.2794923477669555e-7, 0.957916211258885]
 [0.02521614608213966, 1.0470432195780831e-7, 0.9636204815970087]
 [0.025187746750192412, 1.0451690725493389e-7, 0.9636488960956322]
 [0.025003614528729616, 1.0373405338488132e-7, 0.9638323513852816]
 [0.02405705910224919, 9.971021115537788e-8, 0.9647748199881884]
 [0.019750460767379453, 8.151428218922708e-8, 0.9689778794510242]
 [0.017683441147082677, 7.276944652347233e-8, 0.9710151320645249]

julia> sol.destats
DiffEqBase.DEStats
Number of function 1 evaluations:                  2413
Number of function 2 evaluations:                  0
Number of W matrix evaluations:                    334
Number of linear solves:                           2680
Number of Jacobians created:                       142
Number of nonlinear solver iterations:             0
Number of nonlinear solver convergence failures:   0
Number of rootfind condition calls:                0
Number of accepted steps:                          61
Number of rejected steps:                          4
```


Deuflhard:
Before:
```
julia> sol = solve(prob,ImplicitDeuflhardExtrapolation())
retcode: Success
Interpolation: 3rd order Hermite
t: 266-element Array{Float64,1}:
      0.0
      0.0015609382820287144
      0.0032217252350683883
      0.01982959476546512
      0.18590829006943244
      1.7413117435097187
     17.295346277912582
    120.40325314382655
    190.3944315840111
    506.1534205826651
    565.634619320892
    598.4393273694461
    680.4510974908312
      ⋮
  81804.89423174993
  82130.8440492469
  85390.34222421655
  87153.7514292188
  87478.99321562044
  90731.41107963688
  91889.98469468227
  92211.32729231728
  95424.75326866735
  98098.71397471431
  98336.37472787502
 100000.0
u: 266-element Array{Array{Float64,1},1}:
 [1.0, 0.0, 0.0]
 [0.9999375686612252, 3.419772436599121e-5, 2.8233614409315348e-5]
 [0.9998711793059183, 3.643895343817835e-5, 9.238244240272467e-5]
 [0.9992097316972253, 3.637778804778818e-5, 0.0007538906470362338]
 [0.9928287617193092, 3.521636664652303e-5, 0.007136022376041776]
 [0.9474470086527546, 2.785254568935326e-5, 0.05252224935480626]
 [0.7953203081193456, 1.3017081009911101e-5, 0.20443773423933295]
 [0.5952845474350942, 5.813522451020289e-6, 0.40353817157384103]
 [0.5400931658705648, 4.602543847951828e-6, 0.457970574063262]
 [0.4253840881465049, 3.2407089171974766e-6, 0.5783195793910817]
 [0.4109172894786555, 2.9404459423460187e-6, 0.5926057436798334]
 [0.40357968338912564, 2.8495014912796716e-6, 0.599786471588226]
 [0.3868933970296751, 2.515299797208381e-6, 0.6161456892001972]
 ⋮
 [0.01998871820907305, 8.213120459754458e-8, 0.9735499870593487]
 [0.01991198409721469, 8.179236729457067e-8, 0.9736157287027103]
 [0.0192477725379255, 7.902060244101943e-8, 0.9742500999139704]
 [0.018886062606549125, 7.75200123989674e-8, 0.9745755543568018]
 [0.018817248416069667, 7.721588401073183e-8, 0.974634005683447]
 [0.01822420128055194, 7.474675317483454e-8, 0.9751992533253037]
 [0.018006900233900017, 7.384467127131498e-8, 0.975391638098227]
 [0.017947275546914818, 7.358412815835018e-8, 0.975444051635461]
 [0.017419860734750027, 7.139025081357386e-8, 0.9759518448313058]
 [0.016984699279155385, 6.958893419099181e-8, 0.9763523642123009]
 [0.016945267341560107, 6.941164337956342e-8, 0.9763868133849163]
 [0.016692488863459237, 6.836399668715074e-8, 0.9766241235297372]

julia> sol.destats
DiffEqBase.DEStats
Number of function 1 evaluations:                  7099
Number of function 2 evaluations:                  0
Number of W matrix evaluations:                    1465
Number of linear solves:                           8244
Number of Jacobians created:                       914
Number of nonlinear solver iterations:             0
Number of nonlinear solver convergence failures:   0
Number of rootfind condition calls:                0
Number of accepted steps:                          265
Number of rejected steps:                          53
```
After:
```
julia> sol = solve(prob,ImplicitDeuflhardExtrapolation())
retcode: Success
Interpolation: 3rd order Hermite
t: 238-element Array{Float64,1}:
      0.0
      0.0015609382820287144
      0.0042454723295892935
      0.029509752478930486
      0.2821525539723424
      0.9802049506971475
      7.9607289179451985
     42.86334875418545
    181.12050062696358
    367.5378832812985
    467.71759214187045
    968.6161364447304
   1561.7986114039966
      ⋮
  95991.17030758501
  96241.72216336094
  96618.47341505639
  96724.14612083588
  97582.89606077307
  97658.43055887391
  98351.2193903415
  98557.31696654881
  99099.71976692814
  99212.25479606213
  99970.34941668982
 100000.0
u: 238-element Array{Array{Float64,1},1}:
 [1.0, 0.0, 0.0]
 [0.9999375686612398, 3.419788713381114e-5, 2.8233451626510687e-5]
 [0.999830277761131, 3.647109670792945e-5, 0.0001333153896490659]
 [0.998826234301541, 3.6307781285570585e-5, 0.0011376038450111674]
 [0.9893123533365569, 3.4589944277119534e-5, 0.010653144824928492]
 [0.9670226757764754, 3.083615170325988e-5, 0.03294646506326185]
 [0.8589064777985862, 1.7697035488578012e-5, 0.14106282809314252]
 [0.7089743786664564, 8.893577392121487e-6, 0.2912525601972607]
 [0.5479361514090116, 4.689845391400004e-6, 0.4523450631756651]
 [0.4610754185612017, 3.3451587753888765e-6, 0.5389705094034931]
 [0.4308687174969683, 2.983944662508429e-6, 0.5690461965630191]
 [0.33974358771128393, 2.0507854359197013e-6, 0.6590164840052891]
 [0.2832917190561938, 1.728914720740022e-6, 0.7167899660502243]
 ⋮
 [0.019285560116060703, 7.813484646054062e-8, 0.9872673442966365]
 [0.019240090145882963, 7.791283753667864e-8, 0.987313099966667]
 [0.01917241941506847, 7.768521372975455e-8, 0.987381499686431]
 [0.01915359242064408, 7.756468387858009e-8, 0.9874005937206731]
 [0.019006102642926487, 7.699848522840611e-8, 0.9875543550002359]
 [0.018992787593113673, 7.690441695418321e-8, 0.9875677670644417]
 [0.018872777535653508, 7.643113865622336e-8, 0.9876898996057886]
 [0.01883711632155089, 7.625320151518994e-8, 0.9877259298059433]
 [0.018745844184231607, 7.592805567135533e-8, 0.9878201020471566]
 [0.01872677174623929, 7.580055909846064e-8, 0.9878395230929707]
 [0.01860287157598028, 7.533940618105638e-8, 0.987969314524561]
 [0.018597829263500777, 7.527824202117365e-8, 0.9879743563769822]

julia> sol.destats
DiffEqBase.DEStats
Number of function 1 evaluations:                  9579
Number of function 2 evaluations:                  0
Number of W matrix evaluations:                    1762
Number of linear solves:                           11100
Number of Jacobians created:                       908
Number of nonlinear solver iterations:             0
Number of nonlinear solver convergence failures:   0
Number of rootfind condition calls:                0
Number of accepted steps:                          237
Number of rejected steps:                          2
```
I had also tested results on Van-der pol, the results followed same trend in ImplicitHairerWanner, but some different results persisted in Deuflhard's case. The algorithm was returning `Maxiters` when tested with these changes while working well on the master. Should we implement smoothing in Deuflhard's case?
@ChrisRackauckas @kanav99 could you please have a look?
