### PR TITLE
Update Work Calculation in ImplicitEulerExtrapolation

### DIFF
--- a/src/caches/extrapolation_caches.jl
+++ b/src/caches/extrapolation_caches.jl
@@ -113,7 +113,11 @@ function alg_cache(alg::ImplicitEulerExtrapolation,u,rate_prototype,uEltypeNoUni
   dtpropose = zero(dt)
   cur_order = max(alg.init_order, alg.min_order)
   T = Array{typeof(u),2}(undef, alg.max_order, alg.max_order)
-  @.. T = u
+  for i=1:alg.max_order
+    for j=1:i
+      T[i,j] = zero(u)
+    end
+  end
   work = zero(dt)
   A = one(Int)
   step_no = zero(Int)

--- a/src/caches/extrapolation_caches.jl
+++ b/src/caches/extrapolation_caches.jl
@@ -91,6 +91,7 @@ end
   jac_config::JCType
   grad_config::GCType
   sequence::sequenceType #support for different sequences
+  stage_number::Vector{Int} # stage_number[n] contains information for extrapolation order (n - 1)
 end
 
 @cache mutable struct ImplicitEulerExtrapolationConstantCache{dtType,arrayType,TF,UF,sequenceType} <: OrdinaryDiffEqConstantCache
@@ -105,6 +106,7 @@ end
   uf::UF
 
   sequence::sequenceType #support for different sequences
+  stage_number::Vector{Int}
 end
 
 function alg_cache(alg::ImplicitEulerExtrapolation,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{false})
@@ -118,7 +120,16 @@ function alg_cache(alg::ImplicitEulerExtrapolation,u,rate_prototype,uEltypeNoUni
   tf = TimeDerivativeWrapper(f,u,p)
   uf = UDerivativeWrapper(f,t,p)
   sequence = generate_sequence(constvalue(uBottomEltypeNoUnits),alg)
-  ImplicitEulerExtrapolationConstantCache(dtpropose,T,cur_order,work,A,step_no,tf,uf,sequence)
+  stage_number = Vector{Int}(undef, alg.max_order + 1)
+
+  for n in 1:length(stage_number)
+    s = zero(eltype(sequence))
+    for i in 1:n
+      s += sequence[i]
+    end
+    stage_number[n] = 8 * Int(s) - n + 3
+  end
+  ImplicitEulerExtrapolationConstantCache(dtpropose,T,cur_order,work,A,step_no,tf,uf,sequence,stage_number)
 end
 
 function alg_cache(alg::ImplicitEulerExtrapolation,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{true})
@@ -193,8 +204,9 @@ function alg_cache(alg::ImplicitEulerExtrapolation,u,rate_prototype,uEltypeNoUni
   grad_config = build_grad_config(alg,f,tf,du1,t)
   jac_config = build_jac_config(alg,f,uf,du1,uprev,u,du1,du2)
   sequence = generate_sequence(constvalue(uBottomEltypeNoUnits),alg)
+  cc = alg_cache(alg,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,Val(false))
   ImplicitEulerExtrapolationCache(uprev,u_tmps,utilde,tmp,atmp,k_tmps,dtpropose,T,cur_order,work,A,step_no,
-    du1,du2,J,W,tf,uf,linsolve_tmps,linsolve,jac_config,grad_config,sequence)
+    du1,du2,J,W,tf,uf,linsolve_tmps,linsolve,jac_config,grad_config,sequence,cc.stage_number)
 end
 
 

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -248,7 +248,7 @@ end
 
 function perform_step!(integrator,cache::ImplicitEulerExtrapolationCache,repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
-  @unpack T,utilde,atmp,dtpropose,cur_order,A = cache
+  @unpack T,utilde,atmp,dtpropose,cur_order,A,stage_number = cache
   @unpack J,W,uf,tf,jac_config = cache
   @unpack u_tmps, k_tmps, linsolve_tmps = cache
 
@@ -329,7 +329,7 @@ function perform_step!(integrator,cache::ImplicitEulerExtrapolationCache,repeat_
     end
 
     for i in range_start:max_order
-        A = sum(sequence[1:i]) + 1
+        A = stage_number[i]
         @.. utilde = T[i,i] - T[i,i-1]
         atmp = calculate_residuals(utilde, uprev, T[i,i], integrator.opts.abstol, integrator.opts.reltol, integrator.opts.internalnorm, t)
         EEst = integrator.opts.internalnorm(atmp,t)
@@ -378,7 +378,7 @@ end
 function perform_step!(integrator,cache::ImplicitEulerExtrapolationConstantCache,repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack dtpropose, T, cur_order, work, A, tf, uf = cache
-  @unpack sequence = cache
+  @unpack sequence,stage_number = cache
 
   max_order = min(size(T, 1), cur_order+1)
 
@@ -449,7 +449,7 @@ function perform_step!(integrator,cache::ImplicitEulerExtrapolationConstantCache
       end
 
       for i in range_start:max_order
-          A = sum(sequence[1:i]) + 1
+          A = stage_number[i]
           utilde = T[i,i] - T[i,i-1]
           atmp = calculate_residuals(utilde, uprev, T[i,i], integrator.opts.abstol, integrator.opts.reltol, integrator.opts.internalnorm, t)
           EEst = integrator.opts.internalnorm(atmp,t)


### PR DESCRIPTION
Hi, I have updated work calculation to take account of the Jacobian, using Hairer Wanner Adaptivity, as mentioned in Hairer II. After that, I will update adaptivity coinciding with Hairer Wanner.
Work Calculation:
![image](https://user-images.githubusercontent.com/37050056/88487544-a39fd000-cfa3-11ea-83e2-02f6e24b26a0.png)

@ChrisRackauckas @kanav99 can you have a look?