### PR TITLE
Extend tests to cover autodiff=false for StaticArrays

### DIFF
--- a/test/regression/time_derivative_test.jl
+++ b/test/regression/time_derivative_test.jl
@@ -1,71 +1,97 @@
-using OrdinaryDiffEq, Test
+using OrdinaryDiffEq, StaticArrays, Test
 
 function time_derivative(du,u,p,t)
   du[1] = -t
 end
+function time_derivative_static(u,p,t)
+  SVector(-t)
+end
 function time_derivative_analytic(u0,p,t)
   u0 .- t.^2 ./ 2
 end
-
-ff_time_derivative = ODEFunction(time_derivative,
-                                 analytic=time_derivative_analytic)
-u0 = [1.0]
-tspan = (0.0,1.0)
-prob = ODEProblem(ff_time_derivative,u0,tspan)
-
-sol = solve(prob,Rosenbrock32(),reltol=1e-9,abstol=1e-9)
-@test sol.errors[:final] < 1e-5
-@show Rosenbrock23()
-sol = solve(prob,Rosenbrock23(),reltol=1e-9,abstol=1e-9)
-@test sol.errors[:final] < 1e-10
-@show Rodas4
-sol = solve(prob,Rodas4(),reltol=1e-9,abstol=1e-9)
-@test sol.errors[:final] < 1e-10
-@show Rodas5
-sol = solve(prob,Rodas5(),reltol=1e-9,abstol=1e-9)
-@test sol.errors[:final] < 1e-10
-@show Veldd4
-sol = solve(prob,Veldd4(),reltol=1e-9,abstol=1e-9)
-@test sol.errors[:final] < 1e-10
-@show KenCarp3
-sol = solve(prob,KenCarp3(),reltol=1e-12,abstol=1e-12)
-@test length(sol) > 2
-@test sol.errors[:final] < 1e-10
-@show KenCarp4
-sol = solve(prob,KenCarp4(),reltol=1e-12,abstol=1e-12)
-@test length(sol) > 2
-@test sol.errors[:final] < 1e-10
-@show KenCarp47
-sol = solve(prob,KenCarp47(),reltol=1e-12,abstol=1e-12)
-@test length(sol) > 2
-@test sol.errors[:final] < 1e-10
-@show KenCarp5
-sol = solve(prob,KenCarp5(),reltol=1e-12,abstol=1e-12)
-@test length(sol) > 2
-@test sol.errors[:final] < 1e-10
-@show KenCarp58
-sol = solve(prob,KenCarp5(),reltol=1e-12,abstol=1e-12)
-@test length(sol) > 2
-@test sol.errors[:final] < 1e-10
-@show TRBDF2
-sol = solve(prob,TRBDF2(),reltol=1e-9,abstol=1e-9)
-@test sol.errors[:final] < 1e-10
-sol = solve(prob,ImplicitEuler(),dt=1/10)
-@test sol.errors[:final] < 1e-1
-sol = solve(prob,Trapezoid(),dt=1/10)
-@test sol.errors[:final] < 1e-12
-sol = solve(prob,Euler(),dt=1/100)
-@test sol.errors[:final] < 6e-3
-
 
 const CACHE_TEST_ALGS = [Euler(),Midpoint(),RK4(),SSPRK22(),SSPRK33(),SSPRK53(),
   SSPRK63(),SSPRK73(),SSPRK83(),SSPRK432(),SSPRK932(),SSPRK54(),SSPRK104(),CarpenterKennedy2N54(),
   BS3(),BS5(),DP5(),DP8(),Feagin10(),Feagin12(),Feagin14(),TanYam7(),
   Tsit5(),TsitPap8(),Vern6(),Vern7(),Vern8(),Vern9(),OwrenZen3(),OwrenZen4(),OwrenZen5()]
 
-for alg in CACHE_TEST_ALGS
-  sol = solve(prob,alg,dt=1/10)
-  if !(typeof(alg) <: Euler)
-    @test sol.errors[:final] < 4e-14
+tspan = (0.0,1.0)
+
+for (ff_time_derivative, u0) in
+  ((ODEFunction(time_derivative, analytic=time_derivative_analytic), [1.0]),
+   (ODEFunction(time_derivative_static, analytic=time_derivative_analytic), SVector(1.0)))
+
+  @info "StaticArrays?: $(u0 isa StaticArray)"
+
+  prob = ODEProblem(ff_time_derivative,u0,tspan)
+
+  for _autodiff in (true, false)
+    @info "autodiff=$(_autodiff)"
+
+    @show Rosenbrock23
+    sol = solve(prob,Rosenbrock32(autodiff=_autodiff),reltol=1e-9,abstol=1e-9)
+    @test sol.errors[:final] < 1e-5*10^(!_autodiff)
+    sol = solve(prob,Rosenbrock23(autodiff=_autodiff),reltol=1e-9,abstol=1e-9)
+    @test sol.errors[:final] < 1e-10*10_000^(!_autodiff)
+
+    @show Rodas4
+    sol = solve(prob,Rodas4(autodiff=_autodiff),reltol=1e-9,abstol=1e-9)
+    @test sol.errors[:final] < 1e-10*100_000^(!_autodiff)
+
+    @show Rodas5
+    sol = solve(prob,Rodas5(autodiff=_autodiff),reltol=1e-9,abstol=1e-9)
+    @test sol.errors[:final] < 1e-10*1_000_000_000^(!_autodiff)
+
+    @show Veldd4
+    sol = solve(prob,Veldd4(autodiff=_autodiff),reltol=1e-9,abstol=1e-9)
+    @test sol.errors[:final] < 1e-10*100_000^(!_autodiff)
+
+    @show KenCarp3
+    sol = solve(prob,KenCarp3(autodiff=_autodiff),reltol=1e-12,abstol=1e-12)
+    @test length(sol) > 2
+    @test sol.errors[:final] < 1e-10
+
+    @show KenCarp4
+    sol = solve(prob,KenCarp4(autodiff=_autodiff),reltol=1e-12,abstol=1e-12)
+    @test length(sol) > 2
+    @test sol.errors[:final] < 1e-10
+
+    @show KenCarp47
+    sol = solve(prob,KenCarp47(autodiff=_autodiff),reltol=1e-12,abstol=1e-12)
+    @test length(sol) > 2
+    @test sol.errors[:final] < 1e-10
+
+    @show KenCarp5
+    sol = solve(prob,KenCarp5(autodiff=_autodiff),reltol=1e-12,abstol=1e-12)
+    @test length(sol) > 2
+    @test sol.errors[:final] < 1e-10
+
+    @show KenCarp58
+    sol = solve(prob,KenCarp58(autodiff=_autodiff),reltol=1e-12,abstol=1e-12)
+    @test length(sol) > 2
+    @test sol.errors[:final] < 1e-10
+
+    @show TRBDF2
+    sol = solve(prob,TRBDF2(autodiff=_autodiff),reltol=1e-9,abstol=1e-9)
+    @test sol.errors[:final] < 1e-10
+
+    @show ImplicitEuler
+    sol = solve(prob,ImplicitEuler(autodiff=_autodiff),dt=1/10)
+    @test sol.errors[:final] < 1e-1
+
+    @show Trapezoid
+    sol = solve(prob,Trapezoid(autodiff=_autodiff),dt=1/10)
+    @test sol.errors[:final] < 1e-12
+  end
+
+  @show Euler
+  sol = solve(prob,Euler(),dt=1/100)
+  @test sol.errors[:final] < 6e-3
+
+  for alg in CACHE_TEST_ALGS
+    sol = solve(prob,alg,dt=1/10)
+    if !(typeof(alg) <: Euler)
+      @test sol.errors[:final] < 4e-14
+    end
   end
 end


### PR DESCRIPTION
This triggers https://github.com/SciML/OrdinaryDiffEq.jl/issues/1219. It looks like the root cause might be https://github.com/JuliaDiff/FiniteDiff.jl/blob/310da8c934c249c978a5e359d5bcadeafffe64ce/src/jacobians.jl#L198 since
```julia
julia> reshape(SMatrix{1,1}(1.0), (1,1))
1×1 reshape(::SArray{Tuple{1,1},Float64,2,1}, 1, 1) with eltype Float64:
 1.0

julia> reshape(SMatrix{1,1}(1.0), (1,1))*1.0
1×1 Array{Float64,2}:
 1.0
```
i.e. no longer a StaticArray but I'm not yet completely sure that this is the actual problem.