### PR TITLE
Update step-sizing in Implicit Euler Extrapolation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ os:
   - linux
 #  - osx
 julia:
-  - 1
+  - 1.4
 #  - nightly
 env:
   - GROUP=InterfaceI

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -134,8 +134,10 @@ get_current_adaptive_order(alg::ExtrapolationMidpointDeuflhard,cache) = 2cache.n
 get_current_adaptive_order(alg::ImplicitDeuflhardExtrapolation,cache) = 2cache.n_curr
 get_current_alg_order(alg::ExtrapolationMidpointHairerWanner,cache) = 2(cache.n_curr + 1)
 get_current_alg_order(alg::ImplicitHairerWannerExtrapolation,cache) = 2(cache.n_curr + 1)
+get_current_alg_order(alg::ImplicitEulerExtrapolation,cache) = 2(cache.n_curr + 1)
 get_current_adaptive_order(alg::ExtrapolationMidpointHairerWanner,cache) = 2cache.n_curr
 get_current_adaptive_order(alg::ImplicitHairerWannerExtrapolation,cache) = 2cache.n_curr
+get_current_adaptive_order(alg::ImplicitEulerExtrapolation,cache) = 2cache.n_curr
 
 
 #alg_adaptive_order(alg::OrdinaryDiffEqAdaptiveAlgorithm) = error("Algorithm is adaptive with no order")
@@ -145,7 +147,6 @@ get_current_adaptive_order(alg::CompositeAlgorithm,cache) = alg_adaptive_order(a
 alg_order(alg::FunctionMap) = 0
 alg_order(alg::Euler) = 1
 alg_order(alg::AitkenNeville) = alg.init_order
-alg_order(alg::ImplicitEulerExtrapolation) = alg.init_order
 alg_order(alg::Heun) = 2
 alg_order(alg::Ralston) = 2
 alg_order(alg::LawsonEuler) = 1
@@ -395,6 +396,8 @@ alg_maximum_order(alg::ExtrapolationMidpointDeuflhard) = 2(alg.n_max+1)
 alg_maximum_order(alg::ImplicitDeuflhardExtrapolation) = 2(alg.n_max+1)
 alg_maximum_order(alg::ExtrapolationMidpointHairerWanner) = 2(alg.n_max+1)
 alg_maximum_order(alg::ImplicitHairerWannerExtrapolation) = 2(alg.n_max+1)
+alg_maximum_order(alg::ImplicitEulerExtrapolation) = 2(alg.n_max+1)
+
 
 alg_adaptive_order(alg::ExplicitRK) = alg.tableau.adaptiveorder
 alg_adaptive_order(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = alg_order(alg)-1
@@ -431,6 +434,7 @@ beta2_default(alg::ExtrapolationMidpointDeuflhard) = 0//1
 beta2_default(alg::ImplicitDeuflhardExtrapolation) = 0//1
 beta2_default(alg::ExtrapolationMidpointHairerWanner) = 0//1
 beta2_default(alg::ImplicitHairerWannerExtrapolation) = 0//1
+beta2_default(alg::ImplicitEulerExtrapolation) = 0//1
 
 beta1_default(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm},beta2) = isadaptive(alg) ? 7//(10alg_order(alg)) : 0
 beta1_default(alg::FunctionMap,beta2) = 0
@@ -440,6 +444,7 @@ beta1_default(alg::ExtrapolationMidpointDeuflhard,beta2) =  1//(2alg.n_init+1)
 beta1_default(alg::ImplicitDeuflhardExtrapolation,beta2) =  1//(2alg.n_init+1)
 beta1_default(alg::ExtrapolationMidpointHairerWanner,beta2) =  1//(2alg.n_init+1)
 beta1_default(alg::ImplicitHairerWannerExtrapolation,beta2) =  1//(2alg.n_init+1)
+beta1_default(alg::ImplicitEulerExtrapolation,beta2) =  1//(2alg.n_init+1)
 
 gamma_default(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = isadaptive(alg) ? 9//10 : 0
 gamma_default(alg::RKC) = 8//10
@@ -448,6 +453,8 @@ gamma_default(alg::ExtrapolationMidpointDeuflhard) = (1//4)^beta1_default(alg,be
 gamma_default(alg::ImplicitDeuflhardExtrapolation) = (1//4)^beta1_default(alg,beta2_default(alg))
 gamma_default(alg::ExtrapolationMidpointHairerWanner) = (65//100)^beta1_default(alg,beta2_default(alg))
 gamma_default(alg::ImplicitHairerWannerExtrapolation) = (65//100)^beta1_default(alg,beta2_default(alg))
+gamma_default(alg::ImplicitEulerExtrapolation) = (65//100)^beta1_default(alg,beta2_default(alg))
+
 
 qsteady_min_default(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = 1
 qsteady_max_default(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = 1

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -64,9 +64,9 @@ AitkenNeville(;max_order=10,min_order=1,init_order=5,threading=true) = AitkenNev
 
 struct ImplicitEulerExtrapolation{CS,AD,F,FDT} <: OrdinaryDiffEqImplicitExtrapolationAlgorithm{CS,AD}
   linsolve::F
-  max_order::Int
-  min_order::Int
-  init_order::Int
+  n_max::Int
+  n_min::Int
+  n_init::Int
   threading::Bool
   diff_type::FDT
   sequence::Symbol # Name of the subdividing sequence
@@ -75,6 +75,10 @@ end
 function ImplicitEulerExtrapolation(;chunk_size=0,autodiff=true,
     diff_type=Val{:forward},linsolve=DEFAULT_LINSOLVE,
     max_order=10,min_order=1,init_order=5,threading=true,sequence = :bulirsch)
+    
+    n_min = max(2,min_order)
+    n_init = max(n_min + 1,init_order)
+    n_max = max(n_init + 1, max_order)
     if threading
       @warn "Threading in `ImplicitEulerExtrapolation` is currently disabled. Thus `threading` has been changed from `true` to `false`."
       threading = false
@@ -89,7 +93,7 @@ function ImplicitEulerExtrapolation(;chunk_size=0,autodiff=true,
       sequence = :bulirsch
     end
     ImplicitEulerExtrapolation{chunk_size,autodiff,typeof(linsolve),typeof(diff_type)}(
-      linsolve,max_order,min_order,init_order,threading,diff_type,sequence)
+      linsolve,n_max,n_min,n_init,threading,diff_type,sequence)
 end
 
 struct ExtrapolationMidpointDeuflhard <: OrdinaryDiffEqExtrapolationVarOrderVarStepAlgorithm

--- a/src/caches/extrapolation_caches.jl
+++ b/src/caches/extrapolation_caches.jl
@@ -67,7 +67,7 @@ function alg_cache(alg::AitkenNeville,u,rate_prototype,uEltypeNoUnits,uBottomElt
   AitkenNevilleConstantCache(dtpropose,T,cur_order,work,A,step_no)
 end
 
-@cache mutable struct ImplicitEulerExtrapolationCache{uType,rateType,arrayType,dtType,JType,WType,F,JCType,GCType,uNoUnitsType,TFType,UFType,sequenceType} <: OrdinaryDiffEqMutableCache
+@cache mutable struct ImplicitEulerExtrapolationCache{uType,rateType,QType,arrayType,dtType,JType,WType,F,JCType,GCType,uNoUnitsType,TFType,UFType,sequenceType} <: OrdinaryDiffEqMutableCache
   uprev::uType
   u_tmps::Array{uType,1}
   utilde::uType
@@ -76,7 +76,6 @@ end
   k_tmps::Array{rateType,1}
   dtpropose::dtType
   T::arrayType
-  cur_order::Int
   work::dtType
   A::Int
   step_no::Int
@@ -92,15 +91,24 @@ end
   grad_config::GCType
   sequence::sequenceType #support for different sequences
   stage_number::Vector{Int} # stage_number[n] contains information for extrapolation order (n - 1)
+
+  Q::Vector{QType} # Storage for stepsize scaling factors. Q[n] contains information for extrapolation order (n - 1)
+  n_curr::Int # Storage for the current extrapolation order
+  n_old::Int # Storage for the extrapolation order n_curr before perfom_step! changes the latter
+  sigma::Rational{Int} # Parameter for order selection
+  res::uNoUnitsType # Storage for the scaled residual of u and utilde
 end
 
-@cache mutable struct ImplicitEulerExtrapolationConstantCache{dtType,arrayType,TF,UF,sequenceType} <: OrdinaryDiffEqConstantCache
+@cache mutable struct ImplicitEulerExtrapolationConstantCache{QType,dtType,arrayType,TF,UF,sequenceType} <: OrdinaryDiffEqConstantCache
+  Q::Vector{QType} # Storage for stepsize scaling factors. Q[n] contains information for extrapolation order (n)
   dtpropose::dtType
   T::arrayType
-  cur_order::Int
+  n_curr::Int
+  n_old::Int
   work::dtType
   A::Int
   step_no::Int
+  sigma::Rational{Int}
 
   tf::TF
   uf::UF
@@ -111,9 +119,13 @@ end
 
 function alg_cache(alg::ImplicitEulerExtrapolation,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{false})
   dtpropose = zero(dt)
-  cur_order = max(alg.init_order, alg.min_order)
-  T = Array{typeof(u),2}(undef, alg.max_order, alg.max_order)
-  for i=1:alg.max_order
+  #cur_order = max(alg.init_order, alg.min_order)
+  QType = tTypeNoUnits <: Integer ? typeof(qmin_default(alg)) : tTypeNoUnits # Cf. DiffEqBase.__init in solve.jl
+  Q = fill(zero(QType),alg.n_max + 1)
+  n_curr = alg.n_init
+  n_old = alg.n_init
+  T = Array{typeof(u),2}(undef, alg.n_max + 1, alg.n_max + 1)
+  for i=1:alg.n_max + 1
     for j=1:i
       T[i,j] = zero(u)
     end
@@ -124,16 +136,17 @@ function alg_cache(alg::ImplicitEulerExtrapolation,u,rate_prototype,uEltypeNoUni
   tf = TimeDerivativeWrapper(f,u,p)
   uf = UDerivativeWrapper(f,t,p)
   sequence = generate_sequence(constvalue(uBottomEltypeNoUnits),alg)
-  stage_number = Vector{Int}(undef, alg.max_order + 1)
+  stage_number = Vector{Int}(undef, alg.n_max + 1)
 
   for n in 1:length(stage_number)
     s = zero(eltype(sequence))
     for i in 1:n
       s += sequence[i]
     end
-    stage_number[n] = 8 * Int(s) - n + 3
+    stage_number[n] = 2 * Int(s) + n + 7
   end
-  ImplicitEulerExtrapolationConstantCache(dtpropose,T,cur_order,work,A,step_no,tf,uf,sequence,stage_number)
+  sigma = 9//10
+  ImplicitEulerExtrapolationConstantCache(Q,dtpropose,T,n_curr,n_old,work,A,step_no,sigma,tf,uf,sequence,stage_number)
 end
 
 function alg_cache(alg::ImplicitEulerExtrapolation,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{true})
@@ -155,11 +168,11 @@ function alg_cache(alg::ImplicitEulerExtrapolation,u,rate_prototype,uEltypeNoUni
     k_tmps[i] = zero(rate_prototype)
   end
 
-  cur_order = max(alg.init_order, alg.min_order)
+  #cur_order = max(alg.init_order, alg.min_order)
   dtpropose = zero(dt)
-  T = Array{typeof(u),2}(undef, alg.max_order, alg.max_order)
+  T = Array{typeof(u),2}(undef, alg.n_max + 1, alg.n_max + 1)
   # Initialize lower triangle of T to different instance of zeros array similar to u
-  for i=1:alg.max_order
+  for i=1:alg.n_max + 1
     for j=1:i
       T[i,j] = zero(u)
     end
@@ -205,12 +218,13 @@ function alg_cache(alg::ImplicitEulerExtrapolation,u,rate_prototype,uEltypeNoUni
   for i=2:Threads.nthreads()
     linsolve[i] = alg.linsolve(Val{:init},uf,u)
   end
+  res = uEltypeNoUnits.(zero(u))
   grad_config = build_grad_config(alg,f,tf,du1,t)
   jac_config = build_jac_config(alg,f,uf,du1,uprev,u,du1,du2)
   sequence = generate_sequence(constvalue(uBottomEltypeNoUnits),alg)
   cc = alg_cache(alg,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,Val(false))
-  ImplicitEulerExtrapolationCache(uprev,u_tmps,utilde,tmp,atmp,k_tmps,dtpropose,T,cur_order,work,A,step_no,
-    du1,du2,J,W,tf,uf,linsolve_tmps,linsolve,jac_config,grad_config,sequence,cc.stage_number)
+  ImplicitEulerExtrapolationCache(uprev,u_tmps,utilde,tmp,atmp,k_tmps,dtpropose,T,work,A,step_no,
+    du1,du2,J,W,tf,uf,linsolve_tmps,linsolve,jac_config,grad_config,sequence,cc.stage_number,cc.Q,cc.n_curr,cc.n_old,cc.sigma,res)
 end
 
 
@@ -332,15 +346,15 @@ end
 function generate_sequence(T, alg::ImplicitEulerExtrapolation)
   # Compute and return extrapolation_coefficients
 
-  @unpack min_order, init_order, max_order, sequence = alg
+  @unpack n_min, n_init, n_max, sequence = alg
 
   # Initialize subdividing_sequence:
   if sequence == :harmonic
-      subdividing_sequence = BigInt.(1:(max_order + 1))
+      subdividing_sequence = BigInt.(1:(n_max + 1))
   elseif sequence == :romberg
-      subdividing_sequence = BigInt(2).^(0:max_order)
+      subdividing_sequence = BigInt(2).^(0:n_max)
   else # sequence == :bulirsch
-      subdividing_sequence = [n==0 ? BigInt(1) : (isodd(n) ? BigInt(2)^((n + 1) ÷ 2) : 3 * BigInt(2)^(n ÷ 2 - 1)) for n = 0:max_order]
+      subdividing_sequence = [n==0 ? BigInt(1) : (isodd(n) ? BigInt(2)^((n + 1) ÷ 2) : 3 * BigInt(2)^(n ÷ 2 - 1)) for n = 0:n_max]
   end
 
   subdividing_sequence
@@ -349,15 +363,15 @@ end
 function generate_sequence(T::Type{<:CompiledFloats}, alg::ImplicitEulerExtrapolation)
   # Compute and return extrapolation_coefficients
 
-  @unpack min_order, init_order, max_order, sequence = alg
+  @unpack n_min, n_init, n_max, sequence = alg
 
   # Initialize subdividing_sequence:
   if sequence == :harmonic
-    subdividing_sequence = Int.(1:(max_order + 1))
+    subdividing_sequence = Int.(1:(n_max + 1))
   elseif sequence == :romberg
-    subdividing_sequence = Int(2).^(0:max_order)
+    subdividing_sequence = Int(2).^(0:n_max)
   else # sequence == :bulirsch
-    subdividing_sequence = [n==0 ? Int(1) : (isodd(n) ? Int(2)^((n + 1) ÷ 2) : 3 * Int(2)^(n ÷ 2 - 1)) for n = 0:max_order]
+    subdividing_sequence = [n==0 ? Int(1) : (isodd(n) ? Int(2)^((n + 1) ÷ 2) : 3 * Int(2)^(n ÷ 2 - 1)) for n = 0:n_max]
   end
 
   subdividing_sequence

--- a/src/integrators/controllers.jl
+++ b/src/integrators/controllers.jl
@@ -369,14 +369,14 @@ function step_reject_controller!(integrator, alg::Union{ExtrapolationMidpointDeu
   integrator.dt = dt_red
 end
 
-@inline function stepsize_controller!(integrator,alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation})
+@inline function stepsize_controller!(integrator,alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation, ImplicitEulerExtrapolation})
   # Dummy function
   # ExtrapolationMidpointHairerWanner's stepsize scaling is stored in the cache;
   # it is computed by  stepsize_controller_internal! (in perfom_step!), step_accept_controller! or step_reject_controller!
   zero(typeof(integrator.opts.qmax))
 end
 
-function stepsize_controller_internal!(integrator,alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation})
+function stepsize_controller_internal!(integrator,alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation, ImplicitEulerExtrapolation})
   # Standard stepsize controller
   # Compute and save the stepsize scaling based on the latest error estimate of the current order
   if iszero(integrator.EEst)
@@ -392,7 +392,7 @@ function stepsize_controller_internal!(integrator,alg::Union{ExtrapolationMidpoi
   integrator.cache.Q[integrator.cache.n_curr + 1] = q
 end
 
-function step_accept_controller!(integrator,alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation},q)
+function step_accept_controller!(integrator,alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation, ImplicitEulerExtrapolation},q)
   # Compute new order and stepsize, return new stepsize
   @unpack n_min, n_max = alg
   @unpack n_curr, n_old, Q, sigma = integrator.cache
@@ -441,7 +441,7 @@ function step_accept_controller!(integrator,alg::Union{ExtrapolationMidpointHair
   dt_new[n_new + 1]
 end
 
-function step_reject_controller!(integrator, alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation})
+function step_reject_controller!(integrator, alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation, ImplicitEulerExtrapolation})
   # Compute and save order and stepsize for redoing the current step
   @unpack n_old, n_curr, Q = integrator.cache
 

--- a/src/integrators/controllers.jl
+++ b/src/integrators/controllers.jl
@@ -369,22 +369,14 @@ function step_reject_controller!(integrator, alg::Union{ExtrapolationMidpointDeu
   integrator.dt = dt_red
 end
 
-<<<<<<< HEAD
-@inline function stepsize_controller!(integrator,alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation, ImplicitEulerExtrapolation})
-=======
-@inline function stepsize_controller!(integrator,alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation, ImplicitEulerBarycentricExtrapolation})
->>>>>>> master
+@inline function stepsize_controller!(integrator,alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation, ImplicitEulerExtrapolation, ImplicitEulerBarycentricExtrapolation})
   # Dummy function
   # ExtrapolationMidpointHairerWanner's stepsize scaling is stored in the cache;
   # it is computed by  stepsize_controller_internal! (in perfom_step!), step_accept_controller! or step_reject_controller!
   zero(typeof(integrator.opts.qmax))
 end
 
-<<<<<<< HEAD
-function stepsize_controller_internal!(integrator,alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation, ImplicitEulerExtrapolation})
-=======
-function stepsize_controller_internal!(integrator,alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation, ImplicitEulerBarycentricExtrapolation})
->>>>>>> master
+function stepsize_controller_internal!(integrator,alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation, ImplicitEulerExtrapolation, ImplicitEulerBarycentricExtrapolation})
   # Standard stepsize controller
   # Compute and save the stepsize scaling based on the latest error estimate of the current order
   if iszero(integrator.EEst)
@@ -400,11 +392,7 @@ function stepsize_controller_internal!(integrator,alg::Union{ExtrapolationMidpoi
   integrator.cache.Q[integrator.cache.n_curr + 1] = q
 end
 
-<<<<<<< HEAD
-function step_accept_controller!(integrator,alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation, ImplicitEulerExtrapolation},q)
-=======
-function step_accept_controller!(integrator,alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation, ImplicitEulerBarycentricExtrapolation},q)
->>>>>>> master
+function step_accept_controller!(integrator,alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation, ImplicitEulerExtrapolation, ImplicitEulerBarycentricExtrapolation},q)
   # Compute new order and stepsize, return new stepsize
   @unpack n_min, n_max = alg
   @unpack n_curr, n_old, Q, sigma = integrator.cache
@@ -453,11 +441,7 @@ function step_accept_controller!(integrator,alg::Union{ExtrapolationMidpointHair
   dt_new[n_new + 1]
 end
 
-<<<<<<< HEAD
-function step_reject_controller!(integrator, alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation, ImplicitEulerExtrapolation})
-=======
-function step_reject_controller!(integrator, alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation, ImplicitEulerBarycentricExtrapolation})
->>>>>>> master
+function step_reject_controller!(integrator, alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation, ImplicitEulerExtrapolation, ImplicitEulerBarycentricExtrapolation})
   # Compute and save order and stepsize for redoing the current step
   @unpack n_old, n_curr, Q = integrator.cache
 


### PR DESCRIPTION
Hi, I have updated `ImplicitEulerExtrapolation` with Hairer Wanner Adaptivity as written previously. The results are much better, but as I suggested earlier, it would be beneficial if we use barycentric extrapolation instead of Richardson's extrapolation. However, I made these changes earlier with Richardson's extrapolation and we could decide and review these changes. I feel that we should implement barycentric extrapolation from Implicit Euler from scratch because it would result in our caches being optimised and better control rather altering the previous one. What are your views? Maybe we could keep them both.

@ChrisRackauckas @kanav99 could you please share your thoughts on how to proceed and review this?