### PR TITLE
[WIP] Implicit Euler Barycentric Extrapolation

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -243,7 +243,7 @@ module OrdinaryDiffEq
          AutoVern6, AutoVern7, AutoVern8, AutoVern9
 
   export AitkenNeville, ExtrapolationMidpointDeuflhard, ExtrapolationMidpointHairerWanner, ImplicitEulerExtrapolation,
-         ImplicitDeuflhardExtrapolation, ImplicitHairerWannerExtrapolation
+         ImplicitDeuflhardExtrapolation, ImplicitHairerWannerExtrapolation, ImplicitEulerBarycentricExtrapolation
 
   export KuttaPRK2p5, PDIRK44, DImplicitEuler, DABDF2
 

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -134,8 +134,10 @@ get_current_adaptive_order(alg::ExtrapolationMidpointDeuflhard,cache) = 2cache.n
 get_current_adaptive_order(alg::ImplicitDeuflhardExtrapolation,cache) = 2cache.n_curr
 get_current_alg_order(alg::ExtrapolationMidpointHairerWanner,cache) = 2(cache.n_curr + 1)
 get_current_alg_order(alg::ImplicitHairerWannerExtrapolation,cache) = 2(cache.n_curr + 1)
+get_current_alg_order(alg::ImplicitEulerBarycentricExtrapolation,cache) = 2(cache.n_curr + 1)
 get_current_adaptive_order(alg::ExtrapolationMidpointHairerWanner,cache) = 2cache.n_curr
 get_current_adaptive_order(alg::ImplicitHairerWannerExtrapolation,cache) = 2cache.n_curr
+get_current_adaptive_order(alg::ImplicitEulerBarycentricExtrapolation,cache) = 2cache.n_curr
 
 
 #alg_adaptive_order(alg::OrdinaryDiffEqAdaptiveAlgorithm) = error("Algorithm is adaptive with no order")
@@ -396,6 +398,7 @@ alg_maximum_order(alg::ExtrapolationMidpointDeuflhard) = 2(alg.n_max+1)
 alg_maximum_order(alg::ImplicitDeuflhardExtrapolation) = 2(alg.n_max+1)
 alg_maximum_order(alg::ExtrapolationMidpointHairerWanner) = 2(alg.n_max+1)
 alg_maximum_order(alg::ImplicitHairerWannerExtrapolation) = 2(alg.n_max+1)
+alg_maximum_order(alg::ImplicitEulerBarycentricExtrapolation) = 2(alg.n_max+1)
 
 alg_adaptive_order(alg::ExplicitRK) = alg.tableau.adaptiveorder
 alg_adaptive_order(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = alg_order(alg)-1
@@ -432,6 +435,7 @@ beta2_default(alg::ExtrapolationMidpointDeuflhard) = 0//1
 beta2_default(alg::ImplicitDeuflhardExtrapolation) = 0//1
 beta2_default(alg::ExtrapolationMidpointHairerWanner) = 0//1
 beta2_default(alg::ImplicitHairerWannerExtrapolation) = 0//1
+beta2_default(alg::ImplicitEulerBarycentricExtrapolation) = 0//1
 
 beta1_default(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm},beta2) = isadaptive(alg) ? 7//(10alg_order(alg)) : 0
 beta1_default(alg::FunctionMap,beta2) = 0
@@ -441,6 +445,7 @@ beta1_default(alg::ExtrapolationMidpointDeuflhard,beta2) =  1//(2alg.n_init+1)
 beta1_default(alg::ImplicitDeuflhardExtrapolation,beta2) =  1//(2alg.n_init+1)
 beta1_default(alg::ExtrapolationMidpointHairerWanner,beta2) =  1//(2alg.n_init+1)
 beta1_default(alg::ImplicitHairerWannerExtrapolation,beta2) =  1//(2alg.n_init+1)
+beta1_default(alg::ImplicitEulerBarycentricExtrapolation,beta2) =  1//(2alg.n_init+1)
 
 gamma_default(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = isadaptive(alg) ? 9//10 : 0
 gamma_default(alg::RKC) = 8//10
@@ -449,6 +454,7 @@ gamma_default(alg::ExtrapolationMidpointDeuflhard) = (1//4)^beta1_default(alg,be
 gamma_default(alg::ImplicitDeuflhardExtrapolation) = (1//4)^beta1_default(alg,beta2_default(alg))
 gamma_default(alg::ExtrapolationMidpointHairerWanner) = (65//100)^beta1_default(alg,beta2_default(alg))
 gamma_default(alg::ImplicitHairerWannerExtrapolation) = (65//100)^beta1_default(alg,beta2_default(alg))
+gamma_default(alg::ImplicitEulerBarycentricExtrapolation) = (65//100)^beta1_default(alg,beta2_default(alg))
 
 qsteady_min_default(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = 1
 qsteady_max_default(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = 1

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -263,6 +263,48 @@ function ImplicitHairerWannerExtrapolation(;chunk_size=0,autodiff=true,
       sequence,diff_type,threading)
 end
 
+struct ImplicitEulerBarycentricExtrapolation{CS,AD,F,FDT} <: OrdinaryDiffEqImplicitExtrapolationAlgorithm{CS,AD}
+  linsolve::F
+  n_min::Int # Minimal extrapolation order
+  n_init::Int # Initial extrapolation order
+  n_max::Int # Maximal extrapolation order
+  sequence::Symbol # Name of the subdividing sequence
+  diff_type::FDT
+  threading::Bool
+end
+function ImplicitEulerBarycentricExtrapolation(;chunk_size=0,autodiff=true,
+  linsolve=DEFAULT_LINSOLVE,diff_type=Val{:forward},
+  min_order=2,init_order=5,max_order=10,sequence = :harmonic,threading=false)
+  # Enforce 2 <=  min_order
+  # and min_order + 1 <= init_order <= max_order - 1:
+  n_min = max(2, min_order)
+  n_init = max(n_min + 1, init_order)
+  n_max = max(n_init + 1, max_order)
+
+  # Warn user if orders have been changed
+  if (min_order, init_order, max_order) != (n_min,n_init,n_max)
+    @warn "The range of extrapolation orders and/or the initial order given to the
+      `ImplicitEulerBarycentricExtrapolation` algorithm are not valid and have been changed:
+      Minimal order: " * lpad(min_order,2," ") * " --> "  * lpad(n_min,2," ") * "
+      Maximal order: " * lpad(max_order,2," ") * " --> "  * lpad(n_max,2," ") * "
+      Initial order: " * lpad(init_order,2," ") * " --> "  * lpad(n_init,2," ")
+  end
+
+  # Warn user if sequence has been changed:
+  if sequence != :harmonic && sequence != :romberg && sequence != :bulirsch
+    @warn "The `sequence` given to the `ImplicitEulerBarycentricExtrapolation` algorithm
+       is not valid: it must match `:harmonic`, `:romberg` or `:bulirsch`.
+       Thus it has been changed
+      :$(sequence) --> :harmonic"
+    sequence = :harmonic
+  end
+
+  # Initialize algorithm
+  ImplicitEulerBarycentricExtrapolation{chunk_size, autodiff,
+      typeof(linsolve), typeof(diff_type)}(linsolve,n_min,n_init,n_max,
+      sequence,diff_type,threading)
+end
+
 """
 Julien Berland, Christophe Bogey, Christophe Bailly. Low-Dissipation and Low-Dispersion
 Fourth-Order Runge-Kutta Algorithm. Computers & Fluids, 35(10), pp 1459-1463, 2006.

--- a/src/caches/extrapolation_caches.jl
+++ b/src/caches/extrapolation_caches.jl
@@ -235,7 +235,8 @@ end
 function create_extrapolation_coefficients(T, alg::Union{ExtrapolationMidpointDeuflhard,
                                                          ExtrapolationMidpointHairerWanner,
                                                          ImplicitDeuflhardExtrapolation,
-                                                         ImplicitHairerWannerExtrapolation})
+                                                         ImplicitHairerWannerExtrapolation,
+                                                         ImplicitEulerBarycentricExtrapolation})
   # Compute and return extrapolation_coefficients
 
   @unpack n_min, n_init, n_max, sequence = alg
@@ -297,7 +298,8 @@ end
 function create_extrapolation_coefficients(T::Type{<:CompiledFloats}, alg::Union{ExtrapolationMidpointDeuflhard,
                                                                                  ExtrapolationMidpointHairerWanner,
                                                                                  ImplicitDeuflhardExtrapolation,
-                                                                                 ImplicitHairerWannerExtrapolation})
+                                                                                 ImplicitHairerWannerExtrapolation,
+                                                                                 ImplicitEulerBarycentricExtrapolation})
   # Compute and return extrapolation_coefficients
 
   @unpack n_min, n_init, n_max, sequence = alg

--- a/src/caches/extrapolation_caches.jl
+++ b/src/caches/extrapolation_caches.jl
@@ -890,3 +890,163 @@ function alg_cache(alg::ImplicitHairerWannerExtrapolation,u,rate_prototype,uElty
       cc.Q, cc.n_curr, cc.n_old, cc.coefficients, cc.stage_number, cc.sigma, du1, du2, J, W, tf, uf, linsolve_tmps,
       linsolve, jac_config, grad_config,diff1,diff2)
 end
+
+@cache mutable struct ImplicitEulerBarycentricExtrapolationConstantCache{QType,extrapolation_coefficients,TF,UF} <: OrdinaryDiffEqConstantCache
+  # Values that are mutated
+  Q::Vector{QType} # Storage for stepsize scaling factors. Q[n] contains information for extrapolation order (n - 1)
+  n_curr::Int # Storage for the current extrapolation order
+  n_old::Int # Storage for the extrapolation order n_curr before perfom_step! changes the latter
+
+  # Constant values
+  coefficients::extrapolation_coefficients
+  stage_number::Vector{Int} # stage_number[n] contains information for extrapolation order (n - 1)
+  sigma::Rational{Int} # Parameter for order selection
+
+  tf::TF
+  uf::UF
+end
+
+function alg_cache(alg::ImplicitEulerBarycentricExtrapolation,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{false})
+  # Initialize cache's members
+  QType = tTypeNoUnits <: Integer ? typeof(qmin_default(alg)) : tTypeNoUnits # Cf. DiffEqBase.__init in solve.jl
+
+  Q = fill(zero(QType),alg.n_max + 1)
+  n_curr = alg.n_init
+  n_old = alg.n_init
+
+  coefficients = create_extrapolation_coefficients(constvalue(uBottomEltypeNoUnits),alg)
+
+  stage_number = Vector{Int}(undef, alg.n_max + 1)
+  for n in 1:length(stage_number)
+    s = zero(eltype(coefficients.subdividing_sequence))
+    for i in 1:n
+      s += coefficients.subdividing_sequence[i]
+    end
+    stage_number[n] = 2 * Int(s) + n + 7
+  end
+  sigma = 9//10
+
+  # Initialize the constant cache
+  tf = TimeDerivativeWrapper(f,u,p)
+  uf = UDerivativeWrapper(f,t,p)
+  ImplicitEulerBarycentricExtrapolationConstantCache(Q, n_curr, n_old, coefficients, stage_number, sigma, tf, uf)
+end
+
+@cache mutable struct ImplicitEulerBarycentricExtrapolationCache{uType,uNoUnitsType,rateType,QType,extrapolation_coefficients,JType,WType,F,JCType,GCType,TFType,UFType} <: OrdinaryDiffEqMutableCache
+  # Values that are mutated
+  utilde::uType
+  u_temp1::uType
+  u_temp2::uType
+  u_temp3::Array{uType,1}
+  u_temp4::Array{uType,1}
+  tmp::uType # for get_tmp_cache()
+  T::Array{uType,1}  # Storage for the internal discretisations obtained by the explicit midpoint rule
+  res::uNoUnitsType # Storage for the scaled residual of u and utilde
+
+  fsalfirst::rateType
+  k::rateType
+  k_tmps::Array{rateType,1}
+
+  # Constant values
+  Q::Vector{QType} # Storage for stepsize scaling factors. Q[n] contains information for extrapolation order (n - 1)
+  n_curr::Int # Storage for the current extrapolation order
+  n_old::Int # Storage for the extrapolation order n_curr before perfom_step! changes the latter
+  coefficients::extrapolation_coefficients
+  stage_number::Vector{Int} # stage_number[n] contains information for extrapolation order (n - 1)
+  sigma::Rational{Int} # Parameter for order selection
+
+  du1::rateType
+  du2::rateType
+  J::JType
+  W::WType
+  tf::TFType
+  uf::UFType
+  linsolve_tmps::Array{rateType,1}
+  linsolve::Array{F,1}
+  jac_config::JCType
+  grad_config::GCType
+  # Values to check overflow in T1 computation
+  diff1::Array{uType,1}
+  diff2::Array{uType,1} 
+end
+
+
+function alg_cache(alg::ImplicitEulerBarycentricExtrapolation,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{true})
+  # Initialize cache's members
+  utilde = zero(u)
+  u_temp1 = zero(u)
+  u_temp2 = zero(u)
+  u_temp3 = Array{typeof(u),1}(undef, Threads.nthreads())
+  u_temp4 = Array{typeof(u),1}(undef, Threads.nthreads())
+
+  for i=1:Threads.nthreads()
+    u_temp3[i] = zero(u)
+    u_temp4[i] = zero(u)
+  end
+  tmp = zero(u)
+  T = Vector{typeof(u)}(undef,alg.n_max + 1)
+  for i in 1:alg.n_max+1
+    T[i] = zero(u)
+  end
+  res = uEltypeNoUnits.(zero(u))
+  fsalfirst = zero(rate_prototype)
+  k = zero(rate_prototype)
+  k_tmps = Array{typeof(k),1}(undef, Threads.nthreads())
+  for i=1:Threads.nthreads()
+      k_tmps[i] = zero(rate_prototype)
+  end
+
+  cc = alg_cache(alg,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,Val(false))
+
+  du1 = zero(rate_prototype)
+  du2 = zero(rate_prototype)
+
+  if DiffEqBase.has_jac(f) && !DiffEqBase.has_Wfact(f) && f.jac_prototype !== nothing
+    W_el = WOperator(f, dt, true)
+    J = nothing # is J = W.J better?
+  else
+    J = false .* vec(rate_prototype) .* vec(rate_prototype)' # uEltype?
+    W_el = similar(J)
+  end
+
+  W = Array{typeof(W_el),1}(undef, Threads.nthreads())
+  W[1] = W_el
+  for i=2:Threads.nthreads()
+    if W_el isa WOperator
+      W[i] = WOperator(f, dt, true)
+    else
+      W[i] = zero(W_el)
+    end
+  end
+  
+  tf = TimeGradientWrapper(f,uprev,p)
+  uf = UJacobianWrapper(f,t,p)
+  linsolve_tmp = zero(rate_prototype)
+  linsolve_tmps = Array{typeof(linsolve_tmp),1}(undef, Threads.nthreads())
+  
+  for i=1:Threads.nthreads()
+    linsolve_tmps[i] = zero(rate_prototype)
+  end
+
+  linsolve_el = alg.linsolve(Val{:init},uf,u)
+  linsolve = Array{typeof(linsolve_el),1}(undef, Threads.nthreads())
+  linsolve[1] = linsolve_el
+  for i=2:Threads.nthreads()
+    linsolve[i] = alg.linsolve(Val{:init},uf,u)
+  end
+  grad_config = build_grad_config(alg,f,tf,du1,t)
+  jac_config = build_jac_config(alg,f,uf,du1,uprev,u,du1,du2)
+
+  
+  diff1 = Array{typeof(u),1}(undef, Threads.nthreads())
+  diff2 = Array{typeof(u),1}(undef, Threads.nthreads())
+  for i=1:Threads.nthreads()
+    diff1[i] = zero(u)
+    diff2[i] = zero(u)
+  end
+  
+  # Initialize the cache
+  ImplicitEulerBarycentricExtrapolationCache(utilde, u_temp1, u_temp2, u_temp3, u_temp4, tmp, T, res, fsalfirst, k, k_tmps,
+      cc.Q, cc.n_curr, cc.n_old, cc.coefficients, cc.stage_number, cc.sigma, du1, du2, J, W, tf, uf, linsolve_tmps,
+      linsolve, jac_config, grad_config,diff1,diff2)
+end

--- a/src/integrators/controllers.jl
+++ b/src/integrators/controllers.jl
@@ -369,14 +369,14 @@ function step_reject_controller!(integrator, alg::Union{ExtrapolationMidpointDeu
   integrator.dt = dt_red
 end
 
-@inline function stepsize_controller!(integrator,alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation})
+@inline function stepsize_controller!(integrator,alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation, ImplicitEulerBarycentricExtrapolation})
   # Dummy function
   # ExtrapolationMidpointHairerWanner's stepsize scaling is stored in the cache;
   # it is computed by  stepsize_controller_internal! (in perfom_step!), step_accept_controller! or step_reject_controller!
   zero(typeof(integrator.opts.qmax))
 end
 
-function stepsize_controller_internal!(integrator,alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation})
+function stepsize_controller_internal!(integrator,alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation, ImplicitEulerBarycentricExtrapolation})
   # Standard stepsize controller
   # Compute and save the stepsize scaling based on the latest error estimate of the current order
   if iszero(integrator.EEst)
@@ -392,7 +392,7 @@ function stepsize_controller_internal!(integrator,alg::Union{ExtrapolationMidpoi
   integrator.cache.Q[integrator.cache.n_curr + 1] = q
 end
 
-function step_accept_controller!(integrator,alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation},q)
+function step_accept_controller!(integrator,alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation, ImplicitEulerBarycentricExtrapolation},q)
   # Compute new order and stepsize, return new stepsize
   @unpack n_min, n_max = alg
   @unpack n_curr, n_old, Q, sigma = integrator.cache
@@ -441,7 +441,7 @@ function step_accept_controller!(integrator,alg::Union{ExtrapolationMidpointHair
   dt_new[n_new + 1]
 end
 
-function step_reject_controller!(integrator, alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation})
+function step_reject_controller!(integrator, alg::Union{ExtrapolationMidpointHairerWanner, ImplicitHairerWannerExtrapolation, ImplicitEulerBarycentricExtrapolation})
   # Compute and save order and stepsize for redoing the current step
   @unpack n_old, n_curr, Q = integrator.cache
 

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -2455,7 +2455,7 @@ function perform_step!(integrator, cache::ImplicitEulerBarycentricExtrapolationC
   calc_J!(J,integrator,cache) # Store the calculated jac as it won't change in internal discretisation
   if !integrator.alg.threading
     for i in 0:n_curr
-      j_int = 4 * subdividing_sequence[i+1]
+      j_int = subdividing_sequence[i+1]
       dt_int = dt / j_int # Stepsize of the ith internal discretisation
       jacobian2W!(W[1], integrator.f.mass_matrix, dt_int, J, false)
       integrator.destats.nw +=1
@@ -2469,11 +2469,11 @@ function perform_step!(integrator, cache::ImplicitEulerBarycentricExtrapolationC
       for j in 2:j_int + 1
         f(k, cache.u_temp1, p, t + (j - 1) * dt_int)
         integrator.destats.nf += 1
-        @.. linsolve_tmps[1] = dt_int*k - (u_temp1 - u_temp2)
+        @.. linsolve_tmps[1] = dt_int*k
         cache.linsolve[1](vec(k), W[1], vec(linsolve_tmps[1]), !repeat_step)
         integrator.destats.nsolve += 1
         @.. k = -k
-        @.. T[i+1] = 2*u_temp1 - u_temp2 + 2*k # Explicit Midpoint rule
+        @.. T[i+1] = u_temp1 + k
         if(j == j_int + 1)
           @.. T[i + 1] = 0.5(T[i + 1] + u_temp2)
         end
@@ -2625,7 +2625,7 @@ function perform_step!(integrator, cache::ImplicitEulerBarycentricExtrapolationC
         cache.n_curr = n_curr
 
         # Update cache.T
-        j_int = 4 * subdividing_sequence[n_curr+1]
+        j_int = subdividing_sequence[n_curr+1]
         dt_int = dt / j_int # Stepsize of the new internal discretisation
         jacobian2W!(W[1], integrator.f.mass_matrix, dt_int, J, false)
         integrator.destats.nw +=1
@@ -2638,11 +2638,11 @@ function perform_step!(integrator, cache::ImplicitEulerBarycentricExtrapolationC
         for j in 2:j_int + 1
           f(k, cache.u_temp1, p, t + (j - 1) * dt_int)
           integrator.destats.nf += 1
-          @.. linsolve_tmps[1] = dt_int*k - (u_temp1 - u_temp2)
+          @.. linsolve_tmps[1] = dt_int*k
           cache.linsolve[1](vec(k), W[1], vec(linsolve_tmps[1]), !repeat_step)
           integrator.destats.nsolve += 1
           @.. k = -k
-          @.. T[n_curr+1] = 2*u_temp1 - u_temp2 + 2*k # Explicit Midpoint rule
+          @.. T[n_curr+1] = u_temp1 + k # Explicit Midpoint rule
           if(j == j_int + 1)
             @.. T[n_curr+ 1] = 0.5(T[n_curr + 1] + u_temp2)
           end

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -2232,7 +2232,7 @@ function perform_step!(integrator, cache::ImplicitEulerBarycentricExtrapolationC
   J = calc_J(integrator,cache) # Store the calculated jac as it won't change in internal discretisation
   if !integrator.alg.threading
     for i in 0:n_curr
-      j_int = 4 * subdividing_sequence[i+1]
+      j_int = subdividing_sequence[i+1]
       dt_int = dt / j_int # Stepsize of the ith internal discretisation
       W = dt_int*J - integrator.f.mass_matrix
       integrator.destats.nw += 1
@@ -2240,7 +2240,7 @@ function perform_step!(integrator, cache::ImplicitEulerBarycentricExtrapolationC
       u_temp1 = u_temp2 + _reshape(W\-_vec(dt_int*integrator.fsalfirst), axes(uprev)) # Euler starting step
       diff1 = u_temp1 - u_temp2
       for j in 2:j_int + 1
-        T[i+1] = 2*u_temp1 - u_temp2 + 2*_reshape(W\-_vec(dt_int * f(u_temp1, p, t + (j-1) * dt_int) - (u_temp1 - u_temp2)),axes(uprev))
+        T[i+1] = u_temp1 + _reshape(W\-_vec(dt_int * f(u_temp1, p, t + (j-1) * dt_int)),axes(uprev))
         integrator.destats.nf += 1
         if(j == j_int + 1)
           T[i + 1] = 0.5(T[i + 1] + u_temp2)
@@ -2370,14 +2370,14 @@ function perform_step!(integrator, cache::ImplicitEulerBarycentricExtrapolationC
         cache.n_curr = n_curr
 
         # Update T
-        j_int = 4 * subdividing_sequence[n_curr + 1]
+        j_int = subdividing_sequence[n_curr + 1]
         dt_int = dt / j_int # Stepsize of the new internal discretisation
         W = dt_int*J - integrator.f.mass_matrix
         integrator.destats.nw += 1
         u_temp2 = uprev
         u_temp1 = u_temp2 + _reshape(W\-_vec(dt_int*integrator.fsalfirst), axes(uprev)) # Euler starting step
         for j in 2:j_int + 1
-          T[n_curr+1] = 2*u_temp1 - u_temp2 + 2*_reshape(W\-_vec(dt_int * f(u_temp1, p, t + (j-1) * dt_int) - (u_temp1 - u_temp2)),axes(uprev))
+          T[n_curr+1] = u_temp1 + _reshape(W\-_vec(dt_int * f(u_temp1, p, t + (j-1) * dt_int)),axes(uprev))
           integrator.destats.nf += 1
           if(j == j_int + 1)
             T[n_curr+ 1] = 0.5(T[n_curr + 1] + u_temp2)

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -2183,3 +2183,507 @@ function perform_step!(integrator, cache::ImplicitHairerWannerExtrapolationCache
   f(cache.k, integrator.u, p, t+dt) # Update FSAL
   integrator.destats.nf += 1
 end
+
+function initialize!(integrator,cache::ImplicitEulerBarycentricExtrapolationConstantCache)
+  # cf. initialize! of MidpointConstantCache
+  integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+  integrator.kshortsize = 2
+  integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
+
+  # Avoid undefined entries if k is an array of arrays
+  integrator.fsallast = zero(integrator.fsalfirst)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
+end
+
+function perform_step!(integrator, cache::ImplicitEulerBarycentricExtrapolationConstantCache, repeat_step = false)
+  # Unpack all information needed
+  @unpack t, uprev, dt, f, p = integrator
+  @unpack n_curr = cache
+  # Coefficients for obtaining u
+  @unpack extrapolation_weights, extrapolation_scalars = cache.coefficients
+  # Coefficients for obtaining utilde
+  @unpack extrapolation_weights_2, extrapolation_scalars_2 = cache.coefficients
+  # Additional constant information
+  @unpack subdividing_sequence = cache.coefficients
+
+  # Create auxiliary variables
+  u_temp1, u_temp2 = copy(uprev), copy(uprev) # Auxiliary variables for computing the internal discretisations
+  u, utilde = copy(uprev), copy(uprev) # Storage for the latest approximation and its internal counterpart
+  T = fill(zero(uprev), integrator.alg.n_max + 1) # Storage for the internal discretisations obtained by the explicit midpoint rule
+  fill!(cache.Q, zero(eltype(cache.Q)))
+
+  if integrator.opts.adaptive
+    # Set up the order window
+    # integrator.alg.n_min + 1 ≦ n_curr ≦ integrator.alg.n_max - 1 is enforced by step_*_controller!
+    if !(integrator.alg.n_min + 1 <= n_curr <= integrator.alg.n_max-1)
+       error("Something went wrong while setting up the order window: $n_curr ∉ [$(integrator.alg.n_min+1),$(integrator.alg.n_max-1)].
+       Please report this error  ")
+    end
+    win_min =  n_curr - 1
+    win_max =  n_curr + 1
+
+    # Set up the current extrapolation order
+    cache.n_old = n_curr # Save the suggested order for step_*_controller!
+    n_curr = win_min # Start with smallest order in the order window
+  end
+
+  #Compute the internal discretisations
+  J = calc_J(integrator,cache) # Store the calculated jac as it won't change in internal discretisation
+  if !integrator.alg.threading
+    for i in 0:n_curr
+      j_int = 4 * subdividing_sequence[i+1]
+      dt_int = dt / j_int # Stepsize of the ith internal discretisation
+      W = dt_int*J - integrator.f.mass_matrix
+      integrator.destats.nw += 1
+      u_temp2 = uprev
+      u_temp1 = u_temp2 + _reshape(W\-_vec(dt_int*integrator.fsalfirst), axes(uprev)) # Euler starting step
+      diff1 = u_temp1 - u_temp2
+      for j in 2:j_int + 1
+        T[i+1] = 2*u_temp1 - u_temp2 + 2*_reshape(W\-_vec(dt_int * f(u_temp1, p, t + (j-1) * dt_int) - (u_temp1 - u_temp2)),axes(uprev))
+        integrator.destats.nf += 1
+        if(j == j_int + 1)
+          T[i + 1] = 0.5(T[i + 1] + u_temp2)
+        end
+        u_temp2 = u_temp1
+        u_temp1 = T[i+1]
+        if(i<=1)
+          # Deuflhard Stability check for initial two sequences 
+          diff2 = u_temp1 - u_temp2
+          if(integrator.opts.internalnorm(diff1,t)<integrator.opts.internalnorm(0.5*(diff2 - diff1),t))
+            # Divergence of iteration, overflow is possible. Force fail and start with smaller step
+            integrator.force_stepfail = true
+            return
+          end
+        end
+        diff1 = u_temp1 - u_temp2
+      end
+    end
+  else
+    if integrator.alg.sequence == :romberg
+      # Compute solution by using maximum two threads for romberg sequence
+      # One thread will fill T matrix till second last element and another thread will
+      # fill last element of T matrix.
+      # Romberg sequence --> 1, 2, 4, 8, ..., 2^(i)
+      # 1 + 2 + 4 + ... + 2^(i-1) = 2^(i) - 1
+      let n_curr=n_curr,subdividing_sequence=subdividing_sequence,uprev=uprev,dt=dt,u_temp2=u_temp2,
+          u_temp2=u_temp2,p=p,t=t,T=T
+        Threads.@threads for i = 1 : 2
+          startIndex = (i == 1) ? 0 : n_curr
+          endIndex = (i == 1) ? n_curr - 1 : n_curr
+
+          for index in startIndex:endIndex
+            j_int = 4 * subdividing_sequence[index+1]
+            dt_int = dt / j_int # Stepsize of the ith internal discretisation
+            W = dt_int*J - integrator.f.mass_matrix
+            integrator.destats.nw += 1
+            u_temp4 = uprev
+            u_temp3 = u_temp4 + _reshape(W\-_vec(dt_int*integrator.fsalfirst), axes(uprev)) # Euler starting step
+            diff1 = u_temp3 - u_temp4
+            for j in 2:j_int + 1
+              T[index+1] = 2*u_temp3 - u_temp4 + 2*_reshape(W\-_vec(dt_int * f(u_temp3, p, t + (j-1) * dt_int) - (u_temp3 - u_temp4)),axes(uprev))
+              integrator.destats.nf += 1
+              if(j == j_int + 1)
+                T[index + 1] = 0.5(T[index + 1] + u_temp4)
+              end
+              u_temp4 = u_temp3
+              u_temp3 = T[index+1]
+              if(index<=1)
+                # Deuflhard Stability check for initial two sequences 
+                diff2 = u_temp3 - u_temp4
+                if(integrator.opts.internalnorm(diff1,t)<integrator.opts.internalnorm(0.5*(diff2 - diff1),t))
+                  # Divergence of iteration, overflow is possible. Force fail and start with smaller step
+                  integrator.force_stepfail = true
+                  return
+                end
+              end
+              diff1 = u_temp3 - u_temp4
+            end
+          end
+          integrator.force_stepfail ? break : continue
+        end
+      end
+    else
+      let n_curr=n_curr,subdividing_sequence=subdividing_sequence,uprev=uprev,dt=dt,
+        integrator=integrator,p=p,t=t,T=T
+        Threads.@threads for i in 0:(n_curr ÷ 2)
+          indices = i != n_curr - i ? (i, n_curr - i) : (n_curr-i) #Avoid duplicate entry in tuple
+          for index in indices
+            j_int = 4 * subdividing_sequence[index+1]
+            dt_int = dt / j_int # Stepsize of the ith internal discretisation
+            W = dt_int*J - integrator.f.mass_matrix
+            integrator.destats.nw += 1
+            u_temp4 = uprev
+            u_temp3 = u_temp4 + _reshape(W\-_vec(dt_int*integrator.fsalfirst), axes(uprev)) # Euler starting step
+            diff1 = u_temp3 - u_temp4
+            for j in 2:j_int + 1
+              T[index+1] = 2*u_temp3 - u_temp4 + 2*_reshape(W\-_vec(dt_int * f(u_temp3, p, t + (j-1) * dt_int) - (u_temp3 - u_temp4)),axes(uprev))
+              integrator.destats.nf += 1
+              if(j == j_int + 1)
+                T[index + 1] = 0.5(T[index + 1] + u_temp4)
+              end
+              u_temp4 = u_temp3
+              u_temp3 = T[index+1]
+              if(index<=1)
+                # Deuflhard Stability check for initial two sequences 
+                diff2 = u_temp3 - u_temp4
+                if(integrator.opts.internalnorm(diff1,t)<integrator.opts.internalnorm(0.5*(diff2 - diff1),t))
+                  # Divergence of iteration, overflow is possible. Force fail and start with smaller step
+                  integrator.force_stepfail = true
+                  return
+                end
+              end
+              diff1 = u_temp3 - u_temp4
+            end
+          end
+          integrator.force_stepfail ? break : continue
+        end
+      end
+    end
+  end
+
+  if integrator.force_stepfail
+    return
+  end
+
+  if integrator.opts.adaptive
+    # Compute all information relating to an extrapolation order ≦ win_min
+    for i = win_min - 1 : win_min
+      u = eltype(uprev).(extrapolation_scalars[i+1]) * sum( broadcast(*, T[1:(i+1)], eltype(uprev).(extrapolation_weights[1:(i+1), (i+1)])) ) # Approximation of extrapolation order i
+      utilde = eltype(uprev).(extrapolation_scalars_2[i]) * sum( broadcast(*, T[2:(i+1)], eltype(uprev).(extrapolation_weights_2[1:i, i])) ) # and its internal counterpart
+      res = calculate_residuals(u, utilde, integrator.opts.abstol, integrator.opts.reltol, integrator.opts.internalnorm, t)
+      integrator.EEst = integrator.opts.internalnorm(res, t)
+      cache.n_curr = i # Update chache's n_curr for stepsize_controller_internal!
+      stepsize_controller_internal!(integrator, integrator.alg) # Update cache.Q
+    end
+
+    # Check if an approximation of some order in the order window can be accepted
+    # Make sure a stepsize scaling factor of order (integrator.alg.n_min + 1) is provided for the step_*_controller!
+    while n_curr <= win_max
+      if integrator.EEst <= 1.0
+        # Accept current approximation u of order n_curr
+        break
+      elseif (n_curr < integrator.alg.n_min + 1) || integrator.EEst <= typeof(integrator.EEst)(prod(subdividing_sequence[n_curr+2:win_max+1] .// subdividing_sequence[1]^2))
+        # Reject current approximation order but pass convergence monitor
+        # Always compute approximation of order (n_curr + 1)
+        n_curr = n_curr + 1
+        cache.n_curr = n_curr
+
+        # Update T
+        j_int = 4 * subdividing_sequence[n_curr + 1]
+        dt_int = dt / j_int # Stepsize of the new internal discretisation
+        W = dt_int*J - integrator.f.mass_matrix
+        integrator.destats.nw += 1
+        u_temp2 = uprev
+        u_temp1 = u_temp2 + _reshape(W\-_vec(dt_int*integrator.fsalfirst), axes(uprev)) # Euler starting step
+        for j in 2:j_int + 1
+          T[n_curr+1] = 2*u_temp1 - u_temp2 + 2*_reshape(W\-_vec(dt_int * f(u_temp1, p, t + (j-1) * dt_int) - (u_temp1 - u_temp2)),axes(uprev))
+          integrator.destats.nf += 1
+          if(j == j_int + 1)
+            T[n_curr+ 1] = 0.5(T[n_curr + 1] + u_temp2)
+          end
+          u_temp2 = u_temp1
+          u_temp1 = T[n_curr+1]
+        end
+
+        # Update u, integrator.EEst and cache.Q
+        u = eltype(uprev).(extrapolation_scalars[n_curr+1]) * sum( broadcast(*, T[1:(n_curr+1)], eltype(uprev).(extrapolation_weights[1:(n_curr+1), (n_curr+1)])) ) # Approximation of extrapolation order n_curr
+        utilde = eltype(uprev).(extrapolation_scalars_2[n_curr]) * sum( broadcast(*, T[2:(n_curr+1)], eltype(uprev).(extrapolation_weights_2[1:n_curr, n_curr])) ) # and its internal counterpart
+        res = calculate_residuals(u, utilde, integrator.opts.abstol, integrator.opts.reltol, integrator.opts.internalnorm, t)
+        integrator.EEst = integrator.opts.internalnorm(res, t)
+        stepsize_controller_internal!(integrator, integrator.alg) # Update cache.Q
+      else
+          # Reject the current approximation and not pass convergence monitor
+          break
+      end
+    end
+  else
+    u = eltype(uprev).(extrapolation_scalars[n_curr+1]) * sum( broadcast(*, T[1:(n_curr+1)], eltype(uprev).(extrapolation_weights[1:(n_curr+1), (n_curr+1)])) ) # Approximation of extrapolation order n_curr
+  end
+
+  # Save the latest approximation and update FSAL
+  integrator.u = u
+  integrator.fsallast = f(u, p, t + dt)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
+end
+
+function initialize!(integrator,cache::ImplicitEulerBarycentricExtrapolationCache)
+  # cf. initialize! of MidpointCache
+  @unpack k,fsalfirst = cache
+  integrator.fsalfirst = fsalfirst
+  integrator.fsallast = k
+  integrator.kshortsize = 2
+  resize!(integrator.k, integrator.kshortsize)
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
+  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # FSAL for interpolation
+end
+
+function perform_step!(integrator, cache::ImplicitEulerBarycentricExtrapolationCache, repeat_step = false)
+  # Unpack all information needed
+  @unpack t, uprev, dt, f, p = integrator
+  @unpack n_curr, u_temp1, u_temp2, utilde, res, T, fsalfirst, k, diff1, diff2  = cache
+  @unpack u_temp3, u_temp4, k_tmps = cache
+  # Coefficients for obtaining u
+  @unpack extrapolation_weights, extrapolation_scalars = cache.coefficients
+  # Coefficients for obtaining utilde
+  @unpack extrapolation_weights_2, extrapolation_scalars_2 = cache.coefficients
+  # Additional constant information
+  @unpack subdividing_sequence = cache.coefficients
+
+  @unpack J,W,uf,tf,linsolve_tmps,jac_config = cache
+
+  fill!(cache.Q, zero(eltype(cache.Q)))
+
+  if integrator.opts.adaptive
+    # Set up the order window
+    # integrator.alg.n_min + 1 ≦ n_curr ≦ integrator.alg.n_max - 1 is enforced by step_*_controller!
+    if !(integrator.alg.n_min + 1 <= n_curr <= integrator.alg.n_max-1)
+       error("Something went wrong while setting up the order window: $n_curr ∉ [$(integrator.alg.n_min+1),$(integrator.alg.n_max-1)].
+       Please report this error  ")
+    end
+    win_min =  n_curr - 1
+    win_max =  n_curr + 1
+
+    # Set up the current extrapolation order
+    cache.n_old = n_curr # Save the suggested order for step_*_controller!
+    n_curr = win_min # Start with smallest order in the order window
+  end
+
+  #Compute the internal discretisations
+  calc_J!(J,integrator,cache) # Store the calculated jac as it won't change in internal discretisation
+  if !integrator.alg.threading
+    for i in 0:n_curr
+      j_int = 4 * subdividing_sequence[i+1]
+      dt_int = dt / j_int # Stepsize of the ith internal discretisation
+      jacobian2W!(W[1], integrator.f.mass_matrix, dt_int, J, false)
+      integrator.destats.nw +=1
+      @.. u_temp2 = uprev
+      @.. linsolve_tmps[1] = dt_int * fsalfirst
+      cache.linsolve[1](vec(k), W[1], vec(linsolve_tmps[1]), !repeat_step)
+      integrator.destats.nsolve += 1
+      @.. k = -k
+      @.. u_temp1 = u_temp2 + k # Euler starting step
+      @.. diff1[1] = u_temp1 - u_temp2
+      for j in 2:j_int + 1
+        f(k, cache.u_temp1, p, t + (j - 1) * dt_int)
+        integrator.destats.nf += 1
+        @.. linsolve_tmps[1] = dt_int*k - (u_temp1 - u_temp2)
+        cache.linsolve[1](vec(k), W[1], vec(linsolve_tmps[1]), !repeat_step)
+        integrator.destats.nsolve += 1
+        @.. k = -k
+        @.. T[i+1] = 2*u_temp1 - u_temp2 + 2*k # Explicit Midpoint rule
+        if(j == j_int + 1)
+          @.. T[i + 1] = 0.5(T[i + 1] + u_temp2)
+        end
+        @.. u_temp2 = u_temp1
+        @.. u_temp1 = T[i+1]
+        if(i<=1)
+          # Deuflhard Stability check for initial two sequences 
+          @.. diff2[1] = u_temp1 - u_temp2
+          if(integrator.opts.internalnorm(diff1[1],t)<integrator.opts.internalnorm(0.5*(diff2[1] - diff1[1]),t))
+            # Divergence of iteration, overflow is possible. Force fail and start with smaller step
+            integrator.force_stepfail = true
+            return
+          end
+        end
+        @.. diff1[1] = u_temp1 - u_temp2
+      end
+    end
+  else
+    if integrator.alg.sequence == :romberg
+      # Compute solution by using maximum two threads for romberg sequence
+      # One thread will fill T matrix till second last element and another thread will
+      # fill last element of T matrix.
+      # Romberg sequence --> 1, 2, 4, 8, ..., 2^(i)
+      # 1 + 2 + 4 + ... + 2^(i-1) = 2^(i) - 1
+      let n_curr=n_curr,subdividing_sequence=subdividing_sequence,uprev=uprev,dt=dt,u_temp3=u_temp3,
+          u_temp4=u_temp4,k_tmps=k_tmps,p=p,t=t,T=T
+        Threads.@threads for i = 1 : 2
+          startIndex = (i == 1) ? 0 : n_curr
+          endIndex = (i == 1) ? n_curr - 1 : n_curr
+
+          for index in startIndex:endIndex
+            j_int_temp = 4 * subdividing_sequence[index+1]
+            dt_int_temp = dt / j_int_temp # Stepsize of the ith internal discretisation
+            jacobian2W!(W[Threads.threadid()], integrator.f.mass_matrix, dt_int_temp, J, false)
+            @.. u_temp4[Threads.threadid()] = uprev
+            @.. linsolve_tmps[Threads.threadid()] = dt_int_temp * fsalfirst
+            cache.linsolve[Threads.threadid()](vec(k_tmps[Threads.threadid()]), W[Threads.threadid()], vec(linsolve_tmps[Threads.threadid()]), !repeat_step)
+            @.. k_tmps[Threads.threadid()] = -k_tmps[Threads.threadid()]
+            @.. u_temp3[Threads.threadid()] = u_temp4[Threads.threadid()] + k_tmps[Threads.threadid()] # Euler starting step
+            @.. diff1[Threads.threadid()] = u_temp3[Threads.threadid()] - u_temp4[Threads.threadid()]
+            for j in 2:j_int_temp + 1
+              f(k_tmps[Threads.threadid()], cache.u_temp3[Threads.threadid()], p, t + (j-1) * dt_int_temp)
+              @.. linsolve_tmps[Threads.threadid()] = dt_int_temp*k_tmps[Threads.threadid()] - (u_temp3[Threads.threadid()] - u_temp4[Threads.threadid()])
+              cache.linsolve[Threads.threadid()](vec(k_tmps[Threads.threadid()]), W[Threads.threadid()], vec(linsolve_tmps[Threads.threadid()]), !repeat_step)
+              @.. k_tmps[Threads.threadid()] = -k_tmps[Threads.threadid()]
+              @.. T[index+1] = 2*u_temp3[Threads.threadid()] - u_temp4[Threads.threadid()] + 2*k_tmps[Threads.threadid()] # Explicit Midpoint rule
+              if(j == j_int_temp + 1)
+                @.. T[index + 1] = 0.5(T[index + 1] + u_temp4[Threads.threadid()])
+              end
+              @.. u_temp4[Threads.threadid()] = u_temp3[Threads.threadid()]
+              @.. u_temp3[Threads.threadid()] = T[index+1]
+              if(index<=1)
+                # Deuflhard Stability check for initial two sequences 
+                @.. diff2[Threads.threadid()] = u_temp3[Threads.threadid()] - u_temp4[Threads.threadid()]
+                if(integrator.opts.internalnorm(diff1[Threads.threadid()],t)<integrator.opts.internalnorm(0.5*(diff2[Threads.threadid()] - diff1[Threads.threadid()]),t))
+                  # Divergence of iteration, overflow is possible. Force fail and start with smaller step
+                  integrator.force_stepfail = true
+                  return
+                end
+              end
+              @.. diff1[Threads.threadid()] = u_temp3[Threads.threadid()] - u_temp4[Threads.threadid()]
+            end
+          end
+          integrator.force_stepfail ? break : continue
+        end
+      end
+    else
+      let n_curr=n_curr,subdividing_sequence=subdividing_sequence,uprev=uprev,dt=dt,u_temp3=u_temp3,
+          u_temp4=u_temp4,k_tmps=k_tmps,p=p,t=t,T=T
+        Threads.@threads for i in 0:(n_curr ÷ 2)
+          indices = i != n_curr - i ? (i, n_curr - i) : (n_curr-i) #Avoid duplicate entry in tuple
+          for index in indices
+            j_int_temp = 4 * subdividing_sequence[index+1]
+            dt_int_temp = dt / j_int_temp # Stepsize of the ith internal discretisation
+            jacobian2W!(W[Threads.threadid()], integrator.f.mass_matrix, dt_int_temp, J, false)
+            @.. u_temp4[Threads.threadid()] = uprev
+            @.. linsolve_tmps[Threads.threadid()] = dt_int_temp * fsalfirst
+            cache.linsolve[Threads.threadid()](vec(k_tmps[Threads.threadid()]), W[Threads.threadid()], vec(linsolve_tmps[Threads.threadid()]), !repeat_step)
+            @.. k_tmps[Threads.threadid()] = -k_tmps[Threads.threadid()]
+            @.. u_temp3[Threads.threadid()] = u_temp4[Threads.threadid()] + k_tmps[Threads.threadid()] # Euler starting step
+            @.. diff1[Threads.threadid()] = u_temp3[Threads.threadid()] - u_temp4[Threads.threadid()]
+            for j in 2:j_int_temp + 1
+              f(k_tmps[Threads.threadid()], cache.u_temp3[Threads.threadid()], p, t + (j-1) * dt_int_temp)
+              @.. linsolve_tmps[Threads.threadid()] = dt_int_temp*k_tmps[Threads.threadid()] - (u_temp3[Threads.threadid()] - u_temp4[Threads.threadid()])
+              cache.linsolve[Threads.threadid()](vec(k_tmps[Threads.threadid()]), W[Threads.threadid()], vec(linsolve_tmps[Threads.threadid()]), !repeat_step)
+              @.. k_tmps[Threads.threadid()] = -k_tmps[Threads.threadid()]
+              @.. T[index+1] = 2*u_temp3[Threads.threadid()] - u_temp4[Threads.threadid()] + 2*k_tmps[Threads.threadid()] # Explicit Midpoint rule
+              if(j == j_int_temp + 1)
+                @.. T[index + 1] = 0.5(T[index + 1] + u_temp4[Threads.threadid()])
+              end
+              @.. u_temp4[Threads.threadid()] = u_temp3[Threads.threadid()]
+              @.. u_temp3[Threads.threadid()] = T[index+1]
+              if(index<=1)
+                # Deuflhard Stability check for initial two sequences 
+                @.. diff2[Threads.threadid()] = u_temp3[Threads.threadid()] - u_temp4[Threads.threadid()]
+                if(integrator.opts.internalnorm(diff1[Threads.threadid()],t)<integrator.opts.internalnorm(0.5*(diff2[Threads.threadid()] - diff1[Threads.threadid()]),t))
+                  # Divergence of iteration, overflow is possible. Force fail and start with smaller step
+                  integrator.force_stepfail = true
+                  return
+                end
+              end
+              @.. diff1[Threads.threadid()] = u_temp3[Threads.threadid()] - u_temp4[Threads.threadid()]
+            end
+          end
+          integrator.force_stepfail ? break : continue
+        end
+      end
+    end
+  end
+
+  if integrator.force_stepfail
+    return
+  end
+
+  if integrator.opts.adaptive
+    # Compute all information relating to an extrapolation order ≦ win_min
+    for i = win_min - 1 : win_min
+
+      #integrator.u .= extrapolation_scalars[i+1] * sum( broadcast(*, cache.T[1:(i+1)], extrapolation_weights[1:(i+1), (i+1)]) ) # Approximation of extrapolation order i
+      #cache.utilde .= extrapolation_scalars_2[i] * sum( broadcast(*, cache.T[2:(i+1)], extrapolation_weights_2[1:i, i]) ) # and its internal counterpart
+
+      u_temp1 .= false
+      u_temp2 .= false
+      for j in 1:(i+1)
+        @.. u_temp1 += cache.T[j] * extrapolation_weights[j, (i+1)]
+      end
+      for j in 2:i+1
+        @.. u_temp2 += cache.T[j] * extrapolation_weights_2[j-1, i]
+      end
+      @.. integrator.u = extrapolation_scalars[i+1] * u_temp1
+      @.. cache.utilde  = extrapolation_scalars_2[i] * u_temp2
+
+      calculate_residuals!(cache.res, integrator.u, cache.utilde, integrator.opts.abstol, integrator.opts.reltol, integrator.opts.internalnorm, t)
+      integrator.EEst = integrator.opts.internalnorm(cache.res, t)
+      cache.n_curr = i # Update chache's n_curr for stepsize_controller_internal!
+      stepsize_controller_internal!(integrator, integrator.alg) # Update cache.Q
+    end
+
+    # Check if an approximation of some order in the order window can be accepted
+    # Make sure a stepsize scaling factor of order (integrator.alg.n_min + 1) is provided for the step_*_controller!
+    while n_curr <= win_max
+      if integrator.EEst <= 1.0
+        # Accept current approximation u of order n_curr
+        break
+    elseif (n_curr < integrator.alg.n_min + 1) || integrator.EEst <= typeof(integrator.EEst)(prod(subdividing_sequence[n_curr+2:win_max+1] .// subdividing_sequence[1]^2))
+        # Reject current approximation order but pass convergence monitor
+        # Compute approximation of order (n_curr + 1)
+        n_curr = n_curr + 1
+        cache.n_curr = n_curr
+
+        # Update cache.T
+        j_int = 4 * subdividing_sequence[n_curr+1]
+        dt_int = dt / j_int # Stepsize of the new internal discretisation
+        jacobian2W!(W[1], integrator.f.mass_matrix, dt_int, J, false)
+        integrator.destats.nw +=1
+        @.. u_temp2 = uprev
+        @.. linsolve_tmps[1] = dt_int * fsalfirst
+        cache.linsolve[1](vec(k), W[1], vec(linsolve_tmps[1]), !repeat_step)
+        integrator.destats.nsolve += 1
+        @.. k = -k
+        @.. u_temp1 = u_temp2 + k # Euler starting step
+        for j in 2:j_int + 1
+          f(k, cache.u_temp1, p, t + (j - 1) * dt_int)
+          integrator.destats.nf += 1
+          @.. linsolve_tmps[1] = dt_int*k - (u_temp1 - u_temp2)
+          cache.linsolve[1](vec(k), W[1], vec(linsolve_tmps[1]), !repeat_step)
+          integrator.destats.nsolve += 1
+          @.. k = -k
+          @.. T[n_curr+1] = 2*u_temp1 - u_temp2 + 2*k # Explicit Midpoint rule
+          if(j == j_int + 1)
+            @.. T[n_curr+ 1] = 0.5(T[n_curr + 1] + u_temp2)
+          end
+          @.. u_temp2 = u_temp1
+          @.. u_temp1 = T[n_curr+1]
+        end
+
+        # Update u, integrator.EEst and cache.Q
+        #integrator.u .= extrapolation_scalars[n_curr+1] * sum( broadcast(*, cache.T[1:(n_curr+1)], extrapolation_weights[1:(n_curr+1), (n_curr+1)]) ) # Approximation of extrapolation order n_curr
+        #cache.utilde .= extrapolation_scalars_2[n_curr] * sum( broadcast(*, cache.T[2:(n_curr+1)], extrapolation_weights_2[1:n_curr, n_curr]) ) # and its internal counterpart
+
+        u_temp1 .= false
+        u_temp2 .= false
+        for j in 1:n_curr+1
+          @.. u_temp1 += cache.T[j] * extrapolation_weights[j, (n_curr+1)]
+        end
+        for j in 2:n_curr+1
+          @.. u_temp2 += cache.T[j] * extrapolation_weights_2[j-1, n_curr]
+        end
+        @.. integrator.u = extrapolation_scalars[n_curr+1] * u_temp1
+        @.. cache.utilde  = extrapolation_scalars_2[n_curr]* u_temp2
+
+        calculate_residuals!(cache.res, integrator.u, cache.utilde, integrator.opts.abstol, integrator.opts.reltol, integrator.opts.internalnorm, t)
+        integrator.EEst = integrator.opts.internalnorm(cache.res, t)
+        stepsize_controller_internal!(integrator, integrator.alg) # Update cache.Q
+      else
+          # Reject the current approximation and not pass convergence monitor
+          break
+      end
+    end
+  else
+
+    #integrator.u .= extrapolation_scalars[n_curr+1] * sum( broadcast(*, cache.T[1:(n_curr+1)], extrapolation_weights[1:(n_curr+1), (n_curr+1)]) ) # Approximation of extrapolation order n_curr
+    u_temp1 .= false
+    for j in 1:n_curr+1
+      @.. u_temp1 += cache.T[j] * extrapolation_weights[j, (n_curr+1)]
+    end
+    @.. integrator.u = extrapolation_scalars[n_curr+1] * u_temp1
+
+  end
+
+  f(cache.k, integrator.u, p, t+dt) # Update FSAL
+  integrator.destats.nf += 1
+end


### PR DESCRIPTION
Hi, I added Implicit Euler Barycentric Extrapolation for testing purposes. There are changes yet to be made in the threading version, just checking and optimising the non-threaded version first. The subdividing sequence is also non-scaled version because overflow is not happening currently, but could be altered to improve accuracy. There's a significant improvement in the adaptivity before it used to take around ~1500 steps:
Results:
ROBER
```
julia> sol = solve(prob,ImplicitEulerBarycentricExtrapolation())
retcode: Success
Interpolation: 3rd order Hermite
t: 94-element Array{Float64,1}:
      0.0
      0.0007804691410143572
      0.0020788828568038082
      0.003745452933172179
      0.0084424003426813
      0.0418329803433523
      0.133784229911673
      0.3384336202132905
      0.7313132675982609
      1.4125147343331985
      2.5230877716117215
      4.281548271455018
      7.045611435626178
      ⋮
  62648.50145195949
  65635.82890254141
  68738.97544769452
  71961.72009630663
  75307.96337879008
  78781.73162439177
  82387.18109883313
  86128.60243765338
  90010.4261880201
  94037.22756386714
  98213.7312904604
 100000.0
u: 94-element Array{Array{Float64,1},1}:
 [1.0, 0.0, 0.0]
 [0.9999687819531755, 2.5793343142065786e-5, 5.425156076064023e-6]
 [0.9999168592309505, 3.561487797285224e-5, 4.594463839514755e-5]
 [0.9998502554786627, 3.6447941071366455e-5, 0.00011110126239552879]
 [0.9996628068352206, 3.646655208881115e-5, 0.0002985178267423984]
 [0.9983418169119611, 3.625038824023791e-5, 0.0016203913155380977]
 [0.9948007859121666, 3.565818573699484e-5, 0.005165184262085637]
 [0.9873810658864121, 3.4423364301628644e-5, 0.01259805313700003]
 [0.9746316583052161, 3.235602952432764e-5, 0.025385306598872455]
 [0.9560313901304092, 2.9504080225050206e-5, 0.04407758767798024]
 [0.9320591950344825, 2.6152200865266426e-5, 0.06825025010532088]
 [0.9036429101017482, 2.2659726771098243e-5, 0.09707934871519779]
 [0.8716431391604512, 1.9309241634938164e-5, 0.12990287373566714]
 ⋮
 [0.07508899269616687, 2.2282789745212505e-7, 1.346886620637566]
 [0.0728600717302911, 2.1552375489749652e-7, 1.3512342478116077]
 [0.07069581686858023, 2.0847537801101814e-7, 1.3554594845591335]
 [0.06859441042136237, 2.0167270965594892e-7, 1.359565505087804]
 [0.06655408205699063, 1.9510615325495652e-7, 1.3635554211491425]
 [0.06457310785286369, 1.8876654816039375e-7, 1.3674322815498123]
 [0.06264980949188631, 1.82645146988374e-7, 1.3711990715613445]
 [0.06078255333325592, 1.7673359394083105e-7, 1.3748587127511176]
 [0.05896974903846737, 1.7102390302901e-7, 1.378414063853706]
 [0.05720984875215139, 1.6550843930270433e-7, 1.3818679206855131]
 [0.055501346283446704, 1.6017990118525416e-7, 1.385223016191019]
 [0.05509199750732979, 1.5895545543706158e-7, 1.3865807077512788]

julia> sol.destats
DiffEqBase.DEStats
Number of function 1 evaluations:                  951
Number of function 2 evaluations:                  0
Number of W matrix evaluations:                    357
Number of linear solves:                           1213
Number of Jacobians created:                       98
Number of nonlinear solver iterations:             0
Number of nonlinear solver convergence failures:   0
Number of rootfind condition calls:                0
Number of accepted steps:                          93
Number of rejected steps:                          0
```

However, while just running tests locally, the convergence order is fixed to 1, but the regression tests are passing:
```
julia> @testset "Testing ImplicitEulerBarycentricExtrapolation" begin
         for prob in problem_array, seq in sequence_array
           global dts

           # Convergence test
           for j = 1:6
             alg = ImplicitEulerBarycentricExtrapolation(min_order = j,
               init_order = j, max_order=j,
               sequence = seq,threading=false)
             sim = test_convergence(dts,prob,alg)
                   @test sim.�est[:final] ≈ 2*(alg.n_init+1) atol=testTol
           end

           # Regression test
           alg = ImplicitEulerBarycentricExtrapolation(max_order=9, min_order=1,
             init_order=9, sequence=seq,threading=false)
                 sol = solve(prob, alg, reltol=1e-3)
           @test length(sol.u) < 10
         end
       end
┌ Warning: The range of extrapolation orders and/or the initial order given to the
│       `ImplicitEulerBarycentricExtrapolation` algorithm are not valid and have been changed:
│       Minimal order:  1 -->  2
│       Maximal order:  1 -->  4
│       Initial order:  1 -->  3
└ @ OrdinaryDiffEq C:\Users\Utkarsh\.julia\dev\OrdinaryDiffEq\src\algorithms.jl:286
Testing ImplicitEulerBarycentricExtrapolation: Test Failed at REPL[153]:11
  Expression: ≈(sim.�est[:final], 2 * (alg.n_init + 1), atol = testTol)
   Evaluated: 0.9958819159862579153841019701376346095592753223093247634461212374182920307646815 ≈ 8 (atol=0.2)
Stacktrace:
 [1] macro expansion at .\REPL[153]:11 [inlined]
 [2] macro expansion at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.4\Test\src\Test.jl:1113 [inlined]
 [3] top-level scope at .\REPL[153]:2
┌ Warning: The range of extrapolation orders and/or the initial order given to the
│       `ImplicitEulerBarycentricExtrapolation` algorithm are not valid and have been changed:
│       Minimal order:  2 -->  2
│       Maximal order:  2 -->  4
│       Initial order:  2 -->  3
└ @ OrdinaryDiffEq C:\Users\Utkarsh\.julia\dev\OrdinaryDiffEq\src\algorithms.jl:286
```
@ChrisRackauckas @kanav99 could have a look, please? Could you point out what's going wrong or how to debug it?