### PR TITLE
Fixes in ImplicitEulerBarycentricExtrapolation

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -275,10 +275,11 @@ struct ImplicitEulerBarycentricExtrapolation{CS,AD,F,FDT} <: OrdinaryDiffEqImpli
   sequence::Symbol # Name of the subdividing sequence
   diff_type::FDT
   threading::Bool
+  sequence_factor::Int
 end
 function ImplicitEulerBarycentricExtrapolation(;chunk_size=0,autodiff=true,
   linsolve=DEFAULT_LINSOLVE,diff_type=Val{:forward},
-  min_order=2,init_order=5,max_order=10,sequence = :harmonic,threading=false)
+  min_order=2,init_order=5,max_order=10,sequence = :harmonic,threading=false,sequence_factor = 2)
   # Enforce 2 <=  min_order
   # and min_order + 1 <= init_order <= max_order - 1:
   n_min = max(2, min_order)
@@ -306,7 +307,7 @@ function ImplicitEulerBarycentricExtrapolation(;chunk_size=0,autodiff=true,
   # Initialize algorithm
   ImplicitEulerBarycentricExtrapolation{chunk_size, autodiff,
       typeof(linsolve), typeof(diff_type)}(linsolve,n_min,n_init,n_max,
-      sequence,diff_type,threading)
+      sequence,diff_type,threading,sequence_factor)
 end
 
 """

--- a/src/caches/extrapolation_caches.jl
+++ b/src/caches/extrapolation_caches.jl
@@ -1018,6 +1018,7 @@ function alg_cache(alg::ImplicitEulerBarycentricExtrapolation,u,rate_prototype,u
   Q = fill(zero(QType),alg.n_max + 1)
   n_curr = alg.n_init
   n_old = alg.n_init
+  sequence_factor = alg.sequence_factor
 
   coefficients = create_extrapolation_coefficients(constvalue(uBottomEltypeNoUnits),alg)
 
@@ -1027,7 +1028,7 @@ function alg_cache(alg::ImplicitEulerBarycentricExtrapolation,u,rate_prototype,u
     for i in 1:n
       s += coefficients.subdividing_sequence[i]
     end
-    stage_number[n] = 2 * Int(s) - n + 7
+    stage_number[n] = 2 * sequence_factor * Int(s) - n + 7
   end
   sigma = 9//10
 

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -2362,7 +2362,7 @@ function perform_step!(integrator, cache::ImplicitEulerBarycentricExtrapolationC
               end
               u_temp4 = u_temp3
               u_temp3 = T[index+1]
-              if(index<=1 && j==2)
+              if(index<=1)
                 # Deuflhard Stability check for initial two sequences 
                 diff2 = u_temp3 - u_temp4
                 if(integrator.opts.internalnorm(diff1,t)<integrator.opts.internalnorm(0.5*(diff2 - diff1),t))
@@ -2557,7 +2557,7 @@ function perform_step!(integrator, cache::ImplicitEulerBarycentricExtrapolationC
         if(i<=1)
           # Deuflhard Stability check for initial two sequences 
           @.. diff2[1] = u_temp1 - u_temp2
-          if(integrator.opts.internalnorm(diff1[1],t)<integrator.opts.internalnorm((diff2[1] - diff1[1]),t))
+          if(integrator.opts.internalnorm(diff1[1],t)<integrator.opts.internalnorm(0.5*(diff2[1] - diff1[1]),t))
             # Divergence of iteration, overflow is possible. Force fail and start with smaller step
             integrator.force_stepfail = true
             return

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -2504,6 +2504,7 @@ function perform_step!(integrator, cache::ImplicitEulerBarycentricExtrapolationC
   @unpack extrapolation_weights_2, extrapolation_scalars_2 = cache.coefficients
   # Additional constant information
   @unpack subdividing_sequence = cache.coefficients
+  @unpack sequence_factor = integrator.alg
 
   @unpack J,W,uf,tf,linsolve_tmps,jac_config = cache
 

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -2595,14 +2595,14 @@ function perform_step!(integrator, cache::ImplicitEulerBarycentricExtrapolationC
               @.. k_tmps[Threads.threadid()] = -k_tmps[Threads.threadid()]
               @.. T[index+1] = u_temp3[Threads.threadid()] + k_tmps[Threads.threadid()] # Explicit Midpoint rule
               if(j == j_int_temp + 1)
-                @.. T[index + 1] = 0.5(T[index + 1] + u_temp4[Threads.threadid()])
+                @.. T[index + 1] = 0.25(T[index + 1] + 2*u_temp3[Threads.threadid()] + u_temp4[Threads.threadid()])
               end
               @.. u_temp4[Threads.threadid()] = u_temp3[Threads.threadid()]
               @.. u_temp3[Threads.threadid()] = T[index+1]
-              if(index<=1)
+              if(index<=1 && j==2)
                 # Deuflhard Stability check for initial two sequences 
                 @.. diff2[Threads.threadid()] = u_temp3[Threads.threadid()] - u_temp4[Threads.threadid()]
-                if(integrator.opts.internalnorm(diff1[Threads.threadid()],t)<integrator.opts.internalnorm(0.5*(diff2[Threads.threadid()] - diff1[Threads.threadid()]),t))
+                if(integrator.opts.internalnorm(diff1[Threads.threadid()],t)<integrator.opts.internalnorm((diff2[Threads.threadid()]),t))
                   # Divergence of iteration, overflow is possible. Force fail and start with smaller step
                   integrator.force_stepfail = true
                   return
@@ -2636,11 +2636,11 @@ function perform_step!(integrator, cache::ImplicitEulerBarycentricExtrapolationC
               @.. k_tmps[Threads.threadid()] = -k_tmps[Threads.threadid()]
               @.. T[index+1] = u_temp3[Threads.threadid()] + k_tmps[Threads.threadid()] # Explicit Midpoint rule
               if(j == j_int_temp + 1)
-                @.. T[index + 1] = 0.5(T[index + 1] + u_temp4[Threads.threadid()])
+                @.. T[index + 1] = 0.25(T[index + 1] + 2*u_temp3[Threads.threadid()] + u_temp4[Threads.threadid()])
               end
               @.. u_temp4[Threads.threadid()] = u_temp3[Threads.threadid()]
               @.. u_temp3[Threads.threadid()] = T[index+1]
-              if(index<=1)
+              if(index<=1 && j==2)
                 # Deuflhard Stability check for initial two sequences 
                 @.. diff2[Threads.threadid()] = u_temp3[Threads.threadid()] - u_temp4[Threads.threadid()]
                 if(integrator.opts.internalnorm(diff1[Threads.threadid()],t)<integrator.opts.internalnorm(0.5*(diff2[Threads.threadid()] - diff1[Threads.threadid()]),t))


### PR DESCRIPTION
Hi, I have updated smoothing & added API for `sequence_factor` in `ImplicitEulerBarycentricExtrapolation`. These were the results of ROBER:

Before:
```
julia> sol = solve(prob,ImplicitEulerBarycentricExtrapolation())
retcode: Success
Interpolation: 3rd order Hermite
t: 735-element Array{Float64,1}:
      0.0
      0.0007804691410143572
      0.0012928049122421024
      0.001779230376630409
      0.0026976189518879076
      0.004593247494614582
      0.00982318681252459
      0.025959211527813317
      0.05894138201023005
      0.1146170213220058
      0.19933421448633254
      0.32028280317149244
      0.48582348927340346
      ⋮
  97324.95480371919
  97583.81595095301
  97840.36909624105
  98096.00071610826
  98373.70841384509
  98639.57039005749
  98900.12151184973
  99158.34730893603
  99415.64279645523
  99695.14359951086
  99972.01821800332
 100000.0
u: 735-element Array{Array{Float64,1},1}:
 [1.0, 0.0, 0.0]
 [0.9999687819984653, 2.5378969289930586e-5, 5.842280671100004e-6]
 [0.9999482913189734, 3.2469924947677e-5, 2.301534305749022e-5]
 [0.9999288406100082, 3.508785552155402e-5, 3.8694780903763995e-5]
 [0.9998921267953147, 3.632197031955678e-5, 7.326487299495826e-5]
 [0.9998163893448577, 3.6491566881699283e-5, 0.00014861617376977164]
 [0.9996077345523073, 3.646162117036865e-5, 0.00035736400329775664]
 [0.9989667349721589, 3.637160569177917e-5, 0.0009986547529333139]
 [0.9976693482594007, 3.618034114668738e-5, 0.002296523179421331]
 [0.9955173445672584, 3.585168447721858e-5, 0.004449001326174204]
 [0.9923306680361907, 3.5355219052201335e-5, 0.007635786241278095]
 [0.9879536883502447, 3.466830210889213e-5, 0.01201209910926726]
 [0.982264774182583, 3.3778584463574584e-5, 0.017699339681656823]
 ⋮
 [0.16101311610756355, 3.6409483951866994e-7, 1.7717393859724986]
 [0.16097698503207641, 3.6380026699353855e-7, 1.7727617084153096]
 [0.16093965370430868, 3.635063893124764e-7, 1.7737733180299007]
 [0.16090188330881788, 3.632135954299369e-7, 1.7747796907692384]
 [0.1608763891096321, 3.6293869407092225e-7, 1.7758710320410174]
 [0.16084433237478693, 3.626506634003173e-7, 1.7769143132863736]
 [0.16080941606305643, 3.623608463786976e-7, 1.7779351961855394]
 [0.16077329295908052, 3.620716770995924e-7, 1.7789453922557155]
 [0.16073672555084775, 3.617835555782565e-7, 1.7799503674176607]
 [0.16071244700492104, 3.6151331295537085e-7, 1.781040158149396]
 [0.1606867406194908, 3.61236959550888e-7, 1.7821180917835804]
 [0.1606270267919411, 3.608284157304295e-7, 1.7822270910875606]
julia> sol.destats
DiffEqBase.DEStats
Number of function 1 evaluations:                  31374
Number of function 2 evaluations:                  0
Number of W matrix evaluations:                    10393
Number of linear solves:                           39398
Number of Jacobians created:                       2372
Number of nonlinear solver iterations:             0
Number of nonlinear solver convergence failures:   0
Number of rootfind condition calls:                0
Number of accepted steps:                          734
Number of rejected steps:                          1633
```
After:
```
julia> sol = solve(prob,ImplicitEulerBarycentricExtrapolation())
retcode: Success
Interpolation: 3rd order Hermite
t: 80-element Array{Float64,1}:
      0.0
      0.0015609382820287144
      0.0038833624899373516
      0.007502342478267317
      0.024797873022477254
      0.07304938472754041
      0.17841192362251737
      0.3767745550872523
      0.7173315557285374
      1.2695427726421196
      2.136016246092731
      3.473535050518359
      5.52378127166028
      ⋮
  26528.645070333834
  31180.844798025428
  36055.85564540747
  41250.527799529336
  46868.45389663336
  53029.789859258875
  59880.259286347835
  67602.40709501403
  76429.57743665235
  86661.53553388221
  98673.80510369067
 100000.0
u: 80-element Array{Array{Float64,1},1}:
 [1.0, 0.0, 0.0]
 [0.999937568656632, 3.4174828624568736e-5, 2.8256514751432795e-5]
 [0.9998447429788678, 3.648042892008056e-5, 0.00011869563872186919]
 [0.999700268799024, 3.6468807903125026e-5, 0.0002631849882886165]
 [0.9990127168280291, 3.634190683624001e-5, 0.0009510040183157015]
 [0.9971195432746125, 3.599428585378989e-5, 0.0028450427445917714]
 [0.9931080631276625, 3.5266676833273e-5, 0.006858401954158697]
 [0.985974468238819, 3.400306866655391e-5, 0.013995096573923994]
 [0.974827869309884, 3.210673918577629e-5, 0.025145520857089876]
 [0.9591060476597548, 2.959426080847843e-5, 0.04087011128598496]
 [0.9386786980737309, 2.6610030853776247e-5, 0.06129597463639398]
 [0.9137910043678629, 2.3386199837557187e-5, 0.08617425179404514]
 [0.8849129246853812, 2.0170425688698916e-5, 0.11503293969183888]
 ⋮
 [0.09856757789434414, 3.7724875480643603e-7, 1.0446766292627245]
 [0.09177208085963502, 3.4524614406375155e-7, 1.0628588307439415]
 [0.0857940504723483, 3.179650772058156e-7, 1.078918314585921]
 [0.08040166581436958, 2.940185916026992e-7, 1.0934916532085452]
 [0.075440378384415, 2.7251744314580534e-7, 1.1069993554082842]
 [0.07080032410738986, 2.528526433822939e-7, 1.1197389562419766]
 [0.06639983411652342, 2.3458814227485295e-7, 1.1319313741124781]
 [0.06217593865895769, 2.1740051333283115e-7, 1.1437474068379008]
 [0.05807915754085324, 2.0104528715423021e-7, 1.155322060447837]
 [0.0540716184557164, 1.853413163074036e-7, 1.1667591854190698]
 [0.05012928481110871, 1.7017324867228753e-7, 1.178123401832567]
 [0.04965327738747586, 1.6839170489581858e-7, 1.1792639536172758]
julia> sol.destats
DiffEqBase.DEStats
Number of function 1 evaluations:                  1467
Number of function 2 evaluations:                  0
Number of W matrix evaluations:                    295
Number of linear solves:                           1681
Number of Jacobians created:                       83
Number of nonlinear solver iterations:             0
Number of nonlinear solver convergence failures:   0
Number of rootfind condition calls:                0
Number of accepted steps:                          79
Number of rejected steps:                          0 
```
I will attach the benchmarks of the same problem shortly.
@ChrisRackauckas @kanav99 please have a look.