### PR TITLE
Order and step-sizing fixes in Implicit Euler Extrapolation Methods

### DIFF
--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -135,11 +135,11 @@ get_current_adaptive_order(alg::ImplicitDeuflhardExtrapolation,cache) = 2cache.n
 get_current_alg_order(alg::ExtrapolationMidpointHairerWanner,cache) = 2(cache.n_curr + 1)
 get_current_alg_order(alg::ImplicitHairerWannerExtrapolation,cache) = 2(cache.n_curr + 1)
 get_current_alg_order(alg::ImplicitEulerBarycentricExtrapolation,cache) = cache.n_curr
-get_current_alg_order(alg::ImplicitEulerExtrapolation,cache) = cache.n_curr
+get_current_alg_order(alg::ImplicitEulerExtrapolation,cache) = cache.n_curr + 1
 get_current_adaptive_order(alg::ExtrapolationMidpointHairerWanner,cache) = 2cache.n_curr
 get_current_adaptive_order(alg::ImplicitHairerWannerExtrapolation,cache) = 2cache.n_curr
-get_current_adaptive_order(alg::ImplicitEulerExtrapolation,cache) = cache.n_curr
-get_current_adaptive_order(alg::ImplicitEulerBarycentricExtrapolation,cache) = cache.n_curr - 1
+get_current_adaptive_order(alg::ImplicitEulerExtrapolation,cache) = cache.n_curr - 1
+get_current_adaptive_order(alg::ImplicitEulerBarycentricExtrapolation,cache) = cache.n_curr - 2
 
 
 #alg_adaptive_order(alg::OrdinaryDiffEqAdaptiveAlgorithm) = error("Algorithm is adaptive with no order")
@@ -447,7 +447,7 @@ beta1_default(alg::ExtrapolationMidpointDeuflhard,beta2) =  1//(2alg.n_init+1)
 beta1_default(alg::ImplicitDeuflhardExtrapolation,beta2) =  1//(2alg.n_init+1)
 beta1_default(alg::ExtrapolationMidpointHairerWanner,beta2) =  1//(2alg.n_init+1)
 beta1_default(alg::ImplicitHairerWannerExtrapolation,beta2) =  1//(2alg.n_init+1)
-beta1_default(alg::ImplicitEulerExtrapolation,beta2) =  1//(2alg.n_init+1)
+beta1_default(alg::ImplicitEulerExtrapolation,beta2) =  1//(alg.n_init+1)
 beta1_default(alg::ImplicitEulerBarycentricExtrapolation,beta2) =  1//(alg.n_init - 1)
 
 gamma_default(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = isadaptive(alg) ? 9//10 : 0

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -134,12 +134,12 @@ get_current_adaptive_order(alg::ExtrapolationMidpointDeuflhard,cache) = 2cache.n
 get_current_adaptive_order(alg::ImplicitDeuflhardExtrapolation,cache) = 2cache.n_curr
 get_current_alg_order(alg::ExtrapolationMidpointHairerWanner,cache) = 2(cache.n_curr + 1)
 get_current_alg_order(alg::ImplicitHairerWannerExtrapolation,cache) = 2(cache.n_curr + 1)
-get_current_alg_order(alg::ImplicitEulerBarycentricExtrapolation,cache) = 2(cache.n_curr + 1)
-get_current_alg_order(alg::ImplicitEulerExtrapolation,cache) = 2(cache.n_curr + 1)
+get_current_alg_order(alg::ImplicitEulerBarycentricExtrapolation,cache) = cache.n_curr
+get_current_alg_order(alg::ImplicitEulerExtrapolation,cache) = cache.n_curr
 get_current_adaptive_order(alg::ExtrapolationMidpointHairerWanner,cache) = 2cache.n_curr
 get_current_adaptive_order(alg::ImplicitHairerWannerExtrapolation,cache) = 2cache.n_curr
-get_current_adaptive_order(alg::ImplicitEulerExtrapolation,cache) = 2cache.n_curr
-get_current_adaptive_order(alg::ImplicitEulerBarycentricExtrapolation,cache) = 2cache.n_curr
+get_current_adaptive_order(alg::ImplicitEulerExtrapolation,cache) = cache.n_curr
+get_current_adaptive_order(alg::ImplicitEulerBarycentricExtrapolation,cache) = cache.n_curr - 1
 
 
 #alg_adaptive_order(alg::OrdinaryDiffEqAdaptiveAlgorithm) = error("Algorithm is adaptive with no order")
@@ -402,7 +402,7 @@ alg_maximum_order(alg::ExtrapolationMidpointHairerWanner) = 2(alg.n_max+1)
 alg_maximum_order(alg::ImplicitHairerWannerExtrapolation) = 2(alg.n_max+1)
 alg_maximum_order(alg::ImplicitEulerExtrapolation) = 2(alg.n_max+1)
 
-alg_maximum_order(alg::ImplicitEulerBarycentricExtrapolation) = 2(alg.n_max+1)
+alg_maximum_order(alg::ImplicitEulerBarycentricExtrapolation) = alg.n_max
 alg_adaptive_order(alg::ExplicitRK) = alg.tableau.adaptiveorder
 alg_adaptive_order(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = alg_order(alg)-1
 alg_adaptive_order(alg::Feagin10) = 8
@@ -448,7 +448,7 @@ beta1_default(alg::ImplicitDeuflhardExtrapolation,beta2) =  1//(2alg.n_init+1)
 beta1_default(alg::ExtrapolationMidpointHairerWanner,beta2) =  1//(2alg.n_init+1)
 beta1_default(alg::ImplicitHairerWannerExtrapolation,beta2) =  1//(2alg.n_init+1)
 beta1_default(alg::ImplicitEulerExtrapolation,beta2) =  1//(2alg.n_init+1)
-beta1_default(alg::ImplicitEulerBarycentricExtrapolation,beta2) =  1//(2alg.n_init+1)
+beta1_default(alg::ImplicitEulerBarycentricExtrapolation,beta2) =  1//(alg.n_init - 1)
 
 gamma_default(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = isadaptive(alg) ? 9//10 : 0
 gamma_default(alg::RKC) = 8//10
@@ -459,7 +459,7 @@ gamma_default(alg::ExtrapolationMidpointHairerWanner) = (65//100)^beta1_default(
 gamma_default(alg::ImplicitHairerWannerExtrapolation) = (65//100)^beta1_default(alg,beta2_default(alg))
 gamma_default(alg::ImplicitEulerExtrapolation) = (65//100)^beta1_default(alg,beta2_default(alg))
 
-gamma_default(alg::ImplicitEulerBarycentricExtrapolation) = (65//100)^beta1_default(alg,beta2_default(alg))
+gamma_default(alg::ImplicitEulerBarycentricExtrapolation) = (80//100)^beta1_default(alg,beta2_default(alg))
 
 qsteady_min_default(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = 1
 qsteady_max_default(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = 1

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -74,9 +74,9 @@ end
 
 function ImplicitEulerExtrapolation(;chunk_size=0,autodiff=true,
     diff_type=Val{:forward},linsolve=DEFAULT_LINSOLVE,
-    max_order=10,min_order=1,init_order=5,threading=true,sequence = :bulirsch)
+    max_order=12,min_order=3,init_order=5,threading=true,sequence = :bulirsch)
 
-    n_min = max(2,min_order)
+    n_min = max(3,min_order)
     n_init = max(n_min + 1,init_order)
     n_max = max(n_init + 1, max_order)
     if threading
@@ -279,10 +279,10 @@ struct ImplicitEulerBarycentricExtrapolation{CS,AD,F,FDT} <: OrdinaryDiffEqImpli
 end
 function ImplicitEulerBarycentricExtrapolation(;chunk_size=0,autodiff=true,
   linsolve=DEFAULT_LINSOLVE,diff_type=Val{:forward},
-  min_order=2,init_order=5,max_order=10,sequence = :harmonic,threading=false,sequence_factor = 2)
+  min_order=3,init_order=5,max_order=12,sequence = :harmonic,threading=false,sequence_factor = 2)
   # Enforce 2 <=  min_order
   # and min_order + 1 <= init_order <= max_order - 1:
-  n_min = max(2, min_order)
+  n_min = max(3, min_order)
   n_init = max(n_min + 1, init_order)
   n_max = max(n_init + 1, max_order)
 


### PR DESCRIPTION
Hi, so I had checked step-sizing implementation for Implicit Euler Extrapolation Methods. The order scaling was being used of Midpoint Methods which are of higher-order, hence resulting in small step-sizes.  It is fixed now in `controllers.jl` with correct order step-sizing and also updated in `alg_utils.jl`. The order window has been changed to default Hairer code values as mentioned here https://github.com/luchr/ODEInterface.jl/blob/master/src/Seulex.jl#L336-L338.

Results:
Before:
```
julia> sol = solve(prob,ImplicitEulerBarycentricExtrapolation())
retcode: Success
Interpolation: 3rd order Hermite
t: 80-element Array{Float64,1}:
      0.0
      0.0015609382820287144
      0.0038833624899373516
      0.007502342478267317
      0.024797873022477254
      0.07304938472754041
      0.17841192362251737
      0.3767745550872523
      0.7173315557285374
      1.2695427726421196
      2.136016246092731
      3.473535050518359
      5.52378127166028
      ⋮
  26528.645070333834
  31180.844798025428
  36055.85564540747
  41250.527799529336
  46868.45389663336
  53029.789859258875
  59880.259286347835
  67602.40709501403
  76429.57743665235
  86661.53553388221
  98673.80510369067
 100000.0
u: 80-element Array{Array{Float64,1},1}:
 [1.0, 0.0, 0.0]
 [0.999937568656632, 3.4174828624568736e-5, 2.8256514751432795e-5]
 [0.9998447429788678, 3.648042892008056e-5, 0.00011869563872186919]
 [0.999700268799024, 3.6468807903125026e-5, 0.0002631849882886165]
 [0.9990127168280291, 3.634190683624001e-5, 0.0009510040183157015]
 [0.9971195432746125, 3.599428585378989e-5, 0.0028450427445917714]
 [0.9931080631276625, 3.5266676833273e-5, 0.006858401954158697]
 [0.985974468238819, 3.400306866655391e-5, 0.013995096573923994]
 [0.974827869309884, 3.210673918577629e-5, 0.025145520857089876]
 [0.9591060476597548, 2.959426080847843e-5, 0.04087011128598496]
 [0.9386786980737309, 2.6610030853776247e-5, 0.06129597463639398]
 [0.9137910043678629, 2.3386199837557187e-5, 0.08617425179404514]
 [0.8849129246853812, 2.0170425688698916e-5, 0.11503293969183888]
 ⋮
 [0.09856757789434414, 3.7724875480643603e-7, 1.0446766292627245]
 [0.09177208085963502, 3.4524614406375155e-7, 1.0628588307439415]
 [0.0857940504723483, 3.179650772058156e-7, 1.078918314585921]
 [0.08040166581436958, 2.940185916026992e-7, 1.0934916532085452]
 [0.075440378384415, 2.7251744314580534e-7, 1.1069993554082842]
 [0.07080032410738986, 2.528526433822939e-7, 1.1197389562419766]
 [0.06639983411652342, 2.3458814227485295e-7, 1.1319313741124781]
 [0.06217593865895769, 2.1740051333283115e-7, 1.1437474068379008]
 [0.05807915754085324, 2.0104528715423021e-7, 1.155322060447837]
 [0.0540716184557164, 1.853413163074036e-7, 1.1667591854190698]
 [0.05012928481110871, 1.7017324867228753e-7, 1.178123401832567]
 [0.04965327738747586, 1.6839170489581858e-7, 1.1792639536172758]
julia> sol.destats
DiffEqBase.DEStats
Number of function 1 evaluations:                  1467
Number of function 2 evaluations:                  0
Number of W matrix evaluations:                    295
Number of linear solves:                           1681
Number of Jacobians created:                       83
Number of nonlinear solver iterations:             0
Number of nonlinear solver convergence failures:   0
Number of rootfind condition calls:                0
Number of accepted steps:                          79
Number of rejected steps:                          0
```
After:
```
julia> sol = solve(prob,ImplicitEulerBarycentricExtrapolation())
retcode: Success
Interpolation: 3rd order Hermite
t: 38-element Array{Float64,1}:
      0.0
      0.0019895916617064663
      0.01069580615688682
      0.13622727097111514
      1.9462158334088258
      5.5752843582279645
     13.781845437376278
     34.07685512942656
     99.02265309345259
    227.44016199230782
    347.2351102898627
    529.3359987937949
    739.7400402695904
      ⋮
   7650.788363787001
   9095.893639719112
  11040.033656727233
  13737.191756433422
  17611.554210817994
  23197.090881970995
  31319.04274886979
  40966.225811987424
  49446.46793573887
  59890.19493863742
  77533.18742686865
 100000.0
u: 38-element Array{Array{Float64,1},1}:
 [1.0, 0.0, 0.0]
 [0.9999204291393691, 3.5561185041121356e-5, 4.400967561260886e-5]
 [0.9995729559223238, 3.644642952896081e-5, 0.00039011041609949995]
 [0.994694537695402, 3.555312970053462e-5, 0.005270839698152516]
 [0.942799839980213, 2.7178123922722368e-5, 0.05719602148659764]
 [0.8843085150876675, 2.0089558270704015e-5, 0.11571878419341841]
 [0.8151453811674056, 1.4302247412452992e-5, 0.1849116710073444]
 [0.7319424907408939, 9.831783949413653e-6, 0.2681550535743972]
 [0.6188560096987714, 6.1818853000485e-6, 0.3818285529815796]
 [0.5232799324643338, 4.243528290332341e-6, 0.4807485075624622]
 [0.4723137834333632, 3.4750626494168956e-6, 0.5334800338739247]
 [0.4207263939079945, 2.8280332276717456e-6, 0.586882312762292]
 [0.3821356482406467, 2.402080628448163e-6, 0.6297112063291876]
 ⋮
 [0.16491794942656252, 7.189209483624563e-7, 0.9164558075422301]
 [0.1554180870952484, 6.626886949474939e-7, 0.9371371701605717]
 [0.14537427725267418, 6.048659083705944e-7, 0.9605390583967856]
 [0.13462413739231938, 5.450737202766779e-7, 0.9872311349508216]
 [0.12299702279641862, 4.830764171287055e-7, 1.0178361471252302]
 [0.11001871844103826, 4.182640327891675e-7, 1.051659642831036]
 [0.09683670918952411, 3.5591436078449825e-7, 1.0878571227195948]
 [0.08557637457011254, 3.0572022320626515e-7, 1.1192890635607418]
 [0.0777968905854029, 2.72780085477308e-7, 1.1404974359146611]
 [0.07059752682956451, 2.4310440195287806e-7, 1.161273325722123]
 [0.06129612078370883, 2.0629784026809529e-7, 1.1878833034246667]
 [0.05262483532980392, 1.73522393239353e-7, 1.2122395832464197]

julia> sol.destats
DiffEqBase.DEStats
Number of function 1 evaluations:                  1027
Number of function 2 evaluations:                  0
Number of W matrix evaluations:                    176
Number of linear solves:                           1164
Number of Jacobians created:                       41
Number of nonlinear solver iterations:             0
Number of nonlinear solver convergence failures:   0
Number of rootfind condition calls:                0
Number of accepted steps:                          37
Number of rejected steps:                          0
```
We have become much closer to SEULEX which is around ~ 24 steps. I didn't find any optimal init_order, so using the default one.
@ChrisRackauckas @kanav99 please have a look.