### PR TITLE
Allocation fixes in controllers for Hanner Wanner Methods

### DIFF
--- a/src/caches/extrapolation_caches.jl
+++ b/src/caches/extrapolation_caches.jl
@@ -1009,6 +1009,10 @@ end
 
   tf::TF
   uf::UF
+
+  #Stepsizing caches
+  work::Array{QType, 1}
+  dt_new::Array{QType,1}
 end
 
 function alg_cache(alg::ImplicitEulerBarycentricExtrapolation,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{false})
@@ -1032,10 +1036,12 @@ function alg_cache(alg::ImplicitEulerBarycentricExtrapolation,u,rate_prototype,u
   end
   sigma = 9//10
 
+  work = fill(zero(eltype(Q)),alg.n_max + 1)
+  dt_new = fill(zero(eltype(Q)), alg.n_max + 1)
   # Initialize the constant cache
   tf = TimeDerivativeWrapper(f,u,p)
   uf = UDerivativeWrapper(f,t,p)
-  ImplicitEulerBarycentricExtrapolationConstantCache(Q, n_curr, n_old, coefficients, stage_number, sigma, tf, uf)
+  ImplicitEulerBarycentricExtrapolationConstantCache(Q, n_curr, n_old, coefficients, stage_number, sigma, tf, uf, work, dt_new)
 end
 
 @cache mutable struct ImplicitEulerBarycentricExtrapolationCache{uType,uNoUnitsType,rateType,QType,extrapolation_coefficients,JType,WType,F,JCType,GCType,TFType,UFType} <: OrdinaryDiffEqMutableCache
@@ -1073,7 +1079,10 @@ end
   grad_config::GCType
   # Values to check overflow in T1 computation
   diff1::Array{uType,1}
-  diff2::Array{uType,1} 
+  diff2::Array{uType,1}
+  #Stepsizing caches
+  work::Array{QType, 1}
+  dt_new::Array{QType,1} 
 end
 
 
@@ -1154,5 +1163,5 @@ function alg_cache(alg::ImplicitEulerBarycentricExtrapolation,u,rate_prototype,u
   # Initialize the cache
   ImplicitEulerBarycentricExtrapolationCache(utilde, u_temp1, u_temp2, u_temp3, u_temp4, tmp, T, res, fsalfirst, k, k_tmps,
       cc.Q, cc.n_curr, cc.n_old, cc.coefficients, cc.stage_number, cc.sigma, du1, du2, J, W, tf, uf, linsolve_tmps,
-      linsolve, jac_config, grad_config,diff1,diff2)
+      linsolve, jac_config, grad_config,diff1,diff2,cc.work,cc.dt_new)
 end

--- a/src/caches/extrapolation_caches.jl
+++ b/src/caches/extrapolation_caches.jl
@@ -76,7 +76,6 @@ end
   k_tmps::Array{rateType,1}
   dtpropose::dtType
   T::arrayType
-  work::dtType
   A::Int
   step_no::Int
   du1::rateType
@@ -97,6 +96,10 @@ end
   n_old::Int # Storage for the extrapolation order n_curr before perfom_step! changes the latter
   sigma::Rational{Int} # Parameter for order selection
   res::uNoUnitsType # Storage for the scaled residual of u and utilde
+
+  #Stepsizing caches
+  work::Array{QType, 1}
+  dt_new::Array{QType,1} 
 end
 
 @cache mutable struct ImplicitEulerExtrapolationConstantCache{QType,dtType,arrayType,TF,UF,sequenceType} <: OrdinaryDiffEqConstantCache
@@ -105,7 +108,6 @@ end
   T::arrayType
   n_curr::Int
   n_old::Int
-  work::dtType
   A::Int
   step_no::Int
   sigma::Rational{Int}
@@ -115,6 +117,10 @@ end
 
   sequence::sequenceType #support for different sequences
   stage_number::Vector{Int}
+
+  #Stepsizing caches
+  work::Array{QType, 1}
+  dt_new::Array{QType,1} 
 end
 
 function alg_cache(alg::ImplicitEulerExtrapolation,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{false})
@@ -130,7 +136,6 @@ function alg_cache(alg::ImplicitEulerExtrapolation,u,rate_prototype,uEltypeNoUni
       T[i,j] = zero(u)
     end
   end
-  work = zero(dt)
   A = one(Int)
   step_no = zero(Int)
   tf = TimeDerivativeWrapper(f,u,p)
@@ -146,7 +151,9 @@ function alg_cache(alg::ImplicitEulerExtrapolation,u,rate_prototype,uEltypeNoUni
     stage_number[n] = 2 * Int(s) - n + 7
   end
   sigma = 9//10
-  ImplicitEulerExtrapolationConstantCache(Q,dtpropose,T,n_curr,n_old,work,A,step_no,sigma,tf,uf,sequence,stage_number)
+  work = fill(zero(eltype(Q)),alg.n_max + 1)
+  dt_new = fill(zero(eltype(Q)), alg.n_max + 1)
+  ImplicitEulerExtrapolationConstantCache(Q,dtpropose,T,n_curr,n_old,A,step_no,sigma,tf,uf,sequence,stage_number,work,dt_new)
 end
 
 function alg_cache(alg::ImplicitEulerExtrapolation,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{true})
@@ -177,7 +184,6 @@ function alg_cache(alg::ImplicitEulerExtrapolation,u,rate_prototype,uEltypeNoUni
       T[i,j] = zero(u)
     end
   end
-  work = zero(dt)
   A = one(Int)
   atmp = similar(u,uEltypeNoUnits)
   step_no = zero(Int)
@@ -223,8 +229,8 @@ function alg_cache(alg::ImplicitEulerExtrapolation,u,rate_prototype,uEltypeNoUni
   jac_config = build_jac_config(alg,f,uf,du1,uprev,u,du1,du2)
   sequence = generate_sequence(constvalue(uBottomEltypeNoUnits),alg)
   cc = alg_cache(alg,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,Val(false))
-  ImplicitEulerExtrapolationCache(uprev,u_tmps,utilde,tmp,atmp,k_tmps,dtpropose,T,work,A,step_no,
-    du1,du2,J,W,tf,uf,linsolve_tmps,linsolve,jac_config,grad_config,sequence,cc.stage_number,cc.Q,cc.n_curr,cc.n_old,cc.sigma,res)
+  ImplicitEulerExtrapolationCache(uprev,u_tmps,utilde,tmp,atmp,k_tmps,dtpropose,T,A,step_no,
+    du1,du2,J,W,tf,uf,linsolve_tmps,linsolve,jac_config,grad_config,sequence,cc.stage_number,cc.Q,cc.n_curr,cc.n_old,cc.sigma,res,cc.work,cc.dt_new)
 end
 
 
@@ -736,6 +742,10 @@ end
   coefficients::extrapolation_coefficients
   stage_number::Vector{Int} # stage_number[n] contains information for extrapolation order (n - 1)
   sigma::Rational{Int} # Parameter for order selection
+
+  #Stepsizing caches
+  work::Array{QType, 1}
+  dt_new::Array{QType,1} 
 end
 
 function alg_cache(alg::ExtrapolationMidpointHairerWanner,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{false})
@@ -758,8 +768,10 @@ function alg_cache(alg::ExtrapolationMidpointHairerWanner,u,rate_prototype,uElty
   end
   sigma = 9//10
 
+  work = fill(zero(eltype(Q)),alg.n_max + 1)
+  dt_new = fill(zero(eltype(Q)), alg.n_max + 1)
   # Initialize the constant cache
-  ExtrapolationMidpointHairerWannerConstantCache(Q, n_curr, n_old, coefficients, stage_number, sigma)
+  ExtrapolationMidpointHairerWannerConstantCache(Q, n_curr, n_old, coefficients, stage_number, sigma, work, dt_new)
 end
 
 @cache mutable struct ExtrapolationMidpointHairerWannerCache{uType,uNoUnitsType,rateType,QType,extrapolation_coefficients} <: OrdinaryDiffEqMutableCache
@@ -784,6 +796,10 @@ end
   coefficients::extrapolation_coefficients
   stage_number::Vector{Int} # stage_number[n] contains information for extrapolation order (n - 1)
   sigma::Rational{Int} # Parameter for order selection
+
+  #Stepsizing caches  
+  work::Array{QType, 1}
+  dt_new::Array{QType,1}
 end
 
 
@@ -816,7 +832,7 @@ function alg_cache(alg::ExtrapolationMidpointHairerWanner,u,rate_prototype,uElty
 
   # Initialize the cache
   ExtrapolationMidpointHairerWannerCache(utilde, u_temp1, u_temp2, u_temp3, u_temp4, tmp, T, res, fsalfirst, k, k_tmps,
-      cc.Q, cc.n_curr, cc.n_old, cc.coefficients, cc.stage_number, cc.sigma)
+      cc.Q, cc.n_curr, cc.n_old, cc.coefficients, cc.stage_number, cc.sigma,cc.work,cc.dt_new)
 end
 
 @cache mutable struct ImplicitHairerWannerExtrapolationConstantCache{QType,extrapolation_coefficients,TF,UF} <: OrdinaryDiffEqConstantCache
@@ -832,6 +848,10 @@ end
 
   tf::TF
   uf::UF
+
+  #Stepsizing caches
+  work::Array{QType, 1}
+  dt_new::Array{QType,1}   
 end
 
 function alg_cache(alg::ImplicitHairerWannerExtrapolation,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{false})
@@ -874,7 +894,9 @@ function alg_cache(alg::ImplicitHairerWannerExtrapolation,u,rate_prototype,uElty
   # Initialize the constant cache
   tf = TimeDerivativeWrapper(f,u,p)
   uf = UDerivativeWrapper(f,t,p)
-  ImplicitHairerWannerExtrapolationConstantCache(Q, n_curr, n_old, coefficients, stage_number, sigma, tf, uf)
+  work = fill(zero(eltype(Q)),alg.n_max + 1)
+  dt_new = fill(zero(eltype(Q)), alg.n_max + 1)
+  ImplicitHairerWannerExtrapolationConstantCache(Q, n_curr, n_old, coefficients, stage_number, sigma, tf, uf, work, dt_new)
 end
 
 @cache mutable struct ImplicitHairerWannerExtrapolationCache{uType,uNoUnitsType,rateType,QType,extrapolation_coefficients,JType,WType,F,JCType,GCType,TFType,UFType} <: OrdinaryDiffEqMutableCache
@@ -912,7 +934,11 @@ end
   grad_config::GCType
   # Values to check overflow in T1 computation
   diff1::Array{uType,1}
-  diff2::Array{uType,1} 
+  diff2::Array{uType,1}
+
+  #Stepsizing caches
+  work::Array{QType, 1}
+  dt_new::Array{QType,1} 
 end
 
 
@@ -993,7 +1019,7 @@ function alg_cache(alg::ImplicitHairerWannerExtrapolation,u,rate_prototype,uElty
   # Initialize the cache
   ImplicitHairerWannerExtrapolationCache(utilde, u_temp1, u_temp2, u_temp3, u_temp4, tmp, T, res, fsalfirst, k, k_tmps,
       cc.Q, cc.n_curr, cc.n_old, cc.coefficients, cc.stage_number, cc.sigma, du1, du2, J, W, tf, uf, linsolve_tmps,
-      linsolve, jac_config, grad_config,diff1,diff2)
+      linsolve, jac_config, grad_config,diff1,diff2,cc.work,cc.dt_new)
 end
 
 @cache mutable struct ImplicitEulerBarycentricExtrapolationConstantCache{QType,extrapolation_coefficients,TF,UF} <: OrdinaryDiffEqConstantCache

--- a/src/integrators/controllers.jl
+++ b/src/integrators/controllers.jl
@@ -427,7 +427,6 @@ function step_accept_controller!(integrator,alg::Union{ExtrapolationMidpointHair
   copyto!(dt_new,win_min_old,Q,win_min_old,(max(n_curr, n_old) + 1) - win_min_old + 1)
   @.. Q = integrator.dt/Q
   dtmin = timedepentdtmin(integrator)
-  dt_new[tmp] = max.(dtmin, min.(abs(integrator.opts.dtmax), abs.(dt_new[tmp]))) # Safety scaling
   fill!(work,zero(eltype(work))) # work[n] is the work for order (n-1)
   for i in tmp
     work[i] = s[i]/dt_new[i]


### PR DESCRIPTION
Hi, we were not previously caching `work` and `dt_new` arrays which were required in controllers calculation, and hence being redundant allocation was happening. I have made a fix for these methods. The performance improvement is not humongous, but unnecessary allocations have been swooped away. 

Before:
```
julia> for tfinal = 1.0:2.0:30.0
           tspan = (0.0, tfinal)
           prob = ODEProblem(test!, u0, tspan)
           integrator = init(prob, ExtrapolationMidpointHairerWanner(), save_everystep = false)
           @time solve!(integrator)
       end
  1.555949 seconds (3.29 M allocations: 150.225 MiB, 4.37% gc time)
  0.000075 seconds (95 allocations: 12.891 KiB)
  0.000206 seconds (141 allocations: 19.172 KiB)
  0.000194 seconds (186 allocations: 25.469 KiB)
  0.000195 seconds (186 allocations: 25.469 KiB)
  0.000114 seconds (188 allocations: 25.672 KiB)
  0.000184 seconds (233 allocations: 31.938 KiB)
  0.000165 seconds (280 allocations: 38.391 KiB)
  0.000279 seconds (281 allocations: 38.406 KiB)
  0.000198 seconds (326 allocations: 44.703 KiB)
  0.000181 seconds (326 allocations: 44.703 KiB)
  0.000209 seconds (328 allocations: 44.906 KiB)
  0.000207 seconds (373 allocations: 51.172 KiB)
  0.000287 seconds (420 allocations: 57.625 KiB)
  0.000351 seconds (420 allocations: 57.625 KiB)
```
After:
```
julia> for tfinal = 1.0:2.0:30.0
           tspan = (0.0, tfinal)
           prob = ODEProblem(test!, u0, tspan)
           integrator = init(prob, ExtrapolationMidpointHairerWanner(), save_everystep = false)
           @time solve!(integrator)
       end
  0.156939 seconds (368.53 k allocations: 17.480 MiB)
  0.000054 seconds (77 allocations: 10.672 KiB)
  0.000073 seconds (113 allocations: 15.828 KiB)
  0.000093 seconds (150 allocations: 21.031 KiB)
  0.000214 seconds (150 allocations: 21.031 KiB)
  0.000095 seconds (152 allocations: 21.234 KiB)
  0.000192 seconds (188 allocations: 26.391 KiB)
  0.000195 seconds (226 allocations: 31.734 KiB)
  0.000197 seconds (226 allocations: 31.734 KiB)
  0.000156 seconds (263 allocations: 36.938 KiB)
  0.000192 seconds (263 allocations: 36.938 KiB)
  0.000311 seconds (265 allocations: 37.141 KiB)
  0.000217 seconds (301 allocations: 42.297 KiB)
  0.000207 seconds (339 allocations: 47.641 KiB)
  0.000250 seconds (339 allocations: 47.641 KiB)
```
And proportional changes in other methods.