### PR TITLE
Higher order calculations in ImplicitEulerExtrapolation

### DIFF
--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -289,7 +289,7 @@ function perform_step!(integrator,cache::ImplicitEulerExtrapolationCache,repeat_
           # Deuflhard Stability check for initial two sequences 
           @.. diff2[1] = u_tmps[1] - u_tmps2[1]
           @.. diff2[1] = 0.5*(diff2[1] - diff1[1])
-          if(integrator.opts.internalnorm(diff1[1],t)<integrator.opts.internalnorm(diff2[1],t))
+          if integrator.opts.internalnorm(diff1[1],t)<integrator.opts.internalnorm(diff2[1],t)
             # Divergence of iteration, overflow is possible. Force fail and start with smaller step
             integrator.force_stepfail = true
             return
@@ -322,11 +322,11 @@ function perform_step!(integrator,cache::ImplicitEulerExtrapolationCache,repeat_
               @.. k_tmps[Threads.threadid()] = -k_tmps[Threads.threadid()]
               @.. u_tmps2[Threads.threadid()] = u_tmps[Threads.threadid()]
               @.. u_tmps[Threads.threadid()] = u_tmps[Threads.threadid()] + k_tmps[Threads.threadid()]
-              if(index<=2 && j>=2)
+              if index<=2 && j>=2
                 # Deuflhard Stability check for initial two sequences 
                 @.. diff2[Threads.threadid()] = u_tmps[Threads.threadid()] - u_tmps2[Threads.threadid()]
                 @.. diff2[Threads.threadid()] = 0.5*(diff2[Threads.threadid()] - diff1[Threads.threadid()])
-                if(integrator.opts.internalnorm(diff1[Threads.threadid()],t)<integrator.opts.internalnorm(diff2[Threads.threadid()],t))
+                if integrator.opts.internalnorm(diff1[Threads.threadid()],t)<integrator.opts.internalnorm(diff2[Threads.threadid()],t)
                   # Divergence of iteration, overflow is possible. Force fail and start with smaller step
                   integrator.force_stepfail = true
                   return
@@ -349,7 +349,7 @@ function perform_step!(integrator,cache::ImplicitEulerExtrapolationCache,repeat_
     integrator.destats.nsolve += nevals
   end
 
-  if(integrator.force_stepfail)
+  if integrator.force_stepfail
     return
   end
 
@@ -477,11 +477,11 @@ function perform_step!(integrator,cache::ImplicitEulerExtrapolationConstantCache
         integrator.destats.nsolve += 1
         u_tmp2 = u_tmp
         u_tmp = u_tmp + k
-        if(index<=2 && j>=2)
+        if index<=2 && j>=2
           # Deuflhard Stability check for initial two sequences
           diff2 = u_tmp - u_tmp2
           diff2 = 0.5*(diff2 - diff1)
-          if(integrator.opts.internalnorm(diff1,t)<integrator.opts.internalnorm(diff2,t))
+          if integrator.opts.internalnorm(diff1,t)<integrator.opts.internalnorm(diff2,t)
             # Divergence of iteration, overflow is possible. Force fail and start with smaller step
             integrator.force_stepfail = true
             return
@@ -511,11 +511,11 @@ function perform_step!(integrator,cache::ImplicitEulerExtrapolationConstantCache
               k = _reshape(W\-_vec(dt_temp*k_copy), axes(uprev))
               u_tmp2 = u_tmp
               u_tmp = u_tmp + k
-              if(index<=2 && j>=2)
+              if index<=2 && j>=2
                 # Deuflhard Stability check for initial two sequences
                 diff2 = u_tmp - u_tmp2
                 diff2 = 0.5*(diff2 - diff1)
-                if(integrator.opts.internalnorm(diff1,t)<integrator.opts.internalnorm(diff2,t))
+                if integrator.opts.internalnorm(diff1,t)<integrator.opts.internalnorm(diff2,t)
                   # Divergence of iteration, overflow is possible. Force fail and start with smaller step
                   integrator.force_stepfail = true
                   return
@@ -530,7 +530,7 @@ function perform_step!(integrator,cache::ImplicitEulerExtrapolationConstantCache
       end
     end
     
-    if(integrator.force_stepfail)
+    if integrator.force_stepfail
       return
     end
 

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -285,7 +285,7 @@ function perform_step!(integrator,cache::ImplicitEulerExtrapolationCache,repeat_
         @.. k_tmps[1] = -k_tmps[1]
         @.. u_tmps2[1] = u_tmps[1]
         @.. u_tmps[1] = u_tmps[1] + k_tmps[1]
-        if(index<=2 && j>=2)
+        if index<=2 && j>=2
           # Deuflhard Stability check for initial two sequences 
           @.. diff2[1] = u_tmps[1] - u_tmps2[1]
           @.. diff2[1] = 0.5*(diff2[1] - diff1[1])

--- a/src/perform_step/extrapolation_perform_step.jl
+++ b/src/perform_step/extrapolation_perform_step.jl
@@ -287,8 +287,8 @@ function perform_step!(integrator,cache::ImplicitEulerExtrapolationCache,repeat_
         @.. u_tmps[1] = u_tmps[1] + k_tmps[1]
         if(index<=2 && j>=2)
           # Deuflhard Stability check for initial two sequences 
-          diff2[1] = u_tmps[1] - u_tmps2[1]
-          diff2[1] = 0.5*(diff2[1] - diff1[1])
+          @.. diff2[1] = u_tmps[1] - u_tmps2[1]
+          @.. diff2[1] = 0.5*(diff2[1] - diff1[1])
           if(integrator.opts.internalnorm(diff1[1],t)<integrator.opts.internalnorm(diff2[1],t))
             # Divergence of iteration, overflow is possible. Force fail and start with smaller step
             integrator.force_stepfail = true
@@ -324,8 +324,8 @@ function perform_step!(integrator,cache::ImplicitEulerExtrapolationCache,repeat_
               @.. u_tmps[Threads.threadid()] = u_tmps[Threads.threadid()] + k_tmps[Threads.threadid()]
               if(index<=2 && j>=2)
                 # Deuflhard Stability check for initial two sequences 
-                diff2[Threads.threadid()] = u_tmps[Threads.threadid()] - u_tmps2[Threads.threadid()]
-                diff2[Threads.threadid()] = 0.5*(diff2[Threads.threadid()] - diff1[Threads.threadid()])
+                @.. diff2[Threads.threadid()] = u_tmps[Threads.threadid()] - u_tmps2[Threads.threadid()]
+                @.. diff2[Threads.threadid()] = 0.5*(diff2[Threads.threadid()] - diff1[Threads.threadid()])
                 if(integrator.opts.internalnorm(diff1[Threads.threadid()],t)<integrator.opts.internalnorm(diff2[Threads.threadid()],t))
                   # Divergence of iteration, overflow is possible. Force fail and start with smaller step
                   integrator.force_stepfail = true


### PR DESCRIPTION
Hi, so I was checking whether Implicit Euler with Aitken Neville works with higher-order or not. It turns out that it overflows, and we need to reduce the `dt` at which we are computing. Hence, I made a fix similar to other Implicit Methods.
For eg.
**using high order like 20 in ROBER ODE:**
Before:
```
julia> sol = solve(prob,ImplicitEulerExtrapolation(min_order = 20))
┌ Warning: Threading in `ImplicitEulerExtrapolation` is currently disabled. Thus `threading` has been changed from `true` to `false`.
└ @ OrdinaryDiffEq C:\Users\Utkarsh\.julia\dev\OrdinaryDiffEq\src\algorithms.jl:83
┌ Warning: Instability detected. Aborting
└ @ DiffEqBase C:\Users\Utkarsh\.julia\packages\DiffEqBase\dKNbf\src\integrator_interface.jl:349
retcode: Unstable
Interpolation: 3rd order Hermite
t: 1-element Array{Float64,1}:
 0.0
u: 1-element Array{Array{Float64,1},1}:
 [1.0, 0.0, 0.0]
```
After:
```
julia> sol = solve(prob,ImplicitEulerExtrapolation(min_order = 20))
┌ Warning: Threading in `ImplicitEulerExtrapolation` is currently disabled. Thus `threading` has been changed from `true` to `false`.
└ @ OrdinaryDiffEq C:\Users\Utkarsh\.julia\dev\OrdinaryDiffEq\src\algorithms.jl:83
retcode: Success
Interpolation: 3rd order Hermite
t: 21-element Array{Float64,1}:
      0.0
      0.0015609382820287144
      0.011001749605620578
      0.06775757172412648
      0.36983974389820923
      1.2962698391952399
      3.727942365172029
      9.943568634020206
     26.518773814266726
     74.81637205296006
    233.42581098519383
    832.7345676290291
   2158.145539152609
   4617.786637793755
   8190.726946702099
  12775.039383312673
  23739.63765698102
  34582.62996253259
  56226.64660513247
  95508.56166612636
 100000.0
u: 21-element Array{Array{Float64,1},1}:
 [1.0, 0.0, 0.0]
 [0.9999375686614472, 3.419779507102845e-5, 2.8233543696178877e-5]
 [0.9995607692774234, 3.644310635560517e-5, 0.00040278761661060946]
 [0.9973253987875421, 3.603212015972786e-5, 0.0026385690927053767]
 [0.9862150979775987, 3.404561128801746e-5, 0.013750857308980647]
 [0.9584052224151375, 2.9486668787613843e-5, 0.041565483842833414]
 [0.9097046229790426, 2.2893296159717246e-5, 0.0902746733906135]
 [0.8418190697228017, 1.626899663050772e-5, 0.1581710179338828]
 [0.7562003655408687, 1.0935494405337653e-5, 0.2437983374789446]
 [0.649673994337944, 6.998439936510152e-6, 0.3503301375385432]
 [0.5170762184830957, 4.174558895618247e-6, 0.48293123536812804]
 [0.35928741460840796, 2.219941119577383e-6, 0.6407221213062583]
 [0.24709599501952081, 1.3059484842979802e-6, 0.7529144704674314]
 [0.16970248920687017, 8.151387513513569e-7, 0.8303084850268713]
 [0.12170588283853598, 5.532304675683344e-7, 0.8783055386991467]
 [0.09128398865668488, 4.012783156482845e-7, 0.9087282987499247]
 [0.05864932261618709, 2.4900386324924527e-7, 0.9414159506628607]
 [0.043853527781572026, 1.8333665735582641e-7, 0.9562424263516499]
 [0.029640188048821736, 1.2209433890434602e-7, 0.9707482303660615]
 [0.019270179932253242, 7.84833194615212e-8, 0.9820219281140218]
 [0.018475338753422835, 7.517616781533427e-8, 0.9828168096391945]
```
@ChrisRackauckas @kanav99 could you please have a look?