### PR TITLE
Fix AD of the Radau integrators

### DIFF
--- a/src/caches/firk_caches.jl
+++ b/src/caches/firk_caches.jl
@@ -16,8 +16,8 @@ end
 function alg_cache(alg::RadauIIA3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{false})
   uf  = UDerivativeWrapper(f, t, p)
-  uToltype = real(uBottomEltypeNoUnits)
-  tab = RadauIIA3Tableau(uToltype, real(tTypeNoUnits))
+  uToltype = constvalue(uBottomEltypeNoUnits)
+  tab = RadauIIA3Tableau(uToltype, constvalue(tTypeNoUnits))
 
   κ = convert(uToltype, 1//100)
   J = false .* _vec(rate_prototype) .* _vec(rate_prototype)'
@@ -63,8 +63,8 @@ end
 function alg_cache(alg::RadauIIA3,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{true})
   uf = UJacobianWrapper(f, t, p)
-  uToltype = real(uBottomEltypeNoUnits)
-  tab = RadauIIA3Tableau(uToltype, real(tTypeNoUnits))
+  uToltype = constvalue(uBottomEltypeNoUnits)
+  tab = RadauIIA3Tableau(uToltype, constvalue(tTypeNoUnits))
 
   κ = alg.κ !== nothing ? convert(uToltype, alg.κ) : convert(uToltype, 1//100)
 
@@ -117,8 +117,8 @@ end
 function alg_cache(alg::RadauIIA5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{false})
   uf  = UDerivativeWrapper(f, t, p)
-  uToltype = real(uBottomEltypeNoUnits)
-  tab = RadauIIA5Tableau(uToltype, real(tTypeNoUnits))
+  uToltype = constvalue(uBottomEltypeNoUnits)
+  tab = RadauIIA5Tableau(uToltype, constvalue(tTypeNoUnits))
 
   κ = alg.κ !== nothing ? convert(uToltype, alg.κ) : convert(uToltype, 1//100)
   J = false .* _vec(rate_prototype) .* _vec(rate_prototype)'
@@ -171,8 +171,8 @@ end
 function alg_cache(alg::RadauIIA5,u,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,
                    tTypeNoUnits,uprev,uprev2,f,t,dt,reltol,p,calck,::Val{true})
   uf = UJacobianWrapper(f, t, p)
-  uToltype = real(uBottomEltypeNoUnits)
-  tab = RadauIIA5Tableau(uToltype, real(tTypeNoUnits))
+  uToltype = constvalue(uBottomEltypeNoUnits)
+  tab = RadauIIA5Tableau(uToltype, constvalue(tTypeNoUnits))
 
   κ = alg.κ !== nothing ? convert(uToltype, alg.κ) : convert(uToltype, 1//100)
 

--- a/src/integrators/controllers.jl
+++ b/src/integrators/controllers.jl
@@ -15,7 +15,7 @@
       end
       fac = min(gamma,(1+2*maxiters)*gamma/(iter+2*maxiters))
     end
-    expo = 1/(get_current_adaptive_order(integrator.alg,integrator.cache)+1)
+    expo = 1/(get_current_adaptive_order(integrator.alg,integrator.cache) + 1)
     qtmp = DiffEqBase.fastpow(integrator.EEst,expo)/fac
     @fastmath q = DiffEqBase.value(max(inv(integrator.opts.qmax),min(inv(integrator.opts.qmin),qtmp)))
     integrator.qold = q

--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -190,8 +190,7 @@ function _loopfooter!(integrator)
       integrator.last_stepfail = false
       dtnew = DiffEqBase.value(step_accept_controller!(integrator,integrator.alg,q)) * oneunit(integrator.dt)
       integrator.tprev = integrator.t
-      # integrator.EEst has unitless type of integrator.t
-      if typeof(integrator.EEst)<: AbstractFloat && !isempty(integrator.opts.tstops)
+      if integrator.t isa AbstractFloat && !isempty(integrator.opts.tstops)
         tstop = integrator.tdir * first(integrator.opts.tstops)
         abs(ttmp - tstop) < 10eps(max(integrator.t,tstop)/oneunit(integrator.t))*oneunit(integrator.t) ?
                                   (integrator.t = tstop) : (integrator.t = ttmp)
@@ -206,8 +205,7 @@ function _loopfooter!(integrator)
   elseif !integrator.opts.adaptive #Not adaptive
     integrator.destats.naccept += 1
     integrator.tprev = integrator.t
-    # integrator.EEst has unitless type of integrator.t
-    if typeof(integrator.EEst)<: AbstractFloat && !isempty(integrator.opts.tstops)
+    if integrator.t isa AbstractFloat && !isempty(integrator.opts.tstops)
       tstop = integrator.tdir * first(integrator.opts.tstops)
       abs(ttmp - tstop) < 10eps(integrator.t/oneunit(integrator.t))*oneunit(integrator.t) ?
                                   (integrator.t = tstop) : (integrator.t = ttmp)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -266,7 +266,14 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
     sizehint!(ks,2)
   end
 
-  QT = tTypeNoUnits <: Integer ? typeof(qmin) : typeof(internalnorm(u, t))
+  QT = if tTypeNoUnits <: Integer
+    typeof(qmin)
+  elseif prob isa DiscreteProblem
+    # The QT fields are not used for DiscreteProblems
+    constvalue(tTypeNoUnits)
+  else
+    typeof(internalnorm(u, t))
+  end
 
   k = rateType[]
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -266,7 +266,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
     sizehint!(ks,2)
   end
 
-  QT = tTypeNoUnits <: Integer ? typeof(qmin) : tTypeNoUnits
+  QT = tTypeNoUnits <: Integer ? typeof(qmin) : constvalue(tTypeNoUnits)
 
   k = rateType[]
 
@@ -359,7 +359,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
   kshortsize = 0
   reeval_fsal = false
   u_modified = false
-  EEst = tTypeNoUnits(1)
+  EEst = QT(1)
   just_hit_tstop = false
   isout = false
   accept_step = false
@@ -369,9 +369,9 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
   vector_event_last_time = 1
   last_event_error = typeof(alg) <: FunctionMap ? false : zero(uBottomEltypeNoUnits)
   dtchangeable = isdtchangeable(alg)
-  q11 = tTypeNoUnits(1)
+  q11 = QT(1)
   success_iter = 0
-  erracc = tTypeNoUnits(1)
+  erracc = QT(1)
   dtacc = tType(1)
   reinitiailize = true
   saveiter = 0 # Starts at 0 so first save is at 1

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -266,7 +266,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
     sizehint!(ks,2)
   end
 
-  QT = tTypeNoUnits <: Integer ? typeof(qmin) : constvalue(tTypeNoUnits)
+  QT = tTypeNoUnits <: Integer ? typeof(qmin) : typeof(internalnorm(u, t))
 
   k = rateType[]
 

--- a/test/integrators/dae_initialization_tests.jl
+++ b/test/integrators/dae_initialization_tests.jl
@@ -158,14 +158,14 @@ f = function (du,u,p,t)
 	du - u
 end
 
-u₀ = 1.0
-du₀ = 0.0
-tspan = (0.0,1.0)
-differential_vars = [true]
+u₀ = SVector(1.0)
+du₀ = SVector(0.0)
+tspan = (0.0, 1.0)
+differential_vars = SVector(true)
 prob = DAEProblem(f,du₀,u₀,tspan,differential_vars=differential_vars)
 integrator = init(prob, DABDF2())
 
-@test integrator.du ≈ 1.0 atol=1e-9
+@test integrator.du ≈ [1.0] atol=1e-9
 
 f = function (du,u,p,t)
 	du .- u

--- a/test/interface/ad_tests.jl
+++ b/test/interface/ad_tests.jl
@@ -224,7 +224,7 @@ SOLVERS_FOR_AD = (
     (Rosenbrock32, 1e-11),
     (Vern6       , 1e-11),
     (Vern7       , 1e-11),
-    (RadauIIA3   , 1e-12),
+    (RadauIIA3   , 1e-04),
     (RadauIIA5   , 1e-12),
 )
 

--- a/test/interface/ad_tests.jl
+++ b/test/interface/ad_tests.jl
@@ -224,6 +224,8 @@ SOLVERS_FOR_AD = (
     (Rosenbrock32, 1e-11),
     (Vern6       , 1e-11),
     (Vern7       , 1e-11),
+    (RadauIIA3   , 1e-12),
+    (RadauIIA5   , 1e-12),
 )
 
 @testset "$alg can handle ForwardDiff.Dual in u0 with rtol=$rtol when iip=$iip" for


### PR DESCRIPTION
The change is to use `internalnorm` to intialize `EEst` correctly.