### PR TITLE
Fix initialization of W for static arrays

### DIFF
--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -575,7 +575,7 @@ function build_J_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits,::Val{IIP}) where IIP
     elseif IIP
       similar(J)
     else
-      ArrayInterface.lu_instance(J)
+      lu(J, check=false)
     end
   end
   return J, W


### PR DESCRIPTION
To trigger this, I'm using LabelledArrays in the AD tests I recently added. I'm not sure the `ArrayInterface.lu_instance` approach can be made completely robust and, at least, it isn't right for `LabelledArrays` right now. The setup costs of computing the LU once should be small. Generally, I think it would be useful if initialization was based on the actual values since it's so easy to get the types wrong when you do it heuristically instead of using the instances.