### PR TITLE
support resize! with non-Int size; help wanted

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -53,6 +53,7 @@ DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 DiffEqOperators = "9fdde737-9c7f-55bf-ade8-46b3f136cc48"
 DiffEqProblemLibrary = "a077e3f3-b75c-5d7f-a0c6-6bc4c8ec64a9"
 DiffEqSensitivity = "41bf760c-e81c-5289-8e54-58b1f1f8abe2"
+ElasticArrays = "fdbdab4c-e67f-52f5-8c3f-e7b388dad3d4"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -66,4 +67,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Calculus", "DelayDiffEq", "DiffEqCallbacks", "DiffEqDevTools", "DiffEqOperators", "DiffEqProblemLibrary", "DiffEqSensitivity", "InteractiveUtils", "PoissonRandom", "Printf", "Random", "SafeTestsets", "SparseArrays", "Statistics", "Test", "Unitful", "ModelingToolkit", "Pkg"]
+test = ["Calculus", "DelayDiffEq", "DiffEqCallbacks", "DiffEqDevTools", "DiffEqOperators", "DiffEqProblemLibrary", "DiffEqSensitivity", "ElasticArrays", "InteractiveUtils", "PoissonRandom", "Printf", "Random", "SafeTestsets", "SparseArrays", "Statistics", "Test", "Unitful", "ModelingToolkit", "Pkg"]

--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -113,6 +113,18 @@ function resize!(integrator::ODEIntegrator, i::Int)
   resize_J_W!(cache, integrator, i)
   resize_non_user_cache!(integrator, cache, i)
 end
+# we can't use resize!(..., i::Union{Int, NTuple{N,Int}}) where {N} because of method ambiguities with DiffEqBase
+function resize!(integrator::ODEIntegrator, i::NTuple{N,Int}) where {N}
+  @unpack cache = integrator
+
+  for c in full_cache(cache)
+    resize!(c,i)
+  end
+  # TODO the parts below need to be adapted for implicit methods
+  isdefined(integrator.cache, :nlsolver) && resize_nlsolver!(integrator, i)
+  resize_J_W!(cache, integrator, i)
+  resize_non_user_cache!(integrator, cache, i)
+end
 
 function resize_J_W!(cache, integrator, i)
   (isdefined(cache, :J) && isdefined(cache, :W)) || return


### PR DESCRIPTION
**Background**

We want to make use of OrdinaryDiffEq.jl etc. for our hyperbolic PDE solver package [Trixi.jl](https://github.com/trixi-framework/Trixi.jl), see https://github.com/trixi-framework/Trixi.jl/issues/83. For us, the most natural data layout is given by multidimensional arrays. To use adaptive mesh refinement (AMR), we need to resize the last dimension of these arrays.

For me, the best option how to implement AMR seems to be to create an appropriate callback. However, multidimensional `Array`s don't support `resize!`. One option might be to use [ElasticArrays.jl](https://github.com/JuliaArrays/ElasticArrays.jl), but these are not supported by OrdinaryDiffEq.jl's `resize!(integrator, i)`. Hence, I've modified that code to support this additional flexibility.

**Limitations**

Currently, this works only for explicit methods. I think it would be nice to enable the same for implicit methods, but I would like to ask for help to do that, since I'm not that experienced with the overall structure of implicit solvers in OrdinaryDiffEq.jl.

**Other approaches**

Are there other approaches we could use?
- We cannot simply set the relevant parts of the caches to something new as we did before in our own implementation since the caches in OrdinaryDiffEq.jl are immutable (`struct`). Or am I missing something here?
- Needing to use `ElasticArray` doesn't feel completely good to me, since we also want to experiment with other array types such as [PaddedMatrices.jl](https://github.com/chriselrod/PaddedMatrices.jl), see https://github.com/trixi-framework/Trixi.jl/issues/166. Then, we would need to wrap an `Array` inside something from PaddedMatrices.jl inside something from ElasticArrays.jl - or the other way round? Is that possible at all? If we go further, this looks like it could easily explode.
- We could try to use `Vector`s inside OrdinaryDiffEq.jl which we somehow wrap inside Trixi.jl as our multidimensional `Array`s. However, that feels a bit like in the old days when FORTRAN ODE solvers only accepted plain vectors. Additionally, the most straightforward approach I can think of fails:
  ```julia
  julia> v = ones(6)
  6-element Array{Float64,1}:
  1.0
  1.0
  1.0
  1.0
  1.0
  1.0

  julia> function foo(v)
            vm = reshape(v, (2, length(v)÷2))
            vm[1, 2]
        end
  foo (generic function with 1 method)

  julia> foo(v)
  1.0

  julia> v[3] = 5
  5

  julia> foo(v)
  5.0

  julia> resize!(v, 8)
  ERROR: cannot resize array with shared data
  Stacktrace:
  [1] _growend! at ./array.jl:892 [inlined]
  [2] resize!(::Array{Float64,1}, ::Int64) at ./array.jl:1085
  [3] top-level scope at REPL[6]:1
  ```
  Instead, it looks like we need to use something like 
  ```julia
  julia> function foo(v)
            vm = unsafe_wrap(Array{eltype(v), 2}, pointer(v), (2, length(v)÷2))
            vm[1, 2]
        end
  ```
  That might work but doesn't look completely convincing to me. But maybe it's our best option...

Do you have any ideas how to achieve our goal using OrdinaryDiffEq.jl and callbacks?