### PR TITLE
fix resize! for LowStorageRK2NCache; closes #1277

### DIFF
--- a/src/perform_step/low_storage_rk_perform_step.jl
+++ b/src/perform_step/low_storage_rk_perform_step.jl
@@ -50,6 +50,13 @@ end
   @unpack k,tmp,williamson_condition = cache
   @unpack A2end,B1,B2end,c2end = cache.tab
 
+  if integrator.u_modified
+    if !get_current_isfsal(integrator.alg, integrator.cache)
+      f(k, u, p, t+dt)
+    end
+    @.. tmp = dt*k
+  end
+
   # u1
   @.. u   = u + B1*tmp
   # other stages


### PR DESCRIPTION
This fixes #1277 for `DiscreteCallback`s. I had to re-eval the FSAL part, since the 2N methods are not recognized as FSAL methods although they evaluate the RHS for the new step. Why?