### PR TITLE
Make composite ode_interpolant type stable

### DIFF
--- a/src/dense/generic_dense.jl
+++ b/src/dense/generic_dense.jl
@@ -142,7 +142,7 @@ end
   if !(typeof(integrator.cache) <: CompositeCache)
     ode_interpolant!(val,Θ,integrator.t-integrator.tprev,integrator.uprev2,integrator.uprev,integrator.k,integrator.cache,idxs,deriv)
   else
-    composite_ode_extrapolant!(val,θ,integrator,integrator.cache.caches,integrator.cache.current,idxs,deriv)
+    composite_ode_extrapolant!(val,Θ,integrator,integrator.cache.caches,integrator.cache.current,idxs,deriv)
   end
 end
 

--- a/test/interface/composite_algorithm_test.jl
+++ b/test/interface/composite_algorithm_test.jl
@@ -21,3 +21,7 @@ solve!(integrator2)
 
 sol = solve(prob,alg_switch)
 @inferred DiffEqBase.__init(prob, alg_switch)
+v = @inferred OrdinaryDiffEq.ode_interpolant(1.0, integrator1, integrator1.opts.save_idxs, Val{0})
+@inferred OrdinaryDiffEq.ode_interpolant!(v, 1.0, integrator1, integrator1.opts.save_idxs, Val{0})
+v = @inferred OrdinaryDiffEq.ode_extrapolant(1.0, integrator1, integrator1.opts.save_idxs, Val{0})
+@inferred OrdinaryDiffEq.ode_extrapolant!(v, 1.0, integrator1, integrator1.opts.save_idxs, Val{0})


### PR DESCRIPTION
This PR removes a dynamic dispatch in the composite branch of `ode_interpolant`.