### PR TITLE
Change initialization of heaps and add interface for DelayDiffEq

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.group == 'Downstream' }}
     strategy:
       matrix:
         group:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEq"
 uuid = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "5.45.1"
+version = "5.46.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -252,12 +252,11 @@ function DiffEqBase.reinit!(integrator::ODEIntegrator,u0 = integrator.sol.prob.u
   integrator.tprev = t0
 
   tType = typeof(integrator.t)
-  tstops_internal, saveat_internal, d_discontinuities_internal =
-    tstop_saveat_disc_handling(tstops, saveat, d_discontinuities, (tType(t0), tType(tf)))
-
-  integrator.opts.tstops = tstops_internal
-  integrator.opts.saveat = saveat_internal
-  integrator.opts.d_discontinuities = d_discontinuities_internal
+  tspan = (tType(t0), tType(tf))
+  integrator.opts.tstops = initialize_tstops(tType, tstops, d_discontinuities, tspan)
+  integrator.opts.saveat = initialize_saveat(tType, saveat, tspan)
+  integrator.opts.d_discontinuities =
+    initialize_d_discontinuities(tType, d_discontinuities, tspan)
 
   if erase_sol
     if integrator.opts.save_start


### PR DESCRIPTION
This PR adds separate functions for the initialization of the `tstops`, `saveat`, and `d_discontinuities` heaps which makes it easier to initialize these heaps with different types in DelayDiffEq. Moreover, it adds an interface for retrieving the next time stop and discontinuity instead of operating with `integrator.opts.tstops` and `integrator.opts.d_discontinuities` directly. This allows to separate user-provided time stops and discontinuities and propagated discontinuities and their corresponding time stops in DelayDiffEq, which allows to fix https://github.com/SciML/DelayDiffEq.jl/issues/188.