### PR TITLE
Fix setting of rate_prototype in __init for ArrayPartition types

### DIFF
--- a/src/misc_utils.jl
+++ b/src/misc_utils.jl
@@ -54,3 +54,8 @@ function diffdir(integrator::DiffEqBase.DEIntegrator)
           integrator.t > integrator.sol.prob.tspan[2] - difference ? -true :  true :
           integrator.t < integrator.sol.prob.tspan[2] + difference ?  true : -true
 end
+
+# Recursively test if all elements in an ArrayPartition are AbstractArray
+isarrays(u::ArrayPartition) = all(isarrays(x) for x in u.x)
+isarrays(u::T) where {T<:AbstractArray} = true
+isarrays(u) = false

--- a/src/misc_utils.jl
+++ b/src/misc_utils.jl
@@ -54,8 +54,3 @@ function diffdir(integrator::DiffEqBase.DEIntegrator)
           integrator.t > integrator.sol.prob.tspan[2] - difference ? -true :  true :
           integrator.t < integrator.sol.prob.tspan[2] + difference ?  true : -true
 end
-
-# Recursively test if all elements in an ArrayPartition are AbstractArray
-isarrays(u::ArrayPartition) = all(isarrays(x) for x in u.x)
-isarrays(u::T) where {T<:AbstractArray} = true
-isarrays(u) = false

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -178,11 +178,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
   # dtmin is all abs => does not care about sign already.
 
   if !isdae && isinplace(prob) && typeof(u) <: AbstractArray && eltype(u) <: Number && uBottomEltypeNoUnits == uBottomEltype && tType == tTypeNoUnits # Could this be more efficient for other arrays?
-    if !(typeof(u) <: ArrayPartition) || isarrays(u)
-      rate_prototype = recursivecopy(u)
-    else # this is for ArrayPartition that is unitless but holds non-arrays
-      rate_prototype = similar(u, typeof.(oneunit.(recursive_bottom_eltype.(u.x))./oneunit(tType))...)
-    end
+    rate_prototype = recursivecopy(u)
   elseif prob isa DAEProblem
     rate_prototype = prob.du0
   else

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -178,9 +178,9 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
   # dtmin is all abs => does not care about sign already.
 
   if !isdae && isinplace(prob) && typeof(u) <: AbstractArray && eltype(u) <: Number && uBottomEltypeNoUnits == uBottomEltype && tType == tTypeNoUnits # Could this be more efficient for other arrays?
-    if typeof(u) <: ArrayPartition
+    if !(typeof(u) <: ArrayPartition) || isarrays(u)
       rate_prototype = recursivecopy(u)
-    else
+    else # this is for ArrayPartition that is unitless but holds non-arrays
       rate_prototype = similar(u, typeof.(oneunit.(recursive_bottom_eltype.(u.x))./oneunit(tType))...)
     end
   elseif prob isa DAEProblem
@@ -470,6 +470,7 @@ function DiffEqBase.solve!(integrator::ODEIntegrator)
 end
 
 # Helpers
+
 
 function handle_dt!(integrator)
   if iszero(integrator.dt) && integrator.opts.adaptive

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -178,7 +178,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
   # dtmin is all abs => does not care about sign already.
 
   if !isdae && isinplace(prob) && typeof(u) <: AbstractArray && eltype(u) <: Number && uBottomEltypeNoUnits == uBottomEltype && tType == tTypeNoUnits # Could this be more efficient for other arrays?
-    if !(typeof(u) <: ArrayPartition)
+    if typeof(u) <: ArrayPartition
       rate_prototype = recursivecopy(u)
     else
       rate_prototype = similar(u, typeof.(oneunit.(recursive_bottom_eltype.(u.x))./oneunit(tType))...)


### PR DESCRIPTION
I removed the negation on the conditional `typeof(u) <: ArrayPartition` to enable use of `recursivecopy` to set `rate_prototype` for `ArrayPartition` type `u`.

Fixes #1308 