### PR TITLE
Simplify type construction with AbstractFloat time

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -263,7 +263,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
     sizehint!(ks,2)
   end
 
-  QT = if tTypeNoUnits <: Integer
+  QT = if tTypeNoUnits <: Union{Integer,AbstractFloat}
     typeof(qmin)
   elseif prob isa DiscreteProblem
     # The QT fields are not used for DiscreteProblems


### PR DESCRIPTION
Unitful numbers are not AbstractFloat so it handles this case better.