### PR TITLE
addtest arraypartition and callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.jl.*.mem
 Manifest.toml
 *.DS_Store
+.vscode

--- a/test/integrators/ode_event_tests.jl
+++ b/test/integrators/ode_event_tests.jl
@@ -374,7 +374,7 @@ end
 
 affect! = nothingf =
 affect_neg! = function (integrator)
-  integrator.u = ArrayPartition(integrator.u[1], -integrator.u[2])
+  integrator.u = ArrayPartition(SVector{1}(integrator.u[1]), SVector{1}(-integrator.u[2]))
 end
 
 callback = ContinuousCallback(condition,affect!,affect_neg!,interp_points=100)

--- a/test/integrators/ode_event_tests.jl
+++ b/test/integrators/ode_event_tests.jl
@@ -362,3 +362,25 @@ end
 callback = VectorContinuousCallback(condition, affect!, 1)
 sol = solve(prob, Tsit5(), callback=callback)
 @test n == 1
+
+# case of immutable partitioned state
+f = function (u,p,t)
+  ArrayPartition(SVector{1}(u[2]), SVector{1}(-9.81))
+end
+
+condition= function (u,t,integrator) # Event when event_f(u,t,k) == 0
+  u[1]
+end
+
+affect! = nothingf =
+affect_neg! = function (integrator)
+  integrator.u = ArrayPartition(integrator.u[1], -integrator.u[2])
+end
+
+callback = ContinuousCallback(condition,affect!,affect_neg!,interp_points=100)
+
+u0 = ArrayPartition(SVector{1}(50.0), SVector{1}(0.0))
+tspan = (0.0,15.0)
+prob = ODEProblem(f,u0,tspan)
+
+sol = solve(prob,Tsit5(),callback=callback,adaptive=false,dt=1/4)


### PR DESCRIPTION
Added a test with state variable of type `ArrayPartition{Float64,Tuple{SVector,SVector}}` and using a callback.
The failing `addsteps!` tries to change the state variable after the user callbacks are finished.

This test should error as long as this fix is not in place https://github.com/SciML/RecursiveArrayTools.jl/pull/128

with a stacktrace like
```
[7] copyat_or_push! at .julia/packages/RecursiveArrayTools/mTQGQ/src/utils.jl:68 [inlined]
[9] addsteps!(::Array{ArrayPartition{Float64,Tuple{StaticArrays.SArray{Tuple{1},Float64,1,1},StaticArrays.SArray{Tuple{1},Float64,1,1}}},1}, ::Float64, ::ArrayPartition{Float64,Tuple{StaticArrays.SArray{Tuple{1},Float64,1,1},StaticArrays.SArray{Tuple{1},Float64,1,1}}}, ::ArrayPartition{Float64,Tuple{StaticArrays.SArray{Tuple{1},Float64,1,1},StaticArrays.SArray{Tuple{1},Float64,1,1}}}, ::Float64, ::ODEFunction{false,Main.Part.var"#97#98",UniformScaling{Bool},Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing}, ::DiffEqBase.NullParameters, ::OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}, ::Bool, ::Bool, ::Bool) at dev/OrdinaryDiffEq/src/dense/low_order_rk_addsteps.jl:451