### PR TITLE
Fix ElasticArray tests

### DIFF
--- a/test/integrators/ode_cache_tests.jl
+++ b/test/integrators/ode_cache_tests.jl
@@ -87,6 +87,11 @@ affect_matrix! = function (integrator)
 end
 callback_matrix = ContinuousCallback(condition_matrix, affect_matrix!)
 
+Base.similar(x::ElasticArrays.ElasticArray, ::Type{T}) where T = deepcopy(x)
+Base.copy(x::ElasticArrays.ElasticArray) = deepcopy(x)
+Base.zero(x::ElasticArrays.ElasticArray) = ElasticArray(zero(Array(x)))
+Base.resize!(x::ElasticArrays.ElasticArray,i::Tuple) = resize!(x,i...)
+
 for alg in CACHE_TEST_ALGS
   OrdinaryDiffEq.isimplicit(alg) && continue # this restriction should be removed in the future
   @show alg


### PR DESCRIPTION
This is kind of a hack, but it looks like there was a major regression in that library and I'm not quite sure why, but given I found this while working on https://github.com/SciML/SciMLBase.jl/pull/1 I'm putting a fix to ElasticArrays right inline and will upstream that later. I'm kind of confused because I don't see a recent tag from ElasticArrays but it could've been a versioning thing.