### PR TITLE
Try running GPU tests without code coverage.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@ steps:
     agents:
       queue: "juliagpu"
       cuda: "*"
-    timeout_in_minutes: 120
+    timeout_in_minutes: 30
     # Don't run Buildkite if the commit message includes the text [skip tests]
     if: build.message !~ /\[skip tests\]/
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,8 +4,7 @@ steps:
       - JuliaCI/julia#v0.6:
           version: "1.5"
       - JuliaCI/julia-test#v0.3:
-      # - JuliaCI/julia-coverage#v0.3:
-      #     codecov: true
+           coverage: false # 1000x slowdown
     agents:
       queue: "juliagpu"
       cuda: "*"


### PR DESCRIPTION
It isn't submitted anyway, and this looks to be the cause for a 1000x slowdown.