### PR TITLE
Enforce correct saveat after final tstop change

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -1,0 +1,51 @@
+name: IntegrationTest
+on:
+  push:
+    branches: [master]
+    tags: [v*]
+  pull_request:
+
+jobs:
+  test:
+    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}
+    runs-on: ${{ matrix.os }}
+    env:
+      GROUP: ${{ matrix.package.group }}
+    strategy:
+      fail-fast: false
+      matrix:
+        julia-version: [1]
+        os: [ubuntu-latest]
+        package:
+          - {user: SciML, repo: DelayDiffEq.jl, group: All}
+          - {user: SciML, repo: StochasticDiffEq.jl, group: All}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: x64
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: Clone Downstream
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
+          path: downstream
+      - name: Load this and run the downstream tests
+        shell: julia --color=yes --project=downstream {0}
+        run: |
+          using Pkg
+          try
+            # force it to use this PR's version of the package
+            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
+            Pkg.update()
+            Pkg.test()  # resolver may fail with test time deps
+          catch err
+            err isa Pkg.Resolve.ResolverError || rethrow()
+            # If we can't resolve that means this is incompatible by SemVer and this is fine
+            # It means we marked this as a breaking change, so we don't need to worry about
+            # Mistakenly introducing a breaking change, as we have intentionally made one
+            @info "Not compatible with this release. No problem." exception=err
+            exit(0)  # Exit immediately, as a success
+          end

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEq"
 uuid = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "5.50.2"
+version = "5.51.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -136,7 +136,9 @@ end
 function solution_endpoint_match_cur_integrator!(integrator)
   if integrator.opts.save_end &&
      (integrator.saveiter == 0 || integrator.sol.t[integrator.saveiter] !=  integrator.t &&
-     ((integrator.opts.save_end_user isa Bool && integrator.opts.save_end_user) || integrator.t ∈ integrator.opts.saveat_cache))
+     ((integrator.opts.save_end_user isa Bool && integrator.opts.save_end_user) ||
+       integrator.t ∈ integrator.opts.saveat_cache ||
+       integrator.t == integrator.sol.prob.tspan[2]))
 
     integrator.saveiter += 1
     copyat_or_push!(integrator.sol.t,integrator.saveiter,integrator.t)

--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -134,7 +134,10 @@ function _postamble!(integrator)
 end
 
 function solution_endpoint_match_cur_integrator!(integrator)
-  if integrator.opts.save_end && (integrator.saveiter == 0 || integrator.sol.t[integrator.saveiter] !=  integrator.t)
+  if integrator.opts.save_end &&
+     (integrator.saveiter == 0 || integrator.sol.t[integrator.saveiter] !=  integrator.t &&
+     ((integrator.opts.save_end_user isa Bool && integrator.opts.save_end_user) || integrator.t ∈ integrator.opts.saveat_cache))
+
     integrator.saveiter += 1
     copyat_or_push!(integrator.sol.t,integrator.saveiter,integrator.t)
     if integrator.opts.save_idxs === nothing

--- a/src/integrators/type.jl
+++ b/src/integrators/type.jl
@@ -1,4 +1,4 @@
-mutable struct DEOptions{absType,relType,QT,tType,F1,F2,F3,F4,F5,F6,tstopsType,discType,ECType,SType,MI,tcache,savecache,disccache}
+mutable struct DEOptions{absType,relType,QT,tType,F1,F2,F3,F4,F5,F6,F7,tstopsType,discType,ECType,SType,MI,tcache,savecache,disccache}
   maxiters::MI
   save_everystep::Bool
   adaptive::Bool
@@ -25,7 +25,7 @@ mutable struct DEOptions{absType,relType,QT,tType,F1,F2,F3,F4,F5,F6,tstopsType,d
   progress::Bool
   progress_steps::Int
   progress_name::String
-  progress_message::F5
+  progress_message::F6
   timeseries_errors::Bool
   dense_errors::Bool
   beta1::QT
@@ -35,9 +35,10 @@ mutable struct DEOptions{absType,relType,QT,tType,F1,F2,F3,F4,F5,F6,tstopsType,d
   save_on::Bool
   save_start::Bool
   save_end::Bool
-  callback::F3
-  isoutofdomain::F4
-  unstable_check::F6
+  save_end_user::F3
+  callback::F4
+  isoutofdomain::F5
+  unstable_check::F7
   verbose::Bool
   calck::Bool
   force_dtmin::Bool

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -19,7 +19,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
                            save_everystep = isempty(saveat),
                            save_on = true,
                            save_start = save_everystep || isempty(saveat) || saveat isa Number || prob.tspan[1] in saveat,
-                           save_end = save_everystep || isempty(saveat) || saveat isa Number || prob.tspan[2] in saveat,
+                           save_end = nothing,
                            callback = nothing,
                            dense = save_everystep && !(typeof(alg) <: Union{DAEAlgorithm,FunctionMap}) && isempty(saveat),
                            calck = (callback !== nothing && callback != CallbackSet()) || (dense), # and no dense output
@@ -305,8 +305,13 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
 
   dtmin === nothing && (dtmin = DiffEqBase.prob2dtmin(prob; use_end_time=false))
 
+  save_end_user = save_end
+  save_end = save_everystep || isempty(saveat) || saveat isa Number || prob.tspan[2] in saveat
+
   opts = DEOptions{typeof(abstol_internal),typeof(reltol_internal),QT,tType,
-                   typeof(internalnorm),typeof(internalopnorm),typeof(callbacks_internal),typeof(isoutofdomain),
+                   typeof(internalnorm),typeof(internalopnorm),typeof(save_end_user),
+                   typeof(callbacks_internal),
+                   typeof(isoutofdomain),
                    typeof(progress_message),typeof(unstable_check),typeof(tstops_internal),
                    typeof(d_discontinuities_internal),typeof(userdata),typeof(save_idxs),
                    typeof(maxiters),typeof(tstops),typeof(saveat),
@@ -321,7 +326,8 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
                        userdata,progress,progress_steps,
                        progress_name,progress_message,timeseries_errors,dense_errors,
                        QT(beta1),QT(beta2),QT(qoldinit),dense,
-                       save_on,save_start,save_end,callbacks_internal,isoutofdomain,
+                       save_on,save_start,save_end,save_end_user,
+                       callbacks_internal,isoutofdomain,
                        unstable_check,verbose,
                        calck,force_dtmin,advance_to_tstop,stop_at_next_tstop)
 
@@ -529,7 +535,7 @@ function initialize_saveat(::Type{T}, saveat, tspan) where T
   elseif !isempty(saveat)
     for t in saveat
       tdir_t = tdir * t
-      tdir_t0 < tdir_t < tdir_tf && push!(saveat_internal, tdir_t)
+      tdir_t0 < tdir_t ≤ tdir_tf && push!(saveat_internal, tdir_t)
     end
   end
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -306,7 +306,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
   dtmin === nothing && (dtmin = DiffEqBase.prob2dtmin(prob; use_end_time=false))
 
   save_end_user = save_end
-  save_end = save_everystep || isempty(saveat) || saveat isa Number || prob.tspan[2] in saveat
+  save_end = save_end === nothing ? save_everystep || isempty(saveat) || saveat isa Number || prob.tspan[2] in saveat : save_end
 
   opts = DEOptions{typeof(abstol_internal),typeof(reltol_internal),QT,tType,
                    typeof(internalnorm),typeof(internalopnorm),typeof(save_end_user),

--- a/test/interface/ode_saveat_tests.jl
+++ b/test/interface/ode_saveat_tests.jl
@@ -129,3 +129,9 @@ tspan = (0.0, 15.0)
 prob = ODEProblem(small_f,u0,tspan)
 sol = solve(prob, Tsit5(), saveat=4.)
 @test sol.t == [0.0,4,8,12,15]
+
+_saveat = [0.0,0.25,0.5,1.0]
+integ = init(ODEProblem((u,p,t)->u,0.0,(0.0,1.0)),Tsit5(),saveat=_saveat)
+add_tstop!(integ,2.0)
+solve!(integ)
+@test integ.sol.t == _saveat

--- a/test/interface/ode_saveat_tests.jl
+++ b/test/interface/ode_saveat_tests.jl
@@ -140,3 +140,8 @@ integ = init(ODEProblem((u,p,t)->u,0.0,(0.0,1.0)),Tsit5(),saveat=_saveat,save_en
 add_tstop!(integ,2.0)
 solve!(integ)
 @test integ.sol.t == [0.0,0.25,0.5,1.0,2.0]
+
+integ = init(ODEProblem((u,p,t)->u,0.0,(0.0,1.0)),Tsit5(),saveat=_saveat,save_end = false)
+add_tstop!(integ,2.0)
+solve!(integ)
+@test integ.sol.t == _saveat

--- a/test/interface/ode_saveat_tests.jl
+++ b/test/interface/ode_saveat_tests.jl
@@ -135,3 +135,8 @@ integ = init(ODEProblem((u,p,t)->u,0.0,(0.0,1.0)),Tsit5(),saveat=_saveat)
 add_tstop!(integ,2.0)
 solve!(integ)
 @test integ.sol.t == _saveat
+
+integ = init(ODEProblem((u,p,t)->u,0.0,(0.0,1.0)),Tsit5(),saveat=_saveat,save_end = true)
+add_tstop!(integ,2.0)
+solve!(integ)
+@test integ.sol.t == [0.0,0.25,0.5,1.0,2.0]


### PR DESCRIPTION
This is an odd one. If the user has the final time point in the `saveat` array, then `save_end == true`. Then if you `add_tstop!`, the final time point is no longer the final `saveat` which broke an assumption in the system. This decouples the `save_end` handling from the `saveat` mechanism so that if this `tstop` changes, it doesn't save the wrong point. It then needs to store whether the user overrode `save_end` (vs `save_end` as calculated by the default) in order to allow saving that new and improved endpoint.

A similar change is needed in StochasticDiffEq.jl, DelayDiffEq.jl, and StochasticDelayDiffEq.jl since they are vulnerable to the same issue.