### PR TITLE
hotfix save early end with maxiters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEq"
 uuid = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "5.51.0"
+version = "5.51.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -138,7 +138,8 @@ function solution_endpoint_match_cur_integrator!(integrator)
      (integrator.saveiter == 0 || integrator.sol.t[integrator.saveiter] !=  integrator.t &&
      ((integrator.opts.save_end_user isa Bool && integrator.opts.save_end_user) ||
        integrator.t ∈ integrator.opts.saveat_cache ||
-       integrator.t == integrator.sol.prob.tspan[2]))
+       integrator.t == integrator.sol.prob.tspan[2] ||
+       isempty(integrator.opts.saveat_cache)))
 
     integrator.saveiter += 1
     copyat_or_push!(integrator.sol.t,integrator.saveiter,integrator.t)

--- a/test/interface/ode_saveat_tests.jl
+++ b/test/interface/ode_saveat_tests.jl
@@ -145,3 +145,11 @@ integ = init(ODEProblem((u,p,t)->u,0.0,(0.0,1.0)),Tsit5(),saveat=_saveat,save_en
 add_tstop!(integ,2.0)
 solve!(integ)
 @test integ.sol.t == _saveat
+
+# Catch save for maxiters
+ode = ODEProblem((u,p,t) -> u, 1.0, (0.0, 1.0))
+sol = solve(ode, Tsit5(), save_everystep=false) # okay, as expected
+@test length(sol) == 2
+@info "Warning Expected"
+sol = solve(ode, Tsit5(), save_everystep=false, maxiters=3) # doesn't save the final solution anymore!
+@test length(sol) == 2


### PR DESCRIPTION
It was no longer saving the end point when one exited early with no saveat after https://github.com/SciML/OrdinaryDiffEq.jl/pull/1348. This fixes the behavior that was before by opting out of the new system if no saveat is found, and adds a test.