### PR TITLE
Do not allow error exit when switching in autoswitch

### DIFF
--- a/src/composite_algs.jl
+++ b/src/composite_algs.jl
@@ -31,7 +31,9 @@ function is_stiff(integrator, alg, ntol, stol, is_stiffalg)
   stiffness = abs(eigen_est*dt/alg_stability_size(alg)) # `abs` here is just for safety
   tol = is_stiffalg ? stol : ntol
   os = oneunit(stiffness)
-  stiffness > os * tol
+  bool = stiffness > os * tol
+  integrator.do_error_check = !bool
+  bool
 end
 
 function (AS::AutoSwitchCache)(integrator)

--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -174,6 +174,7 @@ function _loopfooter!(integrator)
   # But not set to false when reset so algorithms can check if reset occurred
   integrator.reeval_fsal = false
   integrator.u_modified = false
+  integrator.do_error_check = true
   ttmp = integrator.t + integrator.dt
   if integrator.force_stepfail
       if integrator.opts.adaptive
@@ -265,6 +266,7 @@ function handle_callbacks!(integrator)
 
   integrator.u_modified = continuous_modified || discrete_modified
   if integrator.u_modified
+    integrator.do_error_check = false
     handle_callback_modifiers!(integrator)
   end
 end

--- a/src/integrators/type.jl
+++ b/src/integrators/type.jl
@@ -109,6 +109,7 @@ mutable struct ODEIntegrator{algType<:Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm
   force_stepfail::Bool
   last_stepfail::Bool
   just_hit_tstop::Bool
+  do_error_check::Bool
   event_last_time::Int
   vector_event_last_time::Int
   last_event_error::EventErrorType
@@ -131,6 +132,7 @@ mutable struct ODEIntegrator{algType<:Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm
       eigen_est,EEst,qold,q11,erracc,dtacc,success_iter,
       iter,saveiter,saveiter_dense,cache,callback_cache,
       kshortsize,force_stepfail,last_stepfail,just_hit_tstop,
+      do_error_check,
       event_last_time,vector_event_last_time,last_event_error,
       accept_step,isout,reeval_fsal,u_modified,reinitialize,isdae,
       opts,destats,initializealg) where {algType,IIP,uType,duType,tType,pType,
@@ -146,6 +148,7 @@ mutable struct ODEIntegrator{algType<:Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm
       eigen_est,EEst,qold,q11,erracc,dtacc,success_iter,
       iter,saveiter,saveiter_dense,cache,callback_cache,
       kshortsize,force_stepfail,last_stepfail,just_hit_tstop,
+      do_error_check,
       event_last_time,vector_event_last_time,last_event_error,
       accept_step,isout,reeval_fsal,u_modified,reinitialize,isdae,
       opts,destats,initializealg) # Leave off fsalfirst and last

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -375,6 +375,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
   accept_step = false
   force_stepfail = false
   last_stepfail = false
+  do_error_check = true
   event_last_time = 0
   vector_event_last_time = 1
   last_event_error = typeof(_alg) <: FunctionMap ? false : zero(uBottomEltypeNoUnits)
@@ -401,7 +402,8 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
                              erracc,dtacc,success_iter,
                              iter,saveiter,saveiter_dense,cache,callback_cache,
                              kshortsize,force_stepfail,last_stepfail,
-                             just_hit_tstop,event_last_time,vector_event_last_time,
+                             just_hit_tstop,do_error_check,
+                             event_last_time,vector_event_last_time,
                              last_event_error,accept_step,
                              isout,reeval_fsal,
                              u_modified,reinitiailize,isdae,
@@ -447,7 +449,7 @@ function DiffEqBase.solve!(integrator::ODEIntegrator)
   @inbounds while !isempty(integrator.opts.tstops)
     while integrator.tdir * integrator.t < first(integrator.opts.tstops)
       loopheader!(integrator)
-      if check_error!(integrator) != :Success
+      if integrator.do_error_check && check_error!(integrator) != :Success
         return integrator.sol
       end
       perform_step!(integrator,integrator.cache)

--- a/test/interface/composite_algorithm_test.jl
+++ b/test/interface/composite_algorithm_test.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq, Test
+using OrdinaryDiffEq, Test, LinearAlgebra
 using DiffEqProblemLibrary.ODEProblemLibrary: importodeproblems; importodeproblems()
 import DiffEqProblemLibrary.ODEProblemLibrary: prob_ode_linear, prob_ode_2Dlinear
 prob = prob_ode_2Dlinear
@@ -25,3 +25,13 @@ v = @inferred OrdinaryDiffEq.ode_interpolant(1.0, integrator1, integrator1.opts.
 @inferred OrdinaryDiffEq.ode_interpolant!(v, 1.0, integrator1, integrator1.opts.save_idxs, Val{0})
 v = @inferred OrdinaryDiffEq.ode_extrapolant(1.0, integrator1, integrator1.opts.save_idxs, Val{0})
 @inferred OrdinaryDiffEq.ode_extrapolant!(v, 1.0, integrator1, integrator1.opts.save_idxs, Val{0})
+
+condition(u,t,integrator) = t==192.0
+function affect!(integrator)
+   integrator.u[1] += 14000
+   integrator.u[2] += 14000
+end
+A = [-0.027671669470584172 -0.0 -0.0 -0.0 -0.0 -0.0; -0.0 -0.05540281553537378 -0.0 -0.0 -0.0 -0.0; 0.011534597161021629 0.011933539591245327 -0.24891886153387743 0.023054812171672122 0.0 0.0; 0.0 0.0 0.17011732278405356 -0.023054812171672122 0.0 0.0; 0.01613707230956254 0.04346927594412846 0.03148193084515083 0.0 -1.5621055510998967e9 7.293040577236404; 0.0 0.0 0.0 0.0 1.559509231932001e9 -7.293040577236404]
+prob = ODEProblem((du,u,p,t) -> mul!(du,A,u), zeros(6), (0.0, 1000), tstops=[192], callback=DiscreteCallback(condition, affect!));
+sol = solve(prob, alg=AutoVern7(Rodas5()))
+@test sol.t[end] == 1000.0


### PR DESCRIPTION
It's possible for a step to go unstable, switch to an implicit integrator, and then exit before it tries to start using the new method. This prevents ithat