### PR TITLE
Bypass autoswitch allocs on fully FSAL composites

### DIFF
--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -45,7 +45,16 @@ isfsal(alg::SSPRK54) = false
 isfsal(alg::SSPRK104) = false
 
 get_current_isfsal(alg, cache) = isfsal(alg)
-get_current_isfsal(alg::CompositeAlgorithm, cache) = isfsal(alg.algs[cache.current])
+get_current_isfsal(alg::CompositeAlgorithm, cache) = isfsal(alg.algs[cache.current])::Bool
+all_fsal(alg, cache) = isfsal(alg)
+all_fsal(alg::CompositeAlgorithm, cache) = _all_fsal(alg.algs)
+
+@generated function _all_fsal(algs::T) where {T <: Tuple}
+  ex = Expr(:tuple, map(1:length(T.types)) do i
+    :(isfsal(algs[$i]))
+  end...)
+  :(all($ex))
+end
 
 issplit(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = false
 issplit(alg::SplitAlgorithms) = true
@@ -73,7 +82,7 @@ end
   return expr
 end
 
-  
+
 fsal_typeof(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm},rate_prototype) = typeof(rate_prototype)
 fsal_typeof(alg::ETD2,rate_prototype) = ETD2Fsal{typeof(rate_prototype)}
 function fsal_typeof(alg::CompositeAlgorithm,rate_prototype)

--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -308,7 +308,7 @@ function apply_step!(integrator)
   if has_discontinuity(integrator) && first_discontinuity(integrator) == integrator.tdir * integrator.t
       handle_discontinuities!(integrator)
       get_current_isfsal(integrator.alg, integrator.cache) && reset_fsal!(integrator)
-  elseif get_current_isfsal(integrator.alg, integrator.cache)
+  elseif all_fsal(integrator.alg, integrator.cache) || get_current_isfsal(integrator.alg, integrator.cache)
     if integrator.reeval_fsal || integrator.u_modified || (typeof(integrator.alg)<:DP8 && !integrator.opts.calck) || (typeof(integrator.alg)<:Union{Rosenbrock23,Rosenbrock32} && !integrator.opts.adaptive)
         reset_fsal!(integrator)
     else # Do not reeval_fsal, instead copyto! over


### PR DESCRIPTION
From profiling I noticed that this was the main hotspot for composite algorithm overhead on small problems. `all_fsal` specializes on the algorithms and will hardcode a `true` if all of the algorithms are FSAL. This is true for common combinations like `AutoTsit5(Rosenbrock23())` and `AutoVern7(Rodas5())`, which then bypasses the dynamic dispatch (on the other algorithms, it just compiles to false in which case it's no overhead).

On a Lorenz system this is justified:

```julia
using OrdinaryDiffEq, StaticArrays
function lorenz(u,p,t)
  SA[10.0(u[2]-u[1]),u[1]*(28.0-u[3]) - u[2],u[1]*u[2] - (8/3)*u[3]]
end
u0 = SA[1.0;0.0;0.0]
tspan = (0.0,100.0)
prob = ODEProblem(lorenz,u0,tspan)
sol = solve(prob,Tsit5())
using Plots; plot(sol,vars=(1,2,3))

using BenchmarkTools
@btime sol = solve(prob,Tsit5(),save_everystep=false)
@btime sol = solve(prob,AutoTsit5(Rosenbrock23()),save_everystep=false)
```

```
Before: 284.100 μs (2609 allocations: 85.19 KiB)
After: 248.500 μs (57 allocations: 5.44 KiB)
No AutoSwitch: 215.700 μs (21 allocations: 3.67 KiB)
```

The remaining allocations seem to come from the tableau cache, which of course is hard to get rid of (and cannot necessarily be completely removed). There doesn't seem to be one source, and instead it seems to just be a small overhead which goes away for larger `f`