### PR TITLE
Convert mass matrix explicitely

### DIFF
--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -503,7 +503,7 @@ end
     if isdae
       W = J
     else
-      W_full = W_transform ? J - mass_matrix*inv(dtgamma) :
+      W_full = W_transform ? J - convert(AbstractMatrix,mass_matrix)*inv(dtgamma) :
                              dtgamma*J - mass_matrix
       W = W_full isa Number ? W_full : DiffEqBase.default_factorize(W_full)
     end


### PR DESCRIPTION
This PR is trying to address https://github.com/SciML/SciMLBase.jl/pull/44#issuecomment-810045123

I'm getting the following test error on the Dependent Mass Matrix Tests

MWE:
```julia
using OrdinaryDiffEq, Test, LinearAlgebra, Statistics

# create mass matrix problems
function make_mm_probs(mm_A, ::Val{iip}) where iip
  # iip
  function mm_f(du,u,p,t)
    update_coefficients!(mm_A,OrdinaryDiffEq.constvalue.(u),p,t)
    mm_b = vec(sum(mm_A; dims=2))
    mul!(du,mm_A,u)
    du .+= t * mm_b
    nothing
  end
  mm_g(du,u,p,t) = (@. du = u + t; nothing)

  # oop
  mm_f(u,p,t) = (update_coefficients!(mm_A,OrdinaryDiffEq.constvalue.(u),p,t);
                 mm_A * (u .+ t))
  mm_g(u,p,t) = u .+ t

  mm_analytic(u0, p, t) = @. 2 * u0 * exp(t) - t - 1

  u0 = ones(3)
  tspan = (0.0, 1.0)

  prob = ODEProblem(ODEFunction{iip,true}(mm_f, analytic=mm_analytic, mass_matrix=mm_A), u0, tspan)
  prob2 = ODEProblem(ODEFunction{iip,true}(mm_g, analytic=mm_analytic), u0, tspan)

  prob, prob2
end

function _norm_dsol(alg,prob,prob2,dt=1/10)
  sol = solve(prob,  alg,dt=dt,adaptive=false)
  sol2 = solve(prob2,alg,dt=dt,adaptive=false)
  norm(sol .- sol2)
end

function update_func1(A,u,p,t)
    A[1,1] = cos(t)
    A[2,1] = sin(t)*u[1]
    A[3,1] = t^2
    A[1,2] = cos(t)*sin(t)
    A[2,2] = cos(t)^2 + u[3]
    A[3,2] = sin(t)*u[2]
    A[1,3] = sin(t)
    A[2,3] = t^2
    A[3,3] = t*cos(t) + 1
end

function update_func2(A,u,p,t)
    A[1,1] = cos(t)
    A[2,1] = sin(t)
    A[3,1] = t^2
    A[1,2] = cos(t)*sin(t)
    A[2,2] = cos(t)^2
    A[3,2] = sin(t)
    A[1,3] = sin(t)
    A[2,3] = t^2
    A[3,3] = t*cos(t) + 1
end

function _norm_dsol2(alg,prob,prob2; kwargs...)
  sol = solve(prob,  alg; kwargs...)
  sol2 = solve(prob2,alg; kwargs...)
  norm(sol[end] .- sol2[end])
end

almost_I = Matrix{Float64}(1.01I, 3, 3)
mm_A = Float64[-2 1 4; 4 -2 1; 2 1 3]
dependent_M1 = DiffEqArrayOperator(ones(3,3),update_func=update_func1)
dependent_M2 = DiffEqArrayOperator(ones(3,3),update_func=update_func2)

iip = false
mm = dependent_M1
prob, prob2 = make_mm_probs(mm, Val(iip))
eulersol = solve(prob, ImplicitEuler(nlsolve=NLNewton(κ=1e-10)), reltol=1e-10)
@test _norm_dsol2(ImplicitEuler(nlsolve=NLNewton(κ=1e-10)),prob,prob2,reltol=1e-10) ≈ 0 atol=5e-4
```

and the error is 
```julia
Error During Test at REPL[35]:1
  Test threw exception
  Expression: ≈(_norm_dsol2(ImplicitEuler(nlsolve = NLNewton(κ = 1.0e-10)), prob, prob2, reltol = 1.0e-10), 0, atol = 0.0005)
  MethodError: Cannot `convert` an object of type
    UniformScaling{Bool} to an object of type
    AbstractMatrix{T} where T
  Closest candidates are:
    convert(::Type{T}, ::Factorization) where T<:AbstractArray at C:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.6\LinearAlgebra\src\factorization.jl:58
    convert(::Type{AbstractMatrix{T} where T}, ::DiffEqScaledOperator) at C:\Users\sebastian\.julia\dev\SciMLBase\src\operators\diffeq_operator.jl:97
    convert(::Type{AbstractMatrix{T} where T}, ::SciMLBase.FactorizedDiffEqArrayOperator) at C:\Users\sebastian\.julia\dev\SciMLBase\src\operators\basic_operators.jl:130
    ...
  Stacktrace:
    [1] calc_W(integrator::OrdinaryDiffEq.ODEIntegrator{ImplicitEuler{0, true, DefaultLinSolve, NLNewton{Float64, Rational{Int64}, Rational{Int64}}, DataType}, false, Vector{Float64}, Nothing, Float64, SciMLBase.NullParameters, Float64, Float64, Float64, Vector{Vector{Float64}}, ODESolution{Float64, 2, Vector{Vector{Float64}}, Vector{Vector{Float64}}, Dict{Symbol, Float64}, Vector{Float64}, Vector{Vector{Vector{Float64}}}, ODEProblem{Vector{Float64}, Tuple{Float64, Float64}, false, SciMLBase.NullParameters, ODEFunction{false, var"#mm_g#54", UniformScaling{Bool}, var"#mm_analytic#55", Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing}, Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, SciMLBase.StandardODEProblem}, ImplicitEuler{0, true, DefaultLinSolve, NLNewton{Float64, Rational{Int64}, Rational{Int64}}, DataType}, 
OrdinaryDiffEq.InterpolationData{ODEFunction{false, var"#mm_g#54", UniformScaling{Bool}, var"#mm_analytic#55", Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing}, Vector{Vector{Float64}}, Vector{Float64}, Vector{Vector{Vector{Float64}}}, OrdinaryDiffEq.ImplicitEulerConstantCache{OrdinaryDiffEq.NLSolver{NLNewton{Float64, Rational{Int64}, Rational{Int64}}, false, Vector{Float64}, Int64, Nothing, Float64, OrdinaryDiffEq.NLNewtonConstantCache{Float64, Float64, Matrix{Float64}, LU{Float64, Matrix{Float64}}, SciMLBase.UDerivativeWrapper{ODEFunction{false, var"#mm_g#54", UniformScaling{Bool}, var"#mm_analytic#55", Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing}, Float64, SciMLBase.NullParameters}}}}}, DiffEqBase.DEStats}, ODEFunction{false, var"#mm_g#54", UniformScaling{Bool}, var"#mm_analytic#55", Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing}, OrdinaryDiffEq.ImplicitEulerConstantCache{OrdinaryDiffEq.NLSolver{NLNewton{Float64, Rational{Int64}, Rational{Int64}}, false, Vector{Float64}, Int64, Nothing, Float64, OrdinaryDiffEq.NLNewtonConstantCache{Float64, Float64, Matrix{Float64}, LU{Float64, Matrix{Float64}}, SciMLBase.UDerivativeWrapper{ODEFunction{false, var"#mm_g#54", UniformScaling{Bool}, var"#mm_analytic#55", Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing}, Float64, SciMLBase.NullParameters}}}}, OrdinaryDiffEq.DEOptions{Float64, Float64, Float64, Float64, typeof(DiffEqBase.ODE_DEFAULT_NORM), typeof(opnorm), Nothing, CallbackSet{Tuple{}, Tuple{}}, typeof(DiffEqBase.ODE_DEFAULT_ISOUTOFDOMAIN), typeof(DiffEqBase.ODE_DEFAULT_PROG_MESSAGE), typeof(DiffEqBase.ODE_DEFAULT_UNSTABLE_CHECK), DataStructures.BinaryMinHeap{Float64}, DataStructures.BinaryMinHeap{Float64}, Nothing, Nothing, Int64, Tuple{}, Tuple{}, Tuple{}}, Vector{Float64}, Float64, Nothing, OrdinaryDiffEq.DefaultInit}, cache::OrdinaryDiffEq.NLNewtonConstantCache{Float64, Float64, Matrix{Float64}, LU{Float64, Matrix{Float64}}, SciMLBase.UDerivativeWrapper{ODEFunction{false, var"#mm_g#54", UniformScaling{Bool}, var"#mm_analytic#55", Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing}, Float64, SciMLBase.NullParameters}}, dtgamma::Float64, repeat_step::Bool, W_transform::Bool)        
      @ OrdinaryDiffEq ~\.julia\dev\OrdinaryDiffEq\src\derivative_utils.jl:506
```

This appears that the error appears to be due to the fact that the `mass_matrix` is `I` and 
```julia
convert(AbstractMatrix, I)
```
fails.

