### PR TITLE
Move isdae to kwargs

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -61,6 +61,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
                            alias_u0 = false,
                            alias_du0 = false,
                            initializealg = DefaultInit(),
+                           isdae = is_dae(prob,alg),
                            kwargs...) where recompile_flag
 
   if prob isa DiffEqBase.AbstractDAEProblem && alg isa OrdinaryDiffEqAlgorithm
@@ -98,10 +99,6 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
       error("Fixed timestep methods require a choice of dt or choosing the tstops")
   end
 
-  isdae = alg isa DAEAlgorithm || (!(typeof(prob)<:DiscreteProblem) &&
-                                     prob.f.mass_matrix != I &&
-                                     !(typeof(prob.f.mass_matrix)<:Tuple) &&
-                                     ArrayInterface.issingular(prob.f.mass_matrix))
   if alg isa CompositeAlgorithm && alg.choice_function isa AutoSwitch
     auto = alg.choice_function
     _alg = CompositeAlgorithm(alg.algs,
@@ -475,6 +472,12 @@ end
 
 # Helpers
 
+function is_dae(prob, alg)
+  return alg isa DAEAlgorithm || (!(typeof(prob)<:DiscreteProblem) &&
+                                     prob.f.mass_matrix != I &&
+                                     !(typeof(prob.f.mass_matrix)<:Tuple) &&
+                                     ArrayInterface.issingular(prob.f.mass_matrix))
+end
 
 function handle_dt!(integrator)
   if iszero(integrator.dt) && integrator.opts.adaptive


### PR DESCRIPTION
* moves the `isdae` value into the `kwargs` so the user can manually set it
* Allows for the user to bypass singularity checks on the mass matrix, which is beneficial when the mass matrix type does not play well with the singular functions or is large
* Default value is to run the checks

MWE of motivation:
```
M = Symmetric(sparse([1,2,3,1],[1,2,3,3],[2.,2.,2.,1.]))
fode = ODEFunction(DiffEqArrayOperator(M'M); mass_matrix=M)
ode_prob = ODEProblem(fode, [1.,1.,1.], (0.,1.))
sol = solve(ode_prob, Rosenbrock23(); mm_singular=false)
```