### PR TITLE
Prevent velocity Verlet integrator calculating the acceleration twice at each time step

### DIFF
--- a/src/perform_step/symplectic_perform_step.jl
+++ b/src/perform_step/symplectic_perform_step.jl
@@ -171,7 +171,7 @@ end
   duprev, uprev = load_symp_state(integrator)
 
   # x(t+Δt) = x(t) + v(t)*Δt + 1/2*a(t)*Δt^2
-  ku = f.f1(duprev,uprev,p,t)
+  ku = integrator.fsallast.x[1]
   dtsq = dt^2
   half = cache.half
   u = uprev + dt*duprev + dtsq*(half*ku)
@@ -189,7 +189,7 @@ end
   du, u, kdu, ku = alloc_symp_state(integrator)
 
   # x(t+Δt) = x(t) + v(t)*Δt + 1/2*a(t)*Δt^2
-  f.f1(ku,duprev,uprev,p,t)
+  ku = integrator.fsallast.x[1]
   dtsq = dt^2
   half = cache.half
   @.. u = uprev + dt*duprev + dtsq*(half*ku)


### PR DESCRIPTION
As discussed in https://github.com/SciML/OrdinaryDiffEq.jl/issues/1387, use the FSAL value to avoid calculating the acceleration twice in the `VelocityVerlet` integrator.

Obtains similar results for a small system I tested on. I am running the package tests locally now.

Closes https://github.com/SciML/OrdinaryDiffEq.jl/issues/1387.