### PR TITLE
Remove stiffness detection loop

### DIFF
--- a/src/composite_algs.jl
+++ b/src/composite_algs.jl
@@ -32,7 +32,7 @@ function is_stiff(integrator, alg, ntol, stol, is_stiffalg)
   tol = is_stiffalg ? stol : ntol
   os = oneunit(stiffness)
   bool = stiffness > os * tol
-  integrator.do_error_check = !bool
+  integrator.do_error_check = integrator.do_error_check || !bool
   bool
 end
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -106,7 +106,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
     auto = alg.choice_function
     _alg = CompositeAlgorithm(alg.algs,
                              AutoSwitchCache(
-                                             0,
+                                             0,0,
                                              auto.nonstiffalg,
                                              auto.stiffalg,
                                              auto.stiffalgfirst,
@@ -116,6 +116,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
                                              auto.stifftol,
                                              auto.dtfac,
                                              auto.stiffalgfirst,
+                                             auto.switch_max
                                             ))
   else
     _alg = alg


### PR DESCRIPTION
https://github.com/SciML/OrdinaryDiffEq.jl/pull/1358 allowed for skipping the instability check when changing the algorithm. However, this can loop back and forth, as seen in https://github.com/SciML/DiffEqFlux.jl/issues/539. This PR makes it so that way if the error check was off in the last step, it would be on in the next, making it so that way if it's truly unstable this will get caught.

Fixes https://github.com/SciML/DiffEqFlux.jl/issues/539