### PR TITLE
Use `DiffEqBase.value` on arguments to `fastpow` call in `stepsize_controller`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -62,11 +62,13 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PoissonRandom = "e409e4f3-bfea-5376-8464-e040bb5c01ab"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Calculus", "DelayDiffEq", "DiffEqCallbacks", "DiffEqDevTools", "DiffEqOperators", "DiffEqProblemLibrary", "DiffEqSensitivity", "ElasticArrays", "InteractiveUtils", "PoissonRandom", "Printf", "Random", "SafeTestsets", "SparseArrays", "Statistics", "Test", "Unitful", "ModelingToolkit", "Pkg"]
+test = ["Calculus", "DelayDiffEq", "DiffEqCallbacks", "DiffEqDevTools", "DiffEqOperators", "DiffEqProblemLibrary", "DiffEqSensitivity", "ElasticArrays", "InteractiveUtils", "PoissonRandom", "Printf", "Random", "ReverseDiff", "SafeTestsets", "SparseArrays", "Statistics", "Test", "Unitful", "Zygote", "ModelingToolkit", "Pkg"]

--- a/src/integrators/controllers.jl
+++ b/src/integrators/controllers.jl
@@ -132,8 +132,8 @@ end
   if iszero(EEst)
     q = inv(qmax)
   else
-    q11 = DiffEqBase.fastpow(EEst, beta1)
-    q = DiffEqBase.value(q11 / DiffEqBase.fastpow(qold, beta2))
+    q11 = DiffEqBase.fastpow(DiffEqBase.value(EEst), DiffEqBase.value(beta1))
+    q = DiffEqBase.value(q11 / DiffEqBase.fastpow(DiffEqBase.value(qold), DiffEqBase.value(beta2)))
     integrator.q11 = q11
     @fastmath q = max(inv(qmax), min(inv(qmin), q / gamma))
   end

--- a/src/integrators/controllers.jl
+++ b/src/integrators/controllers.jl
@@ -127,13 +127,13 @@ end
   @unpack qold = integrator
   @unpack qmin, qmax, gamma = integrator.opts
   @unpack beta1, beta2 = controller
-  EEst = integrator.EEst
+  EEst = DiffEqBase.value(integrator.EEst)
 
   if iszero(EEst)
     q = inv(qmax)
   else
-    q11 = DiffEqBase.fastpow(DiffEqBase.value(EEst), float(beta1))
-    q = DiffEqBase.value(q11 / DiffEqBase.fastpow(DiffEqBase.value(qold), float(beta2)))
+    q11 = DiffEqBase.fastpow(EEst, float(beta1))
+    q = q11 / DiffEqBase.fastpow(qold, float(beta2))
     integrator.q11 = q11
     @fastmath q = max(inv(qmax), min(inv(qmin), q / gamma))
   end

--- a/src/integrators/controllers.jl
+++ b/src/integrators/controllers.jl
@@ -65,7 +65,7 @@ end
     qtmp = DiffEqBase.fastpow(EEst, expo) / gamma
     @fastmath q = DiffEqBase.value(max(inv(qmax), min(inv(qmin), qtmp)))
     # TODO: Shouldn't this be in `step_accept_controller!` as for the PI controller?
-    integrator.qold = integrator.dt / q
+    integrator.qold =  DiffEqBase.value(integrator.dt) / q
   end
   q
 end

--- a/src/integrators/controllers.jl
+++ b/src/integrators/controllers.jl
@@ -132,8 +132,8 @@ end
   if iszero(EEst)
     q = inv(qmax)
   else
-    q11 = DiffEqBase.fastpow(DiffEqBase.value(EEst), DiffEqBase.value(beta1))
-    q = DiffEqBase.value(q11 / DiffEqBase.fastpow(DiffEqBase.value(qold), DiffEqBase.value(beta2)))
+    q11 = DiffEqBase.fastpow(DiffEqBase.value(EEst), float(beta1))
+    q = DiffEqBase.value(q11 / DiffEqBase.fastpow(DiffEqBase.value(qold), float(beta2)))
     integrator.q11 = q11
     @fastmath q = max(inv(qmax), min(inv(qmin), q / gamma))
   end

--- a/src/integrators/controllers.jl
+++ b/src/integrators/controllers.jl
@@ -65,7 +65,7 @@ end
     qtmp = DiffEqBase.fastpow(EEst, expo) / gamma
     @fastmath q = DiffEqBase.value(max(inv(qmax), min(inv(qmin), qtmp)))
     # TODO: Shouldn't this be in `step_accept_controller!` as for the PI controller?
-    integrator.qold =  DiffEqBase.value(integrator.dt) / q
+    integrator.qold = DiffEqBase.value(integrator.dt) / q
   end
   q
 end

--- a/src/integrators/type.jl
+++ b/src/integrators/type.jl
@@ -75,7 +75,7 @@ integrator.opts.abstol = 1e-9
 ```
 For more info see the linked documentation page.
 """
-mutable struct ODEIntegrator{algType<:Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm},IIP,uType,duType,tType,pType,eigenType,QT,tdirType,ksEltype,SolType,F,CacheType,O,FSALType,EventErrorType,CallbackCacheType,IA} <: DiffEqBase.AbstractODEIntegrator{algType,IIP,uType,tType}
+mutable struct ODEIntegrator{algType<:Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm},IIP,uType,duType,tType,pType,eigenType,EEstT,QT,tdirType,ksEltype,SolType,F,CacheType,O,FSALType,EventErrorType,CallbackCacheType,IA} <: DiffEqBase.AbstractODEIntegrator{algType,IIP,uType,tType}
   sol::SolType
   u::uType
   du::duType
@@ -94,7 +94,7 @@ mutable struct ODEIntegrator{algType<:Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm
   dtpropose::tType
   tdir::tdirType
   eigen_est::eigenType
-  EEst::QT
+  EEst::EEstT
   qold::QT
   q11::QT
   erracc::QT
@@ -125,7 +125,7 @@ mutable struct ODEIntegrator{algType<:Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm
   fsalfirst::FSALType
   fsallast::FSALType
 
-  function ODEIntegrator{algType,IIP,uType,duType,tType,pType,eigenType,tTypeNoUnits,tdirType,ksEltype,SolType,
+  function ODEIntegrator{algType,IIP,uType,duType,tType,pType,eigenType,EEstT,tTypeNoUnits,tdirType,ksEltype,SolType,
                 F,CacheType,O,FSALType,EventErrorType,CallbackCacheType,InitializeAlgType}(
                 sol,u,du,k,t,dt,f,p,uprev,uprev2,duprev,tprev,
       alg,dtcache,dtchangeable,dtpropose,tdir,
@@ -136,12 +136,12 @@ mutable struct ODEIntegrator{algType<:Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm
       event_last_time,vector_event_last_time,last_event_error,
       accept_step,isout,reeval_fsal,u_modified,reinitialize,isdae,
       opts,destats,initializealg) where {algType,IIP,uType,duType,tType,pType,
-                                         eigenType,tTypeNoUnits,tdirType,
+                                         eigenType,EEstT,tTypeNoUnits,tdirType,
                                          ksEltype,SolType,F,CacheType,O,
                                          FSALType,EventErrorType,
                                          CallbackCacheType,InitializeAlgType}
 
-      new{algType,IIP,uType,duType,tType,pType,eigenType,tTypeNoUnits,tdirType,ksEltype,SolType,
+      new{algType,IIP,uType,duType,tType,pType,eigenType,EEstT,tTypeNoUnits,tdirType,ksEltype,SolType,
                   F,CacheType,O,FSALType,EventErrorType,CallbackCacheType,InitializeAlgType}(
                   sol,u,du,k,t,dt,f,p,uprev,uprev2,duprev,tprev,
       alg,dtcache,dtchangeable,dtpropose,tdir,

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -265,13 +265,13 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
     sizehint!(ks,2)
   end
 
-  QT = if tTypeNoUnits <: Integer
-    typeof(qmin)
+  QT, EEstT = if tTypeNoUnits <: Integer
+    typeof(qmin), typeof(qmin)
   elseif prob isa DiscreteProblem
     # The QT fields are not used for DiscreteProblems
-    constvalue(tTypeNoUnits)
+    constvalue(tTypeNoUnits), constvalue(tTypeNoUnits)
   else
-    typeof(internalnorm(u, t))
+    typeof(DiffEqBase.value(internalnorm(u, t))), typeof(internalnorm(u, t))
   end
 
   k = rateType[]
@@ -391,7 +391,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
   kshortsize = 0
   reeval_fsal = false
   u_modified = false
-  EEst = QT(1)
+  EEst = EEstT(1)
   just_hit_tstop = false
   isout = false
   accept_step = false
@@ -412,7 +412,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
 
   integrator = ODEIntegrator{typeof(_alg),isinplace(prob),uType,typeof(du),
                              tType,typeof(p),
-                             typeof(eigen_est),
+                             typeof(eigen_est),typeof(EEst),
                              QT,typeof(tdir),typeof(k),SolType,
                              FType,cacheType,
                              typeof(opts),fsal_typeof(_alg,rate_prototype),
@@ -430,6 +430,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
                              isout,reeval_fsal,
                              u_modified,reinitiailize,isdae,
                              opts,destats,initializealg)
+
   if initialize_integrator
     if isdae
       DiffEqBase.initialize_dae!(integrator)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -308,9 +308,9 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,DiffEqBase.
   end
 
   if controller === nothing
-    controller = default_controller(_alg, cache, convert(QT,qoldinit),
-                                    beta1 === nothing ? nothing : convert(QT,beta1),
-                                    beta2 === nothing ? nothing : convert(QT,beta2))
+    controller = default_controller(_alg, cache, qoldinit,
+                                    beta1 === nothing ? nothing : beta1,
+                                    beta2 === nothing ? nothing : beta2)
   end
 
 

--- a/test/integrators/autodiff_events.jl
+++ b/test/integrators/autodiff_events.jl
@@ -1,19 +1,32 @@
 using DiffEqSensitivity
 using OrdinaryDiffEq, Calculus, Test
+using Zygote
 
 function f(du,u,p,t)
-  du[1] = -p[1]
-  du[2] = p[2]
+  du[1] = u[2]
+  du[2] = -p[1]
 end
 
-cb = ContinuousCallback((u,t,i) -> u[1], (integrator)->(println("Stopped.");integrator.p[2]=0.0))
-p = [2.0, 1.0]
-
-function test_f(p)
-  prob = ODEProblem(f,eltype(p).([1.0,0.0]),eltype(p).((0.0,1.0)),copy(p))
-  solve(prob,Tsit5(),abstol=1e-14,reltol=1e-14,callback=cb,save_everystep=false)[end]
+function condition(u,t,integrator) # Event when event_f(u,t) == 0
+  u[1]
 end
-p = [2.0, 1.0]
+
+function affect!(integrator)
+  @show integrator.t
+  println("bounced.")
+  integrator.u[2] = -integrator.p[2]*integrator.u[2]
+end
+
+cb = ContinuousCallback(condition, affect!)
+p = [9.8, 0.8]
+prob = ODEProblem(f,eltype(p).([1.0,0.0]),eltype(p).((0.0,1.0)),copy(p))
+
+solve(prob,Tsit5(),abstol=1e-14,reltol=1e-14,callback=cb,save_everystep=true)[end]
+
+function test_f(p, sensealg=ForwardDiffSensitivity())
+  _prob = remake(prob, p=p)
+  solve(_prob,Tsit5(),sensealg=sensealg,abstol=1e-14,reltol=1e-14,callback=cb,save_everystep=false)[end]
+end
 findiff = Calculus.finite_difference_jacobian(test_f,p)
 findiff
 
@@ -22,3 +35,9 @@ ad = ForwardDiff.jacobian(test_f,p)
 ad
 
 @test ad ≈ findiff
+
+g1 = Zygote.gradient(θ->test_f(θ,ForwardDiffSensitivity())[1], p)
+g2 = Zygote.gradient(θ->test_f(θ,ReverseDiffAdjoint())[1], p)
+
+@test g1[1] ≈ findiff[1,1:2]
+@test g2[1] ≈ findiff[2,1:2]

--- a/test/integrators/autodiff_events.jl
+++ b/test/integrators/autodiff_events.jl
@@ -36,9 +36,9 @@ ad
 
 function test_f2(p, sensealg=ForwardDiffSensitivity(), controller=nothing)
   _prob = remake(prob, p=p)
-  u = Array(solve(_prob,Tsit5(),sensealg=sensealg,controller=controller,
-    abstol=1e-14,reltol=1e-14,callback=cb,save_everystep=false))
-  u[end]
+  u = solve(_prob,Tsit5(),sensealg=sensealg,controller=controller,
+    abstol=1e-14,reltol=1e-14,callback=cb,save_everystep=false)
+  u[end][end]
 end
 
 @test test_f2(p) == test_f(p)[end]
@@ -47,10 +47,10 @@ g1 = Zygote.gradient(θ->test_f2(θ,ForwardDiffSensitivity()), p)
 g2 = Zygote.gradient(θ->test_f2(θ,ReverseDiffAdjoint()), p)
 g3 = Zygote.gradient(θ->test_f2(θ,ReverseDiffAdjoint(), IController()), p)
 g4 = Zygote.gradient(θ->test_f2(θ,ReverseDiffAdjoint(), PIController(7//50, 2//25)), p)
-g5 = Zygote.gradient(θ->test_f2(θ,ReverseDiffAdjoint(), PIDController(1/18. , 1/9., 1/18.)), p)
+@test_broken g5 = Zygote.gradient(θ->test_f2(θ,ReverseDiffAdjoint(), PIDController(1/18. , 1/9., 1/18.)), p)
 
 @test g1[1] ≈ findiff[2,1:2]
 @test g2[1] ≈ findiff[2,1:2]
 @test g3[1] ≈ findiff[2,1:2]
 @test g4[1] ≈ findiff[2,1:2]
-@test g5[1] ≈ findiff[2,1:2]
+@test_broken g5[1] ≈ findiff[2,1:2]

--- a/test/integrators/autodiff_events.jl
+++ b/test/integrators/autodiff_events.jl
@@ -23,9 +23,9 @@ prob = ODEProblem(f,eltype(p).([1.0,0.0]),eltype(p).((0.0,1.0)),copy(p))
 
 solve(prob,Tsit5(),abstol=1e-14,reltol=1e-14,callback=cb,save_everystep=true)[end]
 
-function test_f(p, sensealg=ForwardDiffSensitivity())
+function test_f(p)
   _prob = remake(prob, p=p)
-  solve(_prob,Tsit5(),sensealg=sensealg,abstol=1e-14,reltol=1e-14,callback=cb,save_everystep=false)[end]
+  solve(_prob,Tsit5(),abstol=1e-14,reltol=1e-14,callback=cb,save_everystep=false)[end]
 end
 findiff = Calculus.finite_difference_jacobian(test_f,p)
 findiff
@@ -36,8 +36,16 @@ ad
 
 @test ad ≈ findiff
 
-g1 = Zygote.gradient(θ->test_f(θ,ForwardDiffSensitivity())[1], p)
-g2 = Zygote.gradient(θ->test_f(θ,ReverseDiffAdjoint())[1], p)
+function test_f2(p, sensealg=ForwardDiffSensitivity())
+  _prob = remake(prob, p=p)
+  u = Array(solve(_prob,Tsit5(),sensealg=sensealg,abstol=1e-14,reltol=1e-14,callback=cb,save_everystep=false))
+  u[end]
+end
 
-@test g1[1] ≈ findiff[1,1:2]
+@test test_f2(p) == test_f(p)[end]
+
+g1 = Zygote.gradient(θ->test_f2(θ,ForwardDiffSensitivity()), p)
+g2 = Zygote.gradient(θ->test_f2(θ,ReverseDiffAdjoint()), p)
+
+@test g1[1] ≈ findiff[2,1:2]
 @test g2[1] ≈ findiff[2,1:2]


### PR DESCRIPTION
Fixes `ReverseDiffAdjoint` example at https://diffeqflux.sciml.ai/dev/examples/bouncing_ball/