### PR TITLE
remove function passing in perform_step!

### DIFF
--- a/src/perform_step/feagin_rk_perform_step.jl
+++ b/src/perform_step/feagin_rk_perform_step.jl
@@ -442,7 +442,7 @@ end
   integrator.destats.nf += 1
 end
 
-function initialize!(integrator,cache::Feagin14ConstantCache,f=integrator.f)
+function initialize!(integrator,cache::Feagin14ConstantCache)
   integrator.fsalfirst = f(integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
   integrator.destats.nf += 1
   integrator.kshortsize = 2

--- a/src/perform_step/feagin_rk_perform_step.jl
+++ b/src/perform_step/feagin_rk_perform_step.jl
@@ -443,7 +443,7 @@ end
 end
 
 function initialize!(integrator,cache::Feagin14ConstantCache)
-  integrator.fsalfirst = f(integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
+  integrator.fsalfirst = integrator.f(integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
   integrator.destats.nf += 1
   integrator.kshortsize = 2
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)

--- a/src/perform_step/low_order_rk_perform_step.jl
+++ b/src/perform_step/low_order_rk_perform_step.jl
@@ -165,7 +165,7 @@ end
   integrator.u = u
 end
 
-function initialize!(integrator,cache::OwrenZen4Cache,f=integrator.f)
+function initialize!(integrator,cache::OwrenZen4Cache)
   integrator.kshortsize = 6
   resize!(integrator.k, integrator.kshortsize)
   integrator.k[1]=cache.k1; integrator.k[2]=cache.k2;
@@ -984,7 +984,7 @@ end
 end
 
 
-function initialize!(integrator, cache::RKO65Cache, f=integrator.f)
+function initialize!(integrator, cache::RKO65Cache)
   @unpack k,fsalfirst = cache
   integrator.kshortsize = 6
   resize!(integrator.k, integrator.kshortsize)

--- a/src/perform_step/low_order_rk_perform_step.jl
+++ b/src/perform_step/low_order_rk_perform_step.jl
@@ -172,7 +172,7 @@ function initialize!(integrator,cache::OwrenZen4Cache)
   integrator.k[3]=cache.k3; integrator.k[4]=cache.k4;
   integrator.k[5]=cache.k5; integrator.k[6]=cache.k6;
   integrator.fsalfirst = cache.k1; integrator.fsallast = cache.k6  # setup pointers
-  f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
+  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
   integrator.destats.nf += 1
 end
 
@@ -997,7 +997,7 @@ function initialize!(integrator, cache::RKO65Cache)
 
   integrator.fsalfirst = cache.k1; integrator.fsallast = cache.k6  # setup pointers
 
-  f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
+  integrator.f(integrator.fsalfirst,integrator.uprev,integrator.p,integrator.t) # Pre-start fsal
 
   integrator.destats.nf += 1
 


### PR DESCRIPTION
Works around inference issue https://github.com/JuliaLang/julia/issues/41293, but is also unnecessary since that was just there for DelayDiffEq.jl which no longer uses it.