### PR TITLE
avoid reshapedarray when scalar indexing is fast

### DIFF
--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -380,7 +380,13 @@ end
       copyto!(W, J)
       idxs = diagind(W)
       λ = -mass_matrix.λ
-      @.. @view(W[idxs]) = muladd(λ, invdtgamma, @view(J[idxs]))
+      if ArrayInterface.fast_scalar_indexing(J) && ArrayInterface.fast_scalar_indexing(W)
+          for i in 1:size(J,1)
+              W[i,i] = muladd(λ, invdtgamma, J[i,i])
+          end
+      else
+          @.. @view(W[idxs]) = muladd(λ, invdtgamma, @view(J[idxs]))
+      end
     else
       @.. W = muladd(-mass_matrix, invdtgamma, J)
     end


### PR DESCRIPTION
Profiles saw that this could allocate quite a bit because the views form a ReshapedArray. In many cases this won't matter, but if fast scalar indexing exists we might as well optimize those out and improve memory performance to help with threading.