### PR TITLE
reuse W factorization in Rodas5 OOP

### DIFF
--- a/src/perform_step/rosenbrock_perform_step.jl
+++ b/src/perform_step/rosenbrock_perform_step.jl
@@ -933,13 +933,14 @@ end
   dT = calc_tderivative(integrator, cache)
 
   W = calc_W(integrator, cache, dtgamma, repeat_step, true)
+  luW = lu(convert(AbstractMatrix,W))
 
   du1 = f(uprev, p, t)
   integrator.destats.nf += 1
 
   linsolve_tmp =  du1 + dtd1*dT
 
-  k1 = _reshape(W\-_vec(linsolve_tmp), axes(uprev))
+  k1 = _reshape(luW\-_vec(linsolve_tmp), axes(uprev))
   integrator.destats.nsolve += 1
   u = uprev  + a21*k1
   du = f(u, p, t+c2*dt)
@@ -951,7 +952,7 @@ end
     linsolve_tmp = du + dtd2*dT + mass_matrix * (dtC21*k1)
   end
 
-  k2 = _reshape(W\-_vec(linsolve_tmp), axes(uprev))
+  k2 = _reshape(luW\-_vec(linsolve_tmp), axes(uprev))
   integrator.destats.nsolve += 1
   u = uprev  + a31*k1 + a32*k2
   du = f(u, p, t+c3*dt)
@@ -963,7 +964,7 @@ end
     linsolve_tmp =  du + dtd3*dT + mass_matrix * (dtC31*k1 + dtC32*k2)
   end
 
-  k3 = _reshape(W\-_vec(linsolve_tmp), axes(uprev))
+  k3 = _reshape(luW\-_vec(linsolve_tmp), axes(uprev))
   integrator.destats.nsolve += 1
   u = uprev  + a41*k1 + a42*k2 + a43*k3
   du = f(u, p, t+c4*dt)
@@ -975,7 +976,7 @@ end
     linsolve_tmp =  du + dtd4*dT + mass_matrix * (dtC41*k1 + dtC42*k2 + dtC43*k3)
   end
 
-  k4 = _reshape(W\-_vec(linsolve_tmp), axes(uprev))
+  k4 = _reshape(luW\-_vec(linsolve_tmp), axes(uprev))
   integrator.destats.nsolve += 1
   u = uprev  + a51*k1 + a52*k2 + a53*k3 + a54*k4
   du = f(u, p, t+c5*dt)
@@ -987,7 +988,7 @@ end
     linsolve_tmp = du + dtd5*dT + mass_matrix * (dtC52*k2 + dtC54*k4 + dtC51*k1 + dtC53*k3)
   end
 
-  k5 = _reshape(W\-_vec(linsolve_tmp), axes(uprev))
+  k5 = _reshape(luW\-_vec(linsolve_tmp), axes(uprev))
   integrator.destats.nsolve += 1
   u = uprev  + a61*k1 + a62*k2 + a63*k3 + a64*k4 + a65*k5
   du = f(u, p, t+dt)
@@ -999,7 +1000,7 @@ end
     linsolve_tmp =  du + mass_matrix * (dtC61*k1 + dtC62*k2 + dtC63*k3 + dtC64*k4 + dtC65*k5)
   end
 
-  k6 = _reshape(W\-_vec(linsolve_tmp), axes(uprev))
+  k6 = _reshape(luW\-_vec(linsolve_tmp), axes(uprev))
   integrator.destats.nsolve += 1
   u = u + k6
   du = f(u, p, t+dt)
@@ -1011,7 +1012,7 @@ end
     linsolve_tmp = du + mass_matrix * (dtC71*k1 + dtC72*k2 + dtC73*k3 + dtC74*k4 + dtC75*k5 + dtC76*k6)
   end
 
-  k7 = _reshape(W\-_vec(linsolve_tmp), axes(uprev))
+  k7 = _reshape(luW\-_vec(linsolve_tmp), axes(uprev))
   integrator.destats.nsolve += 1
   u = u + k7
   du = f(u, p, t+dt)
@@ -1023,7 +1024,7 @@ end
     linsolve_tmp = du + mass_matrix * (dtC81*k1 + dtC82*k2 + dtC83*k3 + dtC84*k4 + dtC85*k5 + dtC86*k6 + dtC87*k7)
   end
 
-  k8 = _reshape(W\-_vec(linsolve_tmp), axes(uprev))
+  k8 = _reshape(luW\-_vec(linsolve_tmp), axes(uprev))
   integrator.destats.nsolve += 1
   u = u + k8
   du = f(u, p, t+dt)


### PR DESCRIPTION
```julia
using OrdinaryDiffEq, BenchmarkTools
using StaticArrays, LinearAlgebra

# rober
function rober(u,p,t)
    y₁,y₂,y₃ = u
    k₁,k₂,k₃ = p
    du1 = -k₁*y₁+k₃*y₂*y₃
    du2 =  k₁*y₁-k₂*y₂^2-k₃*y₂*y₃
    du3 =  k₂*y₂^2
    SA[du1,du2,du3]
end
ff = ODEFunction(rober,tgrad = (u,p,t)->SA[0.0,0.0,0.0])
prob = ODEProblem{false}(rober,SA[1.0,0.0,0.0],(0.0,1e5),SA[0.04,3e7,1e4])
@btime solve(prob,Rodas5(),reltol=1.0e-8,abstol=1.0e-8, saveat = 1000) # Fail?

using ModelingToolkit
prob2 = ODEProblem{false}(modelingtoolkitize(prob),SA[1.0,0.0,0.0],(0.0,1e5),SA[0.04,3e7,1e4],jac=true)

# Before
@btime solve(prob2,Rodas5(), reltol=1.0e-8, abstol=1.0e-8, saveat = 1000) # 75.000 μs (401 allocations: 51.38 KiB)
# After
@btime solve(prob2,Rodas5(), reltol=1.0e-8, abstol=1.0e-8, saveat = 1000) # 108.200 μs (401 allocations: 51.38 KiB)
```

Takes longer to do less computation. And some things fail. @yingboma got any ideas on this one?