### PR TITLE
Fix algevent tests and multi-dimensional input bugs in FBDF

### DIFF
--- a/src/bdf_utils.jl
+++ b/src/bdf_utils.jl
@@ -113,7 +113,6 @@ function compute_weights!(ts,k,weights)
 end
 
 function calc_Lagrange_interp(k,weights,t,ts,u_history,u::Number)
-  #@show t,ts,u_history
   if t in ts
     i = searchsortedfirst(ts,t,rev=true)
     return u_history[i]
@@ -125,22 +124,18 @@ function calc_Lagrange_interp(k,weights,t,ts,u_history,u::Number)
       u *= t-ts[i]
     end
   end
-  #@show weights
   u
 end
 
 function calc_Lagrange_interp(k,weights,t,ts,u_history,u)
+  vc = _vec(u)
   if t in ts
     i = searchsortedfirst(ts,t,rev=true)
-    for j in eachindex(u)
-      u[j] = u_history[j,i]
-    end
+    @.. @views vc = u_history[:,i]
     return u
   else
     for i in 1:k+1
-      for j in eachindex(u)
-        u[j] += weights[i]/(t-ts[i])*u_history[j,i]
-      end
+      @.. @views vc += weights[i]/(t-ts[i])*u_history[:,i]
     end
     for i in 1:k+1
       @.. u *= t-ts[i]
@@ -150,16 +145,13 @@ function calc_Lagrange_interp(k,weights,t,ts,u_history,u)
 end
 
 function calc_Lagrange_interp!(k,weights,t,ts,u_history,u)
+  vc = _vec(u)
   if t in ts
     i = searchsortedfirst(ts,t,rev=true)
-    for j in eachindex(u)
-      u[j] = u_history[j,i]
-    end
+    @.. @views vc = u_history[:,i]
   else
     for i in 1:k+1
-      for j in eachindex(u)
-        u[j] += weights[i]/(t-ts[i])*u_history[j,i]
-      end
+      @.. @views vc += weights[i]/(t-ts[i])*u_history[:,i]
     end
     for i in 1:k+1
       @.. u *= t-ts[i]

--- a/src/bdf_utils.jl
+++ b/src/bdf_utils.jl
@@ -132,10 +132,15 @@ end
 function calc_Lagrange_interp(k,weights,t,ts,u_history,u)
   if t in ts
     i = searchsortedfirst(ts,t,rev=true)
-    return u_history[:,i]
+    for j in eachindex(u)
+      u[j] = u_history[j,i]
+    end
+    return u
   else
     for i in 1:k+1
-      @.. u += weights[i]/(t-ts[i])*u_history[:,i]
+      for j in eachindex(u)
+        u[j] += weights[i]/(t-ts[i])*u_history[j,i]
+      end
     end
     for i in 1:k+1
       @.. u *= t-ts[i]
@@ -147,10 +152,14 @@ end
 function calc_Lagrange_interp!(k,weights,t,ts,u_history,u)
   if t in ts
     i = searchsortedfirst(ts,t,rev=true)
-    @.. u = u_history[:,i]
+    for j in eachindex(u)
+      u[j] = u_history[j,i]
+    end
   else
     for i in 1:k+1
-      @.. u += weights[i]/(t-ts[i])*u_history[:,i]
+      for j in eachindex(u)
+        u[j] += weights[i]/(t-ts[i])*u_history[j,i]
+      end
     end
     for i in 1:k+1
       @.. u *= t-ts[i]

--- a/src/caches/bdf_caches.jl
+++ b/src/caches/bdf_caches.jl
@@ -492,11 +492,12 @@ function alg_cache(alg::FBDF{MO},u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
                   11//6 -3 3//2 -1//3  0 0 ;
                   25//12 -4 3 -4//3 1//4 0 ;
                   137//60 -5 5 -10//3 5//4 -1//5]
-  ts = zero(Vector{typeof(t)}(undef,max_order+2)) #ts is the successful past points, it will be updated after successful step
-  u_history = zero(Matrix{eltype(u)}(undef,length(u),max_order+2))
+  ts = Vector{typeof(t)}(undef,max_order+2) #ts is the successful past points, it will be updated after successful step
+  u_history = Matrix{eltype(u)}(undef,length(u),max_order+2)
   order = 1
   prev_order = 1
   u_corrector = similar(u_history)
+  fill!(ts,zero(t))
   fill!(u_corrector,zero(eltype(u)))
   fill!(u_history,zero(eltype(u_history)))
   terkm2 = tTypeNoUnits(1)
@@ -505,8 +506,10 @@ function alg_cache(alg::FBDF{MO},u,rate_prototype,uEltypeNoUnits,uBottomEltypeNo
   terkp1 = tTypeNoUnits(1)
   terk_tmp = similar(u)
   terkp1_tmp = similar(u)
-  r = zero(Vector{typeof(t)}(undef,max_order+2)) 
-  weights = zero(Vector{typeof(t)}(undef,max_order+2))
+  r = Vector{typeof(t)}(undef,max_order+2)
+  weights = Vector{typeof(t)}(undef,max_order+2)
+  fill!(r,zero(t))
+  fill!(weights,zero(t))
   weights[1] = 1
   nconsteps = 0
   consfailcnt = 0

--- a/src/integrators/controllers.jl
+++ b/src/integrators/controllers.jl
@@ -580,7 +580,9 @@ function stepsize_controller!(integrator, alg::FBDF{max_order}) where max_order
         terk_tmp *= abs(dt^(k-2))
       else
         for i in 2:k-2
-          @.. @views terk_tmp += fd_weights[i,k-2] * u_history[:,i-1]
+          for j in eachindex(terk_tmp)
+            terk_tmp[j] += fd_weights[i,k-2] * u_history[j,i-1]
+          end
         end
         @.. terk_tmp *= abs(dt^(k-2))
       end

--- a/src/integrators/controllers.jl
+++ b/src/integrators/controllers.jl
@@ -580,9 +580,7 @@ function stepsize_controller!(integrator, alg::FBDF{max_order}) where max_order
         terk_tmp *= abs(dt^(k-2))
       else
         for i in 2:k-2
-          for j in eachindex(terk_tmp)
-            terk_tmp[j] += fd_weights[i,k-2] * u_history[j,i-1]
-          end
+          @.. @views terk_tmp += fd_weights[i,k-2] * u_history[:,i-1]
         end
         @.. terk_tmp *= abs(dt^(k-2))
       end

--- a/src/integrators/controllers.jl
+++ b/src/integrators/controllers.jl
@@ -579,8 +579,9 @@ function stepsize_controller!(integrator, alg::FBDF{max_order}) where max_order
         #@show fd_weights,u_history,u,terk
         terk_tmp *= abs(dt^(k-2))
       else
+        vc = _vec(terk_tmp)
         for i in 2:k-2
-          @.. @views terk_tmp += fd_weights[i,k-2] * u_history[:,i-1]
+          @.. @views vc += fd_weights[i,k-2] * u_history[:,i-1]
         end
         @.. terk_tmp *= abs(dt^(k-2))
       end

--- a/src/perform_step/bdf_perform_step.jl
+++ b/src/perform_step/bdf_perform_step.jl
@@ -1063,7 +1063,7 @@ function perform_step!(integrator, cache::FBDFConstantCache{max_order}, repeat_s
     end
   else
     for i in 1:k-1
-      @views u_corrector[:,i] = calc_Lagrange_interp(k,weights,equi_ts[i],ts,u_history,u_corrector[:,i])
+      @.. @views u_corrector[:,i] = $calc_Lagrange_interp(k,weights,equi_ts[i],ts,u_history,u_corrector[:,i])
     end
     tmp = - uprev * bdf_coeffs[k,2]
     vc = _vec(tmp)

--- a/src/perform_step/bdf_perform_step.jl
+++ b/src/perform_step/bdf_perform_step.jl
@@ -1038,7 +1038,7 @@ function perform_step!(integrator, cache::FBDFConstantCache{max_order}, repeat_s
     
   u₀ = zero(u)
   if nonevesuccsteps >= 1
-    @.. u₀ = $calc_Lagrange_interp(k,weights,t+dt,ts,u_history,u₀)
+    u₀ = calc_Lagrange_interp(k,weights,t+dt,ts,u_history,u₀)
   else
     u₀ = u
   end

--- a/src/perform_step/bdf_perform_step.jl
+++ b/src/perform_step/bdf_perform_step.jl
@@ -1015,21 +1015,21 @@ function perform_step!(integrator, cache::FBDFConstantCache{max_order}, repeat_s
   if nonevesuccsteps == 0
     weights[1] = 1/dt
     ts[1] = t
-    u_history[:,1] .= _vec(uprev)
+    @.. u_history[:,1] = $_vec(uprev)
   elseif nonevesuccsteps == 1
     weights[1] = inv(t-ts[1])
     weights[2] = inv(ts[1]-t)
     ts[2] = ts[1]
     ts[1] = t
     @.. u_history[:,2] = u_history[:,1]
-    u_history[:,1] .= _vec(uprev)
+    @.. u_history[:,1] = $_vec(uprev)
   elseif consfailcnt == 0
     for i in k+2:-1:2
       ts[i] = ts[i-1]
       u_history[:,i] = u_history[:,i-1]
     end
     ts[1] = t
-    u_history[:,1] .= _vec(uprev)
+    @.. u_history[:,1] = $_vec(uprev)
   end
   
   if nonevesuccsteps >= 1
@@ -1038,7 +1038,7 @@ function perform_step!(integrator, cache::FBDFConstantCache{max_order}, repeat_s
     
   u₀ = zero(u)
   if nonevesuccsteps >= 1
-    u₀ = calc_Lagrange_interp(k,weights,t+dt,ts,u_history,u₀)
+    @.. u₀ = $calc_Lagrange_interp(k,weights,t+dt,ts,u_history,u₀)
   else
     u₀ = u
   end
@@ -1221,21 +1221,21 @@ function perform_step!(integrator, cache::FBDFCache{max_order}, repeat_step=fals
   if nonevesuccsteps == 0
     weights[1] = 1/dt
     ts[1] = t
-    u_history[:,1] .= _vec(uprev)
+    @.. u_history[:,1] = $_vec(uprev)
   elseif nonevesuccsteps == 1
     weights[1] = inv(t-ts[1])
     weights[2] = inv(ts[1]-t)
     ts[2] = ts[1]
     ts[1] = t
     @.. u_history[:,2] = u_history[:,1]
-    u_history[:,1] .= _vec(uprev)
+    @.. u_history[:,1] = $_vec(uprev)
   elseif consfailcnt == 0
     for i in k+2:-1:2
       ts[i] = ts[i-1]
       @.. u_history[:,i] = u_history[:,i-1]
     end
     ts[1] = t
-    u_history[:,1] .= _vec(uprev)
+    @.. u_history[:,1] = $_vec(uprev)
   end
   if nonevesuccsteps >= 1
     compute_weights!(ts,k,weights)

--- a/src/perform_step/bdf_perform_step.jl
+++ b/src/perform_step/bdf_perform_step.jl
@@ -1063,7 +1063,7 @@ function perform_step!(integrator, cache::FBDFConstantCache{max_order}, repeat_s
     end
   else
     for i in 1:k-1
-      u_corrector[:,i] = calc_Lagrange_interp(k,weights,equi_ts[i],ts,u_history,u_corrector[:,i])
+      @views u_corrector[:,i] = calc_Lagrange_interp(k,weights,equi_ts[i],ts,u_history,u_corrector[:,i])
     end
     tmp = - uprev * bdf_coeffs[k,2]
     vc = _vec(tmp)

--- a/test/integrators/alg_events_tests.jl
+++ b/test/integrators/alg_events_tests.jl
@@ -265,5 +265,5 @@ println(".")
 @test test_callback_inplace(QNDF())
 
 println("adaptive multistep methods")
-@test test_callback_adaptive_multistep(QNDF(),reltol=1e-8,abstol=1e-8)
-@test_broken test_callback_adaptive_multistep(FBDF(),reltol=1e-8,abstol=1e-8)
+@test test_callback_adaptive_multistep(QNDF(),reltol=1e-10,abstol=1e-8)
+@test test_callback_adaptive_multistep(FBDF(),reltol=1e-10,abstol=1e-8)


### PR DESCRIPTION
```julia
using OrdinaryDiffEq, DiffEqProblemLibrary.ODEProblemLibrary, Test
ODEProblemLibrary.importodeproblems()
prob = ODEProblemLibrary.prob_ode_2Dlinear
sol = solve(prob, FBDF(), abstol=1e-8,reltol=1e-8)
sol2 = solve(prob, Tsit5(),abstol=1e-8,reltol=1e-8)
@test sol.u[end] ≈ sol2.u[end]

> Test Passed
```