### PR TITLE
Remove scope warnings from unit tests.

### DIFF
--- a/test/interface/ode_initdt_tests.jl
+++ b/test/interface/ode_initdt_tests.jl
@@ -11,7 +11,7 @@ sol =solve(prob,ExplicitRK(tableau=constructBogakiShampine3()))
 dt₀ = sol.t[2]
 
 @test  1e-7 < dt₀ < .1
-@test_throws ErrorException sol = solve(prob,Euler())
+@test_throws ErrorException local sol = solve(prob,Euler())
 #dt₀ = sol.t[2]
 
 sol3 =solve(prob,ExplicitRK(tableau=constructDormandPrince8_64bit()))

--- a/test/interface/umodified_test.jl
+++ b/test/interface/umodified_test.jl
@@ -27,7 +27,7 @@ for τ in tvector
   # evolve until rescaling:
   push!(integ1.opts.tstops, τ); step!(integ1)
   push!(integ2.opts.tstops, τ); step!(integ2)
-  dist = norm(integ1.u .- integ2.u)
+  global dist = norm(integ1.u .- integ2.u)
   # Rescale:
   if dist ≥ threshold
     # Rescale and reset everything:


### PR DESCRIPTION
Warnings removed:

```
┌ Warning: Assignment to `sol` in soft scope is ambiguous because a global variable by the same name exists: `sol` will be treated as a new local. Disambiguate by using `local sol` to suppress this warning or `global sol` to assign to the existing global variable.
└ @ ~/OrdinaryDiffEq.jl/test/interface/ode_initdt_tests.jl:14
┌ Warning: Assignment to `dist` in soft scope is ambiguous because a global variable by the same name exists: `dist` will be treated as a new local. Disambiguate by using `local dist` to suppress this warning or `global dist` to assign to the existing global variable.
└ @ ~/OrdinaryDiffEq.jl/test/interface/umodified_test.jl:30
```