### PR TITLE
Fix resize_J_W! for Vector{Matrix{Float64}}

### DIFF
--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -163,7 +163,11 @@ function resize_J_W!(cache, integrator, i)
     if cache.J !== nothing
       cache.J = similar(cache.J, i, i)
     end
-    cache.W = similar(cache.W, i, i)
+    if typeof(cache.W) <: Vector{Matrix{Float64}}
+      fill!(cache.W,similar(eltype(cache.W),i,i))
+    else
+      cache.W = similar(cache.W, i, i)
+    end
   end
 
   nothing


### PR DESCRIPTION
Attempts to Fix #1436.

MWE:
```
f = function (du,u,p,t)
  for i in 1:length(u)
    du[i] = (0.3/length(u))*u[i]
  end
end

condition = function (u,t,integrator)
  1-maximum(u)
end

affect! = function (integrator)
  u = integrator.u
  resize!(integrator,length(u)+1)
  maxidx = findmax(u)[2]
  Θ = rand()/5 + 0.25
  u[maxidx] = Θ
  u[end] = 1-Θ
  nothing
end

callback = ContinuousCallback(condition,affect!)

u0 = [0.2]
tspan = (0.0,10.0)
prob = ODEProblem(f,u0,tspan)

sol = solve(prob, ImplicitHairerWannerExtrapolation(),callback=callback)
```
Previously:

```
ERROR: MethodError: no method matching Vector{Matrix{Float64}}(::Matrix{Matrix{Float64}})
The closest candidates are:
  Array{T, N}(::AbstractArray{S, N}) where {T, N, S} at array.jl:540
  Vector{T}() where T at boot.jl:467
  Vector{T}(::Core.Compiler.AbstractRange{T}) where T at range.jl:1042
```

After:

```
┌ Warning: Interrupted. Larger maxiters is needed.
└ @ SciMLBase ~/.julia/packages/SciMLBase/cU5k7/src/integrator_interface.jl:331
retcode: MaxIters
Interpolation: 3rd order Hermite
t: 196073-element Vector{Float64}:
 0.0
 0.4237279064034065
 4.661006970437471
 5.385928365605549
 5.385928365605549
 5.38592836560555
 ⋮
 5.385928365779689
 5.38592836577969
 5.385928365779691
 5.385928365779692
 5.385928365779693
u: 196073-element Vector{Vector{Float64}}:
 [0.2]
 [0.2271102854460072]
 [0.8096636848795802]
 [0.9999999999999999]
 [0.630100191321227]
 [0.6301001913212272]
 ⋮
 [0.6301001913212272]
 [0.6301001913212272]
 [0.6301001913212272]
 [0.6301001913212272]
 [0.6301001913212272]
```

The problem we currently have with Extrapolation Methods and QNDF is the same; resizing of `integrator.u` is not happening.

See in QNDF:

```
 Warning: Interrupted. Larger maxiters is needed.
└ @ SciMLBase ~/.julia/packages/SciMLBase/cU5k7/src/integrator_interface.jl:331
retcode: MaxIters
Interpolation: 3rd order Hermite
t: 27-element Vector{Float64}:
 0.0
 3.350000000000003e-5
 6.700000000000006e-5
 0.00010050000000000008
 0.00043550000000000034
 0.0007705000000000006
 ⋮
 3.7028119459535453
 4.44080242793806
 5.178792909922574
 5.357995644079828
 5.357995644079828
u: 27-element Vector{Vector{Float64}}:
 [0.2]
 [0.20000169621691732]
 [0.20000365726070232]
 [0.20000565966574863]
 [0.20002539992745905]
 [0.2000455165235902]
 ⋮
 [0.6083341846429979]
 [0.7592640782476203]
 [0.9476395095023401]
 [0.9999999999999998]
 [0.5845412151714129]
```
So yeah, we need to address it.