### PR TITLE
Add limiter to Tsit5()

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1123,7 +1123,11 @@ struct DP5 <: OrdinaryDiffEqAdaptiveAlgorithm end
 Tsit5: Explicit Runge-Kutta Method
    Tsitouras 5/4 Runge-Kutta method. (free 4th order interpolant).
 """
-struct Tsit5 <: OrdinaryDiffEqAdaptiveAlgorithm end
+struct Tsit5{StageLimiter,StepLimiter} <: OrdinaryDiffEqAdaptiveAlgorithm
+  stage_limiter!::StageLimiter
+  step_limiter!::StepLimiter
+  Tsit5(stage_limiter! =trivial_limiter!, step_limiter! =trivial_limiter!) = new{typeof(stage_limiter!), typeof(step_limiter!)}(stage_limiter!, step_limiter!)
+end
 
 """
 E. Hairer, S.P. Norsett, G. Wanner, (1993) Solving Ordinary Differential Equations I.

--- a/src/caches/low_order_rk_caches.jl
+++ b/src/caches/low_order_rk_caches.jl
@@ -284,7 +284,7 @@ alg_cache(alg::BS5,u,rate_prototype,::Type{uEltypeNoUnits},::Type{uBottomEltypeN
   tab::TabType
   stage_limiter!::StageLimiter
   step_limiter!::StepLimiter
-  Tsit5(u, uprev, k1, k2, k3, k4, k5, k6, k7, utilde, tmp, atmp, tab, stage_limiter! =trivial_limiter!, step_limiter! =trivial_limiter!) = new{typeof(u), typeof(uprev), typeof(k1), typeof(k2), typeof(k3), typeof(k4), typeof(k5), typeof(k6), typeof(k7), typeof(utilde), typeof(tmp), typeof(atmp), typeof(tab), typeof(stage_limiter!), typeof(step_limiter!)}(u, uprev, k1, k2, k3, k4, k5, k6, k7, utilde, tmp, atmp, tab, stage_limiter!, step_limiter!)
+  Tsit5Cache(u, uprev, k1, k2, k3, k4, k5, k6, k7, utilde, tmp, atmp, tab, stage_limiter! =trivial_limiter!, step_limiter! =trivial_limiter!) = new{typeof(u), typeof(uprev), typeof(k1), typeof(k2), typeof(k3), typeof(k4), typeof(k5), typeof(k6), typeof(k7), typeof(utilde), typeof(tmp), typeof(atmp), typeof(tab), typeof(stage_limiter!), typeof(step_limiter!)}(u, uprev, k1, k2, k3, k4, k5, k6, k7, utilde, tmp, atmp, tab, stage_limiter!, step_limiter!)
 end
 
 @cache struct RK46NLCache{uType,rateType,TabType} <: OrdinaryDiffEqMutableCache

--- a/src/caches/low_order_rk_caches.jl
+++ b/src/caches/low_order_rk_caches.jl
@@ -284,6 +284,7 @@ alg_cache(alg::BS5,u,rate_prototype,::Type{uEltypeNoUnits},::Type{uBottomEltypeN
   tab::TabType
   stage_limiter!::StageLimiter
   step_limiter!::StepLimiter
+  Tsit5(u, uprev, k1, k2, k3, k4, k5, k6, k7, utilde, tmp, atmp, tab, stage_limiter! =trivial_limiter!, step_limiter! =trivial_limiter!) = new{typeof(u), typeof(uprev), typeof(k1), typeof(k2), typeof(k3), typeof(k4), typeof(k5), typeof(k6), typeof(k7), typeof(utilde), typeof(tmp), typeof(atmp), typeof(tab), typeof(stage_limiter!), typeof(step_limiter!)}(u, uprev, k1, k2, k3, k4, k5, k6, k7, utilde, tmp, atmp, tab, stage_limiter!, step_limiter!)
 end
 
 @cache struct RK46NLCache{uType,rateType,TabType} <: OrdinaryDiffEqMutableCache

--- a/src/caches/low_order_rk_caches.jl
+++ b/src/caches/low_order_rk_caches.jl
@@ -268,7 +268,7 @@ end
 
 alg_cache(alg::BS5,u,rate_prototype,::Type{uEltypeNoUnits},::Type{uBottomEltypeNoUnits},::Type{tTypeNoUnits},uprev,uprev2,f,t,dt,reltol,p,calck,::Val{false}) where {uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits} = BS5ConstantCache(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits))
 
-@cache struct Tsit5Cache{uType,rateType,uNoUnitsType,TabType} <: OrdinaryDiffEqMutableCache
+@cache struct Tsit5Cache{uType,rateType,uNoUnitsType,TabType,StageLimiter,StepLimiter} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   k1::rateType
@@ -282,6 +282,8 @@ alg_cache(alg::BS5,u,rate_prototype,::Type{uEltypeNoUnits},::Type{uBottomEltypeN
   tmp::uType
   atmp::uNoUnitsType
   tab::TabType
+  stage_limiter!::StageLimiter
+  step_limiter!::StepLimiter
 end
 
 @cache struct RK46NLCache{uType,rateType,TabType} <: OrdinaryDiffEqMutableCache
@@ -356,7 +358,7 @@ function alg_cache(alg::Tsit5,u,rate_prototype,::Type{uEltypeNoUnits},::Type{uBo
   utilde = zero(u)
   atmp = similar(u,uEltypeNoUnits)
   tmp = zero(u)
-  Tsit5Cache(u,uprev,k1,k2,k3,k4,k5,k6,k7,utilde,tmp,atmp,tab)
+  Tsit5Cache(u,uprev,k1,k2,k3,k4,k5,k6,k7,utilde,tmp,atmp,tab,alg.stage_limiter!,alg.step_limiter!)
 end
 
 alg_cache(alg::Tsit5,u,rate_prototype,::Type{uEltypeNoUnits},::Type{uBottomEltypeNoUnits},::Type{tTypeNoUnits},uprev,uprev2,f,t,dt,reltol,p,calck,::Val{false}) where {uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits} = Tsit5ConstantCache(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits))

--- a/src/caches/low_order_rk_caches.jl
+++ b/src/caches/low_order_rk_caches.jl
@@ -284,7 +284,6 @@ alg_cache(alg::BS5,u,rate_prototype,::Type{uEltypeNoUnits},::Type{uBottomEltypeN
   tab::TabType
   stage_limiter!::StageLimiter
   step_limiter!::StepLimiter
-  Tsit5Cache(u, uprev, k1, k2, k3, k4, k5, k6, k7, utilde, tmp, atmp, tab, stage_limiter! =trivial_limiter!, step_limiter! =trivial_limiter!) = new{typeof(u), typeof(uprev), typeof(k1), typeof(k2), typeof(k3), typeof(k4), typeof(k5), typeof(k6), typeof(k7), typeof(utilde), typeof(tmp), typeof(atmp), typeof(tab), typeof(stage_limiter!), typeof(step_limiter!)}(u, uprev, k1, k2, k3, k4, k5, k6, k7, utilde, tmp, atmp, tab, stage_limiter!, step_limiter!)
 end
 
 @cache struct RK46NLCache{uType,rateType,TabType} <: OrdinaryDiffEqMutableCache

--- a/src/caches/nordsieck_caches.jl
+++ b/src/caches/nordsieck_caches.jl
@@ -65,7 +65,7 @@ function alg_cache(alg::AN5,u,rate_prototype,::Type{uEltypeNoUnits},::Type{uBott
   k6 = zero(rate_prototype); k7 = zero(rate_prototype)
   utilde = zero(u)
   atmp = similar(u,uEltypeNoUnits); tmp = zero(u)
-  tsit5cache = Tsit5Cache(u,uprev,k1,k2,k3,k4,k5,k6,k7,utilde,tmp,atmp,tab)
+  tsit5cache = Tsit5Cache(u,uprev,k1,k2,k3,k4,k5,k6,k7,utilde,tmp,atmp,tab,trivial_limiter!,trivial_limiter!)
   #################################################
   N = 5
   Δ = similar(atmp)
@@ -190,7 +190,7 @@ function alg_cache(alg::JVODE,u,rate_prototype,::Type{uEltypeNoUnits},::Type{uBo
   k5 = zero(rate_prototype); k6 = zero(rate_prototype); k7 = zero(rate_prototype)
   utilde = zero(u)
   atmp = similar(u,uEltypeNoUnits); tmp = zero(u)
-  tsit5cache = Tsit5Cache(u,uprev,k1,k2,k3,k4,k5,k6,k7,utilde,tmp,atmp,tab)
+  tsit5cache = Tsit5Cache(u,uprev,k1,k2,k3,k4,k5,k6,k7,utilde,tmp,atmp,tab,trivial_limiter!,trivial_limiter!)
   #################################################
   fsalfirst = zero(rate_prototype)
   N = 12

--- a/src/perform_step/low_order_rk_perform_step.jl
+++ b/src/perform_step/low_order_rk_perform_step.jl
@@ -627,21 +627,28 @@ end
 @muladd function perform_step!(integrator, cache::Tsit5Cache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack c1,c2,c3,c4,c5,c6,a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a62,a63,a64,a65,a71,a72,a73,a74,a75,a76,btilde1,btilde2,btilde3,btilde4,btilde5,btilde6,btilde7 = cache.tab
-  @unpack k1,k2,k3,k4,k5,k6,k7,utilde,tmp,atmp = cache
+  @unpack k1,k2,k3,k4,k5,k6,k7,utilde,tmp,atmp,stage_limiter!,step_limiter! = cache
   a = dt*a21
   @.. tmp = uprev+a*k1
+  stage_limiter!(tmp, f, p, t+c1*dt)
   f(k2, tmp, p, t+c1*dt)
   @.. tmp = uprev+dt*(a31*k1+a32*k2)
+  stage_limiter!(tmp, f, p, t+c2*dt)
   f(k3, tmp, p, t+c2*dt)
   @.. tmp = uprev+dt*(a41*k1+a42*k2+a43*k3)
+  stage_limiter!(tmp, f, p, t+c3*dt)
   f(k4, tmp, p, t+c3*dt)
   @.. tmp = uprev+dt*(a51*k1+a52*k2+a53*k3+a54*k4)
+  stage_limiter!(tmp, f, p, t+c4*dt)
   f(k5, tmp, p, t+c4*dt)
   @.. tmp = uprev+dt*(a61*k1+a62*k2+a63*k3+a64*k4+a65*k5)
+  stage_limiter!(tmp, f, p, t+dt)
   f(k6, tmp, p, t+dt)
   @.. u = uprev+dt*(a71*k1+a72*k2+a73*k3+a74*k4+a75*k5+a76*k6)
+  stage_limiter!(u, f, p, t+dt)
   f(k7, u, p, t+dt)
   integrator.destats.nf += 6
+  step_limiter!(u, f, p, t+dt)
   if integrator.alg isa CompositeAlgorithm
     g7 = u
     g6 = tmp
@@ -664,33 +671,40 @@ end
   @unpack t,dt,uprev,u,f,p = integrator
   uidx = eachindex(integrator.uprev)
   @unpack c1,c2,c3,c4,c5,c6,a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a62,a63,a64,a65,a71,a72,a73,a74,a75,a76,btilde1,btilde2,btilde3,btilde4,btilde5,btilde6,btilde7 = cache.tab
-  @unpack k1,k2,k3,k4,k5,k6,k7,utilde,tmp,atmp = cache
+  @unpack k1,k2,k3,k4,k5,k6,k7,utilde,tmp,atmp,stage_limiter!,step_limiter! = cache
   a = dt*a21
   @inbounds @simd ivdep for i in uidx
     tmp[i] = uprev[i]+a*k1[i]
   end
+  stage_limiter!(tmp, f, p, t+c1*dt)
   f(k2, tmp, p, t+c1*dt)
   @inbounds @simd ivdep for i in uidx
     tmp[i] = uprev[i]+dt*(a31*k1[i]+a32*k2[i])
   end
+  stage_limiter!(tmp, f, p, t+c2*dt)
   f(k3, tmp, p, t+c2*dt)
   @inbounds @simd ivdep for i in uidx
     tmp[i] = uprev[i]+dt*(a41*k1[i]+a42*k2[i]+a43*k3[i])
   end
+  stage_limiter!(tmp, f, p, t+c3*dt)
   f(k4, tmp, p, t+c3*dt)
   @inbounds @simd ivdep for i in uidx
     tmp[i] = uprev[i]+dt*(a51*k1[i]+a52*k2[i]+a53*k3[i]+a54*k4[i])
   end
+  stage_limiter!(tmp, f, p, t+c4*dt)
   f(k5, tmp, p, t+c4*dt)
   @inbounds @simd ivdep for i in uidx
     tmp[i] = uprev[i]+dt*(a61*k1[i]+a62*k2[i]+a63*k3[i]+a64*k4[i]+a65*k5[i])
   end
+  stage_limiter!(tmp, f, p, t+dt)
   f(k6, tmp, p, t+dt)
   @inbounds @simd ivdep for i in uidx
     u[i] = uprev[i]+dt*(a71*k1[i]+a72*k2[i]+a73*k3[i]+a74*k4[i]+a75*k5[i]+a76*k6[i])
   end
+  stage_limiter!(u, f, p, t+dt)
   f(k7, u, p, t+dt)
   integrator.destats.nf += 6
+  step_limiter!(u, f, p, t+dt)
   if typeof(integrator.alg) <: CompositeAlgorithm
     g7 = u
     g6 = tmp


### PR DESCRIPTION
This is to add the `stage_limiter!` and `step_limiter!` to `Tsit5()`. Currently, there are are no fifth order solvers with this functionality.

I have taken the same route as https://github.com/SciML/OrdinaryDiffEq.jl/pull/1293, also discussed in https://github.com/SciML/OrdinaryDiffEq.jl/issues/1292.

Result seems to be matching with a hard-coded version.