### PR TITLE
add stage/step limiters to RDPK3Sp* methods

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -762,13 +762,21 @@ struct ParsaniKetchesonDeconinck3S205 <: OrdinaryDiffEqAlgorithm end
 A third-order, five-stage explicit Runge-Kutta method with embedded error estimator
 designed for spectral element discretizations of compressible fluid mechanics.
 
+Like SSPRK methods, this method also takes optional arguments `stage_limiter!`
+and `step_limiter!`, where `stage_limiter!` and `step_limiter!` are functions
+of the form `limiter!(u, integrator, p, t)`.
+
 ## References
 - Ranocha, Dalcin, Parsani, Ketcheson (2021)
   Optimized Runge-Kutta Methods with Automatic Step Size Control for
   Compressible Computational Fluid Dynamics
   [arXiv:2104.06836](https://arxiv.org/abs/2104.06836)
 """
-struct RDPK3Sp35 <: OrdinaryDiffEqAdaptiveAlgorithm end
+struct RDPK3Sp35{StageLimiter,StepLimiter} <: OrdinaryDiffEqAdaptiveAlgorithm
+  stage_limiter!::StageLimiter
+  step_limiter!::StepLimiter
+  RDPK3Sp35(stage_limiter! = trivial_limiter!, step_limiter! = trivial_limiter!) = new{typeof(stage_limiter!), typeof(step_limiter!)}(stage_limiter!, step_limiter!)
+end
 
 """
     RDPK3SpFSAL35()
@@ -777,13 +785,21 @@ A third-order, five-stage explicit Runge-Kutta method with embedded error estima
 using the FSAL property designed for spectral element discretizations of
 compressible fluid mechanics.
 
+Like SSPRK methods, this method also takes optional arguments `stage_limiter!`
+and `step_limiter!`, where `stage_limiter!` and `step_limiter!` are functions
+of the form `limiter!(u, integrator, p, t)`.
+
 ## References
 - Ranocha, Dalcin, Parsani, Ketcheson (2021)
   Optimized Runge-Kutta Methods with Automatic Step Size Control for
   Compressible Computational Fluid Dynamics
   [arXiv:2104.06836](https://arxiv.org/abs/2104.06836)
 """
-struct RDPK3SpFSAL35 <: OrdinaryDiffEqAdaptiveAlgorithm end
+struct RDPK3SpFSAL35{StageLimiter,StepLimiter} <: OrdinaryDiffEqAdaptiveAlgorithm
+  stage_limiter!::StageLimiter
+  step_limiter!::StepLimiter
+  RDPK3SpFSAL35(stage_limiter! = trivial_limiter!, step_limiter! = trivial_limiter!) = new{typeof(stage_limiter!), typeof(step_limiter!)}(stage_limiter!, step_limiter!)
+end
 
 """
     RDPK3Sp49()
@@ -791,13 +807,21 @@ struct RDPK3SpFSAL35 <: OrdinaryDiffEqAdaptiveAlgorithm end
 A fourth-order, nine-stage explicit Runge-Kutta method with embedded error estimator
 designed for spectral element discretizations of compressible fluid mechanics.
 
+  Like SSPRK methods, this method also takes optional arguments `stage_limiter!`
+  and `step_limiter!`, where `stage_limiter!` and `step_limiter!` are functions
+  of the form `limiter!(u, integrator, p, t)`.
+
 ## References
 - Ranocha, Dalcin, Parsani, Ketcheson (2021)
   Optimized Runge-Kutta Methods with Automatic Step Size Control for
   Compressible Computational Fluid Dynamics
   [arXiv:2104.06836](https://arxiv.org/abs/2104.06836)
 """
-struct RDPK3Sp49 <: OrdinaryDiffEqAdaptiveAlgorithm end
+struct RDPK3Sp49{StageLimiter,StepLimiter} <: OrdinaryDiffEqAdaptiveAlgorithm
+  stage_limiter!::StageLimiter
+  step_limiter!::StepLimiter
+  RDPK3Sp49(stage_limiter! = trivial_limiter!, step_limiter! = trivial_limiter!) = new{typeof(stage_limiter!), typeof(step_limiter!)}(stage_limiter!, step_limiter!)
+end
 
 """
     RDPK3SpFSAL49()
@@ -806,13 +830,21 @@ A fourth-order, nine-stage explicit Runge-Kutta method with embedded error estim
 using the FSAL property designed for spectral element discretizations of
 compressible fluid mechanics.
 
+Like SSPRK methods, this method also takes optional arguments `stage_limiter!`
+and `step_limiter!`, where `stage_limiter!` and `step_limiter!` are functions
+of the form `limiter!(u, integrator, p, t)`.
+
 ## References
 - Ranocha, Dalcin, Parsani, Ketcheson (2021)
   Optimized Runge-Kutta Methods with Automatic Step Size Control for
   Compressible Computational Fluid Dynamics
   [arXiv:2104.06836](https://arxiv.org/abs/2104.06836)
 """
-struct RDPK3SpFSAL49 <: OrdinaryDiffEqAdaptiveAlgorithm end
+struct RDPK3SpFSAL49{StageLimiter,StepLimiter} <: OrdinaryDiffEqAdaptiveAlgorithm
+  stage_limiter!::StageLimiter
+  step_limiter!::StepLimiter
+  RDPK3SpFSAL49(stage_limiter! = trivial_limiter!, step_limiter! = trivial_limiter!) = new{typeof(stage_limiter!), typeof(step_limiter!)}(stage_limiter!, step_limiter!)
+end
 
 """
     RDPK3Sp510()
@@ -820,13 +852,21 @@ struct RDPK3SpFSAL49 <: OrdinaryDiffEqAdaptiveAlgorithm end
 A fifth-order, ten-stage explicit Runge-Kutta method with embedded error estimator
 designed for spectral element discretizations of compressible fluid mechanics.
 
+  Like SSPRK methods, this method also takes optional arguments `stage_limiter!`
+  and `step_limiter!`, where `stage_limiter!` and `step_limiter!` are functions
+  of the form `limiter!(u, integrator, p, t)`.
+
 ## References
 - Ranocha, Dalcin, Parsani, Ketcheson (2021)
   Optimized Runge-Kutta Methods with Automatic Step Size Control for
   Compressible Computational Fluid Dynamics
   [arXiv:2104.06836](https://arxiv.org/abs/2104.06836)
 """
-struct RDPK3Sp510 <: OrdinaryDiffEqAdaptiveAlgorithm end
+struct RDPK3Sp510{StageLimiter,StepLimiter} <: OrdinaryDiffEqAdaptiveAlgorithm
+  stage_limiter!::StageLimiter
+  step_limiter!::StepLimiter
+  RDPK3Sp510(stage_limiter! = trivial_limiter!, step_limiter! = trivial_limiter!) = new{typeof(stage_limiter!), typeof(step_limiter!)}(stage_limiter!, step_limiter!)
+end
 
 """
     RDPK3SpFSAL510()
@@ -835,13 +875,21 @@ A fifth-order, ten-stage explicit Runge-Kutta method with embedded error estimat
 using the FSAL property designed for spectral element discretizations of
 compressible fluid mechanics.
 
+Like SSPRK methods, this method also takes optional arguments `stage_limiter!`
+and `step_limiter!`, where `stage_limiter!` and `step_limiter!` are functions
+of the form `limiter!(u, integrator, p, t)`.
+
 ## References
 - Ranocha, Dalcin, Parsani, Ketcheson (2021)
   Optimized Runge-Kutta Methods with Automatic Step Size Control for
   Compressible Computational Fluid Dynamics
   [arXiv:2104.06836](https://arxiv.org/abs/2104.06836)
 """
-struct RDPK3SpFSAL510 <: OrdinaryDiffEqAdaptiveAlgorithm end
+struct RDPK3SpFSAL510{StageLimiter,StepLimiter} <: OrdinaryDiffEqAdaptiveAlgorithm
+  stage_limiter!::StageLimiter
+  step_limiter!::StepLimiter
+  RDPK3SpFSAL510(stage_limiter! = trivial_limiter!, step_limiter! = trivial_limiter!) = new{typeof(stage_limiter!), typeof(step_limiter!)}(stage_limiter!, step_limiter!)
+end
 
 struct KYK2014DGSSPRK_3S2 <: OrdinaryDiffEqAlgorithm end
 

--- a/src/caches/low_storage_rk_caches.jl
+++ b/src/caches/low_storage_rk_caches.jl
@@ -1427,7 +1427,7 @@ end
 #   Optimized Runge-Kutta Methods with Automatic Step Size Control for
 #   Compressible Computational Fluid Dynamics
 #   [arXiv:2104.06836](https://arxiv.org/abs/2104.06836)
-@cache struct LowStorageRK3SpCache{uType,rateType,uNoUnitsType,TabType} <: OrdinaryDiffEqMutableCache
+@cache struct LowStorageRK3SpCache{uType,rateType,uNoUnitsType,TabType,StageLimiter,StepLimiter} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   fsalfirst::rateType
@@ -1436,6 +1436,8 @@ end
   tmp::uType
   atmp::uNoUnitsType
   tab::TabType
+  stage_limiter!::StageLimiter
+  step_limiter!::StepLimiter
 end
 
 struct LowStorageRK3SpConstantCache{N,T,T2} <: OrdinaryDiffEqConstantCache
@@ -1528,7 +1530,7 @@ function alg_cache(alg::RDPK3Sp35,u,rate_prototype,::Type{uEltypeNoUnits},::Type
     atmp = similar(u,uEltypeNoUnits)
   end
   tab = RDPK3Sp35ConstantCache(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits))
-  LowStorageRK3SpCache(u,uprev,fsalfirst,k,utilde,tmp,atmp,tab)
+  LowStorageRK3SpCache(u,uprev,fsalfirst,k,utilde,tmp,atmp,tab,alg.stage_limiter!,alg.step_limiter!)
 end
 
 function alg_cache(alg::RDPK3Sp35,u,rate_prototype,::Type{uEltypeNoUnits},::Type{uBottomEltypeNoUnits},::Type{tTypeNoUnits},uprev,uprev2,f,t,dt,reltol,p,calck,::Val{false}) where {uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits}
@@ -1644,7 +1646,7 @@ function alg_cache(alg::RDPK3Sp49,u,rate_prototype,::Type{uEltypeNoUnits},::Type
     atmp = similar(u,uEltypeNoUnits)
   end
   tab = RDPK3Sp49ConstantCache(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits))
-  LowStorageRK3SpCache(u,uprev,fsalfirst,k,utilde,tmp,atmp,tab)
+  LowStorageRK3SpCache(u,uprev,fsalfirst,k,utilde,tmp,atmp,tab,alg.stage_limiter!,alg.step_limiter!)
 end
 
 function alg_cache(alg::RDPK3Sp49,u,rate_prototype,::Type{uEltypeNoUnits},::Type{uBottomEltypeNoUnits},::Type{tTypeNoUnits},uprev,uprev2,f,t,dt,reltol,p,calck,::Val{false}) where {uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits}
@@ -1768,7 +1770,7 @@ function alg_cache(alg::RDPK3Sp510,u,rate_prototype,::Type{uEltypeNoUnits},::Typ
     atmp = similar(u,uEltypeNoUnits)
   end
   tab = RDPK3Sp510ConstantCache(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits))
-  LowStorageRK3SpCache(u,uprev,fsalfirst,k,utilde,tmp,atmp,tab)
+  LowStorageRK3SpCache(u,uprev,fsalfirst,k,utilde,tmp,atmp,tab,alg.stage_limiter!,alg.step_limiter!)
 end
 
 function alg_cache(alg::RDPK3Sp510,u,rate_prototype,::Type{uEltypeNoUnits},::Type{uBottomEltypeNoUnits},::Type{tTypeNoUnits},uprev,uprev2,f,t,dt,reltol,p,calck,::Val{false}) where {uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits}
@@ -1782,7 +1784,7 @@ end
 #   Optimized Runge-Kutta Methods with Automatic Step Size Control for
 #   Compressible Computational Fluid Dynamics
 #   [arXiv:2104.06836](https://arxiv.org/abs/2104.06836)
-@cache struct LowStorageRK3SpFSALCache{uType,rateType,uNoUnitsType,TabType} <: OrdinaryDiffEqMutableCache
+@cache struct LowStorageRK3SpFSALCache{uType,rateType,uNoUnitsType,TabType,StageLimiter,StepLimiter} <: OrdinaryDiffEqMutableCache
   u::uType
   uprev::uType
   fsalfirst::rateType
@@ -1791,6 +1793,8 @@ end
   tmp::uType
   atmp::uNoUnitsType
   tab::TabType
+  stage_limiter!::StageLimiter
+  step_limiter!::StepLimiter
 end
 
 struct LowStorageRK3SpFSALConstantCache{N,T,T2} <: OrdinaryDiffEqConstantCache
@@ -1885,7 +1889,7 @@ function alg_cache(alg::RDPK3SpFSAL35,u,rate_prototype,::Type{uEltypeNoUnits},::
     atmp = similar(u,uEltypeNoUnits)
   end
   tab = RDPK3SpFSAL35ConstantCache(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits))
-  LowStorageRK3SpFSALCache(u,uprev,fsalfirst,k,utilde,tmp,atmp,tab)
+  LowStorageRK3SpFSALCache(u,uprev,fsalfirst,k,utilde,tmp,atmp,tab,alg.stage_limiter!,alg.step_limiter!)
 end
 
 function alg_cache(alg::RDPK3SpFSAL35,u,rate_prototype,::Type{uEltypeNoUnits},::Type{uBottomEltypeNoUnits},::Type{tTypeNoUnits},uprev,uprev2,f,t,dt,reltol,p,calck,::Val{false}) where {uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits}
@@ -2002,7 +2006,7 @@ function alg_cache(alg::RDPK3SpFSAL49,u,rate_prototype,::Type{uEltypeNoUnits},::
     atmp = similar(u,uEltypeNoUnits)
   end
   tab = RDPK3SpFSAL49ConstantCache(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits))
-  LowStorageRK3SpFSALCache(u,uprev,fsalfirst,k,utilde,tmp,atmp,tab)
+  LowStorageRK3SpFSALCache(u,uprev,fsalfirst,k,utilde,tmp,atmp,tab,alg.stage_limiter!,alg.step_limiter!)
 end
 
 function alg_cache(alg::RDPK3SpFSAL49,u,rate_prototype,::Type{uEltypeNoUnits},::Type{uBottomEltypeNoUnits},::Type{tTypeNoUnits},uprev,uprev2,f,t,dt,reltol,p,calck,::Val{false}) where {uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits}
@@ -2127,7 +2131,7 @@ function alg_cache(alg::RDPK3SpFSAL510,u,rate_prototype,::Type{uEltypeNoUnits},:
     atmp = similar(u,uEltypeNoUnits)
   end
   tab = RDPK3SpFSAL510ConstantCache(constvalue(uBottomEltypeNoUnits),constvalue(tTypeNoUnits))
-  LowStorageRK3SpFSALCache(u,uprev,fsalfirst,k,utilde,tmp,atmp,tab)
+  LowStorageRK3SpFSALCache(u,uprev,fsalfirst,k,utilde,tmp,atmp,tab,alg.stage_limiter!,alg.step_limiter!)
 end
 
 function alg_cache(alg::RDPK3SpFSAL510,u,rate_prototype,::Type{uEltypeNoUnits},::Type{uBottomEltypeNoUnits},::Type{tTypeNoUnits},uprev,uprev2,f,t,dt,reltol,p,calck,::Val{false}) where {uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits}


### PR DESCRIPTION
I added `stage_limiter!` and `step_limiter!` to our low-storage methods `RDPK3Sp*` optimized for hyperbolic PDEs. I also tested them locally with [Trixi.jl](https://github.com/trixi-framework/Trixi.jl).