### PR TITLE
Issue#440 - Fix interpolation printing for composites

### DIFF
--- a/src/interp_func.jl
+++ b/src/interp_func.jl
@@ -20,7 +20,7 @@ struct CompositeInterpolationData{F,uType,tType,kType,cacheType} <: OrdinaryDiff
 end
 
 function DiffEqBase.interp_summary(interp::OrdinaryDiffEqInterpolation{cacheType}) where {cacheType}
-    DiffEqBase.interp_summary(cacheType, interp.dense)
+  DiffEqBase.interp_summary(cacheType, interp.dense)
 end
 DiffEqBase.interp_summary(::Type{cacheType}, dense::Bool) where {cacheType<:FunctionMapConstantCache} = "left-endpoint piecewise constant"
 DiffEqBase.interp_summary(::Type{cacheType}, dense::Bool) where {cacheType<:FunctionMapCache} = "left-endpoint piecewise constant"


### PR DESCRIPTION
Hi, 

This is my proposal for fix the printing of Composite type (issue#440) 
I tried to change as little as possible(with limited success). 
The main idea: 
```
function DiffEqBase.interp_summary(interp::OrdinaryDiffEqInterpolation{cacheType}) where {cacheType}
  DiffEqBase.interp_summary(cacheType, interp.dense)
end
```
follows the same interface as before but change the "inner" functions. That's for using the same functions for the Composite type (caches). 
For example: 
```
function DiffEqBase.interp_summary(interp::OrdinaryDiffEqInterpolation{cacheType}) where cacheType<:Union{Rosenbrock23ConstantCache,Rosenbrock32ConstantCache,Rosenbrock23Cache,Rosenbrock32Cache}
  interp.dense ? "specialized 2nd order \"free\" stiffness-aware interpolation" : "1st order linear"
end
```
change to:
```
function DiffEqBase.interp_summary(::Type{cacheType}, dense::Bool) where cacheType<:Union{Rosenbrock23ConstantCache,Rosenbrock32ConstantCache,Rosenbrock23Cache,Rosenbrock32Cache}
  dense ? "specialized 2nd order \"free\" stiffness-aware interpolation" : "1st order linear"
end
```
All that is for (the fix)
```
function DiffEqBase.interp_summary(::Type{cacheType}, dense::Bool) where cacheType<:CompositeCache
  if !dense; return "1st order linear"; end
  caches = fieldtype(cacheType,:caches)
  join([DiffEqBase.interp_summary(ct, dense) for ct in fieldtypes(caches)],", ")
end
```
That wasn't possible with the old interface(I didn't mange to do so). 
I'm not sure why the diff is so aggressive I only change the functions signatures and added two functions.  

The return string format is <first interp>, <second interp>, ..., <last interp>

If you have a simpler solution let me know. 
 