### PR TITLE
set proposed dt in `auto_reset_dt!`

### DIFF
--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -330,6 +330,7 @@ function DiffEqBase.auto_dt_reset!(integrator::ODEIntegrator)
   integrator.tdir,integrator.opts.dtmax,integrator.opts.abstol,integrator.opts.reltol,
   integrator.opts.internalnorm,integrator.sol.prob,integrator)
   integrator.destats.nf += 2
+  set_proposed_dt!(integrator, integrator.dt)
 end
 
 function DiffEqBase.set_t!(integrator::ODEIntegrator, t::Real)

--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -329,8 +329,8 @@ function DiffEqBase.auto_dt_reset!(integrator::ODEIntegrator)
   integrator.dt = ode_determine_initdt(integrator.u,integrator.t,
   integrator.tdir,integrator.opts.dtmax,integrator.opts.abstol,integrator.opts.reltol,
   integrator.opts.internalnorm,integrator.sol.prob,integrator)
+  integrator.dtpropose = integrator.dt
   integrator.destats.nf += 2
-  set_proposed_dt!(integrator, integrator.dt)
 end
 
 function DiffEqBase.set_t!(integrator::ODEIntegrator, t::Real)


### PR DESCRIPTION
Right now, `auto_reset_dt!` does not actually change the next timestep when used inside a callback for example.

I think it would be also nice to think about integrating
```julia
  if integrator.opts.adaptive
    auto_dt_reset!(integrator)
  end
```
next to 

https://github.com/SciML/OrdinaryDiffEq.jl/blob/02f85eae4b281ecdd9db4572aa0439694d5e0c61/src/integrators/integrator_interface.jl#L40-L42

so the adaptive timestepping is reset automaticially after introducing a discontinuity.
I think this is a saner default for callbacks. Well at least in my case, where I often introduce a pertubation to a system in a fixpoint. In the fixpoint the adaptive timestep is to big to capure the behaviour of the system right after the callback.