### PR TITLE
Backport get_chunksize_int to 5.61.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEq"
 uuid = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "5.61.2"
+version = "5.61.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -134,7 +134,7 @@ function DiffEqBase.build_jac_config(alg,f::F1,uf::F2,du1,uprev,u,tmp,du2,::Val{
 end
 
 get_chunksize(jac_config::ForwardDiff.JacobianConfig{T,V,N,D}) where {T,V,N,D} = Val(N) # don't degrade compile time information to runtime information
-_unwrap(::Val{N}) where {N} = N
+_unwrap(::Val{N}) where {N} = N::Int
 get_chunksize_int(x) = _unwrap(get_chunksize(x))
 
 function DiffEqBase.resize_jac_config!(jac_config::SparseDiffTools.ForwardColorJacCache, i)

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -43,7 +43,7 @@ function jacobian_autodiff(f, x::AbstractArray, odefun, alg)
   jac_prototype = odefun.jac_prototype
   sparsity,colorvec = sparsity_colorvec(odefun,x)
   maxcolor = maximum(colorvec)
-  chunk_size = get_chunksize(alg)===Val(0) ? nothing : get_chunksize(alg) # SparseDiffEq uses different convection...
+  chunk_size = get_chunksize(alg)===Val(0) ? nothing : get_chunksize_int(alg) # SparseDiffEq uses different convection...
   num_of_chunks = chunk_size===nothing ? Int(ceil(maxcolor / getsize(ForwardDiff.pickchunksize(maxcolor)))) :
                                         Int(ceil(maxcolor / chunk_size))
   (forwarddiff_color_jacobian(f,x,colorvec = colorvec, sparsity = sparsity,
@@ -134,6 +134,8 @@ function DiffEqBase.build_jac_config(alg,f::F1,uf::F2,du1,uprev,u,tmp,du2,::Val{
 end
 
 get_chunksize(jac_config::ForwardDiff.JacobianConfig{T,V,N,D}) where {T,V,N,D} = Val(N) # don't degrade compile time information to runtime information
+_unwrap(::Val{N}) where {N} = N
+get_chunksize_int(x) = _unwrap(get_chunksize(x))
 
 function DiffEqBase.resize_jac_config!(jac_config::SparseDiffTools.ForwardColorJacCache, i)
   resize!(jac_config.fx, i)


### PR DESCRIPTION
Backports the `get_chunksize_int` fix.