### PR TITLE
Keep chunksize as type information

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}
+    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.julia-version }}
     runs-on: ${{ matrix.os }}
     env:
       GROUP: ${{ matrix.package.group }}
@@ -32,7 +32,7 @@ jobs:
       - name: Clone Downstream
         uses: actions/checkout@v2
         with:
-          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}/${{ matrix.julia-version }}
+          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
           path: downstream
       - name: Load this and run the downstream tests
         shell: julia --color=yes --project=downstream {0}

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -171,7 +171,7 @@ function DiffEqBase.prepare_alg(alg::Union{OrdinaryDiffEqAdaptiveImplicitAlgorit
     if typeof(alg) <: OrdinaryDiffEqImplicitExtrapolationAlgorithm
       return alg # remake fails, should get fixed
     else
-      remake(alg,chunk_size=ForwardDiff.pickchunksize(x))
+      remake(alg,chunk_size=Val{ForwardDiff.pickchunksize(x)}())
     end
 end
 

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -397,7 +397,7 @@ end
 @noinline _throwWMerror(W, mass_matrix) = throw(DimensionMismatch("W: $(axes(W)), mass matrix: $(axes(mass_matrix))"))
 @noinline _throwJMerror(J, mass_matrix) = throw(DimensionMismatch("J: $(axes(J)), mass matrix: $(axes(mass_matrix))"))
 
-@inline function jacobian2W!(W::AbstractMatrix, mass_matrix::MT, dtgamma::Number, J::AbstractMatrix, W_transform::Bool)::Nothing where MT
+function jacobian2W!(W::AbstractMatrix, mass_matrix::MT, dtgamma::Number, J::AbstractMatrix, W_transform::Bool)::Nothing where MT
   # check size and dimension
   iijj = axes(W)
   @boundscheck (iijj == axes(J) && length(iijj) == 2) || _throwWJerror(W, J)
@@ -431,7 +431,7 @@ end
   return nothing
 end
 
-@inline function jacobian2W(mass_matrix::MT, dtgamma::Number, J::AbstractMatrix, W_transform::Bool)::Nothing where MT
+function jacobian2W(mass_matrix::MT, dtgamma::Number, J::AbstractMatrix, W_transform::Bool)::Nothing where MT
   # check size and dimension
   mass_matrix isa UniformScaling || @boundscheck axes(mass_matrix) == axes(J) || _throwJMerror(J, mass_matrix)
   @inbounds if W_transform

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -598,7 +598,7 @@ function update_W!(nlsolver::AbstractNLSolver, integrator, cache, dtgamma, repea
   nothing
 end
 
-function build_J_W(alg,u,uprev,p,t,dt,f::F,uEltypeNoUnits,::Val{IIP}) where {IIP,F}
+function build_J_W(alg,u,uprev,p,t,dt,f::F,::Type{uEltypeNoUnits},::Val{IIP}) where {IIP,uEltypeNoUnits,F}
   islin, isode = islinearfunction(f, alg)
   if f.jac_prototype isa DiffEqBase.AbstractDiffEqLinearOperator
     W = WOperator{IIP}(f, u, dt)

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -43,9 +43,9 @@ function jacobian_autodiff(f, x::AbstractArray, odefun, alg)
   jac_prototype = odefun.jac_prototype
   sparsity,colorvec = sparsity_colorvec(odefun,x)
   maxcolor = maximum(colorvec)
-  chunk_size = get_chunksize(alg)===Val(0) ? nothing : get_chunksize_int(alg) # SparseDiffEq uses different convection...
+  chunk_size = get_chunksize(alg)===Val(0) ? nothing : get_chunksize(alg)
   num_of_chunks = chunk_size===nothing ? Int(ceil(maxcolor / getsize(ForwardDiff.pickchunksize(maxcolor)))) :
-                                        Int(ceil(maxcolor / chunk_size))
+                                        Int(ceil(maxcolor / _unwrap_val(chunk_size)))
   (forwarddiff_color_jacobian(f,x,colorvec = colorvec, sparsity = sparsity,
                               jac_prototype = jac_prototype, chunksize=chunk_size),
    num_of_chunks)


### PR DESCRIPTION
```julia
function rober2(u,p,t)
  y₁,y₂,y₃ = u
  k₁,k₂,k₃ = p
  du1 = -k₁*y₁+k₃*y₂*y₃
  du2 =  k₁*y₁-k₂*y₂^2-k₃*y₂*y₃
  du3 =  k₂*y₂^2
  SA[du1,du2,du3]
end
prob2 = ODEProblem{false}(rober2,SA[1.0,0.0,0.0],(0.0,1e5),SA[0.04,3e7,1e4])
@btime sol = solve(prob2,Rosenbrock23(),save_everystep=false)
```

Sends this from `28.900 μs (206 allocations: 17.34 KiB)` to `14.900 μs (26 allocations: 3.28 KiB)` and removes all dynamic dispatches.