### PR TITLE
Manually union split chunksize calculation

### DIFF
--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -171,7 +171,15 @@ function DiffEqBase.prepare_alg(alg::Union{OrdinaryDiffEqAdaptiveImplicitAlgorit
     if typeof(alg) <: OrdinaryDiffEqImplicitExtrapolationAlgorithm
       return alg # remake fails, should get fixed
     else
-      remake(alg,chunk_size=Val{ForwardDiff.pickchunksize(x)}())
+      chunk_size = ForwardDiff.pickchunksize(x)
+      if chunk_size > 8
+        cs = Val{8}()
+      elseif chunk_size > 4
+        cs = Val{4}()
+      else
+        cs = Val{1}()
+      end
+      remake(alg,chunk_size=cs)
     end
 end
 

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -174,12 +174,14 @@ function DiffEqBase.prepare_alg(alg::Union{OrdinaryDiffEqAdaptiveImplicitAlgorit
       chunk_size = ForwardDiff.pickchunksize(x)
       if chunk_size > 8
         cs = Val{8}()
+        remake(alg,chunk_size=cs)
       elseif chunk_size > 4
         cs = Val{4}()
+        remake(alg,chunk_size=cs)
       else
         cs = Val{1}()
+        remake(alg,chunk_size=cs)
       end
-      remake(alg,chunk_size=cs)
     end
 end
 

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -174,10 +174,10 @@ function DiffEqBase.prepare_alg(alg::Union{OrdinaryDiffEqAdaptiveImplicitAlgorit
       L = ArrayInterface.known_length(typeof(u0))
       if L === nothing # dynamic sized
         chunk_size = ForwardDiff.pickchunksize(x)
-        if chunk_size > 8
+        if chunk_size >= 8
           cs = Val{8}()
           remake(alg,chunk_size=cs)
-        elseif chunk_size > 4
+        elseif chunk_size >= 4
           cs = Val{4}()
           remake(alg,chunk_size=cs)
         else


### PR DESCRIPTION
```julia
using DifferentialEquations, SnoopCompile

function lorenz(du,u,p,t)
 du[1] = 10.0(u[2]-u[1])
 du[2] = u[1]*(28.0-u[3]) - u[2]
 du[3] = u[1]*u[2] - (8/3)*u[3]
end

u0 = [1.0;0.0;0.0]
tspan = (0.0,100.0)
prob = ODEProblem(lorenz,u0,tspan)
alg = Rodas5()
tinf = @snoopi_deep solve(prob,alg)
```

Before:
```julia
InferenceTimingNode: 1.524478/15.326828 on Core.Compiler.Timings.ROOT() with 4 direct children

julia> inference_triggers(tinf)
3-element Vector{InferenceTrigger}:
 Inference triggered to call (NamedTuple{(:chunk_size,)})(::Tuple{Val{3}}) from prepare_alg (C:\Users\accou\.julia\dev\OrdinaryDiffEq\src\alg_utils.jl:174) with specialization DiffEqBase.prepare_alg(::Rodas5{0, true, DefaultLinSolve, Val{:forward}}, ::Vector{Float64}, ::SciMLBase.NullParameters, ::ODEProblem{Vector{Float64}, Tuple{Float64, Float64}, true, SciMLBase.NullParameters, ODEFunction{true, typeof(lorenz), LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing}, Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, SciMLBase.StandardODEProblem})
 Inference triggered to call DiffEqBase.solve_call(::ODEProblem{Vector{Float64}, Tuple{Float64, Float64}, true, SciMLBase.NullParameters, ODEFunction{true, typeof(lorenz), LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing}, Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, SciMLBase.StandardODEProblem}, ::Rodas5{3, true, DefaultLinSolve, Val{:forward}}) from #solve_up#44 (C:\Users\accou\.julia\packages\DiffEqBase\b1nST\src\solve.jl:87) with specialization DiffEqBase.var"#solve_up#44"(::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, ::typeof(DiffEqBase.solve_up), ::ODEProblem{Vector{Float64}, Tuple{Float64, Float64}, true, SciMLBase.NullParameters, ODEFunction{true, typeof(lorenz), LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing}, Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, SciMLBase.StandardODEProblem}, ::Nothing, ::Vector{Float64}, ::SciMLBase.NullParameters, ::Rodas5{0, true, DefaultLinSolve, Val{:forward}})
 Inference triggered to call OrdinaryDiffEq.jacobian2W!(::Matrix{Float64}, ::LinearAlgebra.UniformScaling{Bool}, ::Float64, ::Matrix{Float64}, ::Bool) called from toplevel
 ```

After:
```julia
InferenceTimingNode: 3.082193/16.376914 on Core.Compiler.Timings.ROOT() with 2 direct children

julia> inference_triggers(tinf)
1-element Vector{InferenceTrigger}:
 Inference triggered to call OrdinaryDiffEq.jacobian2W!(::Matrix{Float64}, ::LinearAlgebra.UniformScaling{Bool}, ::Float64, ::Matrix{Float64}, ::Bool) called from toplevel
```

That's without the static array handling branch.