### PR TITLE
Chunk size 1 when eltype is already dual

### DIFF
--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -181,6 +181,12 @@ function DiffEqBase.prepare_alg(alg::Union{OrdinaryDiffEqAdaptiveImplicitAlgorit
       end
     end
 end
+function DiffEqBase.prepare_alg(alg::Union{OrdinaryDiffEqAdaptiveImplicitAlgorithm{0,AD,FDT},
+                        OrdinaryDiffEqImplicitAlgorithm{0,AD,FDT},
+                        DAEAlgorithm{0,AD,FDT}},u0::AbstractArray{<:ForwardDiff.Dual},p,prob) where {AD,FDT}
+# If our element type consists of dual numbers already, we prefer a chunk size of `1`.
+  remake(alg,chunk_size=Val(1))
+end
 
 @generated function pick_static_chunksize(::Val{chunksize}) where chunksize
   x = ForwardDiff.pickchunksize(chunksize)

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -160,6 +160,7 @@ get_chunksize_int(alg::ExponentialAlgorithm) = alg.chunksize
 function DiffEqBase.prepare_alg(alg::Union{OrdinaryDiffEqAdaptiveImplicitAlgorithm{0,AD,FDT},
                         OrdinaryDiffEqImplicitAlgorithm{0,AD,FDT},
                         DAEAlgorithm{0,AD,FDT}},u0::AbstractArray,p,prob) where {AD,FDT}
+    sizeof(eltype(u0)) > 24 && return remake(alg, chunk_size=Val{1}())
     # If chunksize is zero, pick chunksize right at the start of solve and
     # then do function barrier to infer the full solve
     x = if prob.f.colorvec === nothing
@@ -180,12 +181,6 @@ function DiffEqBase.prepare_alg(alg::Union{OrdinaryDiffEqAdaptiveImplicitAlgorit
         remake(alg,chunk_size=cs)
       end
     end
-end
-function DiffEqBase.prepare_alg(alg::Union{OrdinaryDiffEqAdaptiveImplicitAlgorithm{0,AD,FDT},
-                        OrdinaryDiffEqImplicitAlgorithm{0,AD,FDT},
-                        DAEAlgorithm{0,AD,FDT}},u0::AbstractArray{<:ForwardDiff.Dual},p,prob) where {AD,FDT}
-# If our element type consists of dual numbers already, we prefer a chunk size of `1`.
-  remake(alg,chunk_size=Val(1))
 end
 
 @generated function pick_static_chunksize(::Val{chunksize}) where chunksize

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -159,9 +159,9 @@ get_chunksize_int(alg::ExponentialAlgorithm) = alg.chunksize
 
 function DiffEqBase.prepare_alg(alg::Union{OrdinaryDiffEqAdaptiveImplicitAlgorithm{0,AD,FDT},
                         OrdinaryDiffEqImplicitAlgorithm{0,AD,FDT},
-                        DAEAlgorithm{0,AD,FDT}},u0::AbstractArray,p,prob) where {AD,FDT}
+                        DAEAlgorithm{0,AD,FDT}},u0::AbstractArray{T},p,prob) where {AD,FDT,T}
     alg isa OrdinaryDiffEqImplicitExtrapolationAlgorithm && return alg # remake fails, should get fixed
-    sizeof(eltype(u0)) > 24 && return remake(alg, chunk_size=Val{1}())
+    isbitstype(T) && sizeof(T) > 24 && return remake(alg, chunk_size=Val{1}())
     # If chunksize is zero, pick chunksize right at the start of solve and
     # then do function barrier to infer the full solve
     x = if prob.f.colorvec === nothing


### PR DESCRIPTION
Would probably be worth actually running a variety of benchmarks here and picking between strategies.

For now, I'm setting the chunk size to `1` if `sizeof(eltype(u0)) > 24`, which would (for example) mean the element type are duals of `Float64` with 3 or more partials.

Pumas hasn't been eager to merge any of the chunk size PRs as they cause a few regressions when applied globally.
But we can apply it more selectively here when choosing the chunk size as a function of the eltype.