### PR TITLE
reduce compile times by unrolling fastbroadcast on array

### DIFF
--- a/src/dense/generic_dense.jl
+++ b/src/dense/generic_dense.jl
@@ -639,7 +639,6 @@ end
 end
 
 @muladd function hermite_interpolant!(out::Array,Θ,dt,y₀,y₁,k,idxs,T::Type{Val{3}}) # Default interpolant is Hermite
-  @views @.. out = (6*dt*k[1][idxs] + 6*dt*k[2][idxs] + 12*y₀[idxs] - 12*y₁[idxs])/(dt*dt*dt)
   @inbounds for (j,i) in enumerate(idxs)
     out[j] = (6*dt*k[1][i] + 6*dt*k[2][i] + 12*y₀[i] - 12*y₁[i])/(dt*dt*dt)
   end

--- a/src/dense/generic_dense.jl
+++ b/src/dense/generic_dense.jl
@@ -131,7 +131,7 @@ end
 
 @inline function current_interpolant!(val,t::Array,integrator::DiffEqBase.DEIntegrator,idxs,deriv)
   Θ = similar(t)
-  @inbounds @simd for i in eachindex(t)
+  @inbounds @simd ivdep for i in eachindex(t)
     Θ[i] = (t[i]-integrator.tprev)/integrator.dt
   end
   [ode_interpolant!(val,ϕ,integrator,idxs,deriv) for ϕ in Θ]
@@ -485,7 +485,7 @@ end
 
 @muladd function hermite_interpolant(Θ,dt,y₀::Array,y₁,k,::Type{Val{true}},idxs::Nothing,T::Type{Val{0}}) # Default interpolant is Hermite
   out = similar(y₀)
-  @inbounds @simd for i in eachindex(y₀)
+  @inbounds @simd ivdep for i in eachindex(y₀)
     out[i] = (1-Θ)*y₀[i]+Θ*y₁[i]+Θ*(Θ-1)*((1-2Θ)*(y₁[i]-y₀[i])+(Θ-1)*dt*k[1][i] + Θ*dt*k[2][i])
   end
 end
@@ -500,7 +500,7 @@ end
 end
 
 @muladd function hermite_interpolant!(out::Array,Θ,dt,y₀,y₁,k,idxs::Nothing,T::Type{Val{0}}) # Default interpolant is Hermite
-  @inbounds @simd for i in eachindex(out)
+  @inbounds @simd ivdep for i in eachindex(out)
     out[i] = (1-Θ)*y₀[i]+Θ*y₁[i]+Θ*(Θ-1)*((1-2Θ)*(y₁[i]-y₀[i])+(Θ-1)*dt*k[1][i] + Θ*dt*k[2][i])
   end
   out
@@ -539,7 +539,7 @@ end
 end
 
 @muladd function hermite_interpolant!(out::Array,Θ,dt,y₀,y₁,k,idxs::Nothing,T::Type{Val{1}}) # Default interpolant is Hermite
-  @inbounds @simd for i in eachindex(out)
+  @inbounds @simd ivdep for i in eachindex(out)
     out[i] = k[1][i] + Θ*(-4*dt*k[1][i] - 2*dt*k[2][i] - 6*y₀[i] + Θ*(3*dt*k[1][i] + 3*dt*k[2][i] + 6*y₀[i] - 6*y₁[i]) + 6*y₁[i])/dt
   end
   out
@@ -581,7 +581,7 @@ end
 end
 
 @muladd function hermite_interpolant!(out::Array,Θ,dt,y₀,y₁,k,idxs::Nothing,T::Type{Val{2}}) # Default interpolant is Hermite
-  @inbounds @simd for i in eachindex(out)
+  @inbounds @simd ivdep for i in eachindex(out)
     out[i] = (-4*dt*k[1][i] - 2*dt*k[2][i] - 6*y₀[i] + Θ*(6*dt*k[1][i] + 6*dt*k[2][i] + 12*y₀[i] - 12*y₁[i]) + 6*y₁[i])/(dt*dt)
   end
   out
@@ -628,7 +628,7 @@ end
 end
 
 @muladd function hermite_interpolant!(out::Array,Θ,dt,y₀,y₁,k,idxs::Nothing,T::Type{Val{3}}) # Default interpolant is Hermite
-  @inbounds @simd for i in eachindex(out)
+  @inbounds @simd ivdep for i in eachindex(out)
     out[i] = (6*dt*k[1][i] + 6*dt*k[2][i] + 12*y₀[i] - 12*y₁[i])/(dt*dt*dt)
   end
   out

--- a/src/dense/generic_dense.jl
+++ b/src/dense/generic_dense.jl
@@ -482,18 +482,24 @@ end
 
 @muladd function hermite_interpolant!(out,Θ,dt,y₀,y₁,k,idxs::Nothing,T::Type{Val{0}}) # Default interpolant is Hermite
   @inbounds @.. out = (1-Θ)*y₀+Θ*y₁+Θ*(Θ-1)*((1-2Θ)*(y₁-y₀)+(Θ-1)*dt*k[1] + Θ*dt*k[2])
-  #@inbounds for i in eachindex(out)
-  #  out[i] = (1-Θ)*y₀[i]+Θ*y₁[i]+Θ*(Θ-1)*((1-2Θ)*(y₁[i]-y₀[i])+(Θ-1)*dt*k[1][i] + Θ*dt*k[2][i])
-  #end
-  #out
+end
+
+@muladd function hermite_interpolant!(out::Array,Θ,dt,y₀,y₁,k,idxs::Nothing,T::Type{Val{0}}) # Default interpolant is Hermite
+  @inbounds @simd for i in eachindex(out)
+    out[i] = (1-Θ)*y₀[i]+Θ*y₁[i]+Θ*(Θ-1)*((1-2Θ)*(y₁[i]-y₀[i])+(Θ-1)*dt*k[1][i] + Θ*dt*k[2][i])
+  end
+  out
 end
 
 @muladd function hermite_interpolant!(out,Θ,dt,y₀,y₁,k,idxs,T::Type{Val{0}}) # Default interpolant is Hermite
   @views @.. out = (1-Θ)*y₀[idxs]+Θ*y₁[idxs]+Θ*(Θ-1)*((1-2Θ)*(y₁[idxs]-y₀[idxs])+(Θ-1)*dt*k[1][idxs] + Θ*dt*k[2][idxs])
-  #@inbounds for (j,i) in enumerate(idxs)
-  #  out[j] = (1-Θ)*y₀[i]+Θ*y₁[i]+Θ*(Θ-1)*((1-2Θ)*(y₁[i]-y₀[i])+(Θ-1)*dt*k[1][i] + Θ*dt*k[2][i])
-  #end
-  #out
+end
+
+@muladd function hermite_interpolant!(out::Array,Θ,dt,y₀,y₁,k,idxs,T::Type{Val{0}}) # Default interpolant is Hermite
+  @inbounds for (j,i) in enumerate(idxs)
+    out[j] = (1-Θ)*y₀[i]+Θ*y₁[i]+Θ*(Θ-1)*((1-2Θ)*(y₁[i]-y₀[i])+(Θ-1)*dt*k[1][i] + Θ*dt*k[2][i])
+  end
+  out
 end
 
 """
@@ -515,18 +521,24 @@ end
 
 @muladd function hermite_interpolant!(out,Θ,dt,y₀,y₁,k,idxs::Nothing,T::Type{Val{1}}) # Default interpolant is Hermite
   @inbounds @.. out = k[1] + Θ*(-4*dt*k[1] - 2*dt*k[2] - 6*y₀ + Θ*(3*dt*k[1] + 3*dt*k[2] + 6*y₀ - 6*y₁) + 6*y₁)/dt
-  #@inbounds for i in eachindex(out)
-  #  out[i] = k[1][i] + Θ*(-4*dt*k[1][i] - 2*dt*k[2][i] - 6*y₀[i] + Θ*(3*dt*k[1][i] + 3*dt*k[2][i] + 6*y₀[i] - 6*y₁[i]) + 6*y₁[i])/dt
-  #end
-  #out
+end
+
+@muladd function hermite_interpolant!(out::Array,Θ,dt,y₀,y₁,k,idxs::Nothing,T::Type{Val{1}}) # Default interpolant is Hermite
+  @inbounds @simd for i in eachindex(out)
+    out[i] = k[1][i] + Θ*(-4*dt*k[1][i] - 2*dt*k[2][i] - 6*y₀[i] + Θ*(3*dt*k[1][i] + 3*dt*k[2][i] + 6*y₀[i] - 6*y₁[i]) + 6*y₁[i])/dt
+  end
+  out
 end
 
 @muladd function hermite_interpolant!(out,Θ,dt,y₀,y₁,k,idxs,T::Type{Val{1}}) # Default interpolant is Hermite
   @views @.. out = k[1][idxs] + Θ*(-4*dt*k[1][idxs] - 2*dt*k[2][idxs] - 6*y₀[idxs] + Θ*(3*dt*k[1][idxs] + 3*dt*k[2][idxs] + 6*y₀[idxs] - 6*y₁[idxs]) + 6*y₁[idxs])/dt
-  #@inbounds for (j,i) in enumerate(idxs)
-  #  out[j] = k[1][i] + Θ*(-4*dt*k[1][i] - 2*dt*k[2][i] - 6*y₀[i] + Θ*(3*dt*k[1][i] + 3*dt*k[2][i] + 6*y₀[i] - 6*y₁[i]) + 6*y₁[i])/dt
-  #end
-  #out
+end
+
+@muladd function hermite_interpolant!(out::Array,Θ,dt,y₀,y₁,k,idxs,T::Type{Val{1}}) # Default interpolant is Hermite
+  @inbounds for (j,i) in enumerate(idxs)
+    out[j] = k[1][i] + Θ*(-4*dt*k[1][i] - 2*dt*k[2][i] - 6*y₀[i] + Θ*(3*dt*k[1][i] + 3*dt*k[2][i] + 6*y₀[i] - 6*y₁[i]) + 6*y₁[i])/dt
+  end
+  out
 end
 
 """
@@ -551,18 +563,25 @@ end
 
 @muladd function hermite_interpolant!(out,Θ,dt,y₀,y₁,k,idxs::Nothing,T::Type{Val{2}}) # Default interpolant is Hermite
   @inbounds @.. out = (-4*dt*k[1] - 2*dt*k[2] - 6*y₀ + Θ*(6*dt*k[1] + 6*dt*k[2] + 12*y₀ - 12*y₁) + 6*y₁)/(dt*dt)
-  #@inbounds for i in eachindex(out)
-  #  out[i] = (-4*dt*k[1][i] - 2*dt*k[2][i] - 6*y₀[i] + Θ*(6*dt*k[1][i] + 6*dt*k[2][i] + 12*y₀[i] - 12*y₁[i]) + 6*y₁[i])/(dt*dt)
-  #end
-  #out
+end
+
+@muladd function hermite_interpolant!(out::Array,Θ,dt,y₀,y₁,k,idxs::Nothing,T::Type{Val{2}}) # Default interpolant is Hermite
+  @inbounds @simd for i in eachindex(out)
+    out[i] = (-4*dt*k[1][i] - 2*dt*k[2][i] - 6*y₀[i] + Θ*(6*dt*k[1][i] + 6*dt*k[2][i] + 12*y₀[i] - 12*y₁[i]) + 6*y₁[i])/(dt*dt)
+  end
+  out
 end
 
 @muladd function hermite_interpolant!(out,Θ,dt,y₀,y₁,k,idxs,T::Type{Val{2}}) # Default interpolant is Hermite
   @views @.. out = (-4*dt*k[1][idxs] - 2*dt*k[2][idxs] - 6*y₀[idxs] + Θ*(6*dt*k[1][idxs] + 6*dt*k[2][idxs] + 12*y₀[idxs] - 12*y₁[idxs]) + 6*y₁[idxs])/(dt*dt)
-  #@inbounds for (j,i) in enumerate(idxs)
-  #  out[j] = (-4*dt*k[1][i] - 2*dt*k[2][i] - 6*y₀[i] + Θ*(6*dt*k[1][i] + 6*dt*k[2][i] + 12*y₀[i] - 12*y₁[i]) + 6*y₁[i])/(dt*dt)
-  #end
-  #out
+end
+
+@muladd function hermite_interpolant!(out::Array,Θ,dt,y₀,y₁,k,idxs,T::Type{Val{2}}) # Default interpolant is Hermite
+  @views @.. out = (-4*dt*k[1][idxs] - 2*dt*k[2][idxs] - 6*y₀[idxs] + Θ*(6*dt*k[1][idxs] + 6*dt*k[2][idxs] + 12*y₀[idxs] - 12*y₁[idxs]) + 6*y₁[idxs])/(dt*dt)
+  @inbounds for (j,i) in enumerate(idxs)
+    out[j] = (-4*dt*k[1][i] - 2*dt*k[2][i] - 6*y₀[i] + Θ*(6*dt*k[1][i] + 6*dt*k[2][i] + 12*y₀[i] - 12*y₁[i]) + 6*y₁[i])/(dt*dt)
+  end
+  out
 end
 
 """
@@ -593,12 +612,23 @@ end
   #out
 end
 
+@muladd function hermite_interpolant!(out::Array,Θ,dt,y₀,y₁,k,idxs::Nothing,T::Type{Val{3}}) # Default interpolant is Hermite
+  @inbounds @simd for i in eachindex(out)
+    out[i] = (6*dt*k[1][i] + 6*dt*k[2][i] + 12*y₀[i] - 12*y₁[i])/(dt*dt*dt)
+  end
+  out
+end
+
 @muladd function hermite_interpolant!(out,Θ,dt,y₀,y₁,k,idxs,T::Type{Val{3}}) # Default interpolant is Hermite
   @views @.. out = (6*dt*k[1][idxs] + 6*dt*k[2][idxs] + 12*y₀[idxs] - 12*y₁[idxs])/(dt*dt*dt)
-  #for (j,i) in enumerate(idxs)
-  #  out[j] = (6*dt*k[1][i] + 6*dt*k[2][i] + 12*y₀[i] - 12*y₁[i])/(dt*dt*dt)
-  #end
-  #out
+end
+
+@muladd function hermite_interpolant!(out::Array,Θ,dt,y₀,y₁,k,idxs,T::Type{Val{3}}) # Default interpolant is Hermite
+  @views @.. out = (6*dt*k[1][idxs] + 6*dt*k[2][idxs] + 12*y₀[idxs] - 12*y₁[idxs])/(dt*dt*dt)
+  @inbounds for (j,i) in enumerate(idxs)
+    out[j] = (6*dt*k[1][i] + 6*dt*k[2][i] + 12*y₀[i] - 12*y₁[i])/(dt*dt*dt)
+  end
+  out
 end
 
 ######################## Linear Interpolants

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -473,7 +473,7 @@ function jacobian2W!(W::Matrix, mass_matrix::MT, dtgamma::Number, J::Matrix, W_t
   else
     if MT <: UniformScaling
       idxs = diagind(W)
-      @inbounds for i in eachindex(W)
+      @inbounds @simd ivdep for i in eachindex(W)
         W[i] = dtgamma*J[i]
       end
       λ = -mass_matrix.λ
@@ -481,7 +481,7 @@ function jacobian2W!(W::Matrix, mass_matrix::MT, dtgamma::Number, J::Matrix, W_t
         W[i] = W[i] + λ
       end
     else
-      @inbounds for i in eachindex(W)
+      @inbounds @simd ivdep for i in eachindex(W)
         W[i] = muladd(dtgamma, J[i], -mass_matrix[i])
       end
     end

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -429,7 +429,7 @@ function jacobian2W!(W::AbstractMatrix, mass_matrix::MT, dtgamma::Number, J::Abs
       idxs = diagind(W)
       λ = -mass_matrix.λ
       if ArrayInterface.fast_scalar_indexing(J) && ArrayInterface.fast_scalar_indexing(W)
-          for i in 1:size(J,1)
+          @inbounds for i in 1:size(J,1)
               W[i,i] = muladd(λ, invdtgamma, J[i,i])
           end
       else
@@ -446,6 +446,44 @@ function jacobian2W!(W::AbstractMatrix, mass_matrix::MT, dtgamma::Number, J::Abs
       @.. @view(W[idxs]) = @view(W[idxs]) + λ
     else
       @.. W = muladd(dtgamma, J, -mass_matrix)
+    end
+  end
+  return nothing
+end
+
+function jacobian2W!(W::Matrix, mass_matrix::MT, dtgamma::Number, J::Matrix, W_transform::Bool)::Nothing where MT
+  # check size and dimension
+  iijj = axes(W)
+  @boundscheck (iijj == axes(J) && length(iijj) == 2) || _throwWJerror(W, J)
+  mass_matrix isa UniformScaling || @boundscheck axes(mass_matrix) == axes(W) || _throwWMerror(W, mass_matrix)
+  @inbounds if W_transform
+    invdtgamma = inv(dtgamma)
+    if MT <: UniformScaling
+      copyto!(W, J)
+      idxs = diagind(W)
+      λ = -mass_matrix.λ
+      @inbounds for i in 1:size(J,1)
+          W[i,i] = muladd(λ, invdtgamma, J[i,i])
+      end
+    else
+      @inbounds for i in eachindex(W)
+        W[i] = muladd(-mass_matrix[i], invdtgamma, J[i])
+      end
+    end
+  else
+    if MT <: UniformScaling
+      idxs = diagind(W)
+      @inbounds for i in eachindex(W)
+        W[i] = dtgamma*J[i]
+      end
+      λ = -mass_matrix.λ
+      @inbounds for i in idxs
+        W[i] = W[i] + λ
+      end
+    else
+      @inbounds for i in eachindex(W)
+        W[i] = muladd(dtgamma, J[i], -mass_matrix[i])
+      end
     end
   end
   return nothing


### PR DESCRIPTION
With https://github.com/SciML/DiffEqBase.jl/pull/722 as well.

```julia
using OrdinaryDiffEq, SnoopCompile, ForwardDiff

lorenz = (du,u,p,t) -> begin
        du[1] = 10.0(u[2]-u[1])
        du[2] = u[1]*(28.0-u[3]) - u[2]
        du[3] = u[1]*u[2] - (8/3)*u[3]
end

u0 = [1.0;0.0;0.0]; tspan = (0.0,100.0);
prob = ODEProblem(lorenz,u0,tspan); alg = Rodas5();
tinf = @snoopi_deep ForwardDiff.gradient(u0 -> sum(solve(ODEProblem(lorenz,u0,tspan),alg)), u0)
tinf = @snoopi_deep ForwardDiff.gradient(u0 -> sum(solve(ODEProblem(lorenz,u0,tspan),alg)), u0)
```

Before:

```julia
#First
InferenceTimingNode: 1.849625/14.538148 on Core.Compiler.Timings.ROOT() with 32 direct children

#Second
InferenceTimingNode: 1.531660/4.170409 on Core.Compiler.Timings.ROOT() with 12 direct children
```

After:

```julia
#First
InferenceTimingNode: 1.181086/3.320321 on Core.Compiler.Timings.ROOT() with 32 direct children

#Second
InferenceTimingNode: 0.998814/1.650488 on Core.Compiler.Timings.ROOT() with 11 direct children
```