### PR TITLE
Specialize non-zero iteration for CUSPARSE

### DIFF
--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -443,7 +443,10 @@ function jacobian2W!(W::AbstractMatrix, mass_matrix::MT, dtgamma::Number, J::Abs
   else
     if MT <: UniformScaling
       λ = -mass_matrix.λ
-      if W isa AbstractSparseMatrix
+      if W isa AbstractSparseMatrix && !(W isa SparseMatrixCSC)
+        # This is specifically to catch the GPU sparse matrix cases
+        # Which do not support diagonal indexing
+        # https://github.com/JuliaGPU/CUDA.jl/issues/1395
         Wn = nonzeros(W)
         Jn = nonzeros(J)
         @.. Wn = dtgamma*Jn

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -442,16 +442,17 @@ function jacobian2W!(W::AbstractMatrix, mass_matrix::MT, dtgamma::Number, J::Abs
     end
   else
     if MT <: UniformScaling
-      idxs = diagind(W)
       λ = -mass_matrix.λ
       if W isa AbstractSparseMatrix
         Wn = nonzeros(W)
         Jn = nonzeros(J)
         @.. Wn = dtgamma*Jn
+        W .= W + λ*I
       else
+        idxs = diagind(W)
         @.. W = dtgamma*J
+        @.. @view(W[idxs]) = @view(W[idxs]) + λ
       end
-      @.. @view(W[idxs]) = @view(W[idxs]) + λ
     else
       @.. W = muladd(dtgamma, J, -mass_matrix)
     end

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -443,8 +443,14 @@ function jacobian2W!(W::AbstractMatrix, mass_matrix::MT, dtgamma::Number, J::Abs
   else
     if MT <: UniformScaling
       idxs = diagind(W)
-      @.. W = dtgamma*J
       λ = -mass_matrix.λ
+      if W isa AbstractSparseMatrix
+        Wn = nonzeros(W)
+        Jn = nonzeros(J)
+        @.. Wn = dtgamma*Jn
+      else
+        @.. W = dtgamma*J
+      end
       @.. @view(W[idxs]) = @view(W[idxs]) + λ
     else
       @.. W = muladd(dtgamma, J, -mass_matrix)


### PR DESCRIPTION
CUSPARSE is still missing some dispatches for full generic handling, but specializing this would still make sense anyways.

Currently still blocked on https://github.com/SciML/OrdinaryDiffEq.jl/issues/1566 by https://github.com/JuliaGPU/CUDA.jl/issues/1372