### PR TITLE
Minor fixes: #1619, #1623

### DIFF
--- a/src/perform_step/prk_perform_step.jl
+++ b/src/perform_step/prk_perform_step.jl
@@ -23,7 +23,7 @@ end
 
   if !isthreaded(integrator.alg.threading)
     k5_6[1] = f(uprev + dt*(α5_6[1,1]*k1 + α5_6[1,2]*k2 + α5_6[1,3]*k3 + α5_6[1,4]*k4), p, t + c5_6[1]*dt)
-    k5_6[2] = f(uprev + dt*(α5_6[2,1]*k1 + α5_6[2,2]*k2 + α5_6[2,3]*k3 + α5_6[2,4]*k4), p, t + c5_6[2]*dt)  
+    k5_6[2] = f(uprev + dt*(α5_6[2,1]*k1 + α5_6[2,2]*k2 + α5_6[2,3]*k3 + α5_6[2,4]*k4), p, t + c5_6[2]*dt)
   else
     let
       @threaded integrator.alg.threading for i in [1,2]
@@ -37,7 +37,7 @@ end
 
   integrator.fsallast = k # For interpolation, then FSAL'd
   integrator.k[1] = integrator.fsalfirst
-  integrator.k[1] = integrator.fsallast
+  integrator.k[2] = integrator.fsallast
   integrator.u = u
 end
 

--- a/src/perform_step/rkc_perform_step.jl
+++ b/src/perform_step/rkc_perform_step.jl
@@ -372,7 +372,6 @@ end
   end
   @.. integrator.fsallast = k
   integrator.k[1] = integrator.fsalfirst
-  integrator.destats.nf += 1
   integrator.k[2] = integrator.fsallast
   integrator.u = u
 end

--- a/test/interface/destats_tests.jl
+++ b/test/interface/destats_tests.jl
@@ -76,3 +76,13 @@ sol = solve(prob, Rodas5(;autodiff=false, diff_type=Val{:central}))
 x[] = 0
 sol = solve(prob, Rodas5(;autodiff=false, diff_type=Val{:complex}))
 @test x[] == sol.destats.nf
+
+function g(du, u,p,t)
+  x[] += 1
+  @. du = 5*u
+end
+probip = ODEProblem(g,u0,tspan)
+
+x[] = 0
+sol = solve(probip, ROCK4())
+@test x[] == sol.destats.nf


### PR DESCRIPTION
Decided to squash these two into a single PR.

The ROCK4 function count fix is solid and tested.

I don't know how I would write a test for the KuttaPRK2p5 fsallast assignment, and as a matter of fact I don't understand 100 % of what's going on with the fsal stuff in there anyway. Seems like something more should have happened to fsalfirst, and even more seems to be missing in the in-place version further down in the file. But the issue that's fixed in this PR, regarding the assignment index, seems unambiguous.

Let me know if you'd rather split off the PRK part into a separate PR where we can work through whatever else might be incorrect or missing there.

EDIT: Worked a little harder to understand how the fsal stuff works and I think the only problem here, for both out-of-place and in-place, is that it's not actually being used to save on function calls during the computation. So it's not a bug, just a missing optimization. (But the thing that this PR fixes is an actual bug.)