### PR TITLE
Fix missing and incorrect uses of `unwrap_alg` in `perform_step!`

### DIFF
--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -747,6 +747,9 @@ function unwrap_alg(alg::SciMLBase.DEAlgorithm, is_stiff)
   if !iscomp
     return alg
   elseif typeof(alg.choice_function) <: AutoSwitchCache
+    if is_stiff === nothing
+      throwautoswitch(alg)
+    end
     num = is_stiff ? 2 : 1
     if num == 1
       return alg.algs[1]
@@ -764,6 +767,9 @@ function unwrap_alg(integrator, is_stiff)
   if !iscomp
     return alg
   elseif typeof(alg.choice_function) <: AutoSwitchCache
+    if is_stiff === nothing
+      throwautoswitch(alg)
+    end
     num = is_stiff ? 2 : 1
     if num == 1
       return alg.algs[1]
@@ -779,6 +785,10 @@ function unwrap_alg(integrator, is_stiff)
       return alg.algs[integrator.cache.current]
     end
   end
+end
+
+function throwautoswitch(alg)
+  throw(ArgumentError("one of $(alg.algs) is not compatible with stiffness-based autoswitching"))
 end
 
 # Whether `uprev` is used in the algorithm directly.

--- a/src/perform_step/adams_bashforth_moulton_perform_step.jl
+++ b/src/perform_step/adams_bashforth_moulton_perform_step.jl
@@ -1516,7 +1516,7 @@ function initialize!(integrator,cache::CNAB2ConstantCache)
 end
 
 function perform_step!(integrator,cache::CNAB2ConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p,alg = integrator
+  @unpack t,dt,uprev,u,f,p = integrator
   @unpack k2,nlsolver = cache
   cnt = integrator.iter
   f1 = integrator.f.f1
@@ -1567,7 +1567,7 @@ function initialize!(integrator, cache::CNAB2Cache)
 end
 
 function perform_step!(integrator, cache::CNAB2Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p,alg = integrator
+  @unpack t,dt,uprev,u,f,p = integrator
   @unpack k1,k2,du₁,nlsolver = cache
   @unpack z,tmp = nlsolver
   @unpack f1 = f
@@ -1618,7 +1618,7 @@ function initialize!(integrator,cache::CNLF2ConstantCache)
 end
 
 function perform_step!(integrator,cache::CNLF2ConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p,alg = integrator
+  @unpack t,dt,uprev,u,f,p = integrator
   @unpack k2,uprev2,nlsolver = cache
   cnt = integrator.iter
   f1 = integrator.f.f1
@@ -1671,7 +1671,7 @@ function initialize!(integrator, cache::CNLF2Cache)
 end
 
 function perform_step!(integrator, cache::CNLF2Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p,alg = integrator
+  @unpack t,dt,uprev,u,f,p = integrator
   @unpack uprev2,k2,du₁,nlsolver = cache
   @unpack z,tmp = nlsolver
   @unpack f1 = f

--- a/src/perform_step/bdf_perform_step.jl
+++ b/src/perform_step/bdf_perform_step.jl
@@ -698,6 +698,7 @@ end
 function perform_step!(integrator,cache::QNDFConstantCache{max_order},repeat_step=false) where max_order
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack dtprev,order,D,U,nlsolver,γₖ = cache
+  alg = unwrap_alg(integrator, true)
 
   if integrator.u_modified
     dtprev = one(dt)
@@ -709,7 +710,7 @@ function perform_step!(integrator,cache::QNDFConstantCache{max_order},repeat_ste
   end
 
   k = order
-  κlist = integrator.alg.kappa
+  κlist = alg.kappa
   κ = κlist[k]
   if cache.consfailcnt > 0
     copyto!(D, cache.prevD)
@@ -806,6 +807,7 @@ end
 function perform_step!(integrator, cache::QNDFCache{max_order}, repeat_step=false) where max_order
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack dtprev,order,D,nlsolver,γₖ,dd,atmp,atmpm1,atmpp1,utilde,utildem1,utildep1,ϕ,u₀ = cache
+  alg = unwrap_alg(integrator, true)
 
   if integrator.u_modified
     dtprev = one(dt)
@@ -817,7 +819,7 @@ function perform_step!(integrator, cache::QNDFCache{max_order}, repeat_step=fals
   end
 
   k = order
-  κlist = integrator.alg.kappa
+  κlist = alg.kappa
   κ = κlist[k]
   if cache.consfailcnt > 0
     copyto!(D, cache.prevD)

--- a/src/perform_step/bdf_perform_step.jl
+++ b/src/perform_step/bdf_perform_step.jl
@@ -185,7 +185,8 @@ function initialize!(integrator, cache::SBDFConstantCache)
 end
 
 function perform_step!(integrator,cache::SBDFConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p,alg = integrator
+  @unpack t,dt,uprev,u,f,p = integrator
+  alg = unwrap_alg(integrator, true)
   @unpack uprev2,uprev3,uprev4,du₁,du₂,k₁,k₂,k₃,nlsolver = cache
   @unpack f1, f2 = integrator.f
   cnt = cache.cnt = min(alg.order, integrator.iter+1)
@@ -254,7 +255,8 @@ function initialize!(integrator, cache::SBDFCache)
 end
 
 function perform_step!(integrator, cache::SBDFCache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p,alg = integrator
+  @unpack t,dt,uprev,u,f,p = integrator
+  alg = unwrap_alg(integrator, true)
   @unpack uprev2,uprev3,uprev4,k₁,k₂,k₃,du₁,du₂,nlsolver = cache
   @unpack tmp,z = nlsolver
   @unpack f1, f2 = integrator.f

--- a/src/perform_step/dae_perform_step.jl
+++ b/src/perform_step/dae_perform_step.jl
@@ -15,7 +15,6 @@ end
 
 @muladd function perform_step!(integrator, cache::DImplicitEulerConstantCache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
-  alg = unwrap_alg(integrator, true)
   @unpack nlsolver = cache
 
   nlsolver.z = zero(u)
@@ -59,7 +58,6 @@ end
   @unpack t,dt,uprev,du,u,f,p = integrator
   @unpack atmp,nlsolver = cache
   @unpack tmp = nlsolver
-  alg = unwrap_alg(integrator, true)
 
   @. nlsolver.z = false
   @. nlsolver.tmp = false
@@ -104,7 +102,6 @@ end
 @muladd function perform_step!(integrator, cache::DABDF2ConstantCache, repeat_step=false)
   @unpack t,f,p = integrator
   @unpack dtₙ₋₁,nlsolver = cache
-  alg = unwrap_alg(integrator, true)
   dtₙ, uₙ, uₙ₋₁, uₙ₋₂ = integrator.dt, integrator.u, integrator.uprev, integrator.uprev2
 
   if integrator.iter == 1 && !integrator.u_modified
@@ -171,7 +168,6 @@ end
   @unpack t,dt,du,f,p = integrator
   @unpack atmp,dtₙ₋₁,nlsolver = cache
   @unpack z,tmp = nlsolver
-  alg = unwrap_alg(integrator, true)
   uₙ,uₙ₋₁,uₙ₋₂,dtₙ = integrator.u,integrator.uprev,integrator.uprev2,integrator.dt
 
   if integrator.iter == 1 && !integrator.u_modified

--- a/src/perform_step/explicit_rk_perform_step.jl
+++ b/src/perform_step/explicit_rk_perform_step.jl
@@ -12,6 +12,7 @@ end
 
 @muladd function perform_step!(integrator, cache::ExplicitRKConstantCache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
+  alg = unwrap_alg(integrator, nothing)
   @unpack A,c,α,αEEst,stages = cache
   @unpack kk = cache
 
@@ -53,7 +54,7 @@ end
     integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
 
-  if !isfsal(integrator.alg.tableau)
+  if !isfsal(alg.tableau)
     integrator.fsallast = f(u, p, t+dt)
     integrator.destats.nf += 1
   end
@@ -76,6 +77,7 @@ end
 
 @muladd function perform_step!(integrator, cache::ExplicitRKCache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
+  alg = unwrap_alg(integrator, nothing)
   @unpack A,c,α,αEEst,stages = cache.tab
   @unpack kk,utilde,tmp,atmp = cache
 
@@ -100,7 +102,7 @@ end
   integrator.destats.nf += 1
 
   #Accumulate
-  if !isfsal(integrator.alg.tableau)
+  if !isfsal(alg.tableau)
     @.. utilde = α[1]*kk[1]
     for i = 2:stages
       @.. utilde = utilde + α[i]*kk[i]
@@ -120,7 +122,7 @@ end
     integrator.EEst = integrator.opts.internalnorm(atmp,t)
   end
 
-  if !isfsal(integrator.alg.tableau)
+  if !isfsal(alg.tableau)
     f(integrator.fsallast,u,p,t+dt)
     integrator.destats.nf += 1
   end

--- a/src/perform_step/fixed_timestep_perform_step.jl
+++ b/src/perform_step/fixed_timestep_perform_step.jl
@@ -5,9 +5,10 @@ end
 
 function perform_step!(integrator,cache::FunctionMapConstantCache,repeat_step=false)
   @unpack uprev,dt,t,f,p = integrator
+  alg = unwrap_alg(integrator, nothing)
   if integrator.f != DiffEqBase.DISCRETE_OUTOFPLACE_DEFAULT &&
      !(typeof(integrator.f) <: DiffEqBase.EvalFunc &&  integrator.f.f === DiffEqBase.DISCRETE_OUTOFPLACE_DEFAULT)
-    if FunctionMap_scale_by_time(integrator.alg)
+    if FunctionMap_scale_by_time(alg)
       tmp = f(uprev, p, t + dt)
       integrator.destats.nf += 1
       @muladd integrator.u = @.. uprev + dt * tmp
@@ -25,10 +26,11 @@ end
 
 function perform_step!(integrator,cache::FunctionMapCache,repeat_step=false)
   @unpack u,uprev,dt,t,f,p = integrator
+  alg = unwrap_alg(integrator, nothing)
   @unpack tmp = cache
   if integrator.f != DiffEqBase.DISCRETE_INPLACE_DEFAULT &&
      !(typeof(integrator.f) <: DiffEqBase.EvalFunc &&  integrator.f.f === DiffEqBase.DISCRETE_INPLACE_DEFAULT)
-    if FunctionMap_scale_by_time(integrator.alg)
+    if FunctionMap_scale_by_time(alg)
       f(tmp, uprev, p, t+dt)
       @muladd @.. u = uprev + dt*tmp
     else

--- a/src/perform_step/fixed_timestep_perform_step.jl
+++ b/src/perform_step/fixed_timestep_perform_step.jl
@@ -449,7 +449,8 @@ end
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a62,a63,a64,c2,c3,c4,c5,c6,b1,b3,b4,b5,b6 = cache
   ## Note that c1 and b2 were 0.
-  w = integrator.alg.w
+  alg = unwrap_alg(integrator, false)
+  w = alg.w
   v = w*dt
   ## Formula by Z.A. Anastassi, see the Anas5 caches in tableaus/low_order_rk_tableaus.jl for the full citation.
   a65 = (-8000//1071)*(-a43*(v^5) + 6*tan(v)*(v^4) + 24*(v^3) - 72*tan(v)*(v^2) - 144*v + 144*tan(v))/((v^5)*(a43*tan(v)*v + 12 - 10*a43))
@@ -487,7 +488,8 @@ end
   uidx = eachindex(integrator.uprev)
   @unpack k1,k2,k3,k4,k5,k6,k7,utilde,tmp,atmp = cache
   @unpack a21,a31,a32,a41,a42,a43,a51,a52,a53,a54,a61,a62,a63,a64,c2,c3,c4,c5,c6,b1,b3,b4,b5,b6 = cache.tab
-  w = integrator.alg.w
+  alg = unwrap_alg(integrator, false)
+  w = alg.w
   v = w*dt
   ## Formula by Z.A. Anastassi, see the Anas5 caches in tableaus/low_order_rk_tableaus.jl for the full citation.
   a65 = (-8000//1071)*(-a43*(v^5) + 6*tan(v)*(v^4) + 24*(v^3) - 72*tan(v)*(v^2) - 144*v + 144*tan(v))/((v^5)*(a43*tan(v)*v + 12 - 10*a43))

--- a/src/perform_step/high_order_rk_perform_step.jl
+++ b/src/perform_step/high_order_rk_perform_step.jl
@@ -617,7 +617,7 @@ end
 @muladd function perform_step!(integrator, cache::PFRK87ConstantCache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack α0201, α0301, α0401, α0501, α0601, α0701, α0302, α0403, α0503, α0504, α0604, α0704, α0605, α0705, α0706, α0908, α1008, α1108, α1208, α1308, α1009, α1109, α1209, α1309, α1110, α1210, α1310, α1211, α1311, β1, β6, β7, β8, β9, β10, β11, β12, β13, β1tilde, β6tilde, β7tilde, β8tilde, β9tilde, β10tilde, β11tilde, β12tilde, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13 = cache
-  alg = unwrap_alg(integrator, true)
+  alg = unwrap_alg(integrator, false)
   ν = alg.omega*dt
   νsq = ν^2
 
@@ -699,7 +699,7 @@ end
   @unpack α0201, α0301, α0401, α0501, α0601, α0701, α0302, α0403, α0503, α0504, α0604, α0704, α0605, α0705, α0706, α0908, α1008, α1108, α1208, α1308, α1009, α1109, α1209, α1309, α1110, α1210, α1310, α1211, α1311, β1, β6, β7, β8, β9, β10, β11, β12, β13, β1tilde, β6tilde, β7tilde, β8tilde, β9tilde, β10tilde, β11tilde, β12tilde, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13 = cache.tab
   @unpack k2,k3,k4,k5,k6,k7,k8,k9,k10,k11,k12,k13,utilde,tmp,atmp,k = cache
 
-  alg = unwrap_alg(integrator, true)
+  alg = unwrap_alg(integrator, false)
   ν = alg.omega*dt
   νsq = ν^2
 

--- a/src/perform_step/linear_perform_step.jl
+++ b/src/perform_step/linear_perform_step.jl
@@ -17,7 +17,7 @@ function perform_step!(integrator, cache::MagnusMidpointCache, repeat_step=false
   L = integrator.f.f
   update_coefficients!(L,u,p,t+dt/2)
 
-  if integrator.alg.krylov
+  if alg.krylov
     u .= expv(dt, L, u; m=min(alg.m, size(L,1)), opnorm=integrator.opts.internalopnorm, iop=alg.iop)
   else
     A = Matrix(L) #size(L) == () ? convert(Number, L) : convert(AbstractMatrix, L)
@@ -67,7 +67,7 @@ function perform_step!(integrator, cache::LieRK4Cache, repeat_step=false)
 
   y1_2 = exp((3*k1 + 2*k2 + 2*k3 -k4)/12)*uprev
 
-  if integrator.alg.krylov
+  if alg.krylov
     u .= expv((1/12), (-k1 + 2*k2 + 2*k3 + 3*k4), y1_2; m=min(alg.m, size(L,1)), opnorm=integrator.opts.internalopnorm, iop=alg.iop)
   else
     u .= exp((1/12)*(-k1 + 2*k2 + 2*k3 + 3*k4)) * y1_2
@@ -106,7 +106,7 @@ function perform_step!(integrator, cache::RKMK4Cache, repeat_step=false)
   update_coefficients!(L,exp(k3)*uprev,p,t)
   D = Matrix(deepcopy(L))
   k4 = dt*D
-  if integrator.alg.krylov
+  if alg.krylov
     u .= expv(1/6, (k1 + 2*k2 + 2*k3 + k4 - (k1*k4 - k4*k1)/2), uprev; m=min(alg.m, size(L,1)), opnorm=integrator.opts.internalopnorm, iop=alg.iop)
   else
     u .= exp((1/6)*(k1 + 2*k2 + 2*k3 + k4 - (k1*k4 - k4*k1)/2)) * uprev
@@ -139,7 +139,7 @@ function perform_step!(integrator, cache::RKMK2Cache, repeat_step=false)
   update_coefficients!(L,exp(k1)*uprev,p,t)
   B = Matrix(deepcopy(L))
   k2 = dt*B
-  if integrator.alg.krylov
+  if alg.krylov
     u .= expv(1/2, (k1+k2), uprev; m=min(alg.m, size(L,1)), opnorm=integrator.opts.internalopnorm, iop=alg.iop)
   else
     u .= exp((1/2)*(k1+k2)) * uprev
@@ -161,7 +161,7 @@ function initialize!(integrator, cache::CG3Cache)
 end
 
 function perform_step!(integrator, cache::CG3Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,p,alg = integrator
+  @unpack t,dt,uprev,u,p = integrator
   @unpack W,k,tmp = cache
   mass_matrix = integrator.f.mass_matrix
 
@@ -192,7 +192,7 @@ function initialize!(integrator, cache::CG2Cache)
 end
 
 function perform_step!(integrator, cache::CG2Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,p,alg = integrator
+  @unpack t,dt,uprev,u,p = integrator
   @unpack W,k,tmp = cache
   mass_matrix = integrator.f.mass_matrix
 
@@ -221,7 +221,7 @@ function initialize!(integrator, cache::MagnusAdapt4Cache)
 end
 
 function perform_step!(integrator, cache::MagnusAdapt4Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,p,alg = integrator
+  @unpack t,dt,uprev,u,p = integrator
   @unpack W,k,tmp, utilde, atmp = cache
   mass_matrix = integrator.f.mass_matrix
 
@@ -331,7 +331,7 @@ function perform_step!(integrator, cache::MagnusNC8Cache, repeat_step=false)
   Ω1 = dt*B0
   Ω2 = (dt^2)*(Q1 + Q2)
   Ω3_4_5_6 = (dt^3)*(Q3 + Q4) + (dt^4)*(Q5 + Q6) + (dt^5)*Q7
-  if integrator.alg.krylov
+  if alg.krylov
     u .= expv(1.0,Ω1 + Ω2 + Ω3_4_5_6, uprev; m=min(alg.m, size(L1,1)), opnorm=integrator.opts.internalopnorm, iop=alg.iop)
   else
     u .= exp(Ω1 + Ω2 + Ω3_4_5_6) * uprev
@@ -363,7 +363,7 @@ function perform_step!(integrator, cache::MagnusGL4Cache, repeat_step=false)
 
   Ω = (dt/2)*(A1 + A2) - (dt^2)*(sqrt(3)/12)*(A1*A2 - A2*A1)
 
-  if integrator.alg.krylov
+  if alg.krylov
     u .= expv(1.0, Ω , uprev; m=min(alg.m, size(L1,1)), opnorm=integrator.opts.internalopnorm, iop=alg.iop)
   else
     u .= exp(Ω) * uprev
@@ -423,7 +423,7 @@ function perform_step!(integrator, cache::MagnusGL8Cache, repeat_step=false)
   Ω1 = dt*B0
   Ω2 = (dt^2)*(Q1 + Q2)
   Ω3_4_5_6 = (dt^3)*(Q3 + Q4) + (dt^4)*(Q5 + Q6) + (dt^5)*Q7
-  if integrator.alg.krylov
+  if alg.krylov
     u .= expv(1.0,Ω1 + Ω2 + Ω3_4_5_6, uprev; m=min(alg.m, size(L1,1)), opnorm=integrator.opts.internalopnorm, iop=alg.iop)
   else
     u .= exp(Ω1 + Ω2 + Ω3_4_5_6) * uprev
@@ -468,7 +468,7 @@ function perform_step!(integrator, cache::MagnusNC6Cache, repeat_step=false)
   Ω1 = dt*B0
   Ω2 = (dt*dt)*(B1*(3*B0/2 - 6*B2) - (3*B0/2 - 6*B2)*B1)
   Ω3_4 = (dt*dt)*(B0*(B0*(dt*B2/2-Ω2/60)-(dt*B2/2-Ω2/60)*B0) - (B0*(dt*B2/2-Ω2/60)-(dt*B2/2-Ω2/60)*B0)*B0) + (3*dt/5)*(B1*Ω2 - Ω2*B1)
-  if integrator.alg.krylov
+  if alg.krylov
     u .= expv(1.0,Ω1 + Ω2 + Ω3_4, uprev; m=min(alg.m, size(L1,1)), opnorm=integrator.opts.internalopnorm, iop=alg.iop)
   else
     u .= exp(Ω1 + Ω2 + Ω3_4) * uprev
@@ -507,7 +507,7 @@ function perform_step!(integrator, cache::MagnusGL6Cache, repeat_step=false)
   Ω1 = dt*B0
   Ω2 = (dt*dt)*(B1*(3*B0/2 - 6*B2) - (3*B0/2 - 6*B2)*B1)
   Ω3_4 = (dt*dt)*(B0*(B0*(dt*B2/2-Ω2/60)-(dt*B2/2-Ω2/60)*B0) - (B0*(dt*B2/2-Ω2/60)-(dt*B2/2-Ω2/60)*B0)*B0) + (3*dt/5)*(B1*Ω2 - Ω2*B1)
-  if integrator.alg.krylov
+  if alg.krylov
     u .= expv(1.0,Ω1 + Ω2 + Ω3_4, uprev; m=min(alg.m, size(L1,1)), opnorm=integrator.opts.internalopnorm, iop=alg.iop)
   else
     u .= exp(Ω1 + Ω2 + Ω3_4) * uprev
@@ -537,7 +537,7 @@ function perform_step!(integrator, cache::MagnusGauss4Cache, repeat_step=false)
   A = Matrix(L1)
   update_coefficients!(L2,uprev,p,t+dt*(1/2-sqrt(3)/6))
   B = Matrix(L2)
-  if integrator.alg.krylov
+  if alg.krylov
     u .= expv(dt,(A+B) ./ 2 + (dt*sqrt(3)) .* (B*A-A*B) ./ 12, u; m=min(alg.m, size(L1,1)), opnorm=integrator.opts.internalopnorm, iop=alg.iop)
   else
     u .= exp((dt/2) .* (A+B)+((dt^2)*(sqrt(3)/12)) .* (B*A-A*B)) * uprev
@@ -565,7 +565,7 @@ function perform_step!(integrator, cache::LieEulerCache, repeat_step=false)
   L = integrator.f.f
   update_coefficients!(L,u,p,t)
 
-  if integrator.alg.krylov
+  if alg.krylov
     u .= expv(dt, L, u; m=min(alg.m, size(L,1)), opnorm=integrator.opts.internalopnorm, iop=alg.iop)
   else
     A = Matrix(L) #size(L) == () ? convert(Number, L) : convert(AbstractMatrix, L)
@@ -595,7 +595,7 @@ function perform_step!(integrator, cache::MagnusLeapfrogCache, repeat_step=false
   if iter==1
     L = integrator.f.f
     update_coefficients!(L,u,p,t+dt/2)
-    if integrator.alg.krylov
+    if alg.krylov
       u .= expv(dt, L, u; m=min(alg.m, size(L,1)), opnorm=integrator.opts.internalopnorm, iop=alg.iop)
     else
       A = Matrix(L) #size(L) == () ? convert(Number, L) : convert(AbstractMatrix, L)
@@ -608,7 +608,7 @@ function perform_step!(integrator, cache::MagnusLeapfrogCache, repeat_step=false
   else
     L = integrator.f.f
     update_coefficients!(L,u,p,t)
-    if integrator.alg.krylov
+    if alg.krylov
       u .= expv(2*dt, L, uprev2; m=min(alg.m, size(L,1)), opnorm=integrator.opts.internalopnorm, iop=alg.iop)
     else
       A = Matrix(L) #size(L) == () ? convert(Number, L) : convert(AbstractMatrix, L)
@@ -712,7 +712,6 @@ end
 
 function perform_step!(integrator, cache::CayleyEulerConstantCache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
-  alg = unwrap_alg(integrator, true)
 
   if f isa SplitFunction
     A = f.f1.f
@@ -744,7 +743,7 @@ function initialize!(integrator, cache::CayleyEulerCache)
 end
 
 function perform_step!(integrator, cache::CayleyEulerCache, repeat_step=false)
-  @unpack t,dt,uprev,u,p,f,alg = integrator
+  @unpack t,dt,uprev,u,p,f = integrator
   @unpack k,V,tmp = cache
   mass_matrix = integrator.f.mass_matrix
 

--- a/src/perform_step/linear_perform_step.jl
+++ b/src/perform_step/linear_perform_step.jl
@@ -10,7 +10,8 @@ function initialize!(integrator, cache::MagnusMidpointCache)
 end
 
 function perform_step!(integrator, cache::MagnusMidpointCache, repeat_step=false)
-  @unpack t,dt,uprev,u,p,alg = integrator
+  @unpack t,dt,uprev,u,p = integrator
+  alg = unwrap_alg(integrator, nothing)
   @unpack W,k,tmp = cache
   mass_matrix = integrator.f.mass_matrix
 
@@ -39,7 +40,8 @@ function initialize!(integrator, cache::LieRK4Cache)
 end
 
 function perform_step!(integrator, cache::LieRK4Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,p,alg = integrator
+  @unpack t,dt,uprev,u,p = integrator
+  alg = unwrap_alg(integrator, nothing)
   @unpack W,k,tmp = cache
   mass_matrix = integrator.f.mass_matrix
 
@@ -89,7 +91,8 @@ function initialize!(integrator, cache::RKMK4Cache)
 end
 
 function perform_step!(integrator, cache::RKMK4Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,p,alg = integrator
+  @unpack t,dt,uprev,u,p = integrator
+  alg = unwrap_alg(integrator, nothing)
   @unpack W,k,tmp = cache
   mass_matrix = integrator.f.mass_matrix
 
@@ -128,7 +131,8 @@ function initialize!(integrator, cache::RKMK2Cache)
 end
 
 function perform_step!(integrator, cache::RKMK2Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,p,alg = integrator
+  @unpack t,dt,uprev,u,p = integrator
+  alg = unwrap_alg(integrator, nothing)
   @unpack W,k,tmp = cache
   mass_matrix = integrator.f.mass_matrix
 
@@ -286,7 +290,8 @@ function initialize!(integrator, cache::MagnusNC8Cache)
 end
 
 function perform_step!(integrator, cache::MagnusNC8Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,p,alg = integrator
+  @unpack t,dt,uprev,u,p = integrator
+  alg = unwrap_alg(integrator, nothing)
   @unpack W,k,tmp = cache
   mass_matrix = integrator.f.mass_matrix
 
@@ -352,7 +357,8 @@ function initialize!(integrator, cache::MagnusGL4Cache)
 end
 
 function perform_step!(integrator, cache::MagnusGL4Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,p,alg = integrator
+  @unpack t,dt,uprev,u,p = integrator
+  alg = unwrap_alg(integrator, nothing)
   @unpack W,k,tmp = cache
   mass_matrix = integrator.f.mass_matrix
   L1 = deepcopy(integrator.f.f)
@@ -384,7 +390,8 @@ function initialize!(integrator, cache::MagnusGL8Cache)
 end
 
 function perform_step!(integrator, cache::MagnusGL8Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,p,alg = integrator
+  @unpack t,dt,uprev,u,p = integrator
+  alg = unwrap_alg(integrator, nothing)
   @unpack W,k,tmp = cache
   mass_matrix = integrator.f.mass_matrix
   L1 = deepcopy(integrator.f.f)
@@ -444,7 +451,8 @@ function initialize!(integrator, cache::MagnusNC6Cache)
 end
 
 function perform_step!(integrator, cache::MagnusNC6Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,p,alg = integrator
+  @unpack t,dt,uprev,u,p = integrator
+  alg = unwrap_alg(integrator, nothing)
   @unpack W,k,tmp = cache
   mass_matrix = integrator.f.mass_matrix
   L0 = deepcopy(integrator.f.f)
@@ -489,7 +497,8 @@ function initialize!(integrator, cache::MagnusGL6Cache)
 end
 
 function perform_step!(integrator, cache::MagnusGL6Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,p,alg = integrator
+  @unpack t,dt,uprev,u,p = integrator
+  alg = unwrap_alg(integrator, nothing)
   @unpack W,k,tmp = cache
   mass_matrix = integrator.f.mass_matrix
   L1 = deepcopy(integrator.f.f)
@@ -528,7 +537,8 @@ function initialize!(integrator, cache::MagnusGauss4Cache)
 end
 
 function perform_step!(integrator, cache::MagnusGauss4Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,p,alg = integrator
+  @unpack t,dt,uprev,u,p = integrator
+  alg = unwrap_alg(integrator, nothing)
   @unpack W,k,tmp = cache
   mass_matrix = integrator.f.mass_matrix
   L1 = deepcopy(integrator.f.f)
@@ -558,7 +568,8 @@ function initialize!(integrator, cache::LieEulerCache)
 end
 
 function perform_step!(integrator, cache::LieEulerCache, repeat_step=false)
-  @unpack t,dt,uprev,u,p,alg = integrator
+  @unpack t,dt,uprev,u,p = integrator
+  alg = unwrap_alg(integrator, nothing)
   @unpack W,k,tmp = cache
   mass_matrix = integrator.f.mass_matrix
 
@@ -588,7 +599,8 @@ function initialize!(integrator, cache::MagnusLeapfrogCache)
 end
 
 function perform_step!(integrator, cache::MagnusLeapfrogCache, repeat_step=false, alg_extrapolates=true, iter=1)
-  @unpack t,dt,uprev,uprev2,u,p,alg,iter = integrator
+  @unpack t,dt,uprev,uprev2,u,p,iter = integrator
+  alg = unwrap_alg(integrator, nothing)
   @unpack W,k,tmp = cache
   mass_matrix = integrator.f.mass_matrix
     # println("iter   : $iter")
@@ -635,7 +647,7 @@ end
 
 function perform_step!(integrator, cache::LinearExponentialConstantCache, repeat_step=false)
   @unpack t,dt,uprev,f,p = integrator
-  alg = unwrap_alg(integrator, true)
+  alg = unwrap_alg(integrator, nothing)
   A = f.f # assume f to be an ODEFunction wrapped around a linear operator
 
   if alg.krylov == :off
@@ -672,7 +684,7 @@ end
 function perform_step!(integrator, cache::LinearExponentialCache, repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack tmp, KsCache = cache
-  alg = unwrap_alg(integrator, true)
+  alg = unwrap_alg(integrator, nothing)
   A = f.f # assume f to be an ODEFunction wrapped around a linear operator
 
   if alg.krylov == :off

--- a/src/perform_step/low_order_rk_perform_step.jl
+++ b/src/perform_step/low_order_rk_perform_step.jl
@@ -1069,7 +1069,7 @@ end
 @muladd function perform_step!(integrator, cache::FRK65ConstantCache, repeat_step=false)
   @unpack t, dt, uprev, u, f, p = integrator
   @unpack α21, α31, α41, α51, α61, α71, α81, α91, α32, α43, α53, α63, α73, α83, α54, α64, α74, α84, α94, α65, α75, α85, α95, α76, α86, α96, α87, α97, α98, β1, β7, β8, β1tilde, β4tilde, β5tilde, β6tilde, β7tilde, β8tilde, β9tilde, c2, c3, c4, c5, c6, c7, c8, c9, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11 = cache
-  alg = unwrap_alg(integrator, true)
+  alg = unwrap_alg(integrator, false)
   ν = alg.omega*dt
   νsq = ν^2
   β4 = (d1 + νsq*(d2 + νsq*(d3 + νsq*(d4 + νsq*(d5 + νsq*(d6 + +νsq*d7))))))/(1 + νsq*(d8 + νsq*(d9 + νsq*(d10 + νsq*(d11 + νsq*(d12 + +νsq*d13))))))
@@ -1133,7 +1133,7 @@ end
   @unpack t, dt, uprev, u, f, p = integrator
   @unpack tmp, k1, k2, k3, k4, k5, k6, k7, k8, k9, utilde, atmp  = cache
   @unpack α21, α31, α41, α51, α61, α71, α81, α91, α32, α43, α53, α63, α73, α83, α54, α64, α74, α84, α94, α65, α75, α85, α95, α76, α86, α96, α87, α97, α98, β1, β7, β8, β1tilde, β4tilde, β5tilde, β6tilde, β7tilde, β8tilde, β9tilde, c2, c3, c4, c5, c6, c7, c8, c9, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11 = cache.tab
-  alg = unwrap_alg(integrator, true)
+  alg = unwrap_alg(integrator, false)
 
   ν = alg.omega*dt
   νsq = ν^2

--- a/src/perform_step/pdirk_perform_step.jl
+++ b/src/perform_step/pdirk_perform_step.jl
@@ -71,7 +71,8 @@ end
 function initialize!(integrator, cache::PDIRK44Cache) end
 
 @muladd function perform_step!(integrator, cache::PDIRK44Cache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p,alg = integrator
+  @unpack t,dt,uprev,u,f,p = integrator
+  alg = unwrap_alg(integrator, true)
   @unpack nlsolver,k1,k2,tab = cache
   @unpack γs,cs,α1,α2,b1,b2,b3,b4 = tab
   if isthreaded(alg.threading)

--- a/src/perform_step/prk_perform_step.jl
+++ b/src/perform_step/prk_perform_step.jl
@@ -11,6 +11,7 @@ end
 
 @muladd function perform_step!(integrator,cache::KuttaPRK2p5ConstantCache,repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
+  alg = unwrap_alg(integrator, false)
   @unpack α21,α31,α32,α41,α42,α43,α5_6 = cache
   @unpack β1,β3,β5,β6,c2,c3,c4,c5_6 = cache
 
@@ -21,12 +22,12 @@ end
 
   k5_6 = Array{typeof(k1)}(undef, 2)
 
-  if !isthreaded(integrator.alg.threading)
+  if !isthreaded(alg.threading)
     k5_6[1] = f(uprev + dt*(α5_6[1,1]*k1 + α5_6[1,2]*k2 + α5_6[1,3]*k3 + α5_6[1,4]*k4), p, t + c5_6[1]*dt)
     k5_6[2] = f(uprev + dt*(α5_6[2,1]*k1 + α5_6[2,2]*k2 + α5_6[2,3]*k3 + α5_6[2,4]*k4), p, t + c5_6[2]*dt)  
   else
     let
-      @threaded integrator.alg.threading for i in [1,2]
+      @threaded alg.threading for i in [1,2]
         k5_6[i] = f(uprev + dt*(α5_6[i,1]*k1 + α5_6[i,2]*k2 + α5_6[i,3]*k3 + α5_6[i,4]*k4), p, t + c5_6[i]*dt)
       end
     end
@@ -54,6 +55,7 @@ end
 
 @muladd function perform_step!(integrator,cache::KuttaPRK2p5Cache,repeat_step=false)
   @unpack t,dt,uprev,u,f,p = integrator
+  alg = unwrap_alg(integrator, false)
   @unpack k,k1,k2,k3,k4,k5_6,fsalfirst,tmp = cache
   @unpack α21,α31,α32,α41,α42,α43,α5_6 = cache.tab
   @unpack β1,β3,β5,β6,c2,c3,c4,c5_6 = cache.tab
@@ -69,7 +71,7 @@ end
   @.. u = uprev + dt*(α41*k1 + α42*k2 + α43*k3)
   f( k4, u, p, t + c4*dt)
 
-  if !isthreaded(integrator.alg.threading)
+  if !isthreaded(alg.threading)
     @.. u = uprev + dt*(α5_6[1,1]*k1 + α5_6[1,2]*k2 + α5_6[1,3]*k3 + α5_6[1,4]*k4)
     f( k5_6[1], u, p, t + c5_6[1]*dt)
 
@@ -78,7 +80,7 @@ end
   else
     tmps = (u, tmp)
     let
-      @threaded integrator.alg.threading for i in [1,2]
+      @threaded alg.threading for i in [1,2]
         @.. tmps[i] = uprev + dt*(α5_6[i,1]*k1 + α5_6[i,2]*k2 + α5_6[i,3]*k3 + α5_6[i,4]*k4)
         f( k5_6[i], tmps[i], p, t + c5_6[i]*dt)
       end

--- a/src/perform_step/rkc_perform_step.jl
+++ b/src/perform_step/rkc_perform_step.jl
@@ -3,8 +3,9 @@ function initialize!(integrator, cache::ROCK2ConstantCache)
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
   integrator.destats.nf += 1
-  cache.max_stage = (integrator.alg.max_stages < 1 || integrator.alg.max_stages > 200) ? 200 : integrator.alg.max_stages
-  cache.min_stage = (integrator.alg.min_stages > cache.max_stage) ? cache.max_stage : integrator.alg.min_stages
+  alg = unwrap_alg(integrator, true)
+  cache.max_stage = (alg.max_stages < 1 || alg.max_stages > 200) ? 200 : alg.max_stages
+  cache.min_stage = (alg.min_stages > cache.max_stage) ? cache.max_stage : alg.min_stages
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
   integrator.k[1] = integrator.fsalfirst
@@ -72,8 +73,9 @@ function initialize!(integrator, cache::ROCK2Cache)
   resize!(integrator.k, integrator.kshortsize)
   integrator.fsalfirst = cache.fsalfirst  # done by pointers, no copying
   integrator.fsallast = cache.k
-  cache.constantcache.max_stage = (integrator.alg.max_stages < 1 || integrator.alg.max_stages > 200) ? 200 : integrator.alg.max_stages
-  cache.constantcache.min_stage = (integrator.alg.min_stages > cache.constantcache.max_stage) ? cache.constantcache.max_stage : integrator.alg.min_stages
+  alg = unwrap_alg(integrator, true)
+  cache.constantcache.max_stage = (alg.max_stages < 1 || alg.max_stages > 200) ? 200 : alg.max_stages
+  cache.constantcache.min_stage = (alg.min_stages > cache.constantcache.max_stage) ? cache.constantcache.max_stage : alg.min_stages
 
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
@@ -155,8 +157,9 @@ function initialize!(integrator, cache::ROCK4ConstantCache)
   integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
   integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
   integrator.destats.nf += 1
-  cache.max_stage = (integrator.alg.max_stages < 1 || integrator.alg.max_stages > 152) ? 152 : integrator.alg.max_stages
-  cache.min_stage = (integrator.alg.min_stages > cache.max_stage) ? cache.max_stage : integrator.alg.min_stages
+  alg = unwrap_alg(integrator, true)
+  cache.max_stage = (alg.max_stages < 1 || alg.max_stages > 152) ? 152 : alg.max_stages
+  cache.min_stage = (alg.min_stages > cache.max_stage) ? cache.max_stage : alg.min_stages
   # Avoid undefined entries if k is an array of arrays
   integrator.fsallast = zero(integrator.fsalfirst)
   integrator.k[1] = integrator.fsalfirst
@@ -264,8 +267,9 @@ function initialize!(integrator, cache::ROCK4Cache)
   resize!(integrator.k, integrator.kshortsize)
   integrator.fsalfirst = cache.fsalfirst
   integrator.fsallast = cache.k
-  cache.constantcache.max_stage = (integrator.alg.max_stages < 1 || integrator.alg.max_stages > 152) ? 152 : integrator.alg.max_stages
-  cache.constantcache.min_stage = (integrator.alg.min_stages > cache.constantcache.max_stage) ? cache.constantcache.max_stage : integrator.alg.min_stages
+  alg = unwrap_alg(integrator, true)
+  cache.constantcache.max_stage = (alg.max_stages < 1 || alg.max_stages > 152) ? 152 : alg.max_stages
+  cache.constantcache.min_stage = (alg.min_stages > cache.constantcache.max_stage) ? cache.constantcache.max_stage : alg.min_stages
 
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
@@ -565,7 +569,7 @@ function initialize!(integrator, cache::IRKCConstantCache)
 end
 
 function perform_step!(integrator,cache::IRKCConstantCache,repeat_step=false)
-  @unpack t,dt,uprev,u,f,p,alg,fsalfirst = integrator
+  @unpack t,dt,uprev,u,f,p,fsalfirst = integrator
   @unpack minm,du₁,du₂,nlsolver = cache
   @unpack f1, f2 = integrator.f
   alg = unwrap_alg(integrator, true)
@@ -693,7 +697,7 @@ function initialize!(integrator, cache::IRKCCache)
 end
 
 function perform_step!(integrator, cache::IRKCCache, repeat_step=false)
-  @unpack t,dt,uprev,u,f,p,alg = integrator
+  @unpack t,dt,uprev,u,f,p = integrator
   @unpack gprev,gprev2,f1ⱼ₋₁,f1ⱼ₋₂,f2ⱼ₋₁,du₁,du₂,atmp,nlsolver = cache
   @unpack tmp,z = nlsolver
   @unpack minm = cache.constantcache

--- a/src/perform_step/symplectic_perform_step.jl
+++ b/src/perform_step/symplectic_perform_step.jl
@@ -404,6 +404,7 @@ end
 
 @muladd function perform_step!(integrator,cache::Symplectic45ConstantCache,repeat_step=false)
   @unpack t,dt,f,p = integrator
+  alg = unwrap_alg(integrator, false)
   @unpack a1,a2,a3,a4,a5,b1,b2,b3,b4,b5 = cache
   duprev, uprev, _, kuprev  = load_symp_state(integrator)
 
@@ -442,7 +443,7 @@ end
   u = u + dt*b5*ku
 
   kdu = f.f1(du,u,p,tnew)
-  if typeof(integrator.alg) <: McAte42
+  if typeof(alg) <: McAte42
     du = du + dt*a5*kdu
     kdu = f.f1(du,u,p,tnew)
     integrator.destats.nf += 1
@@ -456,6 +457,7 @@ end
 
 @muladd function perform_step!(integrator,cache::Symplectic45Cache,repeat_step=false)
   @unpack t,dt,f,p = integrator
+  alg = unwrap_alg(integrator, false)
   @unpack a1,a2,a3,a4,a5,b1,b2,b3,b4,b5 = cache.tab
   duprev, uprev, _, kuprev  = load_symp_state(integrator)
   du, u, kdu, ku = alloc_symp_state(integrator)
@@ -495,7 +497,7 @@ end
   @.. u = u + dt*b5*ku
 
   f.f1(kdu,du,u,p,tnew)
-  if typeof(integrator.alg) <: McAte42
+  if typeof(alg) <: McAte42
     @.. du = du + dt*a5*kdu
     f.f1(kdu,du,u,p,tnew)
     integrator.destats.nf += 1


### PR DESCRIPTION
I took a comprehensive approach to fixing #1618. I'm not equally confident in all of the changes so feel free to pick and choose commits. There are also potential issues that I wasn't certain enough to do something about at all, see below. Feedback appreciated.

**Summary**

* Added missing `unwrap_alg` calls to make all RKC methods, including ROCK4, work in composite algorithms (`is_stiff = true`)
* Same for `QNDF` (`is_stiff = true`)
* Same for all extrapolation methods (`is_stiff = false` for explicit methods, `is_stiff = true` for implicit methods including the undocumented `ImplicitEulerBarycentricExtrapolation`)
* Same for Anas5, KuttaPRK2p5, and PDIRK44 (`is_stiff = false` for Anas5 and KuttaPRK2p5, `is_stiff = true` for PDIRK44)
* Changed `is_stiff` from `true` to `false` for FRK65 and PFRK87 (both are listed as non-stiff in the docs)
* Removed a bunch of redundant unpackings of `alg`, mostly from Lie group and DAE methods but also a couple from RKC methods

Here are the remaining methods that still reference `integrator.alg` directly and are thus incompatible with any form of `CompositeAlgorithm`:

* FunctionMap
* ExplicitRK
* McAte42 (will fail silently when part of a CompositeAlgorithm---it's just a branch adding extra steps `if typeof(integrator.alg) <: McAte42`)
* CNAB2, CNLF2, and SBDF
* Every Krylov-enabled Lie group solver _except_ LinearExponential
  * Full list: MagnusMidpoint, LieRK4, RKMK4, RKMK2, MagnusNC8, MagnusGL4, MagnusGL8, MagnusNC6, MagnusGL6, MagnusGauss4, LieEuler, MagnusLeapfrog 

Things that kinda seem wrong to me but I wasn't sure:

* LinearExponential calls `unwrap_alg(integrator, true)`, i.e., it claims to be a stiff algorithm. This is the exact solver for LTI systems. Does this make sense at all? 

**Questions/TL;DR**

* Was I correct assuming that it's a bug for FRK65 and PFRK87 to identify as stiff?
* Do any of the following have good choices for `is_stiff` or should they remain uncomposable?
  * FunctionMap (wouldn't ever make sense to compose would it?)
  * ExplicitRK (general, takes tableau, so probably can't make such an assumption?)
  * McAte42 (symplectic, perhaps that's too specialized for composition anyway, but also I'm guessing `false`?)
  * CNAB2, CNLF2, SBDF (split solvers, perhaps don't make much sense to compose but also probably `true`?)
  * Lie group solvers
* Should LinearExponential really identify as stiff?
* Would it make sense to do `unwrap_alg(integrator, nothing)` for algorithms that aren't unambiguously stiff or non-stiff (ExplicitRK, perhaps Lie group solvers?)? That way they could still participate in custom CompositeAlgorithms, just not the built-in stiffness-based autoswitching, and one could make `unwrap_alg` throw a friendly, descriptive error about the latter.

Apologies for handing out lots of work with all the recent PRs---please take it as a sign of appreciation of this package.