### PR TITLE
use integrator tolerance in init

### DIFF
--- a/src/initialize_dae.jl
+++ b/src/initialize_dae.jl
@@ -38,13 +38,13 @@ end
 function _initialize_dae!(integrator, prob::ODEProblem,
              alg::DefaultInit, x::Val{true})
   _initialize_dae!(integrator, prob,
-          BrownFullBasicInit(), x)
+          BrownFullBasicInit(integrator.opts.abstol), x)
 end
 
 function _initialize_dae!(integrator, prob::ODEProblem,
              alg::DefaultInit, x::Val{false})
   _initialize_dae!(integrator, prob,
-          BrownFullBasicInit(), x)
+          BrownFullBasicInit(integrator.opts.abstol), x)
 end
 
 function _initialize_dae!(integrator, prob::DAEProblem,
@@ -54,7 +54,7 @@ function _initialize_dae!(integrator, prob::DAEProblem,
             ShampineCollocationInit(), x)
   else
     _initialize_dae!(integrator, prob,
-            BrownFullBasicInit(), x)
+            BrownFullBasicInit(integrator.opts.abstol), x)
   end
 end
 
@@ -65,7 +65,7 @@ function _initialize_dae!(integrator, prob::DAEProblem,
             ShampineCollocationInit(), x)
   else
     _initialize_dae!(integrator, prob,
-            BrownFullBasicInit(), x)
+            BrownFullBasicInit(integrator.opts.abstol ), x)
   end
 end
 
@@ -280,7 +280,7 @@ function _initialize_dae!(integrator, prob::ODEProblem, alg::BrownFullBasicInit,
   M = integrator.f.mass_matrix
   update_coefficients!(M,u,p,t)
   algebraic_vars = [all(iszero,x) for x in eachcol(M)]
-  algebraic_eqs  = [all(iszero,x) for x in eachrow(M)]
+  algebraic_eqs = [all(iszero,x) for x in eachrow(M)]
   (iszero(algebraic_vars) || iszero(algebraic_eqs)) && return
   tmp = get_tmp_cache(integrator)[1]
 

--- a/src/initialize_dae.jl
+++ b/src/initialize_dae.jl
@@ -310,7 +310,11 @@ function _initialize_dae!(integrator, prob::ODEProblem, alg::BrownFullBasicInit,
     return nothing
   end
 
-  r = nlsolve(nlequation, u[algebraic_vars], autodiff=isad ? :forward : :central, method=:newton)
+  r = nlsolve(nlequation,
+              u[algebraic_vars],
+              autodiff=isad ? :forward : :central,
+              method=:newton,
+              ftol = alg.abstol)
   alg_u .= r.zero
 
   recursivecopy!(integrator.uprev,integrator.u)
@@ -394,7 +398,7 @@ function _initialize_dae!(integrator, prob::DAEProblem,
     f(out, du, u, p, t)
   end
 
-  r = nlsolve(nlequation, ifelse.(differential_vars,du,u))
+  r = nlsolve(nlequation, ifelse.(differential_vars,du,u), ftol = alg.abstol)
 
   @. du = ifelse(differential_vars,r.zero,du)
   @. u  = ifelse(differential_vars,u,r.zero)


### PR DESCRIPTION
This PR addresses an inconsistency in the tolerances used in `BrownFullBasicInit`. The current code uses a default tolerance of `1e-10` even if the solver tolerances are higher. Also, in cases where the nlsolve call is triggered, it uses Nlsolve default tolerances `1e-8` which is less than the default `1e-10`