### PR TITLE
Docstrings of SSP linear multistep methods

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1763,11 +1763,48 @@ function Base.show(io::IO, alg::SSPRK432)
                    ", thread = ", alg.thread, ")")
 end
 
+"""
+    SSPRKMSVS43(; stage_limiter! = OrdinaryDiffEq.trivial_limiter!,
+                  step_limiter! = OrdinaryDiffEq.trivial_limiter!)
+
+A third-order, four-step explicit strong stability preserving (SSP) linear multistep method.
+This method does not come with an error estimator and requires a fixed time step
+size.
+
+Like all SSP methods, this method takes optional arguments `stage_limiter!`
+and `step_limiter!`, where `stage_limiter!` and `step_limiter!` are functions
+of the form `limiter!(u, integrator, p, t)`.
+
+## References
+- Shu, Chi-Wang.
+  "Total-variation-diminishing time discretizations."
+  SIAM Journal on Scientific and Statistical Computing 9, no. 6 (1988): 1073-1084.
+  [DOI: 10.1137/0909073](https://doi.org/10.1137/0909073)
+"""
 struct SSPRKMSVS43{StageLimiter,StepLimiter} <: OrdinaryDiffEqAdaptiveAlgorithm
   stage_limiter!::StageLimiter
   step_limiter!::StepLimiter
 end
 SSPRKMSVS43(stage_limiter! = trivial_limiter!) = SSPRKMSVS43(stage_limiter!, trivial_limiter!)
+
+"""
+    SSPRKMSVS32(; stage_limiter! = OrdinaryDiffEq.trivial_limiter!,
+                  step_limiter! = OrdinaryDiffEq.trivial_limiter!)
+
+A second-order, three-step explicit strong stability preserving (SSP) linear multistep method.
+This method does not come with an error estimator and requires a fixed time step
+size.
+
+Like all SSP methods, this method takes optional arguments `stage_limiter!`
+and `step_limiter!`, where `stage_limiter!` and `step_limiter!` are functions
+of the form `limiter!(u, integrator, p, t)`.
+
+## References
+- Shu, Chi-Wang.
+  "Total-variation-diminishing time discretizations."
+  SIAM Journal on Scientific and Statistical Computing 9, no. 6 (1988): 1073-1084.
+  [DOI: 10.1137/0909073](https://doi.org/10.1137/0909073)
+"""
 struct SSPRKMSVS32{StageLimiter,StepLimiter} <: OrdinaryDiffEqAdaptiveAlgorithm
   stage_limiter!::StageLimiter
   step_limiter!::StepLimiter

--- a/src/perform_step/ssprk_perform_step.jl
+++ b/src/perform_step/ssprk_perform_step.jl
@@ -1159,11 +1159,11 @@ end
     k = f(u, p, t+dt)
     integrator.destats.nf += 2
     u = (uprev + u + dt*k) / 2
-      if cache.step == 1
-        u_2 = uprev
-      else
-        u_1 = uprev
-      end
+    if cache.step == 1
+      u_2 = uprev
+    else
+      u_1 = uprev
+    end
     if integrator.opts.adaptive
       v_n = dt/dts[2]*0.5
       cache.dtf[2] = dtf[1]
@@ -1176,7 +1176,6 @@ end
       cache.dts[2] = dt
       dt = 0.9*dtf[1]
       μ = min(dtf[1],dtf[2])
-
     end
   else
     if integrator.opts.adaptive
@@ -1276,21 +1275,21 @@ end
     u = uprev + dt*integrator.fsalfirst
     k = f(u, p, t+dt)
     u = (uprev + u + dt*k) / 2
-      if cache.step == 1
-        u_3 = uprev
-        cache.k3 = f(u_3,p,t+dt)
-        integrator.destats.nf += 1
-      end
-      if cache.step == 2
-        u_2 = uprev
-        cache.k2 = f(u_2,p,t+dt)
-        integrator.destats.nf += 1
-      end
-      if cache.step == 3
-        u_1 = uprev
-        cache.k1 = f(u_1,p,t+dt)
-        integrator.destats.nf += 1
-      end
+    if cache.step == 1
+      u_3 = uprev
+      cache.k3 = f(u_3,p,t+dt)
+      integrator.destats.nf += 1
+    end
+    if cache.step == 2
+      u_2 = uprev
+      cache.k2 = f(u_2,p,t+dt)
+      integrator.destats.nf += 1
+    end
+    if cache.step == 3
+      u_1 = uprev
+      cache.k1 = f(u_1,p,t+dt)
+      integrator.destats.nf += 1
+    end
   # u
   else
     u = (16/27)*(uprev + 3*dt*integrator.fsalfirst) + (11/27)*(u_3 + (12/11)*dt*k3)


### PR DESCRIPTION
I added docstrings to the SSP linear multistep methods introduced in #613.

By the way, I really dislike the names of these two methods - SSPRK* indicates an SSP Runge-Kutta (RK) method, but these are linear multistep methods, not RK methods...