### PR TITLE
Lee1

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -261,7 +261,7 @@ using DocStringExtensions
          RosenbrockW6S4OS, ROS34PW1a, ROS34PW1b, ROS34PW2, ROS34PW3
 
   export LawsonEuler, NorsettEuler, ETD1, ETDRK2, ETDRK3, ETDRK4, HochOst4, Exp4, EPIRK4s3A, EPIRK4s3B,
-         EPIRK5s3, EXPRB53s3, EPIRK5P1, EPIRK5P2, ETD2, Exprb32, Exprb43
+         EPIRK5s3, EXPRB53s3, EPIRK5P1, EPIRK5P2, ETD2, Exprb32, Exprb43, ETD2RK4
 
   export SymplecticEuler, VelocityVerlet, VerletLeapfrog, PseudoVerletLeapfrog,
          McAte2, Ruth3, McAte3, CandyRoz4, McAte4, McAte42, McAte5,

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -256,6 +256,7 @@ alg_extrapolates(alg::ABDF2) = true
 alg_extrapolates(alg::SBDF) = true
 alg_extrapolates(alg::MEBDF2) = true
 alg_extrapolates(alg::MagnusLeapfrog) = true
+alg_extrapolates(alg::ETD2RK4) = true
 
 alg_order(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = error("Order is not defined for this algorithm")
 get_current_alg_order(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm},cache) = alg_order(alg)

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -51,6 +51,8 @@ isfsal(alg::SSPRK932) = false
 isfsal(alg::SSPRK54) = false
 isfsal(alg::SSPRK104) = false
 
+isfsal(alg::ETD2RK4) = false
+
 get_current_isfsal(alg, cache) = isfsal(alg)
 get_current_isfsal(alg::CompositeAlgorithm, cache) = isfsal(alg.algs[cache.current])::Bool
 all_fsal(alg, cache) = isfsal(alg)
@@ -301,6 +303,7 @@ alg_order(alg::CayleyEuler) = 2
 alg_order(alg::ETDRK2) = 2
 alg_order(alg::ETDRK3) = 3
 alg_order(alg::ETDRK4) = 4
+alg_order(alg::ETD2RK4) = 4
 alg_order(alg::HochOst4) = 4
 alg_order(alg::Exp4) = 4
 alg_order(alg::EPIRK4s3A) = 4

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -3854,11 +3854,12 @@ RosenbrockW6S4OS(;chunk_size=Val{0}(),autodiff=true, standardtag = Val{true}(),
 
 ######################################
 
-for Alg in [:LawsonEuler, :NorsettEuler, :ETDRK2, :ETDRK3, :ETDRK4, :HochOst4]
+for Alg in [:LawsonEuler, :NorsettEuler, :ETDRK2, :ETDRK3, :ETDRK4, :HochOst4, :ETD2RK4]
 
   """
   Hochbruck, Marlis, and Alexander Ostermann. “Exponential Integrators.” Acta
     Numerica 19 (2010): 209–86. doi:10.1017/S0962492910000048.
+  ETD2RK4 from Krogstad, 2005
   """
   @eval struct $Alg{FDT,ST,CJ} <: OrdinaryDiffEqExponentialAlgorithm{FDT,ST,CJ}
     krylov::Bool

--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -58,6 +58,12 @@ function expRK_operators(::HochOst4, dt, A)
   B5 = 4P[3] - 8P[4]
   return A21, A31, A32, A41, A42, A51, A52, A54, B1, B4, B5
 end
+function expRK_operators(::ETD2RK4, dt, A)
+  P = phi(dt * A, 2)
+  Phalf = phi(dt/2 * A, 2)
+
+  return P,Phalf
+end
 
 # Unified constructor for constant caches
 for (Alg, Cache) in [(:LawsonEuler, :LawsonEulerConstantCache),

--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -316,32 +316,6 @@ function alg_cache(alg::HochOst4,u,rate_prototype,::Type{uEltypeNoUnits},::Type{
   HochOst4Cache(u,uprev,tmp,dz,rtmp,rtmp2,Au,F2,F3,F4,F5,du1,jac_config,uf,J,ops,KsCache)
 end
 
-@cache struct ETD2RK4Cache{uType,rateType,JCType,FType,JType,opType,KsType} <: ExpRKCache
-  u::uType
-  uprev::uType
-  tmp::uType
-  dz::uType
-  rtmp::rateType
-  Au::rateType
-  F2::rateType
-  F3::rateType
-  F4::rateType
-  du1::rateType
-  jac_config::JCType
-  uf::FType
-  J::JType
-  ops::opType
-  KsCache::KsType
-end
-
-function alg_cache(alg::ETDRK4,u,rate_prototype,::Type{uEltypeNoUnits},::Type{uBottomEltypeNoUnits},::Type{tTypeNoUnits},uprev,uprev2,f,t,dt,reltol,p,calck,::Val{true}) where {uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits}
-  tmp, dz = (zero(u) for i = 1:2)                             # uType caches
-  rtmp, Au, F2, F3, F4, du1 = (zero(rate_prototype) for i = 1:6) # rateType caches
-  plist = (1,1,3,3,3,3)
-  uf,jac_config,J,ops,KsCache = alg_cache_expRK(alg,u,uEltypeNoUnits,uprev,f,t,dt,p,du1,tmp,dz,plist) # other caches
-  ETDRK4Cache(u,uprev,tmp,dz,rtmp,Au,F2,F3,F4,du1,jac_config,uf,J,ops,KsCache)
-end
-
 
 ####################################
 # EPIRK method caches

--- a/src/caches/linear_nonlinear_caches.jl
+++ b/src/caches/linear_nonlinear_caches.jl
@@ -65,7 +65,8 @@ for (Alg, Cache) in [(:LawsonEuler, :LawsonEulerConstantCache),
                      (:ETDRK2, :ETDRK2ConstantCache),
                      (:ETDRK3, :ETDRK3ConstantCache),
                      (:ETDRK4, :ETDRK4ConstantCache),
-                     (:HochOst4, :HochOst4ConstantCache)]
+                     (:HochOst4, :HochOst4ConstantCache),
+                     (:ETD2RK4, :ETD2RK4ConstantCache)]
   @eval struct $Cache{opType,FType} <: ExpRKConstantCache
     ops::opType # precomputed operators
     uf::FType   # derivative wrapper
@@ -308,6 +309,33 @@ function alg_cache(alg::HochOst4,u,rate_prototype,::Type{uEltypeNoUnits},::Type{
   uf,jac_config,J,ops,KsCache = alg_cache_expRK(alg,u,uEltypeNoUnits,uprev,f,t,dt,p,du1,tmp,dz,plist) # other caches
   HochOst4Cache(u,uprev,tmp,dz,rtmp,rtmp2,Au,F2,F3,F4,F5,du1,jac_config,uf,J,ops,KsCache)
 end
+
+@cache struct ETD2RK4Cache{uType,rateType,JCType,FType,JType,opType,KsType} <: ExpRKCache
+  u::uType
+  uprev::uType
+  tmp::uType
+  dz::uType
+  rtmp::rateType
+  Au::rateType
+  F2::rateType
+  F3::rateType
+  F4::rateType
+  du1::rateType
+  jac_config::JCType
+  uf::FType
+  J::JType
+  ops::opType
+  KsCache::KsType
+end
+
+function alg_cache(alg::ETDRK4,u,rate_prototype,::Type{uEltypeNoUnits},::Type{uBottomEltypeNoUnits},::Type{tTypeNoUnits},uprev,uprev2,f,t,dt,reltol,p,calck,::Val{true}) where {uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits}
+  tmp, dz = (zero(u) for i = 1:2)                             # uType caches
+  rtmp, Au, F2, F3, F4, du1 = (zero(rate_prototype) for i = 1:6) # rateType caches
+  plist = (1,1,3,3,3,3)
+  uf,jac_config,J,ops,KsCache = alg_cache_expRK(alg,u,uEltypeNoUnits,uprev,f,t,dt,p,du1,tmp,dz,plist) # other caches
+  ETDRK4Cache(u,uprev,tmp,dz,rtmp,Au,F2,F3,F4,du1,jac_config,uf,J,ops,KsCache)
+end
+
 
 ####################################
 # EPIRK method caches

--- a/src/perform_step/exponential_rk_perform_step.jl
+++ b/src/perform_step/exponential_rk_perform_step.jl
@@ -646,6 +646,74 @@ function perform_step!(integrator, cache::HochOst4Cache, repeat_step=false)
   # integrator.k is automatically set due to aliasing
 end
 
+function perform_step!(integrator, cache::ETD2RK4ConstantCache, repeat_step=false)
+
+  #Draft code for new ETD2RK4 integrator
+  #Variable names follow those in Krogstad, 2005
+  if integrator.iter == 1
+    print("Using Krogstad's ETD2RK4 algorithm!\n")
+  end
+
+  @unpack t,dt,uprev,uprev2,f,p = integrator
+  A = isa(f, SplitFunction) ? f.f1.f : calc_J(integrator, cache) # get linear operator
+  alg = unwrap_alg(integrator, true)
+
+  #F1 = integrator.fsalfirst #not sure if FSAL, so ignore for now
+  halfdt = dt/2
+  if alg.krylov
+    kwargs = (m=min(alg.m, size(A,1)), opnorm=integrator.opts.internalopnorm, iop=alg.iop)
+    # Krylov on F1 (first column)
+    Nn = _compute_nl(f,uprev,p,t,A) # uprev??
+    Nnprev = _compute_nl(f,uprev2,p,t,A) # uprev2??
+    PhiFbar = phiv_timestep([halfdt,dt],A,[uprev Nn (Nn.-Nnprev)./dt])
+    Na = _compute_nl(f,PhiFbar[:,1],p,t+halfdt,A)
+    c = PhiFbar[:,1] .+ (halfdt).*(Na .- (3/2).*Nn .+ (1/2).*Nnprev)
+    Nc = _compute_nl(f,c,p,t+halfdt,A)
+    d = PhiFbar[:,2] .+ dt.*expv(halfdt,A,(Nc .- (3/2).*Nn .+ (1/2).*Nnprev))
+    Nd = _compute_nl(f,d,p,t+dt,A)
+
+    if isa(f, SplitFunction)
+      integrator.destats.nf2 += 3
+    else
+      integrator.destats.nf += 3
+    end
+
+    # update u
+
+    u = PhiFbar[:,2] .+ (dt/3).*expv(halfdt,A,(Na .+ Nc .- 3 .*Nn .+ Nnprev)) .+ (dt/6).*(Nd .- 2 .*Nn .+ Nnprev)
+
+    else
+
+    #The non-krylov part not implemented yet
+    error("non-krylov not yet implemented for ETD2RK4")
+
+    A21, A41, A43, B1, B2, B4 = cache.ops
+    # stage 1 (fsaled)
+    # stage 2
+    U2 = uprev + dt * (A21 * F1)
+    F2 = f.f2(U2, p, t + halfdt) + Au
+    # stage 3
+    U3 = uprev + dt * (A21 * F2) # A32 = A21
+    F3 = f.f2(U3, p, t + halfdt) + Au
+    # stage 4
+    U4 = uprev + dt * (A41 * F1 + A43 * F3)
+    F4 = f.f2(U4, p, t + dt) + Au
+    integrator.destats.nf2 += 3
+    # update u
+    u = uprev + dt * (B1 * F1 + B2 * (F2 + F3) + B4 * F4) # B3 = B2
+  end
+
+  # Update integrator state
+  integrator.fsallast = f(u, p, t + dt)
+  integrator.destats.nf += 1
+  integrator.k[1] = integrator.fsalfirst
+  integrator.k[2] = integrator.fsallast
+  integrator.u = u
+end
+
+
+
+
 #############################################
 # EPIRK integrators
 function perform_step!(integrator, cache::Exp4ConstantCache, repeat_step=false)

--- a/src/perform_step/exponential_rk_perform_step.jl
+++ b/src/perform_step/exponential_rk_perform_step.jl
@@ -658,15 +658,13 @@ function perform_step!(integrator, cache::ETD2RK4ConstantCache, repeat_step=fals
   halfdt = dt/2
 
   if integrator.iter == 1
-    print("Using Krogstad's ETD2RK4 algorithm!\n")
     # Initialize the first step using Euler method (not sure of a better way to do it)
     u = uprev .+ dt.*f(uprev,p,t)
   else
     if alg.krylov
       kwargs = (m=min(alg.m, size(A,1)), opnorm=integrator.opts.internalopnorm, iop=alg.iop)
-      # Krylov on F1 (first column)
-      Nn = _compute_nl(f,uprev,p,t,A) # uprev??
-      Nnprev = _compute_nl(f,uprev2,p,t,A) # uprev2??
+      Nn = _compute_nl(f,uprev,p,t,A)
+      Nnprev = _compute_nl(f,uprev2,p,t,A)
       PhiFbar = phiv_timestep([halfdt,dt],A,[uprev Nn (Nn.-Nnprev)./dt])
       Na = _compute_nl(f,PhiFbar[:,1],p,t+halfdt,A)
       c = PhiFbar[:,1] .+ (halfdt).*(Na .- (3/2).*Nn .+ (1/2).*Nnprev)
@@ -686,23 +684,24 @@ function perform_step!(integrator, cache::ETD2RK4ConstantCache, repeat_step=fals
 
     else
 
-      #The non-krylov part not implemented yet
-      error("non-krylov not yet implemented for ETD2RK4")
+      P, Phalf = cache.ops
 
-      A21, A41, A43, B1, B2, B4 = cache.ops
-      # stage 1 (fsaled)
-      # stage 2
-      U2 = uprev + dt * (A21 * F1)
-      F2 = f.f2(U2, p, t + halfdt) + Au
-      # stage 3
-      U3 = uprev + dt * (A21 * F2) # A32 = A21
-      F3 = f.f2(U3, p, t + halfdt) + Au
-      # stage 4
-      U4 = uprev + dt * (A41 * F1 + A43 * F3)
-      F4 = f.f2(U4, p, t + dt) + Au
+      Nn = _compute_nl(f,uprev,p,t,A)
+      Nnprev = _compute_nl(f,uprev2,p,t,A)
+      a = (Phalf[1]*uprev) .+ (halfdt .* Phalf[2] * Nn) .+ (halfdt/2 .* Phalf[3] * (Nn .- Nnprev))
+      b = (P[1]*uprev) .+ (dt .* P[2] * Nn) .+ (dt .* P[3] * (Nn .- Nnprev))
+      Na = _compute_nl(f,a,p,t+halfdt,A)
+      c = a .+ (halfdt).*(Na .- (3/2).*Nn .+ (1/2).*Nnprev)
+      Nc = _compute_nl(f,c,p,t+halfdt,A)
+      d = b .+ dt .* Phalf[1] * (Nc .- (3/2).*Nn .+ (1/2).*Nnprev)
+      Nd = _compute_nl(f,d,p,t+dt,A)
+
       integrator.destats.nf2 += 3
+
       # update u
-      u = uprev + dt * (B1 * F1 + B2 * (F2 + F3) + B4 * F4) # B3 = B2
+
+      u = b .+ (dt/3) .* Phalf[1] * (Na .+ Nc .- 3 .*Nn .+ Nnprev) .+ (dt/6).*(Nd .- 2 .*Nn .+ Nnprev)
+
     end
   end
   # Update integrator state
@@ -712,8 +711,6 @@ function perform_step!(integrator, cache::ETD2RK4ConstantCache, repeat_step=fals
   integrator.k[2] = integrator.fsallast
   integrator.u = u
 end
-
-
 
 
 #############################################

--- a/test/algconvergence/linear_nonlinear_convergence_tests.jl
+++ b/test/algconvergence/linear_nonlinear_convergence_tests.jl
@@ -11,7 +11,7 @@ using OrdinaryDiffEq: alg_order
 
   Random.seed!(100)
   dts = 1 ./2 .^(7:-1:4) #14->7 good plot
-  for Alg in [LawsonEuler,NorsettEuler,ETDRK2,ETDRK3,ETDRK4,HochOst4,ETD2,KenCarp3,CFNLIRK3]
+  for Alg in [LawsonEuler,NorsettEuler,ETDRK2,ETDRK3,ETDRK4,HochOst4,ETD2,KenCarp3,CFNLIRK3,ETD2RK4]
     sim  = test_convergence(dts,prob,Alg())
     @test sim.𝒪est[:l2] ≈ alg_order(Alg()) atol=0.2
   end

--- a/test/algconvergence/linear_nonlinear_krylov_tests.jl
+++ b/test/algconvergence/linear_nonlinear_krylov_tests.jl
@@ -50,6 +50,11 @@ end
 
     println(Alg) # prevent Travis hanging
   end
+  for Alg = ETD2RK4 #iip version not implemened yet
+    sol = solve(prob, Alg(krylov=true, m=20); dt=dt, reltol=tol)
+    sol_ref = solve(prob, Tsit5(); reltol=tol)
+    @test isapprox(sol(1.0), sol_ref(1.0); rtol=tol)
+  end  
 end
 
 @testset "EPIRK" begin


### PR DESCRIPTION
Development to add a new exponential integrator, ETD2RK4 from Krogstad's 2005 paper. Krylov/non-krylov OOP versions are implemented and seem to be working (although tests are throwing an error). IIP versions still need to be added. First step is calculated using DP5 (which is also 4th-order).
