### PR TITLE
static thread schedule

### DIFF
--- a/src/misc_utils.jl
+++ b/src/misc_utils.jl
@@ -69,7 +69,7 @@ macro threaded(option, ex)
   quote
     opt = $(esc(option))
     if (opt === BaseThreads()) || ((opt isa Bool) && opt)
-      $(esc(:(Threads.@threads $ex)))
+      $(esc(:(Threads.@threads :static $ex)))
     elseif opt === PolyesterThreads()
       $(esc(:(Polyester.@batch $ex)))
     else


### PR DESCRIPTION
```julia
julia> ??Threads.@threads
#  :static scheduler creates one task per thread and divides the iterations equally among them, assigning each task specifically to each thread. In particular, the value of threadid() is
#  guranteed to be constant within one iteration. Specifying :static is an error if used from inside another @threads loop or from a thread other than 1.
```
On the one hand, we use `threadid()` a lot in a way that requires it remain constant within an iteration, so we need `:static` to guarantee correctness.

On the other hand, this means `@threaded` with `threads=true` would error when nested inside other `@threads` loops or when the `threadid()` is not `1. But given that the current behavior is to potentially be wrong in this case...