### PR TITLE
Add always_new and check_div options for NLsolve

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -27,6 +27,8 @@ using DocStringExtensions
 
   using DiffEqBase: TimeGradientWrapper, UJacobianWrapper, TimeDerivativeWrapper, UDerivativeWrapper
 
+  using DiffEqBase: DEIntegrator
+
   import RecursiveArrayTools: chain, recursivecopy!
 
   using UnPack, ForwardDiff, RecursiveArrayTools,

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -860,5 +860,6 @@ isesdirk(alg::Union{KenCarp3, KenCarp4, KenCarp5, KenCarp58,
 isesdirk(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = false
 
 is_mass_matrix_alg(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = false
+is_mass_matrix_alg(alg::CompositeAlgorithm) = all(is_mass_matrix_alg, alg.algs)
 is_mass_matrix_alg(alg::RosenbrockAlgorithm) = true
 is_mass_matrix_alg(alg::NewtonAlgorithm) = !isesdirk(alg)

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -662,14 +662,14 @@ end
 update_W!(integrator, cache, dtgamma, repeat_step, newJW = nothing) =
   update_W!(cache.nlsolver, integrator, cache, dtgamma, repeat_step, newJW)
 
-function update_W!(nlsolver::AbstractNLSolver, integrator, cache::OrdinaryDiffEqMutableCache, dtgamma, repeat_step, newJW = nothing)
+function update_W!(nlsolver::AbstractNLSolver, integrator::DEIntegrator, cache::OrdinaryDiffEqMutableCache, dtgamma, repeat_step, newJW = nothing)
   if isnewton(nlsolver)
     calc_W!(get_W(nlsolver), integrator, nlsolver, cache, dtgamma, repeat_step, true, newJW)
   end
   nothing
 end
 
-function update_W!(nlsolver::AbstractNLSolver, integrator, cache, dtgamma, repeat_step)
+function update_W!(nlsolver::AbstractNLSolver, integrator::DEIntegrator, cache, dtgamma, repeat_step, newJW = nothing)
   if isnewton(nlsolver)
     isdae = integrator.alg isa DAEAlgorithm
     new_jac, new_W = true, true

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -659,17 +659,17 @@ function calc_rosenbrock_differentiation!(integrator, cache, dtd1, dtgamma, repe
 end
 
 # update W matrix (only used in Newton method)
-update_W!(integrator, cache, dtgamma, repeat_step, newJW = nothing) =
+update_W!(integrator, cache, dtgamma, repeat_step::Bool, newJW = nothing) =
   update_W!(cache.nlsolver, integrator, cache, dtgamma, repeat_step, newJW)
 
-function update_W!(nlsolver::AbstractNLSolver, integrator::DEIntegrator, cache::OrdinaryDiffEqMutableCache, dtgamma, repeat_step, newJW = nothing)
+function update_W!(nlsolver::AbstractNLSolver, integrator, cache::OrdinaryDiffEqMutableCache, dtgamma, repeat_step::Bool, newJW = nothing)
   if isnewton(nlsolver)
     calc_W!(get_W(nlsolver), integrator, nlsolver, cache, dtgamma, repeat_step, true, newJW)
   end
   nothing
 end
 
-function update_W!(nlsolver::AbstractNLSolver, integrator::DEIntegrator, cache, dtgamma, repeat_step, newJW = nothing)
+function update_W!(nlsolver::AbstractNLSolver, integrator, cache, dtgamma, repeat_step::Bool, newJW = nothing)
   if isnewton(nlsolver)
     isdae = integrator.alg isa DAEAlgorithm
     new_jac, new_W = true, true

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -659,17 +659,17 @@ function calc_rosenbrock_differentiation!(integrator, cache, dtd1, dtgamma, repe
 end
 
 # update W matrix (only used in Newton method)
-update_W!(integrator, cache, dtgamma, repeat_step::Bool, newJW = nothing) =
+update_W!(integrator, cache, dtgamma, repeat_step, newJW = nothing) =
   update_W!(cache.nlsolver, integrator, cache, dtgamma, repeat_step, newJW)
 
-function update_W!(nlsolver::AbstractNLSolver, integrator, cache::OrdinaryDiffEqMutableCache, dtgamma, repeat_step::Bool, newJW = nothing)
+function update_W!(nlsolver::AbstractNLSolver, integrator::SciMLBase.DEIntegrator{<:Any, true}, cache, dtgamma, repeat_step::Bool, newJW = nothing)
   if isnewton(nlsolver)
     calc_W!(get_W(nlsolver), integrator, nlsolver, cache, dtgamma, repeat_step, true, newJW)
   end
   nothing
 end
 
-function update_W!(nlsolver::AbstractNLSolver, integrator, cache, dtgamma, repeat_step::Bool, newJW = nothing)
+function update_W!(nlsolver::AbstractNLSolver, integrator::SciMLBase.DEIntegrator{<:Any, false}, cache, dtgamma, repeat_step::Bool, newJW = nothing)
   if isnewton(nlsolver)
     isdae = integrator.alg isa DAEAlgorithm
     new_jac, new_W = true, true

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -523,7 +523,7 @@ function jacobian2W(mass_matrix::MT, dtgamma::Number, J::AbstractMatrix, W_trans
   return W
 end
 
-function calc_W!(W, integrator, nlsolver::Union{Nothing,AbstractNLSolver}, cache, dtgamma, repeat_step, W_transform=false)
+function calc_W!(W, integrator, nlsolver::Union{Nothing,AbstractNLSolver}, cache, dtgamma, repeat_step, W_transform=false, newJW = nothing)
   @unpack t,dt,uprev,u,f,p = integrator
   lcache = nlsolver === nothing ? cache : nlsolver.cache
   @unpack J = lcache
@@ -551,7 +551,11 @@ function calc_W!(W, integrator, nlsolver::Union{Nothing,AbstractNLSolver}, cache
   end
 
   # check if we need to update J or W
-  new_jac, new_W = do_newJW(integrator, alg, nlsolver, repeat_step)
+  if newJW === nothing
+    new_jac, new_W = do_newJW(integrator, alg, nlsolver, repeat_step)
+  else
+    new_jac, new_W = newJW
+  end
 
   if new_jac && isnewton(lcache)
     lcache.J_t = t
@@ -655,12 +659,12 @@ function calc_rosenbrock_differentiation!(integrator, cache, dtd1, dtgamma, repe
 end
 
 # update W matrix (only used in Newton method)
-update_W!(integrator, cache, dtgamma, repeat_step) =
-  update_W!(cache.nlsolver, integrator, cache, dtgamma, repeat_step)
+update_W!(integrator, cache, dtgamma, repeat_step, newJW = nothing) =
+  update_W!(cache.nlsolver, integrator, cache, dtgamma, repeat_step, newJW)
 
-function update_W!(nlsolver::AbstractNLSolver, integrator, cache::OrdinaryDiffEqMutableCache, dtgamma, repeat_step)
+function update_W!(nlsolver::AbstractNLSolver, integrator, cache::OrdinaryDiffEqMutableCache, dtgamma, repeat_step, newJW = nothing)
   if isnewton(nlsolver)
-    calc_W!(get_W(nlsolver), integrator, nlsolver, cache, dtgamma, repeat_step, true)
+    calc_W!(get_W(nlsolver), integrator, nlsolver, cache, dtgamma, repeat_step, true, newJW)
   end
   nothing
 end

--- a/src/misc_utils.jl
+++ b/src/misc_utils.jl
@@ -90,7 +90,7 @@ function dolinsolve(integrator, linsolve; A = nothing, linu = nothing, b = nothi
   Plprev = linsolve.Pl isa LinearSolve.ComposePreconditioner ? linsolve.Pl.outer : linsolve.Pl
   Prprev = linsolve.Pr isa LinearSolve.ComposePreconditioner ? linsolve.Pr.outer : linsolve.Pr
 
-  _alg = unwrap_alg(integrator.alg, true)
+  _alg = unwrap_alg(integrator, true)
 
   _Pl,_Pr = _alg.precs(linsolve.A,du,u,p,t,A !== nothing,Plprev,Prprev,solverdata)
   if (_Pl !== nothing || _Pr !== nothing)

--- a/src/nlsolve/newton.jl
+++ b/src/nlsolve/newton.jl
@@ -173,8 +173,8 @@ end
     reltol = eps(eltype(dz))
   end
 
-  if iter == 1 && new_W
-    linres = dolinsolve(integrator, linsolve; A =  W, b = _vec(b), linu = _vec(dz), reltol = reltol)
+  if is_always_new(nlsolver) || (iter == 1 && new_W)
+    linres = dolinsolve(integrator, linsolve; A = W, b = _vec(b), linu = _vec(dz), reltol = reltol)
   else
     linres = dolinsolve(integrator, linsolve; A = nothing, b = _vec(b), linu = _vec(dz), reltol = reltol)
   end
@@ -287,7 +287,7 @@ end
     reltol = eps(eltype(dz))
   end
 
-  if iter == 1 && new_W
+  if is_always_new(nlsolver) || (iter == 1 && new_W)
     linres = dolinsolve(integrator, linsolve; A = W, b = _vec(b), linu = _vec(dz), reltol = reltol)
   else
     linres = dolinsolve(integrator, linsolve; A = nothing, b = _vec(b), linu = _vec(dz), reltol = reltol)

--- a/src/nlsolve/nlsolve.jl
+++ b/src/nlsolve/nlsolve.jl
@@ -10,6 +10,8 @@ dt⋅f(innertmp + γ⋅z, p, t + c⋅dt) + outertmp = z
 where `dt` is the step size and `γ` and `c` are constants, and return the solution `z`.
 """
 function nlsolve!(nlsolver::AbstractNLSolver, integrator, cache=nothing, repeat_step=false)
+  always_new = is_always_new(nlsolver)
+  check_div′ = check_div(nlsolver)
   @label REDO
   if isnewton(nlsolver)
     cache === nothing && throw(ArgumentError("cache is not passed to `nlsolve!` when using NLNewton"))
@@ -18,17 +20,18 @@ function nlsolve!(nlsolver::AbstractNLSolver, integrator, cache=nothing, repeat_
     else
       γW = nlsolver.γ * integrator.dt / nlsolver.α
     end
-    update_W!(nlsolver, integrator, cache, γW, repeat_step)
+    always_new || update_W!(nlsolver, integrator, cache, γW, repeat_step)
   end
 
   @unpack maxiters, κ, fast_convergence_cutoff = nlsolver
 
   initialize!(nlsolver, integrator)
-  nlsolver.status = Divergence
+  nlsolver.status = check_div′ ? Divergence : Convergence
   η = get_new_W!(nlsolver) ? initial_η(nlsolver, integrator) : nlsolver.ηold
 
   local ndz
   for iter in 1:maxiters
+    always_new && update_W!(nlsolver, integrator, cache, γW, repeat_step, (true, true))
     nlsolver.iter = iter
 
     # compute next step and calculate norm of residuals
@@ -52,7 +55,7 @@ function nlsolve!(nlsolver::AbstractNLSolver, integrator, cache=nothing, repeat_
           nlsolver.status = Convergence
           nlsolver.nfails = 0
           break
-        else
+        elseif check_div′
           nlsolver.status = Divergence
           nlsolver.nfails += 1
           break
@@ -60,7 +63,7 @@ function nlsolve!(nlsolver::AbstractNLSolver, integrator, cache=nothing, repeat_
       end
 
       # divergence
-      if θ > 2
+      if check_div′ && θ > 2
         nlsolver.status = Divergence
         nlsolver.nfails += 1
         break
@@ -81,7 +84,7 @@ function nlsolve!(nlsolver::AbstractNLSolver, integrator, cache=nothing, repeat_
   if isnewton(nlsolver) && nlsolver.status == Divergence && !isJcurrent(nlsolver, integrator)
     nlsolver.status = TryAgain
     nlsolver.nfails += 1
-    @goto REDO
+    always_new || @goto REDO
   end
 
   nlsolver.ηold = η

--- a/src/nlsolve/utils.jl
+++ b/src/nlsolve/utils.jl
@@ -11,6 +11,11 @@ isnewton(nlsolver::AbstractNLSolver) = isnewton(nlsolver.cache)
 isnewton(::AbstractNLSolverCache) = false
 isnewton(::Union{NLNewtonCache,NLNewtonConstantCache}) = true
 
+is_always_new(nlsolver::AbstractNLSolver) = is_always_new(nlsolver.alg)
+is_always_new(alg) = isdefined(alg, :always_new) ? alg.always_new : false
+check_div(nlsolver::AbstractNLSolver) = check_div(nlsolver.alg)
+check_div(alg) = isdefined(alg, :check_div) ? alg.check_div : true
+
 isJcurrent(nlsolver::AbstractNLSolver, integrator) = integrator.t == nlsolver.cache.J_t
 isfirstcall(nlsolver::AbstractNLSolver) = nlsolver.cache.firstcall
 isfirststage(nlsolver::AbstractNLSolver) = nlsolver.cache.firststage

--- a/src/perform_step/sdirk_perform_step.jl
+++ b/src/perform_step/sdirk_perform_step.jl
@@ -99,7 +99,6 @@ end
   @unpack t,dt,uprev,u,f,p = integrator
   @unpack atmp,nlsolver = cache
   @unpack z,tmp = nlsolver
-  mass_matrix = integrator.f.mass_matrix
   alg = unwrap_alg(integrator, true)
   markfirststage!(nlsolver)
 


### PR DESCRIPTION
`always_new` forces Newton iterations to always evaluate new J and W
matrices. `check_div = false` disables divergence checking.

This PR requires https://github.com/SciML/DiffEqBase.jl/pull/794 .