### PR TITLE
Keep a consistent sparsity pattern

### DIFF
--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -232,7 +232,10 @@ mutable struct WOperator{IIP,T,
             # we get the right sparsity pattern. If gamma is not zero, then it's a case where
             # a new W is created (as part of an out-of-place solve) and thus the actual
             # values actually matter!
-            if gamma == 0
+            #
+            # Constant operators never refactorize so always use the correct values there
+            # as well
+            if gamma == 0 && !(J isa DiffEqArrayOperator && SciMLBase.isconstant(J))
                 # Workaround https://github.com/JuliaSparse/SparseArrays.jl/issues/190
                 # Hopefully `rand()` does not match any value in the array (prob ~ 0, with a check)
                 # Then `one` is required since gamma is zero

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -226,7 +226,7 @@ mutable struct WOperator{IIP,T,
       AJ = J isa DiffEqArrayOperator ? convert(AbstractMatrix, J) : J
       if AJ isa AbstractMatrix
         mm = mass_matrix isa DiffEqArrayOperator ? convert(AbstractMatrix, mass_matrix) : mass_matrix
-        if AJ isa AbstractSparseMatrixCSC
+        if AJ isa AbstractSparseMatrix
             # Workaround https://github.com/JuliaSparse/SparseArrays.jl/issues/190
             # Hopefully `rand()` does not match any value in the array (prob ~ 0, with a check)
             # Then `one` is required since gamma is zero

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -522,6 +522,10 @@ function jacobian2W!(W::AbstractMatrix, mass_matrix::MT, dtgamma::Number, J::Abs
         @.. broadcast=false W.nzval = dtgamma*J.nzval
         idxs = diagind(W)
         @.. broadcast=false @view(W[idxs]) = @view(W[idxs]) + λ
+      else # Anything not a sparse matrix
+        @.. broadcast=false W = dtgamma*J
+        idxs = diagind(W)
+        @.. broadcast=false @view(W[idxs]) = @view(W[idxs]) + λ
       end
     else
       @.. broadcast=false W = muladd(dtgamma, J, -mass_matrix)

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -261,9 +261,9 @@ mutable struct WOperator{IIP,T,
             end
         else
             if transform
-                _concrete_form = -mm / one(gamma) + AJ
+                _concrete_form = -mm / gamma + AJ
             else
-                _concrete_form = -mm + one(gamma) * AJ
+                _concrete_form = -mm + gamma * AJ
             end
         end
 

--- a/test/interface/linear_solver_test.jl
+++ b/test/interface/linear_solver_test.jl
@@ -30,7 +30,7 @@ odef = ODEFunction(foop; jac=jac, jac_prototype=jac(u0, p, 0.0), paramjac=paramj
 
 function g_helper(p; alg=Rosenbrock23(linsolve=LUFactorization()))
     prob = ODEProblem(odef, u0, tspan, p)
-    soln = Array(solve(prob, alg; u0=prob.u0, p=prob.p, abstol=1e-4, reltol=1e-4))[:, end]
+    soln = Array(solve(prob, alg; u0=prob.u0, p=prob.p, abstol=1e-5, reltol=1e-5))[:, end]
     return soln
 end
 function g(p; kwargs...)

--- a/test/interface/linear_solver_test.jl
+++ b/test/interface/linear_solver_test.jl
@@ -30,7 +30,53 @@ odef = ODEFunction(foop; jac=jac, jac_prototype=jac(u0, p, 0.0), paramjac=paramj
 
 function g_helper(p; alg=Rosenbrock23(linsolve=LUFactorization()))
     prob = ODEProblem(odef, u0, tspan, p)
-    soln = Array(solve(prob, alg; u0=prob.u0, p=prob.p, abstol=1e-7, reltol=1e-7))[:, end]
+    soln = Array(solve(prob, alg; u0=prob.u0, p=prob.p, abstol=1e-4, reltol=1e-4))[:, end]
+    return soln
+end
+function g(p; kwargs...)
+    soln = g_helper(p; kwargs...)
+    return sum(soln)
+end
+
+@test isapprox(exp.(p), g_helper(p; alg=Rosenbrock23(linsolve=KLUFactorization())); atol=1e-3, rtol=1e-3)
+@test isapprox(exp.(p), g_helper(p; alg=Rosenbrock23(linsolve=UMFPACKFactorization())); atol=1e-1, rtol=1e-1)
+@test isapprox(exp.(p), g_helper(p; alg=Rosenbrock23(linsolve=KrylovJL_GMRES())); atol=1e-1, rtol=1e-1)
+
+@test isapprox(exp.(p), g_helper(p; alg=Rodas4(linsolve=KLUFactorization())); atol=1e-3, rtol=1e-3)
+@test isapprox(exp.(p), g_helper(p; alg=Rodas4(linsolve=UMFPACKFactorization())); atol=1e-1, rtol=1e-1)
+@test isapprox(exp.(p), g_helper(p; alg=Rodas4(linsolve=KrylovJL_GMRES())); atol=1e-1, rtol=1e-1)
+
+@test isapprox(exp.(p), g_helper(p; alg=Rodas5(linsolve=KLUFactorization())); atol=1e-3, rtol=1e-3)
+@test isapprox(exp.(p), g_helper(p; alg=Rodas5(linsolve=UMFPACKFactorization())); atol=1e-1, rtol=1e-1)
+@test isapprox(exp.(p), g_helper(p; alg=Rodas5(linsolve=KrylovJL_GMRES())); atol=1e-1, rtol=1e-1)
+
+@test isapprox(exp.(p), g_helper(p; alg=ImplicitEuler(linsolve=KLUFactorization())); atol=1e-1, rtol=1e-1)
+@test isapprox(exp.(p), g_helper(p; alg=ImplicitEuler(linsolve=UMFPACKFactorization())); atol=1e-1, rtol=1e-1)
+@test isapprox(exp.(p), g_helper(p; alg=ImplicitEuler(linsolve=KrylovJL_GMRES())); atol=1e-1, rtol=1e-1)
+
+@test isapprox(exp.(p), g_helper(p; alg=TRBDF2(linsolve=KLUFactorization())); atol=1e-1, rtol=1e-1)
+@test isapprox(exp.(p), g_helper(p; alg=TRBDF2(linsolve=UMFPACKFactorization())); atol=1e-1, rtol=1e-1)
+@test isapprox(exp.(p), g_helper(p; alg=TRBDF2(linsolve=KrylovJL_GMRES())); atol=1e-1, rtol=1e-1)
+
+@test isapprox(exp.(p), g_helper(p; alg=KenCarp47(linsolve=KLUFactorization())); atol=1e-1, rtol=1e-1)
+@test isapprox(exp.(p), g_helper(p; alg=KenCarp47(linsolve=UMFPACKFactorization())); atol=1e-1, rtol=1e-1)
+@test isapprox(exp.(p), g_helper(p; alg=KenCarp47(linsolve=KrylovJL_GMRES())); atol=1e-1, rtol=1e-1)
+
+## IIP
+
+fiip(du, u, p, t) = du .= jac(u, p, t) * u
+jac(du, u, p, t) = du .= spdiagm(0=>p)
+paramjac(du, u, p, t) = du .= SparseArrays.spdiagm(0=>u)
+
+n = 2
+p = collect(1.0:n)
+u0 = ones(n)
+tspan = [0.0, 1]
+odef = ODEFunction{true}(fiip; jac=jac, jac_prototype=jac(u0, p, 0.0), paramjac=paramjac)
+
+function g_helper(p; alg=Rosenbrock23(linsolve=LUFactorization()))
+    prob = ODEProblem(odef, u0, tspan, p)
+    soln = Array(solve(prob, alg; u0=prob.u0, p=prob.p, abstol=1e-4, reltol=1e-4))[:, end]
     return soln
 end
 function g(p; kwargs...)

--- a/test/interface/linear_solver_test.jl
+++ b/test/interface/linear_solver_test.jl
@@ -30,7 +30,7 @@ odef = ODEFunction(foop; jac=jac, jac_prototype=jac(u0, p, 0.0), paramjac=paramj
 
 function g_helper(p; alg=Rosenbrock23(linsolve=LUFactorization()))
     prob = ODEProblem(odef, u0, tspan, p)
-    soln = Array(solve(prob, alg; u0=prob.u0, p=prob.p, abstol=1e-5, reltol=1e-5))[:, end]
+    soln = Array(solve(prob, alg; u0=prob.u0, p=prob.p, abstol=1e-7, reltol=1e-7))[:, end]
     return soln
 end
 function g(p; kwargs...)


### PR DESCRIPTION
See the comment. This fixes the MTK downstream failure that was introduced when symbolic factorizations started getting cached