### PR TITLE
allow DDEProblem to also use prepare_alg

### DIFF
--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -186,7 +186,7 @@ function DiffEqBase.prepare_alg(alg::Union{OrdinaryDiffEqAdaptiveImplicitAlgorit
                 @warn msg
                 linsolve = KrylovJL()
             end
-        elseif prob isa ODEProblem && (prob.f.mass_matrix === nothing ||
+        elseif (prob isa ODEProblem || prob isa DDEProblem) && (prob.f.mass_matrix === nothing ||
                                        (prob.f.mass_matrix !== nothing &&
                                         !(typeof(prob.f.jac_prototype) <: SciMLBase.AbstractDiffEqOperator)))
             linsolve = LinearSolve.defaultalg(prob.f.jac_prototype, u0)


### PR DESCRIPTION
This small change allows `prepare_alg` to prepare a linear solver when encountering a DDEProblem from DelayDiffEq.

This is part of a solution to https://github.com/SciML/DelayDiffEq.jl/issues/235