### PR TITLE
Early terminate perform step when factorization fails

### DIFF
--- a/src/misc_utils.jl
+++ b/src/misc_utils.jl
@@ -134,3 +134,7 @@ function wrapprecs(_Pl,_Pr,weight)
   end
   Pl, Pr
 end
+
+issuccess_W(W::LinearAlgebra.Factorization) = LinearAlgebra.issuccess(W)
+issuccess_W(W::Number) = !iszero(W)
+issuccess_W(::Any) = true

--- a/src/perform_step/rosenbrock_perform_step.jl
+++ b/src/perform_step/rosenbrock_perform_step.jl
@@ -342,7 +342,7 @@ end
   dT = calc_tderivative(integrator, cache)
 
   W = calc_W(integrator, cache, γ, repeat_step)
-  if !LinearAlgebra.issuccess(W)
+  if !issuccess_W(W)
     integrator.EEst = 2
     return nothing
   end
@@ -403,7 +403,7 @@ end
   dT = calc_tderivative(integrator, cache)
 
   W = calc_W(integrator, cache, γ, repeat_step)
-  if !LinearAlgebra.issuccess(W)
+  if !issuccess_W(W)
     integrator.EEst = 2
     return nothing
   end
@@ -497,7 +497,7 @@ end
   dT = calc_tderivative(integrator, cache)
 
   W = calc_W(integrator, cache, dtgamma, repeat_step, true)
-  if !LinearAlgebra.issuccess(W)
+  if !issuccess_W(W)
     integrator.EEst = 2
     return nothing
   end
@@ -666,7 +666,7 @@ end
   dT = ForwardDiff.derivative(tf, t)
 
   W = calc_W(integrator, cache, dtgamma, repeat_step, true)
-  if !LinearAlgebra.issuccess(W)
+  if !issuccess_W(W)
     integrator.EEst = 2
     return nothing
   end
@@ -892,7 +892,7 @@ end
   dT = ForwardDiff.derivative(tf, t)
 
   W = calc_W(integrator, cache, dtgamma, repeat_step, true)
-  if !LinearAlgebra.issuccess(W)
+  if !issuccess_W(W)
     integrator.EEst = 2
     return nothing
   end
@@ -1409,7 +1409,7 @@ end
   dT = calc_tderivative(integrator, cache)
 
   W = calc_W(integrator, cache, dtgamma, repeat_step, true)
-  if !LinearAlgebra.issuccess(W)
+  if !issuccess_W(W)
     integrator.EEst = 2
     return nothing
   end

--- a/src/perform_step/rosenbrock_perform_step.jl
+++ b/src/perform_step/rosenbrock_perform_step.jl
@@ -342,6 +342,11 @@ end
   dT = calc_tderivative(integrator, cache)
 
   W = calc_W(integrator, cache, γ, repeat_step)
+  if !LinearAlgebra.issuccess(W)
+    integrator.EEst = 2
+    return nothing
+  end
+
   k₁ = _reshape(W\-_vec((integrator.fsalfirst + γ*dT)), axes(uprev))
   integrator.destats.nsolve += 1
   f₁ = f(uprev  + dto2*k₁, p, t+dto2)
@@ -375,6 +380,7 @@ end
   integrator.k[1] = k₁
   integrator.k[2] = k₂
   integrator.u = u
+  return nothing
 end
 
 @muladd function perform_step!(integrator, cache::Rosenbrock32ConstantCache, repeat_step=false)
@@ -397,6 +403,10 @@ end
   dT = calc_tderivative(integrator, cache)
 
   W = calc_W(integrator, cache, γ, repeat_step)
+  if !LinearAlgebra.issuccess(W)
+    integrator.EEst = 2
+    return nothing
+  end
 
   k₁ = _reshape(W\-_vec((integrator.fsalfirst + γ*dT)), axes(uprev))
   integrator.destats.nsolve += 1
@@ -434,6 +444,7 @@ end
   integrator.k[1] = k₁
   integrator.k[2] = k₂
   integrator.u = u
+  return nothing
 end
 
 function initialize!(integrator, cache::Union{Rosenbrock33ConstantCache,
@@ -486,6 +497,10 @@ end
   dT = calc_tderivative(integrator, cache)
 
   W = calc_W(integrator, cache, dtgamma, repeat_step, true)
+  if !LinearAlgebra.issuccess(W)
+    integrator.EEst = 2
+    return nothing
+  end
 
   linsolve_tmp =  integrator.fsalfirst + dtd1*dT
 
@@ -529,6 +544,7 @@ end
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.u = u
+  return nothing
 end
 
 @muladd function perform_step!(integrator, cache::Rosenbrock33Cache, repeat_step=false)
@@ -650,6 +666,10 @@ end
   dT = ForwardDiff.derivative(tf, t)
 
   W = calc_W(integrator, cache, dtgamma, repeat_step, true)
+  if !LinearAlgebra.issuccess(W)
+    integrator.EEst = 2
+    return nothing
+  end
 
   linsolve_tmp =  integrator.fsalfirst + dtd1*dT
 
@@ -701,6 +721,7 @@ end
   integrator.k[1] = integrator.fsalfirst
   integrator.k[2] = integrator.fsallast
   integrator.u = u
+  return nothing
 end
 
 @muladd function perform_step!(integrator, cache::Rosenbrock34Cache, repeat_step=false)

--- a/src/perform_step/rosenbrock_perform_step.jl
+++ b/src/perform_step/rosenbrock_perform_step.jl
@@ -871,6 +871,10 @@ end
   dT = ForwardDiff.derivative(tf, t)
 
   W = calc_W(integrator, cache, dtgamma, repeat_step, true)
+  if !LinearAlgebra.issuccess(W)
+    integrator.EEst = 2
+    return nothing
+  end
 
   du = f(uprev, p, t)
   integrator.destats.nf += 1
@@ -953,6 +957,7 @@ end
     integrator.k[2] =  h31*k1 + h32*k2 + h33*k3 + h34*k4 + h35*k5
   end
   integrator.u = u
+  return nothing
 end
 
 
@@ -1383,6 +1388,10 @@ end
   dT = calc_tderivative(integrator, cache)
 
   W = calc_W(integrator, cache, dtgamma, repeat_step, true)
+  if !LinearAlgebra.issuccess(W)
+    integrator.EEst = 2
+    return nothing
+  end
 
   du1 = f(uprev, p, t)
   integrator.destats.nf += 1
@@ -1491,6 +1500,7 @@ end
   end
 
   integrator.u = u
+  return nothing
 end
 
 function initialize!(integrator, cache::Rosenbrock5Cache)

--- a/test/downstream/Project.toml
+++ b/test/downstream/Project.toml
@@ -1,7 +1,7 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DelayDiffEq = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
-DiffEqSensitivity = "41bf760c-e81c-5289-8e54-58b1f1f8abe2"
 ODEInterface = "54ca160b-1b9f-5127-a996-1867f4bc2a2c"
 ODEInterfaceDiffEq = "09606e27-ecf5-54fc-bb29-004bd9f985bf"
+SciMLSensitivity = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"

--- a/test/downstream/autodiff_events.jl
+++ b/test/downstream/autodiff_events.jl
@@ -1,4 +1,4 @@
-using DiffEqSensitivity
+using SciMLSensitivity
 using OrdinaryDiffEq, Calculus, Test
 using Zygote
 

--- a/test/regression/ode_adaptive_tests.jl
+++ b/test/regression/ode_adaptive_tests.jl
@@ -69,3 +69,13 @@ differential_vars = [true,true,true]
 prob = DAEProblem{false}(lorenz,du0,u0,tspan,differential_vars=differential_vars)
 sol = solve(prob,DFBDF())
 @test length(sol.t) < 6600
+
+rr(x1, x2) = (x1 * (-2.1474936f0 * (x2 + x1)))
+possibly_singular(u, p, t) = [-rr(u...), rr(u...)]
+tspan = (1.6078221f0, 2f0)
+initial_condition = [2.1349438f6, -2.1349438f6]
+prob = ODEProblem(possibly_singular, initial_condition, tspan)
+for alg in [Rosenbrock23(), Rosenbrock32(), Rodas3(), Rodas4(), Rodas4P(), Rodas5(), Rodas5P()]
+  sol = solve(prob, alg)
+  @test sol.retcode == :Success
+end


### PR DESCRIPTION
Using the example in https://github.com/SciML/OrdinaryDiffEq.jl/issues/1710, we have
```julia
julia> DiffEqBase.default_factorize(A) = lu(A, check=false)

julia> sol = solve(prob, Rodas5()); # before
┌ Warning: Instability detected. Aborting
└ @ SciMLBase ~/.julia/packages/SciMLBase/YasGG/src/integrator_interface.jl:512

julia> sol = solve(prob, Rodas5()); # after

julia> sol.retcode
:Success
```