### PR TITLE
Add downstream tests for ProbNumDiffEq.jl

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -26,6 +26,7 @@ jobs:
           - {user: SciML, repo: StochasticDiffEq.jl, group: AlgConvergence}
           - {user: SciML, repo: DiffEqCallbacks.jl, group: All}
           - {user: SciML, repo: DiffEqSensitivity.jl, group: Downstream}
+          - {user: nathanaelbosch, repo: ProbNumDiffEq.jl, group: Downstream}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
[ProbNumDiffEq.jl](https://github.com/nathanaelbosch/ProbNumDiffEq.jl) currently builds on quite a few non-public parts of OrdinaryDiffEq.jl to implement its solvers. Therefore, [as discussed on discourse](https://discourse.julialang.org/t/building-on-ordinarydiffeq-jl-vs-diffeqbase-jl/85620/4) it would be great to add downstream tests that ensure that ProbNumDiffEq.jl does not break due to changes to OrdinaryDiffEq.jl - or at least, to provide some very early notifications on possible upcoming problems.

I added a very simple test to `./test/downstream/probnumdiffeq.jl`, which is called as part of the `Downstream` group in `./test/runtests.jl`. Is there more that should be added here in this PR? E.g. should there be a corresponding entry in `./.github/workflows/Downstream.yml`? Let me know what's missing. 