### PR TITLE
remove outdated comments

### DIFF
--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -356,9 +356,9 @@ function fix_dt_at_bounds!(integrator)
   end
   dtmin = timedepentdtmin(integrator)
   if integrator.tdir > 0
-    integrator.dt = max(integrator.dt,dtmin) #abs to fix complex sqrt issue at end
+    integrator.dt = max(integrator.dt,dtmin)
   else
-    integrator.dt = min(integrator.dt,dtmin) #abs to fix complex sqrt issue at end
+    integrator.dt = min(integrator.dt,dtmin)
   end
 end
 


### PR DESCRIPTION
I am reading some code again (see https://github.com/SciML/OrdinaryDiffEq.jl/pull/1728). While doing that, I was confused by the comments I removed here, since there was no `abs` in these lines. This code seems to be quite old and I could not find a reason for this comment quickly. Thus, I think they should be removed to avoid confusion - unless there is really a reason for them, in which case the comments should be adapted to be more clear.