### PR TITLE
Fix interface breaks with Exponential integrators

### DIFF
--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -247,6 +247,12 @@ function DiffEqBase.prepare_alg(alg::Union{OrdinaryDiffEqAdaptiveImplicitAlgorit
     end
 end
 
+# Linear Exponential doesn't have any of the AD stuff
+function DiffEqBase.prepare_alg(alg::Union{LinearExponential,OrdinaryDiffEqLinearExponentialAlgorithm}, u0::AbstractArray{T},
+        p, prob)
+        alg
+end
+
 @generated function pick_static_chunksize(::Val{chunksize}) where {chunksize}
     x = ForwardDiff.pickchunksize(chunksize)
     :(Val{$x}())

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -248,7 +248,7 @@ function DiffEqBase.prepare_alg(alg::Union{OrdinaryDiffEqAdaptiveImplicitAlgorit
 end
 
 # Linear Exponential doesn't have any of the AD stuff
-function DiffEqBase.prepare_alg(alg::Union{LinearExponential,OrdinaryDiffEqLinearExponentialAlgorithm}, u0::AbstractArray,
+function DiffEqBase.prepare_alg(alg::Union{SplitEuler,LinearExponential,OrdinaryDiffEqLinearExponentialAlgorithm}, u0::AbstractArray,
         p, prob)
         alg
 end

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -248,7 +248,7 @@ function DiffEqBase.prepare_alg(alg::Union{OrdinaryDiffEqAdaptiveImplicitAlgorit
 end
 
 # Linear Exponential doesn't have any of the AD stuff
-function DiffEqBase.prepare_alg(alg::Union{LinearExponential,OrdinaryDiffEqLinearExponentialAlgorithm}, u0::AbstractArray{T},
+function DiffEqBase.prepare_alg(alg::Union{LinearExponential,OrdinaryDiffEqLinearExponentialAlgorithm}, u0::AbstractArray,
         p, prob)
         alg
 end

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -162,13 +162,19 @@ get_chunksize(alg::OrdinaryDiffEqAlgorithm) = error("This algorithm does not hav
 get_chunksize(alg::OrdinaryDiffEqAdaptiveImplicitAlgorithm{CS,AD}) where {CS,AD} = Val(CS)
 get_chunksize(alg::OrdinaryDiffEqImplicitAlgorithm{CS,AD}) where {CS,AD} = Val(CS)
 get_chunksize(alg::DAEAlgorithm{CS,AD}) where {CS,AD} = Val(CS)
-get_chunksize(alg::ExponentialAlgorithm) = Val(alg.chunksize)
+function get_chunksize_int(alg::Union{OrdinaryDiffEqExponentialAlgorithm{CS,AD},
+                             OrdinaryDiffEqAdaptiveExponentialAlgorithm{CS,AD}}) where {CS,AD}
+                             Val(CS)
+end
 
 get_chunksize_int(alg::OrdinaryDiffEqAlgorithm) = error("This algorithm does not have a chunk size defined.")
 get_chunksize_int(alg::OrdinaryDiffEqAdaptiveImplicitAlgorithm{CS,AD}) where {CS,AD} = CS
 get_chunksize_int(alg::OrdinaryDiffEqImplicitAlgorithm{CS,AD}) where {CS,AD} = CS
 get_chunksize_int(alg::DAEAlgorithm{CS,AD}) where {CS,AD} = CS
-get_chunksize_int(alg::ExponentialAlgorithm) = alg.chunksize
+function get_chunksize_int(alg::Union{OrdinaryDiffEqExponentialAlgorithm{CS,AD},
+                             OrdinaryDiffEqAdaptiveExponentialAlgorithm{CS,AD}}) where {CS,AD}
+                             CS
+end
 # get_chunksize(alg::CompositeAlgorithm) = get_chunksize(alg.algs[alg.current_alg])
 
 function DiffEqBase.prepare_alg(alg::Union{OrdinaryDiffEqAdaptiveImplicitAlgorithm{0,AD,FDT},
@@ -255,24 +261,31 @@ alg_autodiff(alg::OrdinaryDiffEqAlgorithm) = error("This algorithm does not have
 alg_autodiff(alg::OrdinaryDiffEqAdaptiveImplicitAlgorithm{CS,AD}) where {CS,AD} = AD
 alg_autodiff(alg::DAEAlgorithm{CS,AD}) where {CS,AD} = AD
 alg_autodiff(alg::OrdinaryDiffEqImplicitAlgorithm{CS,AD}) where {CS,AD} = AD
-alg_autodiff(alg::ExponentialAlgorithm) = alg.autodiff
+function alg_autodiff(alg::Union{OrdinaryDiffEqExponentialAlgorithm{CS,AD},
+    OrdinaryDiffEqAdaptiveExponentialAlgorithm{CS,AD}}) where {CS,AD}
+    AD
+end
+
 # alg_autodiff(alg::CompositeAlgorithm) = alg_autodiff(alg.algs[alg.current_alg])
 get_current_alg_autodiff(alg, cache) = alg_autodiff(alg)
 get_current_alg_autodiff(alg::CompositeAlgorithm, cache) = alg_autodiff(alg.algs[cache.current])
 
 alg_difftype(alg::Union{OrdinaryDiffEqAdaptiveImplicitAlgorithm{CS,AD,FDT,ST,CJ},
     OrdinaryDiffEqImplicitAlgorithm{CS,AD,FDT,ST,CJ},
-    OrdinaryDiffEqExponentialAlgorithm{FDT,ST,CJ},
+    OrdinaryDiffEqExponentialAlgorithm{CS,AD,FDT,ST,CJ},
+    OrdinaryDiffEqAdaptiveExponentialAlgorithm{CS,AD,FDT,ST,CJ},
     DAEAlgorithm{CS,AD,FDT,ST,CJ}}) where {CS,AD,FDT,ST,CJ} = FDT
 
 standardtag(alg::Union{OrdinaryDiffEqAdaptiveImplicitAlgorithm{CS,AD,FDT,ST,CJ},
     OrdinaryDiffEqImplicitAlgorithm{CS,AD,FDT,ST,CJ},
-    OrdinaryDiffEqExponentialAlgorithm{FDT,ST,CJ},
+    OrdinaryDiffEqExponentialAlgorithm{CS,AD,FDT,ST,CJ},
+    OrdinaryDiffEqAdaptiveExponentialAlgorithm{CS,AD,FDT,ST,CJ},
     DAEAlgorithm{CS,AD,FDT,ST,CJ}}) where {CS,AD,FDT,ST,CJ} = ST
 
 concrete_jac(alg::Union{OrdinaryDiffEqAdaptiveImplicitAlgorithm{CS,AD,FDT,ST,CJ},
     OrdinaryDiffEqImplicitAlgorithm{CS,AD,FDT,ST,CJ},
-    OrdinaryDiffEqExponentialAlgorithm{FDT,ST,CJ},
+    OrdinaryDiffEqExponentialAlgorithm{CS,AD,FDT,ST,CJ},
+    OrdinaryDiffEqAdaptiveExponentialAlgorithm{CS,AD,FDT,ST,CJ},
     DAEAlgorithm{CS,AD,FDT,ST,CJ}}) where {CS,AD,FDT,ST,CJ} = CJ
 
 alg_extrapolates(alg::Union{OrdinaryDiffEqAlgorithm,DAEAlgorithm}) = false

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -162,7 +162,7 @@ get_chunksize(alg::OrdinaryDiffEqAlgorithm) = error("This algorithm does not hav
 get_chunksize(alg::OrdinaryDiffEqAdaptiveImplicitAlgorithm{CS,AD}) where {CS,AD} = Val(CS)
 get_chunksize(alg::OrdinaryDiffEqImplicitAlgorithm{CS,AD}) where {CS,AD} = Val(CS)
 get_chunksize(alg::DAEAlgorithm{CS,AD}) where {CS,AD} = Val(CS)
-function get_chunksize_int(alg::Union{OrdinaryDiffEqExponentialAlgorithm{CS,AD},
+function get_chunksize(alg::Union{OrdinaryDiffEqExponentialAlgorithm{CS,AD},
                              OrdinaryDiffEqAdaptiveExponentialAlgorithm{CS,AD}}) where {CS,AD}
                              Val(CS)
 end

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -248,8 +248,9 @@ function DiffEqBase.prepare_alg(alg::Union{OrdinaryDiffEqAdaptiveImplicitAlgorit
 end
 
 # Linear Exponential doesn't have any of the AD stuff
-function DiffEqBase.prepare_alg(alg::Union{SplitEuler,LinearExponential,OrdinaryDiffEqLinearExponentialAlgorithm}, u0::AbstractArray,
-        p, prob)
+function DiffEqBase.prepare_alg(alg::Union{ETD2,SplitEuler,LinearExponential,
+                            OrdinaryDiffEqLinearExponentialAlgorithm}, u0::AbstractArray,
+                            p, prob)
         alg
 end
 

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -3885,8 +3885,6 @@ for Alg in [:Exp4, :EPIRK4s3A, :EPIRK4s3B, :EPIRK5s3, :EXPRB53s3, :EPIRK5P1, :EP
     adaptive_krylov::Bool
     m::Int
     iop::Int
-    autodiff::Bool
-    chunksize::Int
   end
   @eval $Alg(;adaptive_krylov=true, m=30, iop=0, autodiff=true, standardtag = Val{true}(), concrete_jac = nothing,
               chunk_size=Val{0}(), diff_type = Val{:forward}) =

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -3130,7 +3130,7 @@ end
 
 struct MagnusAdapt4 <: OrdinaryDiffEqAdaptiveAlgorithm end
 
-struct LinearExponential <: OrdinaryDiffEqExponentialAlgorithm{Val{:forward},Val{true},nothing}
+struct LinearExponential <: OrdinaryDiffEqExponentialAlgorithm{0,false,Val{:forward},Val{true},nothing}
   krylov::Symbol
   m::Int
   iop::Int

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -3130,7 +3130,7 @@ end
 
 struct MagnusAdapt4 <: OrdinaryDiffEqAdaptiveAlgorithm end
 
-struct LinearExponential <: OrdinaryDiffEqExponentialAlgorithm{0,false,Val{:forward},Val{true},nothing}
+struct LinearExponential <: OrdinaryDiffEqExponentialAlgorithm{1,false,Val{:forward},Val{true},nothing}
   krylov::Symbol
   m::Int
   iop::Int

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -14,7 +14,7 @@ const RosenbrockAlgorithm = Union{OrdinaryDiffEqRosenbrockAlgorithm,OrdinaryDiff
 
 abstract type OrdinaryDiffEqExponentialAlgorithm{CS,AD,FDT,ST,CJ} <: OrdinaryDiffEqAlgorithm end
 abstract type OrdinaryDiffEqAdaptiveExponentialAlgorithm{CS,AD,FDT,ST,CJ} <: OrdinaryDiffEqAdaptiveAlgorithm end
-abstract type OrdinaryDiffEqLinearExponentialAlgorithm <: OrdinaryDiffEqExponentialAlgorithm{Val{:forward},Val{true},nothing} end
+abstract type OrdinaryDiffEqLinearExponentialAlgorithm <: OrdinaryDiffEqExponentialAlgorithm{0,false,Val{:forward},Val{true},nothing} end
 const ExponentialAlgorithm = Union{OrdinaryDiffEqExponentialAlgorithm,OrdinaryDiffEqAdaptiveExponentialAlgorithm}
 
 abstract type OrdinaryDiffEqAdamsVarOrderVarStepAlgorithm <: OrdinaryDiffEqAdaptiveAlgorithm end

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -12,8 +12,8 @@ abstract type OrdinaryDiffEqRosenbrockAlgorithm{CS,AD,FDT,ST,CJ} <:  OrdinaryDif
 const NewtonAlgorithm = Union{OrdinaryDiffEqNewtonAlgorithm,OrdinaryDiffEqNewtonAdaptiveAlgorithm}
 const RosenbrockAlgorithm = Union{OrdinaryDiffEqRosenbrockAlgorithm,OrdinaryDiffEqRosenbrockAdaptiveAlgorithm}
 
-abstract type OrdinaryDiffEqExponentialAlgorithm{FDT,ST,CJ} <: OrdinaryDiffEqAlgorithm end
-abstract type OrdinaryDiffEqAdaptiveExponentialAlgorithm{FDT,ST,CJ} <: OrdinaryDiffEqAdaptiveAlgorithm end
+abstract type OrdinaryDiffEqExponentialAlgorithm{CS,AD,FDT,ST,CJ} <: OrdinaryDiffEqAlgorithm end
+abstract type OrdinaryDiffEqAdaptiveExponentialAlgorithm{CS,AD,FDT,ST,CJ} <: OrdinaryDiffEqAdaptiveAlgorithm end
 abstract type OrdinaryDiffEqLinearExponentialAlgorithm <: OrdinaryDiffEqExponentialAlgorithm{Val{:forward},Val{true},nothing} end
 const ExponentialAlgorithm = Union{OrdinaryDiffEqExponentialAlgorithm,OrdinaryDiffEqAdaptiveExponentialAlgorithm}
 
@@ -3856,34 +3856,32 @@ RosenbrockW6S4OS(;chunk_size=Val{0}(),autodiff=true, standardtag = Val{true}(),
 
 for Alg in [:LawsonEuler, :NorsettEuler, :ETDRK2, :ETDRK3, :ETDRK4, :HochOst4]
 
-  """
-  Hochbruck, Marlis, and Alexander Ostermann. “Exponential Integrators.” Acta
-    Numerica 19 (2010): 209–86. doi:10.1017/S0962492910000048.
-  """
-  @eval struct $Alg{FDT,ST,CJ} <: OrdinaryDiffEqExponentialAlgorithm{FDT,ST,CJ}
-    krylov::Bool
-    m::Int
-    iop::Int
-    autodiff::Bool
-    chunksize::Int
-  end
-  @eval $Alg(;krylov=false, m=30, iop=0, autodiff=true, standardtag = Val{true}(), concrete_jac = nothing, chunksize=0,
-            diff_type = Val{:forward}) = $Alg{diff_type,_unwrap_val(standardtag),_unwrap_val(concrete_jac)}(krylov, m, iop, _unwrap_val(autodiff),
-            chunksize)
+    """
+    Hochbruck, Marlis, and Alexander Ostermann. “Exponential Integrators.” Acta
+      Numerica 19 (2010): 209–86. doi:10.1017/S0962492910000048.
+    """
+    @eval struct $Alg{CS,AD,FDT,ST,CJ} <: OrdinaryDiffEqExponentialAlgorithm{CS,AD,FDT,ST,CJ}
+        krylov::Bool
+        m::Int
+        iop::Int
+    end
+    @eval $Alg(; krylov=false, m=30, iop=0, autodiff=true, standardtag=Val{true}(), concrete_jac=nothing, chunk_size=Val{0}(),
+        diff_type=Val{:forward}) = $Alg{_unwrap_val(chunk_size),_unwrap_val(autodiff),
+        diff_type,_unwrap_val(standardtag),_unwrap_val(concrete_jac)}(krylov, m, iop)
 end
 const ETD1 = NorsettEuler # alias
 for Alg in [:Exprb32, :Exprb43]
-  @eval struct $Alg{FDT,ST,CJ} <: OrdinaryDiffEqAdaptiveExponentialAlgorithm{FDT,ST,CJ}
+  @eval struct $Alg{CS,AD,FDT,ST,CJ} <: OrdinaryDiffEqAdaptiveExponentialAlgorithm{CS,AD,FDT,ST,CJ}
     m::Int
     iop::Int
-    autodiff::Bool
-    chunksize::Int
   end
-  @eval $Alg(;m=30, iop=0, autodiff=true, standardtag = Val{true}(), concrete_jac = nothing, chunksize=0,
-            diff_type = Val{:forward}) = $Alg{diff_type,_unwrap_val(standardtag),_unwrap_val(concrete_jac)}(m, iop, _unwrap_val(autodiff), chunksize)
+  @eval $Alg(;m=30, iop=0, autodiff=true, standardtag = Val{true}(), concrete_jac = nothing, chunk_size=Val{0}(),
+            diff_type = Val{:forward}) = $Alg{_unwrap_val(chunk_size),_unwrap_val(autodiff),
+            diff_type,_unwrap_val(standardtag),
+            _unwrap_val(concrete_jac)}(m, iop)
 end
 for Alg in [:Exp4, :EPIRK4s3A, :EPIRK4s3B, :EPIRK5s3, :EXPRB53s3, :EPIRK5P1, :EPIRK5P2]
-  @eval struct $Alg{FDT,ST,CJ} <: OrdinaryDiffEqExponentialAlgorithm{FDT,ST,CJ}
+  @eval struct $Alg{CS,AD,FDT,ST,CJ} <: OrdinaryDiffEqExponentialAlgorithm{CS,AD,FDT,ST,CJ}
     adaptive_krylov::Bool
     m::Int
     iop::Int
@@ -3891,15 +3889,16 @@ for Alg in [:Exp4, :EPIRK4s3A, :EPIRK4s3B, :EPIRK5s3, :EXPRB53s3, :EPIRK5P1, :EP
     chunksize::Int
   end
   @eval $Alg(;adaptive_krylov=true, m=30, iop=0, autodiff=true, standardtag = Val{true}(), concrete_jac = nothing,
-              chunksize=0, diff_type = Val{:forward}) =
-              $Alg{diff_type,_unwrap_val(standardtag),_unwrap_val(concrete_jac)}(adaptive_krylov, m, iop, _unwrap_val(autodiff), chunksize)
+              chunk_size=Val{0}(), diff_type = Val{:forward}) =
+              $Alg{_unwrap_val(chunk_size),_unwrap_val(autodiff),diff_type,
+              _unwrap_val(standardtag),_unwrap_val(concrete_jac)}(adaptive_krylov, m, iop)
 end
-struct SplitEuler <: OrdinaryDiffEqExponentialAlgorithm{Val{:forward},Val{true},nothing} end
+struct SplitEuler <: OrdinaryDiffEqExponentialAlgorithm{0,false,Val{:forward},Val{true},nothing} end
 """
 ETD2: Exponential Runge-Kutta Method
   Second order Exponential Time Differencing method (in development).
 """
-struct ETD2 <: OrdinaryDiffEqExponentialAlgorithm{Val{:forward},Val{true},nothing} end
+struct ETD2 <: OrdinaryDiffEqExponentialAlgorithm{0,false,Val{:forward},Val{true},nothing} end
 
 #########################################
 

--- a/test/interface/norecompile.jl
+++ b/test/interface/norecompile.jl
@@ -28,6 +28,8 @@ if VERSION >= v"1.8"
     @test t2 < t4
 end
 
+solve(prob, EPIRK4s3A(), dt=1e-1)
+
 function f_oop(u, p, t)
     [0.2u[1], 0.4u[2]]
 end


### PR DESCRIPTION
They had a few non-conformities that were causing issues once no recompile mode was enabled.