### PR TITLE
Fix incorrect FSAL logic causing instability in KenCarp algorithms

### DIFF
--- a/src/perform_step/kencarp_kvaerno_perform_step.jl
+++ b/src/perform_step/kencarp_kvaerno_perform_step.jl
@@ -569,13 +569,9 @@ end
 
     markfirststage!(nlsolver)
 
-    if typeof(integrator.f) <: SplitFunction
-        # Explicit tableau is not FSAL
-        # Make this not compute on repeat
-        if !repeat_step && !integrator.last_stepfail
-            f(z₁, integrator.uprev, p, integrator.t)
-            z₁ .*= dt
-        end
+    if typeof(integrator.f) <: SplitFunction && !repeat_step && !integrator.last_stepfail
+        f(z₁, integrator.uprev, p, integrator.t)
+        z₁ .*= dt
     else
         # FSAL Step 1
         @.. broadcast=false z₁=dt * integrator.fsalfirst

--- a/src/perform_step/kencarp_kvaerno_perform_step.jl
+++ b/src/perform_step/kencarp_kvaerno_perform_step.jl
@@ -330,13 +330,11 @@ end
 
     markfirststage!(nlsolver)
 
-    if typeof(integrator.f) <: SplitFunction
+    if typeof(integrator.f) <: SplitFunction && !repeat_step && !integrator.last_stepfail
         # Explicit tableau is not FSAL
         # Make this not compute on repeat
-        if !repeat_step && !integrator.last_stepfail
-            f(z₁, integrator.uprev, p, integrator.t)
-            z₁ .*= dt
-        end
+        f(z₁, integrator.uprev, p, integrator.t)
+        z₁ .*= dt
     else
         # FSAL Step 1
         @.. broadcast=false z₁=dt * integrator.fsalfirst
@@ -1024,13 +1022,11 @@ end
 
     ##### Step 1
 
-    if typeof(integrator.f) <: SplitFunction
+    if typeof(integrator.f) <: SplitFunction && !repeat_step && !integrator.last_stepfail
         # Explicit tableau is not FSAL
         # Make this not compute on repeat
-        if !repeat_step && !integrator.last_stepfail
-            f(z₁, integrator.uprev, p, integrator.t)
-            z₁ .*= dt
-        end
+        f(z₁, integrator.uprev, p, integrator.t)
+        z₁ .*= dt
     else
         # FSAL Step 1
         @.. broadcast=false z₁=dt * integrator.fsalfirst
@@ -1629,13 +1625,11 @@ end
 
     ##### Step 1
 
-    if typeof(integrator.f) <: SplitFunction
+    if typeof(integrator.f) <: SplitFunction && !repeat_step && !integrator.last_stepfail
         # Explicit tableau is not FSAL
         # Make this not compute on repeat
-        if !repeat_step && !integrator.last_stepfail
-            f(z₁, integrator.uprev, p, integrator.t)
-            z₁ .*= dt
-        end
+        f(z₁, integrator.uprev, p, integrator.t)
+        z₁ .*= dt
     else
         # FSAL Step 1
         @.. broadcast=false z₁=dt * integrator.fsalfirst
@@ -2046,13 +2040,11 @@ end
 
     ##### Step 1
 
-    if typeof(integrator.f) <: SplitFunction
+    if typeof(integrator.f) <: SplitFunction && !repeat_step && !integrator.last_stepfail
         # Explicit tableau is not FSAL
         # Make this not compute on repeat
-        if !repeat_step && !integrator.last_stepfail
-            f(z₁, integrator.uprev, p, integrator.t)
-            z₁ .*= dt
-        end
+        f(z₁, integrator.uprev, p, integrator.t)
+        z₁ .*= dt
     else
         # FSAL Step 1
         @.. broadcast=false z₁=dt * integrator.fsalfirst
@@ -2469,13 +2461,11 @@ end
 
     ##### Step 1
 
-    if typeof(integrator.f) <: SplitFunction
+    if typeof(integrator.f) <: SplitFunction && !repeat_step && !integrator.last_stepfail
         # Explicit tableau is not FSAL
         # Make this not compute on repeat
-        if !repeat_step && !integrator.last_stepfail
-            f(z₁, integrator.uprev, p, integrator.t)
-            z₁ .*= dt
-        end
+        f(z₁, integrator.uprev, p, integrator.t)
+        z₁ .*= dt
     else
         # FSAL Step 1
         @.. broadcast=false z₁=dt * integrator.fsalfirst

--- a/test/integrators/split_ode_tests.jl
+++ b/test/integrators/split_ode_tests.jl
@@ -1,0 +1,72 @@
+using OrdinaryDiffEq, SparseArrays, LinearAlgebra, Test
+
+function explicit_fun(du, _, _, _)
+    du .= 0
+    nothing
+end
+
+#Capillary leveling in an axisymmetric polar domain
+@views function capillary_leveling(du, u, dr, nodes, boundaries)
+    #Boundary conditions
+    h = similar(u, length(u)+4)
+    h[3:end-2] .= u
+    h[2:-1:1] .= u[1:2]
+    h[end-1:end] .= u[end]
+    tmp = similar(h)
+
+    #r*dh/dr
+    @. tmp[1:end-1] = (h[2:end]-h[1:end-1])/dr*boundaries
+    #Capillary pressure p=-1/r*d/dr(r*dh/dr)
+    @. tmp[2:end-1] = -(tmp[2:end-1]-tmp[1:end-2])/dr/nodes[2:end-1]
+    #Disjoining pressure A/h^3
+    @. tmp[2:end-1] -= 1E-3/h[2:end-1]^3
+
+    #r*h^3*dp/dr
+    @. tmp[2:end-2] = (tmp[3:end-1]-tmp[2:end-2])/dr*boundaries[2:end-1]*(h[2:end-2]^3+h[3:end-1]^3)/2
+    #1/3*1/r*d/dr(r*h^3*dp/dr)
+    @. du = (tmp[3:end-2]-tmp[2:end-3])/dr/nodes[3:end-2]/3
+    nothing
+end
+
+#Initial droplet shape
+function droplet(r, h_p)
+    if r <= 1
+        h_p+(2-h_p)*(1-r^2)
+    else
+        h_p
+    end
+end
+
+tspan = [0, 1E-2]
+N = 1000
+dr = 4/N
+r = @. dr/2+dr*(0:N-1)
+h0 = map(x -> droplet(x, 1E-4), r)
+r = [r[2]; r[1]; r; r[end]; r[end]]
+boundaries = @. (r[1:end-1]+r[2:end])/2
+
+jac_proto = spdiagm(0 => ones(N), -1 => ones(N-1), 1 => ones(N-1), -2 => ones(N-2), 2 => ones(N-2))
+
+fun = ODEFunction((dh, h, p, t) -> capillary_leveling(dh, h, dr, r, boundaries), jac_prototype = jac_proto)
+prob = ODEProblem(fun, h0, tspan)
+
+#Should be functionally equivalent to above, explicit_fun does nothing
+sfun = SplitFunction(fun, explicit_fun, jac_prototype = jac_proto)
+sprob = ODEProblem(sfun, h0, tspan)
+
+#CFNLIRK3 has same erroneous FSAL logic as KenCarp solvers
+#Can't efficiently test with stiff problem (to cause dtmin issue) because it requires constant dt
+@test_broken solve(sprob, CFNLIRK3(), reltol = 1E-8, dt=1E-5).retcode === :Success
+
+for Alg in (KenCarp3, KenCarp4, KenCarp5, KenCarp47, KenCarp58)
+    print(Alg)
+    sol = solve(prob, Alg(), reltol = 1E-8)
+    @test sol.retcode === :Success
+
+    split_sol = solve(sprob, Alg(), reltol = 1E-8)
+    @test split_sol.retcode === :Success
+    
+    L2 = norm(sol[end].-split_sol[end])/sqrt(N)
+    println(" ", L2)
+    @test L2 < 1E-6
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,6 +90,7 @@ end
         @time @safetestset "DAE Event Tests" begin include("integrators/dae_event.jl") end
         @time @safetestset "Cache Tests" begin include("integrators/ode_cache_tests.jl") end
         @time @safetestset "Add Steps Tests" begin include("integrators/ode_add_steps_tests.jl") end
+        @time @safetestset "IMEX Split Function Tests" begin include("integrators/split_ode_tests.jl") end
     end
 
     if !is_APPVEYOR && (GROUP == "All" || GROUP == "Regression_I" || GROUP == "Regression")


### PR DESCRIPTION
Fixes some incorrect FSAL logic in the `KenCarp` algorithms. The same logic is also present in the `CFNLIRK3` algorithm, but I am unable to test it efficiently because it requires a constant timestep so I have left that algorithm untouched. 

The provided tests use the stiff problem of axisymmetric droplet spreading which would cause instability (dtmin too small) if a `SplitFunction` is used (due to the incorrect FSAL logic). A broken test is also included for `CFNLIRK3` since I can't test it properly.

Fixes #1730 