### PR TITLE
Use both sides of `tspan` when determining `dtmin`

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -260,7 +260,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,
             steps = length(tstops)
         else
             # For fixed dt, the only time dtmin makes sense is if it's smaller than eps().
-            # Thereore user specified dtmin doesn't matter, but we need to ensure dt>=eps()
+            # Therefore user specified dtmin doesn't matter, but we need to ensure dt>=eps()
             # to prevent infinite loops.
             dtmin = DiffEqBase.prob2dtmin(prob)
             abs(dt) < dtmin && throw(ArgumentError("Supplied dt is smaller than dtmin"))

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -259,8 +259,10 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,
         if dt == 0
             steps = length(tstops)
         else
-            # if not adaptive, user set `dt` should be respected.
-            dtmin = something(dtmin, zero(tspan[1]))
+            # For fixed dt, the only time dtmin makes sense is if it's smaller than eps().
+            # Thereore user specified dtmin doesn't matter, but we need to ensure dt>=eps()
+            # to prevent infinite loops.
+            dtmin = DiffEqBase.prob2dtmin(prob)
             abs(dt) < dtmin && throw(ArgumentError("Supplied dt is smaller than dtmin"))
             steps = ceil(Int, internalnorm((tspan[2] - tspan[1]) / dt, tspan[1]))
         end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -241,7 +241,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,
         ksEltype = Vector{typeof(ks_prototype)}
     end
 
-    # Have to convert incase passed in wrong.
+    # Have to convert in case passed in wrong.
     if save_idxs === nothing
         timeseries = timeseries_init === () ? uType[] :
                      convert(Vector{uType}, timeseries_init)
@@ -259,7 +259,8 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,
         if dt == 0
             steps = length(tstops)
         else
-            dtmin === nothing && (dtmin = DiffEqBase.prob2dtmin(prob; use_end_time = true))
+            # if not adaptive, user set `dt` should be respected.
+            dtmin = something(dtmin, zero(tspan[1]))
             abs(dt) < dtmin && throw(ArgumentError("Supplied dt is smaller than dtmin"))
             steps = ceil(Int, internalnorm((tspan[2] - tspan[1]) / dt, tspan[1]))
         end
@@ -329,7 +330,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,
         controller = default_controller(_alg, cache, qoldinit, beta1, beta2)
     end
 
-    dtmin === nothing && (dtmin = DiffEqBase.prob2dtmin(prob; use_end_time = false))
+    dtmin === nothing && (dtmin = DiffEqBase.prob2dtmin(prob))
 
     save_end_user = save_end
     save_end = save_end === nothing ?

--- a/test/interface/ode_initdt_tests.jl
+++ b/test/interface/ode_initdt_tests.jl
@@ -27,7 +27,8 @@ prob = remake(prob, u0 = u0, tspan = tspan)
 
 tspan = T.((2000, 2100))
 prob = remake(prob, tspan = tspan)
-@test_throws ArgumentError solve(prob, Euler(); dt = T(0.0001)) # Loops forever
+# set maxiters to prevent infinite loop on test failure
+@test_throws ArgumentError solve(prob, Euler(); dt = T(0.0001), maxiters = 10)
 
 function rober(du, u, p, t)
     y₁, y₂, y₃ = u
@@ -58,3 +59,7 @@ tspan = (0.0, 1e6)
 prob = ODEProblem(ODEFunction(f, mass_matrix = M), u0, tspan, p)
 sol = solve(prob, Rodas5())
 @test sol.t[end] == 1e6
+
+# test that dtmin is set based on timespan
+prob = ODEProblem((u, p, t) -> 1e20 * sin(1e20 * t), 0.1, (0, 1e-19))
+@test solve(prob, Tsit5()).retcode == :Success


### PR DESCRIPTION
This prevents spurious errors when solving with small `tspan` (e.g. circuits).