### PR TITLE
Fixed error for LinearExponential algorithm when using Callbacks

### DIFF
--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -165,6 +165,11 @@ end
                                           cache::OrdinaryDiffEqMutableCache)
     (cache.tmp,)
 end
+@inline function DiffEqBase.get_tmp_cache(integrator,
+    alg::LinearExponential,
+    cache::OrdinaryDiffEqMutableCache)
+(cache.tmp,)
+end
 @inline function DiffEqBase.get_tmp_cache(integrator, alg::CompositeAlgorithm,
                                           cache::CompositeCache)
     get_tmp_cache(integrator, integrator.alg.algs[1], cache.caches[1])


### PR DESCRIPTION
Hello,

similarly to #1248 I created a separate definition of `get_tmp_cache` for the LinearExponential algorithm. Indeed, prior to this change the following code failed

```julia
using OrdinaryDiffEq
using LinearAlgebra
using SparseArrays
A = sprand(ComplexF64, 100, 100, 0.5)
A += A'

t_l = LinRange(0, 1, 100)

saved_values = SavedValues(Float64, Float64)
function save_func(u, t, integrator)
    real(u' * A * u)
end
cb = SavingCallback(save_func, saved_values, saveat = t_l)

u0 = normalize(rand(ComplexF64, 100))
A = DiffEqArrayOperator(-1im * A)
prob = ODEProblem(A, u0, (0, 1.0))
solve(prob, LinearExponential(), dt = t_l[2] - t_l[1], callback = cb);




ERROR: LoadError: type LinearExponential has no field dz
```