### PR TITLE
Added modification and test to allow for AD of LinearExponential

### DIFF
--- a/src/perform_step/linear_perform_step.jl
+++ b/src/perform_step/linear_perform_step.jl
@@ -732,7 +732,7 @@ function perform_step!(integrator, cache::LinearExponentialCache, repeat_step = 
     A = f.f # assume f to be an ODEFunction wrapped around a linear operator
 
     if alg.krylov == :off
-        E = exponential!(dt * Matrix(A))
+        E = exp(dt * Matrix(A))
         mul!(tmp, E, u)
     elseif alg.krylov == :simple
         Ks, expv_cache = KsCache

--- a/src/perform_step/linear_perform_step.jl
+++ b/src/perform_step/linear_perform_step.jl
@@ -732,7 +732,7 @@ function perform_step!(integrator, cache::LinearExponentialCache, repeat_step = 
     A = f.f # assume f to be an ODEFunction wrapped around a linear operator
 
     if alg.krylov == :off
-        E = exp(dt * Matrix(A))
+        E = exponential!(dt * Matrix(A))
         mul!(tmp, E, u)
     elseif alg.krylov == :simple
         Ks, expv_cache = KsCache

--- a/test/interface/ad_tests.jl
+++ b/test/interface/ad_tests.jl
@@ -326,3 +326,13 @@ fn(x, solver) = objfun(x, prob, data, solver, reltol, abstol)
 @test norm(ForwardDiff.gradient(x -> fn(x, Rosenbrock23()), p0)) < 1e-6
 @test norm(ForwardDiff.gradient(x -> fn(x, AutoTsit5(Rosenbrock23())), p0)) < 1e-9
 @test norm(ForwardDiff.gradient(x -> fn(x, AutoVern9(Rodas4())), p0)) < 1e-9
+
+# test AD with LinearExponential()
+function f(x)
+    K = DiffEqArrayOperator(x) 
+    u0 = eltype(x).([1.0,0.0])
+    prob = ODEProblem(K, u0, (0.0,10.0))
+    sol = solve(prob, LinearExponential(), tstops = [0.0,10.0])[2,:]
+end
+K_ = [-1.0 0.0; 1.0 -1.0]
+@test isapprox(ForwardDiff.jacobian(f,K_)[2], 0.00226999, atol=1e-6)


### PR DESCRIPTION
Updated line 735 in `src/perform_step/linear_perform_step.jl` to swap `exp` with `exponential!` which would allow for AD of LinearExponential. Also added an accompanying test to the end of `test/interface/ad_tests.jl`. Related to the issue here https://discourse.julialang.org/t/can-we-use-linearexponential-with-turing-jl-model/88479