### PR TITLE
Fix DAE Jacobian reuse

### DIFF
--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -462,8 +462,11 @@ function do_newJW(integrator, alg, nlsolver, repeat_step)::NTuple{2, Bool}
     islin && return false, false # no further JW eval when it's linear
     !integrator.opts.adaptive && return true, true # Not adaptive will always refactorize
     errorfail = integrator.EEst > one(integrator.EEst)
+    if alg isa DAEAlgorithm
+        return true, true
+    end
     # TODO: add `isJcurrent` support for Rosenbrock solvers
-    if !isnewton(nlsolver) || alg isa DAEAlgorithm
+    if !isnewton(nlsolver)
         isfreshJ = !(integrator.alg isa CompositeAlgorithm) &&
                    (integrator.iter > 1 && errorfail && !integrator.u_modified)
         return !isfreshJ, true


### PR DESCRIPTION
Fix https://github.com/SciML/OrdinaryDiffEq.jl/issues/1787 We cannot save the Jacobian for DAEs even when it's fresh because `df/du` is intertwined with `df/du'`.