### PR TITLE
Use `promote_type`/ `eltype` instead of indexing

### DIFF
--- a/src/initdt.jl
+++ b/src/initdt.jl
@@ -57,7 +57,7 @@
     #tmp = cache[2]
 
     if u0 isa Array
-        tmp = similar(u0, typeof(u0[1] / sk[1]))
+        tmp = similar(u0, promote_type(eltype(u0), eltype(sk)))
         @inbounds @simd ivdep for i in eachindex(u0)
             tmp[i] = u0[i] / sk[i]
         end


### PR DESCRIPTION
This is a minor change to make this function more correct in the presence of empty arrays, arrays that have weird indexing, or heterogeneous arrays.