### PR TITLE
Throw customized error messages with automatic differentiation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEq"
 uuid = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "6.36.0"
+version = "6.36.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -2,7 +2,7 @@ const FIRST_AUTODIFF_TGRAD_MESSAGE = """
                                First call to automatic differentiation for time gradient
                                failed. This means that the user `f` function is not compatible
                                with automatic differentiation. Methods to fix this include:
-                               
+
                                1. Turn off automatic differentiation (e.g. Rosenbrock23() becomes
                                   Rosenbrock23(autodiff=false)). More details can befound at
                                   https://docs.sciml.ai/DiffEqDocs/stable/features/performance_overloads/
@@ -31,8 +31,8 @@ const FIRST_AUTODIFF_TGRAD_MESSAGE = """
                                algorithm as well.
                                """
 
-struct FirstAutodiffTgradError <: Exception 
-    e
+struct FirstAutodiffTgradError <: Exception
+    e::Any
 end
 
 function Base.showerror(io::IO, e::FirstAutodiffTgradError)
@@ -44,7 +44,7 @@ const FIRST_AUTODIFF_JAC_MESSAGE = """
                                First call to automatic differentiation for the Jacobian
                                failed. This means that the user `f` function is not compatible
                                with automatic differentiation. Methods to fix this include:
-                               
+
                                1. Turn off automatic differentiation (e.g. Rosenbrock23() becomes
                                   Rosenbrock23(autodiff=false)). More details can befound at
                                   https://docs.sciml.ai/DiffEqDocs/stable/features/performance_overloads/
@@ -66,8 +66,8 @@ const FIRST_AUTODIFF_JAC_MESSAGE = """
                                algorithm as well.
                                """
 
-struct FirstAutodiffJacError <: Exception 
-    e
+struct FirstAutodiffJacError <: Exception
+    e::Any
 end
 
 function Base.showerror(io::IO, e::FirstAutodiffJacError)
@@ -99,7 +99,7 @@ function derivative!(df::AbstractArray{<:Number}, f,
         else
             f(grad_config, xdual)
         end
-        
+
         df .= first.(ForwardDiff.partials.(grad_config))
         integrator.destats.nf += 1
     else

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -1,3 +1,80 @@
+const FIRST_AUTODIFF_TGRAD_MESSAGE = """
+                               First call to automatic differentiation for time gradient
+                               failed. This means that the user `f` function is not compatible
+                               with automatic differentiation. Methods to fix this include:
+                               
+                               1. Turn off automatic differentiation (e.g. Rosenbrock23() becomes
+                                  Rosenbrock23(autodiff=false)). More details can befound at
+                                  https://docs.sciml.ai/DiffEqDocs/stable/features/performance_overloads/
+                               2. Improving the compatibility of `f` with ForwardDiff.jl automatic 
+                                  differentiation (using tools like PreallocationTools.jl). More details
+                                  can be found at https://docs.sciml.ai/DiffEqDocs/stable/basics/faq/#Autodifferentiation-and-Dual-Numbers
+                               3. Defining analytical Jacobians and time gradients. More details can be
+                                  found at https://docs.sciml.ai/DiffEqDocs/stable/types/ode_types/#SciMLBase.ODEFunction
+
+                               Note 1: this failure occured inside of the time gradient function. These
+                               time gradients are only required by Rosenbrock methods (`Rosenbrock23`,
+                               `Rodas4`, etc.) are are done by automatic differentiation w.r.t. the
+                               argument `t`. If your function is compatible with automatic differentiation
+                               w.r.t. `u`, i.e. for Jacobian generation, another way to work around this
+                               issue is to switch to a non-Rosenbrock method.
+
+                               Note 2: turning off automatic differentiation tends to have a very minimal
+                               performance impact (for this use case, because it's forward mode for a
+                               square Jacobian. This is different from optimization gradient scenarios).
+                               However, one should be careful as some methods are more sensitive to
+                               accurate gradients than others. Specifically, Rodas methods like `Rodas4`
+                               and `Rodas5P` require accurate Jacobians in order to have good convergence,
+                               while many other methods like BDF (`QNDF`, `FBDF`), SDIRK (`KenCarp4`),
+                               and Rosenbrock-W (`Rosenbrock23`) do not. Thus if using an algorithm which
+                               is sensitive to autodiff and solving at a low tolerance, please change the
+                               algorithm as well.
+                               """
+
+struct FirstAutodiffTgradError <: Exception 
+    e
+end
+
+function Base.showerror(io::IO, e::FirstAutodiffTgradError)
+    println(io, FIRST_AUTODIFF_TGRAD_MESSAGE)
+    Base.showerror(io, e.e)
+end
+
+const FIRST_AUTODIFF_JAC_MESSAGE = """
+                               First call to automatic differentiation for the Jacobian
+                               failed. This means that the user `f` function is not compatible
+                               with automatic differentiation. Methods to fix this include:
+                               
+                               1. Turn off automatic differentiation (e.g. Rosenbrock23() becomes
+                                  Rosenbrock23(autodiff=false)). More details can befound at
+                                  https://docs.sciml.ai/DiffEqDocs/stable/features/performance_overloads/
+                               2. Improving the compatibility of `f` with ForwardDiff.jl automatic 
+                                  differentiation (using tools like PreallocationTools.jl). More details
+                                  can be found at https://docs.sciml.ai/DiffEqDocs/stable/basics/faq/#Autodifferentiation-and-Dual-Numbers
+                               3. Defining analytical Jacobians. More details can be
+                                  found at https://docs.sciml.ai/DiffEqDocs/stable/types/ode_types/#SciMLBase.ODEFunction
+
+                               Note: turning off automatic differentiation tends to have a very minimal
+                               performance impact (for this use case, because it's forward mode for a
+                               square Jacobian. This is different from optimization gradient scenarios).
+                               However, one should be careful as some methods are more sensitive to
+                               accurate gradients than others. Specifically, Rodas methods like `Rodas4`
+                               and `Rodas5P` require accurate Jacobians in order to have good convergence,
+                               while many other methods like BDF (`QNDF`, `FBDF`), SDIRK (`KenCarp4`),
+                               and Rosenbrock-W (`Rosenbrock23`) do not. Thus if using an algorithm which
+                               is sensitive to autodiff and solving at a low tolerance, please change the
+                               algorithm as well.
+                               """
+
+struct FirstAutodiffJacError <: Exception 
+    e
+end
+
+function Base.showerror(io::IO, e::FirstAutodiffJacError)
+    println(io, FIRST_AUTODIFF_JAC_MESSAGE)
+    Base.showerror(io, e.e)
+end
+
 function derivative!(df::AbstractArray{<:Number}, f,
                      x::Union{Number, AbstractArray{<:Number}}, fx::AbstractArray{<:Number},
                      integrator, grad_config)
@@ -12,7 +89,17 @@ function derivative!(df::AbstractArray{<:Number}, f,
 
         xdual = Dual{T, eltype(df), 1}(convert(eltype(df), x),
                                        ForwardDiff.Partials((one(eltype(df)),)))
-        f(grad_config, xdual)
+
+        if integrator.iter == 1
+            try
+                f(grad_config, xdual)
+            catch e
+                throw(FirstAutodiffTgradError(e))
+            end
+        else
+            f(grad_config, xdual)
+        end
+        
         df .= first.(ForwardDiff.partials.(grad_config))
         integrator.destats.nf += 1
     else
@@ -37,7 +124,15 @@ function derivative(f, x::Union{Number, AbstractArray{<:Number}},
     alg = unwrap_alg(integrator, true)
     if alg_autodiff(alg)
         integrator.destats.nf += 1
-        d = ForwardDiff.derivative(f, x)
+        if integrator.iter == 1
+            try
+                d = ForwardDiff.derivative(f, x)
+            catch e
+                throw(FirstAutodiffTgradError(e))
+            end
+        else
+            d = ForwardDiff.derivative(f, x)
+        end
     else
         d = FiniteDiff.finite_difference_derivative(f, x, alg_difftype(alg),
                                                     dir = diffdir(integrator))
@@ -92,7 +187,15 @@ function jacobian(f, x, integrator)
     alg = unwrap_alg(integrator, true)
     local tmp
     if alg_autodiff(alg)
-        J, tmp = jacobian_autodiff(f, x, integrator.f, alg)
+        if integrator.iter == 1
+            try
+                J, tmp = jacobian_autodiff(f, x, integrator.f, alg)
+            catch e
+                throw(FirstAutodiffJacError(e))
+            end
+        else
+            J, tmp = jacobian_autodiff(f, x, integrator.f, alg)
+        end
     else
         jac_prototype = integrator.f.jac_prototype
         sparsity, colorvec = sparsity_colorvec(integrator.f, x)
@@ -120,7 +223,15 @@ function jacobian!(J::AbstractMatrix{<:Number}, f, x::AbstractArray{<:Number},
                    jac_config)
     alg = unwrap_alg(integrator, true)
     if alg_autodiff(alg)
-        forwarddiff_color_jacobian!(J, f, x, jac_config)
+        if integrator.iter == 1
+            try
+                forwarddiff_color_jacobian!(J, f, x, jac_config)
+            catch e
+                throw(FirstAutodiffJacError(e))
+            end
+        else
+            forwarddiff_color_jacobian!(J, f, x, jac_config)
+        end
         integrator.destats.nf += 1
     else
         isforward = alg_difftype(alg) === Val{:forward}

--- a/test/interface/autodiff_error_tests.jl
+++ b/test/interface/autodiff_error_tests.jl
@@ -2,42 +2,42 @@ using OrdinaryDiffEq, Test
 
 const a = Float64[1.0]
 
-function lorenz(u,p,t)
-    du1 = 10.0(u[2]-u[1])
+function lorenz(u, p, t)
+    du1 = 10.0(u[2] - u[1])
     a[1] = u[2]
-    du2 = u[1]*(28.0-u[3]) - u[2]
-    du3 = u[1]*u[2] - (8/3)*u[3]
-    [du1,du2,du3]
-   end
-u0 = [1.0;0.0;0.0]
-tspan = (0.0,1.0)
-prob = ODEProblem(lorenz,u0,tspan)
-@test_throws OrdinaryDiffEq.FirstAutodiffJacError solve(prob,Rosenbrock23())
-
-function lorenz(u,p,t)
-    du1 = 10.0(u[2]-u[1])
-    a[1] = t
-    du2 = u[1]*(28.0-u[3]) - u[2]
-    du3 = u[1]*u[2] - (8/3)*u[3]
-    [du1,du2,du3]
+    du2 = u[1] * (28.0 - u[3]) - u[2]
+    du3 = u[1] * u[2] - (8 / 3) * u[3]
+    [du1, du2, du3]
 end
-@test_throws OrdinaryDiffEq.FirstAutodiffTgradError solve(prob,Rosenbrock23())
+u0 = [1.0; 0.0; 0.0]
+tspan = (0.0, 1.0)
+prob = ODEProblem(lorenz, u0, tspan)
+@test_throws OrdinaryDiffEq.FirstAutodiffJacError solve(prob, Rosenbrock23())
 
-function lorenz!(du,u,p,t)
-    du[1] = 10.0(u[2]-u[1])
+function lorenz(u, p, t)
+    du1 = 10.0(u[2] - u[1])
+    a[1] = t
+    du2 = u[1] * (28.0 - u[3]) - u[2]
+    du3 = u[1] * u[2] - (8 / 3) * u[3]
+    [du1, du2, du3]
+end
+@test_throws OrdinaryDiffEq.FirstAutodiffTgradError solve(prob, Rosenbrock23())
+
+function lorenz!(du, u, p, t)
+    du[1] = 10.0(u[2] - u[1])
     a[1] = u[2]
-    du[2] = u[1]*(28.0-u[3]) - u[2]
-    du[3] = u[1]*u[2] - (8/3)*u[3]
-   end
-u0 = [1.0;0.0;0.0]
-tspan = (0.0,1.0)
-prob = ODEProblem(lorenz!,u0,tspan)
-@test_throws OrdinaryDiffEq.FirstAutodiffJacError solve(prob,Rosenbrock23())
-
-function lorenz!(du,u,p,t)
-    du[1] = 10.0(u[2]-u[1])
-    a[1] = t
-    du[2] = u[1]*(28.0-u[3]) - u[2]
-    du[3] = u[1]*u[2] - (8/3)*u[3]
+    du[2] = u[1] * (28.0 - u[3]) - u[2]
+    du[3] = u[1] * u[2] - (8 / 3) * u[3]
 end
-@test_throws OrdinaryDiffEq.FirstAutodiffTgradError solve(prob,Rosenbrock23())
+u0 = [1.0; 0.0; 0.0]
+tspan = (0.0, 1.0)
+prob = ODEProblem(lorenz!, u0, tspan)
+@test_throws OrdinaryDiffEq.FirstAutodiffJacError solve(prob, Rosenbrock23())
+
+function lorenz!(du, u, p, t)
+    du[1] = 10.0(u[2] - u[1])
+    a[1] = t
+    du[2] = u[1] * (28.0 - u[3]) - u[2]
+    du[3] = u[1] * u[2] - (8 / 3) * u[3]
+end
+@test_throws OrdinaryDiffEq.FirstAutodiffTgradError solve(prob, Rosenbrock23())

--- a/test/interface/autodiff_error_tests.jl
+++ b/test/interface/autodiff_error_tests.jl
@@ -1,0 +1,43 @@
+using OrdinaryDiffEq, Test
+
+const a = Float64[1.0]
+
+function lorenz(u,p,t)
+    du1 = 10.0(u[2]-u[1])
+    a[1] = u[2]
+    du2 = u[1]*(28.0-u[3]) - u[2]
+    du3 = u[1]*u[2] - (8/3)*u[3]
+    [du1,du2,du3]
+   end
+u0 = [1.0;0.0;0.0]
+tspan = (0.0,1.0)
+prob = ODEProblem(lorenz,u0,tspan)
+@test_throws OrdinaryDiffEq.FirstAutodiffJacError solve(prob,Rosenbrock23())
+
+function lorenz(u,p,t)
+    du1 = 10.0(u[2]-u[1])
+    a[1] = t
+    du2 = u[1]*(28.0-u[3]) - u[2]
+    du3 = u[1]*u[2] - (8/3)*u[3]
+    [du1,du2,du3]
+end
+@test_throws OrdinaryDiffEq.FirstAutodiffTgradError solve(prob,Rosenbrock23())
+
+function lorenz!(du,u,p,t)
+    du[1] = 10.0(u[2]-u[1])
+    a[1] = u[2]
+    du[2] = u[1]*(28.0-u[3]) - u[2]
+    du[3] = u[1]*u[2] - (8/3)*u[3]
+   end
+u0 = [1.0;0.0;0.0]
+tspan = (0.0,1.0)
+prob = ODEProblem(lorenz!,u0,tspan)
+@test_throws OrdinaryDiffEq.FirstAutodiffJacError solve(prob,Rosenbrock23())
+
+function lorenz!(du,u,p,t)
+    du[1] = 10.0(u[2]-u[1])
+    a[1] = t
+    du[2] = u[1]*(28.0-u[3]) - u[2]
+    du[3] = u[1]*u[2] - (8/3)*u[3]
+end
+@test_throws OrdinaryDiffEq.FirstAutodiffTgradError solve(prob,Rosenbrock23())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,6 +61,7 @@ end
     end
 
     if !is_APPVEYOR && (GROUP == "All" || GROUP == "InterfaceIV" || GROUP == "Interface")
+        @time @safetestset "Autodiff Error Tests" begin include("interface/autodiff_error_tests.jl") end
         @time @safetestset "Ambiguity Tests" begin include("interface/ambiguity_tests.jl") end
         @time @safetestset "Second Order with First Order Solver Tests" begin include("interface/second_order_with_first_order_solvers.jl") end
     end


### PR DESCRIPTION
```julia
using OrdinaryDiffEq, Test

const a = Float64[1.0]

function lorenz(u,p,t)
    du1 = 10.0(u[2]-u[1])
    a[1] = u[2]
    du2 = u[1]*(28.0-u[3]) - u[2]
    du3 = u[1]*u[2] - (8/3)*u[3]
    [du1,du2,du3]
end
u0 = [1.0;0.0;0.0]
tspan = (0.0,1.0)
prob = ODEProblem(lorenz,u0,tspan)
solve(prob,Rosenbrock23())
```

```
ERROR: First call to automatic differentiation for time gradient
failed. This means that the user `f` function is not compatible
with automatic differentiation. Methods to fix this include:

1. Turn off automatic differentiation (e.g. Rosenbrock23() becomes
   Rosenbrock23(autodiff=false)). More details can befound at
   https://docs.sciml.ai/DiffEqDocs/stable/features/performance_overloads/
2. Improving the compatibility of `f` with ForwardDiff.jl automatic
   differentiation (using tools like PreallocationTools.jl). More details
   can be found at https://docs.sciml.ai/DiffEqDocs/stable/basics/faq/#Autodifferentiation-and-Dual-Numbers
3. Defining analytical Jacobians and time gradients. More details can be
   found at https://docs.sciml.ai/DiffEqDocs/stable/types/ode_types/#SciMLBase.ODEFunction

Note 1: this failure occured inside of the time gradient function. These
time gradients are only required by Rosenbrock methods (`Rosenbrock23`,
`Rodas4`, etc.) are are done by automatic differentiation w.r.t. the
argument `t`. If your function is compatible with automatic differentiation
w.r.t. `u`, i.e. for Jacobian generation, another way to work around this
issue is to switch to a non-Rosenbrock method.

Note 2: turning off automatic differentiation tends to have a very minimal
performance impact (for this use case, because it's forward mode for a
square Jacobian. This is different from optimization gradient scenarios).
However, one should be careful as some methods are more sensitive to
accurate gradients than others. Specifically, Rodas methods like `Rodas4`
and `Rodas5P` require accurate Jacobians in order to have good convergence,
while many other methods like BDF (`QNDF`, `FBDF`), SDIRK (`KenCarp4`),
and Rosenbrock-W (`Rosenbrock23`) do not. Thus if using an algorithm which
is sensitive to autodiff and solving at a low tolerance, please change the
algorithm as well.
```

