### PR TITLE
fix `ode_determine_initdt` for zero-length arrays

### DIFF
--- a/src/initdt.jl
+++ b/src/initdt.jl
@@ -57,7 +57,12 @@
     #tmp = cache[2]
 
     if u0 isa Array
-        tmp = similar(u0, typeof(u0[1] / sk[1]))
+        if length(u0) > 0
+            T = typeof(u0[1] / sk[1])
+        else
+            T = promote_type(eltype(u0), eltype(sk))
+        end
+        tmp = similar(u0, T)
         @inbounds @simd ivdep for i in eachindex(u0)
             tmp[i] = u0[i] / sk[i]
         end

--- a/test/regression/ode_adaptive_tests.jl
+++ b/test/regression/ode_adaptive_tests.jl
@@ -86,3 +86,7 @@ for alg in [
     sol = solve(prob, alg)
     @test sol.retcode == ReturnCode.Success
 end
+
+# test problems with zero-length vectors
+ode = ODEProblem((du, u, semi, t) -> du .= u, Float64[], (0.0, 1.0))
+@test_nowarn solve(ode, Tsit5())


### PR DESCRIPTION
We need to be able to handle zero-length arrays with Trixi.jl - aggressive adaptive mesh refinement for massively parallel MPI simulations can have empty arrays on some ranks initially.

I don't know whether this is the best way to deal with it since it may introduce type instabilities for non-homogeneous arrays. On the other hand, the working version was introduced in #1810 and reverted in #1813 because (citing @oscardssmith)

> the PR caused test suite errors that were not caught before merging

I don't know which kind of errors appeared and whether it would be better to fix these errors somewhere else. But we definitely need to be able to use empty arrays initially.

CC @JoshuaLampert