### PR TITLE
Minor clean up

### DIFF
--- a/src/integrators/controllers.jl
+++ b/src/integrators/controllers.jl
@@ -555,7 +555,7 @@ function bdf_step_reject_controller!(integrator, EEst1)
     F = inv(z)
     if z <= 10
         hₖ = F * h
-    elseif z > 10
+    else # z > 10
         hₖ = 0.1 * h
     end
     hₙ = hₖ


### PR DESCRIPTION
Somehow Zygote errors if we have `elseif`

```julia
julia> Zygote.gradient(deepcopy(p_inv)) do p
           sum(solve(prob, FBDF(), p = p, sensealg = InterpolatingAdjoint())[:, end])
       end
┌ Warning: Automatic AD choice of autojacvec failed in ODE adjoint, failing back to ODE adjoint + numerical vjp
└ @ SciMLSensitivity ~/.julia/packages/SciMLSensitivity/Wb65g/src/sensitivity_interface.jl:381
ERROR: UndefVarError: hₖ not defined
Stacktrace:
  [1] bdf_step_reject_controller!(integrator::OrdinaryDiffEq.ODEIn, EEst1::Float64)
    @ OrdinaryDiffEq ~/src/julia/OrdinaryDiffEq/src/integrators/controllers.jl:561
  [2] step_reject_controller!
    @ ~/src/julia/OrdinaryDiffEq/src/integrators/controllers.jl:541 [inlined]
  [3] loopheader!(integrator::OrdinaryDiffEq.ODEIn)
    @ OrdinaryDiffEq ~/src/julia/OrdinaryDiffEq/src/integrators/integrator_utils.jl:19
  [4] solve!(integrator::OrdinaryDiffEq.ODEIn)
```