### PR TITLE
Fix `ode_determine_initdt` used in parallel for empty `u0`

### DIFF
--- a/src/initdt.jl
+++ b/src/initdt.jl
@@ -173,7 +173,7 @@
     # Constant zone before callback
     # Just return first guess
     # Avoids AD issues
-    f₀ == f₁ && return tdir * max(dtmin, 100dt₀)
+    length(u0) > 0 && f₀ == f₁ && return tdir * max(dtmin, 100dt₀)
 
     if u0 isa Array
         @inbounds @simd ivdep for i in eachindex(u0)

--- a/test/regression/ode_adaptive_tests.jl
+++ b/test/regression/ode_adaptive_tests.jl
@@ -90,3 +90,8 @@ end
 # test problems with zero-length vectors
 ode = ODEProblem((du, u, semi, t) -> du .= u, Float64[], (0.0, 1.0))
 @test_nowarn solve(ode, Tsit5())
+
+# test if the early exit in ode_determine_initdt doesn't hit in the case of
+# zero-length vectors, see https://github.com/SciML/OrdinaryDiffEq.jl/pull/1865
+integrator = init(ode, Tsit5())
+@test integrator.dt ≈ 1.0e-6


### PR DESCRIPTION
We need to use `ode_determine_initdt` in parallel with MPI in Trixi.jl, where some ranks have empty arrays initially, see also https://github.com/trixi-framework/Trixi.jl/issues/1350.
CC @ranocha

Closes https://github.com/trixi-framework/Trixi.jl/issues/1350