### PR TITLE
More fixes on newly introduced show(...) methods

### DIFF
--- a/src/caches/basic_caches.jl
+++ b/src/caches/basic_caches.jl
@@ -94,7 +94,7 @@ function Base.show(io::IO,
     if TruncatedStacktraces.VERBOSE[]
         print(io, "ExplicitRKCache{$uType,$rateType,$uNoUnitsType,$TabType}")
     else
-        print(io, "ExplicitRKCache{$utype,…}")
+        print(io, "ExplicitRKCache{$uType,…}")
     end
 end
 

--- a/src/caches/bdf_caches.jl
+++ b/src/caches/bdf_caches.jl
@@ -401,7 +401,7 @@ function Base.show(io::IO,
         print(io,
               "QNDFCache{$MO,$UType,$RUType,$rateType,$N,$coefType,$dtType,$EEstType,$gammaType,$uType,$uNoUnitsType}")
     else
-        print(io, "QNDFCache{$utype,…}")
+        print(io, "QNDFCache{$uType,…}")
     end
 end
 
@@ -611,7 +611,7 @@ function Base.show(io::IO,
         print(io,
               "FBDFCache{$MO,$N,$rateType,$uNoUnitsType,$tsType,$tType,$uType,$uuType,$coeffType,$EEstType,$rType,$wType}")
     else
-        print(io, "FBDFCache{$utype,…}")
+        print(io, "FBDFCache{$uType,…}")
     end
 end
 

--- a/src/caches/firk_caches.jl
+++ b/src/caches/firk_caches.jl
@@ -224,7 +224,7 @@ function Base.show(io::IO,
         print(io,
               "RadauIIA5Cache{$uType,$cuType,$uNoUnitsType,$rateType,$JType,$W1Type,$W2Type,$UF,$JC,$F1,$F2,$Tab,$Tol,$Dt,$rTol,$aTol}")
     else
-        print(io, "RadauIIA5Cache{$utype,…}")
+        print(io, "RadauIIA5Cache{$uType,…}")
     end
 end
 

--- a/src/caches/kencarp_kvaerno_caches.jl
+++ b/src/caches/kencarp_kvaerno_caches.jl
@@ -228,7 +228,7 @@ function Base.show(io::IO,
     if TruncatedStacktraces.VERBOSE[]
         print(io, "KenCarp4Cache{$uType,$rateType,$uNoUnitsType,$N,$Tab,$kType}")
     else
-        print(io, "KenCarp4Cache{$utype,…}")
+        print(io, "KenCarp4Cache{$uType,…}")
     end
 end
 
@@ -470,7 +470,7 @@ function Base.show(io::IO,
     if TruncatedStacktraces.VERBOSE[]
         print(io, "KenCarp47Cache{$uType,$rateType,$uNoUnitsType,$N,$Tab,$kType}")
     else
-        print(io, "KenCarp47Cache{$utype,…}")
+        print(io, "KenCarp47Cache{$uType,…}")
     end
 end
 
@@ -571,7 +571,7 @@ function Base.show(io::IO,
     if TruncatedStacktraces.VERBOSE[]
         print(io, "KenCarp58Cache{$uType,$rateType,$uNoUnitsType,$N,$Tab,$kType}")
     else
-        print(io, "KenCarp58Cache{$utype,…}")
+        print(io, "KenCarp58Cache{$uType,…}")
     end
 end
 


### PR DESCRIPTION
Follow up from https://github.com/SciML/OrdinaryDiffEq.jl/pull/1890

1890 fixed my immediate issue, but then I went back and checked whether the same typo is present in other caches as well and found a few. I hope that I caught them all. 

This pull request should fix the same issue on the other algorithms as well. 

Sorry for not thinking immediately about it and creating double work with merging two pull requests.