### PR TITLE
fix ROCK2/ROCK4 for arrays of SVectors

### DIFF
--- a/src/caches/rkc_caches.jl
+++ b/src/caches/rkc_caches.jl
@@ -27,7 +27,8 @@ function alg_cache(alg::ROCK2, u, rate_prototype, ::Type{uEltypeNoUnits},
                    ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
                    dt, reltol, p, calck,
                    ::Val{true}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    constantcache = ROCK2ConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits),
+    constantcache = ROCK2ConstantCache(constvalue(uBottomEltypeNoUnits),
+                                       constvalue(tTypeNoUnits),
                                        u)
     uᵢ₋₁ = zero(u)
     uᵢ₋₂ = zero(u)
@@ -78,7 +79,8 @@ function alg_cache(alg::ROCK4, u, rate_prototype, ::Type{uEltypeNoUnits},
                    ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
                    dt, reltol, p, calck,
                    ::Val{true}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    constantcache = ROCK4ConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits),
+    constantcache = ROCK4ConstantCache(constvalue(uBottomEltypeNoUnits),
+                                       constvalue(tTypeNoUnits),
                                        u)
     uᵢ₋₁ = zero(u)
     uᵢ₋₂ = zero(u)

--- a/src/caches/rkc_caches.jl
+++ b/src/caches/rkc_caches.jl
@@ -27,7 +27,7 @@ function alg_cache(alg::ROCK2, u, rate_prototype, ::Type{uEltypeNoUnits},
                    ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
                    dt, reltol, p, calck,
                    ::Val{true}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    constantcache = ROCK2ConstantCache(constvalue(uEltypeNoUnits), constvalue(tTypeNoUnits),
+    constantcache = ROCK2ConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits),
                                        u)
     uᵢ₋₁ = zero(u)
     uᵢ₋₂ = zero(u)
@@ -43,7 +43,7 @@ function alg_cache(alg::ROCK2, u, rate_prototype, ::Type{uEltypeNoUnits},
                    ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
                    dt, reltol, p, calck,
                    ::Val{false}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    ROCK2ConstantCache(uEltypeNoUnits, uEltypeNoUnits, u)
+    ROCK2ConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits), u)
 end
 
 mutable struct ROCK4ConstantCache{T, T2, T3, T4, zType} <: OrdinaryDiffEqConstantCache
@@ -78,7 +78,7 @@ function alg_cache(alg::ROCK4, u, rate_prototype, ::Type{uEltypeNoUnits},
                    ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
                    dt, reltol, p, calck,
                    ::Val{true}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    constantcache = ROCK4ConstantCache(constvalue(uEltypeNoUnits), constvalue(tTypeNoUnits),
+    constantcache = ROCK4ConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits),
                                        u)
     uᵢ₋₁ = zero(u)
     uᵢ₋₂ = zero(u)
@@ -95,7 +95,7 @@ function alg_cache(alg::ROCK4, u, rate_prototype, ::Type{uEltypeNoUnits},
                    ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
                    dt, reltol, p, calck,
                    ::Val{false}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    ROCK4ConstantCache(constvalue(uEltypeNoUnits), constvalue(uEltypeNoUnits), u)
+    ROCK4ConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits), u)
 end
 
 mutable struct RKCConstantCache{zType} <: OrdinaryDiffEqConstantCache

--- a/test/interface/static_array_tests.jl
+++ b/test/interface/static_array_tests.jl
@@ -23,6 +23,8 @@ sol = solve(ode, Tsit5())
 @test !any(iszero.(sol(1.0))) && !any(sol(1.0) .== u0)
 sol = solve(ode, SSPRK22(), dt = 1e-2)
 @test !any(iszero.(sol(1.0))) && !any(sol(1.0) .== u0)
+sol = solve(ode, ROCK4())
+@test !any(iszero.(sol(1.0))) && !any(sol(1.0) .== u0)
 
 u0 = ones(MVector{2, Float64})
 ode = ODEProblem(g, u0, (0.0, 1.0))


### PR DESCRIPTION
This fixes a problem brought up in #1924. However, `RKC` still does not work, so we shouldn't close that issue.