### PR TITLE
Fix and test no autodiff with Rosenbrock out of place methods

### DIFF
--- a/src/perform_step/rosenbrock_perform_step.jl
+++ b/src/perform_step/rosenbrock_perform_step.jl
@@ -696,7 +696,7 @@ end
     mass_matrix = integrator.f.mass_matrix
     # Time derivative
     tf.u = uprev
-    dT = ForwardDiff.derivative(tf, t)
+    dT = calc_tderivative(integrator, cache)
 
     W = calc_W(integrator, cache, dtgamma, repeat_step, true)
     if !issuccess_W(W)
@@ -926,7 +926,7 @@ end
 
     # Time derivative
     tf.u = uprev
-    dT = ForwardDiff.derivative(tf, t)
+    dT = calc_tderivative(integrator, cache)
 
     W = calc_W(integrator, cache, dtgamma, repeat_step, true)
     if !issuccess_W(W)

--- a/test/interface/autodiff_error_tests.jl
+++ b/test/interface/autodiff_error_tests.jl
@@ -41,3 +41,19 @@ function lorenz!(du, u, p, t)
     du[3] = u[1] * u[2] - (8 / 3) * u[3]
 end
 @test_throws OrdinaryDiffEq.FirstAutodiffTgradError solve(prob, Rosenbrock23())
+
+## Test that nothing is using duals when autodiff=false
+## https://discourse.julialang.org/t/rodas4-using-dual-number-for-time-with-autodiff-false/98256
+
+for alg in [Rosenbrock23(autodiff=false), Rodas4(autodiff=false), Rodas5(autodiff=false), QNDF(autodiff=false), TRBDF2(autodiff=false), KenCarp4(autodiff=false)]
+    u = [0.0, 0.0]
+    function du(u,p,t)
+        #display(typeof(t))
+        du = zeros(2)
+        du[1] = 0.1*u[1] + 0.2*u[2]
+        du[2] = 0.1*t
+        return du
+    end
+    prob = ODEProblem(du,u,(0.0,1.0))
+    sol = solve(prob,alg)
+end

--- a/test/interface/autodiff_error_tests.jl
+++ b/test/interface/autodiff_error_tests.jl
@@ -45,15 +45,25 @@ end
 ## Test that nothing is using duals when autodiff=false
 ## https://discourse.julialang.org/t/rodas4-using-dual-number-for-time-with-autodiff-false/98256
 
-for alg in [Rosenbrock23(autodiff=false), Rodas4(autodiff=false), Rodas5(autodiff=false), QNDF(autodiff=false), TRBDF2(autodiff=false), KenCarp4(autodiff=false)]
+for alg in [Rosenbrock23(autodiff=false), Rodas4(autodiff=false), Rodas5(autodiff=false), QNDF(autodiff=false), TRBDF2(autodiff=false), KenCarp4(autodiff=false), FBDF(autodiff=false)]
     u = [0.0, 0.0]
-    function du(u,p,t)
+    function f1(u,p,t)
         #display(typeof(t))
         du = zeros(2)
         du[1] = 0.1*u[1] + 0.2*u[2]
         du[2] = 0.1*t
         return du
     end
-    prob = ODEProblem(du,u,(0.0,1.0))
+    prob = ODEProblem(f1,u,(0.0,1.0))
+    sol = solve(prob,alg)
+
+    function f2(du,u,p,t)
+        #display(typeof(t))
+        du2 = zeros(2)
+        du2[1] = 0.1*u[1] + 0.2*u[2]
+        du2[2] = 0.1*t
+        du .= du2
+    end
+    prob = ODEProblem(f2,u,(0.0,1.0))
     sol = solve(prob,alg)
 end


### PR DESCRIPTION
Found in https://discourse.julialang.org/t/rodas4-using-dual-number-for-time-with-autodiff-false/98256, for some reason the out of place Rosenbrock methods were always autodiffing time. This adds a test to make sure this doesn't regress, and also puts in methods from a few other classes just to double check, and tests both oop and iip