### PR TITLE
Fix broadcast dispatch in Rodas4 and better test AbstractMatrix paths

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEq"
 uuid = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "6.51.0"
+version = "6.51.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/perform_step/rosenbrock_perform_step.jl
+++ b/src/perform_step/rosenbrock_perform_step.jl
@@ -1081,7 +1081,7 @@ end
                             solverdata = (; gamma = dtgamma))
     end
 
-    @.. broadcast=false k1=-linres.u
+    @.. broadcast=false $(_vec(k1))=-linres.u
 
     integrator.stats.nsolve += 1
 
@@ -1098,7 +1098,7 @@ end
     end
 
     linres = dolinsolve(integrator, linres.cache; b = _vec(linsolve_tmp))
-    @.. broadcast=false k2=-linres.u
+    @.. broadcast=false $(_vec(k2))=-linres.u
     integrator.stats.nsolve += 1
 
     @.. broadcast=false u=uprev + a31 * k1 + a32 * k2
@@ -1114,7 +1114,7 @@ end
     end
 
     linres = dolinsolve(integrator, linres.cache; b = _vec(linsolve_tmp))
-    @.. broadcast=false k3=-linres.u
+    @.. broadcast=false $(_vec(k3))=-linres.u
     integrator.stats.nsolve += 1
 
     @.. broadcast=false u=uprev + a41 * k1 + a42 * k2 + a43 * k3
@@ -1131,7 +1131,7 @@ end
     end
 
     linres = dolinsolve(integrator, linres.cache; b = _vec(linsolve_tmp))
-    @.. broadcast=false k4=-linres.u
+    @.. broadcast=false $(_vec(k4))=-linres.u
     integrator.stats.nsolve += 1
 
     @.. broadcast=false u=uprev + a51 * k1 + a52 * k2 + a53 * k3 + a54 * k4
@@ -1148,7 +1148,7 @@ end
     end
 
     linres = dolinsolve(integrator, linres.cache; b = _vec(linsolve_tmp))
-    @.. broadcast=false k5=-linres.u
+    @.. broadcast=false $(_vec(k5))=-linres.u
     integrator.stats.nsolve += 1
 
     u .+= k5
@@ -1166,7 +1166,7 @@ end
     end
 
     linres = dolinsolve(integrator, linres.cache; b = _vec(linsolve_tmp))
-    @.. broadcast=false k6=-linres.u
+    @.. broadcast=false $(_vec(k6))=-linres.u
     integrator.stats.nsolve += 1
 
     u .+= k6

--- a/test/interface/sized_matrix_tests.jl
+++ b/test/interface/sized_matrix_tests.jl
@@ -1,0 +1,21 @@
+using OrdinaryDiffEq, StaticArrays, Test
+
+function dudt!(du, σ, p, t)
+    du .= -σ 
+end
+
+η0 = 1
+τ = 1
+α = 0.8
+p_giesekus = [η0,τ,α]
+
+## Exercise code paths that are in-place but not `<:Array` but not AbstractVector
+σ0 = SizedMatrix{3,3}([1. 0. 0. ; 0. 2. 0. ; 3. 0. 0.])
+
+prob_giesekus = ODEProblem(dudt!, σ0, (0., 2.), p_giesekus)
+solve_giesekus = solve(prob_giesekus, Rodas4(), saveat=0.2, abstol=1e-14, reltol=1e-14) 
+
+for alg in [Rosenbrock23(), Rodas4(), Rodas4P(), Rodas5(), Rodas5P(), Tsit5(), Vern6(), Vern7(), Vern8(), Vern9(), DP5()]
+    sol = solve(prob_giesekus, alg, saveat=0.2, abstol=1e-14, reltol=1e-14)
+    @test Array(sol) ≈ Array(solve_giesekus)
+end

--- a/test/interface/sized_matrix_tests.jl
+++ b/test/interface/sized_matrix_tests.jl
@@ -1,21 +1,34 @@
 using OrdinaryDiffEq, StaticArrays, Test
 
 function dudt!(du, σ, p, t)
-    du .= -σ 
+    du .= -σ
 end
 
 η0 = 1
 τ = 1
 α = 0.8
-p_giesekus = [η0,τ,α]
+p_giesekus = [η0, τ, α]
 
 ## Exercise code paths that are in-place but not `<:Array` but not AbstractVector
-σ0 = SizedMatrix{3,3}([1. 0. 0. ; 0. 2. 0. ; 3. 0. 0.])
+σ0 = SizedMatrix{3, 3}([1.0 0.0 0.0; 0.0 2.0 0.0; 3.0 0.0 0.0])
 
-prob_giesekus = ODEProblem(dudt!, σ0, (0., 2.), p_giesekus)
-solve_giesekus = solve(prob_giesekus, Rodas4(), saveat=0.2, abstol=1e-14, reltol=1e-14) 
+prob_giesekus = ODEProblem(dudt!, σ0, (0.0, 2.0), p_giesekus)
+solve_giesekus = solve(prob_giesekus, Rodas4(), saveat = 0.2, abstol = 1e-14,
+                       reltol = 1e-14)
 
-for alg in [Rosenbrock23(), Rodas4(), Rodas4P(), Rodas5(), Rodas5P(), Tsit5(), Vern6(), Vern7(), Vern8(), Vern9(), DP5()]
-    sol = solve(prob_giesekus, alg, saveat=0.2, abstol=1e-14, reltol=1e-14)
+for alg in [
+    Rosenbrock23(),
+    Rodas4(),
+    Rodas4P(),
+    Rodas5(),
+    Rodas5P(),
+    Tsit5(),
+    Vern6(),
+    Vern7(),
+    Vern8(),
+    Vern9(),
+    DP5(),
+]
+    sol = solve(prob_giesekus, alg, saveat = 0.2, abstol = 1e-14, reltol = 1e-14)
     @test Array(sol) ≈ Array(solve_giesekus)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,6 +63,7 @@ end
     if !is_APPVEYOR && (GROUP == "All" || GROUP == "InterfaceIV" || GROUP == "Interface")
         @time @safetestset "Autodiff Error Tests" begin include("interface/autodiff_error_tests.jl") end
         @time @safetestset "Ambiguity Tests" begin include("interface/ambiguity_tests.jl") end
+        @time @safetestset "Sized Matrix Tests" begin include("interface/sized_matrix_tests.jl") end
         @time @safetestset "Second Order with First Order Solver Tests" begin include("interface/second_order_with_first_order_solvers.jl") end
     end
 


### PR DESCRIPTION
This fixes a case where you have an AbstractMatrix which was not `vec` resized so it was throwing an error in broadcast. Normally this is covered by the convergence tests, since most of the convergence tests use matrices for `u0`. However, for a subset of algorithms there is a separate `<:Array` dispatch for compile time performance. For those cases, it was found that in one fallback `<:AbstractArray` dispatch that the `_vec`s were missing, making a size issue between the linear solver's `_vec(u)` vs `k1`. 

This is fixed, and a general test on all of the algorithms with such a compile time improvement fallback was added:

```julia
using OrdinaryDiffEq, StaticArrays, Test

function dudt!(du, σ, p, t)
    du .= -σ 
end

η0 = 1
τ = 1
α = 0.8
p_giesekus = [η0,τ,α]

## Exercise code paths that are in-place but not `<:Array` but not AbstractVector
σ0 = SizedMatrix{3,3}([1. 0. 0. ; 0. 2. 0. ; 3. 0. 0.])

prob_giesekus = ODEProblem(dudt!, σ0, (0., 2.), p_giesekus)
solve_giesekus = solve(prob_giesekus, Rodas4(), saveat=0.2, abstol=1e-14, reltol=1e-14) 

for alg in [Rosenbrock23(), Rodas4(), Rodas4P(), Rodas5(), Rodas5P(), Tsit5(), Vern6(), Vern7(), Vern8(), Vern9(), DP5()]
    sol = solve(prob_giesekus, alg, saveat=0.2, abstol=1e-14, reltol=1e-14)
    @test Array(sol) ≈ Array(solve_giesekus)
end
```
