### PR TITLE
More docs for stabilized RK methods

### DIFF
--- a/docs/src/stiff/stabilized_rk.md
+++ b/docs/src/stiff/stabilized_rk.md
@@ -2,6 +2,14 @@
 
 ## Explicit Stabilized Runge-Kutta Methods
 
+Explicit stabilized methods utilize an upper bound on the spectral radius of the Jacobian. 
+Users can supply an upper bound by specifying the keyword argument `eigen_est`, for example
+```julia
+`eigen_est = (integrator) -> integrator.eigen_est = upper_bound`
+```
+The methods `ROCK2` and `ROCK4` also include keyword arguments `min_stages` and `max_stages`, 
+which specify upper and lower bounds on the adaptively chosen number of stages for stability. 
+
 ```@docs
 ROCK2
 ROCK4

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -6058,6 +6058,8 @@ is not provided, `upper_bound` will be estimated using the power iteration.
 function RKC end
 
 """
+    ESERK4(; eigen_est = nothing)
+
 J. Martín-Vaquero, B. Kleefeld. Extrapolated stabilized explicit Runge-Kutta methods, 
   Journal of Computational Physics, 326, pp 141-155, 2016. doi:
   https://doi.org/10.1016/j.jcp.2016.08.042.
@@ -6076,6 +6078,8 @@ If `eigen_est` is not provided, `upper_bound` will be estimated using the power 
 function ESERK4 end
 
 """
+    ESERK5(; eigen_est = nothing)
+
 J. Martín-Vaquero, A. Kleefeld. ESERK5: A fifth-order extrapolated stabilized explicit Runge-Kutta method,
   Journal of Computational and Applied Mathematics, 356, pp 22-36, 2019. doi:
   https://doi.org/10.1016/j.cam.2019.01.040.

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -6037,7 +6037,6 @@ for Alg in [:ESERK4, :ESERK5, :RKC]
     end
 end
 
-
 """
 B. P. Sommeijer, L. F. Shampine, J. G. Verwer. RKC: An Explicit Solver for Parabolic PDEs,
   Journal of Computational and Applied Mathematics, 88(2), pp 315-326, 1998. doi:

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -6000,6 +6000,8 @@ function ROCK2(; min_stages = 0, max_stages = 200, eigen_est = nothing)
 end
 
 """
+    ROCK4(; min_stages = 0, max_stages = 152, eigen_est = nothing)
+    
 Assyr Abdulle. Fourth Order Chebyshev Methods With Recurrence Relation. 2002 Society for
 Industrial and Applied Mathematics Journal on Scientific Computing, 23(6), pp 2041-2054, 2001.
 doi: https://doi.org/10.1137/S1064827500379549

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -6028,6 +6028,16 @@ end
 
 # SERK methods
 
+for Alg in [:ESERK4, :ESERK5, :RKC]
+    @eval begin
+        struct $Alg{E} <: OrdinaryDiffEqAdaptiveAlgorithm
+            eigen_est::E
+        end
+        $Alg(; eigen_est = nothing) = $Alg(eigen_est)
+    end
+end
+
+
 """
 B. P. Sommeijer, L. F. Shampine, J. G. Verwer. RKC: An Explicit Solver for Parabolic PDEs,
   Journal of Computational and Applied Mathematics, 88(2), pp 315-326, 1998. doi:
@@ -6082,14 +6092,6 @@ If `eigen_est` is not provided, `upper_bound` will be estimated using the power 
 """
 function ESERK5 end
 
-for Alg in [:ESERK4, :ESERK5, :RKC]
-    @eval begin
-        struct $Alg{E} <: OrdinaryDiffEqAdaptiveAlgorithm
-            eigen_est::E
-        end
-        $Alg(; eigen_est = nothing) = $Alg(eigen_est)
-    end
-end
 struct SERK2{E} <: OrdinaryDiffEqAdaptiveAlgorithm
     controller::Symbol
     eigen_est::E

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -6038,6 +6038,8 @@ for Alg in [:ESERK4, :ESERK5, :RKC]
 end
 
 """
+    RKC(; eigen_est = nothing)
+
 B. P. Sommeijer, L. F. Shampine, J. G. Verwer. RKC: An Explicit Solver for Parabolic PDEs,
   Journal of Computational and Applied Mathematics, 88(2), pp 315-326, 1998. doi:
   https://doi.org/10.1016/S0377-0427(97)00219-7

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -5975,11 +5975,20 @@ JVODE_BDF(; kwargs...) = JVODE(:BDF; kwargs...)
 
 """
 Assyr Abdulle, Alexei A. Medovikov. Second Order Chebyshev Methods based on Orthogonal Polynomials.
-Numerische Mathematik, 90 (1), pp 1-18, 2001. doi: https://dx.doi.org/10.1007/s002110100292
+Numerische Mathematik, 90 (1, pp 1-18, 2001. doi: https://dx.doi.org/10.1007/s002110100292
 
-ROCK2: Stabilized Explicit Method
+ROCK2: Stabilized Explicit Method.
   Second order stabilized Runge-Kutta method.
   Exhibits high stability for real eigenvalues and is smoothened to allow for moderate sized complex eigenvalues.
+
+This method takes optional keyword arguments `min_stages`, `max_stages`, and `eigen_est`. 
+The function `eigen_est` should be of the form 
+  
+  `eigen_est = (integrator) -> integrator.eigen_est = upper_bound`,
+
+where `upper_bound` is an estimated upper bound on the spectral radius of the Jacobian matrix. If `eigen_est` 
+is not provided, `upper_bound` will be estimated using the power iteration. 
+
 """
 struct ROCK2{E} <: OrdinaryDiffEqAdaptiveAlgorithm
     min_stages::Int
@@ -5995,9 +6004,18 @@ Assyr Abdulle. Fourth Order Chebyshev Methods With Recurrence Relation. 2002 Soc
 Industrial and Applied Mathematics Journal on Scientific Computing, 23(6), pp 2041-2054, 2001.
 doi: https://doi.org/10.1137/S1064827500379549
 
-ROCK4: Stabilized Explicit Method
+ROCK4: Stabilized Explicit Method.
   Fourth order stabilized Runge-Kutta method.
   Exhibits high stability for real eigenvalues and is smoothened to allow for moderate sized complex eigenvalues.
+
+This method takes optional keyword arguments `min_stages`, `max_stages`, and `eigen_est`. 
+The function `eigen_est` should be of the form 
+  
+  `eigen_est = (integrator) -> integrator.eigen_est = upper_bound`,
+
+where `upper_bound` is an estimated upper bound on the spectral radius of the Jacobian matrix. If `eigen_est` 
+is not provided, `upper_bound` will be estimated using the power iteration. 
+
 """
 struct ROCK4{E} <: OrdinaryDiffEqAdaptiveAlgorithm
     min_stages::Int
@@ -6010,13 +6028,59 @@ end
 
 # SERK methods
 
-#=
-RKC
-
+"""
 B. P. Sommeijer, L. F. Shampine, J. G. Verwer. RKC: An Explicit Solver for Parabolic PDEs,
   Journal of Computational and Applied Mathematics, 88(2), pp 315-326, 1998. doi:
   https://doi.org/10.1016/S0377-0427(97)00219-7
-=#
+
+RKC: Stabilized Explicit Method.
+  Second order stabilized Runge-Kutta method.
+  Exhibits high stability for real eigenvalues. 
+  
+This method takes the keyword argument `eigen_est` of the form   
+
+  `eigen_est = (integrator) -> integrator.eigen_est = upper_bound`,
+
+where `upper_bound` is an estimated upper bound on the spectral radius of the Jacobian matrix. If `eigen_est` 
+is not provided, `upper_bound` will be estimated using the power iteration. 
+"""
+function RKC end
+
+"""
+J. Martín-Vaquero, B. Kleefeld. Extrapolated stabilized explicit Runge-Kutta methods, 
+  Journal of Computational Physics, 326, pp 141-155, 2016. doi:
+  https://doi.org/10.1016/j.jcp.2016.08.042.
+
+ESERK4: Stabilized Explicit Method.
+  Fourth order extrapolated stabilized Runge-Kutta method.  
+  Exhibits high stability for real eigenvalues and is smoothened to allow for moderate sized complex eigenvalues.
+
+This method takes the keyword argument `eigen_est` of the form 
+  
+  `eigen_est = (integrator) -> integrator.eigen_est = upper_bound`,
+
+where `upper_bound` is an estimated upper bound on the spectral radius of the Jacobian matrix. 
+If `eigen_est` is not provided, `upper_bound` will be estimated using the power iteration. 
+"""
+function ESERK4 end
+
+"""
+J. Martín-Vaquero, A. Kleefeld. ESERK5: A fifth-order extrapolated stabilized explicit Runge-Kutta method,
+  Journal of Computational and Applied Mathematics, 356, pp 22-36, 2019. doi:
+  https://doi.org/10.1016/j.cam.2019.01.040.
+
+ESERK5: Stabilized Explicit Method.
+  Fifth order extrapolated stabilized Runge-Kutta method.  
+  Exhibits high stability for real eigenvalues and is smoothened to allow for moderate sized complex eigenvalues.
+
+This method takes the keyword argument `eigen_est` of the form 
+  
+  `eigen_est = (integrator) -> integrator.eigen_est = upper_bound`,
+
+where `upper_bound` is an estimated upper bound on the spectral radius of the Jacobian matrix. 
+If `eigen_est` is not provided, `upper_bound` will be estimated using the power iteration. 
+"""
+function ESERK5 end
 
 for Alg in [:ESERK4, :ESERK5, :RKC]
     @eval begin

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -5975,7 +5975,7 @@ JVODE_BDF(; kwargs...) = JVODE(:BDF; kwargs...)
 
 """
 Assyr Abdulle, Alexei A. Medovikov. Second Order Chebyshev Methods based on Orthogonal Polynomials.
-Numerische Mathematik, 90 (1, pp 1-18, 2001. doi: https://dx.doi.org/10.1007/s002110100292
+Numerische Mathematik, 90 (1), pp 1-18, 2001. doi: https://dx.doi.org/10.1007/s002110100292
 
 ROCK2: Stabilized Explicit Method.
   Second order stabilized Runge-Kutta method.


### PR DESCRIPTION
Added documentation of keyword arguments for ROCK2, and ROCK4. This PR also adds citations and docstrings for RKC, ESERK4, and ESERK5.

Can probably close https://github.com/SciML/OrdinaryDiffEq.jl/issues/1932 too if this is merged.