### PR TITLE
fix docstring of FineRKN5

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -5254,11 +5254,9 @@ struct Nystrom4 <: OrdinaryDiffEqPartitionedAlgorithm end
 """
     FineRKN5()
 
-A 5th order explicit Runge-Kutta-Nyström method which can be applied directly to second order ODEs. 
+A 5th order explicit Runge-Kutta-Nyström method which can be applied directly to second order ODEs.
+In particular, this method allows the acceleration equation to depend on the velocity.
 Can only be used with fixed time steps.
-
-This method requires that the acceleration equation needs to be independent of the velocity
-otherwise it results in convergence order loss.
 
 ## References
 ```


### PR DESCRIPTION
The new RKN algorithm is explicitly constructed for such general second-order ODEs.

CC @ChrisRackauckas @HenryLangner 

For example, I get
```julia
julia> using OrdinaryDiffEq, Plots

julia> ode = SecondOrderODEProblem((ddu, du, u, p, t) -> @.(ddu = -u - 0.5 * du), [0.0], [1.0], (0.0, 10.0))
ODEProblem with uType RecursiveArrayTools.ArrayPartition{Float64, Tuple{Vector{Float64}, Vector{Float64}}} and tType Float64. In-place: true
timespan: (0.0, 10.0)
u0: ([0.0], [1.0])

julia> begin
       t = range(ode.tspan..., length = 200)
       sol = solve(ode, Tsit5(), abstol = 1.0e-8, reltol = 1.0e-8)
       plot(t, first.(sol.(t)), label = "Tsit5", linewidth = 3)
       sol = solve(ode, DPRKN6(), adaptive = false, dt = 0.25)
       plot!(t, first.(sol.(t)), label = "DPRKN6", linewidth = 3)
       sol = solve(ode, FineRKN5(), adaptive = false, dt = 0.25)
       plot!(t, first.(sol.(t)), label = "FineRKN5", linestyle = :dash, linewidth = 3, color = :black)
       end
```

![tmp](https://github.com/SciML/OrdinaryDiffEq.jl/assets/12693098/fbd76651-bda8-487e-a987-a4d8108ed8ca)
