### PR TITLE
Re-evaluate u_initial after DAE initialization

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -483,11 +483,12 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,
             integrator.saveiter += 1 # Starts at 1 so first save is at 2
             integrator.saveiter_dense += 1
             copyat_or_push!(ts, 1, t)
+            # N.B.: integrator.u can be modified by initialized_dae!
             if save_idxs === nothing
                 copyat_or_push!(timeseries, 1, integrator.u)
                 copyat_or_push!(ks, 1, [rate_prototype])
             else
-                copyat_or_push!(timeseries, 1, u_initial, Val{false})
+                copyat_or_push!(timeseries, 1, integrator.u[save_idxs], Val{false})
                 copyat_or_push!(ks, 1, [ks_prototype])
             end
         else


### PR DESCRIPTION
Found by inspection - I think this acidentally had the same bug as https://github.com/SciML/Sundials.jl/pull/407 if save_idxs is not `nothing`.