### PR TITLE
fix `resize!` with `SplitFunction`

### DIFF
--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -208,6 +208,7 @@ function resize!(integrator::ODEIntegrator, i::Int)
         # may be required for things like units
         c !== nothing && resize!(c, i)
     end
+    resize_f!(integrator.f, i)
     resize_nlsolver!(integrator, i)
     resize_J_W!(cache, integrator, i)
     resize_non_user_cache!(integrator, cache, i)
@@ -219,10 +220,19 @@ function resize!(integrator::ODEIntegrator, i::NTuple{N, Int}) where {N}
     for c in full_cache(cache)
         resize!(c, i)
     end
+    resize_f!(integrator.f, i)
     # TODO the parts below need to be adapted for implicit methods
     isdefined(integrator.cache, :nlsolver) && resize_nlsolver!(integrator, i)
     resize_J_W!(cache, integrator, i)
     resize_non_user_cache!(integrator, cache, i)
+end
+
+# default fallback
+resize_f!(f, i) = nothing
+
+function resize_f!(f::SplitFunction, i)
+    resize!(f.cache, i)
+    return nothing
 end
 
 function resize_J_W!(cache, integrator, i)

--- a/test/integrators/resize_tests.jl
+++ b/test/integrators/resize_tests.jl
@@ -186,3 +186,13 @@ runSim(BS3())
 
 runSim(Rosenbrock23())
 runSim(Rosenbrock23(autodiff = false))
+
+# https://github.com/SciML/OrdinaryDiffEq.jl/issues/1990
+@testset "resize! with SplitODEProblem" begin
+    f!(du, u, p, t) = du .= u
+    ode = SplitODEProblem(f!, f!, [1.0], (0.0, 1.0))
+    integrator = init(ode, Tsit5())
+    @test_nowarn step!(integrator)
+    @test_nowarn resize!(integrator, 2)
+    @test_nowarn step!(integrator)
+end


### PR DESCRIPTION
Fixes #1990 

I wasn't sure whether `resize_f!` should be implemented here or in SciMLBase.jl (where `SplitFunction` is defined). Thus, I chose the simpler way to fix it here for now - but we could change that if you prefer.

CC @DanielDoehring