### PR TITLE
Add `return nothing` in several places

### DIFF
--- a/src/dense/generic_dense.jl
+++ b/src/dense/generic_dense.jl
@@ -80,6 +80,7 @@ end
             end
         end
     end
+    return nothing
 end
 @inline function DiffEqBase.addsteps!(integrator::ODEIntegrator, args...)
     ode_addsteps!(integrator, args...)

--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -21,6 +21,7 @@ function _change_t_via_interpolation!(integrator, t,
             solution_endpoint_match_cur_integrator!(integrator)
         end
     end
+    return nothing
 end
 function DiffEqBase.change_t_via_interpolation!(integrator::ODEIntegrator,
     t,
@@ -30,6 +31,7 @@ function DiffEqBase.change_t_via_interpolation!(integrator::ODEIntegrator,
     T,
 }
     _change_t_via_interpolation!(integrator, t, modify_save_endpoint)
+    return nothing
 end
 
 function DiffEqBase.reeval_internals_due_to_modification!(integrator::ODEIntegrator)
@@ -440,6 +442,7 @@ function DiffEqBase.reinit!(integrator::ODEIntegrator, u0 = integrator.sol.prob.
     if reinit_retcode
         integrator.sol = SciMLBase.solution_new_retcode(integrator.sol, ReturnCode.Default)
     end
+    return nothing
 end
 
 function DiffEqBase.auto_dt_reset!(integrator::ODEIntegrator)

--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -28,6 +28,7 @@ function loopheader!(integrator)
     fix_dt_at_bounds!(integrator)
     modify_dt_for_tstops!(integrator)
     integrator.force_stepfail = false
+    return nothing
 end
 
 function last_step_failed(integrator::ODEIntegrator)
@@ -408,6 +409,7 @@ function apply_step!(integrator)
             end
         end
     end
+    return nothing
 end
 
 handle_discontinuities!(integrator) = pop_discontinuity!(integrator)
@@ -431,6 +433,7 @@ function calc_dt_propose!(integrator, dtnew)
     dtpropose = integrator.tdir * min(abs(integrator.opts.dtmax), abs(dtnew))
     dtpropose = integrator.tdir * max(abs(dtpropose), timedepentdtmin(integrator))
     integrator.dtpropose = dtpropose
+    return nothing
 end
 
 function fix_dt_at_bounds!(integrator)
@@ -445,6 +448,7 @@ function fix_dt_at_bounds!(integrator)
     else
         integrator.dt = min(integrator.dt, dtmin)
     end
+    return nothing
 end
 
 function handle_tstop!(integrator)
@@ -453,7 +457,7 @@ function handle_tstop!(integrator)
         tdir_tstop = first_tstop(integrator)
         if tdir_t == tdir_tstop
             while tdir_t == tdir_tstop #remove all redundant copies
-                pop_tstop!(integrator)
+                res = pop_tstop!(integrator)
                 has_tstop(integrator) ? (tdir_tstop = first_tstop(integrator)) : break
             end
             integrator.just_hit_tstop = true
@@ -468,6 +472,7 @@ function handle_tstop!(integrator)
             end
         end
     end
+    return nothing
 end
 
 function reset_fsal!(integrator)

--- a/src/perform_step/low_order_rk_perform_step.jl
+++ b/src/perform_step/low_order_rk_perform_step.jl
@@ -791,6 +791,7 @@ function initialize!(integrator, cache::Tsit5Cache)
     integrator.k[7] = cache.k7
     integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
     integrator.stats.nf += 1
+    return nothing
 end
 
 @muladd function perform_step!(integrator, cache::Tsit5Cache, repeat_step = false)


### PR DESCRIPTION
Many of the `!` functions unintentionally return values. Most of the time, it isn't a problem. I'm working on some static compilation that's picky about return values. The worst cases are those with an `if` statement preceding the trailing `end`. That often leads to a return with a Union{}.

If this approach is agreeable, I can add more returns to other `!` functions. Options for the explicit return are:

* `return nothing`
* `return`
* `nothing`

To me, all are equally descriptive. The SciML style guide doesn't cover this. The [YASGuide](https://github.com/jrevels/YASGuide) and the [Blue style guide](https://github.com/invenia/BlueStyle) both require `return nothing`.