### PR TITLE
replace typeof(x) <: with x isa

### DIFF
--- a/src/adams_utils.jl
+++ b/src/adams_utils.jl
@@ -7,7 +7,7 @@ function ϕ_and_ϕstar!(cache, du, k)
         ξ = dt = dts[1]
         ξ0 = zero(dt)
         β[1] = one(dt)
-        if typeof(cache) <: OrdinaryDiffEqMutableCache
+        if cache isa OrdinaryDiffEqMutableCache
             ϕ_n[1] .= du
             ϕstar_n[1] .= du
         else
@@ -18,7 +18,7 @@ function ϕ_and_ϕstar!(cache, du, k)
             ξ0 += dts[i]
             β[i] = β[i - 1] * ξ / ξ0
             ξ += dts[i]
-            if typeof(cache) <: OrdinaryDiffEqMutableCache
+            if cache isa OrdinaryDiffEqMutableCache
                 @.. broadcast=false ϕ_n[i]=ϕ_n[i - 1] - ϕstar_nm1[i - 1]
                 @.. broadcast=false ϕstar_n[i]=β[i] * ϕ_n[i]
             else
@@ -35,7 +35,7 @@ function ϕ_and_ϕstar!(cache::Union{VCABMConstantCache, VCABMCache}, du, k)
         ξ = dt = dts[1]
         ξ0 = zero(dt)
         β[1] = one(dt)
-        if typeof(cache) <: OrdinaryDiffEqMutableCache
+        if cache isa OrdinaryDiffEqMutableCache
             ϕ_n[1] .= du
             ϕstar_n[1] .= du
         else
@@ -46,7 +46,7 @@ function ϕ_and_ϕstar!(cache::Union{VCABMConstantCache, VCABMCache}, du, k)
             ξ0 += dts[i]
             β[i] = β[i - 1] * ξ / ξ0
             ξ += dts[i]
-            if typeof(cache) <: OrdinaryDiffEqMutableCache
+            if cache isa OrdinaryDiffEqMutableCache
                 @.. broadcast=false ϕ_n[i]=ϕ_n[i - 1] - ϕstar_nm1[i - 1]
                 @.. broadcast=false ϕstar_n[i]=β[i] * ϕ_n[i]
             else
@@ -63,7 +63,7 @@ function expand_ϕ_and_ϕstar!(cache, i)
     @unpack ξ, ξ0, β, dts, ϕstar_nm1, ϕ_n, ϕstar_n = cache
     ξ0 += dts[i]
     β[i] = β[i - 1] * ξ / ξ0
-    if typeof(cache) <: OrdinaryDiffEqMutableCache
+    if cache isa OrdinaryDiffEqMutableCache
         @.. broadcast=false ϕ_n[i]=ϕ_n[i - 1] - ϕstar_nm1[i - 1]
         @.. broadcast=false ϕstar_n[i]=β[i] * ϕ_n[i]
     else
@@ -77,13 +77,13 @@ function ϕ_np1!(cache, du_np1, k)
         @unpack ϕ_np1, ϕstar_n = cache
         for i in 1:k
             if i != 1
-                if typeof(cache) <: OrdinaryDiffEqMutableCache
+                if cache isa OrdinaryDiffEqMutableCache
                     @.. broadcast=false ϕ_np1[i]=ϕ_np1[i - 1] - ϕstar_n[i - 1]
                 else
                     ϕ_np1[i] = ϕ_np1[i - 1] - ϕstar_n[i - 1]
                 end
             else
-                if typeof(cache) <: OrdinaryDiffEqMutableCache
+                if cache isa OrdinaryDiffEqMutableCache
                     ϕ_np1[i] .= du_np1
                 else
                     ϕ_np1[i] = du_np1

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -251,7 +251,7 @@ function DiffEqBase.prepare_alg(alg::Union{
         elseif (prob isa ODEProblem || prob isa DDEProblem) &&
                (prob.f.mass_matrix === nothing ||
                 (prob.f.mass_matrix !== nothing &&
-                 !(typeof(prob.f.jac_prototype) <: AbstractSciMLOperator)))
+                 !(prob.f.jac_prototype isa AbstractSciMLOperator)))
             linsolve = LinearSolve.defaultalg(prob.f.jac_prototype, u0)
         else
             # If mm is a sparse matrix and A is a MatrixOperator, then let linear
@@ -793,7 +793,7 @@ function default_controller(alg::Union{ExtrapolationMidpointDeuflhard,
 end
 
 function _digest_beta1_beta2(alg, cache, ::Val{QT}, _beta1, _beta2) where {QT}
-    if typeof(alg) <: OrdinaryDiffEqCompositeAlgorithm
+    if alg isa OrdinaryDiffEqCompositeAlgorithm
         beta2 = _beta2 === nothing ?
                 _composite_beta2_default(alg.algs, cache.current, Val(QT)) : _beta2
         beta1 = _beta1 === nothing ?
@@ -966,10 +966,10 @@ alg_can_repeat_jac(alg::OrdinaryDiffEqNewtonAdaptiveAlgorithm) = true
 alg_can_repeat_jac(alg::IRKC) = false
 
 function unwrap_alg(alg::SciMLBase.DEAlgorithm, is_stiff)
-    iscomp = typeof(alg) <: CompositeAlgorithm
+    iscomp = alg isa CompositeAlgorithm
     if !iscomp
         return alg
-    elseif typeof(alg.choice_function) <: AutoSwitchCache
+    elseif alg.choice_function isa AutoSwitchCache
         if is_stiff === nothing
             throwautoswitch(alg)
         end
@@ -986,10 +986,10 @@ end
 
 function unwrap_alg(integrator, is_stiff)
     alg = integrator.alg
-    iscomp = typeof(alg) <: CompositeAlgorithm
+    iscomp = alg isa CompositeAlgorithm
     if !iscomp
         return alg
-    elseif typeof(alg.choice_function) <: AutoSwitchCache
+    elseif alg.choice_function isa AutoSwitchCache
         if is_stiff === nothing
             throwautoswitch(alg)
         end

--- a/src/caches/extrapolation_caches.jl
+++ b/src/caches/extrapolation_caches.jl
@@ -1074,7 +1074,7 @@ function alg_cache(alg::ImplicitDeuflhardExtrapolation, u, rate_prototype,
     end
 
     #Update stage_number by the jacobian size
-    jac_dim = typeof(rate_prototype) <: Union{CompiledFloats, BigFloat} ? 1 :
+    jac_dim = rate_prototype isa Union{CompiledFloats, BigFloat} ? 1 :
               sum(size(rate_prototype))
     stage_number = stage_number .+ jac_dim
 

--- a/src/caches/kencarp_kvaerno_caches.jl
+++ b/src/caches/kencarp_kvaerno_caches.jl
@@ -43,7 +43,7 @@ function alg_cache(alg::KenCarp3, u, rate_prototype, ::Type{uEltypeNoUnits},
         uBottomEltypeNoUnits, tTypeNoUnits, γ, c, Val(true))
     fsalfirst = zero(rate_prototype)
 
-    if typeof(f) <: SplitFunction
+    if f isa SplitFunction
         k1 = zero(u)
         k2 = zero(u)
         k3 = zero(u)
@@ -228,7 +228,7 @@ function alg_cache(alg::KenCarp4, u, rate_prototype, ::Type{uEltypeNoUnits},
         uBottomEltypeNoUnits, tTypeNoUnits, γ, c, Val(true))
     fsalfirst = zero(rate_prototype)
 
-    if typeof(f) <: SplitFunction
+    if f isa SplitFunction
         k1 = zero(u)
         k2 = zero(u)
         k3 = zero(u)
@@ -368,7 +368,7 @@ function alg_cache(alg::KenCarp5, u, rate_prototype, ::Type{uEltypeNoUnits},
         uBottomEltypeNoUnits, tTypeNoUnits, γ, c, Val(true))
     fsalfirst = zero(rate_prototype)
 
-    if typeof(f) <: SplitFunction
+    if f isa SplitFunction
         k1 = zero(u)
         k2 = zero(u)
         k3 = zero(u)
@@ -455,7 +455,7 @@ function alg_cache(alg::KenCarp47, u, rate_prototype, ::Type{uEltypeNoUnits},
         uBottomEltypeNoUnits, tTypeNoUnits, γ, c, Val(true))
     fsalfirst = zero(rate_prototype)
 
-    if typeof(f) <: SplitFunction
+    if f isa SplitFunction
         k1 = zero(u)
         k2 = zero(u)
         k3 = zero(u)
@@ -542,7 +542,7 @@ function alg_cache(alg::KenCarp58, u, rate_prototype, ::Type{uEltypeNoUnits},
         uBottomEltypeNoUnits, tTypeNoUnits, γ, c, Val(true))
     fsalfirst = zero(rate_prototype)
 
-    if typeof(f) <: SplitFunction
+    if f isa SplitFunction
         k1 = zero(u)
         k2 = zero(u)
         k3 = zero(u)

--- a/src/dense/interpolants.jl
+++ b/src/dense/interpolants.jl
@@ -707,7 +707,7 @@ end
 """
 """
 @def owrenzen3unpack begin
-    if typeof(cache) <: OrdinaryDiffEqMutableCache
+    if cache isa OrdinaryDiffEqMutableCache
         @unpack r13, r12, r23, r22, r33, r32 = cache.tab
     else
         @unpack r13, r12, r23, r22, r33, r32 = cache
@@ -891,7 +891,7 @@ end
 """
 """
 @def owrenzen4unpack begin
-    if typeof(cache) <: OrdinaryDiffEqMutableCache
+    if cache isa OrdinaryDiffEqMutableCache
         @unpack r14, r13, r12, r34, r33, r32, r44, r43, r42, r54, r53, r52, r64, r63, r62 = cache.tab
     else
         @unpack r14, r13, r12, r34, r33, r32, r44, r43, r42, r54, r53, r52, r64, r63, r62 = cache
@@ -1143,7 +1143,7 @@ end
 """
 """
 @def owrenzen5unpack begin
-    if typeof(cache) <: OrdinaryDiffEqMutableCache
+    if cache isa OrdinaryDiffEqMutableCache
         @unpack r15, r14, r13, r12, r35, r34, r33, r32, r45, r44, r43, r42, r55, r54, r53, r52, r65, r64, r63, r62, r75, r74, r73, r72, r85, r84, r83, r82 = cache.tab
     else
         @unpack r15, r14, r13, r12, r35, r34, r33, r32, r45, r44, r43, r42, r55, r54, r53, r52, r65, r64, r63, r62, r75, r74, r73, r72, r85, r84, r83, r82 = cache
@@ -1514,7 +1514,7 @@ end
 Coefficients taken from RKSuite
 """
 @def bs5unpack begin
-    if typeof(cache) <: OrdinaryDiffEqMutableCache
+    if cache isa OrdinaryDiffEqMutableCache
         @unpack r016, r015, r014, r013, r012, r036, r035, r034, r033, r032, r046, r045, r044, r043, r042, r056, r055, r054, r053, r052, r066, r065, r064, r063, r062, r076, r075, r074, r073, r072, r086, r085, r084, r083, r082, r096, r095, r094, r093, r106, r105, r104, r103, r102, r116, r115, r114, r113, r112 = cache.tab
     else
         @unpack r016, r015, r014, r013, r012, r036, r035, r034, r033, r032, r046, r045, r044, r043, r042, r056, r055, r054, r053, r052, r066, r065, r064, r063, r062, r076, r075, r074, r073, r072, r086, r085, r084, r083, r082, r096, r095, r094, r093, r106, r105, r104, r103, r102, r116, r115, r114, r113, r112 = cache
@@ -2841,7 +2841,7 @@ end
 """
 """
 @def dprkn6unpack begin
-    if typeof(cache) <: OrdinaryDiffEqMutableCache
+    if cache isa OrdinaryDiffEqMutableCache
         @unpack r14, r13, r12, r11, r10, r34, r33, r32, r31, r44, r43, r42, r41, r54, r53, r52, r51, r64, r63, r62, r61, rp14, rp13, rp12, rp11, rp10, rp34, rp33, rp32, rp31, rp44, rp43, rp42, rp41, rp54, rp53, rp52, rp51, rp64, rp63, rp62, rp61 = cache.tab
     else
         @unpack r14, r13, r12, r11, r10, r34, r33, r32, r31, r44, r43, r42, r41, r54, r53, r52, r51, r64, r63, r62, r61, rp14, rp13, rp12, rp11, rp10, rp34, rp33, rp32, rp31, rp44, rp43, rp42, rp41, rp54, rp53, rp52, rp51, rp64, rp63, rp62, rp61 = cache

--- a/src/dense/rosenbrock_interpolants.jl
+++ b/src/dense/rosenbrock_interpolants.jl
@@ -2,7 +2,7 @@
 From MATLAB ODE Suite by Shampine
 """
 @def rosenbrock2332unpack begin
-    if typeof(cache) <: OrdinaryDiffEqMutableCache
+    if cache isa OrdinaryDiffEqMutableCache
         d = cache.tab.d
     else
         d = cache.d

--- a/src/dense/stiff_addsteps.jl
+++ b/src/dense/stiff_addsteps.jl
@@ -14,7 +14,7 @@ function _ode_addsteps!(k, t, uprev, u, dt, f, p,
         end
 
         mass_matrix = f.mass_matrix
-        if typeof(uprev) <: AbstractArray
+        if uprev isa AbstractArray
             J = ForwardDiff.jacobian(uf, uprev)
             W = mass_matrix - γ * J
         else
@@ -188,7 +188,7 @@ function _ode_addsteps!(k, t, uprev, u, dt, f, p, cache::Rodas4ConstantCache,
 
         # Jacobian
         uf.t = t
-        if typeof(uprev) <: AbstractArray
+        if uprev isa AbstractArray
             J = ForwardDiff.jacobian(uf, uprev)
             W = mass_matrix / dtgamma - J
         else
@@ -574,7 +574,7 @@ function _ode_addsteps!(k, t, uprev, u, dt, f, p, cache::Rosenbrock5ConstantCach
 
         # Jacobian
         uf.t = t
-        if typeof(uprev) <: AbstractArray
+        if uprev isa AbstractArray
             J = ForwardDiff.jacobian(uf, uprev)
             W = mass_matrix / dtgamma - J
         else

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -746,8 +746,8 @@ end
         W = WOperator{false}(mass_matrix, dtgamma, J, uprev; transform = W_transform)
     elseif DiffEqBase.has_jac(f)
         J = f.jac(uprev, p, t)
-        if typeof(J) <: StaticArray &&
-           typeof(integrator.alg) <:
+        if J isa StaticArray &&
+           integrator.alg isa
            Union{Rosenbrock23, Rodas4, Rodas4P, Rodas4P2, Rodas5, Rodas5P}
             W = W_transform ? J - mass_matrix * inv(dtgamma) :
                 dtgamma * J - mass_matrix
@@ -772,7 +772,7 @@ end
             W = if W_full isa Number
                 W_full
             elseif len !== nothing &&
-                   typeof(integrator.alg) <:
+                   integrator.alg isa
                    Union{Rosenbrock23, Rodas4, Rodas4P, Rodas4P2, Rodas5, Rodas5P}
                 StaticWOperator(W_full)
             else
@@ -914,7 +914,7 @@ function build_J_W(alg, u, uprev, p, t, dt, f::F, ::Type{uEltypeNoUnits},
         else
             len = StaticArrayInterface.known_length(typeof(J))
             if len !== nothing &&
-               typeof(alg) <:
+               alg isa
                Union{Rosenbrock23, Rodas4, Rodas4P, Rodas4P2, Rodas5, Rodas5P}
                 StaticWOperator(J, false)
             else

--- a/src/initdt.jl
+++ b/src/initdt.jl
@@ -15,7 +15,7 @@
         return tdir * max(smalldt, dtmin)
     end
 
-    if eltype(u0) <: Number && !(typeof(integrator.alg) <: CompositeAlgorithm)
+    if eltype(u0) <: Number && !(integrator.alg isa CompositeAlgorithm)
         cache = get_tmp_cache(integrator)
         sk = first(cache)
         if u0 isa Array && abstol isa Number && reltol isa Number
@@ -37,7 +37,7 @@
     end
 
     if get_current_isfsal(integrator.alg, integrator.cache) &&
-       typeof(integrator) <: ODEIntegrator
+       integrator isa ODEIntegrator
         # Right now DelayDiffEq has issues with fsallast not being initialized
         f₀ = integrator.fsallast
         f(f₀, u0, p, t)
@@ -103,7 +103,7 @@
     still works for matrix-free definitions of the mass matrix.
     =#
 
-    if prob.f.mass_matrix != I && (!(typeof(prob.f) <: DynamicalODEFunction) ||
+    if prob.f.mass_matrix != I && (!(prob.f isa DynamicalODEFunction) ||
         any(mm != I for mm in prob.f.mass_matrix))
         ftmp = zero(f₀)
         try
@@ -164,7 +164,7 @@
     f₁ = zero(f₀)
     f(f₁, u₁, p, t + dt₀_tdir)
 
-    if prob.f.mass_matrix != I && (!(typeof(prob.f) <: DynamicalODEFunction) ||
+    if prob.f.mass_matrix != I && (!(prob.f isa DynamicalODEFunction) ||
         any(mm != I for mm in prob.f.mass_matrix))
         integrator.alg.linsolve(ftmp, prob.f.mass_matrix, f₁, false)
         copyto!(f₁, ftmp)

--- a/src/integrators/controllers.jl
+++ b/src/integrators/controllers.jl
@@ -676,7 +676,7 @@ function choose_order!(alg::Union{FBDF, DFBDF}, integrator,
             fd_weights = calc_finite_difference_weights(ts_tmp, t + dt, k - 2,
                 Val(max_order))
             terk_tmp = @.. broadcast=false fd_weights[k - 2, 1]*u
-            if typeof(u) <: Number
+            if u isa Number
                 for i in 2:(k - 2)
                     terk_tmp += fd_weights[i, k - 2] * u_history[i - 1]
                 end
@@ -875,17 +875,17 @@ function stepsize_controller_internal!(integrator,
     # Compute and save the stepsize scaling based on the latest error estimate of the current order
     @unpack controller = integrator.opts
 
-    if typeof(alg) <:
+    if alg isa
        Union{ImplicitEulerExtrapolation, ImplicitEulerBarycentricExtrapolation,
         ImplicitHairerWannerExtrapolation}
         if iszero(integrator.EEst)
             q = inv(integrator.opts.qmax)
         else
             # Update gamma and beta1
-            if typeof(alg) <: ImplicitHairerWannerExtrapolation
+            if alg isa ImplicitHairerWannerExtrapolation
                 controller.beta1 = typeof(controller.beta1)(1 //
                                                             (2integrator.cache.n_curr + 1))
-            elseif typeof(alg) <: ImplicitEulerExtrapolation
+            elseif alg isa ImplicitEulerExtrapolation
                 controller.beta1 = typeof(controller.beta1)(1 // (integrator.cache.n_curr))
             else
                 controller.beta1 = typeof(controller.beta1)(1 //

--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -42,8 +42,8 @@ function DiffEqBase.reeval_internals_due_to_modification!(integrator::ODEIntegra
     if integrator.opts.calck
         resize!(integrator.k, integrator.kshortsize) # Reset k for next step!
         alg = unwrap_alg(integrator, false)
-        if typeof(alg) <: BS5 || typeof(alg) <: Vern6 || typeof(alg) <: Vern7 ||
-           typeof(alg) <: Vern8 || typeof(alg) <: Vern9
+        if alg isa BS5 || alg isa Vern6 || alg isa Vern7 ||
+           alg isa Vern8 || alg isa Vern9
             ode_addsteps!(integrator, integrator.f, true, false, !alg.lazy)
         else
             ode_addsteps!(integrator, integrator.f, true, false)
@@ -87,11 +87,11 @@ end
     integrator.cache isa FunctionMapCache ||
         integrator.cache isa FunctionMapConstantCache &&
             error("Derivatives are not defined for this stepper.")
-    if typeof(integrator.cache) <: FunctionMapCache
+    if integrator.cache isa FunctionMapCache
         out .= integrator.cache.tmp
     else
         return if isdefined(integrator, :fsallast) &&
-                  !(typeof(integrator.alg) <:
+                  !(integrator.alg isa
                     Union{Rosenbrock23, Rosenbrock32, Rodas4, Rodas4P, Rodas4P2, Rodas5,
             Rodas5P})
             # Special stiff interpolations do not store the right value in fsallast
@@ -408,7 +408,7 @@ function DiffEqBase.reinit!(integrator::ODEIntegrator, u0 = integrator.sol.prob.
         if integrator.sol.u_analytic !== nothing
             resize!(integrator.sol.u_analytic, 0)
         end
-        if typeof(integrator.alg) <: OrdinaryDiffEqCompositeAlgorithm
+        if integrator.alg isa OrdinaryDiffEqCompositeAlgorithm
             resize!(integrator.sol.alg_choice, resize_start)
         end
         integrator.saveiter = resize_start

--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -74,7 +74,7 @@ function _savevalues!(integrator, force_save, reduce_size)::Tuple{Bool, Bool}
             copyat_or_push!(integrator.sol.t, integrator.saveiter, curt)
             save_val = val
             copyat_or_push!(integrator.sol.u, integrator.saveiter, save_val, false)
-            if typeof(integrator.alg) <: OrdinaryDiffEqCompositeAlgorithm
+            if integrator.alg isa OrdinaryDiffEqCompositeAlgorithm
                 copyat_or_push!(integrator.sol.alg_choice, integrator.saveiter,
                     integrator.cache.current)
             end
@@ -87,7 +87,7 @@ function _savevalues!(integrator, force_save, reduce_size)::Tuple{Bool, Bool}
                 copyat_or_push!(integrator.sol.u, integrator.saveiter,
                     integrator.u[integrator.opts.save_idxs], false)
             end
-            if typeof(integrator.alg) <: FunctionMap || integrator.opts.dense
+            if integrator.alg isa FunctionMap || integrator.opts.dense
                 integrator.saveiter_dense += 1
                 if integrator.opts.dense
                     if integrator.opts.save_idxs === nothing
@@ -100,7 +100,7 @@ function _savevalues!(integrator, force_save, reduce_size)::Tuple{Bool, Bool}
                     end
                 end
             end
-            if typeof(integrator.alg) <: OrdinaryDiffEqCompositeAlgorithm
+            if integrator.alg isa OrdinaryDiffEqCompositeAlgorithm
                 copyat_or_push!(integrator.sol.alg_choice, integrator.saveiter,
                     integrator.cache.current)
             end
@@ -117,7 +117,7 @@ function _savevalues!(integrator, force_save, reduce_size)::Tuple{Bool, Bool}
                 integrator.u[integrator.opts.save_idxs], false)
         end
         copyat_or_push!(integrator.sol.t, integrator.saveiter, integrator.t)
-        if typeof(integrator.alg) <: FunctionMap || integrator.opts.dense
+        if integrator.alg isa FunctionMap || integrator.opts.dense
             integrator.saveiter_dense += 1
             if integrator.opts.dense
                 if integrator.opts.save_idxs === nothing
@@ -130,7 +130,7 @@ function _savevalues!(integrator, force_save, reduce_size)::Tuple{Bool, Bool}
                 end
             end
         end
-        if typeof(integrator.alg) <: OrdinaryDiffEqCompositeAlgorithm
+        if integrator.alg isa OrdinaryDiffEqCompositeAlgorithm
             copyat_or_push!(integrator.sol.alg_choice, integrator.saveiter,
                 integrator.cache.current)
         end
@@ -175,7 +175,7 @@ function solution_endpoint_match_cur_integrator!(integrator)
             copyat_or_push!(integrator.sol.u, integrator.saveiter,
                 integrator.u[integrator.opts.save_idxs], false)
         end
-        if typeof(integrator.alg) <: FunctionMap || integrator.opts.dense
+        if integrator.alg isa FunctionMap || integrator.opts.dense
             integrator.saveiter_dense += 1
             if integrator.opts.dense
                 if integrator.opts.save_idxs === nothing
@@ -188,7 +188,7 @@ function solution_endpoint_match_cur_integrator!(integrator)
                 end
             end
         end
-        if typeof(integrator.alg) <: OrdinaryDiffEqCompositeAlgorithm
+        if integrator.alg isa OrdinaryDiffEqCompositeAlgorithm
             copyat_or_push!(integrator.sol.alg_choice, integrator.saveiter,
                 integrator.cache.current)
         end
@@ -319,7 +319,7 @@ function handle_callbacks!(integrator)
     continuous_modified = false
     discrete_modified = false
     saved_in_cb = false
-    if !(typeof(continuous_callbacks) <: Tuple{})
+    if !(continuous_callbacks isa Tuple{})
         time, upcrossing, event_occurred, event_idx, idx, counter = DiffEqBase.find_first_continuous_callback(integrator,
                                                                                                               continuous_callbacks...)
         if event_occurred
@@ -335,7 +335,7 @@ function handle_callbacks!(integrator)
             integrator.vector_event_last_time = 1
         end
     end
-    if !integrator.force_stepfail && !(typeof(discrete_callbacks) <: Tuple{})
+    if !integrator.force_stepfail && !(discrete_callbacks isa Tuple{})
         discrete_modified, saved_in_cb = DiffEqBase.apply_discrete_callback!(integrator,
                                                                              discrete_callbacks...)
     end
@@ -397,8 +397,8 @@ function apply_step!(integrator)
     elseif all_fsal(integrator.alg, integrator.cache) ||
            get_current_isfsal(integrator.alg, integrator.cache)
         if integrator.reeval_fsal || integrator.u_modified ||
-           (typeof(integrator.alg) <: DP8 && !integrator.opts.calck) ||
-           (typeof(integrator.alg) <: Union{Rosenbrock23, Rosenbrock32} &&
+           (integrator.alg isa DP8 && !integrator.opts.calck) ||
+           (integrator.alg isa Union{Rosenbrock23, Rosenbrock32} &&
             !integrator.opts.adaptive)
             reset_fsal!(integrator)
         else # Do not reeval_fsal, instead copyto! over
@@ -415,7 +415,7 @@ end
 handle_discontinuities!(integrator) = pop_discontinuity!(integrator)
 
 function calc_dt_propose!(integrator, dtnew)
-    if (typeof(integrator.alg) <: Union{ROCK2, ROCK4, SERK2, ESERK4, ESERK5}) &&
+    if (integrator.alg isa Union{ROCK2, ROCK4, SERK2, ESERK4, ESERK5}) &&
        integrator.opts.adaptive && (integrator.iter >= 1)
         (integrator.alg isa ROCK2) && (dtnew = min(dtnew,
             typeof(dtnew)((((min(integrator.alg.max_stages, 200)^2.0) * 0.811 -
@@ -482,9 +482,9 @@ function reset_fsal!(integrator)
     if integrator.sol.prob isa DAEProblem
         DiffEqBase.initialize_dae!(integrator)
     else
-        if typeof(integrator.cache) <: OrdinaryDiffEqMutableCache ||
-           (typeof(integrator.cache) <: CompositeCache &&
-            typeof(integrator.cache.caches[1]) <: OrdinaryDiffEqMutableCache)
+        if integrator.cache isa OrdinaryDiffEqMutableCache ||
+           (integrator.cache isa CompositeCache &&
+            integrator.cache.caches[1] isa OrdinaryDiffEqMutableCache)
             integrator.f(integrator.fsalfirst, integrator.u, integrator.p, integrator.t)
         else
             integrator.fsalfirst = integrator.f(integrator.u, integrator.p, integrator.t)

--- a/src/perform_step/fixed_timestep_perform_step.jl
+++ b/src/perform_step/fixed_timestep_perform_step.jl
@@ -7,7 +7,7 @@ function perform_step!(integrator, cache::FunctionMapConstantCache, repeat_step 
     @unpack uprev, dt, t, f, p = integrator
     alg = unwrap_alg(integrator, nothing)
     if integrator.f != DiffEqBase.DISCRETE_OUTOFPLACE_DEFAULT &&
-       !(typeof(integrator.f) <: DiffEqBase.EvalFunc &&
+       !(integrator.f isa DiffEqBase.EvalFunc &&
          integrator.f.f === DiffEqBase.DISCRETE_OUTOFPLACE_DEFAULT)
         if FunctionMap_scale_by_time(alg)
             tmp = f(uprev, p, t + dt)
@@ -30,7 +30,7 @@ function perform_step!(integrator, cache::FunctionMapCache, repeat_step = false)
     alg = unwrap_alg(integrator, nothing)
     @unpack tmp = cache
     if integrator.f != DiffEqBase.DISCRETE_INPLACE_DEFAULT &&
-       !(typeof(integrator.f) <: DiffEqBase.EvalFunc &&
+       !(integrator.f isa DiffEqBase.EvalFunc &&
          integrator.f.f === DiffEqBase.DISCRETE_INPLACE_DEFAULT)
         if FunctionMap_scale_by_time(alg)
             f(tmp, uprev, p, t + dt)
@@ -102,7 +102,7 @@ end
     @unpack t, dt, uprev, u, f, p, fsalfirst = integrator
 
     # precalculations
-    if typeof(cache) <: HeunConstantCache
+    if cache isa HeunConstantCache
         a₁ = dt
         a₂ = dt / 2
     else # Ralston
@@ -115,14 +115,14 @@ end
     k2 = f(tmp, p, t + a₁)
     integrator.stats.nf += 1
 
-    if typeof(cache) <: HeunConstantCache
+    if cache isa HeunConstantCache
         u = @.. broadcast=false uprev+a₂ * (fsalfirst + k2)
     else
         u = @.. broadcast=false uprev+a₂*fsalfirst+a₃*k2
     end
 
     if integrator.opts.adaptive
-        if typeof(cache) <: HeunConstantCache
+        if cache isa HeunConstantCache
             tmp = @.. broadcast=false a₂*(k2 - fsalfirst)
         else
             tmp = @.. broadcast=false a₃*(k2 - fsalfirst)
@@ -158,7 +158,7 @@ end
     @unpack fsalfirst, k, tmp, atmp, stage_limiter!, step_limiter!, thread = cache
 
     # precalculations
-    if typeof(cache) <: HeunCache
+    if cache isa HeunCache
         a₁ = dt
         a₂ = dt / 2
     else # Ralston
@@ -172,7 +172,7 @@ end
     f(k, tmp, p, t + a₁)
     integrator.stats.nf += 1
 
-    if typeof(cache) <: HeunCache
+    if cache isa HeunCache
         @.. broadcast=false thread=thread u=uprev + a₂ * (fsalfirst + k)
         stage_limiter!(u, integrator, p, t + dt)
         step_limiter!(u, integrator, p, t + dt)
@@ -183,7 +183,7 @@ end
     end
 
     if integrator.opts.adaptive
-        if typeof(cache) <: HeunCache
+        if cache isa HeunCache
             @.. broadcast=false thread=thread tmp=a₂ * (k - fsalfirst)
         else
             @.. broadcast=false thread=thread tmp=a₃ * (k - fsalfirst)

--- a/src/perform_step/kencarp_kvaerno_perform_step.jl
+++ b/src/perform_step/kencarp_kvaerno_perform_step.jl
@@ -146,9 +146,9 @@ end
 
     ################################## Solve Step 4
 
-    if typeof(cache) <: Kvaerno3Cache
+    if cache isa Kvaerno3Cache
         @.. broadcast=false z₄=a31 * z₁ + a32 * z₂ + γ * z₃ # use yhat as prediction
-    elseif typeof(cache) <: KenCarp3Cache
+    elseif cache isa KenCarp3Cache
         @unpack α41, α42 = cache.tab
         @.. broadcast=false z₄=α41 * z₁ + α42 * z₂
     end
@@ -190,7 +190,7 @@ end
     @unpack γ, a31, a32, a41, a42, a43, btilde1, btilde2, btilde3, btilde4, c3, α31, α32, ea21, ea31, ea32, ea41, ea42, ea43, eb1, eb2, eb3, eb4, ebtilde1, ebtilde2, ebtilde3, ebtilde4 = cache.tab
     alg = unwrap_alg(integrator, true)
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         f = integrator.f.f1
         f2 = integrator.f.f2
     else
@@ -203,7 +203,7 @@ end
     # calculate W
     markfirststage!(nlsolver)
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         # Explicit tableau is not FSAL
         # Make this not compute on repeat
         z₁ = dt * f(uprev, p, t)
@@ -219,7 +219,7 @@ end
 
     nlsolver.tmp = uprev + γ * z₁
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         # This assumes the implicit part is cheaper than the explicit part
         k1 = dt * integrator.fsalfirst - z₁
         nlsolver.tmp += ea21 * k1
@@ -231,7 +231,7 @@ end
 
     ################################## Solve Step 3
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₃ = z₂
         u = nlsolver.tmp + γ * z₂
         k2 = dt * f2(u, p, t + 2γdt)
@@ -251,7 +251,7 @@ end
 
     ################################## Solve Step 4
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₄ = z₂
         u = nlsolver.tmp + γ * z₃
         k3 = dt * f2(u, p, t + c3 * dt)
@@ -270,7 +270,7 @@ end
     nlsolvefail(nlsolver) && return
 
     u = nlsolver.tmp + γ * z₄
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         k4 = dt * f2(u, p, t + dt)
         integrator.stats.nf2 += 1
         u = uprev + a41 * z₁ + a42 * z₂ + a43 * z₃ + γ * z₄ + eb1 * k1 + eb2 * k2 +
@@ -280,7 +280,7 @@ end
     ################################### Finalize
 
     if integrator.opts.adaptive
-        if typeof(integrator.f) <: SplitFunction
+        if integrator.f isa SplitFunction
             tmp = btilde1 * z₁ + btilde2 * z₂ + btilde3 * z₃ + btilde4 * z₄ +
                   ebtilde1 * k1 + ebtilde2 * k2 + ebtilde3 * k3 + ebtilde4 * k4
         else
@@ -297,7 +297,7 @@ end
         integrator.EEst = integrator.opts.internalnorm(atmp, t)
     end
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         integrator.k[1] = integrator.fsalfirst
         integrator.fsallast = integrator.f(u, p, t + dt)
         integrator.k[2] = integrator.fsallast
@@ -318,7 +318,7 @@ end
     @unpack ebtilde1, ebtilde2, ebtilde3, ebtilde4 = cache.tab
     alg = unwrap_alg(integrator, true)
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         f = integrator.f.f1
         f2 = integrator.f.f2
     else
@@ -330,7 +330,7 @@ end
 
     markfirststage!(nlsolver)
 
-    if typeof(integrator.f) <: SplitFunction && !repeat_step && !integrator.last_stepfail
+    if integrator.f isa SplitFunction && !repeat_step && !integrator.last_stepfail
         # Explicit tableau is not FSAL
         # Make this not compute on repeat
         f(z₁, integrator.uprev, p, integrator.t)
@@ -348,7 +348,7 @@ end
 
     @.. broadcast=false tmp=uprev + γ * z₁
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         # This assumes the implicit part is cheaper than the explicit part
         @.. broadcast=false k1=dt * integrator.fsalfirst - z₁
         @.. broadcast=false tmp+=ea21 * k1
@@ -361,7 +361,7 @@ end
 
     ################################## Solve Step 3
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₃ .= z₂
         @.. broadcast=false u=tmp + γ * z₂
         f2(k2, u, p, t + 2γdt)
@@ -381,7 +381,7 @@ end
 
     ################################## Solve Step 4
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₄ .= z₂
         @.. broadcast=false u=tmp + γ * z₃
         f2(k3, u, p, t + c3 * dt)
@@ -401,7 +401,7 @@ end
     nlsolvefail(nlsolver) && return
 
     @.. broadcast=false u=tmp + γ * z₄
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         f2(k4, u, p, t + dt)
         k4 .*= dt
         integrator.stats.nf2 += 1
@@ -412,7 +412,7 @@ end
     ################################### Finalize
 
     if integrator.opts.adaptive
-        if typeof(integrator.f) <: SplitFunction
+        if integrator.f isa SplitFunction
             @.. broadcast=false tmp=btilde1 * z₁ + btilde2 * z₂ + btilde3 * z₃ +
                                     btilde4 * z₄ + ebtilde1 * k1 + ebtilde2 * k2 +
                                     ebtilde3 * k3 + ebtilde4 * k4
@@ -435,7 +435,7 @@ end
         integrator.EEst = integrator.opts.internalnorm(atmp, t)
     end
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         integrator.f(integrator.fsallast, u, p, t + dt)
     else
         @.. broadcast=false integrator.fsallast=z₄ / dt
@@ -449,7 +449,7 @@ end
     @unpack γ, a31, a32, a41, a42, a43, c2, c3, ea21, ea31, ea32, ea41, ea42, ea43, eb1, eb2, eb3, eb4 = cache.tab
     alg = unwrap_alg(integrator, true)
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         f = integrator.f.f1
         f2 = integrator.f.f2
     else
@@ -462,7 +462,7 @@ end
     # calculate W
     markfirststage!(nlsolver)
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         # Explicit tableau is not FSAL
         # Make this not compute on repeat
         z₁ = dt .* f(uprev, p, t)
@@ -478,7 +478,7 @@ end
 
     nlsolver.tmp = uprev
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         # This assumes the implicit part is cheaper than the explicit part
         k1 = dt .* f2(uprev, p, t)
         nlsolver.tmp += ea21 * k1
@@ -490,7 +490,7 @@ end
 
     ################################## Solve Step 3
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₃ = z₂
         u = nlsolver.tmp + γ * z₂
         k2 = dt * f2(u, p, t + c2 * dt)
@@ -509,7 +509,7 @@ end
 
     ################################## Solve Step 4
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₄ = z₃
         u = nlsolver.tmp + γ * z₃
         k3 = dt * f2(u, p, t + c3 * dt)
@@ -527,7 +527,7 @@ end
     nlsolvefail(nlsolver) && return
 
     u = nlsolver.tmp + γ * z₄
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         k4 = dt * f2(u, p, t + dt)
         integrator.stats.nf2 += 1
         u = uprev + a41 * z₁ + a42 * z₂ + a43 * z₃ + γ * z₄ + eb1 * k1 + eb2 * k2 +
@@ -536,7 +536,7 @@ end
 
     ################################### Finalize
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         integrator.k[1] = integrator.fsalfirst
         integrator.fsallast = integrator.f(u, p, t + dt)
         integrator.k[2] = integrator.fsallast
@@ -557,7 +557,7 @@ end
 
     alg = unwrap_alg(integrator, true)
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         f = integrator.f.f1
         f2 = integrator.f.f2
     else
@@ -569,7 +569,7 @@ end
 
     markfirststage!(nlsolver)
 
-    if typeof(integrator.f) <: SplitFunction && !repeat_step && !integrator.last_stepfail
+    if integrator.f isa SplitFunction && !repeat_step && !integrator.last_stepfail
         f(z₁, integrator.uprev, p, integrator.t)
         z₁ .*= dt
     else
@@ -585,7 +585,7 @@ end
 
     @.. broadcast=false tmp=uprev
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         # This assumes the implicit part is cheaper than the explicit part
         @.. broadcast=false k1=dt * integrator.fsalfirst - z₁
         @.. broadcast=false tmp+=ea21 * k1
@@ -598,7 +598,7 @@ end
 
     ################################## Solve Step 3
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₃ .= z₂
         @.. broadcast=false u=tmp + γ * z₂
         f2(k2, u, p, t + c2 * dt)
@@ -617,7 +617,7 @@ end
 
     ################################## Solve Step 4
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₄ .= z₂
         @.. broadcast=false u=tmp + γ * z₃
         f2(k3, u, p, t + c3 * dt)
@@ -636,7 +636,7 @@ end
     nlsolvefail(nlsolver) && return
 
     @.. broadcast=false u=tmp + γ * z₄
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         f2(k4, u, p, t + dt)
         k4 .*= dt
         integrator.stats.nf2 += 1
@@ -644,7 +644,7 @@ end
                               eb2 * k2 + eb3 * k3 + eb4 * k4
     end
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         integrator.f(integrator.fsallast, u, p, t + dt)
     else
         @.. broadcast=false integrator.fsallast=z₄ / dt
@@ -830,7 +830,7 @@ end
     @unpack ebtilde1, ebtilde3, ebtilde4, ebtilde5, ebtilde6 = cache.tab
     alg = unwrap_alg(integrator, true)
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         f = integrator.f.f1
         f2 = integrator.f.f2
     else
@@ -843,7 +843,7 @@ end
     # calculate W
     markfirststage!(nlsolver)
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         # Explicit tableau is not FSAL
         # Make this not compute on repeat
         z₁ = dt .* f(uprev, p, t)
@@ -859,7 +859,7 @@ end
 
     tmp = uprev + γ * z₁
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         # This assumes the implicit part is cheaper than the explicit part
         k1 = dt * integrator.fsalfirst - z₁
         tmp += ea21 * k1
@@ -872,7 +872,7 @@ end
 
     ################################## Solve Step 3
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₃ = z₂
         u = nlsolver.tmp + γ * z₂
         k2 = dt * f2(u, p, t + 2γdt)
@@ -892,7 +892,7 @@ end
 
     ################################## Solve Step 4
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₄ = z₂
         u = nlsolver.tmp + γ * z₃
         k3 = dt * f2(u, p, t + c3 * dt)
@@ -911,7 +911,7 @@ end
 
     ################################## Solve Step 5
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₅ = z₄
         u = nlsolver.tmp + γ * z₄
         k4 = dt * f2(u, p, t + c4 * dt)
@@ -932,7 +932,7 @@ end
 
     ################################## Solve Step 6
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₆ = z₅
         u = nlsolver.tmp + γ * z₅
         k5 = dt * f2(u, p, t + c5 * dt)
@@ -951,7 +951,7 @@ end
     nlsolvefail(nlsolver) && return
 
     u = nlsolver.tmp + γ * z₆
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         k6 = dt * f2(u, p, t + dt)
         integrator.stats.nf2 += 1
         u = uprev + a61 * z₁ + a63 * z₃ + a64 * z₄ + a65 * z₅ + γ * z₆ + eb1 * k1 +
@@ -961,7 +961,7 @@ end
     ################################### Finalize
 
     if integrator.opts.adaptive
-        if typeof(integrator.f) <: SplitFunction
+        if integrator.f isa SplitFunction
             tmp = btilde1 * z₁ + btilde3 * z₃ + btilde4 * z₄ + btilde5 * z₅ + btilde6 * z₆ +
                   ebtilde1 * k1 + ebtilde3 * k3 + ebtilde4 * k4 + ebtilde5 * k5 +
                   ebtilde6 * k6
@@ -979,7 +979,7 @@ end
         integrator.EEst = integrator.opts.internalnorm(atmp, t)
     end
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         integrator.k[1] = integrator.fsalfirst
         integrator.fsallast = integrator.f(u, p, t + dt)
         integrator.k[2] = integrator.fsallast
@@ -1004,7 +1004,7 @@ end
     @unpack ebtilde1, ebtilde3, ebtilde4, ebtilde5, ebtilde6 = cache.tab
     alg = unwrap_alg(integrator, true)
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         f = integrator.f.f1
         f2 = integrator.f.f2
     else
@@ -1018,7 +1018,7 @@ end
 
     ##### Step 1
 
-    if typeof(integrator.f) <: SplitFunction && !repeat_step && !integrator.last_stepfail
+    if integrator.f isa SplitFunction && !repeat_step && !integrator.last_stepfail
         # Explicit tableau is not FSAL
         # Make this not compute on repeat
         f(z₁, integrator.uprev, p, integrator.t)
@@ -1036,7 +1036,7 @@ end
 
     @.. broadcast=false tmp=uprev + γ * z₁
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         # This assumes the implicit part is cheaper than the explicit part
         @.. broadcast=false k1=dt * integrator.fsalfirst - z₁
         @.. broadcast=false tmp+=ea21 * k1
@@ -1050,7 +1050,7 @@ end
 
     ################################## Solve Step 3
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₃ .= z₂
         @.. broadcast=false u=tmp + γ * z₂
         f2(k2, u, p, t + 2γdt)
@@ -1070,7 +1070,7 @@ end
 
     ################################## Solve Step 4
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₄ .= z₂
         @.. broadcast=false u=tmp + γ * z₃
         f2(k3, u, p, t + c3 * dt)
@@ -1090,7 +1090,7 @@ end
 
     ################################## Solve Step 5
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₅ .= z₄
         @.. broadcast=false u=tmp + γ * z₄
         f2(k4, u, p, t + c4 * dt)
@@ -1110,7 +1110,7 @@ end
 
     ################################## Solve Step 6
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₆ .= z₅
         @.. broadcast=false u=tmp + γ * z₅
         f2(k5, u, p, t + c5 * dt)
@@ -1129,7 +1129,7 @@ end
     nlsolvefail(nlsolver) && return
 
     @.. broadcast=false u=tmp + γ * z₆
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         f2(k6, u, p, t + dt)
         k6 .*= dt
         integrator.stats.nf2 += 1
@@ -1140,7 +1140,7 @@ end
     ################################### Finalize
 
     if integrator.opts.adaptive
-        if typeof(integrator.f) <: SplitFunction
+        if integrator.f isa SplitFunction
             @.. broadcast=false tmp=btilde1 * z₁ + btilde3 * z₃ + btilde4 * z₄ +
                                     btilde5 * z₅ + btilde6 * z₆ + ebtilde1 * k1 +
                                     ebtilde3 * k3 + ebtilde4 * k4 + ebtilde5 * k5 +
@@ -1165,7 +1165,7 @@ end
         integrator.EEst = integrator.opts.internalnorm(atmp, t)
     end
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         integrator.f(integrator.fsallast, u, p, t + dt)
     else
         @.. broadcast=false integrator.fsallast=z₆ / dt
@@ -1391,7 +1391,7 @@ end
     @unpack ebtilde1, ebtilde4, ebtilde5, ebtilde6, ebtilde7, ebtilde8 = cache.tab
     alg = unwrap_alg(integrator, true)
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         f = integrator.f.f1
         f2 = integrator.f.f2
     else
@@ -1406,7 +1406,7 @@ end
 
     ##### Step 1
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         # Explicit tableau is not FSAL
         # Make this not compute on repeat
         z₁ = dt .* f(uprev, p, t)
@@ -1422,7 +1422,7 @@ end
 
     tmp = uprev + γ * z₁
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         # This assumes the implicit part is cheaper than the explicit part
         k1 = dt * integrator.fsalfirst - z₁
         tmp += ea21 * k1
@@ -1435,7 +1435,7 @@ end
 
     ################################## Solve Step 3
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₃ = z₂
         u = nlsolver.tmp + γ * z₂
         k2 = dt * f2(u, p, t + 2γdt)
@@ -1455,7 +1455,7 @@ end
 
     ################################## Solve Step 4
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₄ = z₂
         u = nlsolver.tmp + γ * z₃
         k3 = dt * f2(u, p, t + c3 * dt)
@@ -1474,7 +1474,7 @@ end
 
     ################################## Solve Step 5
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₅ = z₂
         u = nlsolver.tmp + γ * z₄
         k4 = dt * f2(u, p, t + c4 * dt)
@@ -1493,7 +1493,7 @@ end
 
     ################################## Solve Step 6
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₆ = z₃
         u = nlsolver.tmp + γ * z₅
         k5 = dt * f2(u, p, t + c5 * dt)
@@ -1513,7 +1513,7 @@ end
 
     ################################## Solve Step 7
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₇ = z₂
         u = nlsolver.tmp + γ * z₆
         k6 = dt * f2(u, p, t + c6 * dt)
@@ -1533,7 +1533,7 @@ end
 
     ################################## Solve Step 8
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₈ = z₅
         u = nlsolver.tmp + γ * z₇
         k7 = dt * f2(u, p, t + c7 * dt)
@@ -1552,7 +1552,7 @@ end
     nlsolvefail(nlsolver) && return
 
     u = nlsolver.tmp + γ * z₈
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         k8 = dt * f2(u, p, t + dt)
         integrator.stats.nf2 += 1
         u = uprev + a81 * z₁ + a84 * z₄ + a85 * z₅ + a86 * z₆ + a87 * z₇ + γ * z₈ +
@@ -1562,7 +1562,7 @@ end
     ################################### Finalize
 
     if integrator.opts.adaptive
-        if typeof(integrator.f) <: SplitFunction
+        if integrator.f isa SplitFunction
             tmp = btilde1 * z₁ + btilde4 * z₄ + btilde5 * z₅ + btilde6 * z₆ + btilde7 * z₇ +
                   btilde8 * z₈ + ebtilde1 * k1 + ebtilde4 * k4 + ebtilde5 * k5 +
                   ebtilde6 * k6 + ebtilde7 * k7 + ebtilde8 * k8
@@ -1581,7 +1581,7 @@ end
         integrator.EEst = integrator.opts.internalnorm(atmp, t)
     end
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         integrator.k[1] = integrator.fsalfirst
         integrator.fsallast = integrator.f(u, p, t + dt)
         integrator.k[2] = integrator.fsallast
@@ -1607,7 +1607,7 @@ end
     @unpack ebtilde1, ebtilde4, ebtilde5, ebtilde6, ebtilde7, ebtilde8 = cache.tab
     alg = unwrap_alg(integrator, true)
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         f = integrator.f.f1
         f2 = integrator.f.f2
     else
@@ -1621,7 +1621,7 @@ end
 
     ##### Step 1
 
-    if typeof(integrator.f) <: SplitFunction && !repeat_step && !integrator.last_stepfail
+    if integrator.f isa SplitFunction && !repeat_step && !integrator.last_stepfail
         # Explicit tableau is not FSAL
         # Make this not compute on repeat
         f(z₁, integrator.uprev, p, integrator.t)
@@ -1639,7 +1639,7 @@ end
 
     @.. broadcast=false tmp=uprev + γ * z₁
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         # This assumes the implicit part is cheaper than the explicit part
         @.. broadcast=false k1=dt * integrator.fsalfirst - z₁
         @.. broadcast=false tmp+=ea21 * k1
@@ -1652,7 +1652,7 @@ end
 
     ################################## Solve Step 3
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₃ .= z₂
         @.. broadcast=false u=tmp + γ * z₂
         f2(k2, u, p, t + 2γdt)
@@ -1672,7 +1672,7 @@ end
 
     ################################## Solve Step 4
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₄ .= z₃
         @.. broadcast=false u=tmp + γ * z₃
         f2(k3, u, p, t + c3 * dt)
@@ -1691,7 +1691,7 @@ end
 
     ################################## Solve Step 5
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₅ .= z₂
         @.. broadcast=false u=tmp + γ * z₄
         f2(k4, u, p, t + c4 * dt)
@@ -1711,7 +1711,7 @@ end
 
     ################################## Solve Step 6
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₆ .= z₃
         @.. broadcast=false u=tmp + γ * z₅
         f2(k5, u, p, t + c5 * dt)
@@ -1731,7 +1731,7 @@ end
 
     ################################## Solve Step 7
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₇ .= z₂
         @.. broadcast=false u=tmp + γ * z₆
         f2(k6, u, p, t + c6 * dt)
@@ -1752,7 +1752,7 @@ end
 
     ################################## Solve Step 8
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₈ .= z₅
         @.. broadcast=false u=tmp + γ * z₇
         f2(k7, u, p, t + c7 * dt)
@@ -1772,7 +1772,7 @@ end
     nlsolvefail(nlsolver) && return
 
     @.. broadcast=false u=tmp + γ * z₈
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         f2(k8, u, p, t + dt)
         k8 .*= dt
         integrator.stats.nf += 1
@@ -1784,7 +1784,7 @@ end
     ################################### Finalize
 
     if integrator.opts.adaptive
-        if typeof(integrator.f) <: SplitFunction
+        if integrator.f isa SplitFunction
             @.. broadcast=false tmp=btilde1 * z₁ + btilde4 * z₄ + btilde5 * z₅ +
                                     btilde6 * z₆ + btilde7 * z₇ + btilde8 * z₈ +
                                     ebtilde1 * k1 + ebtilde4 * k4 + ebtilde5 * k5 +
@@ -1809,7 +1809,7 @@ end
         integrator.EEst = integrator.opts.internalnorm(atmp, t)
     end
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         integrator.f(integrator.fsallast, u, p, t + dt)
     else
         @.. broadcast=false integrator.fsallast=z₈ / dt
@@ -1828,7 +1828,7 @@ end
     @unpack ebtilde3, ebtilde4, ebtilde5, ebtilde6, ebtilde7 = cache.tab
     alg = unwrap_alg(integrator, true)
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         f = integrator.f.f1
         f2 = integrator.f.f2
     else
@@ -1843,7 +1843,7 @@ end
 
     ##### Step 1
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         # Explicit tableau is not FSAL
         # Make this not compute on repeat
         z₁ = dt .* f(uprev, p, t)
@@ -1859,7 +1859,7 @@ end
 
     tmp = uprev + γ * z₁
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         # This assumes the implicit part is cheaper than the explicit part
         k1 = dt * integrator.fsalfirst - z₁
         tmp += ea21 * k1
@@ -1872,7 +1872,7 @@ end
 
     ################################## Solve Step 3
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₃ = z₂
         u = nlsolver.tmp + γ * z₂
         k2 = dt * f2(u, p, t + 2γdt)
@@ -1892,7 +1892,7 @@ end
 
     ################################## Solve Step 4
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₄ = z₃
         u = nlsolver.tmp + γ * z₃
         k3 = dt * f2(u, p, t + c3 * dt)
@@ -1911,7 +1911,7 @@ end
 
     ################################## Solve Step 5
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₅ = z₁
         u = nlsolver.tmp + γ * z₄
         k4 = dt * f2(u, p, t + c4 * dt)
@@ -1931,7 +1931,7 @@ end
 
     ################################## Solve Step 6
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₆ = z₃
         u = nlsolver.tmp + γ * z₅
         k5 = dt * f2(u, p, t + c5 * dt)
@@ -1951,7 +1951,7 @@ end
 
     ################################## Solve Step 7
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₇ = z₆
         u = nlsolver.tmp + γ * z₆
         k6 = dt * f2(u, p, t + c6 * dt)
@@ -1970,7 +1970,7 @@ end
     nlsolvefail(nlsolver) && return
 
     u = nlsolver.tmp + γ * z₇
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         k7 = dt * f2(u, p, t + dt)
         u = uprev + a73 * z₃ + a74 * z₄ + a75 * z₅ + a76 * z₆ + γ * z₇ + eb3 * k3 +
             eb4 * k4 + eb5 * k5 + eb6 * k6 + eb7 * k7
@@ -1979,7 +1979,7 @@ end
     ################################### Finalize
 
     if integrator.opts.adaptive
-        if typeof(integrator.f) <: SplitFunction
+        if integrator.f isa SplitFunction
             tmp = btilde3 * z₃ + btilde4 * z₄ + btilde5 * z₅ + btilde6 * z₆ + btilde7 * z₇ +
                   ebtilde3 * k3 + ebtilde4 * k4 + ebtilde5 * k5 + ebtilde6 * k6 +
                   ebtilde7 * k7
@@ -1997,7 +1997,7 @@ end
         integrator.EEst = integrator.opts.internalnorm(atmp, t)
     end
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         integrator.k[1] = integrator.fsalfirst
         integrator.fsallast = integrator.f(u, p, t + dt)
         integrator.k[2] = integrator.fsallast
@@ -2022,7 +2022,7 @@ end
     @unpack ebtilde3, ebtilde4, ebtilde5, ebtilde6, ebtilde7 = cache.tab
     alg = unwrap_alg(integrator, true)
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         f = integrator.f.f1
         f2 = integrator.f.f2
     else
@@ -2036,7 +2036,7 @@ end
 
     ##### Step 1
 
-    if typeof(integrator.f) <: SplitFunction && !repeat_step && !integrator.last_stepfail
+    if integrator.f isa SplitFunction && !repeat_step && !integrator.last_stepfail
         # Explicit tableau is not FSAL
         # Make this not compute on repeat
         f(z₁, integrator.uprev, p, integrator.t)
@@ -2054,7 +2054,7 @@ end
 
     @.. broadcast=false tmp=uprev + γ * z₁
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         # This assumes the implicit part is cheaper than the explicit part
         @.. broadcast=false k1=dt * integrator.fsalfirst - z₁
         @.. broadcast=false tmp+=ea21 * k1
@@ -2067,7 +2067,7 @@ end
 
     ################################## Solve Step 3
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₃ .= z₂
         @.. broadcast=false u=tmp + γ * z₂
         f2(k2, u, p, t + 2γdt)
@@ -2087,7 +2087,7 @@ end
 
     ################################## Solve Step 4
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₄ .= z₃
         @.. broadcast=false u=tmp + γ * z₃
         f2(k3, u, p, t + c3 * dt)
@@ -2107,7 +2107,7 @@ end
 
     ################################## Solve Step 5
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₅ .= z₁
         @.. broadcast=false u=tmp + γ * z₄
         f2(k4, u, p, t + c4 * dt)
@@ -2127,7 +2127,7 @@ end
 
     ################################## Solve Step 6
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₆ .= z₃
         @.. broadcast=false u=tmp + γ * z₅
         f2(k5, u, p, t + c5 * dt)
@@ -2148,7 +2148,7 @@ end
 
     ################################## Solve Step 7
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₇ .= z₆
         @.. broadcast=false u=tmp + γ * z₆
         f2(k6, u, p, t + c6 * dt)
@@ -2169,7 +2169,7 @@ end
     nlsolvefail(nlsolver) && return
 
     @.. broadcast=false u=tmp + γ * z₇
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         f2(k7, u, p, t + dt)
         k7 .*= dt
         integrator.stats.nf += 1
@@ -2180,7 +2180,7 @@ end
     ################################### Finalize
 
     if integrator.opts.adaptive
-        if typeof(integrator.f) <: SplitFunction
+        if integrator.f isa SplitFunction
             @.. broadcast=false tmp=btilde3 * z₃ + btilde4 * z₄ + btilde5 * z₅ +
                                     btilde6 * z₆ + btilde7 * z₇ + ebtilde3 * k3 +
                                     ebtilde4 * k4 + ebtilde5 * k5 + ebtilde6 * k6 +
@@ -2205,7 +2205,7 @@ end
         integrator.EEst = integrator.opts.internalnorm(atmp, t)
     end
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         integrator.f(integrator.fsallast, u, p, t + dt)
     else
         @.. broadcast=false integrator.fsallast=z₇ / dt
@@ -2225,7 +2225,7 @@ end
     @unpack ebtilde3, ebtilde4, ebtilde5, ebtilde6, ebtilde7, ebtilde8 = cache.tab
     alg = unwrap_alg(integrator, true)
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         f = integrator.f.f1
         f2 = integrator.f.f2
     else
@@ -2240,7 +2240,7 @@ end
 
     ##### Step 1
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         # Explicit tableau is not FSAL
         # Make this not compute on repeat
         z₁ = dt .* f(uprev, p, t)
@@ -2257,7 +2257,7 @@ end
 
     tmp = uprev + γ * z₁
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         # This assumes the implicit part is cheaper than the explicit part
         k1 = dt * integrator.fsalfirst - z₁
         tmp += ea21 * k1
@@ -2270,7 +2270,7 @@ end
 
     ################################## Solve Step 3
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₃ = z₂
         u = nlsolver.tmp + γ * z₂
         k2 = dt * f2(u, p, t + 2γdt)
@@ -2290,7 +2290,7 @@ end
 
     ################################## Solve Step 4
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₄ = z₁
         u = nlsolver.tmp + γ * z₃
         k3 = dt * f2(u, p, t + c3 * dt)
@@ -2309,7 +2309,7 @@ end
 
     ################################## Solve Step 5
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₅ = z₂
         u = nlsolver.tmp + γ * z₄
         k4 = dt * f2(u, p, t + c4 * dt)
@@ -2329,7 +2329,7 @@ end
 
     ################################## Solve Step 6
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₆ = z₃
         u = nlsolver.tmp + γ * z₅
         k5 = dt * f2(u, p, t + c5 * dt)
@@ -2349,7 +2349,7 @@ end
 
     ################################## Solve Step 7
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₇ = z₃
         u = nlsolver.tmp + γ * z₆
         k6 = dt * f2(u, p, t + c6 * dt)
@@ -2369,7 +2369,7 @@ end
 
     ################################## Solve Step 8
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₈ = z₇
         u = nlsolver.tmp + γ * z₇
         k7 = dt * f2(u, p, t + c7 * dt)
@@ -2388,7 +2388,7 @@ end
     nlsolvefail(nlsolver) && return
 
     u = nlsolver.tmp + γ * z₈
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         k8 = dt * f2(u, p, t + dt)
         integrator.stats.nf2 += 1
         u = uprev + a83 * z₃ + a84 * z₄ + a85 * z₅ + a86 * z₆ + a87 * z₇ + γ * z₈ +
@@ -2398,7 +2398,7 @@ end
     ################################### Finalize
 
     if integrator.opts.adaptive
-        if typeof(integrator.f) <: SplitFunction
+        if integrator.f isa SplitFunction
             tmp = btilde3 * z₃ + btilde4 * z₄ + btilde5 * z₅ + btilde6 * z₆ + btilde7 * z₇ +
                   btilde8 * z₈ + ebtilde3 * k3 + ebtilde4 * k4 + ebtilde5 * k5 +
                   ebtilde6 * k6 + ebtilde7 * k7 + ebtilde8 * k8
@@ -2417,7 +2417,7 @@ end
         integrator.EEst = integrator.opts.internalnorm(atmp, t)
     end
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         integrator.k[1] = integrator.fsalfirst
         integrator.fsallast = integrator.f(u, p, t + dt)
         integrator.k[2] = integrator.fsallast
@@ -2443,7 +2443,7 @@ end
     @unpack ebtilde3, ebtilde4, ebtilde5, ebtilde6, ebtilde7, ebtilde8 = cache.tab
     alg = unwrap_alg(integrator, true)
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         f = integrator.f.f1
         f2 = integrator.f.f2
     else
@@ -2457,7 +2457,7 @@ end
 
     ##### Step 1
 
-    if typeof(integrator.f) <: SplitFunction && !repeat_step && !integrator.last_stepfail
+    if integrator.f isa SplitFunction && !repeat_step && !integrator.last_stepfail
         # Explicit tableau is not FSAL
         # Make this not compute on repeat
         f(z₁, integrator.uprev, p, integrator.t)
@@ -2475,7 +2475,7 @@ end
 
     @.. broadcast=false tmp=uprev + γ * z₁
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         # This assumes the implicit part is cheaper than the explicit part
         @.. broadcast=false k1=dt * integrator.fsalfirst - z₁
         @.. broadcast=false tmp+=ea21 * k1
@@ -2488,7 +2488,7 @@ end
 
     ################################## Solve Step 3
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₃ .= z₂
         @.. broadcast=false u=tmp + γ * z₂
         f2(k2, u, p, t + 2γdt)
@@ -2508,7 +2508,7 @@ end
 
     ################################## Solve Step 4
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₄ .= z₁
         @.. broadcast=false u=tmp + γ * z₃
         f2(k3, u, p, t + c3 * dt)
@@ -2528,7 +2528,7 @@ end
 
     ################################## Solve Step 5
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₅ .= z₂
         @.. broadcast=false u=tmp + γ * z₄
         f2(k4, u, p, t + c4 * dt)
@@ -2548,7 +2548,7 @@ end
 
     ################################## Solve Step 6
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₆ .= z₃
         @.. broadcast=false u=tmp + γ * z₅
         f2(k5, u, p, t + c5 * dt)
@@ -2569,7 +2569,7 @@ end
 
     ################################## Solve Step 7
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₇ .= z₃
         @.. broadcast=false u=tmp + γ * z₆
         f2(k6, u, p, t + c6 * dt)
@@ -2591,7 +2591,7 @@ end
 
     ################################## Solve Step 8
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         z₈ .= z₇
         @.. broadcast=false u=tmp + γ * z₇
         f2(k7, u, p, t + c7 * dt)
@@ -2612,7 +2612,7 @@ end
     nlsolvefail(nlsolver) && return
 
     @.. broadcast=false u=tmp + γ * z₈
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         f2(k8, u, p, t + dt)
         k8 .*= dt
         integrator.stats.nf += 1
@@ -2624,7 +2624,7 @@ end
     ################################### Finalize
 
     if integrator.opts.adaptive
-        if typeof(integrator.f) <: SplitFunction
+        if integrator.f isa SplitFunction
             @.. broadcast=false tmp=btilde3 * z₃ + btilde4 * z₄ + btilde5 * z₅ +
                                     btilde6 * z₆ + btilde7 * z₇ + btilde8 * z₈ +
                                     ebtilde3 * k3 + ebtilde4 * k4 + ebtilde5 * k5 +
@@ -2649,7 +2649,7 @@ end
         integrator.EEst = integrator.opts.internalnorm(atmp, t)
     end
 
-    if typeof(integrator.f) <: SplitFunction
+    if integrator.f isa SplitFunction
         integrator.f(integrator.fsallast, u, p, t + dt)
     else
         @.. broadcast=false integrator.fsallast=z₈ / dt

--- a/src/perform_step/low_order_rk_perform_step.jl
+++ b/src/perform_step/low_order_rk_perform_step.jl
@@ -752,7 +752,7 @@ end
     integrator.fsallast = f(u, p, t + dt)
     k7 = integrator.fsallast
     integrator.stats.nf += 6
-    if typeof(integrator.alg) <: CompositeAlgorithm
+    if integrator.alg isa CompositeAlgorithm
         g7 = u
         # Hairer II, page 22
         integrator.eigen_est = integrator.opts.internalnorm(k7 - k6, t) /
@@ -880,7 +880,7 @@ end
     integrator.fsallast = f(u, p, t + dt)
     k7 = integrator.fsallast
     integrator.stats.nf += 6
-    if typeof(integrator.alg) <: CompositeAlgorithm
+    if integrator.alg isa CompositeAlgorithm
         g7 = u
         # Hairer II, page 22
         integrator.eigen_est = integrator.opts.internalnorm(k7 - k6, t) /
@@ -1014,7 +1014,7 @@ end
   end
   f(k7, u, p, t+dt)
   integrator.stats.nf += 6
-  if typeof(integrator.alg) <: CompositeAlgorithm
+  if integrator.alg isa CompositeAlgorithm
     g6 = tmp
     g7 = u
     # Hairer II, page 22

--- a/src/perform_step/symplectic_perform_step.jl
+++ b/src/perform_step/symplectic_perform_step.jl
@@ -459,7 +459,7 @@ end
     u = u + dt * b5 * ku
 
     kdu = f.f1(du, u, p, tnew)
-    if typeof(alg) <: McAte42
+    if alg isa McAte42
         du = du + dt * a5 * kdu
         kdu = f.f1(du, u, p, tnew)
         integrator.stats.nf += 1
@@ -513,7 +513,7 @@ end
     @.. broadcast=false u=u + dt * b5 * ku
 
     f.f1(kdu, du, u, p, tnew)
-    if typeof(alg) <: McAte42
+    if alg isa McAte42
         @.. broadcast=false du=du + dt * a5 * kdu
         f.f1(kdu, du, u, p, tnew)
         integrator.stats.nf += 1

--- a/src/perform_step/verner_rk_perform_step.jl
+++ b/src/perform_step/verner_rk_perform_step.jl
@@ -38,7 +38,7 @@ end
     integrator.fsallast = f(u, p, t + dt)
     k9 = integrator.fsallast
     integrator.stats.nf += 8
-    if typeof(integrator.alg) <: CompositeAlgorithm
+    if integrator.alg isa CompositeAlgorithm
         g9 = u
         ϱu = integrator.opts.internalnorm(k9 - k8, t)
         ϱd = integrator.opts.internalnorm(g9 - g8, t)
@@ -241,7 +241,7 @@ end
     k10 = f(g10, p, t + dt)
     integrator.stats.nf += 10
     u = uprev + dt * (b1 * k1 + b4 * k4 + b5 * k5 + b6 * k6 + b7 * k7 + b8 * k8 + b9 * k9)
-    if typeof(integrator.alg) <: CompositeAlgorithm
+    if integrator.alg isa CompositeAlgorithm
         ϱu = integrator.opts.internalnorm(k10 - k9, t)
         ϱd = integrator.opts.internalnorm(g10 - g9, t)
         integrator.eigen_est = ϱu / ϱd
@@ -510,7 +510,7 @@ end
     u = uprev +
         dt * (b1 * k1 + b6 * k6 + b7 * k7 + b8 * k8 + b9 * k9 + b10 * k10 + b11 * k11 +
          b12 * k12)
-    if typeof(integrator.alg) <: CompositeAlgorithm
+    if integrator.alg isa CompositeAlgorithm
         ϱu = integrator.opts.internalnorm(k13 - k12, t)
         ϱd = integrator.opts.internalnorm(g13 - g12, t)
         integrator.eigen_est = ϱu / ϱd
@@ -852,7 +852,7 @@ end
     u = uprev +
         dt * (b1 * k1 + b8 * k8 + b9 * k9 + b10 * k10 + b11 * k11 + b12 * k12 + b13 * k13 +
          b14 * k14 + b15 * k15)
-    if typeof(integrator.alg) <: CompositeAlgorithm
+    if integrator.alg isa CompositeAlgorithm
         ϱu = integrator.opts.internalnorm(k16 - k15, t)
         ϱd = integrator.opts.internalnorm(g16 - g15, t)
         integrator.eigen_est = ϱu / ϱd

--- a/src/rkc_utils.jl
+++ b/src/rkc_utils.jl
@@ -4,12 +4,12 @@ const RKCAlgs = Union{RKC, IRKC, ESERK4, ESERK5, SERK2}
 function maxeig!(integrator, cache::OrdinaryDiffEqConstantCache)
     isfirst = integrator.iter == 1 || integrator.u_modified
     @unpack t, dt, uprev, u, f, p, fsalfirst = integrator
-    maxiter = (typeof(integrator.alg) <: Union{ESERK4, ESERK5, SERK2}) ? 100 : 50
+    maxiter = (integrator.alg isa Union{ESERK4, ESERK5, SERK2}) ? 100 : 50
 
-    safe = (typeof(integrator.alg) <: RKCAlgs) ? 1.0 : 1.2
+    safe = (integrator.alg isa RKCAlgs) ? 1.0 : 1.2
     # Initial guess for eigenvector `z`
     if isfirst
-        if typeof(integrator.alg) <: RKCAlgs
+        if integrator.alg isa RKCAlgs
             if integrator.alg isa IRKC
                 z = cache.du₂
             else
@@ -62,7 +62,7 @@ function maxeig!(integrator, cache::OrdinaryDiffEqConstantCache)
         eig_prev = integrator.eigen_est
         integrator.eigen_est = Δ / dz_u * safe
         # Convergence
-        if typeof(integrator.alg) <: RKCAlgs # To match the constants given in the paper
+        if integrator.alg isa RKCAlgs # To match the constants given in the paper
             if iter >= 2 &&
                abs(eig_prev - integrator.eigen_est) <
                max(integrator.eigen_est, 1.0 / integrator.opts.dtmax) * 0.01
@@ -108,11 +108,11 @@ function maxeig!(integrator, cache::OrdinaryDiffEqMutableCache)
         fz, z, atmp = cache.k, cache.tmp, cache.atmp
     end
     ccache = cache.constantcache
-    maxiter = (typeof(integrator.alg) <: Union{ESERK4, ESERK5, SERK2}) ? 100 : 50
-    safe = (typeof(integrator.alg) <: RKCAlgs) ? 1.0 : 1.2
+    maxiter = (integrator.alg isa Union{ESERK4, ESERK5, SERK2}) ? 100 : 50
+    safe = (integrator.alg isa RKCAlgs) ? 1.0 : 1.2
     # Initial guess for eigenvector `z`
     if isfirst
-        if typeof(integrator.alg) <: RKCAlgs
+        if integrator.alg isa RKCAlgs
             if integrator.alg isa IRKC
                 @.. broadcast=false z=cache.du₂
             else
@@ -165,7 +165,7 @@ function maxeig!(integrator, cache::OrdinaryDiffEqMutableCache)
         eig_prev = integrator.eigen_est
         integrator.eigen_est = Δ / dz_u * safe
         # Convergence
-        if typeof(integrator.alg) <: RKCAlgs # To match the constants given in the paper
+        if integrator.alg isa RKCAlgs # To match the constants given in the paper
             if iter >= 2 &&
                abs(eig_prev - integrator.eigen_est) <
                max(integrator.eigen_est, 1.0 / integrator.opts.dtmax) * 0.01

--- a/test/interface/stiffness_detection_test.jl
+++ b/test/interface/stiffness_detection_test.jl
@@ -35,7 +35,7 @@ for (i, prob) in enumerate(probArr)
     sol2 = solve(prob, alg, maxiters = 1000)
     @test sol.t == sol2.t # test reinitialization
     @test length(sol.t) < 280
-    @test typeof(alg.algs[sol.alg_choice[1]]) <: Rodas5
+    @test alg.algs[sol.alg_choice[1]] isa Rodas5
     i == 1 || @test is_switching_fb(sol) # fails due to eigenvalue estimate of J
     sol = solve(prob,
         AutoDP5(Rodas5(); maxstiffstep = 2, maxnonstiffstep = 2,

--- a/test/regression/ode_dense_tests.jl
+++ b/test/regression/ode_dense_tests.jl
@@ -124,7 +124,7 @@ interpd_idxs = sol(0:(1 // 2^(4)):1, idxs = 1:2:5)
 
 interpd_single = sol(0:(1 // 2^(4)):1, idxs = 1)
 
-@test typeof(interpd_single.u) <: Vector{Float64}
+@test interpd_single.u isa Vector{Float64}
 
 @test typeof(sol(0.5, idxs = 1)) <: Float64
 

--- a/test/regression/time_derivative_test.jl
+++ b/test/regression/time_derivative_test.jl
@@ -94,7 +94,7 @@ for (ff_time_derivative, u0) in ((ODEFunction(time_derivative,
     for alg in CACHE_TEST_ALGS
         @show alg
         sol = solve(prob, alg, dt = 1 / 10)
-        if !(typeof(alg) <: Euler)
+        if !(alg isa Euler)
             @test sol.errors[:final] < 4e-14
         end
     end


### PR DESCRIPTION
@oscardssmith was telling me there is a lot of this pattern all over SciML, and that the Julia compiler can better reason about isa to allow better inference in if statements and such.

It seems like a fairly mechanical no-brainer accomplished with the following shell command in case this PR becomes stale or you'd like to apply the same change elsewhere.

```bash
git ls-files -z | xargs -0 sed -i -e 's/typeof(\([^)]*\)) <:/\1 isa/g'
```