### PR TITLE
fix docstring of BS3

### DIFF
--- a/src/algorithms/explicit_rk.jl
+++ b/src/algorithms/explicit_rk.jl
@@ -254,8 +254,9 @@ function OwrenZen5(stage_limiter!, step_limiter! = trivial_limiter!)
     OwrenZen5(stage_limiter!, step_limiter!, False())
 end
 
-@doc explicit_rk_docstring("Owren-Zennaro optimized interpolation 5/4 method (free 5th order interpolant).",
-    "OwrenZen5",
+@doc explicit_rk_docstring(A third-order, four-stage explicit FSAL Runge-Kutta method with embedded error
+estimator of Bogacki and Shampine.",
+    "BS3",
     references = "@article{bogacki19893,
     title={A 3 (2) pair of Runge-Kutta formulas},
     author={Bogacki, Przemyslaw and Shampine, Lawrence F},

--- a/src/algorithms/explicit_rk.jl
+++ b/src/algorithms/explicit_rk.jl
@@ -254,7 +254,7 @@ function OwrenZen5(stage_limiter!, step_limiter! = trivial_limiter!)
     OwrenZen5(stage_limiter!, step_limiter!, False())
 end
 
-@doc explicit_rk_docstring(A third-order, four-stage explicit FSAL Runge-Kutta method with embedded error
+@doc explicit_rk_docstring("A third-order, four-stage explicit FSAL Runge-Kutta method with embedded error
 estimator of Bogacki and Shampine.",
     "BS3",
     references = "@article{bogacki19893,


### PR DESCRIPTION
Closes https://github.com/SciML/OrdinaryDiffEq.jl/issues/2068

I copied the first sentence of the old docstring in

https://github.com/SciML/OrdinaryDiffEq.jl/blob/b50390f89bf2d11cbe6b64ee0dcc952fc0044a8a/src/algorithms.jl#L4256-L4262