### PR TITLE
Alternative error control on Rosenbrock23 algebraic equations

### DIFF
--- a/src/perform_step/rosenbrock_perform_step.jl
+++ b/src/perform_step/rosenbrock_perform_step.jl
@@ -124,8 +124,8 @@ end
         integrator.EEst = integrator.opts.internalnorm(atmp, t)
 
         if mass_matrix !== I
-            @.. broadcast=false vectmp = ifelse(cache.algebraic_vars,fsallast,false)/integrator.opts.abstol
-            integrator.EEst += integrator.opts.internalnorm(vectmp, t)
+            @.. broadcast=false atmp = ifelse(cache.algebraic_vars,fsallast,false)/integrator.opts.abstol
+            integrator.EEst += integrator.opts.internalnorm(atmp, t)
         end
     end
     cache.linsolve = linres.cache
@@ -357,8 +357,8 @@ end
         integrator.EEst = integrator.opts.internalnorm(atmp, t)
 
         if mass_matrix !== I
-            @.. broadcast=false vectmp = ifelse(cache.algebraic_vars,fsallast,false)/integrator.opts.abstol
-            integrator.EEst += integrator.opts.internalnorm(vectmp, t)
+            @.. broadcast=false atmp = ifelse(cache.algebraic_vars,fsallast,false)/integrator.opts.abstol
+            integrator.EEst += integrator.opts.internalnorm(atmp, t)
         end
     end
     cache.linsolve = linres.cache

--- a/src/perform_step/rosenbrock_perform_step.jl
+++ b/src/perform_step/rosenbrock_perform_step.jl
@@ -424,7 +424,7 @@ end
         integrator.EEst = integrator.opts.internalnorm(atmp, t)
 
         if mass_matrix !== I
-            atmp = ifelse.(!.(integrator.differential_vars),integrator.fsallast,false)./integrator.opts.abstol
+            atmp = @. ifelse(!integrator.differential_vars,integrator.fsallast,false)./integrator.opts.abstol
             integrator.EEst += integrator.opts.internalnorm(atmp, t)
         end
     end
@@ -496,7 +496,7 @@ end
         integrator.EEst = integrator.opts.internalnorm(atmp, t)
 
         if mass_matrix !== I
-            atmp = ifelse.(!.(integrator.differential_vars),integrator.fsallast,false)./integrator.opts.abstol
+            atmp = @. ifelse(!integrator.differential_vars,integrator.fsallast,false)./integrator.opts.abstol
             integrator.EEst += integrator.opts.internalnorm(atmp, t)
         end
     end

--- a/src/perform_step/rosenbrock_perform_step.jl
+++ b/src/perform_step/rosenbrock_perform_step.jl
@@ -424,7 +424,7 @@ end
         integrator.EEst = integrator.opts.internalnorm(atmp, t)
 
         if mass_matrix !== I
-            atmp = ifelse.(cache.algebraic_vars,integrator.fsallast,false)./integrator.opts.abstol
+            atmp = ifelse.(!.(integrator.differential_vars),integrator.fsallast,false)./integrator.opts.abstol
             integrator.EEst += integrator.opts.internalnorm(atmp, t)
         end
     end
@@ -496,7 +496,7 @@ end
         integrator.EEst = integrator.opts.internalnorm(atmp, t)
 
         if mass_matrix !== I
-            atmp = ifelse.(cache.algebraic_vars,integrator.fsallast,false)./integrator.opts.abstol
+            atmp = ifelse.(!.(integrator.differential_vars),integrator.fsallast,false)./integrator.opts.abstol
             integrator.EEst += integrator.opts.internalnorm(atmp, t)
         end
     end

--- a/test/regression/hard_dae.jl
+++ b/test/regression/hard_dae.jl
@@ -221,6 +221,7 @@ refsol = solve(prob, Rodas4(), saveat = 0.1, callback = cb, tstops = [1.0], relt
 for solver in (Rodas4, Rodas4P, Rodas5, Rodas5P, FBDF, QNDF, Rosenbrock23)
     @show solver
     prob = ODEProblem(f, deepcopy(res.zero), (0, 20.0), deepcopy(p_inv))
+    maxiters = solver isa Rosenbrock23 ? 1e6 : 1e5
     sol = solve(prob, solver(), saveat = 0.1, callback = cb, tstops = [1.0], reltol = 1e-12,
         abstol = 1e-16)
     @test sol.retcode == ReturnCode.Success

--- a/test/regression/hard_dae.jl
+++ b/test/regression/hard_dae.jl
@@ -223,7 +223,7 @@ for solver in (Rodas4, Rodas4P, Rodas5, Rodas5P, FBDF, QNDF, Rosenbrock23)
     prob = ODEProblem(f, deepcopy(res.zero), (0, 20.0), deepcopy(p_inv))
     maxiters = solver isa Rosenbrock23 ? 1e6 : 1e5
     sol = solve(prob, solver(), saveat = 0.1, callback = cb, tstops = [1.0], reltol = 1e-12,
-        abstol = 1e-16)
+        abstol = 1e-16, maxiters = maxiters)
     @test sol.retcode == ReturnCode.Success
     @test sol.t[end] == 20.0
     @test maximum(sol - refsol) < 1e-11

--- a/test/regression/hard_dae.jl
+++ b/test/regression/hard_dae.jl
@@ -221,7 +221,7 @@ refsol = solve(prob, Rodas4(), saveat = 0.1, callback = cb, tstops = [1.0], relt
 for solver in (Rodas4, Rodas4P, Rodas5, Rodas5P, FBDF, QNDF, Rosenbrock23)
     @show solver
     prob = ODEProblem(f, deepcopy(res.zero), (0, 20.0), deepcopy(p_inv))
-    maxiters = solver isa Rosenbrock23 ? 1e6 : 1e5
+    maxiters = solver isa Rosenbrock23 ? 1e7 : 1e5
     sol = solve(prob, solver(), saveat = 0.1, callback = cb, tstops = [1.0], reltol = 1e-12,
         abstol = 1e-16, maxiters = maxiters)
     @test sol.retcode == ReturnCode.Success

--- a/test/regression/hard_dae.jl
+++ b/test/regression/hard_dae.jl
@@ -221,7 +221,7 @@ refsol = solve(prob, Rodas4(), saveat = 0.1, callback = cb, tstops = [1.0], relt
 for solver in (Rodas4, Rodas4P, Rodas5, Rodas5P, FBDF, QNDF, Rosenbrock23)
     @show solver
     prob = ODEProblem(f, deepcopy(res.zero), (0, 20.0), deepcopy(p_inv))
-    maxiters = solver isa Rosenbrock23 ? 1e7 : 1e5
+    maxiters = solver isa Rosenbrock23 ? 1e8 : 1e5
     sol = solve(prob, solver(), saveat = 0.1, callback = cb, tstops = [1.0], reltol = 1e-12,
         abstol = 1e-16, maxiters = maxiters)
     @test sol.retcode == ReturnCode.Success

--- a/test/regression/hard_dae.jl
+++ b/test/regression/hard_dae.jl
@@ -216,14 +216,13 @@ cb = DiscreteCallback(condition, affect!)
 
 prob = ODEProblem(f, deepcopy(res.zero), (0, 20.0), deepcopy(p_inv))
 refsol = solve(prob, Rodas4(), saveat = 0.1, callback = cb, tstops = [1.0], reltol = 1e-12,
-    abstol = 1e-18)
+    abstol = 1e-17)
 
 for solver in (Rodas4, Rodas4P, Rodas5, Rodas5P, FBDF, QNDF, Rosenbrock23)
     @show solver
     prob = ODEProblem(f, deepcopy(res.zero), (0, 20.0), deepcopy(p_inv))
-    maxiters = solver isa Rosenbrock23 ? 1e8 : 1e5
-    sol = solve(prob, solver(), saveat = 0.1, callback = cb, tstops = [1.0], reltol = 1e-12,
-        abstol = 1e-16, maxiters = maxiters)
+    sol = solve(prob, solver(), saveat = 0.1, callback = cb, tstops = [1.0], reltol = 1e-14,
+        abstol = 1e-14)
     @test sol.retcode == ReturnCode.Success
     @test sol.t[end] == 20.0
     @test maximum(sol - refsol) < 1e-11


### PR DESCRIPTION
Adds a separate error term for Rosenbrock23 when the mass matrix is not `I` in order to account for the fact that the algebraic conditions are not error controlled. They are added via doing error control on the absolute tolerance of the residual in the algebraic conditions. There isn't a sensible definition of relative tolerance here so leaving it at that.

Note that this technique is not applicable to the Rodas / stiffly stable methods since they always exactly satisfy the algebraic conditions by design, i.e. this term is just zero. Those methods will need to use a different strategy like residual control.

Handles part of https://github.com/SciML/OrdinaryDiffEq.jl/issues/2054.

Fixes https://github.com/SciML/OrdinaryDiffEq.jl/pull/2079
