### PR TITLE
Rodas5(P) 2nd and third derivatives

### DIFF
--- a/src/dense/rosenbrock_interpolants.jl
+++ b/src/dense/rosenbrock_interpolants.jl
@@ -311,4 +311,70 @@ end
                                     y₀[idxs] + y₁[idxs]) / dt
     out
 end
-#-
+
+# Second Derivative
+@muladd function _ode_interpolant(Θ, dt, y₀, y₁, k, cache::Rosenbrock5ConstantCache,
+    idxs::Nothing, T::Type{Val{2}}, differential_vars)
+    @inbounds (-2 * k[1] + 2 * k[2] + Θ * (-6 * k[2] + 6 * k[3] - 12 * Θ * k[3])) / dt^2
+end
+
+@muladd function _ode_interpolant(Θ, dt, y₀, y₁, k, cache::Rosenbrock5Cache, idxs::Nothing,
+    T::Type{Val{2}}, differential_vars)
+    @inbounds @.. broadcast=false (-2 * k[1] + 2 * k[2] +
+                                    Θ * (-6 * k[2] + 6 * k[3] - 12 * Θ * k[3]))/dt^2
+end
+
+@muladd function _ode_interpolant(Θ, dt, y₀, y₁, k,
+    cache::Union{Rosenbrock5ConstantCache, Rosenbrock5Cache},
+    idxs, T::Type{Val{2}}, differential_vars)
+    @.. broadcast=false (-2 * k[1][idxs] + 2 * k[2][idxs] +
+                          Θ * (-6 * k[2][idxs] + 6 * k[3][idxs] - 12 * Θ * k[3][idxs]))/dt^2
+end
+
+@muladd function _ode_interpolant!(out, Θ, dt, y₀, y₁, k,
+    cache::Union{Rosenbrock5ConstantCache, Rosenbrock5Cache},
+    idxs::Nothing, T::Type{Val{2}}, differential_vars)
+    @.. broadcast=false out= (-2 * k[1] + 2 * k[2] +
+                              Θ * (-6 * k[2] + 6 * k[3] - 12 * Θ * k[3])) / dt^2
+    out
+end
+
+@muladd function _ode_interpolant!(out, Θ, dt, y₀, y₁, k,
+    cache::Union{Rosenbrock5ConstantCache, Rosenbrock5Cache},
+    idxs, T::Type{Val{2}}, differential_vars)
+    @views @.. broadcast=false out= (-2 * k[1][idxs] + 2 * k[2][idxs] +
+                                     Θ *
+                                     (-6 * k[2][idxs] + 6 * k[3][idxs] - 12 * Θ * k[3][idxs])) / dt^2
+    out
+end
+
+# Third Derivative
+@muladd function _ode_interpolant(Θ, dt, y₀, y₁, k, cache::Rosenbrock5ConstantCache,
+    idxs::Nothing, T::Type{Val{3}}, differential_vars)
+    @inbounds (-6 * k[2] + 6 * k[3] - 24 * Θ * k[3]) / dt^3
+end
+
+@muladd function _ode_interpolant(Θ, dt, y₀, y₁, k, cache::Rosenbrock5Cache, idxs::Nothing,
+    T::Type{Val{3}}, differential_vars)
+    @inbounds @.. broadcast=false (-6 * k[2] + 6 * k[3] - 24 * Θ * k[3])/dt^3
+end
+
+@muladd function _ode_interpolant(Θ, dt, y₀, y₁, k,
+    cache::Union{Rosenbrock5ConstantCache, Rosenbrock5Cache},
+    idxs, T::Type{Val{3}}, differential_vars)
+    @.. broadcast=false (-6 * k[2][idxs] + 6 * k[3][idxs] - 24 * Θ * k[3][idxs])/dt^3
+end
+
+@muladd function _ode_interpolant!(out, Θ, dt, y₀, y₁, k,
+    cache::Union{Rosenbrock5ConstantCache, Rosenbrock5Cache},
+    idxs::Nothing, T::Type{Val{3}}, differential_vars)
+    @.. broadcast=false out= (-6 * k[2] + 6 * k[3] - 24 * Θ * k[3]) / dt^3
+    out
+end
+
+@muladd function _ode_interpolant!(out, Θ, dt, y₀, y₁, k,
+    cache::Union{Rosenbrock5ConstantCache, Rosenbrock5Cache},
+    idxs, T::Type{Val{3}}, differential_vars)
+    @views @.. broadcast=false out= (-6 * k[2][idxs] + 6 * k[3][idxs] - 24 * Θ * k[3][idxs]) / dt^3
+    out
+end

--- a/test/regression/ode_dense_tests.jl
+++ b/test/regression/ode_dense_tests.jl
@@ -537,10 +537,10 @@ regression_test(Rodas4P(), 4e-5, 6e-5, test_diff1 = true, nth_der = 1, dertol = 
 regression_test(Rodas4P2(), 2e-5, 3e-5, test_diff1 = true, nth_der = 1, dertol = 1e-13)
 
 # Rodas5
-regression_test(Rodas5(), 2e-6, 3e-6, test_diff1 = true, nth_der = 1, dertol = 1e-13)
+regression_test(Rodas5(), 2e-6, 3e-6, test_diff1 = true, nth_der = 3, dertol = 5e-1)
 
 # Rodas5P
-regression_test(Rodas5P(), 2e-5, 3e-5, test_diff1 = true, nth_der = 1, dertol = 1e-13)
+regression_test(Rodas5P(), 2e-5, 3e-5, test_diff1 = true, nth_der = 3, dertol = 5e-1)
 
 # ExplicitRK
 regression_test(ExplicitRK(), 7e-5, 2e-4)


### PR DESCRIPTION
Fixes https://github.com/SciML/OrdinaryDiffEq.jl/issues/2101

Second derivative looks fine, third derivative looks weird.

```julia
using OrdinaryDiffEq, ODEProblemLibrary
prob = prob_ode_linear
sol1 = solve(prob, Rodas5P(), dt = 1 // 2^(8), dense = true)
sol2 = solve(prob, Vern9(), dt = 1 // 2^(8), dense = true)

using Plots
t = 0.0:0.01:1.0
plot(t, Array(sol1(t, Val{1})))
plot!(t, Array(sol2(t, Val{1})))

plot(t, Array(sol1(t, Val{2})))
plot!(t, Array(sol2(t, Val{2})))

plot(t, Array(sol1(t, Val{3})))
plot!(t, Array(sol2(t, Val{3})))
```
