### PR TITLE
refactor: remove getproperty method for ODEIntegrator

### DIFF
--- a/src/integrators/type.jl
+++ b/src/integrators/type.jl
@@ -186,12 +186,3 @@ end
 # When this is changed, DelayDiffEq.jl must be changed as well!
 
 TruncatedStacktraces.@truncate_stacktrace ODEIntegrator 2 1 3 4
-
-function Base.getproperty(integ::ODEIntegrator, s::Symbol)
-    if s === :destats
-        @warn "destats has been deprecated for stats"
-        getfield(integ, :stats)
-    else
-        getfield(integ, s)
-    end
-end


### PR DESCRIPTION
This is already handled in SciMLBase

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
