### PR TITLE
remove error for `Rosenbrock23` with no differential equations

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -97,10 +97,11 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,
     end
 
     if alg isa OrdinaryDiffEqRosenbrockAdaptiveAlgorithm &&
+            # https://github.com/SciML/OrdinaryDiffEq.jl/pull/2079 fixes this for Rosenbrock23 and 32
+            !(alg isa Union{Rosenbrock23, Rosenbrock32}) &&
             prob.f.mass_matrix isa AbstractMatrix &&
             all(isequal(0), prob.f.mass_matrix)
         # technically this should also warn for zero operators but those are hard to check for
-        alg isa Union{Rosenbrock23, Rosenbrock32} && error("Rosenbrock23 and Rosenbrock32 require at least one differential variable to produce valid solutions")
         if (dense || !isempty(saveat)) && verbose
             @warn("Rosenbrock methods on equations without differential states do not bound the error on interpolations.")
         end

--- a/test/integrators/check_error.jl
+++ b/test/integrators/check_error.jl
@@ -43,8 +43,8 @@ end
 
 let
     function f!(out, u, _, t)
-       out[1] = u[1]  - sin(1e8*t)
+       out[1] = u[1]  + 1 - sin(t)
     end
     mprob = ODEProblem(ODEFunction(f!, mass_matrix=[0.0;;]), [0.0], (0, 2.0))
-    @test_throws ErrorException solve(mprob, Rosenbrock23())
+    @test solve(mprob, Rosenbrock23()).retcode == ReturnCode.Success
 end


### PR DESCRIPTION
With https://github.com/SciML/OrdinaryDiffEq.jl/pull/2079, this error is no longer necessary.
## Checklist

- [x ] Appropriate tests were added
- [ x] Any code changes were done in a way that does not break public API
- [ x] All documentation related to code changes were updated
- [ x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
