### PR TITLE
fix location of error check disabling to prevent infinite loop in weird cases

### DIFF
--- a/src/composite_algs.jl
+++ b/src/composite_algs.jl
@@ -41,6 +41,7 @@ function is_stiff(integrator, alg, ntol, stol, is_stiffalg)
 
     if !bool
         integrator.alg.choice_function.successive_switches += 1
+        integrator.do_error_check = false
     else
         integrator.alg.choice_function.successive_switches = 0
     end

--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -352,7 +352,6 @@ function handle_callbacks!(integrator)
 
     integrator.u_modified = continuous_modified || discrete_modified
     if integrator.u_modified
-        integrator.do_error_check = false
         handle_callback_modifiers!(integrator)
     end
     nothing

--- a/test/integrators/check_error.jl
+++ b/test/integrators/check_error.jl
@@ -48,3 +48,11 @@ let
     mprob = ODEProblem(ODEFunction(f!, mass_matrix=[0.0;;]), [0.0], (0, 2.0))
     @test_throws ErrorException solve(mprob, Rosenbrock23())
 end
+
+@testset "Callbacks shouldn't disable error checking" begin
+    callback=ContinuousCallback((u,t,integ)->t-prevfloat(.5), Returns(nothing))
+    prob = ODEProblem((u,p,t) -> u, 0.0, (0.0, 1); tstops=[.5], callback);
+    sol = solve(prob, FBDF(), maxiters=30)
+    @test sol.stats.naccept + sol.stats.nreject <= 30
+    @test_broken sol.retcode = ReturnCode.Success
+end


### PR DESCRIPTION
Before, the test
```
    callback=ContinuousCallback((u,t,integ)->t-prevfloat(.5), Returns(nothing))
    prob = ODEProblem((u,p,t) -> u, 0.0, (0.0, 1); tstops=[.5], callback);
    sol = solve(prob, FBDF(), maxiters=30)
 ```
would just run for ever because the error check was disabled when we hit a callback. It doesn't seem great that this gets stuck in the first place, but that's a separate issue.

## Checklist

- [x ] Appropriate tests were added
- [x ] Any code changes were done in a way that does not break public API
- [x ] All documentation related to code changes were updated
- [x ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
