### PR TITLE
fix DAEProblem initialization with autodiff=false

### DIFF
--- a/src/initialize_dae.jl
+++ b/src/initialize_dae.jl
@@ -618,7 +618,7 @@ function _initialize_dae!(integrator, prob::DAEProblem,
        _tmp = PreallocationTools.dualcache(tmp, chunk)
        _du_tmp = PreallocationTools.dualcache(du_tmp, chunk)
    else
-        _tmp, _du_tmp = tmp, _du_tmp
+        _tmp, _du_tmp = tmp, du_tmp
    end
 
     nlequation! = @closure (out, x, p) -> begin

--- a/test/integrators/dae_initialization_tests.jl
+++ b/test/integrators/dae_initialization_tests.jl
@@ -150,10 +150,15 @@ tspan = (0.0, 100000.0)
 differential_vars = [true, true, false]
 prob = DAEProblem(f, du₀, u₀, tspan, differential_vars = differential_vars)
 integrator = init(prob, DABDF2())
+integrator2 = init(prob, DABDF2(autodiff=false))
 
 @test integrator.du[1]≈-0.04 atol=1e-9
 @test integrator.du[2]≈0.04 atol=1e-9
 @test integrator.u≈u₀ atol=1e-9
+
+@test integrator2.du[1]≈-0.04 atol=1e-99
+@test integrator2.du[2]≈0.04 atol=1e-9
+@test integrator2.u≈u₀ atol=1e-9
 
 integrator = init(prob, DImplicitEuler())
 


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context
This fixes a typo introduced in https://github.com/SciML/OrdinaryDiffEq.jl/pull/2100
