### PR TITLE
Load SENSITIVITY_INTERP_MESSAGE from SciMLBase

### DIFF
--- a/src/dense/generic_dense.jl
+++ b/src/dense/generic_dense.jl
@@ -11,6 +11,8 @@ const DERIVATIVE_ORDER_NOT_POSSIBLE_MESSAGE = """
                                          * https://docs.sciml.ai/DiffEqDocs/stable/solvers/dae_solve/
                                          """
 
+using SciMLBase: SENSITIVITY_INTERP_MESSAGE
+
 struct DerivativeOrderNotPossibleError <: Exception end
 
 function Base.showerror(io::IO, e::DerivativeOrderNotPossibleError)


### PR DESCRIPTION
When working on https://github.com/DARPA-ASKEM/sciml-service/issues/141 I ran into an unhelpful error message

```
ERROR: LoadError: UndefVarError: `SENSITIVITY_INTERP_MESSAGE` not defined
Stacktrace:
  [1] setindex!
    @ ./essentials.jl:645 [inlined]
  [2] _push!
    @ ~/.julia/packages/Zygote/jxHJc/src/compiler/emit.jl:19 [inlined]
  [3] _pullback(::Zygote.Context{…}, ::typeof(OrdinaryDiffEq.ode_interpolation), ::Float64, ::OrdinaryDiffEq.InterpolationData{…}, ::Nothing, ::Type{…}, ::ComponentVector{…}, ::Symbol)
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface2.jl:0
  [4] InterpolationData
    @ ~/.julia/packages/OrdinaryDiffEq/pWCEq/src/interp_func.jl:168 [inlined]
  [5] _pullback(::Zygote.Context{…}, ::OrdinaryDiffEq.InterpolationData{…}, ::Float64, ::Nothing, ::Type{…}, ::ComponentVector{…}, ::Symbol)
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface2.jl:0
  [6] AbstractODESolution
    @ ~/.julia/packages/SciMLBase/Avnpi/src/solutions/ode_solutions.jl:150 [inlined]
  [7] _pullback(::Zygote.Context{…}, ::ODESolution{…}, ::Float64, ::Type{…}, ::Nothing, ::Symbol)
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface2.jl:0
  [8] #_#441
    @ ~/.julia/packages/SciMLBase/Avnpi/src/solutions/ode_solutions.jl:141 [inlined]
  [9] _pullback(::Zygote.Context{…}, ::SciMLBase.var"##_#441", ::Nothing, ::Symbol, ::ODESolution{…}, ::Float64, ::Type{…})
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface2.jl:0
 [10] AbstractODESolution
    @ ~/.julia/packages/SciMLBase/Avnpi/src/solutions/ode_solutions.jl:139 [inlined]
 [11] _pullback(::Zygote.Context{…}, ::ODESolution{…}, ::Float64, ::Type{…})
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface2.jl:0
 [12] AbstractODESolution
    @ ~/.julia/packages/SciMLBase/Avnpi/src/solutions/ode_solutions.jl:139 [inlined]
 [13] _pullback(ctx::Zygote.Context{…}, f::ODESolution{…}, args::Float64)
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface2.jl:0
 [14] f
    @ ~/.julia/dev/decapodes-issue/example.jl:134 [inlined]
 [15] _pullback(::Zygote.Context{false}, ::typeof(f), ::Float64, ::Float64, ::Vector{Float64})
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface2.jl:0
 [16] #108
    @ ~/.julia/dev/decapodes-issue/example.jl:145 [inlined]
 [17] _pullback(ctx::Zygote.Context{false}, f::var"#108#109", args::Vector{Float64})
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface2.jl:0
 [18] pullback(f::Function, cx::Zygote.Context{false}, args::Vector{Float64})
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface.jl:90
 [19] pullback
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface.jl:88 [inlined]
 [20] gradient(f::Function, args::Vector{Float64})
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface.jl:147
 [21] top-level scope
    @ ~/.julia/dev/decapodes-issue/example.jl:145
 [22] include(fname::String)
    @ Base.MainInclude ./client.jl:489
 [23] top-level scope
    @ REPL[5]:1
in expression starting at /home/x/.julia/dev/decapodes-issue/example.jl:145
Some type information was truncated. Use `show(err)` to see complete types.
```

With this change, that error becomes

```
ERROR: LoadError: Standard interpolation is disabled due to sensitivity analysis being
used for the gradients. Only linear and constant interpolations are
compatible with non-AD sensitivity analysis calculations. Either
utilize tooling like saveat to avoid post-solution interpolation, use
the keyword argument dense=false for linear or constant interpolations,
or use the keyword argument sensealg=SensitivityADPassThrough() to revert
to AD-based derivatives.

Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:35
  [2] rrule(::typeof(error), 723::String)
    @ ChainRules ~/.julia/packages/ChainRules/Gw0tZ/src/rulesets/Base/nondiff.jl:153
  [3] rrule(::Zygote.ZygoteRuleConfig{Zygote.Context{false}}, ::Function, ::String)
    @ ChainRulesCore ~/.julia/packages/ChainRulesCore/6DiyF/src/rules.jl:134
  [4] chain_rrule
    @ ~/.julia/packages/Zygote/jxHJc/src/compiler/chainrules.jl:223 [inlined]
  [5] macro expansion
    @ ~/.julia/packages/Zygote/jxHJc/src/compiler/interface2.jl:0 [inlined]
  [6] _pullback(ctx::Zygote.Context{false}, f::typeof(error), args::String)
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface2.jl:81
  [7] ode_interpolation
    @ ~/.julia/dev/OrdinaryDiffEq/src/dense/generic_dense.jl:484 [inlined]
  [8] _pullback(::Zygote.Context{…}, ::typeof(OrdinaryDiffEq.ode_interpolation), ::Float64, ::OrdinaryDiffEq.InterpolationData{…}, ::Nothing, ::Type{…}, ::ComponentVector{…}, ::Symbol)
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface2.jl:0
  [9] InterpolationData
    @ ~/.julia/dev/OrdinaryDiffEq/src/interp_func.jl:168 [inlined]
 [10] _pullback(::Zygote.Context{…}, ::OrdinaryDiffEq.InterpolationData{…}, ::Float64, ::Nothing, ::Type{…}, ::ComponentVector{…}, ::Symbol)
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface2.jl:0
 [11] AbstractODESolution
    @ ~/.julia/packages/SciMLBase/Avnpi/src/solutions/ode_solutions.jl:150 [inlined]
 [12] _pullback(::Zygote.Context{…}, ::ODESolution{…}, ::Float64, ::Type{…}, ::Nothing, ::Symbol)
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface2.jl:0
 [13] #_#441
    @ ~/.julia/packages/SciMLBase/Avnpi/src/solutions/ode_solutions.jl:141 [inlined]
 [14] _pullback(::Zygote.Context{…}, ::SciMLBase.var"##_#441", ::Nothing, ::Symbol, ::ODESolution{…}, ::Float64, ::Type{…})
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface2.jl:0
 [15] AbstractODESolution
    @ ~/.julia/packages/SciMLBase/Avnpi/src/solutions/ode_solutions.jl:139 [inlined]
 [16] _pullback(::Zygote.Context{…}, ::ODESolution{…}, ::Float64, ::Type{…})
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface2.jl:0
 [17] AbstractODESolution
    @ ~/.julia/packages/SciMLBase/Avnpi/src/solutions/ode_solutions.jl:139 [inlined]
 [18] _pullback(ctx::Zygote.Context{…}, f::ODESolution{…}, args::Float64)
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface2.jl:0
 [19] f
    @ ~/.julia/dev/decapodes-issue/example.jl:135 [inlined]
 [20] _pullback(::Zygote.Context{false}, ::typeof(f), ::Float64, ::Float64, ::Vector{Float64})
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface2.jl:0
 [21] #42
    @ ~/.julia/dev/decapodes-issue/example.jl:147 [inlined]
 [22] _pullback(ctx::Zygote.Context{false}, f::var"#42#43", args::Vector{Float64})
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface2.jl:0
 [23] pullback(f::Function, cx::Zygote.Context{false}, args::Vector{Float64})
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface.jl:90
 [24] pullback
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface.jl:88 [inlined]
 [25] gradient(f::Function, args::Vector{Float64})
    @ Zygote ~/.julia/packages/Zygote/jxHJc/src/compiler/interface.jl:147
 [26] top-level scope
    @ ~/.julia/dev/decapodes-issue/example.jl:147
 [27] include(fname::String)
    @ Base.MainInclude ./client.jl:489
 [28] top-level scope
    @ REPL[1]:1
in expression starting at /home/x/.julia/dev/decapodes-issue/example.jl:147
Some type information was truncated. Use `show(err)` to see complete types.
```

## Checklist

- N/A Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- N/A All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- N/A Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
