### PR TITLE
save du and k for DAEs when dense==true

### DIFF
--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -366,15 +366,9 @@ function handle_callbacks!(integrator)
         savevalues!(integrator)
     end
 
-    integrator.u_modified = continuous_modified || discrete_modified
-    if integrator.u_modified
-        handle_callback_modifiers!(integrator)
-    end
+    integrator.u_modified = continuous_modified | discrete_modified
+    integrator.reeval_fsal  && handle_callback_modifiers!(integrator) # Hook for DDEs to add discontinuities
     nothing
-end
-
-function handle_callback_modifiers!(integrator::ODEIntegrator)
-    integrator.reeval_fsal = true
 end
 
 function update_uprev!(integrator)
@@ -515,7 +509,7 @@ function reset_fsal!(integrator)
             integrator.fsalfirst = integrator.f(integrator.u, integrator.p, integrator.t)
         end
     end
-    
+
     # Do not set false here so it can be checked in the algorithm
     # integrator.reeval_fsal = false
 end

--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -102,19 +102,19 @@ function _savevalues!(integrator, force_save, reduce_size)::Tuple{Bool, Bool}
                             [k[integrator.opts.save_idxs] for k in integrator.k],
                             false)
                     end
-                    if integrator.alg isa DAEAlgorithm
-                        if integrator.opts.save_idxs === nothing
-                            copyat_or_push!(integrator.sol.du, integrator.saveiter, integrator.du)
-                        else
-                            copyat_or_push!(integrator.sol.du, integrator.saveiter,
-                                integrator.du[integrator.opts.save_idxs], false)
-                        end
-                    end
                 end
             end
             if integrator.alg isa OrdinaryDiffEqCompositeAlgorithm
                 copyat_or_push!(integrator.sol.alg_choice, integrator.saveiter,
                     integrator.cache.current)
+            end
+            if integrator.opts.save_du
+                if integrator.opts.save_idxs === nothing
+                    copyat_or_push!(integrator.sol.du, integrator.saveiter, integrator(integrator.t, Val{1}))
+                else
+                    copyat_or_push!(integrator.sol.du, integrator.saveiter,
+                        integrator(integrator.t, Val{1}, idxs=integrator.opts.save_idxs), false)
+                end
             end
         end
     end
@@ -142,19 +142,19 @@ function _savevalues!(integrator, force_save, reduce_size)::Tuple{Bool, Bool}
                         [k[integrator.opts.save_idxs] for k in integrator.k],
                         false)
                 end
-                if integrator.alg isa DAEAlgorithm
-                    if integrator.opts.save_idxs === nothing
-                        copyat_or_push!(integrator.sol.du, integrator.saveiter, integrator.du)
-                    else
-                        copyat_or_push!(integrator.sol.du, integrator.saveiter,
-                            integrator.du[integrator.opts.save_idxs], false)
-                    end
-                end
             end
         end
         if integrator.alg isa OrdinaryDiffEqCompositeAlgorithm
             copyat_or_push!(integrator.sol.alg_choice, integrator.saveiter,
                 integrator.cache.current)
+        end
+        if integrator.opts.save_du
+            if integrator.opts.save_idxs === nothing
+                copyat_or_push!(integrator.sol.du, integrator.saveiter, integrator(integrator.t, Val{1}))
+            else
+                copyat_or_push!(integrator.sol.du, integrator.saveiter,
+                    integrator(integrator.t, Val{1}, idxs=integrator.opts.save_idxs), false)
+            end
         end
     end
     reduce_size && resize!(integrator.k, integrator.kshortsize)

--- a/src/integrators/type.jl
+++ b/src/integrators/type.jl
@@ -46,6 +46,7 @@ mutable struct DEOptions{absType, relType, QT, tType, Controller, F1, F2, F3, F4
     force_dtmin::Bool
     advance_to_tstop::Bool
     stop_at_next_tstop::Bool
+    save_du::Bool
 end
 
 TruncatedStacktraces.@truncate_stacktrace DEOptions

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -25,7 +25,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,
     save_end = nothing,
     callback = nothing,
     dense = save_everystep &&
-                !(alg isa Union{DAEAlgorithm, FunctionMap}) &&
+                !(alg isa FunctionMap) &&
                 isempty(saveat),
     calck = (callback !== nothing && callback !== CallbackSet()) ||
                 (dense) || !isempty(saveat), # and no dense output
@@ -413,10 +413,17 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,
     differential_vars = prob isa DAEProblem ? prob.differential_vars : get_differential_vars(f, u)
 
     id = InterpolationData(f, timeseries, ts, ks, alg_choice, dense, cache, differential_vars, false)
-    sol = DiffEqBase.build_solution(prob, _alg, ts, timeseries,
-        dense = dense, k = ks, interp = id,
-        alg_choice = alg_choice,
-        calculate_error = false, stats = stats)
+    if _alg isa DAEAlgorithm
+        sol = DiffEqBase.build_solution(prob, _alg, ts, timeseries, Vector{typeof(du)}(undef,0),
+            dense = dense, k = ks, interp = id,
+            alg_choice = alg_choice,
+            calculate_error = false, stats = stats)
+    else
+        sol = DiffEqBase.build_solution(prob, _alg, ts, timeseries,
+            dense = dense, k = ks, interp = id,
+            alg_choice = alg_choice,
+            calculate_error = false, stats = stats)
+    end
 
     if recompile_flag == true
         FType = typeof(f)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -70,6 +70,7 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,
     alias_u0 = false,
     alias_du0 = false,
     initializealg = DefaultInit(),
+    save_du = false,
     kwargs...) where {recompile_flag}
     if prob isa DiffEqBase.AbstractDAEProblem && alg isa OrdinaryDiffEqAlgorithm
         error("You cannot use an ODE Algorithm with a DAEProblem")
@@ -407,7 +408,8 @@ function DiffEqBase.__init(prob::Union{DiffEqBase.AbstractODEProblem,
         unstable_check,
         verbose, calck, force_dtmin,
         advance_to_tstop,
-        stop_at_next_tstop)
+        stop_at_next_tstop,
+        save_du)
 
     stats = SciMLBase.DEStats(0)
     differential_vars = prob isa DAEProblem ? prob.differential_vars : get_differential_vars(f, u)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
depends on https://github.com/SciML/SciMLBase.jl/pull/622 to add the k field to `DAESolution`.
