### PR TITLE
Avoid throwing error if type inference on u0/t fails

### DIFF
--- a/src/initdt.jl
+++ b/src/initdt.jl
@@ -250,9 +250,9 @@ end
         @warn("First function call produced NaNs. Exiting. Double check that none of the initial conditions, parameters, or timespan values are NaN.")
     end
 
-    if Base.promote_op(/, typeof(u0), typeof(oneunit(t))) !== typeof(f₀)
-        throw(TypeNotConstantError(Base.promote_op(/, typeof(u0), typeof(oneunit(t))),
-            typeof(f₀)))
+    inferredtype = Base.promote_op(/, typeof(u0), typeof(oneunit(t)))
+    if inferredtype !== Any && inferredtype !== typeof(f₀)
+        throw(TypeNotConstantError(inferredtype, typeof(f₀)))
     end
 
     d₁ = internalnorm(f₀ ./ sk .* oneunit_tType, t)

--- a/src/initdt.jl
+++ b/src/initdt.jl
@@ -251,7 +251,7 @@ end
     end
 
     inferredtype = Base.promote_op(/, typeof(u0), typeof(oneunit(t)))
-    if inferredtype !== Any && inferredtype !== typeof(f₀)
+    if !(f₀ isa inferredtype)
         throw(TypeNotConstantError(inferredtype, typeof(f₀)))
     end
 


### PR DESCRIPTION
## Problem

The current implementation checks that `typeof(u0/t) == typeof(du)` by type inference using `Base.promote_op()`. If they are unequal, it throws an error. The problem is that the type inference can fail, even if the actual types are equal. As the documentation of `Base.promote_op()` says:

> WARNING
> Due to its fragility, use of promote_op should be avoided. It is preferable to base the container eltype on the type of the actual elements. Only in the absence of any elements (for an empty result container), it may be unavoidable to call promote_op.

The problem is not hypothetical, but actually occurs at times, but is hard to pin down. For example, with Julia 1.10.2, if I create a new environment with just `MonteCarloMeasurements.jl`:
```julia
julia> using MonteCarloMeasurements

julia> Base.promote_op(/, typeof([Particles(1000, Normal(10.0, 0.1))]), typeof(oneunit(1.0)))
Any

julia> typeof([Particles(1000, Normal(10.0, 0.1))] / oneunit(1.0))
Vector{Particles{Float64, 1000}} (alias for Array{Particles{Float64, 1000}, 1})
```
the inference fails, as seen above. The exact same code works with same version of Julia when the environment has some other packages installed (not loaded), although the exact packages needed have been elusive.

## Solution

The solution is simply to accept that the inference may result in not the exact type, but a supertype sometimes.

## Checklist

- [ ] Appropriate tests were added -- not added, see additional context below
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Test could not be added because the conditions under which type inference fails are highly dependent on Julia version and also what other packages are installed and loaded in what order.
