### PR TITLE
fix DAE init when BrownFullBasic is given a specific nlsolver to use

### DIFF
--- a/src/initialize_dae.jl
+++ b/src/initialize_dae.jl
@@ -20,7 +20,7 @@ function BrownFullBasicInit(; abstol = 1e-10, nlsolve = nothing)
 end
 BrownFullBasicInit(abstol) = BrownFullBasicInit(; abstol = abstol, nlsolve = nothing)
 
-default_nlsolve(alg, isinplace, u, autodiff = false) = alg
+default_nlsolve(alg, isinplace, u, initprob, autodiff = false) = alg
 function default_nlsolve(::Nothing, isinplace, u, ::NonlinearProblem, autodiff = false)
     FastShortcutNonlinearPolyalg(;
         autodiff = autodiff ? AutoForwardDiff() : AutoFiniteDiff())

--- a/test/interface/dae_initialize_integration.jl
+++ b/test/interface/dae_initialize_integration.jl
@@ -64,7 +64,7 @@ sol = solve(prob, Tsit5())
 @test SciMLBase.successful_retcode(sol)
 @test sol[1] == [1.0]
 
-prob = ODEProblem(_f, [0.0], (0.0,1.0))
+prob = ODEProblem(_f, [0.0], (0.0, 1.0))
 sol = solve(prob, Tsit5(), dt = 1e-10)
 @test SciMLBase.successful_retcode(sol)
 @test sol[1] == [1.0]

--- a/test/interface/dae_initialize_integration.jl
+++ b/test/interface/dae_initialize_integration.jl
@@ -40,6 +40,10 @@ sol = solve(prob, Rodas5(), initializealg = BrownFullBasicInit())
 @test prob.u0 == sol[1]
 sol = solve(prob, Rodas5(), initializealg = ShampineCollocationInit())
 @test prob.u0 == sol[1]
+#test initialization when given a specific nonlinear solver
+using NonlinearSolve
+sol = solve(prob, Rodas5(), initializealg = BrownFullBasicInit(1e-10, RobustMultiNewton()))
+@test prob.u0 == sol[1]
 
 # Initialize on ODEs
 # https://github.com/SciML/ModelingToolkit.jl/issues/2508


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.

this regressed in https://github.com/SciML/OrdinaryDiffEq.jl/pull/2151