### PR TITLE
Adding Pseudo-Symplectic Explicit Runge-Kutta methods

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -354,7 +354,7 @@ export FunctionMap, Euler, Heun, Ralston, Midpoint, RK4, ExplicitRK, OwrenZen3, 
        OwrenZen5,
        BS3, BS5, RK46NL, DP5, Tsit5, DP8, Vern6, Vern7, Vern8, TanYam7, TsitPap8,
        Vern9, Feagin10, Feagin12, Feagin14, CompositeAlgorithm, Anas5, RKO65, FRK65, PFRK87,
-       RKM, MSRK5, MSRK6, Stepanov5, SIR54, QPRK98
+       RKM, MSRK5, MSRK6, Stepanov5, SIR54, QPRK98, PSRK4p7q6, PSRK3p6q5, PSRK3p5q4
 
 export SSPRK22, SSPRK33, KYKSSPRK42, SSPRK53, SSPRK53_2N1, SSPRK53_2N2, SSPRK53_H, SSPRK63,
        SSPRK73, SSPRK83, SSPRK43, SSPRK432,

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -76,6 +76,10 @@ isfsal(alg::SSPRK932) = false
 isfsal(alg::SSPRK54) = false
 isfsal(alg::SSPRK104) = false
 
+isfals(alg::PSRK3p5q4) = false
+isfals(alg::PSRK3p6q5) = false
+isfals(alg::PSRK4p7q6) = false
+
 get_current_isfsal(alg, cache) = isfsal(alg)
 
 # evaluates f(t[i])

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -76,9 +76,9 @@ isfsal(alg::SSPRK932) = false
 isfsal(alg::SSPRK54) = false
 isfsal(alg::SSPRK104) = false
 
-isfals(alg::PSRK3p5q4) = false
-isfals(alg::PSRK3p6q5) = false
-isfals(alg::PSRK4p7q6) = false
+isfsal(alg::PSRK3p5q4) = false
+isfsal(alg::PSRK3p6q5) = false
+isfsal(alg::PSRK4p7q6) = false
 
 get_current_isfsal(alg, cache) = isfsal(alg)
 

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -565,6 +565,9 @@ alg_order(alg::MSRK5) = 5
 alg_order(alg::MSRK6) = 6
 alg_order(alg::Stepanov5) = 5
 alg_order(alg::SIR54) = 5
+alg_order(alg::PSRK4p7q6) = 4
+alg_order(alg::PSRK3p6q5) = 3
+alg_order(alg::PSRK3p5q4) = 3
 
 alg_order(alg::BS3) = 3
 alg_order(alg::BS5) = 5

--- a/src/algorithms/explicit_rk.jl
+++ b/src/algorithms/explicit_rk.jl
@@ -130,10 +130,6 @@ Base.@kwdef struct PSRK3p5q4{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffE
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = False()
 end
-# for backwards compatibility
-function PSRK3p5q4(stage_limiter!, step_limiter! = trivial_limiter!)
-    PSRK3p5q4(stage_limiter!, step_limiter!, False())
-end
 
 @doc explicit_rk_docstring("5-stage Pseudo-Symplectic Explicit RK method.", "3p6q(5)",
     references = "@article{Aubry1998,
@@ -151,10 +147,6 @@ Base.@kwdef struct PSRK3p6q5{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffE
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = False()
-end
-# for backwards compatibility
-function PSRK3p6q5(stage_limiter!, step_limiter! = trivial_limiter!)
-    PSRK3p6q5(stage_limiter!, step_limiter!, False())
 end
 
 @doc explicit_rk_docstring("6-stage Pseudo-Symplectic Explicit RK method.", "4p7q(6)",
@@ -179,10 +171,6 @@ Base.@kwdef struct PSRK4p7q6{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffE
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = False()
-end
-# for backwards compatibility
-function PSRK4p7q6(stage_limiter!, step_limiter! = trivial_limiter!)
-    PSRK4p7q6(stage_limiter!, step_limiter!, False())
 end
 
 @doc explicit_rk_docstring("5th order Explicit RK method.", "MSRK5",

--- a/src/algorithms/explicit_rk.jl
+++ b/src/algorithms/explicit_rk.jl
@@ -113,6 +113,78 @@ function RKM(stage_limiter!, step_limiter! = trivial_limiter!)
     RKM(stage_limiter!, step_limiter!, False())
 end
 
+@doc explicit_rk_docstring("4 stage Pseudo-Symplectic Explicit RK method.", "3p5q(4)",
+    references = "@article{Aubry1998,
+    author = {A. Aubry and P. Chartier},
+    journal = {BIT Numer. Math.},
+    title =  {Pseudo-symplectic {R}unge-{K}utta methods},
+    year = {1998},
+    },
+    @article{Capuano2017,
+    title = {Explicit {R}unge–{K}utta schemes for incompressible flow with improved energy-conservation properties},
+    journal = {J. Comput. Phys.},
+    year = {2017},
+    author = {F. Capuano and G. Coppola and L. Rández and L. {de Luca}},}")
+Base.@kwdef struct PSRK3p5q4{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqAlgorithm
+    stage_limiter!::StageLimiter = trivial_limiter!
+    step_limiter!::StepLimiter = trivial_limiter!
+    thread::Thread = False()
+end
+# for backwards compatibility
+function PSRK3p5q4(stage_limiter!, step_limiter! = trivial_limiter!)
+    PSRK3p5q4(stage_limiter!, step_limiter!, False())
+end
+
+@doc explicit_rk_docstring("5 stage Pseudo-Symplectic Explicit RK method.", "3p6q(5)",
+    references = "@article{Aubry1998,
+    author = {A. Aubry and P. Chartier},
+    journal = {BIT Numer. Math.},
+    title =  {Pseudo-symplectic {R}unge-{K}utta methods},
+    year = {1998},
+    },
+    @article{Capuano2017,
+    title = {Explicit {R}unge–{K}utta schemes for incompressible flow with improved energy-conservation properties},
+    journal = {J. Comput. Phys.},
+    year = {2017},
+    author = {F. Capuano and G. Coppola and L. Rández and L. {de Luca}},}")
+Base.@kwdef struct PSRK3p6q5{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqAlgorithm
+    stage_limiter!::StageLimiter = trivial_limiter!
+    step_limiter!::StepLimiter = trivial_limiter!
+    thread::Thread = False()
+end
+# for backwards compatibility
+function PSRK3p6q5(stage_limiter!, step_limiter! = trivial_limiter!)
+    PSRK3p6q5(stage_limiter!, step_limiter!, False())
+end
+
+@doc explicit_rk_docstring("6 stage Pseudo-Symplectic Explicit RK method.", "4p7q(6)",
+    references = "@article{Aubry1998,
+    author = {A. Aubry and P. Chartier},
+    journal = {BIT Numer. Math.},
+    title =  {Pseudo-symplectic {R}unge-{K}utta methods},
+    volume = {38},
+    PAGES = {439-461},
+    year = {1998},
+    },
+    @article{Capuano2017,
+    title = {Explicit {R}unge–{K}utta schemes for incompressible flow with improved energy-conservation properties},
+    journal = {J. Comput. Phys.},
+    volume = {328},
+    pages = {86-94},
+    year = {2017},
+    issn = {0021-9991},
+    doi = {https://doi.org/10.1016/j.jcp.2016.10.040},
+    author = {F. Capuano and G. Coppola and L. Rández and L. {de Luca}},}")
+Base.@kwdef struct PSRK4p7q6{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqAlgorithm
+    stage_limiter!::StageLimiter = trivial_limiter!
+    step_limiter!::StepLimiter = trivial_limiter!
+    thread::Thread = False()
+end
+# for backwards compatibility
+function PSRK4p7q6(stage_limiter!, step_limiter! = trivial_limiter!)
+    PSRK4p7q6(stage_limiter!, step_limiter!, False())
+end
+
 @doc explicit_rk_docstring("5th order Explicit RK method.", "MSRK5",
     references = "Misha Stepanov - https://arxiv.org/pdf/2202.08443.pdf : Figure 3.")
 Base.@kwdef struct MSRK5{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqAlgorithm

--- a/src/algorithms/explicit_rk.jl
+++ b/src/algorithms/explicit_rk.jl
@@ -113,7 +113,7 @@ function RKM(stage_limiter!, step_limiter! = trivial_limiter!)
     RKM(stage_limiter!, step_limiter!, False())
 end
 
-@doc explicit_rk_docstring("4 stage Pseudo-Symplectic Explicit RK method.", "3p5q(4)",
+@doc explicit_rk_docstring("4-stage Pseudo-Symplectic Explicit RK method.", "3p5q(4)",
     references = "@article{Aubry1998,
     author = {A. Aubry and P. Chartier},
     journal = {BIT Numer. Math.},
@@ -135,7 +135,7 @@ function PSRK3p5q4(stage_limiter!, step_limiter! = trivial_limiter!)
     PSRK3p5q4(stage_limiter!, step_limiter!, False())
 end
 
-@doc explicit_rk_docstring("5 stage Pseudo-Symplectic Explicit RK method.", "3p6q(5)",
+@doc explicit_rk_docstring("5-stage Pseudo-Symplectic Explicit RK method.", "3p6q(5)",
     references = "@article{Aubry1998,
     author = {A. Aubry and P. Chartier},
     journal = {BIT Numer. Math.},
@@ -157,7 +157,7 @@ function PSRK3p6q5(stage_limiter!, step_limiter! = trivial_limiter!)
     PSRK3p6q5(stage_limiter!, step_limiter!, False())
 end
 
-@doc explicit_rk_docstring("6 stage Pseudo-Symplectic Explicit RK method.", "4p7q(6)",
+@doc explicit_rk_docstring("6-stage Pseudo-Symplectic Explicit RK method.", "4p7q(6)",
     references = "@article{Aubry1998,
     author = {A. Aubry and P. Chartier},
     journal = {BIT Numer. Math.},

--- a/src/caches/low_order_rk_caches.jl
+++ b/src/caches/low_order_rk_caches.jl
@@ -1339,6 +1339,141 @@ function alg_cache(alg::MSRK6, u, rate_prototype, ::Type{uEltypeNoUnits},
         alg.stage_limiter!, alg.step_limiter!, alg.thread)
 end
 
+@cache struct PSRK4p7q6Cache{uType, rateType, TabType, StageLimiter, StepLimiter, Thread} <:
+              OrdinaryDiffEqMutableCache
+    u::uType
+    uprev::uType
+    tmp::uType
+    fsalfirst::uType
+    k1::rateType
+    k2::rateType
+    k3::rateType
+    k4::rateType
+    k5::rateType
+    k6::rateType
+    k7::rateType
+    k::rateType
+    tab::TabType
+    stage_limiter!::StageLimiter
+    step_limiter!::StepLimiter
+    thread::Thread
+end
+
+function alg_cache(alg::PSRK4p7q6, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{false}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    return PSRK4p7q6ConstantCache(
+        constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
+end
+
+function alg_cache(alg::PSRK4p7q6, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{true}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    k1 = zero(rate_prototype)
+    k2 = zero(rate_prototype)
+    k3 = zero(rate_prototype)
+    k4 = zero(rate_prototype)
+    k5 = zero(rate_prototype)
+    k6 = zero(rate_prototype)
+    k7 = zero(rate_prototype)
+    k = zero(rate_prototype)
+    tmp = zero(u)
+    fsalfirst = zero(u)
+    tab = PSRK4p7q6ConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
+    PSRK4p7q6Cache(u, uprev, tmp, fsalfirst, k1, k2, k3, k4, k5, k6, k7, k, tab,
+        alg.stage_limiter!, alg.step_limiter!, alg.thread)
+end
+
+@cache struct PSRK3p6q5Cache{uType, rateType, TabType, StageLimiter, StepLimiter, Thread} <:
+              OrdinaryDiffEqMutableCache
+    u::uType
+    uprev::uType
+    tmp::uType
+    fsalfirst::uType
+    k1::rateType
+    k2::rateType
+    k3::rateType
+    k4::rateType
+    k5::rateType
+    k6::rateType
+    k::rateType
+    tab::TabType
+    stage_limiter!::StageLimiter
+    step_limiter!::StepLimiter
+    thread::Thread
+end
+
+function alg_cache(alg::PSRK3p6q5, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{false}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    return PSRK3p6q5ConstantCache(
+        constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
+end
+
+function alg_cache(alg::PSRK3p6q5, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{true}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    k1 = zero(rate_prototype)
+    k2 = zero(rate_prototype)
+    k3 = zero(rate_prototype)
+    k4 = zero(rate_prototype)
+    k5 = zero(rate_prototype)
+    k6 = zero(rate_prototype)
+    k = zero(rate_prototype)
+    tmp = zero(u)
+    fsalfirst = zero(u)
+    tab = PSRK3p6q5ConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
+    PSRK3p6q5Cache(u, uprev, tmp, fsalfirst, k1, k2, k3, k4, k5, k6, k, tab,
+        alg.stage_limiter!, alg.step_limiter!, alg.thread)
+end
+
+@cache struct PSRK3p5q4Cache{uType, rateType, TabType, StageLimiter, StepLimiter, Thread} <:
+              OrdinaryDiffEqMutableCache
+    u::uType
+    uprev::uType
+    tmp::uType
+    fsalfirst::uType
+    k1::rateType
+    k2::rateType
+    k3::rateType
+    k4::rateType
+    k5::rateType
+    k::rateType
+    tab::TabType
+    stage_limiter!::StageLimiter
+    step_limiter!::StepLimiter
+    thread::Thread
+end
+
+function alg_cache(alg::PSRK3p5q4, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{false}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    return PSRK3p5q4ConstantCache(
+        constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
+end
+
+function alg_cache(alg::PSRK3p5q4, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{true}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    k1 = zero(rate_prototype)
+    k2 = zero(rate_prototype)
+    k3 = zero(rate_prototype)
+    k4 = zero(rate_prototype)
+    k5 = zero(rate_prototype)
+    k = zero(rate_prototype)
+    tmp = zero(u)
+    fsalfirst = zero(u)
+    tab = PSRK3p5q4ConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
+    PSRK3p5q4Cache(u, uprev, tmp, fsalfirst, k1, k2, k3, k4, k5, k, tab,
+        alg.stage_limiter!, alg.step_limiter!, alg.thread)
+end
+
 @cache struct Stepanov5Cache{uType, rateType, TabType, StageLimiter, StepLimiter, Thread} <:
               OrdinaryDiffEqMutableCache
     u::uType

--- a/src/caches/low_order_rk_caches.jl
+++ b/src/caches/low_order_rk_caches.jl
@@ -1343,16 +1343,13 @@ end
               OrdinaryDiffEqMutableCache
     u::uType
     uprev::uType
-    tmp::uType
-    fsalfirst::uType
     k1::rateType
     k2::rateType
     k3::rateType
     k4::rateType
     k5::rateType
     k6::rateType
-    k7::rateType
-    k::rateType
+    tmp::uType
     tab::TabType
     stage_limiter!::StageLimiter
     step_limiter!::StepLimiter
@@ -1377,12 +1374,9 @@ function alg_cache(alg::PSRK4p7q6, u, rate_prototype, ::Type{uEltypeNoUnits},
     k4 = zero(rate_prototype)
     k5 = zero(rate_prototype)
     k6 = zero(rate_prototype)
-    k7 = zero(rate_prototype)
-    k = zero(rate_prototype)
     tmp = zero(u)
-    fsalfirst = zero(u)
     tab = PSRK4p7q6ConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
-    PSRK4p7q6Cache(u, uprev, tmp, fsalfirst, k1, k2, k3, k4, k5, k6, k7, k, tab,
+    PSRK4p7q6Cache(u, uprev, k1, k2, k3, k4, k5, k6, tmp, tab,
         alg.stage_limiter!, alg.step_limiter!, alg.thread)
 end
 
@@ -1390,15 +1384,12 @@ end
               OrdinaryDiffEqMutableCache
     u::uType
     uprev::uType
-    tmp::uType
-    fsalfirst::uType
     k1::rateType
     k2::rateType
     k3::rateType
     k4::rateType
     k5::rateType
-    k6::rateType
-    k::rateType
+    tmp::uType
     tab::TabType
     stage_limiter!::StageLimiter
     step_limiter!::StepLimiter
@@ -1422,12 +1413,9 @@ function alg_cache(alg::PSRK3p6q5, u, rate_prototype, ::Type{uEltypeNoUnits},
     k3 = zero(rate_prototype)
     k4 = zero(rate_prototype)
     k5 = zero(rate_prototype)
-    k6 = zero(rate_prototype)
-    k = zero(rate_prototype)
     tmp = zero(u)
-    fsalfirst = zero(u)
     tab = PSRK3p6q5ConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
-    PSRK3p6q5Cache(u, uprev, tmp, fsalfirst, k1, k2, k3, k4, k5, k6, k, tab,
+    PSRK3p6q5Cache(u, uprev, tmp, k1, k2, k3, k4, k5, tab,
         alg.stage_limiter!, alg.step_limiter!, alg.thread)
 end
 
@@ -1435,14 +1423,11 @@ end
               OrdinaryDiffEqMutableCache
     u::uType
     uprev::uType
-    tmp::uType
-    fsalfirst::uType
     k1::rateType
     k2::rateType
     k3::rateType
     k4::rateType
-    k5::rateType
-    k::rateType
+    tmp::uType
     tab::TabType
     stage_limiter!::StageLimiter
     step_limiter!::StepLimiter
@@ -1465,12 +1450,9 @@ function alg_cache(alg::PSRK3p5q4, u, rate_prototype, ::Type{uEltypeNoUnits},
     k2 = zero(rate_prototype)
     k3 = zero(rate_prototype)
     k4 = zero(rate_prototype)
-    k5 = zero(rate_prototype)
-    k = zero(rate_prototype)
     tmp = zero(u)
-    fsalfirst = zero(u)
     tab = PSRK3p5q4ConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
-    PSRK3p5q4Cache(u, uprev, tmp, fsalfirst, k1, k2, k3, k4, k5, k, tab,
+    PSRK3p5q4Cache(u, uprev, tmp, k1, k2, k3, k4, tab,
         alg.stage_limiter!, alg.step_limiter!, alg.thread)
 end
 

--- a/src/perform_step/low_order_rk_perform_step.jl
+++ b/src/perform_step/low_order_rk_perform_step.jl
@@ -1467,6 +1467,272 @@ end
     return nothing
 end
 
+function initialize!(integrator, cache::PSRK4p7q6ConstantCache)
+    integrator.kshortsize = 7
+    integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
+    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
+    integrator.fsallast = zero(integrator.fsalfirst)
+    integrator.stats.nf += 1
+    integrator.k[1] = integrator.fsalfirst
+    @inbounds for i in 2:(integrator.kshortsize - 1)
+        integrator.k[i] = zero(integrator.fsalfirst)
+    end
+    integrator.k[integrator.kshortsize] = integrator.fsallast
+end
+
+function perform_step!(integrator, cache::PSRK4p7q6ConstantCache, repeat_step = false)
+    @unpack u, uprev, f, p, dt, t = integrator
+    @unpack a21, a31, a32, a41, a42, a43, a51, a52, a53, a54, a61, a62, a63, a64, a65, b1, b2, b3, b4, b5, b6, c2, c3, c4, c5, c6 = cache
+
+    k1 = integrator.fsalfirst
+    tmp = uprev + dt * (a21 * k1)
+    k2 = f(tmp, p, t + c2 * dt)
+    tmp = uprev + dt * (a31 * k1 + a32 * k2)
+    k3 = f(tmp, p, t + c3 * dt)
+    tmp = uprev + dt * (a41 * k1 + a42 * k2 + a43 * k3)
+    k4 = f(tmp, p, t + dt * c4)
+    tmp = uprev + dt * (a51 * k1 + a52 * k2 + a53 * k3 + a54 * k4)
+    k5 = f(tmp, p, t + dt * c5)
+    tmp = uprev + dt * (a61 * k1 + a62 * k2 + a63 * k3 + a64 * k4 + a65 * k5)
+    k6 = f(tmp, p, t + dt * c6)
+    u = uprev + dt * (b1 * k1 + b2 * k2 + b3 * k3 + b4 * k4 + b5 * k5 + b6 * k6)
+    k7 = f(u, p, t + dt)
+    integrator.fsallast = k7
+    integrator.stats.nf += 6
+
+    integrator.k[1] = k1
+    integrator.k[2] = k2
+    integrator.k[3] = k3
+    integrator.k[4] = k4
+    integrator.k[5] = k5
+    integrator.k[6] = k6
+    integrator.k[7] = k7
+    integrator.u = u
+end
+
+function initialize!(integrator, cache::PSRK4p7q6Cache)
+    @unpack uprev, f, p, t = integrator
+
+    integrator.kshortsize = 7
+    resize!(integrator.k, integrator.kshortsize)
+    integrator.k[1] = cache.k1
+    integrator.k[2] = cache.k2
+    integrator.k[3] = cache.k3
+    integrator.k[4] = cache.k4
+    integrator.k[5] = cache.k5
+    integrator.k[6] = cache.k6
+    integrator.k[7] = cache.k7
+    integrator.fsalfirst = cache.k1
+    integrator.fsallast = cache.k7
+
+    f(integrator.fsalfirst, uprev, p, t)
+    integrator.stats.nf += 1
+end
+
+function perform_step!(integrator, cache::PSRK4p7q6Cache, repeat_step = false)
+    @unpack k1, k2, k3, k4, k5, k6, k7, tmp, stage_limiter!, step_limiter!, thread = cache
+    @unpack a21, a31, a32, a41, a42, a43, a51, a52, a53, a54, a61, a62, a63, a64, a65, b1, b2, b3, b4, b5, b6, c2, c3, c4, c5, c6 = cache.tab
+    @unpack u, uprev, t, dt, f, p = integrator
+
+    @.. broadcast=false thread=thread tmp=uprev + dt * (a21 * k1)
+    stage_limiter!(tmp, integrator, p, t + c2 * dt)
+    f(k2, tmp, p, t + c2 * dt)
+    @.. broadcast=false thread=thread tmp=uprev + dt * (a31 * k1 + a32 * k2)
+    stage_limiter!(tmp, integrator, p, t + c3 * dt)
+    f(k3, tmp, p, t + c3 * dt)
+    @.. broadcast=false thread=thread tmp=uprev + dt * (a41 * k1 + a42 * k2 + a43 * k3)
+    stage_limiter!(tmp, integrator, p, t + c4 * dt)
+    f(k4, tmp, p, t + c4 * dt)
+    @.. broadcast=false thread=thread tmp=uprev +
+                                          dt * (a51 * k1 + a52 * k2 + a53 * k3 + a54 * k4)
+    stage_limiter!(tmp, integrator, p, t + c5 * dt)
+    f(k5, tmp, p, t + c5 * dt)
+    @.. broadcast=false thread=thread tmp=uprev +
+                                          dt * (a61 * k1 + a62 * k2 + a63 * k3 + a64 * k4 +
+                                           a65 * k5)
+    stage_limiter!(tmp, integrator, p, t + c6 * dt)
+    f(k6, tmp, p, t + c6 * dt)
+    @.. broadcast=false thread=thread u=uprev +
+                                        dt *
+                                        (b1 * k1 + b2 * k2 + b3 * k3 + b4 * k4 + b5 * k5 +
+                                         b6 * k6)
+    stage_limiter!(u, integrator, p, t + dt)
+    step_limiter!(u, integrator, p, t + dt)
+    f(k7, u, p, t + dt)
+    integrator.stats.nf += 6
+    integrator.fsallast = k7
+
+    return nothing
+end
+
+function initialize!(integrator, cache::PSRK3p6q5ConstantCache)
+    integrator.kshortsize = 6
+    integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
+    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
+    integrator.fsallast = zero(integrator.fsalfirst)
+    integrator.stats.nf += 1
+    integrator.k[1] = integrator.fsalfirst
+    @inbounds for i in 2:(integrator.kshortsize - 1)
+        integrator.k[i] = zero(integrator.fsalfirst)
+    end
+    integrator.k[integrator.kshortsize] = integrator.fsallast
+end
+
+function perform_step!(integrator, cache::PSRK3p6q5ConstantCache, repeat_step = false)
+    @unpack u, uprev, f, p, dt, t = integrator
+    @unpack a21, a31, a32, a41, a42, a43, a51, a52, a53, a54, b1, b2, b3, b4, b5, c2, c3, c4, c5 = cache
+
+    k1 = integrator.fsalfirst
+    tmp = uprev + dt * (a21 * k1)
+    k2 = f(tmp, p, t + c2 * dt)
+    tmp = uprev + dt * (a31 * k1 + a32 * k2)
+    k3 = f(tmp, p, t + c3 * dt)
+    tmp = uprev + dt * (a41 * k1 + a42 * k2 + a43 * k3)
+    k4 = f(tmp, p, t + dt * c4)
+    tmp = uprev + dt * (a51 * k1 + a52 * k2 + a53 * k3 + a54 * k4)
+    k5 = f(tmp, p, t + dt * c5)
+    u = uprev + dt * (b1 * k1 + b2 * k2 + b3 * k3 + b4 * k4 + b5 * k5)
+    k6 = f(u, p, t + dt)
+    integrator.fsallast = k6
+    integrator.stats.nf += 5
+
+    integrator.k[1] = k1
+    integrator.k[2] = k2
+    integrator.k[3] = k3
+    integrator.k[4] = k4
+    integrator.k[5] = k5
+    integrator.k[6] = k6
+    integrator.u = u
+end
+
+function initialize!(integrator, cache::PSRK3p6q5Cache)
+    @unpack uprev, f, p, t = integrator
+
+    integrator.kshortsize = 6
+    resize!(integrator.k, integrator.kshortsize)
+    integrator.k[1] = cache.k1
+    integrator.k[2] = cache.k2
+    integrator.k[3] = cache.k3
+    integrator.k[4] = cache.k4
+    integrator.k[5] = cache.k5
+    integrator.k[6] = cache.k6
+    integrator.fsalfirst = cache.k1
+    integrator.fsallast = cache.k6
+
+    f(integrator.fsalfirst, uprev, p, t)
+    integrator.stats.nf += 1
+end
+
+function perform_step!(integrator, cache::PSRK3p6q5Cache, repeat_step = false)
+    @unpack k1, k2, k3, k4, k5, k6, tmp, stage_limiter!, step_limiter!, thread = cache
+    @unpack a21, a31, a32, a41, a42, a43, a51, a52, a53, a54, b1, b2, b3, b4, b5, c2, c3, c4, c5 = cache.tab
+    @unpack u, uprev, t, dt, f, p = integrator
+
+    @.. broadcast=false thread=thread tmp=uprev + dt * (a21 * k1)
+    stage_limiter!(tmp, integrator, p, t + c2 * dt)
+    f(k2, tmp, p, t + c2 * dt)
+    @.. broadcast=false thread=thread tmp=uprev + dt * (a31 * k1 + a32 * k2)
+    stage_limiter!(tmp, integrator, p, t + c3 * dt)
+    f(k3, tmp, p, t + c3 * dt)
+    @.. broadcast=false thread=thread tmp=uprev + dt * (a41 * k1 + a42 * k2 + a43 * k3)
+    stage_limiter!(tmp, integrator, p, t + c4 * dt)
+    f(k4, tmp, p, t + c4 * dt)
+    @.. broadcast=false thread=thread tmp=uprev +
+                                          dt * (a51 * k1 + a52 * k2 + a53 * k3 + a54 * k4)
+    stage_limiter!(tmp, integrator, p, t + c5 * dt)
+    f(k5, tmp, p, t + c5 * dt)
+    @.. broadcast=false thread=thread u=uprev +
+                                        dt *
+                                        (b1 * k1 + b2 * k2 + b3 * k3 + b4 * k4 + b5 * k5)
+    stage_limiter!(u, integrator, p, t + dt)
+    step_limiter!(u, integrator, p, t + dt)
+    f(k6, u, p, t + dt)
+    integrator.stats.nf += 5
+    integrator.fsallast = k6
+
+    return nothing
+end
+
+function initialize!(integrator, cache::PSRK3p5q4ConstantCache)
+    integrator.kshortsize = 5
+    integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
+    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
+    integrator.fsallast = zero(integrator.fsalfirst)
+    integrator.stats.nf += 1
+    integrator.k[1] = integrator.fsalfirst
+    @inbounds for i in 2:(integrator.kshortsize - 1)
+        integrator.k[i] = zero(integrator.fsalfirst)
+    end
+    integrator.k[integrator.kshortsize] = integrator.fsallast
+end
+
+function perform_step!(integrator, cache::PSRK3p5q4ConstantCache, repeat_step = false)
+    @unpack u, uprev, f, p, dt, t = integrator
+    @unpack a21, a31, a32, a41, a42, a43, b1, b2, b3, b4, c2, c3, c4 = cache
+
+    k1 = integrator.fsalfirst
+    tmp = uprev + dt * (a21 * k1)
+    k2 = f(tmp, p, t + c2 * dt)
+    tmp = uprev + dt * (a31 * k1 + a32 * k2)
+    k3 = f(tmp, p, t + c3 * dt)
+    tmp = uprev + dt * (a41 * k1 + a42 * k2 + a43 * k3)
+    k4 = f(tmp, p, t + dt * c4)
+    u = uprev + dt * (b1 * k1 + b2 * k2 + b3 * k3 + b4 * k4)
+    k5 = f(u, p, t + dt)
+    integrator.fsallast = k5
+    integrator.stats.nf += 4
+
+    integrator.k[1] = k1
+    integrator.k[2] = k2
+    integrator.k[3] = k3
+    integrator.k[4] = k4
+    integrator.k[5] = k5
+    integrator.u = u
+end
+
+function initialize!(integrator, cache::PSRK3p5q4Cache)
+    @unpack uprev, f, p, t = integrator
+
+    integrator.kshortsize = 5
+    resize!(integrator.k, integrator.kshortsize)
+    integrator.k[1] = cache.k1
+    integrator.k[2] = cache.k2
+    integrator.k[3] = cache.k3
+    integrator.k[4] = cache.k4
+    integrator.k[5] = cache.k5
+    integrator.fsalfirst = cache.k1
+    integrator.fsallast = cache.k5
+
+    f(integrator.fsalfirst, uprev, p, t)
+    integrator.stats.nf += 1
+end
+
+function perform_step!(integrator, cache::PSRK3p5q4Cache, repeat_step = false)
+    @unpack k1, k2, k3, k4, k5, tmp, stage_limiter!, step_limiter!, thread = cache
+    @unpack a21, a31, a32, a41, a42, a43, b1, b2, b3, b4, c2, c3, c4 = cache.tab
+    @unpack u, uprev, t, dt, f, p = integrator
+
+    @.. broadcast=false thread=thread tmp=uprev + dt * (a21 * k1)
+    stage_limiter!(tmp, integrator, p, t + c2 * dt)
+    f(k2, tmp, p, t + c2 * dt)
+    @.. broadcast=false thread=thread tmp=uprev + dt * (a31 * k1 + a32 * k2)
+    stage_limiter!(tmp, integrator, p, t + c3 * dt)
+    f(k3, tmp, p, t + c3 * dt)
+    @.. broadcast=false thread=thread tmp=uprev + dt * (a41 * k1 + a42 * k2 + a43 * k3)
+    stage_limiter!(tmp, integrator, p, t + c4 * dt)
+    f(k4, tmp, p, t + c4 * dt)
+    @.. broadcast=false thread=thread u=uprev +
+                                        dt *
+                                        (b1 * k1 + b2 * k2 + b3 * k3 + b4 * k4)
+    stage_limiter!(u, integrator, p, t + dt)
+    step_limiter!(u, integrator, p, t + dt)
+    f(k5, u, p, t + dt)
+    integrator.stats.nf += 4
+    integrator.fsallast = k5
+
+    return nothing
+end
+
 function initialize!(integrator, cache::MSRK5ConstantCache)
     integrator.kshortsize = 9
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)

--- a/src/tableaus/low_order_rk_tableaus.jl
+++ b/src/tableaus/low_order_rk_tableaus.jl
@@ -1643,13 +1643,13 @@ function PSRK3p6q5ConstantCache(T::Type{<:CompiledFloats}, T1::Type{<:CompiledFl
     a53 = convert(T, 1.87865617737921)
     a54 = convert(T, -1.00257392477721)
 
-    b1 = convert(T, 0.13502027922909)
+    b1 = convert(T, 0.04113894457092)
     b2 = convert(T, 0.26732123194414)
     b3 = convert(T, 0.86700906289955)
     b4 = convert(T, -0.30547139552036)
     b5 = convert(T, 0.13000215610576)
 
-    c2 = convert(T1, 0.23593376536652)
+    c2 = convert(T1, 0.13502027922909)
     c3 = convert(T1, 0.58712036810182)
     c4 = convert(T1, 0.57332577194528)
     c5 = convert(T1, 1.0)

--- a/src/tableaus/low_order_rk_tableaus.jl
+++ b/src/tableaus/low_order_rk_tableaus.jl
@@ -1540,6 +1540,167 @@ function Anas5ConstantCache(T, T2)
         a65, c2, c3, c4, c5, c6, b1, b3, b4, b5, b6)
 end
 
+struct PSRK4p7q6ConstantCache{T, T1} <: OrdinaryDiffEqConstantCache
+    a21::T
+    a31::T
+    a32::T
+    a41::T
+    a42::T
+    a43::T
+    a51::T
+    a52::T
+    a53::T
+    a54::T
+    a61::T
+    a62::T
+    a63::T
+    a64::T
+    a65::T
+
+    b1::T
+    b2::T
+    b3::T
+    b4::T
+    b5::T
+    b6::T
+
+    c2::T1
+    c3::T1
+    c4::T1
+    c5::T1
+    c6::T1
+end
+
+function PSRK4p7q6ConstantCache(T::Type{<:CompiledFloats}, T1::Type{<:CompiledFloats})
+    a21 = convert(T, 0.23593376536652)
+    a31 = convert(T, 0.34750735658424)
+    a32 = convert(T, -0.13561935398346)
+    a41 = convert(T, -0.20592852403227)
+    a42 = convert(T, 1.89179076622108)
+    a43 = convert(T, -0.89775024478958)
+    a51 = convert(T, -0.09435493281455)
+    a52 = convert(T, 1.75617141223762)
+    a53 = convert(T, -0.96707850476948)
+    a54 = convert(T, 0.06932825997989)
+    a61 = convert(T, 0.14157883255197)
+    a62 = convert(T, -1.17039696277833)
+    a63 = convert(T, 1.30579112376331)
+    a64 = convert(T, -2.20354136855289)
+    a65 = convert(T, 2.92656837501595)
+
+    b1 = convert(T, 0.07078941627598)
+    b2 = convert(T, 0.87808570611881)
+    b3 = convert(T, -0.44887512239479)
+    b4 = convert(T, -0.44887512239479)
+    b5 = convert(T, 0.87808570611881)
+    b6 = convert(T, 0.07078941627598)
+
+    c2 = convert(T1, 0.23593376536652)
+    c3 = convert(T1, 0.21188800260078)
+    c4 = convert(T1, 0.78811199739923)
+    c5 = convert(T1, 0.76406623463348)
+    c6 = convert(T1, 1.0)
+
+    PSRK4p7q6ConstantCache(
+        a21, a31, a32, a41, a42, a43, a51, a52, a53, a54, a61, a62, a63, a64, a65,
+        b1, b2, b3, b4, b5, b6,
+        c2, c3, c4, c5, c6)
+end
+
+struct PSRK3p6q5ConstantCache{T, T1} <: OrdinaryDiffEqConstantCache
+    a21::T
+    a31::T
+    a32::T
+    a41::T
+    a42::T
+    a43::T
+    a51::T
+    a52::T
+    a53::T
+    a54::T
+
+    b1::T
+    b2::T
+    b3::T
+    b4::T
+    b5::T
+
+    c2::T1
+    c3::T1
+    c4::T1
+    c5::T1
+end
+
+function PSRK3p6q5ConstantCache(T::Type{<:CompiledFloats}, T1::Type{<:CompiledFloats})
+    a21 = convert(T, 0.13502027922909)
+    a31 = convert(T, -0.47268213605237)
+    a32 = convert(T, 1.05980250415419)
+    a41 = convert(T, -1.21650460595689)
+    a42 = convert(T, 2.16217630216753)
+    a43 = convert(T, -0.37234592426536)
+    a51 = convert(T, 0.33274443036387)
+    a52 = convert(T, -0.20882668296587)
+    a53 = convert(T, 1.87865617737921)
+    a54 = convert(T, -1.00257392477721)
+
+    b1 = convert(T, 0.13502027922909)
+    b2 = convert(T, 0.26732123194414)
+    b3 = convert(T, 0.86700906289955)
+    b4 = convert(T, -0.30547139552036)
+    b5 = convert(T, 0.13000215610576)
+
+    c2 = convert(T1, 0.23593376536652)
+    c3 = convert(T1, 0.58712036810182)
+    c4 = convert(T1, 0.57332577194528)
+    c5 = convert(T1, 1.0)
+
+    PSRK3p6q5ConstantCache(
+        a21, a31, a32, a41, a42, a43, a51, a52, a53, a54,
+        b1, b2, b3, b4, b5,
+        c2, c3, c4, c5)
+end
+
+struct PSRK3p5q4ConstantCache{T, T1} <: OrdinaryDiffEqConstantCache
+    a21::T
+    a31::T
+    a32::T
+    a41::T
+    a42::T
+    a43::T
+
+    b1::T
+    b2::T
+    b3::T
+    b4::T
+
+    c2::T1
+    c3::T1
+    c4::T1
+end
+
+function PSRK3p5q4ConstantCache(T::Type, T1::Type)
+    a21 = T(3 // 8)
+    a31 = T(11 // 12)
+    a32 = T(-2 // 3)
+    a41 = T(-1 // 12)
+    a42 = T(11 // 6)
+    a43 = T(-3 // 4)
+
+    b1 = T(1 // 9)
+    b2 = T(8 // 9)
+    b3 = T(-2 // 9)
+    b4 = T(2 // 9)
+
+    c2 = T1(3 // 8)
+    c3 = T1(1 // 4)
+    c4 = T1(1)
+
+    PSRK3p5q4ConstantCache(
+        a21, a31, a32, a41, a42, a43,
+        b1, b2, b3, b4,
+        c2, c3, c4)
+end
+
 struct MSRK5ConstantCache{T, T1} <: OrdinaryDiffEqConstantCache
     a21::T
     a31::T

--- a/test/algconvergence/ode_convergence_tests.jl
+++ b/test/algconvergence/ode_convergence_tests.jl
@@ -47,8 +47,14 @@ testTol = 0.2
     @test sim3.𝒪est[:l∞]≈4 atol=0.2
 
     sim_ps6 = test_convergence(dts2, prob, PSRK4p7q6())
-    @test sim_ps6.𝒪est[:l∞]≈5 atol=testTol
+    @test sim_ps6.𝒪est[:l∞]≈4 atol=testTol
 
+    sim_ps5 = test_convergence(dts2, prob, PSRK3p6q5())
+    @test sim_ps5.𝒪est[:l∞]≈4 atol=testTol
+
+    sim_ps4 = test_convergence(dts2, prob, PSRK3p5q4())
+    @test sim_ps4.𝒪est[:l∞]≈4 atol=testTol
+    
     sim_ms5 = test_convergence(dts2, prob, MSRK5())
     @test sim_ms5.𝒪est[:l∞]≈5 atol=testTol
 

--- a/test/algconvergence/ode_convergence_tests.jl
+++ b/test/algconvergence/ode_convergence_tests.jl
@@ -12,6 +12,13 @@ dts5 = 1 .// 2 .^ (3:-1:1)
 dts6 = 1 .// 10 .^ (5:-1:1)
 testTol = 0.2
 
+f = (u, p, t) -> sin(u)
+prob_ode_nonlinear = ODEProblem(
+    ODEFunction(f;
+        analytic = (u0, p, t) -> 2 * acot(exp(-t) *
+                                          cot(0.5))), 1.0,
+    (0.0, 0.5))
+
 @testset "Explicit Solver Convergence Tests ($(["out-of-place", "in-place"][i]))" for i in 1:2
     prob = (ODEProblemLibrary.prob_ode_linear,
         ODEProblemLibrary.prob_ode_2Dlinear)[i]
@@ -46,14 +53,14 @@ testTol = 0.2
     sim3 = test_convergence(dts, prob, RKM())
     @test sim3.𝒪est[:l∞]≈4 atol=0.2
 
-    sim_ps6 = test_convergence(dts2, prob, PSRK4p7q6())
+    sim_ps6 = test_convergence(dts2, prob_ode_nonlinear, PSRK4p7q6())
     @test sim_ps6.𝒪est[:l∞]≈4 atol=testTol
 
-    sim_ps5 = test_convergence(dts2, prob, PSRK3p6q5())
-    @test sim_ps5.𝒪est[:l∞]≈4 atol=testTol
+    sim_ps5 = test_convergence(dts2, prob_ode_nonlinear, PSRK3p6q5())
+    @test sim_ps5.𝒪est[:l∞]≈3 atol=testTol
 
-    sim_ps4 = test_convergence(dts2, prob, PSRK3p5q4())
-    @test sim_ps4.𝒪est[:l∞]≈4 atol=testTol
+    sim_ps4 = test_convergence(dts2, prob_ode_nonlinear, PSRK3p5q4())
+    @test sim_ps4.𝒪est[:l∞]≈3 atol=testTol
 
     sim_ms5 = test_convergence(dts2, prob, MSRK5())
     @test sim_ms5.𝒪est[:l∞]≈5 atol=testTol

--- a/test/algconvergence/ode_convergence_tests.jl
+++ b/test/algconvergence/ode_convergence_tests.jl
@@ -46,6 +46,9 @@ testTol = 0.2
     sim3 = test_convergence(dts, prob, RKM())
     @test sim3.𝒪est[:l∞]≈4 atol=0.2
 
+    sim_ps6 = test_convergence(dts2, prob, PSRK4p7q6())
+    @test sim_ps6.𝒪est[:l∞]≈5 atol=testTol
+
     sim_ms5 = test_convergence(dts2, prob, MSRK5())
     @test sim_ms5.𝒪est[:l∞]≈5 atol=testTol
 

--- a/test/algconvergence/ode_convergence_tests.jl
+++ b/test/algconvergence/ode_convergence_tests.jl
@@ -54,7 +54,7 @@ testTol = 0.2
 
     sim_ps4 = test_convergence(dts2, prob, PSRK3p5q4())
     @test sim_ps4.𝒪est[:l∞]≈4 atol=testTol
-    
+
     sim_ms5 = test_convergence(dts2, prob, MSRK5())
     @test sim_ms5.𝒪est[:l∞]≈5 atol=testTol
 

--- a/test/algconvergence/ode_rosenbrock_tests.jl
+++ b/test/algconvergence/ode_rosenbrock_tests.jl
@@ -106,7 +106,7 @@ import LinearSolve
 
     sol = solve(prob, ROS2PR())
     @test length(sol) < 60
-    
+
     ### ROS2PR
     prob = prob_ode_linear
 

--- a/test/regression/iipvsoop_tests.jl
+++ b/test/regression/iipvsoop_tests.jl
@@ -117,8 +117,8 @@ working_rosenbrock_algs = [Rosenbrock23(), ROS3P(), Rodas3(),
     RosShamp4(), Veldd4(), Velds4(), GRK4T(), GRK4A(),
     Ros4LStab(), Rodas4(), Rodas42(), Rodas4P(), Rodas5(),
     ROS2(), ROS2PR(), ROS2S(), ROS3(), ROS3PR(), Scholz4_7(),
-    ROS34PW1a(), ROS34PW1b(), ROS34PW2(), ROS34PW3(), 
-    ROS34PRw(), ROS3PRL(), ROS3PRL2()] 
+    ROS34PW1a(), ROS34PW1b(), ROS34PW2(), ROS34PW3(),
+    ROS34PRw(), ROS3PRL(), ROS3PRL2()]
 
 rosenbrock_algs = [Rosenbrock32()
 ]


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

This implements some methods mentioned in https://github.com/SciML/OrdinaryDiffEq.jl/issues/1987

references
```
 "@article{Aubry1998,
    author = {A. Aubry and P. Chartier},
    journal = {BIT Numer. Math.},
    title =  {Pseudo-symplectic {R}unge-{K}utta methods},
    volume = {38},
    PAGES = {439-461},
    year = {1998},
    },
    https://link.springer.com/article/10.1007/BF02510253
```
    
```
    @article{Capuano2017,
    title = {Explicit {R}unge–{K}utta schemes for incompressible flow with improved energy-conservation properties},
    journal = {J. Comput. Phys.},
    volume = {328},
    pages = {86-94},
    year = {2017},
    issn = {0021-9991},
    doi = {https://doi.org/10.1016/j.jcp.2016.10.040},
    author = {F. Capuano and G. Coppola and L. Rández and L. {de Luca}},}"
```


I just did the ode_convergence_test locally. Please, let me know if any other tests are required. Thank you!