### PR TITLE
Optimistic first time convergence criterion

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -406,7 +406,8 @@ export SplitEuler
 
 export Nystrom4, FineRKN4, FineRKN5, Nystrom4VelocityIndependent,
        Nystrom5VelocityIndependent,
-       IRKN3, IRKN4, DPRKN4, DPRKN5, DPRKN6, DPRKN6FM, DPRKN8, DPRKN12, ERKN4, ERKN5, ERKN7, RKN4
+       IRKN3, IRKN4, DPRKN4, DPRKN5, DPRKN6, DPRKN6FM, DPRKN8, DPRKN12, ERKN4, ERKN5, ERKN7,
+       RKN4
 
 export ROCK2, ROCK4, RKC, IRKC, ESERK4, ESERK5, SERK2
 

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1217,6 +1217,7 @@ struct ERKN7 <: OrdinaryDiffEqAdaptivePartitionedAlgorithm end
 Does not include an adaptive method. Solves for for d-dimensional differential systems of second order linear inhomogeneous equations.
 
 !!! warn
+
     This method is only fourth order for these systems, the method is second order otherwise!
 
 ## References

--- a/src/caches/rkn_caches.jl
+++ b/src/caches/rkn_caches.jl
@@ -693,9 +693,9 @@ end
 end
 
 function alg_cache(alg::RKN4, u, rate_prototype, ::Type{uEltypeNoUnits},
-    ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
-    dt, reltol, p, calck,
-    ::Val{true}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{true}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
     reduced_rate_prototype = rate_prototype.x[2]
     k₁ = zero(rate_prototype)
     k₂ = zero(reduced_rate_prototype)

--- a/src/caches/rosenbrock_caches.jl
+++ b/src/caches/rosenbrock_caches.jl
@@ -1045,7 +1045,8 @@ function alg_cache(alg::Rodas5, u, rate_prototype, ::Type{uEltypeNoUnits},
             constvalue(tTypeNoUnits)), J, W, linsolve)
 end
 
-function alg_cache(alg::Union{Rodas5P, Rodas5Pe, Rodas5Pr}, u, rate_prototype, ::Type{uEltypeNoUnits},
+function alg_cache(
+        alg::Union{Rodas5P, Rodas5Pe, Rodas5Pr}, u, rate_prototype, ::Type{uEltypeNoUnits},
         ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
         dt, reltol, p, calck,
         ::Val{true}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
@@ -1093,7 +1094,8 @@ function alg_cache(alg::Union{Rodas5P, Rodas5Pe, Rodas5Pr}, u, rate_prototype, :
         linsolve, jac_config, grad_config, reltol, alg)
 end
 
-function alg_cache(alg::Union{Rodas5P, Rodas5Pe, Rodas5Pr}, u, rate_prototype, ::Type{uEltypeNoUnits},
+function alg_cache(
+        alg::Union{Rodas5P, Rodas5Pe, Rodas5Pr}, u, rate_prototype, ::Type{uEltypeNoUnits},
         ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
         dt, reltol, p, calck,
         ::Val{false}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -750,7 +750,8 @@ end
         if J isa StaticArray &&
            integrator.alg isa
            Union{
-            Rosenbrock23, Rodas23W, Rodas3P, Rodas4, Rodas4P, Rodas4P2, Rodas5, Rodas5P, Rodas5Pe, Rodas5Pr}
+            Rosenbrock23, Rodas23W, Rodas3P, Rodas4, Rodas4P, Rodas4P2,
+            Rodas5, Rodas5P, Rodas5Pe, Rodas5Pr}
             W = W_transform ? J - mass_matrix * inv(dtgamma) :
                 dtgamma * J - mass_matrix
         else
@@ -775,7 +776,8 @@ end
                 W_full
             elseif len !== nothing &&
                    integrator.alg isa
-                   Union{Rosenbrock23, Rodas23W, Rodas3P, Rodas4, Rodas4P, Rodas4P2, Rodas5, Rodas5P, Rodas5Pe, Rodas5Pr}
+                   Union{Rosenbrock23, Rodas23W, Rodas3P, Rodas4, Rodas4P,
+                Rodas4P2, Rodas5, Rodas5P, Rodas5Pe, Rodas5Pr}
                 StaticWOperator(W_full)
             else
                 DiffEqBase.default_factorize(W_full)
@@ -923,7 +925,8 @@ function build_J_W(alg, u, uprev, p, t, dt, f::F, ::Type{uEltypeNoUnits},
             len = StaticArrayInterface.known_length(typeof(J))
             if len !== nothing &&
                alg isa
-               Union{Rosenbrock23, Rodas23W, Rodas3P, Rodas4, Rodas4P, Rodas4P2, Rodas5, Rodas5P, Rodas5Pe, Rodas5Pr}
+               Union{Rosenbrock23, Rodas23W, Rodas3P, Rodas4, Rodas4P,
+                Rodas4P2, Rodas5, Rodas5P, Rodas5Pe, Rodas5Pr}
                 StaticWOperator(J, false)
             else
                 ArrayInterface.lu_instance(J)

--- a/src/integrators/controllers.jl
+++ b/src/integrators/controllers.jl
@@ -16,6 +16,12 @@ end
 
 @inline function step_reject_controller!(integrator, alg)
     step_reject_controller!(integrator, integrator.opts.controller, alg)
+    cache = integrator.cache
+    if hasfield(typeof(cache), :nlsolve)
+        nlsolve = cache.nlsolve
+        nlsolve.prev_θ = one(nlsolve.prev_θ)
+    end
+    return nothing
 end
 
 reset_alg_dependent_opts!(controller::AbstractController, alg1, alg2) = nothing

--- a/src/nlsolve/nlsolve.jl
+++ b/src/nlsolve/nlsolve.jl
@@ -98,7 +98,8 @@ function nlsolve!(nlsolver::NL, integrator::DiffEqBase.DEIntegrator,
 
         # check for convergence
         η = DiffEqBase.value(θ / (1 - θ))
-        if (iter == 1 && ndz < 1e-5) || (η >= zero(η) && η * ndz < κ)
+        if (iter == 1 && ndz < 1e-5) ||
+           ((iter > 1 || isnewton(nlsolver)) && η >= zero(η) && η * ndz < κ)
             nlsolver.status = Convergence
             nlsolver.nfails = 0
             break

--- a/src/nlsolve/type.jl
+++ b/src/nlsolve/type.jl
@@ -96,7 +96,8 @@ function NLSolver{iip, tType}(z, tmp, ztmp, γ, c, α, alg, κ, fast_convergence
         iter, maxiters, status, cache, method = DIRK, tmp2 = nothing,
         nfails::Int = 0) where {iip, tType}
     T = eltype(z)
-    NLSolver{typeof(alg), iip, typeof(z), typeof(γ), typeof(tmp2), tType, typeof(cache), T}(z,
+    NLSolver{typeof(alg), iip, typeof(z), typeof(γ), typeof(tmp2), tType, typeof(cache), T}(
+        z,
         tmp,
         tmp2,
         ztmp,

--- a/src/nlsolve/type.jl
+++ b/src/nlsolve/type.jl
@@ -95,8 +95,8 @@ end
 function NLSolver{iip, tType}(z, tmp, ztmp, γ, c, α, alg, κ, fast_convergence_cutoff, ηold,
         iter, maxiters, status, cache, method = DIRK, tmp2 = nothing,
         nfails::Int = 0) where {iip, tType}
-    T = eltype(z)
-    NLSolver{typeof(alg), iip, typeof(z), typeof(γ), typeof(tmp2), tType, typeof(cache), T}(
+    RT = real(eltype(z))
+    NLSolver{typeof(alg), iip, typeof(z), typeof(γ), typeof(tmp2), tType, typeof(cache), RT}(
         z,
         tmp,
         tmp2,
@@ -119,7 +119,7 @@ function NLSolver{iip, tType}(z, tmp, ztmp, γ, c, α, alg, κ, fast_convergence
         cache,
         method,
         nfails,
-        one(T))
+        one(RT))
 end
 
 # caches

--- a/src/nlsolve/type.jl
+++ b/src/nlsolve/type.jl
@@ -70,7 +70,7 @@ end
 abstract type AbstractNLSolver{algType, iip} end
 
 mutable struct NLSolver{algType, iip, uType, gamType, tmpType, tType,
-    C <: AbstractNLSolverCache} <: AbstractNLSolver{algType, iip}
+    C <: AbstractNLSolverCache, E} <: AbstractNLSolver{algType, iip}
     z::uType
     tmp::uType # DIRK and multistep methods only use tmp
     tmp2::tmpType # for GLM if neccssary
@@ -88,13 +88,15 @@ mutable struct NLSolver{algType, iip, uType, gamType, tmpType, tType,
     cache::C
     method::MethodType
     nfails::Int
+    prev_η::E
 end
 
 # default to DIRK
 function NLSolver{iip, tType}(z, tmp, ztmp, γ, c, α, alg, κ, fast_convergence_cutoff, ηold,
         iter, maxiters, status, cache, method = DIRK, tmp2 = nothing,
         nfails::Int = 0) where {iip, tType}
-    NLSolver{typeof(alg), iip, typeof(z), typeof(γ), typeof(tmp2), tType, typeof(cache)}(z,
+    T = eltype(z)
+    NLSolver{typeof(alg), iip, typeof(z), typeof(γ), typeof(tmp2), tType, typeof(cache), T}(z,
         tmp,
         tmp2,
         ztmp,
@@ -115,7 +117,8 @@ function NLSolver{iip, tType}(z, tmp, ztmp, γ, c, α, alg, κ, fast_convergence
         status,
         cache,
         method,
-        nfails)
+        nfails,
+        one(T))
 end
 
 # caches

--- a/src/nlsolve/type.jl
+++ b/src/nlsolve/type.jl
@@ -88,7 +88,7 @@ mutable struct NLSolver{algType, iip, uType, gamType, tmpType, tType,
     cache::C
     method::MethodType
     nfails::Int
-    prev_η::E
+    prev_θ::E
 end
 
 # default to DIRK

--- a/src/perform_step/rkn_perform_step.jl
+++ b/src/perform_step/rkn_perform_step.jl
@@ -1840,12 +1840,12 @@ end
     duprev, uprev = integrator.uprev.x
     u, du = integrator.u.x
     #define dt values
-    halfdt = dt/2
+    halfdt = dt / 2
     dtsq = dt^2
-    eightdtsq = dtsq/8
-    halfdtsq = dtsq/2
-    sixthdtsq = dtsq/6
-    sixthdt = dt/6
+    eightdtsq = dtsq / 8
+    halfdtsq = dtsq / 2
+    sixthdtsq = dtsq / 6
+    sixthdt = dt / 6
     ttmp = t + halfdt
 
     #perform operations to find k values
@@ -1860,13 +1860,13 @@ end
     k₃ = f.f1(kdu, ku, p, t + dt)
 
     #perform final calculations to determine new y and y'.
-    u = uprev + sixthdtsq* (1*k₁ + 2*k₂ + 0*k₃) + dt * duprev
-    du = duprev + sixthdt * (1*k₁ + 4*k₂ + 1*k₃)
+    u = uprev + sixthdtsq * (1 * k₁ + 2 * k₂ + 0 * k₃) + dt * duprev
+    du = duprev + sixthdt * (1 * k₁ + 4 * k₂ + 1 * k₃)
 
     integrator.u = ArrayPartition((du, u))
     integrator.fsallast = ArrayPartition((f.f1(du, u, p, t + dt), f.f2(du, u, p, t + dt)))
     integrator.stats.nf += 2
-    integrator.stats.nf2 += 1    
+    integrator.stats.nf2 += 1
     integrator.k[1] = integrator.fsalfirst
     integrator.k[2] = integrator.fsallast
 end
@@ -1879,28 +1879,28 @@ end
     kdu, ku = integrator.cache.tmp.x[1], integrator.cache.tmp.x[2]
 
     #define dt values
-    halfdt = dt/2
+    halfdt = dt / 2
     dtsq = dt^2
-    eightdtsq = dtsq/8
-    halfdtsq = dtsq/2
-    sixthdtsq = dtsq/6
-    sixthdt = dt/6
+    eightdtsq = dtsq / 8
+    halfdtsq = dtsq / 2
+    sixthdtsq = dtsq / 6
+    sixthdt = dt / 6
     ttmp = t + halfdt
 
     #perform operations to find k values
     k₁ = integrator.fsalfirst.x[1]
-    @.. broadcast=false ku = uprev + halfdt * duprev + eightdtsq * k₁
-    @.. broadcast=false kdu = duprev + halfdt * k₁
+    @.. broadcast=false ku=uprev + halfdt * duprev + eightdtsq * k₁
+    @.. broadcast=false kdu=duprev + halfdt * k₁
 
     f.f1(k₂, kdu, ku, p, ttmp)
-    @.. broadcast=false ku = uprev + dt * duprev + halfdtsq * k₂
-    @.. broadcast=false kdu = duprev + dt * k₂
+    @.. broadcast=false ku=uprev + dt * duprev + halfdtsq * k₂
+    @.. broadcast=false kdu=duprev + dt * k₂
 
     f.f1(k₃, kdu, ku, p, t + dt)
 
     #perform final calculations to determine new y and y'.
-    @.. broadcast=false u = uprev + sixthdtsq* (1*k₁ + 2*k₂ + 0*k₃) + dt * duprev
-    @.. broadcast=false du = duprev + sixthdt * (1*k₁ + 4*k₂ + 1*k₃)
+    @.. broadcast=false u=uprev + sixthdtsq * (1 * k₁ + 2 * k₂ + 0 * k₃) + dt * duprev
+    @.. broadcast=false du=duprev + sixthdt * (1 * k₁ + 4 * k₂ + 1 * k₃)
 
     f.f1(k.x[1], du, u, p, t + dt)
     f.f2(k.x[2], du, u, p, t + dt)

--- a/src/perform_step/rosenbrock_perform_step.jl
+++ b/src/perform_step/rosenbrock_perform_step.jl
@@ -1068,16 +1068,18 @@ end
         integrator.k[2] = h31 * k1 + h32 * k2 + h33 * k3 + h34 * k4 + h35 * k5
         integrator.k[3] = h2_21 * k1 + h2_22 * k2 + h2_23 * k3 + h2_24 * k4 + h2_25 * k5
         if integrator.opts.adaptive
-            if  isa(linsolve_tmp,AbstractFloat)
-                u_int, u_diff = calculate_interpoldiff(uprev, du, u, integrator.k[1], integrator.k[2], integrator.k[3])
+            if isa(linsolve_tmp, AbstractFloat)
+                u_int, u_diff = calculate_interpoldiff(
+                    uprev, du, u, integrator.k[1], integrator.k[2], integrator.k[3])
             else
-                u_int = linsolve_tmp 
+                u_int = linsolve_tmp
                 u_diff = linsolve_tmp .+ 0
-                calculate_interpoldiff!(u_int, u_diff, uprev, du, u, integrator.k[1], integrator.k[2], integrator.k[3])
+                calculate_interpoldiff!(u_int, u_diff, uprev, du, u, integrator.k[1],
+                    integrator.k[2], integrator.k[3])
             end
             atmp = calculate_residuals(u_diff, uprev, u_int, integrator.opts.abstol,
                 integrator.opts.reltol, integrator.opts.internalnorm, t)
-            EEst = max(EEst,integrator.opts.internalnorm(atmp, t))  #-- role of t unclear
+            EEst = max(EEst, integrator.opts.internalnorm(atmp, t))  #-- role of t unclear
         end
     end
 
@@ -1087,7 +1089,7 @@ end
         du = k1 .+ 0
         if integrator.opts.calck
             integrator.k[1] = integrator.k[3] .+ 0
-            integrator.k[2] = 0*integrator.k[2]
+            integrator.k[2] = 0 * integrator.k[2]
         end
     end
 
@@ -1465,24 +1467,24 @@ function calculate_interpoldiff(uprev, up2, up3, c_koeff, d_koeff, c2_koeff)
     a1 = up3 + c_koeff - up2 - c2_koeff
     a2 = d_koeff - c_koeff + c2_koeff
     a3 = -d_koeff
-    dis = a2^2 - 3*a1*a3
+    dis = a2^2 - 3 * a1 * a3
     u_int = up3
     u_diff = 0.0
     if dis > 0.0 #-- Min/Max occurs
-        tau1 = (-a2 - sqrt(dis))/(3*a3)
-        tau2 = (-a2 + sqrt(dis))/(3*a3)
-        if tau1 > tau2 
-            tau1,tau2 = tau2,tau1 
+        tau1 = (-a2 - sqrt(dis)) / (3 * a3)
+        tau2 = (-a2 + sqrt(dis)) / (3 * a3)
+        if tau1 > tau2
+            tau1, tau2 = tau2, tau1
         end
-        for tau in (tau1,tau2)
+        for tau in (tau1, tau2)
             if (tau > 0.0) && (tau < 1.0)
-                y_tau = (1 - tau)*uprev + 
-                        tau*(up3 + (1 - tau)*(c_koeff + tau*d_koeff))
-                dy_tau = ((a3*tau + a2)*tau + a1)*tau
+                y_tau = (1 - tau) * uprev +
+                        tau * (up3 + (1 - tau) * (c_koeff + tau * d_koeff))
+                dy_tau = ((a3 * tau + a2) * tau + a1) * tau
                 if abs(dy_tau) > abs(u_diff)
                     u_diff = dy_tau
                     u_int = y_tau
-                 end
+                end
             end
         end
     end
@@ -2215,10 +2217,12 @@ end
     linsolve_tmp = k8
 
     if integrator.opts.adaptive
-	    if (integrator.alg isa Rodas5Pe)
-            linsolve_tmp = 0.2606326497975715*k1 - 0.005158627295444251*k2 + 1.3038988631109731*k3 + 1.235000722062074*k4 +
-               - 0.7931985603795049*k5 - 1.005448461135913*k6 - 0.18044626132120234*k7 + 0.17051519239113755*k8
-	    end
+        if (integrator.alg isa Rodas5Pe)
+            linsolve_tmp = 0.2606326497975715 * k1 - 0.005158627295444251 * k2 +
+                           1.3038988631109731 * k3 + 1.235000722062074 * k4 +
+                           -0.7931985603795049 * k5 - 1.005448461135913 * k6 -
+                           0.18044626132120234 * k7 + 0.17051519239113755 * k8
+        end
         atmp = calculate_residuals(linsolve_tmp, uprev, u, integrator.opts.abstol,
             integrator.opts.reltol, integrator.opts.internalnorm, t)
         integrator.EEst = integrator.opts.internalnorm(atmp, t)
@@ -2232,18 +2236,20 @@ end
                           h37 * k7 + h38 * k8
         integrator.k[3] = h41 * k1 + h42 * k2 + h43 * k3 + h44 * k4 + h45 * k5 + h46 * k6 +
                           h47 * k7 + h48 * k8
-        if (integrator.alg isa Rodas5Pr) && integrator.opts.adaptive && (integrator.EEst < 1.0)
-            k2 = 0.5*(uprev + u + 0.5 * (integrator.k[1] + 0.5 * (integrator.k[2] + 0.5 * integrator.k[3])))
-            du1 = ( 0.25*(integrator.k[2] + integrator.k[3]) - uprev + u) / dt
-            du = f(k2, p, t + dt/2)
+        if (integrator.alg isa Rodas5Pr) && integrator.opts.adaptive &&
+           (integrator.EEst < 1.0)
+            k2 = 0.5 * (uprev + u +
+                  0.5 * (integrator.k[1] + 0.5 * (integrator.k[2] + 0.5 * integrator.k[3])))
+            du1 = (0.25 * (integrator.k[2] + integrator.k[3]) - uprev + u) / dt
+            du = f(k2, p, t + dt / 2)
             integrator.stats.nf += 1
             if mass_matrix === I
                 du2 = du1 - du
             else
-                du2 = mass_matrix*du1 - du
+                du2 = mass_matrix * du1 - du
             end
-	        EEst = norm(du2) / (integrator.opts.abstol + integrator.opts.reltol*norm(k2)) 
-            integrator.EEst = max(EEst,integrator.EEst)
+            EEst = norm(du2) / (integrator.opts.abstol + integrator.opts.reltol * norm(k2))
+            integrator.EEst = max(EEst, integrator.EEst)
         end
     end
 
@@ -2464,10 +2470,12 @@ end
     u .+= k8
 
     if integrator.opts.adaptive
-	    if (integrator.alg isa Rodas5Pe)
-            du = 0.2606326497975715*k1 - 0.005158627295444251*k2 + 1.3038988631109731*k3 + 1.235000722062074*k4 +
-               - 0.7931985603795049*k5 - 1.005448461135913*k6 - 0.18044626132120234*k7 + 0.17051519239113755*k8
-	    end
+        if (integrator.alg isa Rodas5Pe)
+            du = 0.2606326497975715 * k1 - 0.005158627295444251 * k2 +
+                 1.3038988631109731 * k3 + 1.235000722062074 * k4 +
+                 -0.7931985603795049 * k5 - 1.005448461135913 * k6 -
+                 0.18044626132120234 * k7 + 0.17051519239113755 * k8
+        end
         calculate_residuals!(atmp, du, uprev, u, integrator.opts.abstol,
             integrator.opts.reltol, integrator.opts.internalnorm, t)
         integrator.EEst = integrator.opts.internalnorm(atmp, t)
@@ -2481,10 +2489,12 @@ end
                                             h35 * k5 + h36 * k6 + h37 * k7 + h38 * k8
         @.. broadcast=false integrator.k[3]=h41 * k1 + h42 * k2 + h43 * k3 + h44 * k4 +
                                             h45 * k5 + h46 * k6 + h47 * k7 + h48 * k8
-        if (integrator.alg isa Rodas5Pr) && integrator.opts.adaptive && (integrator.EEst < 1.0)
-            k2 = 0.5*(uprev + u + 0.5 * (integrator.k[1] + 0.5 * (integrator.k[2] + 0.5 * integrator.k[3])))
-            du1 = ( 0.25*(integrator.k[2] + integrator.k[3]) - uprev + u) / dt
-            f(du, k2, p, t + dt/2)
+        if (integrator.alg isa Rodas5Pr) && integrator.opts.adaptive &&
+           (integrator.EEst < 1.0)
+            k2 = 0.5 * (uprev + u +
+                  0.5 * (integrator.k[1] + 0.5 * (integrator.k[2] + 0.5 * integrator.k[3])))
+            du1 = (0.25 * (integrator.k[2] + integrator.k[3]) - uprev + u) / dt
+            f(du, k2, p, t + dt / 2)
             integrator.stats.nf += 1
             if mass_matrix === I
                 du2 = du1 - du
@@ -2492,8 +2502,8 @@ end
                 mul!(_vec(du2), mass_matrix, _vec(du1))
                 du2 = du2 - du
             end
-	        EEst = norm(du2) / (integrator.opts.abstol + integrator.opts.reltol*norm(k2)) 
-            integrator.EEst = max(EEst,integrator.EEst)
+            EEst = norm(du2) / (integrator.opts.abstol + integrator.opts.reltol * norm(k2))
+            integrator.EEst = max(EEst, integrator.EEst)
         end
     end
     cache.linsolve = linres.cache
@@ -2783,11 +2793,13 @@ end
     end
 
     if integrator.opts.adaptive
-	    if (integrator.alg isa Rodas5Pe)
-	    	@inbounds @simd ivdep for i in eachindex(u)
-               	du[i] = 0.2606326497975715*k1[i] - 0.005158627295444251*k2[i] + 1.3038988631109731*k3[i] + 1.235000722062074*k4[i] +
-                   	- 0.7931985603795049*k5[i] - 1.005448461135913*k6[i] - 0.18044626132120234*k7[i] + 0.17051519239113755*k8[i]
-	        end					 
+        if (integrator.alg isa Rodas5Pe)
+            @inbounds @simd ivdep for i in eachindex(u)
+                du[i] = 0.2606326497975715 * k1[i] - 0.005158627295444251 * k2[i] +
+                        1.3038988631109731 * k3[i] + 1.235000722062074 * k4[i] +
+                        -0.7931985603795049 * k5[i] - 1.005448461135913 * k6[i] -
+                        0.18044626132120234 * k7[i] + 0.17051519239113755 * k8[i]
+            end
         end
         calculate_residuals!(atmp, du, uprev, u, integrator.opts.abstol,
             integrator.opts.reltol, integrator.opts.internalnorm, t)
@@ -2803,13 +2815,17 @@ end
                                  h35 * k5[i] + h36 * k6[i] + h37 * k7[i] + h38 * k8[i]
             integrator.k[3][i] = h41 * k1[i] + h42 * k2[i] + h43 * k3[i] + h44 * k4[i] +
                                  h45 * k5[i] + h46 * k6[i] + h47 * k7[i] + h48 * k8[i]
-	        if (integrator.alg isa Rodas5Pr)
-                k2[i] = 0.5*(uprev[i] + u[i] + 0.5 * (integrator.k[1][i] + 0.5 * (integrator.k[2][i] + 0.5 * integrator.k[3][i])))
-                du1[i] = ( 0.25*(integrator.k[2][i] + integrator.k[3][i]) - uprev[i] + u[i]) / dt
-	        end
+            if (integrator.alg isa Rodas5Pr)
+                k2[i] = 0.5 * (uprev[i] + u[i] +
+                         0.5 * (integrator.k[1][i] +
+                          0.5 * (integrator.k[2][i] + 0.5 * integrator.k[3][i])))
+                du1[i] = (0.25 * (integrator.k[2][i] + integrator.k[3][i]) - uprev[i] +
+                          u[i]) / dt
+            end
         end
-        if integrator.opts.adaptive && (integrator.EEst < 1.0) && (integrator.alg isa Rodas5Pr) 
-            f(du, k2, p, t + dt/2)
+        if integrator.opts.adaptive && (integrator.EEst < 1.0) &&
+           (integrator.alg isa Rodas5Pr)
+            f(du, k2, p, t + dt / 2)
             integrator.stats.nf += 1
             if mass_matrix === I
                 @inbounds @simd ivdep for i in eachindex(u)
@@ -2821,8 +2837,8 @@ end
                     du2[i] = du2[i] - du[i]
                 end
             end
-	        EEst = norm(du2) / (integrator.opts.abstol + integrator.opts.reltol*norm(k2)) 
-            integrator.EEst = max(EEst,integrator.EEst)
+            EEst = norm(du2) / (integrator.opts.abstol + integrator.opts.reltol * norm(k2))
+            integrator.EEst = max(EEst, integrator.EEst)
         end
     end
     cache.linsolve = linres.cache

--- a/test/algconvergence/ode_convergence_tests.jl
+++ b/test/algconvergence/ode_convergence_tests.jl
@@ -293,7 +293,7 @@ end
     @test sim120.𝒪est[:final]≈4 atol=testTol
 
     sim121 = test_convergence(dts, prob, ESDIRK547L2SA2())
-    @test sim121.𝒪est[:final]≈5 atol=2 * testTol
+    @test 5-testTol <= sim121.𝒪est[:final] <= 6
 
     dts = (1 / 2) .^ (5:-1:1)
     sim122 = test_convergence(dts, prob, ESDIRK659L2SA())

--- a/test/algconvergence/ode_convergence_tests.jl
+++ b/test/algconvergence/ode_convergence_tests.jl
@@ -293,7 +293,7 @@ end
     @test sim120.𝒪est[:final]≈4 atol=testTol
 
     sim121 = test_convergence(dts, prob, ESDIRK547L2SA2())
-    @test 5-testTol <= sim121.𝒪est[:final] <= 6
+    @test 5 - testTol <= sim121.𝒪est[:final] <= 6
 
     dts = (1 / 2) .^ (5:-1:1)
     sim122 = test_convergence(dts, prob, ESDIRK659L2SA())

--- a/test/algconvergence/ode_rosenbrock_tests.jl
+++ b/test/algconvergence/ode_rosenbrock_tests.jl
@@ -106,7 +106,7 @@ import LinearSolve
 
     sol = solve(prob, ROS2PR())
     @test length(sol) < 60
-    
+
     ### ROS2PR
     prob = prob_ode_linear
 
@@ -629,7 +629,7 @@ import LinearSolve
 
     sol = solve(prob, Rodas5P())
     @test length(sol) < 20
-    
+
     println("Rodas5Pe")
 
     prob = prob_ode_linear

--- a/test/algconvergence/partitioned_methods_tests.jl
+++ b/test/algconvergence/partitioned_methods_tests.jl
@@ -15,7 +15,6 @@ end
 ff_harmonic = DynamicalODEFunction(f1_harmonic, f2_harmonic; analytic = harmonic_analytic)
 prob = DynamicalODEProblem(ff_harmonic, v0, u0, (0.0, 5.0))
 
-
 sol = solve(prob, SymplecticEuler(), dt = 1 / 2)
 sol_verlet = solve(prob, VelocityVerlet(), dt = 1 / 100)
 sol_ruth3 = solve(prob, Ruth3(), dt = 1 / 100)
@@ -42,7 +41,7 @@ sol2_verlet(0.1)
 @test sol_ruth3[end][3] == sol2_ruth3[end][3]
 
 prob = DynamicalODEProblem(ff_harmonic, v0, u0, (0.0, 5.0))
-println("Convergence tests")    
+println("Convergence tests")
 
 dts = 1 .// 2 .^ (6:-1:3)
 # Symplectic Euler
@@ -453,7 +452,6 @@ sim = test_convergence(dts, prob, FineRKN4(), dense_errors = true)
 sim = test_convergence(dts, prob, FineRKN5(), dense_errors = true)
 @test sim.𝒪est[:l2]≈5 rtol=1e-1
 @test sim.𝒪est[:L2]≈4 rtol=1e-1
-
 
 # Adaptive methods regression test
 sol = solve(prob, FineRKN4())

--- a/test/interface/static_array_tests.jl
+++ b/test/interface/static_array_tests.jl
@@ -3,10 +3,10 @@ using OrdinaryDiffEq
 using RecursiveArrayTools
 
 u0 = VectorOfArray([fill(2, MVector{2, Float64}), ones(MVector{2, Float64})])
-g(u, p, t) = SA[u[1] + u[2], u[1]]
+g0(u, p, t) = SA[u[1] + u[2], u[1]]
 f = (du, u, p, t) -> begin
     for i in 1:2
-        du[:, i] = g(u[:, i], p, t)
+        du[:, i] = g0(u[:, i], p, t)
     end
 end
 ode = ODEProblem(f, u0, (0.0, 1.0))
@@ -29,7 +29,7 @@ sol = solve(ode, ROCK4())
 @test !any(iszero.(sol(1.0))) && !any(sol(1.0) .== u0)
 
 u0 = ones(MVector{2, Float64})
-ode = ODEProblem(g, u0, (0.0, 1.0))
+ode = ODEProblem(g0, u0, (0.0, 1.0))
 sol = solve(ode, Euler(), dt = 1e-2)
 @test !any(iszero.(sol(1.0))) && !any(sol(1.0) .== u0)
 sol = solve(ode, Tsit5(), dt = 1e-2)
@@ -241,7 +241,7 @@ prob = ODEProblem(pollu, u0, (0.0, 60.0))
 @test_nowarn sol = solve(prob, Rodas5(chunk_size = Val{8}()), save_everystep = false)
 
 # DFBDF
-g(du, u, p, t) = du .^ 2 - conj.(u)
+g1(du, u, p, t) = du .^ 2 - conj.(u)
 u0 = SA[-0.5048235596641171 - 0.8807809019469485im,
     -0.5086319184891589 - 0.8791877406854778im,
     -0.5015635095728721 + 0.8770989403497113im,
@@ -262,7 +262,7 @@ du0 = SA[-0.5051593302918506 - 0.87178524227302im,
     -0.5014121747348508 + 0.8712321173163112im,
     -0.5011616766671037 + 0.8651123244481334im,
     -0.5065728050401669 + 0.8738635859036186im]
-prob = DAEProblem(g, du0, u0, (0.0, 10.0))
+prob = DAEProblem(g1, du0, u0, (0.0, 10.0))
 sol1 = solve(prob, DFBDF(autodiff = false), reltol = 1e-8, abstol = 1e-8)
 
 g2(resid, du, u, p, t) = resid .= du .^ 2 - conj.(u)
@@ -270,4 +270,4 @@ prob = DAEProblem(g2, Array(du0), Array(u0), (0.0, 10.0))
 sol2 = solve(prob, DFBDF(autodiff = false), reltol = 1e-8, abstol = 1e-8)
 
 @test all(iszero, sol1[:, 1] - sol2[:, 1])
-@test all(abs.(sol1[:, end] .- sol2[:, end]) .< 1e-6)
+@test all(abs.(sol1[:, end] .- sol2[:, end]) .< 1.5e-6)

--- a/test/regression/iipvsoop_tests.jl
+++ b/test/regression/iipvsoop_tests.jl
@@ -118,8 +118,8 @@ working_rosenbrock_algs = [Rosenbrock23(), ROS3P(), Rodas3(),
     Ros4LStab(), Rodas4(), Rodas42(), Rodas4P(), Rodas5(),
     Rodas23W(), Rodas3P(), Rodas5Pe(), Rodas5P(),
     ROS2(), ROS2PR(), ROS2S(), ROS3(), ROS3PR(), Scholz4_7(),
-    ROS34PW1a(), ROS34PW1b(), ROS34PW2(), ROS34PW3(), 
-    ROS34PRw(), ROS3PRL(), ROS3PRL2()] 
+    ROS34PW1a(), ROS34PW1b(), ROS34PW2(), ROS34PW3(),
+    ROS34PRw(), ROS3PRL(), ROS3PRL2()]
 
 rosenbrock_algs = [Rosenbrock32()
 ]


### PR DESCRIPTION
CVODE estimates the convergence of the first iteration by reusing the
convergence rate of the previous nonlinear solver iteration.

Reference: https://github.com/LLNL/sundials/blob/2abd63bd6cbc354fb4861bba8e98d0b95d65e24a/src/cvodes/cvodes_nls.c#L325-L331

MWE: https://discourse.julialang.org/t/cvode-bdf-outperforms-julia-solvers-for-stiff-system-biology-model/113936

Master branch:
```julia
julia> sol = solve(oprob_jac, FBDF()).stats
SciMLBase.DEStats
Number of function 1 evaluations:                  311
Number of function 2 evaluations:                  0
Number of W matrix evaluations:                    31
Number of linear solves:                           222
Number of Jacobians created:                       2
Number of nonlinear solver iterations:             212
Number of nonlinear solver convergence failures:   0
Number of fixed-point solver iterations:                     0
Number of fixed-point solver convergence failures:           0
Number of rootfind condition calls:                0
Number of accepted steps:                          84
Number of rejected steps:                          2
```

This PR:
```julia
julia> sol = solve(oprob_jac, FBDF()).stats
SciMLBase.DEStats
Number of function 1 evaluations:                  251
Number of function 2 evaluations:                  0
Number of W matrix evaluations:                    32
Number of linear solves:                           159
Number of Jacobians created:                       2
Number of nonlinear solver iterations:             149
Number of nonlinear solver convergence failures:   0
Number of fixed-point solver iterations:                     0
Number of fixed-point solver convergence failures:           0
Number of rootfind condition calls:                0
Number of accepted steps:                          86
Number of rejected steps:                          3
```