### PR TITLE
shorten timespan on initdt test

### DIFF
--- a/test/interface/ode_initdt_tests.jl
+++ b/test/interface/ode_initdt_tests.jl
@@ -21,7 +21,7 @@ dt₀ = sol3.t[2]
 T = Float32
 u0 = T.([1.0; 0.0; 0.0])
 
-tspan = T.((0, 100))
+tspan = T.((0, 70))
 prob = remake(prob, u0 = u0, tspan = tspan)
 @test_nowarn solve(prob, Euler(); dt = T(0.0001))
 


### PR DESCRIPTION
This previously was testing that you don't get a warning even though the solution was `Inf`. The only reason it worked at all is that `Euler` is simple enough that it stayed `Inf` rather than going to `NaN` and DiffEqBase incorrectly didn't consider `Inf` to be diverged.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
