### PR TITLE
avoid scalar indexing bug in hermite interpolant if diff_vars is a fill of trues

### DIFF
--- a/src/dense/generic_dense.jl
+++ b/src/dense/generic_dense.jl
@@ -748,6 +748,14 @@ end
                                        Θ * dt * k[2])
 end
 
+@muladd function hermite_interpolant!(
+    out, Θ, dt, y₀, y₁, k, idxs::Nothing, T::Type{Val{0}}, differential_vars::FillArrays.Trues{1, Tuple{Base.OneTo{Int}}}) # Default interpolant is Hermite
+@inbounds @.. broadcast=false out=(1 - Θ) * y₀ + Θ * y₁ +
+                                  Θ * (Θ - 1) *
+                                  ((1 - 2Θ) * (y₁ - y₀) + (Θ - 1) * dt * k[1] +
+                                   Θ * dt * k[2])
+end
+
 @muladd function hermite_interpolant!(out::Array, Θ, dt, y₀, y₁, k, idxs::Nothing,
         T::Type{Val{0}}, differential_vars) # Default interpolant is Hermite
     @inbounds @simd ivdep for i in eachindex(out)

--- a/src/dense/generic_dense.jl
+++ b/src/dense/generic_dense.jl
@@ -1077,7 +1077,7 @@ end
                       12 * y₁[idxs]) /
                      (dt * dt * dt)
     else
-        @views out = differential_vars[idxs] .*
+        @views out = differential_vars .*
                      (6 * dt * k[1][idxs] + 6 * dt * k[2][idxs] + 12 * y₀[idxs] -
                       12 * y₁[idxs]) /
                      (dt * dt * dt)

--- a/src/dense/generic_dense.jl
+++ b/src/dense/generic_dense.jl
@@ -747,7 +747,7 @@ end
                  Θ * dt * k[2][idxs]))
     else
         return (1 - Θ) * y₀[idxs] + Θ * y₁[idxs] +
-               differential_vars[idxs] .* (Θ * (Θ - 1) *
+               differential_vars .* (Θ * (Θ - 1) *
                 ((1 - 2Θ) * (y₁[idxs] - y₀[idxs]) + (Θ - 1) * dt * k[1][idxs] +
                  Θ * dt * k[2][idxs]))
     end
@@ -857,8 +857,8 @@ end
              Θ * (3 * dt * k[1][idxs] + 3 * dt * k[2][idxs] + 6 * y₀[idxs] - 6 * y₁[idxs]) +
              6 * y₁[idxs]) / dt)
     else
-        (.!differential_vars[idxs]) .* ((y₁[idxs] - y₀[idxs]) / dt) +
-        differential_vars[idxs] .* (
+        (.!differential_vars) .* ((y₁[idxs] - y₀[idxs]) / dt) +
+        differential_vars .* (
             k[1][idxs] +
             Θ * (-4 * dt * k[1][idxs] - 2 * dt * k[2][idxs] - 6 * y₀[idxs] +
              Θ * (3 * dt * k[1][idxs] + 3 * dt * k[2][idxs] + 6 * y₀[idxs] - 6 * y₁[idxs]) +
@@ -972,7 +972,7 @@ end
                       Θ * (6 * dt * k[1][idxs] + 6 * dt * k[2][idxs] + 12 * y₀[idxs] -
                        12 * y₁[idxs]) + 6 * y₁[idxs]) / (dt * dt)
     else
-        @views out = differential_vars[idxs] .*
+        @views out = differential_vars .*
                      (-4 * dt * k[1][idxs] - 2 * dt * k[2][idxs] - 6 * y₀[idxs] +
                       Θ * (6 * dt * k[1][idxs] + 6 * dt * k[2][idxs] + 12 * y₀[idxs] -
                        12 * y₁[idxs]) + 6 * y₁[idxs]) / (dt * dt)
@@ -1019,7 +1019,7 @@ end
                                          12 * y₀[idxs] - 12 * y₁[idxs]) + 6 * y₁[idxs]) /
                                        (dt * dt)
     else
-        @views @.. broadcast=false out=differential_vars[idxs] *
+        @views @.. broadcast=false out=differential_vars *
                                        (-4 * dt * k[1][idxs] - 2 * dt * k[2][idxs] -
                                         6 * y₀[idxs] +
                                         Θ * (6 * dt * k[1][idxs] + 6 * dt * k[2][idxs] +
@@ -1116,7 +1116,7 @@ end
         @views @.. broadcast=false out=(6 * dt * k[1][idxs] + 6 * dt * k[2][idxs] +
                                         12 * y₀[idxs] - 12 * y₁[idxs]) / (dt * dt * dt)
     else
-        @views @.. broadcast=false out=differential_vars[idxs] *
+        @views @.. broadcast=false out=differential_vars *
                                        (6 * dt * k[1][idxs] + 6 * dt * k[2][idxs] +
                                         12 * y₀[idxs] - 12 * y₁[idxs]) / (dt * dt * dt)
     end

--- a/test/gpu/Project.toml
+++ b/test/gpu/Project.toml
@@ -1,6 +1,11 @@
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
+FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 
 [compat]
 CUDA = "5"

--- a/test/gpu/hermite_test.jl
+++ b/test/gpu/hermite_test.jl
@@ -13,4 +13,4 @@ t = FillArrays.Trues(length(pa))
 
 OrdinaryDiffEq.hermite_interpolant!(pa, 0.1, 0.2, pb, pc, k, nothing, Val{0}, t) # if this doesnt error we're good
 
-@test pa.a != pb.a
+@test pa.x[1] != pb.x[1]

--- a/test/gpu/hermite_test.jl
+++ b/test/gpu/hermite_test.jl
@@ -1,0 +1,15 @@
+using ComponentArrays, CUDA, Adapt, RecursiveArrayTools, FastBroadcast, FillArrays, OrdinaryDiffEq, Test
+
+a = ComponentArray((a=rand(Float32, 5,5), b=rand(Float32, 5, 5)))
+a = adapt(CuArray, a)
+pa = ArrayPartition(a)
+pb = deepcopy(pa)
+pc = deepcopy(pa)
+pd = deepcopy(pa)
+pe = deepcopy(pa)
+k = [pd, pe]
+t = FillArrays.Trues(length(pa))
+
+OrdinaryDiffEq.hermite_interpolant!(pa, 0.1, 0.2, pb, pc, k, nothing, Val{0}, t) # if this doesnt error we're good
+
+@test pa.a != pb.a

--- a/test/gpu/hermite_test.jl
+++ b/test/gpu/hermite_test.jl
@@ -1,6 +1,7 @@
-using ComponentArrays, CUDA, Adapt, RecursiveArrayTools, FastBroadcast, FillArrays, OrdinaryDiffEq, Test
+using ComponentArrays, CUDA, Adapt, RecursiveArrayTools, FastBroadcast, FillArrays,
+      OrdinaryDiffEq, Test
 
-a = ComponentArray((a=rand(Float32, 5,5), b=rand(Float32, 5, 5)))
+a = ComponentArray((a = rand(Float32, 5, 5), b = rand(Float32, 5, 5)))
 a = adapt(CuArray, a)
 pa = ArrayPartition(a)
 pb = deepcopy(pa)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -192,5 +192,6 @@ end
         @time @safetestset "Autoswitch GPU" include("gpu/autoswitch.jl")
         @time @safetestset "Linear LSRK GPU" include("gpu/linear_lsrk.jl")
         @time @safetestset "Reaction-Diffusion Stiff Solver GPU" include("gpu/reaction_diffusion_stiff.jl")
+        @time @safetestset "Scalar indexing bug bypass" include("gpu/hermite_test.jl")
     end
 end # @time


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
