### PR TITLE
don't reset accept-step so SciMLBase.check_error can look at it

### DIFF
--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -381,8 +381,6 @@ function update_uprev!(integrator)
 end
 
 function apply_step!(integrator)
-    integrator.accept_step = false # yay we got here, don't need this no more
-
     update_uprev!(integrator)
 
     #Update dt if adaptive or if fixed and the dt is allowed to change


### PR DESCRIPTION
This line was unnecessarily setting `accept_step` to false which made `check_error` think that your step was always rejected. This was what caused the DelayDiffEq failures on https://github.com/SciML/SciMLBase.jl/pull/693. The problem, however isn't delay problem specific, it just turns out delay diffeqs are much more likely to have tiny timesteps.