### PR TITLE
initialize bitstype caches in `DefaultCache`

### DIFF
--- a/src/caches/basic_caches.jl
+++ b/src/caches/basic_caches.jl
@@ -59,8 +59,29 @@ function alg_cache(alg::CompositeAlgorithm{CS, Tuple{A1, A2, A3, A4, A5, A6}}, u
     T4 = Base.promote_op(alg_cache, A4, argT...)
     T5 = Base.promote_op(alg_cache, A5, argT...)
     T6 = Base.promote_op(alg_cache, A6, argT...)
-    DefaultCache{T1, T2, T3, T4, T5, T6, typeof(alg.choice_function)}(
+    cache = DefaultCache{T1, T2, T3, T4, T5, T6, typeof(alg.choice_function)}(
         args, alg.choice_function, 1)
+    algs = alg.algs
+    # If the type is a bitstype we need to initialize it correctly here since isdefined will always return true.
+    if isbitstype(T1)
+        cache.cache1 = alg_cache(algs[1], args...)
+    end
+    if isbitstype(T2)
+        cache.cache2 = alg_cache(algs[2], args...)
+    end
+    if isbitstype(T3)
+        cache.cache3 = alg_cache(algs[3], args...)
+    end
+    if isbitstype(T4)
+        cache.cache4 = alg_cache(algs[4], args...)
+    end
+    if isbitstype(T5)
+        cache.cache5 = alg_cache(algs[5], args...)
+    end
+    if isbitstype(T6)
+        cache.cache6 = alg_cache(algs[6], args...)
+    end
+    cache
 end
 
 # map + closure approach doesn't infer


### PR DESCRIPTION
otherwise they were getting uninitialized memory. We also don't have to wory about the extra memory use because if it's a bitstype it will be fairly small (this only occurs for `ConstantCache`s).