### PR TITLE
Introduce and propagate stage limiters for Rosenbrock methods.

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -3085,20 +3085,23 @@ for Alg in [
     :Rodas5Pe,
     :Rodas5Pr]
     @eval begin
-        struct $Alg{CS, AD, F, P, FDT, ST, CJ, StepLimiter} <:
+        struct $Alg{CS, AD, F, P, FDT, ST, CJ, StepLimiter, StageLimiter} <:
                OrdinaryDiffEqRosenbrockAdaptiveAlgorithm{CS, AD, FDT, ST, CJ}
             linsolve::F
             precs::P
             step_limiter!::StepLimiter
+            stage_limiter!::StageLimiter
         end
         function $Alg(; chunk_size = Val{0}(), autodiff = Val{true}(),
                 standardtag = Val{true}(), concrete_jac = nothing,
                 diff_type = Val{:forward}, linsolve = nothing,
-                precs = DEFAULT_PRECS, step_limiter! = trivial_limiter!)
+                precs = DEFAULT_PRECS, step_limiter! = trivial_limiter!,
+                stage_limiter! = trivial_limiter!)
             $Alg{_unwrap_val(chunk_size), _unwrap_val(autodiff), typeof(linsolve),
                 typeof(precs), diff_type, _unwrap_val(standardtag),
-                _unwrap_val(concrete_jac), typeof(step_limiter!)}(linsolve,
-                precs, step_limiter!)
+                _unwrap_val(concrete_jac), typeof(step_limiter!),
+                typeof(stage_limiter!)}(linsolve, precs, step_limiter!,
+                stage_limiter!)
         end
     end
 

--- a/src/caches/rosenbrock_caches.jl
+++ b/src/caches/rosenbrock_caches.jl
@@ -5,7 +5,7 @@ abstract type RosenbrockMutableCache <: OrdinaryDiffEqMutableCache end
 
 @cache mutable struct Rosenbrock23Cache{uType, rateType, uNoUnitsType, JType, WType,
     TabType, TFType, UFType, F, JCType, GCType,
-    RTolType, A, AV, StepLimiter} <: RosenbrockMutableCache
+    RTolType, A, AV, StepLimiter, StageLimiter} <: RosenbrockMutableCache
     u::uType
     uprev::uType
     k₁::rateType
@@ -33,13 +33,14 @@ abstract type RosenbrockMutableCache <: OrdinaryDiffEqMutableCache end
     alg::A
     algebraic_vars::AV
     step_limiter!::StepLimiter
+    stage_limiter!::StageLimiter
 end
 
 TruncatedStacktraces.@truncate_stacktrace Rosenbrock23Cache 1
 
 @cache mutable struct Rosenbrock32Cache{uType, rateType, uNoUnitsType, JType, WType,
     TabType, TFType, UFType, F, JCType, GCType,
-    RTolType, A, AV, StepLimiter} <: RosenbrockMutableCache
+    RTolType, A, AV, StepLimiter, StageLimiter} <: RosenbrockMutableCache
     u::uType
     uprev::uType
     k₁::rateType
@@ -67,6 +68,7 @@ TruncatedStacktraces.@truncate_stacktrace Rosenbrock23Cache 1
     alg::A
     algebraic_vars::AV
     step_limiter!::StepLimiter
+    stage_limiter!::StageLimiter
 end
 
 function alg_cache(alg::Rosenbrock23, u, rate_prototype, ::Type{uEltypeNoUnits},
@@ -110,7 +112,8 @@ function alg_cache(alg::Rosenbrock23, u, rate_prototype, ::Type{uEltypeNoUnits},
     Rosenbrock23Cache(u, uprev, k₁, k₂, k₃, du1, du2, f₁,
         fsalfirst, fsallast, dT, J, W, tmp, atmp, weight, tab, tf, uf,
         linsolve_tmp,
-        linsolve, jac_config, grad_config, reltol, alg, algebraic_vars, alg.step_limiter!)
+        linsolve, jac_config, grad_config, reltol, alg, algebraic_vars, alg.step_limiter!,
+        alg.stage_limiter!)
 end
 
 function alg_cache(alg::Rosenbrock32, u, rate_prototype, ::Type{uEltypeNoUnits},
@@ -153,7 +156,7 @@ function alg_cache(alg::Rosenbrock32, u, rate_prototype, ::Type{uEltypeNoUnits},
 
     Rosenbrock32Cache(u, uprev, k₁, k₂, k₃, du1, du2, f₁, fsalfirst, fsallast, dT, J, W,
         tmp, atmp, weight, tab, tf, uf, linsolve_tmp, linsolve, jac_config,
-        grad_config, reltol, alg, algebraic_vars, alg.step_limiter!)
+        grad_config, reltol, alg, algebraic_vars, alg.step_limiter!, alg.stage_limiter!)
 end
 
 struct Rosenbrock23ConstantCache{T, TF, UF, JType, WType, F, AD} <:
@@ -232,7 +235,7 @@ end
 
 @cache mutable struct Rosenbrock33Cache{uType, rateType, uNoUnitsType, JType, WType,
     TabType, TFType, UFType, F, JCType, GCType,
-    RTolType, A, StepLimiter} <: RosenbrockMutableCache
+    RTolType, A, StepLimiter, StageLimiter} <: RosenbrockMutableCache
     u::uType
     uprev::uType
     du::rateType
@@ -260,6 +263,7 @@ end
     reltol::RTolType
     alg::A
     step_limiter!::StepLimiter
+    stage_limiter!::StageLimiter
 end
 
 function alg_cache(alg::ROS3P, u, rate_prototype, ::Type{uEltypeNoUnits},
@@ -298,7 +302,8 @@ function alg_cache(alg::ROS3P, u, rate_prototype, ::Type{uEltypeNoUnits},
     Rosenbrock33Cache(u, uprev, du, du1, du2, k1, k2, k3, k4,
         fsalfirst, fsallast, dT, J, W, tmp, atmp, weight, tab, tf, uf,
         linsolve_tmp,
-        linsolve, jac_config, grad_config, reltol, alg, alg.step_limiter!)
+        linsolve, jac_config, grad_config, reltol, alg, alg.step_limiter!,
+        alg.stage_limiter!)
 end
 
 function alg_cache(alg::ROS3P, u, rate_prototype, ::Type{uEltypeNoUnits},
@@ -316,7 +321,7 @@ function alg_cache(alg::ROS3P, u, rate_prototype, ::Type{uEltypeNoUnits},
 end
 
 @cache mutable struct Rosenbrock34Cache{uType, rateType, uNoUnitsType, JType, WType,
-    TabType, TFType, UFType, F, JCType, GCType, StepLimiter} <:
+    TabType, TFType, UFType, F, JCType, GCType, StepLimiter, StageLimiter} <:
                       RosenbrockMutableCache
     u::uType
     uprev::uType
@@ -343,6 +348,7 @@ end
     jac_config::JCType
     grad_config::GCType
     step_limiter!::StepLimiter
+    stage_limiter!::StageLimiter
 end
 
 function alg_cache(alg::Rodas3, u, rate_prototype, ::Type{uEltypeNoUnits},
@@ -382,7 +388,8 @@ function alg_cache(alg::Rodas3, u, rate_prototype, ::Type{uEltypeNoUnits},
     Rosenbrock34Cache(u, uprev, du, du1, du2, k1, k2, k3, k4,
         fsalfirst, fsallast, dT, J, W, tmp, atmp, weight, tab, tf, uf,
         linsolve_tmp,
-        linsolve, jac_config, grad_config, alg.step_limiter!)
+        linsolve, jac_config, grad_config, alg.step_limiter!,
+        alg.stage_limiter!)
 end
 
 struct Rosenbrock34ConstantCache{TF, UF, Tab, JType, WType, F} <:
@@ -460,7 +467,7 @@ struct Rodas3PConstantCache{TF, UF, Tab, JType, WType, F, AD} <: OrdinaryDiffEqC
 end
 
 @cache mutable struct Rodas23WCache{uType, rateType, uNoUnitsType, JType, WType, TabType,
-    TFType, UFType, F, JCType, GCType, RTolType, A, StepLimiter} <:
+    TFType, UFType, F, JCType, GCType, RTolType, A, StepLimiter, StageLimiter} <:
                       RosenbrockMutableCache
     u::uType
     uprev::uType
@@ -493,10 +500,11 @@ end
     reltol::RTolType
     alg::A
     step_limiter!::StepLimiter
+    stage_limiter!::StageLimiter
 end
 
 @cache mutable struct Rodas3PCache{uType, rateType, uNoUnitsType, JType, WType, TabType,
-    TFType, UFType, F, JCType, GCType, RTolType, A, StepLimiter} <:
+    TFType, UFType, F, JCType, GCType, RTolType, A, StepLimiter, StageLimiter} <:
                       RosenbrockMutableCache
     u::uType
     uprev::uType
@@ -529,6 +537,7 @@ end
     reltol::RTolType
     alg::A
     step_limiter!::StepLimiter
+    stage_limiter!::StageLimiter
 end
 
 function alg_cache(alg::Rodas23W, u, rate_prototype, ::Type{uEltypeNoUnits},
@@ -571,7 +580,8 @@ function alg_cache(alg::Rodas23W, u, rate_prototype, ::Type{uEltypeNoUnits},
     jac_config = build_jac_config(alg, f, uf, du1, uprev, u, tmp, du2)
     Rodas23WCache(u, uprev, dense1, dense2, dense3, du, du1, du2, k1, k2, k3, k4, k5,
         fsalfirst, fsallast, dT, J, W, tmp, atmp, weight, tab, tf, uf, linsolve_tmp,
-        linsolve, jac_config, grad_config, reltol, alg, alg.step_limiter!)
+        linsolve, jac_config, grad_config, reltol, alg, alg.step_limiter!,
+        alg.stage_limiter!)
 end
 
 TruncatedStacktraces.@truncate_stacktrace Rodas23WCache 1
@@ -615,7 +625,8 @@ function alg_cache(alg::Rodas3P, u, rate_prototype, ::Type{uEltypeNoUnits},
     jac_config = build_jac_config(alg, f, uf, du1, uprev, u, tmp, du2)
     Rodas3PCache(u, uprev, dense1, dense2, dense3, du, du1, du2, k1, k2, k3, k4, k5,
         fsalfirst, fsallast, dT, J, W, tmp, atmp, weight, tab, tf, uf, linsolve_tmp,
-        linsolve, jac_config, grad_config, reltol, alg, alg.step_limiter!)
+        linsolve, jac_config, grad_config, reltol, alg, alg.step_limiter!,
+        alg.stage_limiter!)
 end
 
 TruncatedStacktraces.@truncate_stacktrace Rodas3PCache 1
@@ -663,7 +674,7 @@ struct Rodas4ConstantCache{TF, UF, Tab, JType, WType, F, AD} <: OrdinaryDiffEqCo
 end
 
 @cache mutable struct Rodas4Cache{uType, rateType, uNoUnitsType, JType, WType, TabType,
-    TFType, UFType, F, JCType, GCType, RTolType, A, StepLimiter} <:
+    TFType, UFType, F, JCType, GCType, RTolType, A, StepLimiter, StageLimiter} <:
                       RosenbrockMutableCache
     u::uType
     uprev::uType
@@ -696,6 +707,7 @@ end
     reltol::RTolType
     alg::A
     step_limiter!::StepLimiter
+    stage_limiter!::StageLimiter
 end
 
 function alg_cache(alg::Rodas4, u, rate_prototype, ::Type{uEltypeNoUnits},
@@ -739,7 +751,8 @@ function alg_cache(alg::Rodas4, u, rate_prototype, ::Type{uEltypeNoUnits},
     Rodas4Cache(u, uprev, dense1, dense2, du, du1, du2, k1, k2, k3, k4,
         k5, k6,
         fsalfirst, fsallast, dT, J, W, tmp, atmp, weight, tab, tf, uf, linsolve_tmp,
-        linsolve, jac_config, grad_config, reltol, alg, alg.step_limiter!)
+        linsolve, jac_config, grad_config, reltol, alg, alg.step_limiter!,
+        alg.stage_limiter!)
 end
 
 TruncatedStacktraces.@truncate_stacktrace Rodas4Cache 1
@@ -800,7 +813,8 @@ function alg_cache(alg::Rodas42, u, rate_prototype, ::Type{uEltypeNoUnits},
     Rodas4Cache(u, uprev, dense1, dense2, du, du1, du2, k1, k2, k3, k4,
         k5, k6,
         fsalfirst, fsallast, dT, J, W, tmp, atmp, weight, tab, tf, uf, linsolve_tmp,
-        linsolve, jac_config, grad_config, reltol, alg, alg.step_limiter!)
+        linsolve, jac_config, grad_config, reltol, alg, alg.step_limiter!,
+        alg.stage_limiter!)
 end
 
 function alg_cache(alg::Rodas42, u, rate_prototype, ::Type{uEltypeNoUnits},
@@ -859,7 +873,8 @@ function alg_cache(alg::Rodas4P, u, rate_prototype, ::Type{uEltypeNoUnits},
     Rodas4Cache(u, uprev, dense1, dense2, du, du1, du2, k1, k2, k3, k4,
         k5, k6,
         fsalfirst, fsallast, dT, J, W, tmp, atmp, weight, tab, tf, uf, linsolve_tmp,
-        linsolve, jac_config, grad_config, reltol, alg, alg.step_limiter!)
+        linsolve, jac_config, grad_config, reltol, alg, alg.step_limiter!,
+        alg.stage_limiter!)
 end
 
 function alg_cache(alg::Rodas4P, u, rate_prototype, ::Type{uEltypeNoUnits},
@@ -918,7 +933,8 @@ function alg_cache(alg::Rodas4P2, u, rate_prototype, ::Type{uEltypeNoUnits},
     Rodas4Cache(u, uprev, dense1, dense2, du, du1, du2, k1, k2, k3, k4,
         k5, k6,
         fsalfirst, fsallast, dT, J, W, tmp, atmp, weight, tab, tf, uf, linsolve_tmp,
-        linsolve, jac_config, grad_config, reltol, alg, alg.step_limiter!)
+        linsolve, jac_config, grad_config, reltol, alg, alg.step_limiter!,
+        alg.stage_limiter!)
 end
 
 function alg_cache(alg::Rodas4P2, u, rate_prototype, ::Type{uEltypeNoUnits},
@@ -951,7 +967,7 @@ end
 
 @cache mutable struct Rosenbrock5Cache{
     uType, rateType, uNoUnitsType, JType, WType, TabType,
-    TFType, UFType, F, JCType, GCType, RTolType, A, StepLimiter} <:
+    TFType, UFType, F, JCType, GCType, RTolType, A, StepLimiter, StageLimiter} <:
                       RosenbrockMutableCache
     u::uType
     uprev::uType
@@ -987,6 +1003,7 @@ end
     reltol::RTolType
     alg::A
     step_limiter!::StepLimiter
+    stage_limiter!::StageLimiter
 end
 
 TruncatedStacktraces.@truncate_stacktrace Rosenbrock5Cache 1
@@ -1036,7 +1053,8 @@ function alg_cache(alg::Rodas5, u, rate_prototype, ::Type{uEltypeNoUnits},
         k5, k6, k7, k8,
         fsalfirst, fsallast, dT, J, W, tmp, atmp, weight, tab, tf, uf,
         linsolve_tmp,
-        linsolve, jac_config, grad_config, reltol, alg, alg.step_limiter!)
+        linsolve, jac_config, grad_config, reltol, alg, alg.step_limiter!,
+        alg.stage_limiter!)
 end
 
 function alg_cache(alg::Rodas5, u, rate_prototype, ::Type{uEltypeNoUnits},
@@ -1099,7 +1117,8 @@ function alg_cache(
         k5, k6, k7, k8,
         fsalfirst, fsallast, dT, J, W, tmp, atmp, weight, tab, tf, uf,
         linsolve_tmp,
-        linsolve, jac_config, grad_config, reltol, alg, alg.step_limiter!)
+        linsolve, jac_config, grad_config, reltol, alg, alg.step_limiter!,
+        alg.stage_limiter!)
 end
 
 function alg_cache(


### PR DESCRIPTION
The Rosenbrock methods do not have stage limiters on master. This PR propagates them through the caches and step implementations. However, I could not find a reliable way to test if this really works yet. The changes are very mechanical.