### PR TITLE
throw error for `Rosenbrock23` on non-diagonal mass matrices

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -109,6 +109,12 @@ function DiffEqBase.__init(
         end
     end
 
+    if alg isa Union{Rosenbrock23, Rosenbrock32} &&
+       prob.f.mass_matrix isa AbstractMatrix &&
+       !isdiag(prob.f.mass_matrix)
+        error("$(typeof(alg).name.name) only works with diagonal mass matrices. Please choose a solver suitable for your problem (e.g. Rodas5P)")
+    end
+
     if !isempty(saveat) && dense
         @warn("Dense output is incompatible with saveat. Please use the SavingCallback from the Callback Library to mix the two behaviors.")
     end

--- a/test/interface/default_solver_tests.jl
+++ b/test/interface/default_solver_tests.jl
@@ -80,6 +80,6 @@ function swaplinear(u, p, t)
 end
 swaplinearf = ODEFunction(swaplinear, mass_matrix = ones(2, 2) - I(2))
 prob_swaplinear = ODEProblem(swaplinearf, rand(2), (0.0, 1.0), 1.01)
-sol = solve(prob_swaplinear, reltol = 1e-7) # reltol must be set to avoid running into a bug with Rosenbrock23
+sol = solve(prob_swaplinear)
 @test all(isequal(4), sol.alg_choice)
 # for some reason the timestepping here is different from regular Rodas5P (including the initial timestep)

--- a/test/interface/mass_matrix_tests.jl
+++ b/test/interface/mass_matrix_tests.jl
@@ -103,8 +103,10 @@ dependent_M2 = MatrixOperator(ones(3, 3), update_func = update_func2,
         @test _norm_dsol(QNDF(), prob, prob2)≈0 atol=1e-12
 
         println("Rosenbrocks")
-        @test _norm_dsol(Rosenbrock23(), prob, prob2)≈0 atol=1e-11
-        @test _norm_dsol(Rosenbrock32(), prob, prob2)≈0 atol=1e-11
+        if mm == almost_I
+            @test _norm_dsol(Rosenbrock23(), prob, prob2)≈0 atol=1e-11
+            @test _norm_dsol(Rosenbrock32(), prob, prob2)≈0 atol=1e-11
+        end
         @test _norm_dsol(ROS3P(), prob, prob2)≈0 atol=1e-11
         @test _norm_dsol(Rodas3(), prob, prob2)≈0 atol=1e-11
         @test _norm_dsol(ROS2(), prob, prob2)≈0 atol=1e-11
@@ -207,7 +209,7 @@ end
 
     m_ode_prob = ODEProblem(ODEFunction(f2!; mass_matrix = M), u0, tspan)
     println("Rosenbrocks")
-    sol1 = @test_nowarn solve(m_ode_prob, Rosenbrock23(), reltol = 1e-10, abstol = 1e-10)
+    sol1 = @test_nowarn solve(m_ode_prob, Rodas5P(), reltol = 1e-10, abstol = 1e-10)
     sol2 = @test_nowarn solve(m_ode_prob, RadauIIA5(), reltol = 1e-10, abstol = 1e-10)
     sol3 = @test_nowarn solve(m_ode_prob, Cash4(), reltol = 1e-10, abstol = 1e-10)
     println("SDIRKs")


### PR DESCRIPTION
fixes https://github.com/SciML/OrdinaryDiffEq.jl/issues/2203