### PR TITLE
Allocate less in `estimate_terk`

### DIFF
--- a/src/bdf_utils.jl
+++ b/src/bdf_utils.jl
@@ -260,9 +260,7 @@ function estimate_terk(integrator, cache, k, ::Val{max_order}, u) where {max_ord
     else
         vc = _vec(terk)
         for i in 2:k
-            #@show vc
-            vc += @.. broadcast=false fd_weights[i, k]*u_history[:, i - 1]
-            #@show vc ,fd_weights[i,k] * u_history[:,i-1]
+            @.. broadcast=false vc += fd_weights[i, k]*@view(u_history[:, i - 1])
         end
         terk = reshape(vc, size(terk))
         terk *= abs(dt^(k - 1))

--- a/src/bdf_utils.jl
+++ b/src/bdf_utils.jl
@@ -259,8 +259,14 @@ function estimate_terk(integrator, cache, k, ::Val{max_order}, u) where {max_ord
         terk *= abs(dt^(k - 1))
     else
         vc = _vec(terk)
-        for i in 2:k
-            @.. broadcast=false vc += fd_weights[i, k]*@view(u_history[:, i - 1])
+        if ArrayInterface.ismutable(vc)
+            for i in 2:k
+                @.. broadcast=false vc+=fd_weights[i, k] * @view(u_history[:, i - 1])
+            end
+        else
+            for i in 2:k
+                vc = @. vc + fd_weights[i, k] * @view(u_history[:, i - 1])
+            end
         end
         terk = reshape(vc, size(terk))
         terk *= abs(dt^(k - 1))


### PR DESCRIPTION
Why allocate so much?

If we have a reason, those should be explicitly documented/commented, because that means we have spooky interactions at a distance.
Documenting those spooky interactions would make them slightly less scary, even though they'd still be pretty bad.