### PR TITLE
Optimistic first time convergence criterion (without messing with DelayDiffEq)

### DIFF
--- a/src/integrators/controllers.jl
+++ b/src/integrators/controllers.jl
@@ -16,6 +16,12 @@ end
 
 @inline function step_reject_controller!(integrator, alg)
     step_reject_controller!(integrator, integrator.opts.controller, alg)
+    cache = integrator.cache
+    if hasfield(typeof(cache), :nlsolve)
+        nlsolve = cache.nlsolve
+        nlsolve.prev_θ = one(nlsolve.prev_θ)
+    end
+    return nothing
 end
 
 reset_alg_dependent_opts!(controller::AbstractController, alg1, alg2) = nothing

--- a/src/nlsolve/nlsolve.jl
+++ b/src/nlsolve/nlsolve.jl
@@ -58,7 +58,7 @@ function nlsolve!(nlsolver::NL, integrator::DiffEqBase.DEIntegrator,
             nlsolver.nfails += 1
             break
         end
-        
+
         has_prev_θ = hasfield(NL, :prev_θ)
         prev_θ = has_prev_θ ? nlsolver.prev_θ : one(ndz)
 
@@ -88,7 +88,10 @@ function nlsolve!(nlsolver::NL, integrator::DiffEqBase.DEIntegrator,
                 break
             end
         else
-            θ = min(one(prev_θ), prev_θ)
+            if has_prev_θ && !integrator.accept_step
+                prev_θ = one(prev_θ)
+            end
+            θ = prev_θ
         end
 
         if has_prev_θ

--- a/src/nlsolve/nlsolve.jl
+++ b/src/nlsolve/nlsolve.jl
@@ -98,7 +98,8 @@ function nlsolve!(nlsolver::NL, integrator::DiffEqBase.DEIntegrator,
 
         # check for convergence
         η = DiffEqBase.value(θ / (1 - θ))
-        if (iter == 1 && ndz < 1e-5) || (η >= zero(η) && η * ndz < κ)
+        if (iter == 1 && ndz < 1e-5) ||
+           ((iter > 1 || isnewton(nlsolver)) && η >= zero(η) && η * ndz < κ)
             nlsolver.status = Convergence
             nlsolver.nfails = 0
             break

--- a/src/nlsolve/nlsolve.jl
+++ b/src/nlsolve/nlsolve.jl
@@ -58,12 +58,13 @@ function nlsolve!(nlsolver::NL, integrator::DiffEqBase.DEIntegrator,
             nlsolver.nfails += 1
             break
         end
-
-        prev_θ = hasfield(NL, :prev_θ) ? nlsolver.prev_θ : one(ndz)
+        
+        has_prev_θ = hasfield(NL, :prev_θ)
+        prev_θ = has_prev_θ ? nlsolver.prev_θ : one(ndz)
 
         # check divergence (not in initial step)
         if iter > 1
-            θ = prev_θ = max(0.3 * prev_θ, ndz / ndzprev)
+            θ = prev_θ = has_prev_θ ? max(0.3 * prev_θ, ndz / ndzprev) : ndz/ndzprev
 
             # When one Newton iteration basically does nothing, it's likely that we
             # are at the precision limit of floating point number. Thus, we just call
@@ -90,7 +91,7 @@ function nlsolve!(nlsolver::NL, integrator::DiffEqBase.DEIntegrator,
             θ = min(one(prev_θ), prev_θ)
         end
 
-        if hasfield(NL, :prev_θ)
+        if has_prev_θ
             nlsolver.prev_θ = prev_θ
         end
 

--- a/src/nlsolve/type.jl
+++ b/src/nlsolve/type.jl
@@ -117,8 +117,8 @@ end
 function NLSolver{iip, tType}(z, tmp, ztmp, γ, c, α, alg, κ, fast_convergence_cutoff, ηold,
         iter, maxiters, status, cache, method = DIRK, tmp2 = nothing,
         nfails::Int = 0) where {iip, tType}
-    T = eltype(z)
-    NLSolver{typeof(alg), iip, typeof(z), typeof(γ), typeof(tmp2), tType, typeof(cache), T}(
+    RT = real(eltype(z))
+    NLSolver{typeof(alg), iip, typeof(z), typeof(γ), typeof(tmp2), tType, typeof(cache), RT}(
         z,
         tmp,
         tmp2,
@@ -136,7 +136,7 @@ function NLSolver{iip, tType}(z, tmp, ztmp, γ, c, α, alg, κ, fast_convergence
         cache,
         method,
         nfails,
-        one(T))
+        one(RT))
 end
 
 # caches

--- a/src/nlsolve/type.jl
+++ b/src/nlsolve/type.jl
@@ -92,7 +92,7 @@ end
 abstract type AbstractNLSolver{algType, iip} end
 
 mutable struct NLSolver{algType, iip, uType, gamType, tmpType, tType,
-    C <: AbstractNLSolverCache} <: AbstractNLSolver{algType, iip}
+    C <: AbstractNLSolverCache, E} <: AbstractNLSolver{algType, iip}
     z::uType
     tmp::uType # DIRK and multistep methods only use tmp
     tmp2::tmpType # for GLM if necessary
@@ -110,13 +110,15 @@ mutable struct NLSolver{algType, iip, uType, gamType, tmpType, tType,
     cache::C
     method::MethodType
     nfails::Int
+    prev_η::E
 end
 
 # default to DIRK
 function NLSolver{iip, tType}(z, tmp, ztmp, γ, c, α, alg, κ, fast_convergence_cutoff, ηold,
         iter, maxiters, status, cache, method = DIRK, tmp2 = nothing,
         nfails::Int = 0) where {iip, tType}
-    NLSolver{typeof(alg), iip, typeof(z), typeof(γ), typeof(tmp2), tType, typeof(cache)}(z,
+    T = eltype(z)
+    NLSolver{typeof(alg), iip, typeof(z), typeof(γ), typeof(tmp2), tType, typeof(cache), T}(z,
         tmp,
         tmp2,
         ztmp,
@@ -132,7 +134,8 @@ function NLSolver{iip, tType}(z, tmp, ztmp, γ, c, α, alg, κ, fast_convergence
         status,
         cache,
         method,
-        nfails)
+        nfails,
+        one(T))
 end
 
 # caches

--- a/src/nlsolve/type.jl
+++ b/src/nlsolve/type.jl
@@ -110,7 +110,7 @@ mutable struct NLSolver{algType, iip, uType, gamType, tmpType, tType,
     cache::C
     method::MethodType
     nfails::Int
-    prev_η::E
+    prev_θ::E
 end
 
 # default to DIRK

--- a/src/nlsolve/type.jl
+++ b/src/nlsolve/type.jl
@@ -118,7 +118,8 @@ function NLSolver{iip, tType}(z, tmp, ztmp, γ, c, α, alg, κ, fast_convergence
         iter, maxiters, status, cache, method = DIRK, tmp2 = nothing,
         nfails::Int = 0) where {iip, tType}
     T = eltype(z)
-    NLSolver{typeof(alg), iip, typeof(z), typeof(γ), typeof(tmp2), tType, typeof(cache), T}(z,
+    NLSolver{typeof(alg), iip, typeof(z), typeof(γ), typeof(tmp2), tType, typeof(cache), T}(
+        z,
         tmp,
         tmp2,
         ztmp,

--- a/test/algconvergence/ode_convergence_tests.jl
+++ b/test/algconvergence/ode_convergence_tests.jl
@@ -323,7 +323,7 @@ end
     @test sim120.𝒪est[:final]≈4 atol=testTol
 
     sim121 = test_convergence(dts, prob, ESDIRK547L2SA2())
-    @test 5-testTol <= sim121.𝒪est[:final] <= 6
+    @test 5 - testTol <= sim121.𝒪est[:final] <= 6
 
     dts = (1 / 2) .^ (5:-1:1)
     sim122 = test_convergence(dts, prob, ESDIRK659L2SA())

--- a/test/algconvergence/ode_convergence_tests.jl
+++ b/test/algconvergence/ode_convergence_tests.jl
@@ -323,7 +323,7 @@ end
     @test sim120.𝒪est[:final]≈4 atol=testTol
 
     sim121 = test_convergence(dts, prob, ESDIRK547L2SA2())
-    @test sim121.𝒪est[:final]≈5 atol=2 * testTol
+    @test 5-testTol <= sim121.𝒪est[:final] <= 6
 
     dts = (1 / 2) .^ (5:-1:1)
     sim122 = test_convergence(dts, prob, ESDIRK659L2SA())

--- a/test/interface/static_array_tests.jl
+++ b/test/interface/static_array_tests.jl
@@ -3,10 +3,10 @@ using OrdinaryDiffEq
 using RecursiveArrayTools
 
 u0 = VectorOfArray([fill(2, MVector{2, Float64}), ones(MVector{2, Float64})])
-g(u, p, t) = SA[u[1] + u[2], u[1]]
+g0(u, p, t) = SA[u[1] + u[2], u[1]]
 f = (du, u, p, t) -> begin
     for i in 1:2
-        du[:, i] = g(u[:, i], p, t)
+        du[:, i] = g0(u[:, i], p, t)
     end
 end
 ode = ODEProblem(f, u0, (0.0, 1.0))
@@ -29,7 +29,7 @@ sol = solve(ode, ROCK4())
 @test !any(iszero.(sol(1.0))) && !any(sol(1.0) .== u0)
 
 u0 = ones(MVector{2, Float64})
-ode = ODEProblem(g, u0, (0.0, 1.0))
+ode = ODEProblem(g0, u0, (0.0, 1.0))
 sol = solve(ode, Euler(), dt = 1e-2)
 @test !any(iszero.(sol(1.0))) && !any(sol(1.0) .== u0)
 sol = solve(ode, Tsit5(), dt = 1e-2)
@@ -241,7 +241,7 @@ prob = ODEProblem(pollu, u0, (0.0, 60.0))
 @test_nowarn sol = solve(prob, Rodas5(chunk_size = Val{8}()), save_everystep = false)
 
 # DFBDF
-g(du, u, p, t) = du .^ 2 - conj.(u)
+g1(du, u, p, t) = du .^ 2 - conj.(u)
 u0 = SA[-0.5048235596641171 - 0.8807809019469485im,
     -0.5086319184891589 - 0.8791877406854778im,
     -0.5015635095728721 + 0.8770989403497113im,
@@ -262,7 +262,7 @@ du0 = SA[-0.5051593302918506 - 0.87178524227302im,
     -0.5014121747348508 + 0.8712321173163112im,
     -0.5011616766671037 + 0.8651123244481334im,
     -0.5065728050401669 + 0.8738635859036186im]
-prob = DAEProblem(g, du0, u0, (0.0, 10.0))
+prob = DAEProblem(g1, du0, u0, (0.0, 10.0))
 sol1 = solve(prob, DFBDF(autodiff = false), reltol = 1e-8, abstol = 1e-8)
 
 g2(resid, du, u, p, t) = resid .= du .^ 2 - conj.(u)
@@ -270,4 +270,4 @@ prob = DAEProblem(g2, Array(du0), Array(u0), (0.0, 10.0))
 sol2 = solve(prob, DFBDF(autodiff = false), reltol = 1e-8, abstol = 1e-8)
 
 @test all(iszero, sol1[:, 1] - sol2[:, 1])
-@test all(abs.(sol1[:, end] .- sol2[:, end]) .< 1e-6)
+@test all(abs.(sol1[:, end] .- sol2[:, end]) .< 1.5e-6)

--- a/test/interface/utility_tests.jl
+++ b/test/interface/utility_tests.jl
@@ -68,6 +68,6 @@ end
 
         sol1_ip = solve(ODEProblem(fun1_ip, u0, tspan), Alg(); adaptive = false, dt = 0.01)
         sol2_ip = solve(ODEProblem(fun2_ip, u0, tspan), Alg(); adaptive = false, dt = 0.01)
-        @test sol1_ip(1.0)≈sol2_ip(1.0) atol=1e-5
+        @test sol1_ip(1.0)≈sol2_ip(1.0) atol=2e-5
     end
 end


### PR DESCRIPTION
basically just https://github.com/SciML/OrdinaryDiffEq.jl/pull/2183 but made to not use the prev_theta value if it doesn't exist in the integrator. I made a new PR rather than just pushing to yingbo's because I don't want to break his history if I end up needing a rebase.