### PR TITLE
Fix `QNDF` alg_events test

### DIFF
--- a/test/integrators/alg_events_tests.jl
+++ b/test/integrators/alg_events_tests.jl
@@ -265,5 +265,5 @@ println(".")
 @test test_callback_inplace(QNDF())
 
 println("adaptive multistep methods")
-@test test_callback_adaptive_multistep(QNDF(), reltol = 1e-10, abstol = 1e-8)
-@test test_callback_adaptive_multistep(FBDF(), reltol = 1e-10, abstol = 1e-8)
+@test test_callback_adaptive_multistep(QNDF(), reltol = 1e-10, abstol = 1e-10)
+@test test_callback_adaptive_multistep(FBDF(), reltol = 1e-10, abstol = 1e-10)


### PR DESCRIPTION
https://github.com/SciML/OrdinaryDiffEq.jl/pull/2233 merged slightly too early, but this fixes the failing test. The problem was that the test was comparing a QNDF solve to an FBDF solve where the solves had an abstol of 1e-8 but we were looking for agreement of 1e-8. Reducing the abstol of the solve to 1e-10 fixes the failure.