### PR TITLE
fix `get_tmp_cache` for Default solver (and some other default solver DAE fixes)

### DIFF
--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -309,7 +309,7 @@ end
 _alg_autodiff(::OrdinaryDiffEqAdaptiveImplicitAlgorithm{CS, AD}) where {CS, AD} = Val{AD}()
 _alg_autodiff(::DAEAlgorithm{CS, AD}) where {CS, AD} = Val{AD}()
 _alg_autodiff(::OrdinaryDiffEqImplicitAlgorithm{CS, AD}) where {CS, AD} = Val{AD}()
-_alg_autodiff(alg::CompositeAlgorithm) = _alg_autodiff(alg.algs[2])
+_alg_autodiff(alg::CompositeAlgorithm) = _alg_autodiff(alg.algs[end])
 function _alg_autodiff(::Union{OrdinaryDiffEqExponentialAlgorithm{CS, AD},
         OrdinaryDiffEqAdaptiveExponentialAlgorithm{CS, AD}
 }) where {

--- a/src/composite_algs.jl
+++ b/src/composite_algs.jl
@@ -181,7 +181,9 @@ function default_autoswitch(AS::AutoSwitchCache, integrator)
         AS.is_stiffalg, AS.current) ?
                AS.count < 0 ? 1 : AS.count + 1 :
                AS.count > 0 ? -1 : AS.count - 1
-    if integrator.f.mass_matrix != I || (!AS.is_stiffalg && AS.count > AS.maxstiffstep)
+    if integrator.f.mass_matrix != I
+        #don't change anything
+    elseif (!AS.is_stiffalg && AS.count > AS.maxstiffstep)
         integrator.dt = dt * AS.dtfac
         AS.is_stiffalg = true
         AS.current = stiffchoice(reltol, len, integrator.f.mass_matrix)

--- a/src/dense/generic_dense.jl
+++ b/src/dense/generic_dense.jl
@@ -500,7 +500,7 @@ function evaluate_default_cache(f, Θ, dt, timeseries, i₋, i₊,
     elseif cacheid == 2
         return _evaluate_interpolant(f, Θ, dt, timeseries, i₋, i₊,
             cache.cache2, idxs, deriv, ks, ts, p, differential_vars)
-    elseif alg_choice == 3
+    elseif cacheid == 3
         return _evaluate_interpolant(f, Θ, dt, timeseries, i₋, i₊,
             cache.cache3, idxs, deriv, ks, ts, p, differential_vars)
     elseif cacheid == 4

--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -173,12 +173,26 @@ end
 end
 @inline function DiffEqBase.get_tmp_cache(integrator, alg::CompositeAlgorithm,
         cache::CompositeCache)
-    get_tmp_cache(integrator, integrator.alg.algs[1], cache.caches[1])
+    get_tmp_cache(integrator, alg.algs[1], cache.caches[1])
 end
 @inline function DiffEqBase.get_tmp_cache(integrator, alg::CompositeAlgorithm,
         cache::DefaultCache)
-    get_tmp_cache(integrator, integrator.alg.algs[1], cache.cache1)
+    init_ith_default_cache(cache, alg.algs, cache.current)
+    if cache.current == 1
+        get_tmp_cache(integrator, alg.algs[1], cache.cache1)
+    elseif cache.current == 2
+        get_tmp_cache(integrator, alg.algs[2], cache.cache2)
+    elseif cache.current == 3
+        get_tmp_cache(integrator, alg.algs[3], cache.cache3)
+    elseif cache.current == 4
+        get_tmp_cache(integrator, alg.algs[4], cache.cache4)
+    elseif cache.current == 5
+        get_tmp_cache(integrator, alg.algs[5], cache.cache5)
+    else# cache.current == 6
+        get_tmp_cache(integrator, alg.algs[6], cache.cache6)
+    end
 end
+
 @inline function DiffEqBase.get_tmp_cache(integrator, alg::DAEAlgorithm,
         cache::OrdinaryDiffEqMutableCache)
     (cache.nlsolver.cache.dz, cache.atmp)

--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -188,7 +188,8 @@ end
         get_tmp_cache(integrator, alg.algs[4], cache.cache4)
     elseif cache.current == 5
         get_tmp_cache(integrator, alg.algs[5], cache.cache5)
-    else# cache.current == 6
+    else
+        @assert cache.current == 6
         get_tmp_cache(integrator, alg.algs[6], cache.cache6)
     end
 end

--- a/test/interface/default_solver_tests.jl
+++ b/test/interface/default_solver_tests.jl
@@ -85,4 +85,20 @@ swaplinearf = ODEFunction(swaplinear, mass_matrix = ones(2, 2) - I(2))
 prob_swaplinear = ODEProblem(swaplinearf, rand(2), (0.0, 1.0), 1.01)
 sol = solve(prob_swaplinear)
 @test all(isequal(4), sol.alg_choice)
+@test sol(.5) isa Vector{Float64} # test dense output
 # for some reason the timestepping here is different from regular Rodas5P (including the initial timestep)
+
+# test mass matrix DAE where we have to initialize algebraic variables
+function rober_mm(du, u, p, t)
+    y₁, y₂, y₃ = u
+    k₁, k₂, k₃ = p
+    du[1] = -k₁ * y₁ + k₃ * y₂ * y₃
+    du[2] = k₁ * y₁ - k₃ * y₂ * y₃ - k₂ * y₂^2
+    du[3] = y₁ + y₂ + y₃ - 1
+    nothing
+end
+f = ODEFunction(rober_mm, mass_matrix=[1 0 0; 0 1 0; 0 0 0])
+prob_rober_mm = ODEProblem(f, [1.0, 0.0, 1.0], (0.0, 1e5), (0.04, 3e7, 1e4))
+sol = solve(prob_rober_mm)
+@test all(isequal(3), sol.alg_choice)
+@test sol(.5) isa Vector{Float64} # test dense output


### PR DESCRIPTION
Previously, this was assuming that `cache.cache1` was filled in which wasn't always true for DAEs.