### PR TITLE
fix out of place `linsolve=KrylovJL*`

### DIFF
--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -682,9 +682,7 @@ function calc_W!(W, integrator, nlsolver::Union{Nothing, AbstractNLSolver}, cach
     end
 
     # calculate W
-    if W isa AbstractSciMLOperator && !(W isa Union{WOperator, StaticWOperator})
-        update_coefficients!(W, uprev, p, t; transform = W_transform, dtgamma)
-    elseif W isa WOperator
+    if W isa WOperator
         if isnewton(nlsolver)
             # we will call `update_coefficients!` for u/p/t in NLNewton
             update_coefficients!(W; transform = W_transform, dtgamma)
@@ -698,6 +696,8 @@ function calc_W!(W, integrator, nlsolver::Union{Nothing, AbstractNLSolver}, cach
             new_W && !isdae &&
                 jacobian2W!(W._concrete_form, mass_matrix, dtgamma, J, W_transform)
         end
+    elseif W isa AbstractSciMLOperator && !(W isa StaticWOperator)
+        update_coefficients!(W, uprev, p, t; transform = W_transform, dtgamma)
     else # concrete W using jacobian from `calc_J!`
         islin, isode = islinearfunction(integrator)
         islin ? (J = isode ? f.f : f.f1.f) :
@@ -738,7 +738,22 @@ end
     islin, isode = islinearfunction(integrator)
     !isdae && update_coefficients!(mass_matrix, uprev, p, t)
 
-    if cache.W isa AbstractSciMLOperator && !(cache.W isa Union{WOperator, StaticWOperator})
+
+    if cache.W isa WOperator
+        W = cache.W
+        if isnewton(nlsolver)
+            # we will call `update_coefficients!` for u/p/t in NLNewton
+            update_coefficients!(W; transform = W_transform, dtgamma)
+        else
+            update_coefficients!(W, uprev, p, t; transform = W_transform, dtgamma)
+        end
+        if W.J !== nothing && !(W.J isa AbstractSciMLOperator)
+            islin, isode = islinearfunction(integrator)
+            J = islin ? (isode ? f.f : f.f1.f) : calc_J(integrator, cache, next_step)
+            !isdae &&
+                jacobian2W!(W._concrete_form, mass_matrix, dtgamma, J, W_transform)
+        end
+    elseif cache.W isa AbstractSciMLOperator && !(cache.W isa StaticWOperator)
         J = update_coefficients(cache.J, uprev, p, t)
         W = update_coefficients(cache.W, uprev, p, t; dtgamma, transform = W_transform)
     elseif islin

--- a/test/interface/linear_solver_test.jl
+++ b/test/interface/linear_solver_test.jl
@@ -85,6 +85,10 @@ end
 @test isapprox(exp.(p), g_helper(p; alg = KenCarp47(linsolve = KrylovJL_GMRES()));
     atol = 1e-1, rtol = 1e-1)
 
+@test isapprox(exp.(p), g_helper(p; alg = FBDF(linsolve = KrylovJL_GMRES()));
+    atol = 1e-1, rtol = 1e-1)
+
+
 ## IIP
 
 fiip(du, u, p, t) = du .= jac(u, p, t) * u


### PR DESCRIPTION
fixes https://github.com/SciML/OrdinaryDiffEq.jl/issues/2197. This works, but I'm not 100% sure why we are treating `StaticWOperator` differently here, but it is just copying from the in place method.