### PR TITLE
Fixing dolinsolve(), so that it will pass u,p,t to the precs() function

### DIFF
--- a/src/misc_utils.jl
+++ b/src/misc_utils.jl
@@ -81,8 +81,7 @@ macro threaded(option, ex)
 end
 
 function dolinsolve(integrator, linsolve; A = nothing, linu = nothing, b = nothing,
-        du = nothing, u = nothing, p = nothing, t = nothing,
-        weight = nothing, solverdata = nothing,
+    p = nothing, weight = nothing, solverdata = nothing,
         reltol = integrator === nothing ? nothing : integrator.opts.reltol)
     A !== nothing && (linsolve.A = A)
     b !== nothing && (linsolve.b = b)
@@ -95,8 +94,13 @@ function dolinsolve(integrator, linsolve; A = nothing, linu = nothing, b = nothi
 
     _alg = unwrap_alg(integrator, true)
 
-    _Pl, _Pr = _alg.precs(linsolve.A, du, u, p, t, A !== nothing, Plprev, Prprev,
-        solverdata)
+    du, u, p, t = if isnothing(integrator)
+        nothing, nothing, nothing, nothing
+    else
+        integrator.du, integrator.u, integrator.p, integrator.t
+    end
+    _Pl, _Pr = _alg.precs(linsolve.A, du, u, p, t, A !== nothing, Plprev, Prprev, solverdata)
+
     if (_Pl !== nothing || _Pr !== nothing)
         __Pl = _Pl === nothing ? SciMLOperators.IdentityOperator(length(integrator.u)) : _Pl
         __Pr = _Pr === nothing ? SciMLOperators.IdentityOperator(length(integrator.u)) : _Pr


### PR DESCRIPTION
Fixing dolinsolve(), so that it will pass u,p,t to the precs() function properly during the solve. Previously, these were always being passed as ::Nothing.
  
## Additional context

The change was originally proposed by Oscar Smith, but was previously cancelled. I would like to request this be reviewed again. I have tested with and without the change. Without it, the solver never passes u,p,t to precs() - it only ever passes ::Nothing during the solve. With this fix, there are no errors and u,p,t get passed during the solve, which means they can be used for updating the preconditioner.
