### PR TITLE
Fix unescaped name argument in cache macro.

### DIFF
--- a/lib/OrdinaryDiffEqExtrapolation/src/OrdinaryDiffEqExtrapolation.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/OrdinaryDiffEqExtrapolation.jl
@@ -3,7 +3,7 @@ module OrdinaryDiffEqExtrapolation
 import OrdinaryDiffEq: alg_order, alg_maximum_order, get_current_adaptive_order,
                        get_current_alg_order, calculate_residuals!, accept_step_controller,
                        default_controller, beta2_default, beta1_default, gamma_default,
-                       initialize!, perform_step!, @unpack, unwrap_alg, isthreaded,
+                       initialize!, perform_step!, @unpack, @cache, unwrap_alg, isthreaded,
                        step_accept_controller!, calculate_residuals,
                        OrdinaryDiffEqMutableCache, OrdinaryDiffEqConstantCache,
                        reset_alg_dependent_opts!, AbstractController,
@@ -17,25 +17,6 @@ import OrdinaryDiffEq: alg_order, alg_maximum_order, get_current_adaptive_order,
                        build_jac_config, calc_J!, jacobian2W!, dolinsolve
 using DiffEqBase, FastBroadcast, Polyester, MuladdMacro, RecursiveArrayTools, LinearSolve
 
-macro cache(expr)
-    name = expr.args[2].args[1].args[1]
-    fields = [x for x in expr.args[3].args if typeof(x) != LineNumberNode]
-    cache_vars = Expr[]
-    jac_vars = Pair{Symbol, Expr}[]
-    for x in fields
-        if x.args[2] == :uType || x.args[2] == :rateType ||
-           x.args[2] == :kType || x.args[2] == :uNoUnitsType
-            push!(cache_vars, :(c.$(x.args[1])))
-        elseif x.args[2] == :DiffCacheType
-            push!(cache_vars, :(c.$(x.args[1]).du))
-            push!(cache_vars, :(c.$(x.args[1]).dual_du))
-        end
-    end
-    quote
-        $(esc(expr))
-        $(esc(:full_cache))(c::$name) = tuple($(cache_vars...))
-    end
-end
 
 include("algorithms.jl")
 include("alg_utils.jl")

--- a/src/misc_utils.jl
+++ b/src/misc_utils.jl
@@ -35,7 +35,7 @@ macro cache(expr)
     end
     quote
         $(esc(expr))
-        $(esc(:full_cache))(c::$name) = tuple($(cache_vars...))
+        $(esc(:full_cache))(c::$(esc(name))) = tuple($(cache_vars...))
     end
 end
 


### PR DESCRIPTION
Fixes https://github.com/SciML/OrdinaryDiffEq.jl/issues/2158

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context
As discussed in the linked issue, the `@cache` macro generated the line `full_cache(var"#329#c"::OrdinaryDiffEq.RK_ALGCache) = begin`, specifically namespacing RK_ALGCache (leading to `ERROR: UndefVarError: `RK_ALGCache` not defined`), because `RK_ALGCache` was defined elsewhere (Main in this case). This is fixed by escaping the name of the struct.

I also removed a perfect duplicate cache macro (and added an import) in the `lib/OrdinaryDiffEqExtrapolation` code, possibly put there because the original macro didn't work?