### PR TITLE
Don't use prev_theta for non-adaptive solves

### DIFF
--- a/src/nlsolve/nlsolve.jl
+++ b/src/nlsolve/nlsolve.jl
@@ -104,7 +104,7 @@ function nlsolve!(nlsolver::NL, integrator::DiffEqBase.DEIntegrator,
         η = DiffEqBase.value(θ / (1 - θ))
         # don't trust θ for non-adaptive on first iter because the solver doesn't provide feedback
         # for us to know whether our previous nlsolve converged sufficiently well
-        check_η_convergance = (iter > 1 || (isnewton(nlsolver) && isadaptive(nlsolver)))
+        check_η_convergance = (iter > 1 || (isnewton(nlsolver) && isadaptive(integrator.alg)))
         if (iter == 1 && ndz < 1e-5) ||
            (check_η_convergance && η >= zero(η) && η * ndz < κ)
             nlsolver.status = Convergence

--- a/src/nlsolve/nlsolve.jl
+++ b/src/nlsolve/nlsolve.jl
@@ -104,7 +104,7 @@ function nlsolve!(nlsolver::NL, integrator::DiffEqBase.DEIntegrator,
         η = DiffEqBase.value(θ / (1 - θ))
         # don't trust θ for non-adaptive on first iter because the solver doesn't provide feedback
         # for us to know whether our previous nlsolve converged sufficiently well
-        check_η_convergance = (iter > 1 || (isnewton(nlsolver) && isadaptive(solver)))
+        check_η_convergance = (iter > 1 || (isnewton(nlsolver) && isadaptive(nlsolver)))
         if (iter == 1 && ndz < 1e-5) ||
            (check_η_convergance && η >= zero(η) && η * ndz < κ)
             nlsolver.status = Convergence

--- a/src/nlsolve/nlsolve.jl
+++ b/src/nlsolve/nlsolve.jl
@@ -88,7 +88,8 @@ function nlsolve!(nlsolver::NL, integrator::DiffEqBase.DEIntegrator,
                 break
             end
         else
-            if has_prev_θ && !integrator.accept_step
+            # don't use prev_θ for non-adaptive because we own't know if it actually converged
+            if !integrator.opts.adaptive || !integrator.accept_step
                 prev_θ = one(prev_θ)
             end
             θ = prev_θ


### PR DESCRIPTION
found by @bradcarman. The early exit here relies on implicit feedback from the  solver to prevent it from overly aggressively terminating the nonlinear solve as successful. As such, we disable prev_theta for non-adaptive algorithms.