### PR TITLE
use StaticW more often

### DIFF
--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -896,7 +896,7 @@ function build_J_W(alg, u, uprev, p, t, dt, f::F, ::Type{uEltypeNoUnits},
             J
         elseif IIP
             similar(J)
-        elseif J isa StaticMatrix && alg isa OrdinaryDiffEqRosenbrockAdaptiveAlgorithm
+        elseif J isa StaticMatrix
             StaticWOperator(J, false)
         else
             ArrayInterface.lu_instance(J)

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -872,10 +872,8 @@ function build_J_W(alg, u, uprev, p, t, dt, f::F, ::Type{uEltypeNoUnits},
         else
             deepcopy(f.jac_prototype)
         end
-        W = if J isa StaticMatrix && alg isa OrdinaryDiffEqRosenbrockAdaptiveAlgorithm
+        W = if J isa StaticMatrix
             StaticWOperator(J, false)
-        elseif J isa StaticMatrix
-            ArrayInterface.lu_instance(J)
         else
             __f = if IIP
                 (du, u, p, t) -> _f(du, u, p, t)

--- a/test/interface/static_array_tests.jl
+++ b/test/interface/static_array_tests.jl
@@ -40,8 +40,6 @@ f = (u, p, t) -> u
 ode = ODEProblem(f, u0, (0.0, 1.0))
 sol = solve(ode, Euler(), dt = 1e-2)
 @test !any(iszero.(sol(1.0))) && !any(sol(1.0) .== u0)
-integrator = init(ode, ImplicitEuler())
-@test OrdinaryDiffEq.get_W(integrator.cache.nlsolver) isa StaticArrays.LU
 sol = solve(ode, ImplicitEuler())
 @test !any(iszero.(sol(1.0))) && !any(sol(1.0) .== u0)
 sol = solve(ode, ImplicitEuler(nlsolve = NLAnderson()))


### PR DESCRIPTION
as pointed out by @ChrisRackauckas in https://github.com/SciML/OrdinaryDiffEq.jl/pull/2291, we should at least try this for the non-Rosenbrock solvers.