### PR TITLE
Function to strip solutions and interpolation of functions

### DIFF
--- a/src/interp_func.jl
+++ b/src/interp_func.jl
@@ -61,7 +61,7 @@ function InterpolationData(id::InterpolationData, f)
 end
 
 # strip interpolation of function information
-function strip_interpolation(id::InterpolationData)
+function SciMLBase.strip_interpolation(id::InterpolationData)
     InterpolationData(nothing, id.timeseries,
         id.ts,
         id.ks,

--- a/src/interp_func.jl
+++ b/src/interp_func.jl
@@ -59,3 +59,15 @@ function InterpolationData(id::InterpolationData, f)
         id.differential_vars,
         id.sensitivitymode)
 end
+
+# strip interpolation of function information
+function strip_interpolation(id::InterpolationData)
+    InterpolationData(nothing, id.timeseries,
+        id.ts,
+        id.ks,
+        id.alg_choice,
+        id.dense,
+        id.cache,
+        id.differential_vars,
+        id.sensitivitymode)
+end

--- a/src/misc_utils.jl
+++ b/src/misc_utils.jl
@@ -130,3 +130,16 @@ function get_differential_vars(f, u)
 end
 
 isnewton(::Any) = false
+
+function strip_solution(sol::ODESolution)
+    if has_lazy_interpolation(sol.alg)
+        error("change this to a proper error")
+    end
+
+    interp = strip_interpolation(sol.interp)
+
+    ODESolution(sol.u, sol.u_analytic, sol.errors,
+        sol.t, sol.k, sol.discretes, nothing, nothing,
+        sol.interp, sol.dense, sol.tslocation, sol.stats,
+        sol.alg_choice, sol.retcode, sol.resid, sol.original)
+end

--- a/src/misc_utils.jl
+++ b/src/misc_utils.jl
@@ -131,15 +131,3 @@ end
 
 isnewton(::Any) = false
 
-function strip_solution(sol::ODESolution)
-    if has_lazy_interpolation(sol.alg)
-        error("change this to a proper error")
-    end
-
-    interp = strip_interpolation(sol.interp)
-
-    ODESolution(sol.u, sol.u_analytic, sol.errors,
-        sol.t, sol.k, sol.discretes, nothing, nothing,
-        sol.interp, sol.dense, sol.tslocation, sol.stats,
-        sol.alg_choice, sol.retcode, sol.resid, sol.original)
-end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ x] Any code changes were done in a way that does not break public API
- [x ] All documentation related to code changes were updated
- [x ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Adds a function to strip `InterpolationData` objects of their functions, and strip `ODEsolution` objects of their functions, in order to accommodate serialization better.  
