### PR TITLE
remove unused MultistepAlgorithms  constant

### DIFF
--- a/lib/OrdinaryDiffEqAdamsBashforthMoulton/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqAdamsBashforthMoulton/src/algorithms.jl
@@ -137,6 +137,3 @@ An adaptive order adaptive time Adams Moulton method.
 It uses an order adaptivity algorithm is derived from Shampine's DDEABM.
 """
 struct VCABM <: OrdinaryDiffEqAdamsVarOrderVarStepAlgorithm end
-
-const MultistepAlgorithms = Union{
-    AB3, AB4, AB5, ABM32, ABM43, ABM54}


### PR DESCRIPTION
This constant does not appear to be used anywhere within OrdinaryDiffEq.
And also not in the wider SciML:
https://github.com/search?q=org%3ASciML%20MultistepAlgorithms&type=code