### PR TITLE
Add cache stripping to solution stripping 

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/interp_func.jl
+++ b/lib/OrdinaryDiffEqCore/src/interp_func.jl
@@ -59,3 +59,24 @@ function InterpolationData(id::InterpolationData, f)
         id.differential_vars,
         id.sensitivitymode)
 end
+
+# strip interpolation of function information
+function SciMLBase.strip_interpolation(id::InterpolationData)
+    cache = id.cache
+    
+    cache = strip_cache(cache)
+
+    InterpolationData(nothing, id.timeseries,
+        id.ts,
+        id.ks,
+        id.alg_choice,
+        id.dense,
+        cache,
+        id.differential_vars,
+        id.sensitivitymode)
+end
+
+function strip_cache(cache::OrdinaryDiffEqCache)
+    # most caches don't have jac_config or grad_config
+    cache
+end

--- a/lib/OrdinaryDiffEqCore/src/interp_func.jl
+++ b/lib/OrdinaryDiffEqCore/src/interp_func.jl
@@ -62,9 +62,8 @@ end
 
 # strip interpolation of function information
 function SciMLBase.strip_interpolation(id::InterpolationData)
-    cache = id.cache
     
-    cache = strip_cache(cache)
+    cache = strip_cache(id.cache)
 
     InterpolationData(nothing, id.timeseries,
         id.ts,
@@ -77,6 +76,12 @@ function SciMLBase.strip_interpolation(id::InterpolationData)
 end
 
 function strip_cache(cache::OrdinaryDiffEqCache)
-    # most caches don't have jac_config or grad_config
-    cache
+    if hasfield(typeof(cache), :jac_config) || hasfield(typeof(cache), :grad_config)
+        fieldnums = length(fieldnames(typeof(cache)))
+        noth_list = fill(nothing,fieldnums)
+        cache_type_name = nameof(typeof(cache))
+        eval(cache_type_name)(noth_list...)
+    else
+        cache
+    end
 end

--- a/lib/OrdinaryDiffEqCore/src/interp_func.jl
+++ b/lib/OrdinaryDiffEqCore/src/interp_func.jl
@@ -79,7 +79,7 @@ function strip_cache(cache)
     if hasfield(typeof(cache), :jac_config) || hasfield(typeof(cache), :grad_config)
         fieldnums = length(fieldnames(typeof(cache)))
         noth_list = fill(nothing,fieldnums)
-        cache_type_name = typename(typeof(cache)).wrapper
+        cache_type_name = Base.typename(typeof(cache)).wrapper
         cache_type_name(noth_list...)
     else
         cache

--- a/lib/OrdinaryDiffEqCore/src/interp_func.jl
+++ b/lib/OrdinaryDiffEqCore/src/interp_func.jl
@@ -75,12 +75,12 @@ function SciMLBase.strip_interpolation(id::InterpolationData)
         id.sensitivitymode)
 end
 
-function strip_cache(cache::OrdinaryDiffEqCache)
+function strip_cache(cache)
     if hasfield(typeof(cache), :jac_config) || hasfield(typeof(cache), :grad_config)
         fieldnums = length(fieldnames(typeof(cache)))
         noth_list = fill(nothing,fieldnums)
-        cache_type_name = nameof(typeof(cache))
-        eval(cache_type_name)(noth_list...)
+        cache_type_name = typename(typeof(cache)).wrapper
+        cache_type_name(noth_list...)
     else
         cache
     end

--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -58,7 +58,7 @@ import OrdinaryDiffEqCore: trivial_limiter!, CompositeAlgorithm, alg_order,
                            _change_t_via_interpolation!, ODEIntegrator, _ode_interpolant!,
                            current_interpolant, resize_nlsolver!, _ode_interpolant,
                            handle_tstop!, _postamble!, update_uprev!, resize_J_W!,
-                           DAEAlgorithm, get_fsalfirstlast, strip_cache
+                           DAEAlgorithm, get_fsalfirstlast, strip_cache, strip_interpolation
 
 export CompositeAlgorithm, ShampineCollocationInit, BrownFullBasicInit, NoInit
 AutoSwitch

--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -58,7 +58,7 @@ import OrdinaryDiffEqCore: trivial_limiter!, CompositeAlgorithm, alg_order,
                            _change_t_via_interpolation!, ODEIntegrator, _ode_interpolant!,
                            current_interpolant, resize_nlsolver!, _ode_interpolant,
                            handle_tstop!, _postamble!, update_uprev!, resize_J_W!,
-                           DAEAlgorithm, get_fsalfirstlast
+                           DAEAlgorithm, get_fsalfirstlast, strip_cache
 
 export CompositeAlgorithm, ShampineCollocationInit, BrownFullBasicInit, NoInit
 AutoSwitch

--- a/test/interface/ode_strip_test.jl
+++ b/test/interface/ode_strip_test.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq, Test
+using OrdinaryDiffEq, OrdinaryDiffEqCore, Test
 
 function lorenz!(du, u, p, t)
     du[1] = 10.0 * (u[2] - u[1])

--- a/test/interface/ode_strip_test.jl
+++ b/test/interface/ode_strip_test.jl
@@ -1,0 +1,16 @@
+using OrdinaryDiffEq, Test
+
+function lorenz!(du, u, p, t)
+    du[1] = 10.0 * (u[2] - u[1])
+    du[2] = u[1] * (28.0 - u[3]) - u[2]
+    du[3] = u[1] * u[2] - (8 / 3) * u[3]
+end
+
+u0 = [1.0; 0.0; 0.0]
+tspan = (0.0, 0.5)
+prob = ODEProblem(lorenz!, u0, tspan)
+
+sol = solve(prob, Rosenbrock23())
+
+@test isnothing(strip_interpolation(sol.interp).f)
+@test isnothing(strip_interpolation(sol.interp).cache.jac_config)

--- a/test/interface/ode_strip_test.jl
+++ b/test/interface/ode_strip_test.jl
@@ -1,5 +1,4 @@
 using OrdinaryDiffEq, Test
-import OrdinaryDiffEqCore
 
 function lorenz!(du, u, p, t)
     du[1] = 10.0 * (u[2] - u[1])
@@ -13,5 +12,5 @@ prob = ODEProblem(lorenz!, u0, tspan)
 
 sol = solve(prob, Rosenbrock23())
 
-@test isnothing(OrdinaryDiffEqCore.strip_interpolation(sol.interp).f)
-@test isnothing(OrdinaryDiffEqCore.strip_interpolation(sol.interp).cache.jac_config)
+@test isnothing(OrdinaryDiffEq.strip_interpolation(sol.interp).f)
+@test isnothing(OrdinaryDiffEq.strip_interpolation(sol.interp).cache.jac_config)

--- a/test/interface/ode_strip_test.jl
+++ b/test/interface/ode_strip_test.jl
@@ -1,4 +1,5 @@
 using OrdinaryDiffEq, Test
+import SciMLBase
 
 function lorenz!(du, u, p, t)
     du[1] = 10.0 * (u[2] - u[1])
@@ -12,5 +13,5 @@ prob = ODEProblem(lorenz!, u0, tspan)
 
 sol = solve(prob, Rosenbrock23())
 
-@test isnothing(OrdinaryDiffEq.strip_interpolation(sol.interp).f)
-@test isnothing(OrdinaryDiffEq.strip_interpolation(sol.interp).cache.jac_config)
+@test isnothing(SciMLBase.strip_interpolation(sol.interp).f)
+@test isnothing(SciMLBase.strip_interpolation(sol.interp).cache.jac_config)

--- a/test/interface/ode_strip_test.jl
+++ b/test/interface/ode_strip_test.jl
@@ -1,4 +1,5 @@
-using OrdinaryDiffEq, OrdinaryDiffEqCore, Test
+using OrdinaryDiffEq, Test
+import OrdinaryDiffEqCore
 
 function lorenz!(du, u, p, t)
     du[1] = 10.0 * (u[2] - u[1])
@@ -12,5 +13,5 @@ prob = ODEProblem(lorenz!, u0, tspan)
 
 sol = solve(prob, Rosenbrock23())
 
-@test isnothing(strip_interpolation(sol.interp).f)
-@test isnothing(strip_interpolation(sol.interp).cache.jac_config)
+@test isnothing(OrdinaryDiffEqCore.strip_interpolation(sol.interp).f)
+@test isnothing(OrdinaryDiffEqCore.strip_interpolation(sol.interp).cache.jac_config)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,7 @@ end
         @time @safetestset "Inplace Interpolation Tests" include("interface/inplace_interpolation.jl")
         @time @safetestset "Algebraic Interpolation Tests" include("interface/algebraic_interpolation.jl")
         @time @safetestset "Default Solver Tests" include("interface/default_solver_tests.jl")
+        @time @safetestset "Interpolation and Cache Stripping Tests" include("interface/ode_strip_test.jl")
     end
 
     if !is_APPVEYOR && (GROUP == "All" || GROUP == "InterfaceII" || GROUP == "Interface")


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Related to https://github.com/SciML/SciMLBase.jl/issues/629
I still need to add tests. I need to make a problem where the cache has `jac_config` and `grad_config`. And test that it strips the cache correctly. 

This way I don't have to make dispatches for every individual cache that has `jac_config` or `grad_config`. I had to use `eval(nameof(typeof(cache)))` since `typeof` has the parametric type information, so I can't put all `nothing`s into `typeof` of a concrete cache type. 
