### PR TITLE
Fix precompilation of LowStorageRK

### DIFF
--- a/lib/OrdinaryDiffEqLowStorageRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/algorithms.jl
@@ -51,32 +51,6 @@ function DGLDDRK73_C(stage_limiter!, step_limiter! = trivial_limiter!;
         williamson_condition)
 end
 
-@doc explicit_rk_docstring("TBD", "SHLDDRK_2N")
-Base.@kwdef struct SHLDDRK_2N{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqAlgorithm
-    stage_limiter!::StageLimiter = trivial_limiter!
-    step_limiter!::StepLimiter = trivial_limiter!
-    thread::Thread = False()
-end
-# for backwards compatibility
-function SHLDDRK_2N(stage_limiter!, step_limiter! = trivial_limiter!)
-    SHLDDRK_2N(stage_limiter!,
-        step_limiter!,
-        False())
-end
-
-@doc explicit_rk_docstring("TBD", "SHLDDRK52")
-Base.@kwdef struct SHLDDRK52{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqAlgorithm
-    stage_limiter!::StageLimiter = trivial_limiter!
-    step_limiter!::StepLimiter = trivial_limiter!
-    thread::Thread = False()
-end
-# for backwards compatibility
-function SHLDDRK52(stage_limiter!, step_limiter! = trivial_limiter!)
-    SHLDDRK52(stage_limiter!,
-        step_limiter!,
-        False())
-end
-
 @doc explicit_rk_docstring(
     "A fourth-order, five-stage low-storage method of Carpenter and Kennedy
 (free 3rd order Hermite interpolant). Fixed timestep only. Designed for
@@ -1098,4 +1072,10 @@ Base.@kwdef struct SHLDDRK52{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffE
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = False()
+end
+# for backwards compatibility
+function SHLDDRK52(stage_limiter!, step_limiter! = trivial_limiter!)
+    SHLDDRK52(stage_limiter!,
+        step_limiter!,
+        False())
 end


### PR DESCRIPTION
Precompilation on latest master ([373a8ee](https://github.com/SciML/OrdinaryDiffEq.jl/commit/373a8eec8024ef1acc6c5f0c87f479aa0cf128c3) is broken. This should fix it.