### PR TITLE
ci(CompatHelper): fix CompatHelper

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -23,4 +23,4 @@ jobs:
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: julia -e 'using CompatHelper; CompatHelper.main(;subdirs=["", "docs", "test/down", "diagrams"])'
+        run: julia -e 'using CompatHelper; CompatHelper.main(;subdirs=["", "docs", "test/downstream"])'


### PR DESCRIPTION
CompatHelper has been broken for a long time now. Fix it by specifying the right `subdirs`.
* `test/down` should be `test/downstream`
* `diagrams` project does not exist