### PR TITLE
Strip `uf` and `tf` with `strip_cache`

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/interp_func.jl
+++ b/lib/OrdinaryDiffEqCore/src/interp_func.jl
@@ -76,7 +76,7 @@ end
 
 function strip_cache(cache)
     if hasfield(typeof(cache), :jac_config) || hasfield(typeof(cache), :grad_config) ||
-       hasfield(typeof(cache), :nlsolver)
+       hasfield(typeof(cache), :nlsolver) || hasfield(typeof(cache), :tf) || hasfield(typeof(cache), :uf)
         fieldnums = length(fieldnames(typeof(cache)))
         noth_list = fill(nothing, fieldnums)
         cache_type_name = Base.typename(typeof(cache)).wrapper

--- a/test/interface/ode_strip_test.jl
+++ b/test/interface/ode_strip_test.jl
@@ -26,8 +26,8 @@ end
     @test isnothing(SciMLBase.strip_solution(rosenbrock_sol).interp.f)
     @test isnothing(SciMLBase.strip_solution(rosenbrock_sol).interp.cache.jac_config)
     @test isnothing(SciMLBase.strip_solution(rosenbrock_sol).interp.cache.grad_config)
-    @test isnothing(SciMLBase.strip_solution(rosenbrock_sol).interp.cache.uf.f)
-    @test isnothing(SciMLBase.strip_solution(rosenbrock_sol).interp.cache.tf.f)
+    @test isnothing(SciMLBase.strip_solution(rosenbrock_sol).interp.cache.uf)
+    @test isnothing(SciMLBase.strip_solution(rosenbrock_sol).interp.cache.tf)
 end
 
 @testset "TRBDF Solution Stripping" begin

--- a/test/interface/ode_strip_test.jl
+++ b/test/interface/ode_strip_test.jl
@@ -26,6 +26,8 @@ end
     @test isnothing(SciMLBase.strip_solution(rosenbrock_sol).interp.f)
     @test isnothing(SciMLBase.strip_solution(rosenbrock_sol).interp.cache.jac_config)
     @test isnothing(SciMLBase.strip_solution(rosenbrock_sol).interp.cache.grad_config)
+    @test isnothing(SciMLBase.strip_solution(rosenbrock_sol).interp.cache.uf.f)
+    @test isnothing(SciMLBase.strip_solution(rosenbrock_sol).interp.cache.tf.f)
 end
 
 @testset "TRBDF Solution Stripping" begin


### PR DESCRIPTION
## Checklist

- [ x] Appropriate tests were added
- [ x] Any code changes were done in a way that does not break public API
- [ x] All documentation related to code changes were updated
- [ x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ x] Any new documentation only uses public API
  
## Additional context

Related to solution stripping for better serialization of Solution types.
Some caches include fields `tf` and `uf` that hold function information in a field `f`. This makes sure that if `strip_solution` is called on a solution with those included, it strips them away. 
