### PR TITLE
Set `args` to nothing in cache stripping

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/interp_func.jl
+++ b/lib/OrdinaryDiffEqCore/src/interp_func.jl
@@ -90,6 +90,9 @@ function strip_cache(cache)
     if hasfield(typeof(cache), :uf)
         SciMLBase.@reset cache.uf = nothing
     end
+    if hasfield(typeof(cache),:args)
+        SciMLBase.@reset cache.args = nothing
+    end
     
     cache
 end


### PR DESCRIPTION
## Checklist

- [ x] Appropriate tests were added
- [ x] Any code changes were done in a way that does not break public API
- [ x] All documentation related to code changes were updated
- [ x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ x] Any new documentation only uses public API
  
## Additional context
Args can sometimes have an ODEFuntion.

