### PR TITLE
fix initdt calculation

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/initdt.jl
+++ b/lib/OrdinaryDiffEqCore/src/initdt.jl
@@ -8,8 +8,8 @@
     oneunit_tType = oneunit(_tType)
     dtmax_tdir = tdir * dtmax
 
-    dtmin = nextfloat(integrator.opts.dtmin)
-    smalldt = convert(_tType, oneunit_tType * 1 // 10^(6))
+    dtmin = nextfloat(max(integrator.opts.dtmin, eps(t)))
+    smalldt = max(dtmin, convert(_tType, oneunit_tType * 1 // 10^(6)))
 
     if integrator.isdae
         return tdir * max(smalldt, dtmin)
@@ -235,7 +235,7 @@ end
     oneunit_tType = oneunit(_tType)
     dtmax_tdir = tdir * dtmax
 
-    dtmin = nextfloat(integrator.opts.dtmin)
+    dtmin = nextfloat(max(integrator.opts.dtmin, eps(t)))
     smalldt = convert(_tType, oneunit_tType * 1 // 10^(6))
 
     if integrator.isdae

--- a/lib/OrdinaryDiffEqCore/src/initdt.jl
+++ b/lib/OrdinaryDiffEqCore/src/initdt.jl
@@ -236,7 +236,7 @@ end
     dtmax_tdir = tdir * dtmax
 
     dtmin = nextfloat(max(integrator.opts.dtmin, eps(t)))
-    smalldt = convert(_tType, oneunit_tType * 1 // 10^(6))
+    smalldt = max(dtmin, convert(_tType, oneunit_tType * 1 // 10^(6)))
 
     if integrator.isdae
         return tdir * max(smalldt, dtmin)

--- a/test/interface/ode_initdt_tests.jl
+++ b/test/interface/ode_initdt_tests.jl
@@ -64,3 +64,9 @@ sol = solve(prob, Rodas5())
 # test that dtmin is set based on timespan
 prob = ODEProblem((u, p, t) -> 1e20 * sin(1e20 * t), 0.1, (0, 1e-19))
 @test solve(prob, Tsit5()).retcode == ReturnCode.Success
+
+#test that we are robust to u0=0, t0!=0
+integ = init(ODEProblem(((u,p,t)->u), 0f0, (20f0, 0f0)), Tsit5())
+@test abs(integ.dt) > eps(integ.t)
+integ = init(ODEProblem(((du,u,p,t)->du.=u), [0f0], (20f0, 0f0)), Tsit5())
+@test abs(integ.dt) > eps(integ.t)


### PR DESCRIPTION
fixes https://github.com/SciML/OrdinaryDiffEq.jl/issues/2492.
That said, @ChrisRackauckas our initdt selection does seem like we never considered the case where `iszero(u0)`. When this happens, our `d₀` is 0, so our `dt₀ = smalldt`, which puts a hard cap on our return value of `100*smalldt`, which is often incredibly pessimistic. Would it be reasonable to have the 2nd stage of this algorithm loop when `100dt₀ < dt₁` (i.e. we will do an extra function call at  `t + dt₁` to see if our `dt₁` guess was reasonable. This would cost an extra function eval, but in this case, our `dt₁` is 300x bigger than our `d₀`, which will require taking multiple steps with basically no progress before our timestepping is reasonable.