### PR TITLE
Bump delaydiffeq.jl test tolerance

### DIFF
--- a/test/downstream/delaydiffeq.jl
+++ b/test/downstream/delaydiffeq.jl
@@ -24,7 +24,7 @@ using Test
         @test sol.errors[:l∞] < error
 
         sol_scalar = solve(prob_scalar, ddealg)
-        @test sol.t≈sol_scalar.t atol=1e-3
+        @test sol.t≈sol_scalar.t atol=1e-2
         @test sol[1, :] ≈ sol_scalar.u
     end
 end

--- a/test/downstream/delaydiffeq.jl
+++ b/test/downstream/delaydiffeq.jl
@@ -24,7 +24,7 @@ using Test
         @test sol.errors[:l∞] < error
 
         sol_scalar = solve(prob_scalar, ddealg)
-        @test sol.t≈sol_scalar.t atol=1e-6
+        @test sol.t≈sol_scalar.t atol=1e-3
         @test sol[1, :] ≈ sol_scalar.u
     end
 end


### PR DESCRIPTION
This seems to be due to improved SIMD in some operations which leads to a difference in the time stepping value between the two.
