### PR TITLE
Fix iterator tests for v1.11

### DIFF
--- a/test/integrators/iterator_tests.jl
+++ b/test/integrators/iterator_tests.jl
@@ -62,7 +62,7 @@ end
 A = integrator([1.0; 2.0])
 B = integrator([1.0; 2.0], idxs = 1:2:5)
 
-@test minimum([A[i][1:2:5] == B[i] for i in 1:length(A)])
+@test minimum([A[i][1:2:5] ≈ B[i] for i in 1:length(A)])
 
 integrator(A[1], 0.5)
 @test A[1] == integrator(0.5)


### PR DESCRIPTION
The idxs save seems to be slightly floating point different from the non-idxs save on v1.11. Not entirely sure why but it seems to be something with the effect system that makes the non-idxs case slightly more optimal in some way.