### PR TITLE
Allow configuration of the initialization done after interpolation while applying an affect

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
@@ -3,7 +3,7 @@
 # Hence, we need to have two separate functions.
 
 function _change_t_via_interpolation!(integrator, t,
-        modify_save_endpoint::Type{Val{T}}) where {T}
+        modify_save_endpoint::Type{Val{T}}, reinitialization_method=nothing) where {T}
     # Can get rid of an allocation here with a function
     # get_tmp_arr(integrator.cache) which gives a pointer to some
     # cache array which can be modified.
@@ -17,7 +17,7 @@ function _change_t_via_interpolation!(integrator, t,
         end
         integrator.t = t
         integrator.dt = integrator.t - integrator.tprev
-        DiffEqBase.reeval_internals_due_to_modification!(integrator)
+        DiffEqBase.reeval_internals_due_to_modification!(integrator; callback_initializealg=reinitialization_method)
         if T
             solution_endpoint_match_cur_integrator!(integrator)
         end
@@ -28,10 +28,10 @@ function DiffEqBase.change_t_via_interpolation!(integrator::ODEIntegrator,
         t,
         modify_save_endpoint::Type{Val{T}} = Val{
             false,
-        }) where {
+        }, reinitialization_method=nothing) where {
         T,
 }
-    _change_t_via_interpolation!(integrator, t, modify_save_endpoint)
+    _change_t_via_interpolation!(integrator, t, modify_save_endpoint, reinitialization_method)
     return nothing
 end
 

--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
@@ -3,7 +3,7 @@
 # Hence, we need to have two separate functions.
 
 function _change_t_via_interpolation!(integrator, t,
-        modify_save_endpoint::Type{Val{T}}, reinitialization_method=nothing) where {T}
+        modify_save_endpoint::Type{Val{T}}, reinitialize_alg=nothing) where {T}
     # Can get rid of an allocation here with a function
     # get_tmp_arr(integrator.cache) which gives a pointer to some
     # cache array which can be modified.
@@ -17,7 +17,7 @@ function _change_t_via_interpolation!(integrator, t,
         end
         integrator.t = t
         integrator.dt = integrator.t - integrator.tprev
-        DiffEqBase.reeval_internals_due_to_modification!(integrator; callback_initializealg=reinitialization_method)
+        DiffEqBase.reeval_internals_due_to_modification!(integrator; callback_initializealg=reinitialize_alg)
         if T
             solution_endpoint_match_cur_integrator!(integrator)
         end
@@ -28,10 +28,10 @@ function DiffEqBase.change_t_via_interpolation!(integrator::ODEIntegrator,
         t,
         modify_save_endpoint::Type{Val{T}} = Val{
             false,
-        }, reinitialization_method=nothing) where {
+        }, reinitialize_alg=nothing) where {
         T,
 }
-    _change_t_via_interpolation!(integrator, t, modify_save_endpoint, reinitialization_method)
+    _change_t_via_interpolation!(integrator, t, modify_save_endpoint, reinitialize_alg)
     return nothing
 end
 


### PR DESCRIPTION

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Part of https://github.com/SciML/DiffEqBase.jl/pull/1102 and https://github.com/SciML/SciMLBase.jl/pull/842