### PR TITLE
Adapt KrylovSubspace Vtype to u

### DIFF
--- a/lib/OrdinaryDiffEqLinear/Project.toml
+++ b/lib/OrdinaryDiffEqLinear/Project.toml
@@ -18,7 +18,7 @@ SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 [compat]
 DiffEqBase = "6.152.2"
 DiffEqDevTools = "2.44.4"
-ExponentialUtilities = "1.26.1"
+ExponentialUtilities = "1.27"
 LinearAlgebra = "<0.0.1, 1"
 OrdinaryDiffEqCore = "1.1"
 OrdinaryDiffEqRosenbrock = "<0.0.1, 1"

--- a/lib/OrdinaryDiffEqLinear/src/linear_caches.jl
+++ b/lib/OrdinaryDiffEqLinear/src/linear_caches.jl
@@ -591,7 +591,7 @@ function alg_cache(alg::LinearExponential, u, rate_prototype, ::Type{uEltypeNoUn
     if alg.krylov == :off
         KsCache = nothing
     elseif alg.krylov == :simple
-        Ks = KrylovSubspace{T}(n, m)
+        Ks = KrylovSubspace{T,T,typeof(similar(u,size(u,1),2))}(n, m)
         expv_cache = ExpvCache{T}(m)
         KsCache = (Ks, expv_cache)
     elseif alg.krylov == :adaptive


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Specify the type of the `KrylovSubspace` basis vector matrix according to the specified `u`. This allows for `u` being a GPUArray.
 
ExponentiationUtilities has to be adjusted as well to provide this functionality, see my PR [ https://github.com/SciML/ExponentialUtilities.jl/pull/183 ]() there.