### PR TITLE
don't use Rosenbrock23 with mass matrix

### DIFF
--- a/lib/OrdinaryDiffEqDefault/src/default_alg.jl
+++ b/lib/OrdinaryDiffEqDefault/src/default_alg.jl
@@ -81,7 +81,7 @@ function stiffchoice(reltol, len, mass_matrix)
     elseif len > SMALLSIZE
         DefaultSolverChoice.FBDF
     else
-        if reltol < LOW_TOL || !isdiag(mass_matrix)
+        if reltol < LOW_TOL || mass_matrix != I
             DefaultSolverChoice.Rodas5P
         else
             DefaultSolverChoice.Rosenbrock23

--- a/lib/OrdinaryDiffEqDefault/test/default_solver_tests.jl
+++ b/lib/OrdinaryDiffEqDefault/test/default_solver_tests.jl
@@ -108,7 +108,7 @@ end
 f = ODEFunction(rober_mm, mass_matrix = [1 0 0; 0 1 0; 0 0 0])
 prob_rober_mm = ODEProblem(f, [1.0, 0.0, 1.0], (0.0, 1e5), (0.04, 3e7, 1e4))
 sol = solve(prob_rober_mm)
-@test all(isequal(3), sol.alg_choice)
+@test all(isequal(4), sol.alg_choice)
 @test sol(0.5) isa Vector{Float64} # test dense output
 
 # test callback on ConstantCache (https://github.com/SciML/OrdinaryDiffEq.jl/issues/2287)


### PR DESCRIPTION
This wasn't working as intended since Rosenbrock23 is only order 1 on DAEs.