### PR TITLE
Move DAE init alg error message further down the dependency stack

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/initialize_dae.jl
+++ b/lib/OrdinaryDiffEqCore/src/initialize_dae.jl
@@ -50,7 +50,8 @@ function _initialize_dae!(integrator, prob::ODEProblem,
     if SciMLBase.has_initializeprob(prob.f)
         _initialize_dae!(integrator, prob,
             OverrideInit(integrator.opts.abstol), x)
-    elseif !isdefined(Main, :OrdinaryDiffEqNonlinearSolve)
+    elseif !applicable(_initialize_dae!, integrator, prob,
+        BrownFullBasicInit(integrator.opts.abstol), x)
         error("`OrdinaryDiffEqNonlinearSolve` is not loaded, which is required for the default initialization algorithm (`BrownFullBasicInit` or `ShampineCollocationInit`). To solve this problem, either do `using OrdinaryDiffEqNonlinearSolve` or pass `initializealg = CheckInit()` to the `solve` function. This second option requires consistent `u0`.")
     else
         _initialize_dae!(integrator, prob,
@@ -63,7 +64,9 @@ function _initialize_dae!(integrator, prob::DAEProblem,
     if SciMLBase.has_initializeprob(prob.f)
         _initialize_dae!(integrator, prob,
             OverrideInit(integrator.opts.abstol), x)
-    elseif !isdefined(Main, :OrdinaryDiffEqNonlinearSolve)
+    elseif !applicable(_initialize_dae!, integrator, prob, 
+        BrownFullBasicInit(), x) && !applicable(_initialize_dae!, 
+        integrator, prob, ShampineCollocationInit(), x)
         error("`OrdinaryDiffEqNonlinearSolve` is not loaded, which is required for the default initialization algorithm (`BrownFullBasicInit` or `ShampineCollocationInit`). To solve this problem, either do `using OrdinaryDiffEqNonlinearSolve` or pass `initializealg = CheckInit()` to the `solve` function. This second option requires consistent `u0`.")
     elseif prob.differential_vars === nothing
         _initialize_dae!(integrator, prob,

--- a/lib/OrdinaryDiffEqCore/src/initialize_dae.jl
+++ b/lib/OrdinaryDiffEqCore/src/initialize_dae.jl
@@ -51,7 +51,7 @@ function _initialize_dae!(integrator, prob::ODEProblem,
         _initialize_dae!(integrator, prob,
             OverrideInit(integrator.opts.abstol), x)
     elseif !isdefined(Main, :OrdinaryDiffEqNonlinearSolve)
-        throw("`OrdinaryDiffEqNonlinearSolve` is not loaded, which is required for the default initialization algorithm (`BrownFullBasicInit` or `ShampineCollocationInit`). To solve this problem, either do `using OrdinaryDiffEqNonlinearSolve` or pass `initializealg = CheckInit()` to the `solve` function. This second option requires consistent `u0`.")
+        error("`OrdinaryDiffEqNonlinearSolve` is not loaded, which is required for the default initialization algorithm (`BrownFullBasicInit` or `ShampineCollocationInit`). To solve this problem, either do `using OrdinaryDiffEqNonlinearSolve` or pass `initializealg = CheckInit()` to the `solve` function. This second option requires consistent `u0`.")
     else
         _initialize_dae!(integrator, prob,
             BrownFullBasicInit(integrator.opts.abstol), x)
@@ -64,7 +64,7 @@ function _initialize_dae!(integrator, prob::DAEProblem,
         _initialize_dae!(integrator, prob,
             OverrideInit(integrator.opts.abstol), x)
     elseif !isdefined(Main, :OrdinaryDiffEqNonlinearSolve)
-        throw("`OrdinaryDiffEqNonlinearSolve` is not loaded, which is required for the default initialization algorithm (`BrownFullBasicInit` or `ShampineCollocationInit`). To solve this problem, either do `using OrdinaryDiffEqNonlinearSolve` or pass `initializealg = CheckInit()` to the `solve` function. This second option requires consistent `u0`.")
+        error("`OrdinaryDiffEqNonlinearSolve` is not loaded, which is required for the default initialization algorithm (`BrownFullBasicInit` or `ShampineCollocationInit`). To solve this problem, either do `using OrdinaryDiffEqNonlinearSolve` or pass `initializealg = CheckInit()` to the `solve` function. This second option requires consistent `u0`.")
     elseif prob.differential_vars === nothing
         _initialize_dae!(integrator, prob,
             ShampineCollocationInit(), x)

--- a/lib/OrdinaryDiffEqCore/src/initialize_dae.jl
+++ b/lib/OrdinaryDiffEqCore/src/initialize_dae.jl
@@ -44,22 +44,14 @@ end
 
 ## Default algorithms
 
-function _initialize_dae!(integrator, prob::ODEProblem,
-        alg::DefaultInit, x::Val{true})
-    if SciMLBase.has_initializeprob(prob.f)
-        _initialize_dae!(integrator, prob,
-            OverrideInit(integrator.opts.abstol), x)
-    else
-        _initialize_dae!(integrator, prob,
-            BrownFullBasicInit(integrator.opts.abstol), x)
-    end
-end
 
 function _initialize_dae!(integrator, prob::ODEProblem,
-        alg::DefaultInit, x::Val{false})
+        alg::DefaultInit, x::Union{Val{true}, Val{false}})
     if SciMLBase.has_initializeprob(prob.f)
         _initialize_dae!(integrator, prob,
             OverrideInit(integrator.opts.abstol), x)
+    elseif !isdefined(Main, :OrdinaryDiffEqNonlinearSolve)
+        throw("`OrdinaryDiffEqNonlinearSolve` is not loaded, which is required for the default initialization algorithm (`BrownFullBasicInit` or `ShampineCollocationInit`). To solve this problem, either do `using OrdinaryDiffEqNonlinearSolve` or pass `initializealg = CheckInit()` to the `solve` function. This second option requires consistent `u0`.")
     else
         _initialize_dae!(integrator, prob,
             BrownFullBasicInit(integrator.opts.abstol), x)
@@ -67,24 +59,12 @@ function _initialize_dae!(integrator, prob::ODEProblem,
 end
 
 function _initialize_dae!(integrator, prob::DAEProblem,
-        alg::DefaultInit, x::Val{false})
+        alg::DefaultInit, x::Union{Val{true}, Val{false}})
     if SciMLBase.has_initializeprob(prob.f)
         _initialize_dae!(integrator, prob,
             OverrideInit(integrator.opts.abstol), x)
-    elseif prob.differential_vars === nothing
-        _initialize_dae!(integrator, prob,
-            ShampineCollocationInit(), x)
-    else
-        _initialize_dae!(integrator, prob,
-            BrownFullBasicInit(integrator.opts.abstol), x)
-    end
-end
-
-function _initialize_dae!(integrator, prob::DAEProblem,
-        alg::DefaultInit, x::Val{true})
-    if SciMLBase.has_initializeprob(prob.f)
-        _initialize_dae!(integrator, prob,
-            OverrideInit(integrator.opts.abstol), x)
+    elseif !isdefined(Main, :OrdinaryDiffEqNonlinearSolve)
+        throw("`OrdinaryDiffEqNonlinearSolve` is not loaded, which is required for the default initialization algorithm (`BrownFullBasicInit` or `ShampineCollocationInit`). To solve this problem, either do `using OrdinaryDiffEqNonlinearSolve` or pass `initializealg = CheckInit()` to the `solve` function. This second option requires consistent `u0`.")
     elseif prob.differential_vars === nothing
         _initialize_dae!(integrator, prob,
             ShampineCollocationInit(), x)

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
@@ -64,4 +64,6 @@ include("functional.jl")
 include("newton.jl")
 include("initialize_dae.jl")
 
+export BrownFullBasicInit, ShampineCollocationInit
+
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Still working on #2513 ; this pull request attempts to address that issue in a non-breaking way, whereas #2514 solves it more elegantly but with a breaking change to the default initialization algorithm. (That will probably need to be rebased on this pull request once this works as desired.)

## Attempted approach

`BrownFullBasicInit` and `ShampineCollocationInit` both require `OrdinaryDiffEqNonlinearSolve`. The original implementation had an error message when the nonlinear solve is attempted if `ODENLSolve` is not loaded, but that nonlinear solve happens in a method of `_initialize_dae!` which is defined only in `ODENLSolve`, so the error message needs to be placed in `ODECore`. This attempt currently checks in the `DefaultInit` method for `_initialize_dae!` whether `ODENLSolve` is loaded, and if it is, proceeds to use default algorithms as done previously. If not loaded, then an error is thrown.

I don't feel like enough of an expert to say authoritatively what the best way is to check if `ODENLSolve` is loaded. From what I could find of discussions on Discourse, etc., it seems like the recommended way might be to do
```julia
if !isdefined(Main, :OrdinaryDiffEqNonlinearSolve)
```
so that is what I have done here.

Two other approaches I turned up (but that seem brittle or discouraged) might be something along the lines of
```julia
if !hasmethod(_initialize_dae!, Tuple{Any, ODEProblem, BrownFullBasicInit, typeof(isinplace))
```
or checking if `ODENLSolve` is in `Base.loaded_modules`. 