### PR TITLE
Optimize `VerletLeapfrog` method

### DIFF
--- a/lib/OrdinaryDiffEqSymplecticRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqSymplecticRK/src/algorithms.jl
@@ -30,7 +30,7 @@ struct VelocityVerlet <: OrdinaryDiffEqPartitionedAlgorithm end
     verlet1967, "", "")
 struct VerletLeapfrog <: OrdinaryDiffEqPartitionedAlgorithm end
 
-default_linear_interpolation(alg::VerletLeapfrog, prob) = true
+OrdinaryDiffEqCore.default_linear_interpolation(alg::VerletLeapfrog, prob) = true
 
 @doc generic_solver_docstring("2nd order explicit symplectic integrator.",
     "PseudoVerletLeapfrog",

--- a/lib/OrdinaryDiffEqSymplecticRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqSymplecticRK/src/algorithms.jl
@@ -30,6 +30,8 @@ struct VelocityVerlet <: OrdinaryDiffEqPartitionedAlgorithm end
     verlet1967, "", "")
 struct VerletLeapfrog <: OrdinaryDiffEqPartitionedAlgorithm end
 
+default_linear_interpolation(alg::VerletLeapfrog, prob) = true
+
 @doc generic_solver_docstring("2nd order explicit symplectic integrator.",
     "PseudoVerletLeapfrog",
     "Symplectic Runge-Kutta Methods",

--- a/lib/OrdinaryDiffEqSymplecticRK/src/symplectic_perform_step.jl
+++ b/lib/OrdinaryDiffEqSymplecticRK/src/symplectic_perform_step.jl
@@ -218,7 +218,7 @@ end
 
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     integrator.stats.nf2 += 1
-    store_symp_state!(integrator, cache, kdu, ku)
+    store_symp_state!(integrator, cache, du, u, kdu, ku)
 end
 
 @muladd function perform_step!(integrator, cache::VerletLeapfrogCache, repeat_step = false)

--- a/lib/OrdinaryDiffEqSymplecticRK/src/symplectic_perform_step.jl
+++ b/lib/OrdinaryDiffEqSymplecticRK/src/symplectic_perform_step.jl
@@ -199,9 +199,9 @@ end
 @muladd function perform_step!(integrator, cache::VerletLeapfrogConstantCache,
         repeat_step = false)
     @unpack t, dt, f, p = integrator
-    duprev, uprev, kduprev, kuprev = load_symp_state(integrator)
+    duprev, uprev, kduprev, _ = load_symp_state(integrator)
 
-    # kick-drift-kick scheme of the Verlet Leapfrog method:
+    # kick-drift-kick scheme of the Leapfrog method:
     # update velocity
     half = cache.half
     du = duprev + dt * half * kduprev
@@ -223,7 +223,7 @@ end
 
 @muladd function perform_step!(integrator, cache::VerletLeapfrogCache, repeat_step = false)
     @unpack t, dt, f, p = integrator
-    duprev, uprev, kduprev, kuprev = load_symp_state(integrator)
+    duprev, uprev, kduprev, _ = load_symp_state(integrator)
     du, u, kdu, ku = alloc_symp_state(integrator)
 
     # Kick-Drift-Kick scheme of the Verlet Leapfrog method:
@@ -233,8 +233,8 @@ end
 
     # update position
     tnew = t + half * dt
-    f.f2(ku, du, u, p, tnew)
-    @.. broadcast=false u=u + dt * ku
+    f.f2(ku, du, uprev, p, tnew)
+    @.. broadcast=false u=uprev + dt * ku
 
     # update velocity
     tnew = tnew + half * dt

--- a/lib/OrdinaryDiffEqSymplecticRK/src/symplectic_perform_step.jl
+++ b/lib/OrdinaryDiffEqSymplecticRK/src/symplectic_perform_step.jl
@@ -77,8 +77,12 @@ end
 # f.f2(p, q, pa, t) = p which is the Newton/Lagrange equations
 # If called with different functions (which are possible in the Hamiltonian case)
 # an exception is thrown to avoid silently calculate wrong results.
-verify_f2(f, p, q, pa, t, ::Any, ::C) where {C <: HamiltonConstantCache} = f(p, q, pa, t)
-function verify_f2(f, res, p, q, pa, t, ::Any, ::C) where {C <: HamiltonMutableCache}
+function verify_f2(f, p, q, pa, t, ::Any,
+        ::C) where {C <: Union{HamiltonConstantCache, VerletLeapfrogConstantCache}}
+    f(p, q, pa, t)
+end
+function verify_f2(f, res, p, q, pa, t, ::Any,
+        ::C) where {C <: Union{HamiltonMutableCache, VerletLeapfrogCache}}
     f(res, p, q, pa, t)
 end
 
@@ -124,8 +128,8 @@ function store_symp_state!(integrator, ::OrdinaryDiffEqMutableCache, kdu, ku)
 end
 
 function initialize!(integrator,
-        cache::C) where {C <:
-                         Union{HamiltonMutableCache, VelocityVerletCache}}
+        cache::C) where {C <: Union{
+        HamiltonMutableCache, VelocityVerletCache, VerletLeapfrogCache}}
     integrator.kshortsize = 2
     resize!(integrator.k, integrator.kshortsize)
     integrator.k[1] = integrator.fsalfirst
@@ -140,9 +144,8 @@ function initialize!(integrator,
 end
 
 function initialize!(integrator,
-        cache::C) where {
-        C <:
-        Union{HamiltonConstantCache, VelocityVerletConstantCache}}
+        cache::C) where {C <: Union{
+        HamiltonConstantCache, VelocityVerletConstantCache, VerletLeapfrogConstantCache}}
     integrator.kshortsize = 2
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
 
@@ -171,7 +174,7 @@ end
     # v(t+Δt) = v(t) + 1/2*(a(t)+a(t+Δt))*Δt
     du = duprev + dt * (half * ku + half * kdu)
 
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     store_symp_state!(integrator, cache, du, u, kdu, du)
 end
 
@@ -186,11 +189,61 @@ end
     half = cache.half
     @.. broadcast=false u=uprev + dt * duprev + dtsq * (half * ku)
     f.f1(kdu, duprev, u, p, t + dt)
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     # v(t+Δt) = v(t) + 1/2*(a(t)+a(t+Δt))*Δt
     @.. broadcast=false du=duprev + dt * (half * ku + half * kdu)
 
     store_symp_state!(integrator, cache, kdu, du)
+end
+
+@muladd function perform_step!(integrator, cache::VerletLeapfrogConstantCache,
+        repeat_step = false)
+    @unpack t, dt, f, p = integrator
+    duprev, uprev, kduprev, kuprev = load_symp_state(integrator)
+
+    # kick-drift-kick scheme of the Verlet Leapfrog method:
+    # update velocity
+    half = cache.half
+    du = duprev + dt * half * kduprev
+
+    # update position
+    tnew = t + half * dt
+    ku = f.f2(du, uprev, p, tnew)
+    u = uprev + dt * ku
+
+    # update velocity
+    tnew = tnew + half * dt
+    kdu = f.f1(du, u, p, tnew)
+    du = du + dt * half * kdu
+
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.stats.nf2 += 1
+    store_symp_state!(integrator, cache, kdu, ku)
+end
+
+@muladd function perform_step!(integrator, cache::VerletLeapfrogCache, repeat_step = false)
+    @unpack t, dt, f, p = integrator
+    duprev, uprev, kduprev, kuprev = load_symp_state(integrator)
+    du, u, kdu, ku = alloc_symp_state(integrator)
+
+    # Kick-Drift-Kick scheme of the Verlet Leapfrog method:
+    # update velocity
+    half = cache.half
+    @.. broadcast=false du=duprev + dt * half * kduprev
+
+    # update position
+    tnew = t + half * dt
+    f.f2(ku, du, u, p, tnew)
+    @.. broadcast=false u=u + dt * ku
+
+    # update velocity
+    tnew = tnew + half * dt
+    f.f1(kdu, du, u, p, tnew)
+    @.. broadcast=false du=du + dt * half * kdu
+
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.stats.nf2 += 1
+    store_symp_state!(integrator, cache, kdu, ku)
 end
 
 @muladd function perform_step!(integrator, cache::Symplectic2ConstantCache,

--- a/lib/OrdinaryDiffEqSymplecticRK/src/symplectic_tableaus.jl
+++ b/lib/OrdinaryDiffEqSymplecticRK/src/symplectic_tableaus.jl
@@ -21,14 +21,6 @@ function McAte2ConstantCache(T, T2)
     Symplectic2ConstantCache{T, T2}(a1, a2, b1, b2)
 end
 
-function VerletLeapfrogConstantCache(T, T2)
-    a1 = convert(T, 1 // 2)
-    a2 = convert(T, 1 // 2)
-    b1 = convert(T, 0)
-    b2 = convert(T, 1)
-    Symplectic2ConstantCache{T, T2}(a1, a2, b1, b2)
-end
-
 struct Symplectic3ConstantCache{T, T2} <: HamiltonConstantCache
     a1::T
     a2::T


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added (does not require additional tests, method is already tested)
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated (no docs changes necessary, method and API didn't change)
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API (no new docs)
  
## Additional context

The `VerletLeapfrog` method is currently using the generic `Symplectic2Cache` implementation:
https://github.com/SciML/OrdinaryDiffEq.jl/blob/4b29babd6bbe9a4eadd1ffef10b90a812db9aa3c/lib/OrdinaryDiffEqSymplecticRK/src/symplectic_perform_step.jl#L222-L246
This contains 3 calls to `f1` and 2 calls to `f2`. The kick-drift-kick scheme of the Leapfrog method only requires a single call to `f1` and a single call to `f2` in each step, which is the main selling point of the method, making the current implementation basically useless.

I implemented an optimized step for this method, following the `VelocityVerlet` method, which also has its own step function.