### PR TITLE
Implement drift-kick-drift form of the Leapfrog method

### DIFF
--- a/docs/src/dynamicalodeexplicit/SymplecticRK.md
+++ b/docs/src/dynamicalodeexplicit/SymplecticRK.md
@@ -47,6 +47,7 @@ sol = solve(prob, KahanLi8(), dt = 1 / 10)
 SymplecticEuler
 VelocityVerlet
 VerletLeapfrog
+LeapfrogDriftKickDrift
 PseudoVerletLeapfrog
 McAte2
 Ruth3

--- a/lib/OrdinaryDiffEqSymplecticRK/src/OrdinaryDiffEqSymplecticRK.jl
+++ b/lib/OrdinaryDiffEqSymplecticRK/src/OrdinaryDiffEqSymplecticRK.jl
@@ -25,8 +25,8 @@ include("symplectic_caches.jl")
 include("symplectic_tableaus.jl")
 include("symplectic_perform_step.jl")
 
-export SymplecticEuler, VelocityVerlet, VerletLeapfrog, PseudoVerletLeapfrog,
-       McAte2, Ruth3, McAte3, CandyRoz4, McAte4, McAte42, McAte5,
+export SymplecticEuler, VelocityVerlet, VerletLeapfrog, LeapfrogDriftKickDrift,
+       PseudoVerletLeapfrog, McAte2, Ruth3, McAte3, CandyRoz4, McAte4, McAte42, McAte5,
        CalvoSanz4, Yoshida6, KahanLi6, McAte8, KahanLi8, SofSpa10
 
 end

--- a/lib/OrdinaryDiffEqSymplecticRK/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqSymplecticRK/src/alg_utils.jl
@@ -1,6 +1,7 @@
 alg_order(alg::SymplecticEuler) = 1
 alg_order(alg::VelocityVerlet) = 2
 alg_order(alg::VerletLeapfrog) = 2
+alg_order(alg::LeapfrogDriftKickDrift) = 2
 alg_order(alg::PseudoVerletLeapfrog) = 2
 alg_order(alg::McAte2) = 2
 alg_order(alg::Ruth3) = 3

--- a/lib/OrdinaryDiffEqSymplecticRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqSymplecticRK/src/algorithms.jl
@@ -24,13 +24,37 @@ publisher={APS}
     verlet1967, "", "")
 struct VelocityVerlet <: OrdinaryDiffEqPartitionedAlgorithm end
 
-@doc generic_solver_docstring("2nd order explicit symplectic integrator.",
+monaghan2005 = """
+@article{monaghan2005,
+	title = {Smoothed particle hydrodynamics},
+	author = {Monaghan, Joseph J.},
+	year = {2005},
+	journal = {Reports on Progress in Physics},
+	volume = {68},
+	number = {8},
+	pages = {1703--1759},
+	doi = {10.1088/0034-4885/68/8/R01},
+}
+"""
+
+@doc generic_solver_docstring(
+    "2nd order explicit symplectic integrator. Kick-drift-kick form. Requires only one evaluation of `f1` per step.",
     "VerletLeapfrog",
     "Symplectic Runge-Kutta Methods",
-    verlet1967, "", "")
+    monaghan2005, "", "")
 struct VerletLeapfrog <: OrdinaryDiffEqPartitionedAlgorithm end
 
 OrdinaryDiffEqCore.default_linear_interpolation(alg::VerletLeapfrog, prob) = true
+
+@doc generic_solver_docstring(
+    "2nd order explicit symplectic integrator. Drift-kick-drift form of `VerletLeapfrog`
+designed to work when `f1` depends on `v`. Requires two evaluation of `f1` per step.",
+    "LeapfrogDriftKickDrift",
+    "Symplectic Runge-Kutta Methods",
+    monaghan2005, "", "")
+struct LeapfrogDriftKickDrift <: OrdinaryDiffEqPartitionedAlgorithm end
+
+OrdinaryDiffEqCore.default_linear_interpolation(alg::LeapfrogDriftKickDrift, prob) = true
 
 @doc generic_solver_docstring("2nd order explicit symplectic integrator.",
     "PseudoVerletLeapfrog",

--- a/lib/OrdinaryDiffEqSymplecticRK/src/symplectic_caches.jl
+++ b/lib/OrdinaryDiffEqSymplecticRK/src/symplectic_caches.jl
@@ -57,6 +57,38 @@ function alg_cache(alg::VelocityVerlet, u, rate_prototype, ::Type{uEltypeNoUnits
     VelocityVerletConstantCache(uEltypeNoUnits(1 // 2))
 end
 
+@cache struct LeapfrogDriftKickDriftCache{uType, rateType, uEltypeNoUnits} <:
+              OrdinaryDiffEqMutableCache
+    u::uType
+    uprev::uType
+    tmp::uType
+    k::rateType
+    fsalfirst::rateType
+    half::uEltypeNoUnits
+end
+
+struct LeapfrogDriftKickDriftConstantCache{uEltypeNoUnits} <: HamiltonConstantCache
+    half::uEltypeNoUnits
+end
+
+function alg_cache(alg::LeapfrogDriftKickDrift, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{true}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    tmp = zero(rate_prototype)
+    k = zero(rate_prototype)
+    fsalfirst = zero(rate_prototype)
+    half = uEltypeNoUnits(1 // 2)
+    LeapfrogDriftKickDriftCache(u, uprev, k, tmp, fsalfirst, half)
+end
+
+function alg_cache(alg::LeapfrogDriftKickDrift, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{false}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    LeapfrogDriftKickDriftConstantCache(uEltypeNoUnits(1 // 2))
+end
+
 @cache struct VerletLeapfrogCache{uType, rateType, uEltypeNoUnits} <:
               OrdinaryDiffEqMutableCache
     u::uType
@@ -436,6 +468,6 @@ end
 
 function get_fsalfirstlast(
         cache::Union{HamiltonMutableCache, VelocityVerletCache, VerletLeapfrogCache,
-            SymplecticEulerCache}, u)
+            SymplecticEulerCache, LeapfrogDriftKickDriftCache}, u)
     (cache.fsalfirst, cache.k)
 end

--- a/lib/OrdinaryDiffEqSymplecticRK/src/symplectic_perform_step.jl
+++ b/lib/OrdinaryDiffEqSymplecticRK/src/symplectic_perform_step.jl
@@ -78,11 +78,13 @@ end
 # If called with different functions (which are possible in the Hamiltonian case)
 # an exception is thrown to avoid silently calculate wrong results.
 function verify_f2(f, p, q, pa, t, ::Any,
-        ::C) where {C <: Union{HamiltonConstantCache, VerletLeapfrogConstantCache}}
+        ::C) where {C <: Union{HamiltonConstantCache, VerletLeapfrogConstantCache,
+        LeapfrogDriftKickDriftConstantCache}}
     f(p, q, pa, t)
 end
 function verify_f2(f, res, p, q, pa, t, ::Any,
-        ::C) where {C <: Union{HamiltonMutableCache, VerletLeapfrogCache}}
+        ::C) where {C <: Union{HamiltonMutableCache, VerletLeapfrogCache,
+        LeapfrogDriftKickDriftCache}}
     f(res, p, q, pa, t)
 end
 
@@ -128,8 +130,8 @@ function store_symp_state!(integrator, ::OrdinaryDiffEqMutableCache, kdu, ku)
 end
 
 function initialize!(integrator,
-        cache::C) where {C <: Union{
-        HamiltonMutableCache, VelocityVerletCache, VerletLeapfrogCache}}
+        cache::C) where {C <: Union{HamiltonMutableCache, VelocityVerletCache,
+        VerletLeapfrogCache, LeapfrogDriftKickDriftCache}}
     integrator.kshortsize = 2
     resize!(integrator.k, integrator.kshortsize)
     integrator.k[1] = integrator.fsalfirst
@@ -144,8 +146,8 @@ function initialize!(integrator,
 end
 
 function initialize!(integrator,
-        cache::C) where {C <: Union{
-        HamiltonConstantCache, VelocityVerletConstantCache, VerletLeapfrogConstantCache}}
+        cache::C) where {C <: Union{HamiltonConstantCache, VelocityVerletConstantCache,
+        VerletLeapfrogConstantCache, LeapfrogDriftKickDriftConstantCache}}
     integrator.kshortsize = 2
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
 
@@ -226,7 +228,7 @@ end
     duprev, uprev, kduprev, _ = load_symp_state(integrator)
     du, u, kdu, ku = alloc_symp_state(integrator)
 
-    # Kick-Drift-Kick scheme of the Verlet Leapfrog method:
+    # kick-drift-kick scheme of the Leapfrog method:
     # update velocity
     half = cache.half
     @.. broadcast=false du=duprev + dt * half * kduprev
@@ -243,6 +245,71 @@ end
 
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     integrator.stats.nf2 += 1
+    store_symp_state!(integrator, cache, kdu, ku)
+end
+
+@muladd function perform_step!(integrator, cache::LeapfrogDriftKickDriftConstantCache,
+        repeat_step = false)
+    @unpack t, dt, f, p = integrator
+    duprev, uprev, _, _ = load_symp_state(integrator)
+
+    # drift-kick-drift scheme of the Leapfrog method, allowing for f1 to depend on v:
+    # update position half step
+    half = cache.half
+    ku = f.f2(duprev, uprev, p, t)
+    u = uprev + dt * half * ku
+
+    # update velocity half step
+    kdu = f.f1(duprev, u, p, t)
+    du = duprev + dt * half * kdu
+
+    # full step
+    tnew = t + half * dt
+
+    # update velocity (add to previous full step velocity)
+    # note that this extra step is only necessary if f1 depends on v/du (or t)
+    kdu = f.f1(du, u, p, tnew)
+    du = duprev + dt * kdu
+
+    # update position (add to half step position)
+    ku = f.f2(du, u, p, tnew)
+    u = u + dt * half * ku
+
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
+    integrator.stats.nf2 += 2
+    store_symp_state!(integrator, cache, du, u, kdu, ku)
+end
+
+@muladd function perform_step!(integrator, cache::LeapfrogDriftKickDriftCache,
+        repeat_step = false)
+    @unpack t, dt, f, p = integrator
+    duprev, uprev, _, _ = load_symp_state(integrator)
+    du, u, kdu, ku = alloc_symp_state(integrator)
+
+    # drift-kick-drift scheme of the Leapfrog method, allowing for f1 to depend on v:
+    # update position half step
+    half = cache.half
+    f.f2(ku, duprev, uprev, p, t)
+    @.. broadcast=false u=uprev + dt * half * ku
+
+    # update velocity half step
+    f.f1(kdu, duprev, u, p, t)
+    @.. broadcast=false du=duprev + dt * half * kdu
+
+    # full step
+    tnew = t + half * dt
+
+    # update velocity (add to previous full step velocity)
+    # note that this extra step is only necessary if f1 depends on v/du (or t)
+    f.f1(kdu, du, u, p, tnew)
+    @.. broadcast=false du=duprev + dt * kdu
+
+    # update position (add to half step position)
+    f.f2(ku, du, u, p, tnew)
+    @.. broadcast=false u=u + dt * half * ku
+
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
+    integrator.stats.nf2 += 2
     store_symp_state!(integrator, cache, kdu, ku)
 end
 

--- a/lib/OrdinaryDiffEqSymplecticRK/test/symplectic_convergence.jl
+++ b/lib/OrdinaryDiffEqSymplecticRK/test/symplectic_convergence.jl
@@ -62,6 +62,9 @@ position_error = :final => [mean(sim[i].u[2].x[1] - sim[i].u_analytic[2].x[1])
 sim = test_convergence(dts, prob, VerletLeapfrog(), dense_errors = true)
 @test sim.𝒪est[:l2]≈2 rtol=1e-1
 @test sim.𝒪est[:L2]≈2 rtol=1e-1
+sim = test_convergence(dts, prob, LeapfrogDriftKickDrift(), dense_errors = true)
+@test sim.𝒪est[:l2]≈2 rtol=1e-1
+@test sim.𝒪est[:L2]≈2 rtol=1e-1
 sim = test_convergence(dts, prob, PseudoVerletLeapfrog(), dense_errors = true)
 @test sim.𝒪est[:l2]≈2 rtol=1e-1
 @test sim.𝒪est[:L2]≈2 rtol=1e-1
@@ -151,6 +154,9 @@ position_error = :final => [mean(sim[i].u[2].x[1] - sim[i].u_analytic[2].x[1])
 sim = test_convergence(dts, prob, VerletLeapfrog(), dense_errors = true)
 @test sim.𝒪est[:l2]≈2 rtol=1e-1
 @test sim.𝒪est[:L2]≈2 rtol=1e-1
+sim = test_convergence(dts, prob, LeapfrogDriftKickDrift(), dense_errors = true)
+@test sim.𝒪est[:l2]≈2 rtol=1e-1
+@test sim.𝒪est[:L2]≈2 rtol=1e-1
 sim = test_convergence(dts, prob, PseudoVerletLeapfrog(), dense_errors = true)
 @test sim.𝒪est[:l2]≈2 rtol=1e-1
 @test sim.𝒪est[:L2]≈2 rtol=1e-1
@@ -202,3 +208,28 @@ dts = 1.0 ./ 2.0 .^ (2:-1:-2)
 sim = test_convergence(dts, prob, SofSpa10(), dense_errors = true)
 @test sim.𝒪est[:l2]≈10 rtol=1e-1
 @test sim.𝒪est[:L2]≈4 rtol=1e-1
+
+################# f1 dependent on v
+
+println("f1 dependent on v")
+
+u0 = fill(0.0, 2)
+v0 = ones(2)
+function f1_v(dv, v, u, p, t)
+    dv .= v
+end
+function f2_v(du, v, u, p, t)
+    du .= v
+end
+function f_v_analytic(y0, p, x)
+    v0, u0 = y0.x
+    ArrayPartition(v0 * exp(x), v0 * exp(x) - v0 + u0)
+end
+ff_v = DynamicalODEFunction(f1_v, f2_v; analytic = f_v_analytic)
+prob = DynamicalODEProblem(ff_v, v0, u0, (0.0, 5.0))
+
+dts = 1 .// 2 .^ (6:-1:3)
+# LeapfrogDriftKickDrift
+sim = test_convergence(dts, prob, LeapfrogDriftKickDrift(), dense_errors = true)
+@test sim.𝒪est[:l2]≈2 rtol=1e-1
+@test sim.𝒪est[:L2]≈2 rtol=1e-1

--- a/lib/OrdinaryDiffEqSymplecticRK/test/symplectic_tests.jl
+++ b/lib/OrdinaryDiffEqSymplecticRK/test/symplectic_tests.jl
@@ -7,6 +7,7 @@ using OrdinaryDiffEqRKN
 const ALGOS = ((SymplecticEuler, true, 1),
     (VelocityVerlet, false, 2),
     (VerletLeapfrog, true, 2),
+    (LeapfrogDriftKickDrift, true, 2),
     (PseudoVerletLeapfrog, true, 2),
     (McAte2, true, 2),
     (Ruth3, true, 3),

--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -113,8 +113,8 @@ using OrdinaryDiffEqFeagin
 export Feagin10, Feagin12, Feagin14
 
 using OrdinaryDiffEqSymplecticRK
-export SymplecticEuler, VelocityVerlet, VerletLeapfrog, PseudoVerletLeapfrog,
-       McAte2, Ruth3, McAte3, CandyRoz4, McAte4, McAte42, McAte5,
+export SymplecticEuler, VelocityVerlet, VerletLeapfrog, LeapfrogDriftKickDrift,
+       PseudoVerletLeapfrog, McAte2, Ruth3, McAte3, CandyRoz4, McAte4, McAte42, McAte5,
        CalvoSanz4, Yoshida6, KahanLi6, McAte8, KahanLi8, SofSpa10
 
 using OrdinaryDiffEqRKN


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

The kick-drift-kick form of the Leapfrog method (currently implemented as `VerletLeapfrog`) looks like this:
```math
\begin{align}
v^{1/2} &= v^0 + \frac{1}{2} \Delta t\, f_1(v^0, u^0, t^0) \\
u^1 &= u^0 + \Delta t\, f_2 \left( v^{1/2}, u^{1/2}, t^0 + \frac{1}{2} \Delta t\, \right) \\
v^1 &= v^{1/2} + \frac{1}{2} \Delta t\, f_1(v^{1}, u^{1}, t^0 + \Delta t) 
\end{align}
```
The evaluation of $f_2$ requires that it does not depend on $u$. If it does, we can add an intermediate step to compute $u^{1/2}$.
The second evaluation of $f_1$ requires that it does not depend on $v$, otherwise the whole thing doesn't work because we need $v^1$ to compute $v^1$.

This can easily be demonstrated:
```julia
using OrdinaryDiffEq, DiffEqDevTools, RecursiveArrayTools

function f1!(dv, v, u, p, t)
    dv .= v
    return dv
end

function f2!(du, v, u, p, t)
    du .= v
    return du
end

function analytic(y0, p, t)
    v0, u0 = y0.x
    ArrayPartition(v0 * exp(t), v0 * exp(t) - v0 + u0)
end

v0 = [2.0]
u0 = [0.5]

ff = DynamicalODEFunction(f1!, f2!; analytic = analytic)
prob = DynamicalODEProblem(ff, v0, u0, (0.0, 2.0))

dts = 1 .// 2 .^ (6:-1:3)
sim = test_convergence(dts, prob, VerletLeapfrog())
sim.𝒪est
```
```
Dict{Any, Any} with 3 entries:
  :l∞    => 0.931081
  :final => 0.935263
  :l2    => 0.963547
```

In this case, we can use the drift-kick-drift form, which is commonly used in Smoothed Particle Hydrodynamics, where viscosity makes $f_1$ depend on the velocity.
This form looks like this:
```math
\begin{align}
u^{1/2} &= u^0 + \frac{1}{2} \Delta t\, f_2(v^0, u^0, t^0) \\
v^1 &= v^0 + \Delta t\, f_1 \left( v^{1/2}, u^{1/2}, t^0 + \frac{1}{2} \Delta t\, \right) \\
u^1 &= u^{1/2} + \frac{1}{2} \Delta t\, f_2(v^{1}, u^{1}, t^0 + \Delta t).
\end{align}
```
Now, if $f_1$ depends on $v$, we can just add a half step for $v$ as well:
```math
\begin{align}
u^{1/2} &= u^0 + \frac{1}{2} \Delta t\, f_2(v^0, u^0, t^0) \\
v^{1/2} &= v^0 + \frac{1}{2} \Delta t\, f_1(v^0, u^0, t^0) \\
v^1 &= v^0 + \Delta t\, f_1 \left( v^{1/2}, u^{1/2}, t^0 + \frac{1}{2} \Delta t\, \right) \\
u^1 &= u^{1/2} + \frac{1}{2} \Delta t\, f_2(v^{1}, u^{1}, t^0 + \Delta t).
\end{align}
```
This is exactly what I implemented in this PR.
If $f_2$ does not depend on $u$, this can all be written down cleanly and yields the desired order of convergence:
```
julia> sim = test_convergence(dts, prob, LeapfrogDriftKickDrift());

julia> sim.𝒪est
Dict{Any, Any} with 3 entries:
  :l∞    => 1.95964
  :final => 1.95356
  :l2    => 1.98679
```

The cited paper by Verlet does not mention the leapfrog formulation, so I added a paper by Monaghan, which nicely explains the different forms of leapfrog in Section 5.3.