### PR TITLE
Fix hang in BuildKite CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,6 +38,7 @@ steps:
     env:
       BUILDKITE_PLUGIN_JULIA_VERSION: "{{matrix.version}}"
       GROUP: "{{matrix.group}}"
+      JULIA_NUM_THREADS: 2
     plugins:
       - JuliaCI/julia#v1
       - staticfloat/metahook:
@@ -49,7 +50,6 @@ steps:
             '
       - JuliaCI/julia-test#v1:
           coverage: false
-          command: 'export JULIA_NUM_THREADS=2'
     agents:
       os: "linux"
       queue: "juliaecosystem"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -49,7 +49,6 @@ steps:
             '
       - JuliaCI/julia-test#v1:
           coverage: false
-          julia_args: "--threads=auto"
     agents:
       os: "linux"
       queue: "juliaecosystem"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -49,6 +49,7 @@ steps:
             '
       - JuliaCI/julia-test#v1:
           coverage: false
+          command: 'export JULIA_NUM_THREADS=2'
     agents:
       os: "linux"
       queue: "juliaecosystem"

--- a/test/multithreading/ode_extrapolation_tests.jl
+++ b/test/multithreading/ode_extrapolation_tests.jl
@@ -1,6 +1,8 @@
 # Import packages
 using OrdinaryDiffEqExtrapolation, DiffEqDevTools, Test, Random
 
+println("Running on $(Threads.nthreads()) thread(s).")
+
 # Define test problems
 # Note that the time span in ODEProblemLibrary is given by
 # Float64 numbers


### PR DESCRIPTION
I believe that due to the bug documented at https://github.com/JuliaLang/julia/issues/56458, the buildkite CI is hanging indefinitely causing the tests to fail.
This seems to be triggered by the use of the `--threads=auto` flag.

This merge request simply removes the flag for now, since a fix does not yet seem to be available.

https://github.com/JuliaCI/julia-test-buildkite-plugin/blob/main/hooks/command does not seem to support adding the flag at the `julia --threads=auto` invocation level, where it would again be permitted.