### PR TITLE
Fix `cache` for `SplitFunction`

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
@@ -252,7 +252,7 @@ end
 resize_f!(f, i) = nothing
 
 function resize_f!(f::SplitFunction, i)
-    resize!(f.cache, i)
+    resize!(f._func_cache, i)
     return nothing
 end
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

This is similar to https://github.com/SciML/DiffEqBase.jl/pull/1115 adapting the `cache` for `SplitFunction`s. Our CI in Trixi.jl is failing because of this, see https://github.com/trixi-framework/Trixi.jl/actions/runs/13303093848/job/37174015744?pr=2281#step:7:1498. I'm not sure if this needs to be adjusted somewhere else.
