### PR TITLE
Make CheckInit the default for ODEs and DAEs: breaking

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/initialize_dae.jl
+++ b/lib/OrdinaryDiffEqCore/src/initialize_dae.jl
@@ -42,38 +42,17 @@ function DiffEqBase.initialize_dae!(integrator::ODEIntegrator,
         Val(DiffEqBase.isinplace(integrator.sol.prob)))
 end
 
-## Default algorithms
+## Default algorithm is CheckInit
+## Changed in v7--previously was BrownFullBasicInit or ShampineCollocationInit
 
-function _initialize_dae!(integrator, prob::ODEProblem,
+function _initialize_dae!(integrator, prob::Union{ODEProblem, DAEProblem},
         alg::DefaultInit, x::Union{Val{true}, Val{false}})
     if SciMLBase.has_initializeprob(prob.f)
         _initialize_dae!(integrator, prob,
             OverrideInit(integrator.opts.abstol), x)
-    elseif !applicable(_initialize_dae!, integrator, prob,
-        BrownFullBasicInit(integrator.opts.abstol), x)
-        error("`OrdinaryDiffEqNonlinearSolve` is not loaded, which is required for the default initialization algorithm (`BrownFullBasicInit` or `ShampineCollocationInit`). To solve this problem, either do `using OrdinaryDiffEqNonlinearSolve` or pass `initializealg = CheckInit()` to the `solve` function. This second option requires consistent `u0`.")
     else
         _initialize_dae!(integrator, prob,
-            BrownFullBasicInit(integrator.opts.abstol), x)
-    end
-end
-
-function _initialize_dae!(integrator, prob::DAEProblem,
-        alg::DefaultInit, x::Union{Val{true}, Val{false}})
-    if SciMLBase.has_initializeprob(prob.f)
-        _initialize_dae!(integrator, prob,
-            OverrideInit(integrator.opts.abstol), x)
-    elseif !applicable(_initialize_dae!, integrator, prob,
-        BrownFullBasicInit(), x) &&
-           !applicable(_initialize_dae!,
-        integrator, prob, ShampineCollocationInit(), x)
-        error("`OrdinaryDiffEqNonlinearSolve` is not loaded, which is required for the default initialization algorithm (`BrownFullBasicInit` or `ShampineCollocationInit`). To solve this problem, either do `using OrdinaryDiffEqNonlinearSolve` or pass `initializealg = CheckInit()` to the `solve` function. This second option requires consistent `u0`.")
-    elseif prob.differential_vars === nothing
-        _initialize_dae!(integrator, prob,
-            ShampineCollocationInit(), x)
-    else
-        _initialize_dae!(integrator, prob,
-            BrownFullBasicInit(integrator.opts.abstol), x)
+            CheckInit(), x)
     end
 end
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Context

Bulk of the discussion happened in #2514 , see particularly [this comment](https://github.com/SciML/OrdinaryDiffEq.jl/pull/2514#issuecomment-2488706578) . This is a separate pull request because I did a clumsy job rebasing that branch and filled the Git history with all the commits since November.

#2554 worked on this in a non-breaking way, including exporting `BrownFullBasicInit` and `ShampineCollocationInit` from `ODENonlinearSolve`.

## Changes

Currently this is a very simple pull request.

This will require some documentation, which I haven't done yet. 
Note to self: probably needs it at
- https://github.com/SciML/DiffEqDocs.jl/blob/master/docs/src/types/dae_types.md
- https://github.com/SciML/DiffEqDocs.jl/blob/master/docs/src/solvers/dae_solve.md
- Possibly add a file like https://github.com/SciML/NonlinearSolve.jl/blob/master/docs/src/release_notes.md with some upgrade notes?