### PR TITLE
Use aliasing API for LinearSolve

### DIFF
--- a/lib/OrdinaryDiffEqExtrapolation/src/extrapolation_caches.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/extrapolation_caches.jl
@@ -264,7 +264,7 @@ function alg_cache(alg::ImplicitEulerExtrapolation, u, rate_prototype,
     end
 
     linprob = LinearProblem(W[1], _vec(linsolve_tmps[1]); u0 = _vec(k_tmps[1]))
-    linsolve1 = init(linprob, alg.linsolve, alias_A = true, alias_b = true)
+    linsolve1 = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true))
     #Pl = LinearSolve.InvPreconditioner(Diagonal(_vec(weight))),
     #Pr = Diagonal(_vec(weight)))
 
@@ -272,7 +272,7 @@ function alg_cache(alg::ImplicitEulerExtrapolation, u, rate_prototype,
     linsolve[1] = linsolve1
     for i in 2:Threads.nthreads()
         linprob = LinearProblem(W[i], _vec(linsolve_tmps[i]); u0 = _vec(k_tmps[i]))
-        linsolve[i] = init(linprob, alg.linsolve, alias_A = true, alias_b = true)
+        linsolve[i] = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true))
         #Pl = LinearSolve.InvPreconditioner(Diagonal(_vec(weight))),
         #Pr = Diagonal(_vec(weight)))
     end
@@ -1151,7 +1151,7 @@ function alg_cache(alg::ImplicitDeuflhardExtrapolation, u, rate_prototype,
     end
 
     linprob = LinearProblem(W[1], _vec(linsolve_tmps[1]); u0 = _vec(k_tmps[1]))
-    linsolve1 = init(linprob, alg.linsolve, alias_A = true, alias_b = true)
+    linsolve1 = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true))
     #Pl = LinearSolve.InvPreconditioner(Diagonal(_vec(weight))),
     #Pr = Diagonal(_vec(weight)))
 
@@ -1159,7 +1159,7 @@ function alg_cache(alg::ImplicitDeuflhardExtrapolation, u, rate_prototype,
     linsolve[1] = linsolve1
     for i in 2:Threads.nthreads()
         linprob = LinearProblem(W[i], _vec(linsolve_tmps[i]); u0 = _vec(k_tmps[i]))
-        linsolve[i] = init(linprob, alg.linsolve, alias_A = true, alias_b = true)
+        linsolve[i] = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true))
         #Pl = LinearSolve.InvPreconditioner(Diagonal(_vec(weight))),
         #Pr = Diagonal(_vec(weight)))
     end
@@ -1479,7 +1479,7 @@ function alg_cache(alg::ImplicitHairerWannerExtrapolation, u, rate_prototype,
     end
 
     linprob = LinearProblem(W[1], _vec(linsolve_tmps[1]); u0 = _vec(k_tmps[1]))
-    linsolve1 = init(linprob, alg.linsolve, alias_A = true, alias_b = true)
+    linsolve1 = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true))
     #Pl = LinearSolve.InvPreconditioner(Diagonal(_vec(weight))),
     #Pr = Diagonal(_vec(weight)))
 
@@ -1487,7 +1487,7 @@ function alg_cache(alg::ImplicitHairerWannerExtrapolation, u, rate_prototype,
     linsolve[1] = linsolve1
     for i in 2:Threads.nthreads()
         linprob = LinearProblem(W[i], _vec(linsolve_tmps[i]); u0 = _vec(k_tmps[i]))
-        linsolve[i] = init(linprob, alg.linsolve, alias_A = true, alias_b = true)
+        linsolve[i] = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true))
         #Pl = LinearSolve.InvPreconditioner(Diagonal(_vec(weight))),
         #Pr = Diagonal(_vec(weight)))
     end
@@ -1675,7 +1675,7 @@ function alg_cache(alg::ImplicitEulerBarycentricExtrapolation, u, rate_prototype
     end
 
     linprob = LinearProblem(W[1], _vec(linsolve_tmps[1]); u0 = _vec(k_tmps[1]))
-    linsolve1 = init(linprob, alg.linsolve, alias_A = true, alias_b = true)
+    linsolve1 = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true))
     #Pl = LinearSolve.InvPreconditioner(Diagonal(_vec(weight))),
     #Pr = Diagonal(_vec(weight)))
 
@@ -1683,7 +1683,7 @@ function alg_cache(alg::ImplicitEulerBarycentricExtrapolation, u, rate_prototype
     linsolve[1] = linsolve1
     for i in 2:Threads.nthreads()
         linprob = LinearProblem(W[i], _vec(linsolve_tmps[i]); u0 = _vec(k_tmps[i]))
-        linsolve[i] = init(linprob, alg.linsolve, alias_A = true, alias_b = true)
+        linsolve[i] = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true))
         #Pl = LinearSolve.InvPreconditioner(Diagonal(_vec(weight))),
         #Pr = Diagonal(_vec(weight)))
     end

--- a/lib/OrdinaryDiffEqFIRK/src/firk_caches.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_caches.jl
@@ -108,7 +108,7 @@ function alg_cache(alg::RadauIIA3, u, rate_prototype, ::Type{uEltypeNoUnits},
     jac_config = jac_config = build_jac_config(alg, f, uf, du1, uprev, u, tmp, dw12)
 
     linprob = LinearProblem(W1, _vec(cubuff); u0 = _vec(dw12))
-    linsolve = init(linprob, alg.linsolve, alias_A = true, alias_b = true,
+    linsolve = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true),
         assumptions = LinearSolve.OperatorAssumptions(true))
     #Pl = LinearSolve.InvPreconditioner(Diagonal(_vec(weight))),
     #Pr = Diagonal(_vec(weight)))
@@ -253,12 +253,12 @@ function alg_cache(alg::RadauIIA5, u, rate_prototype, ::Type{uEltypeNoUnits},
     jac_config = build_jac_config(alg, f, uf, du1, uprev, u, tmp, dw1)
 
     linprob = LinearProblem(W1, _vec(ubuff); u0 = _vec(dw1))
-    linsolve1 = init(linprob, alg.linsolve, alias_A = true, alias_b = true,
+    linsolve1 = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true),
         assumptions = LinearSolve.OperatorAssumptions(true))
     #Pl = LinearSolve.InvPreconditioner(Diagonal(_vec(weight))),
     #Pr = Diagonal(_vec(weight)))
     linprob = LinearProblem(W2, _vec(cubuff); u0 = _vec(dw23))
-    linsolve2 = init(linprob, alg.linsolve, alias_A = true, alias_b = true,
+    linsolve2 = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true),
         assumptions = LinearSolve.OperatorAssumptions(true))
     #Pl = LinearSolve.InvPreconditioner(Diagonal(_vec(weight))),
     #Pr = Diagonal(_vec(weight)))
@@ -453,17 +453,17 @@ function alg_cache(alg::RadauIIA9, u, rate_prototype, ::Type{uEltypeNoUnits},
     jac_config = build_jac_config(alg, f, uf, du1, uprev, u, tmp, dw1)
 
     linprob = LinearProblem(W1, _vec(ubuff); u0 = _vec(dw1))
-    linsolve1 = init(linprob, alg.linsolve, alias_A = true, alias_b = true,
+    linsolve1 = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true),
         assumptions = LinearSolve.OperatorAssumptions(true))
     #Pl = LinearSolve.InvPreconditioner(Diagonal(_vec(weight))),
     #Pr = Diagonal(_vec(weight)))
     linprob = LinearProblem(W2, _vec(cubuff1); u0 = _vec(dw23))
-    linsolve2 = init(linprob, alg.linsolve, alias_A = true, alias_b = true,
+    linsolve2 = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true),
         assumptions = LinearSolve.OperatorAssumptions(true))
     #Pl = LinearSolve.InvPreconditioner(Diagonal(_vec(weight))),
     #Pr = Diagonal(_vec(weight)))
     linprob = LinearProblem(W3, _vec(cubuff2); u0 = _vec(dw45))
-    linsolve3 = init(linprob, alg.linsolve, alias_A = true, alias_b = true,
+    linsolve3 = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true),
         assumptions = LinearSolve.OperatorAssumptions(true))
     #Pl = LinearSolve.InvPreconditioner(Diagonal(_vec(weight))),
     #Pr = Diagonal(_vec(weight)))
@@ -659,11 +659,11 @@ function alg_cache(alg::AdaptiveRadau, u, rate_prototype, ::Type{uEltypeNoUnits}
     jac_config = build_jac_config(alg, f, uf, du1, uprev, u, zero(u), dw1)
 
     linprob = LinearProblem(W1, _vec(ubuff); u0 = _vec(dw1))
-    linsolve1 = init(linprob, alg.linsolve, alias_A = true, alias_b = true,
+    linsolve1 = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true),
         assumptions = LinearSolve.OperatorAssumptions(true))
 
     linsolve2 = [init(LinearProblem(W2[i], _vec(cubuff[i]); u0 = _vec(dw2[i])),
-                     alg.linsolve, alias_A = true, alias_b = true,
+                     alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true),
                      assumptions = LinearSolve.OperatorAssumptions(true))
                  for i in 1:((max_stages - 1) ÷ 2)]
 

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -196,7 +196,7 @@ function build_nlsolver(
             alg.precs(W, nothing, u, p, t, nothing, nothing, nothing,
                 nothing)...,
             weight, dz)
-        linsolve = init(linprob, alg.linsolve, alias_A = true, alias_b = true,
+        linsolve = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true),
             Pl = Pl, Pr = Pr,
             assumptions = LinearSolve.OperatorAssumptions(true))
 

--- a/lib/OrdinaryDiffEqRosenbrock/src/generic_rosenbrock.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/generic_rosenbrock.jl
@@ -248,7 +248,7 @@ function gen_algcache(cacheexpr::Expr,constcachename::Symbol,algname::Symbol,tab
             uf = UJacobianWrapper(f,t,p)
             linsolve_tmp = zero(rate_prototype)
             linprob = LinearProblem(W,_vec(linsolve_tmp); u0=_vec(tmp))
-            linsolve = init(linprob,alg.linsolve,alias_A=true,alias_b=true,
+            linsolve = init(linprob,alg.linsolve,alias = LinearAliasSpecifier(alias_A=true,alias_b=true),
                             Pl = LinearSolve.InvPreconditioner(Diagonal(_vec(weight))),
                             Pr = Diagonal(_vec(weight)))
             grad_config = build_grad_config(alg,f,tf,du1,t)

--- a/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_caches.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_caches.jl
@@ -155,7 +155,7 @@ function alg_cache(alg::Rosenbrock23, u, rate_prototype, ::Type{uEltypeNoUnits},
     Pl, Pr = wrapprecs(
         alg.precs(W, nothing, u, p, t, nothing, nothing, nothing,
             nothing)..., weight, tmp)
-    linsolve = init(linprob, alg.linsolve, alias_A = true, alias_b = true,
+    linsolve = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true),
         Pl = Pl, Pr = Pr,
         assumptions = LinearSolve.OperatorAssumptions(true))
 
@@ -201,7 +201,7 @@ function alg_cache(alg::Rosenbrock32, u, rate_prototype, ::Type{uEltypeNoUnits},
     Pl, Pr = wrapprecs(
         alg.precs(W, nothing, u, p, t, nothing, nothing, nothing,
             nothing)..., weight, tmp)
-    linsolve = init(linprob, alg.linsolve, alias_A = true, alias_b = true,
+    linsolve = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true),
         Pl = Pl, Pr = Pr,
         assumptions = LinearSolve.OperatorAssumptions(true))
     grad_config = build_grad_config(alg, f, tf, du1, t)
@@ -349,7 +349,7 @@ function alg_cache(alg::ROS3P, u, rate_prototype, ::Type{uEltypeNoUnits},
     Pl, Pr = wrapprecs(
         alg.precs(W, nothing, u, p, t, nothing, nothing, nothing,
             nothing)..., weight, tmp)
-    linsolve = init(linprob, alg.linsolve, alias_A = true, alias_b = true,
+    linsolve = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true),
         Pl = Pl, Pr = Pr,
         assumptions = LinearSolve.OperatorAssumptions(true))
     grad_config = build_grad_config(alg, f, tf, du1, t)
@@ -435,7 +435,7 @@ function alg_cache(alg::Rodas3, u, rate_prototype, ::Type{uEltypeNoUnits},
     Pl, Pr = wrapprecs(
         alg.precs(W, nothing, u, p, t, nothing, nothing, nothing,
             nothing)..., weight, tmp)
-    linsolve = init(linprob, alg.linsolve, alias_A = true, alias_b = true,
+    linsolve = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true),
         Pl = Pl, Pr = Pr,
         assumptions = LinearSolve.OperatorAssumptions(true))
     grad_config = build_grad_config(alg, f, tf, du1, t)
@@ -628,7 +628,7 @@ function alg_cache(alg::Rodas23W, u, rate_prototype, ::Type{uEltypeNoUnits},
     Pl, Pr = wrapprecs(
         alg.precs(W, nothing, u, p, t, nothing, nothing, nothing,
             nothing)..., weight, tmp)
-    linsolve = init(linprob, alg.linsolve, alias_A = true, alias_b = true,
+    linsolve = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true),
         Pl = Pl, Pr = Pr,
         assumptions = LinearSolve.OperatorAssumptions(true))
     grad_config = build_grad_config(alg, f, tf, du1, t)
@@ -672,7 +672,7 @@ function alg_cache(alg::Rodas3P, u, rate_prototype, ::Type{uEltypeNoUnits},
     Pl, Pr = wrapprecs(
         alg.precs(W, nothing, u, p, t, nothing, nothing, nothing,
             nothing)..., weight, tmp)
-    linsolve = init(linprob, alg.linsolve, alias_A = true, alias_b = true,
+    linsolve = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true),
         Pl = Pl, Pr = Pr,
         assumptions = LinearSolve.OperatorAssumptions(true))
     grad_config = build_grad_config(alg, f, tf, du1, t)
@@ -779,7 +779,7 @@ function alg_cache(
         alg.precs(W, nothing, u, p, t, nothing, nothing, nothing,
             nothing)..., weight, tmp)
 
-    linsolve = init(linprob, alg.linsolve, alias_A = true, alias_b = true,
+    linsolve = init(linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true),
         Pl = Pl, Pr = Pr,
         assumptions = LinearSolve.OperatorAssumptions(true))
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context
Uses LinearAliasSpecifier to specify aliasing in linear solves
