### PR TITLE
Fix inconsistencies of type parameters of algorithms with AD settings

### DIFF
--- a/lib/OrdinaryDiffEqBDF/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqBDF/src/algorithms.jl
@@ -119,7 +119,7 @@ function ABDF2(;
         nlsolve = NLNewton(),
         smooth_est = true, extrapolant = :linear,
         controller = :Standard, step_limiter! = trivial_limiter!)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     ABDF2{
         _unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve), typeof(nlsolve),
@@ -177,7 +177,7 @@ function SBDF(order; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(), κ = nothing,
         tol = nothing,
         extrapolant = :linear, ark = false)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     SBDF{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve), typeof(nlsolve),
         typeof(precs), diff_type, _unwrap_val(standardtag), _unwrap_val(concrete_jac),
@@ -200,7 +200,7 @@ function SBDF(;
         tol = nothing,
         extrapolant = :linear,
         order, ark = false)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     SBDF{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve), typeof(nlsolve),
         typeof(precs), diff_type, _unwrap_val(standardtag), _unwrap_val(concrete_jac),
@@ -306,7 +306,7 @@ function QNDF1(;
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :linear, kappa = -37 // 200,
         controller = :Standard, step_limiter! = trivial_limiter!)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     QNDF1{
         _unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve), typeof(nlsolve),
@@ -366,7 +366,7 @@ function QNDF2(;
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :linear, kappa = -1 // 9,
         controller = :Standard, step_limiter! = trivial_limiter!)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     QNDF2{
         _unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve), typeof(nlsolve),
@@ -436,7 +436,7 @@ function QNDF(; max_order::Val{MO} = Val{5}(), chunk_size = Val{0}(),
         extrapolant = :linear, kappa = (
             -37 // 200, -1 // 9, -823 // 10000, -83 // 2000, 0 // 1),
         controller = :Standard, step_limiter! = trivial_limiter!) where {MO}
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     QNDF{MO, _unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -482,7 +482,7 @@ function MEBDF2(;
         concrete_jac = nothing, diff_type = Val{:forward}(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :constant)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     MEBDF2{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -541,7 +541,7 @@ function FBDF(; max_order::Val{MO} = Val{5}(), chunk_size = Val{0}(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(), κ = nothing,
         tol = nothing,
         extrapolant = :linear, controller = :Standard, step_limiter! = trivial_limiter!) where {MO}
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     FBDF{MO, _unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -659,7 +659,7 @@ function DImplicitEuler(;
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :constant,
         controller = :Standard)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     DImplicitEuler{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -701,7 +701,7 @@ function DABDF2(;
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :constant,
         controller = :Standard)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     DABDF2{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -764,7 +764,7 @@ function DFBDF(; max_order::Val{MO} = Val{5}(), chunk_size = Val{0}(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(), κ = nothing,
         tol = nothing,
         extrapolant = :linear, controller = :Standard) where {MO}
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     DFBDF{MO, _unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),

--- a/lib/OrdinaryDiffEqCore/src/misc_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/misc_utils.jl
@@ -147,11 +147,12 @@ function _bool_to_ADType(::Val{false}, _, ::Val{FD}) where {FD}
 end
 
 # Functions to get ADType type from Bool or ADType object, or ADType type
-function _process_AD_choice(ad_alg::Bool, ::Val{CS}, ::Val{FD}) where {CS,FD}
+function _process_AD_choice(ad_alg::Bool, ::Val{CS}, ::Val{FD}) where {CS, FD}
     return _bool_to_ADType(Val(ad_alg), Val{CS}(), Val{FD}()), Val{CS}(), Val{FD}()
 end
 
-function _process_AD_choice(ad_alg::AutoForwardDiff{CS}, ::Val{CS2}, ::Val{FD}) where {CS,CS2,FD}
+function _process_AD_choice(
+        ad_alg::AutoForwardDiff{CS}, ::Val{CS2}, ::Val{FD}) where {CS, CS2, FD}
     # Non-default `chunk_size`
     if CS2 != 0
         @warn "The `chunk_size` keyword is deprecated. Please use an `ADType` specifier. For now defaulting to using `AutoForwardDiff` with `chunksize=$(CS2)`."
@@ -161,7 +162,8 @@ function _process_AD_choice(ad_alg::AutoForwardDiff{CS}, ::Val{CS2}, ::Val{FD}) 
     return ad_alg, Val{_CS}(), Val{FD}()
 end
 
-function _process_AD_choice(ad_alg::AutoFiniteDiff{FD}, ::Val{CS}, ::Val{FD2}) where {FD,CS,FD2}
+function _process_AD_choice(
+        ad_alg::AutoFiniteDiff{FD}, ::Val{CS}, ::Val{FD2}) where {FD, CS, FD2}
     # Non-default `diff_type`
     if FD2 !== :forward
         @warn "The `diff_type` keyword is deprecated. Please use an `ADType` specifier. For now defaulting to using `AutoFiniteDiff` with `fdtype=Val{$FD2}()`."

--- a/lib/OrdinaryDiffEqCore/src/misc_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/misc_utils.jl
@@ -131,33 +131,41 @@ end
 
 isnewton(::Any) = false
 
-function _bool_to_ADType(::Val{true}, chunksize, diff_type)
+function _bool_to_ADType(::Val{true}, ::Val{CS}, _) where {CS}
     Base.depwarn(
         "Using a `Bool` for keyword argument `autodiff` is deprecated. Please use an `ADType` specifier.",
         :_bool_to_ADType)
-    chunksize = SciMLBase._unwrap_val(chunksize) == 0 ? nothing :
-                SciMLBase._unwrap_val(chunksize)
-    AutoForwardDiff(chunksize = chunksize)
+    _CS = CS === 0 ? nothing : CS
+    return AutoForwardDiff{_CS}(nothing)
 end
 
-function _bool_to_ADType(::Val{false}, chunksize, diff_type)
+function _bool_to_ADType(::Val{false}, _, ::Val{FD}) where {FD}
     Base.depwarn(
         "Using a `Bool` for keyword argument `autodiff` is deprecated. Please use an `ADType` specifier.",
         :_bool_to_ADType)
-    return AutoFiniteDiff(fdtype = diff_type)
+    return AutoFiniteDiff(; fdtype = Val{FD}())
 end
 
 # Functions to get ADType type from Bool or ADType object, or ADType type
-function _process_AD_choice(ad_alg::Bool, chunksize, diff_type)
-    _bool_to_ADType(Val(ad_alg), chunksize, diff_type)
+function _process_AD_choice(ad_alg::Bool, ::Val{CS}, ::Val{FD}) where {CS,FD}
+    return _bool_to_ADType(Val(ad_alg), Val{CS}(), Val{FD}()), Val{CS}(), Val{FD}()
 end
 
-function _process_AD_choice(ad_alg::AbstractADType, chunksize, diff_type)
-    # need a path for if just chunksize is specified in the Algorithm construction
-    if !(chunksize === Val{0}())
-        @warn "The `chunksize` keyword is deprecated. Please use an `ADType` specifier. For now defaulting to using `ForwardDiff` with the given `chunksize`."
-        return _bool_to_ADType(Val{true}(), chunksize, diff_type)
+function _process_AD_choice(ad_alg::AutoForwardDiff{CS}, ::Val{CS2}, ::Val{FD}) where {CS,CS2,FD}
+    # Non-default `chunk_size`
+    if CS2 != 0
+        @warn "The `chunk_size` keyword is deprecated. Please use an `ADType` specifier. For now defaulting to using `AutoForwardDiff` with `chunksize=$(CS2)`."
+        return _bool_to_ADType(Val{true}(), Val{CS2}(), Val{FD}()), Val{CS2}(), Val{FD}()
     end
+    _CS = CS === nothing ? 0 : CS
+    return ad_alg, Val{_CS}(), Val{FD}()
+end
 
-    ad_alg
+function _process_AD_choice(ad_alg::AutoFiniteDiff{FD}, ::Val{CS}, ::Val{FD2}) where {FD,CS,FD2}
+    # Non-default `diff_type`
+    if FD2 !== :forward
+        @warn "The `diff_type` keyword is deprecated. Please use an `ADType` specifier. For now defaulting to using `AutoFiniteDiff` with `fdtype=Val{$FD2}()`."
+        return _bool_to_ADType(Val{false}(), Val{CS}(), Val{FD2}()), Val{CS}(), Val{FD2}()
+    end
+    return ad_alg, Val{CS}(), ad_alg.fdtype
 end

--- a/lib/OrdinaryDiffEqExponentialRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/algorithms.jl
@@ -39,7 +39,8 @@ for (Alg, Description, Ref) in [
             standardtag = Val{true}(), concrete_jac = nothing,
             chunk_size = Val{0}(),
             diff_type = Val{:forward}())
-        AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
+        AD_choice, chunk_size, diff_type = _process_AD_choice(
+            autodiff, chunk_size, diff_type)
 
         $Alg{_unwrap_val(chunk_size), typeof(AD_choice),
             diff_type, _unwrap_val(standardtag), _unwrap_val(concrete_jac)}(krylov,
@@ -83,7 +84,8 @@ for (Alg, Description, Ref) in [
             m = 30, iop = 0, autodiff = AutoForwardDiff(), standardtag = Val{true}(),
             concrete_jac = nothing, chunk_size = Val{0}(),
             diff_type = Val{:forward}())
-        AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
+        AD_choice, chunk_size, diff_type = _process_AD_choice(
+            autodiff, chunk_size, diff_type)
 
         $Alg{_unwrap_val(chunk_size), typeof(AD_choice),
             diff_type, _unwrap_val(standardtag),
@@ -145,7 +147,8 @@ for (Alg, Description, Ref) in [(:Exp4, "4th order EPIRK scheme.", REF3)
             adaptive_krylov = true, m = 30, iop = 0, autodiff = AutoForwardDiff(),
             standardtag = Val{true}(), concrete_jac = nothing,
             chunk_size = Val{0}(), diff_type = Val{:forward}())
-        AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
+        AD_choice, chunk_size, diff_type = _process_AD_choice(
+            autodiff, chunk_size, diff_type)
 
         $Alg{_unwrap_val(chunk_size), typeof(AD_choice), diff_type,
             _unwrap_val(standardtag), _unwrap_val(concrete_jac)}(adaptive_krylov,

--- a/lib/OrdinaryDiffEqExponentialRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/algorithms.jl
@@ -39,7 +39,7 @@ for (Alg, Description, Ref) in [
             standardtag = Val{true}(), concrete_jac = nothing,
             chunk_size = Val{0}(),
             diff_type = Val{:forward}())
-        AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+        AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
         $Alg{_unwrap_val(chunk_size), typeof(AD_choice),
             diff_type, _unwrap_val(standardtag), _unwrap_val(concrete_jac)}(krylov,
@@ -83,7 +83,7 @@ for (Alg, Description, Ref) in [
             m = 30, iop = 0, autodiff = AutoForwardDiff(), standardtag = Val{true}(),
             concrete_jac = nothing, chunk_size = Val{0}(),
             diff_type = Val{:forward}())
-        AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+        AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
         $Alg{_unwrap_val(chunk_size), typeof(AD_choice),
             diff_type, _unwrap_val(standardtag),
@@ -145,7 +145,7 @@ for (Alg, Description, Ref) in [(:Exp4, "4th order EPIRK scheme.", REF3)
             adaptive_krylov = true, m = 30, iop = 0, autodiff = AutoForwardDiff(),
             standardtag = Val{true}(), concrete_jac = nothing,
             chunk_size = Val{0}(), diff_type = Val{:forward}())
-        AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+        AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
         $Alg{_unwrap_val(chunk_size), typeof(AD_choice), diff_type,
             _unwrap_val(standardtag), _unwrap_val(concrete_jac)}(adaptive_krylov,

--- a/lib/OrdinaryDiffEqExtrapolation/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/algorithms.jl
@@ -73,7 +73,7 @@ function ImplicitEulerExtrapolation(; chunk_size = Val{0}(), autodiff = AutoForw
         precs = DEFAULT_PRECS,
         max_order = 12, min_order = 3, init_order = 5,
         threading = false, sequence = :harmonic)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     linsolve = (linsolve === nothing &&
                 (threading == true || threading isa PolyesterThreads)) ?
@@ -216,7 +216,7 @@ function ImplicitDeuflhardExtrapolation(;
         diff_type = Val{:forward}(),
         min_order = 1, init_order = 5, max_order = 10,
         sequence = :harmonic, threading = false)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     # Enforce 1 <=  min_order <= init_order <= max_order:
     min_order = max(1, min_order)
@@ -400,7 +400,7 @@ Initial order: " * lpad(init_order, 2, " ") * " --> " * lpad(init_order, 2, " ")
         sequence = :harmonic
     end
 
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
     # Initialize algorithm
     ImplicitHairerWannerExtrapolation{_unwrap_val(chunk_size), typeof(AD_choice),
         typeof(linsolve), typeof(precs), diff_type,
@@ -483,7 +483,7 @@ Initial order: " * lpad(init_order, 2, " ") * " --> " * lpad(init_order, 2, " ")
         sequence = :harmonic
     end
 
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
     # Initialize algorithm
     ImplicitEulerBarycentricExtrapolation{_unwrap_val(chunk_size), typeof(AD_choice),
         typeof(linsolve), typeof(precs), diff_type,

--- a/lib/OrdinaryDiffEqFIRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/algorithms.jl
@@ -183,7 +183,7 @@ end
 
 function AdaptiveRadau(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         standardtag = Val{true}(), concrete_jac = nothing,
-        diff_type = Val{:forward}, min_order = 5, max_order = 13, threading = false,
+        diff_type = Val{:forward}(), min_order = 5, max_order = 13, threading = false,
         linsolve = nothing, precs = DEFAULT_PRECS,
         extrapolant = :dense, fast_convergence_cutoff = 1 // 5,
         new_W_γdt_cutoff = 1 // 5,

--- a/lib/OrdinaryDiffEqFIRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/algorithms.jl
@@ -48,7 +48,7 @@ function RadauIIA3(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         new_W_γdt_cutoff = 1 // 5,
         controller = :Predictive, κ = nothing, maxiters = 10,
         step_limiter! = trivial_limiter!)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     RadauIIA3{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(precs), diff_type, _unwrap_val(standardtag), _unwrap_val(concrete_jac),
@@ -96,7 +96,7 @@ function RadauIIA5(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         new_W_γdt_cutoff = 1 // 5,
         controller = :Predictive, κ = nothing, maxiters = 10, smooth_est = true,
         step_limiter! = trivial_limiter!)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     RadauIIA5{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(precs), diff_type, _unwrap_val(standardtag), _unwrap_val(concrete_jac),
@@ -145,7 +145,7 @@ function RadauIIA9(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         new_W_γdt_cutoff = 1 // 5,
         controller = :Predictive, κ = nothing, maxiters = 10, smooth_est = true,
         step_limiter! = trivial_limiter!)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     RadauIIA9{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(precs), diff_type, _unwrap_val(standardtag), _unwrap_val(concrete_jac),
@@ -189,7 +189,7 @@ function AdaptiveRadau(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         new_W_γdt_cutoff = 1 // 5,
         controller = :Predictive, κ = nothing, maxiters = 10, smooth_est = true,
         step_limiter! = trivial_limiter!)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     AdaptiveRadau{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(precs), diff_type, _unwrap_val(standardtag), _unwrap_val(concrete_jac),

--- a/lib/OrdinaryDiffEqIMEXMultistep/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/src/algorithms.jl
@@ -34,7 +34,7 @@ function CNAB2(;
         concrete_jac = nothing, diff_type = Val{:forward}(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :linear)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     CNAB2{
         _unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve), typeof(nlsolve),
@@ -78,7 +78,7 @@ function CNLF2(;
         concrete_jac = nothing, diff_type = Val{:forward}(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :linear)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     CNLF2{
         _unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve), typeof(nlsolve),

--- a/lib/OrdinaryDiffEqPDIRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqPDIRK/src/algorithms.jl
@@ -35,7 +35,7 @@ function PDIRK44(;
         concrete_jac = nothing, diff_type = Val{:forward}(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :constant, threading = true)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     PDIRK44{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),

--- a/lib/OrdinaryDiffEqRosenbrock/src/OrdinaryDiffEqRosenbrock.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/OrdinaryDiffEqRosenbrock.jl
@@ -51,7 +51,7 @@ function rosenbrock_wolfbrandt_docstring(description::String,
     standardtag = Val{true}(),
     autodiff = AutoForwardDiff(),
     concrete_jac = nothing,
-    diff_type = Val{:central},
+    diff_type = Val{:forward}(),
     linsolve = nothing,
     precs = DEFAULT_PRECS,
     """ * extra_keyword_default

--- a/lib/OrdinaryDiffEqRosenbrock/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/algorithms.jl
@@ -117,7 +117,8 @@ for Alg in [
                 diff_type = Val{:forward}(), linsolve = nothing,
                 precs = DEFAULT_PRECS, step_limiter! = trivial_limiter!,
                 stage_limiter! = trivial_limiter!)
-            AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
+            AD_choice, chunk_size, diff_type = _process_AD_choice(
+                autodiff, chunk_size, diff_type)
             $Alg{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
                 typeof(precs), diff_type, _unwrap_val(standardtag),
                 _unwrap_val(concrete_jac), typeof(step_limiter!),
@@ -136,7 +137,8 @@ end
 function GeneralRosenbrock(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         standardtag = Val{true}(), concrete_jac = nothing,
         factorization = lu!, tableau = ROSENBROCK_DEFAULT_TABLEAU)
-    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, Val{:forward}())
+    AD_choice, chunk_size, diff_type = _process_AD_choice(
+        autodiff, chunk_size, Val{:forward}())
 
     GeneralRosenbrock{
         _unwrap_val(chunk_size), typeof(AD_choice), typeof(factorization),
@@ -202,7 +204,8 @@ for Alg in [
         function $Alg(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
                 standardtag = Val{true}(), concrete_jac = nothing,
                 diff_type = Val{:forward}(), linsolve = nothing, precs = DEFAULT_PRECS)
-            AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
+            AD_choice, chunk_size, diff_type = _process_AD_choice(
+                autodiff, chunk_size, diff_type)
 
             $Alg{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
                 typeof(precs), diff_type, _unwrap_val(standardtag),

--- a/lib/OrdinaryDiffEqRosenbrock/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/algorithms.jl
@@ -117,7 +117,7 @@ for Alg in [
                 diff_type = Val{:forward}(), linsolve = nothing,
                 precs = DEFAULT_PRECS, step_limiter! = trivial_limiter!,
                 stage_limiter! = trivial_limiter!)
-            AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+            AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
             $Alg{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
                 typeof(precs), diff_type, _unwrap_val(standardtag),
                 _unwrap_val(concrete_jac), typeof(step_limiter!),
@@ -136,7 +136,7 @@ end
 function GeneralRosenbrock(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         standardtag = Val{true}(), concrete_jac = nothing,
         factorization = lu!, tableau = ROSENBROCK_DEFAULT_TABLEAU)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, Val{:forward}())
 
     GeneralRosenbrock{
         _unwrap_val(chunk_size), typeof(AD_choice), typeof(factorization),
@@ -160,10 +160,10 @@ struct RosenbrockW6S4OS{CS, AD, F, P, FDT, ST, CJ} <:
 end
 function RosenbrockW6S4OS(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         standardtag = Val{true}(),
-        concrete_jac = nothing, diff_type = Val{:central},
+        concrete_jac = nothing, diff_type = Val{:forward}(),
         linsolve = nothing,
         precs = DEFAULT_PRECS)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     RosenbrockW6S4OS{_unwrap_val(chunk_size),
         typeof(AD_choice), typeof(linsolve), typeof(precs), diff_type,
@@ -202,7 +202,7 @@ for Alg in [
         function $Alg(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
                 standardtag = Val{true}(), concrete_jac = nothing,
                 diff_type = Val{:forward}(), linsolve = nothing, precs = DEFAULT_PRECS)
-            AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+            AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
             $Alg{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
                 typeof(precs), diff_type, _unwrap_val(standardtag),

--- a/lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl
@@ -745,7 +745,8 @@ end
         ROS3PR,
         Scholz4_7
     ]
-        RosenbrockAlgorithm = if T <: OrdinaryDiffEqRosenbrock.OrdinaryDiffEqRosenbrockAlgorithm
+        RosenbrockAlgorithm = if T <:
+                                 OrdinaryDiffEqRosenbrock.OrdinaryDiffEqRosenbrockAlgorithm
             OrdinaryDiffEqRosenbrock.OrdinaryDiffEqRosenbrockAlgorithm
         else
             OrdinaryDiffEqRosenbrock.OrdinaryDiffEqRosenbrockAdaptiveAlgorithm
@@ -753,41 +754,47 @@ end
 
         ad = AutoForwardDiff(; chunksize = 3)
         alg = @test_logs @inferred(T(; autodiff = ad))
-        @test alg isa RosenbrockAlgorithm{3,typeof(ad),Val{:forward}()}
+        @test alg isa RosenbrockAlgorithm{3, typeof(ad), Val{:forward}()}
         @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.alg_autodiff(alg) === ad
         @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.get_chunksize(alg) === Val{3}()
 
-        alg = @test_logs (:warn,r"The `chunk_size` keyword is deprecated") match_mode=:any @inferred(T(; autodiff = ad, chunk_size = Val{4}()))
-        @test alg isa RosenbrockAlgorithm{4,<:AutoForwardDiff{4},Val{:forward}()}
-        @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.alg_autodiff(alg) isa AutoForwardDiff{4}
+        alg = @test_logs (:warn, r"The `chunk_size` keyword is deprecated") match_mode=:any @inferred(T(;
+            autodiff = ad, chunk_size = Val{4}()))
+        @test alg isa RosenbrockAlgorithm{4, <:AutoForwardDiff{4}, Val{:forward}()}
+        @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.alg_autodiff(alg) isa
+              AutoForwardDiff{4}
         @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.get_chunksize(alg) === Val{4}()
 
         ad = AutoFiniteDiff(; fdtype = Val{:central}())
         alg = @test_logs @inferred(T(; autodiff = ad))
-        @test alg isa RosenbrockAlgorithm{0,<:AutoFiniteDiff{Val{:central}},Val{:central}()}
+        @test alg isa
+              RosenbrockAlgorithm{0, <:AutoFiniteDiff{Val{:central}}, Val{:central}()}
         @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.alg_autodiff(alg) === ad
         @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.get_chunksize(alg) === Val{0}()
 
-        alg = @test_logs (:warn,r"The `diff_type` keyword is deprecated") match_mode=:any @inferred(T(; autodiff = ad, diff_type = Val{:complex}()))
-        @test alg isa RosenbrockAlgorithm{0,<:AutoFiniteDiff{Val{:complex}},Val{:complex}()}
-        @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.alg_autodiff(alg) isa AutoFiniteDiff{Val{:complex}}
+        alg = @test_logs (:warn, r"The `diff_type` keyword is deprecated") match_mode=:any @inferred(T(;
+            autodiff = ad, diff_type = Val{:complex}()))
+        @test alg isa
+              RosenbrockAlgorithm{0, <:AutoFiniteDiff{Val{:complex}}, Val{:complex}()}
+        @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.alg_autodiff(alg) isa
+              AutoFiniteDiff{Val{:complex}}
         @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.get_chunksize(alg) === Val{0}()
 
         # issue #2613
         f(u, _, _) = -u
         prob = ODEProblem(f, [1.0, 0.0], (0.0, 1.0))
-        alg = T(; autodiff=AutoForwardDiff(; chunksize=1))
+        alg = T(; autodiff = AutoForwardDiff(; chunksize = 1))
         sol = if alg isa OrdinaryDiffEqRosenbrock.OrdinaryDiffEqRosenbrockAdaptiveAlgorithm
             @inferred(solve(prob, alg))
         else
-            @inferred(solve(prob, alg; dt=0.1))
+            @inferred(solve(prob, alg; dt = 0.1))
         end
         @test sol.alg === alg
-        alg = T(; autodiff=AutoFiniteDiff(; fdtype=Val(:central)))
+        alg = T(; autodiff = AutoFiniteDiff(; fdtype = Val(:central)))
         sol = if alg isa OrdinaryDiffEqRosenbrock.OrdinaryDiffEqRosenbrockAdaptiveAlgorithm
             @inferred(solve(prob, alg))
         else
-            @inferred(solve(prob, alg; dt=0.1))
+            @inferred(solve(prob, alg; dt = 0.1))
         end
         @test sol.alg === alg
     end

--- a/lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl
@@ -706,3 +706,89 @@ end
     sim = test_convergence(dts, prob, Rodas3(linsolve = LinearSolve.KrylovJL()))
     @test sim.𝒪est[:final]≈3 atol=testTol
 end
+
+@testset "ADTypes" begin
+    for T in [
+        Rosenbrock23,
+        Rosenbrock32,
+        RosShamp4,
+        Veldd4,
+        Velds4,
+        GRK4T,
+        GRK4A,
+        Ros4LStab,
+        ROS3P,
+        Rodas3,
+        Rodas23W,
+        Rodas3P,
+        Rodas4,
+        Rodas42,
+        Rodas4P,
+        Rodas4P2,
+        Rodas5,
+        Rodas5P,
+        Rodas5Pe,
+        Rodas5Pr,
+        RosenbrockW6S4OS,
+        ROS34PW1a,
+        ROS34PW1b,
+        ROS34PW2,
+        ROS34PW3,
+        ROS34PRw,
+        ROS3PRL,
+        ROS3PRL2,
+        ROK4a,
+        ROS2,
+        ROS2PR,
+        ROS2S,
+        ROS3,
+        ROS3PR,
+        Scholz4_7
+    ]
+        RosenbrockAlgorithm = if T <: OrdinaryDiffEqRosenbrock.OrdinaryDiffEqRosenbrockAlgorithm
+            OrdinaryDiffEqRosenbrock.OrdinaryDiffEqRosenbrockAlgorithm
+        else
+            OrdinaryDiffEqRosenbrock.OrdinaryDiffEqRosenbrockAdaptiveAlgorithm
+        end
+
+        ad = AutoForwardDiff(; chunksize = 3)
+        alg = @test_logs @inferred(T(; autodiff = ad))
+        @test alg isa RosenbrockAlgorithm{3,typeof(ad),Val{:forward}()}
+        @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.alg_autodiff(alg) === ad
+        @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.get_chunksize(alg) === Val{3}()
+
+        alg = @test_logs (:warn,r"deprecated") @inferred(T(; autodiff = ad, chunk_size = Val{4}()))
+        @test alg isa RosenbrockAlgorithm{4,<:AutoForwardDiff{4},Val{:forward}()}
+        @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.alg_autodiff(alg) isa AutoForwardDiff{4}
+        @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.get_chunksize(alg) === Val{4}()
+
+        ad = AutoFiniteDiff(; fdtype = Val{:central}())
+        alg = @test_logs @inferred(T(; autodiff = ad))
+        @test alg isa RosenbrockAlgorithm{0,<:AutoFiniteDiff{Val{:central}},Val{:central}()}
+        @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.alg_autodiff(alg) === ad
+        @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.get_chunksize(alg) === Val{0}()
+
+        alg = @test_logs (:warn,r"deprecated") @inferred(T(; autodiff = ad, diff_type = Val{:complex}()))
+        @test alg isa RosenbrockAlgorithm{0,<:AutoFiniteDiff{Val{:complex}},Val{:complex}()}
+        @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.alg_autodiff(alg) isa AutoFiniteDiff{Val{:complex}}
+        @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.get_chunksize(alg) === Val{0}()
+
+        # issue #2613
+        f(u, _, _) = -u
+        prob = ODEProblem(f, [1.0, 0.0], (0.0, 1.0))
+        alg = T(; autodiff=AutoForwardDiff(; chunksize=1))
+        sol = if alg isa OrdinaryDiffEqRosenbrock.OrdinaryDiffEqRosenbrockAdaptiveAlgorithm
+            @inferred(solve(prob, alg))
+        else
+            @inferred(solve(prob, alg; dt=0.1))
+        end
+        @test sol.alg === alg
+        alg = T(; autodiff=AutoFiniteDiff(; fdtype=Val(:central)))
+        sol = if alg isa OrdinaryDiffEqRosenbrock.OrdinaryDiffEqRosenbrockAdaptiveAlgorithm
+            @inferred(solve(prob, alg))
+        else
+            @inferred(solve(prob, alg; dt=0.1))
+        end
+        @test sol.alg === alg
+    end
+end

--- a/lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl
@@ -757,7 +757,7 @@ end
         @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.alg_autodiff(alg) === ad
         @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.get_chunksize(alg) === Val{3}()
 
-        alg = @test_logs (:warn,r"deprecated") @inferred(T(; autodiff = ad, chunk_size = Val{4}()))
+        alg = @test_logs (:warn,r"The `chunk_size` keyword is deprecated") match_mode=:any @inferred(T(; autodiff = ad, chunk_size = Val{4}()))
         @test alg isa RosenbrockAlgorithm{4,<:AutoForwardDiff{4},Val{:forward}()}
         @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.alg_autodiff(alg) isa AutoForwardDiff{4}
         @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.get_chunksize(alg) === Val{4}()
@@ -768,7 +768,7 @@ end
         @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.alg_autodiff(alg) === ad
         @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.get_chunksize(alg) === Val{0}()
 
-        alg = @test_logs (:warn,r"deprecated") @inferred(T(; autodiff = ad, diff_type = Val{:complex}()))
+        alg = @test_logs (:warn,r"The `diff_type` keyword is deprecated") match_mode=:any @inferred(T(; autodiff = ad, diff_type = Val{:complex}()))
         @test alg isa RosenbrockAlgorithm{0,<:AutoFiniteDiff{Val{:complex}},Val{:complex}()}
         @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.alg_autodiff(alg) isa AutoFiniteDiff{Val{:complex}}
         @test OrdinaryDiffEqRosenbrock.OrdinaryDiffEqCore.get_chunksize(alg) === Val{0}()

--- a/lib/OrdinaryDiffEqSDIRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/algorithms.jl
@@ -114,7 +114,7 @@ function ImplicitEuler(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :constant,
         controller = :PI, step_limiter! = trivial_limiter!)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     ImplicitEuler{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -154,7 +154,7 @@ function ImplicitMidpoint(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         diff_type = Val{:forward}(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :linear, step_limiter! = trivial_limiter!)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     ImplicitMidpoint{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -200,7 +200,7 @@ function Trapezoid(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :linear,
         controller = :PI, step_limiter! = trivial_limiter!)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     Trapezoid{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -256,7 +256,7 @@ function TRBDF2(;
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         smooth_est = true, extrapolant = :linear,
         controller = :PI, step_limiter! = trivial_limiter!)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     TRBDF2{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -307,7 +307,7 @@ function SDIRK2(;
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         smooth_est = true, extrapolant = :linear,
         controller = :PI, step_limiter! = trivial_limiter!)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     SDIRK2{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -353,7 +353,7 @@ function SDIRK22(;
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :linear,
         controller = :PI, step_limiter! = trivial_limiter!)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     Trapezoid{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -409,7 +409,7 @@ function SSPSDIRK2(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         smooth_est = true, extrapolant = :constant,
         controller = :PI)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     SSPSDIRK2{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -457,7 +457,7 @@ function Kvaerno3(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         smooth_est = true, extrapolant = :linear,
         controller = :PI, step_limiter! = trivial_limiter!)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     Kvaerno3{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -502,7 +502,7 @@ function KenCarp3(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         smooth_est = true, extrapolant = :linear,
         controller = :PI, step_limiter! = trivial_limiter!)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     KenCarp3{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -540,7 +540,7 @@ function CFNLIRK3(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         diff_type = Val{:forward}(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :linear)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     CFNLIRK3{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -591,7 +591,7 @@ function Cash4(;
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         smooth_est = true, extrapolant = :linear,
         controller = :PI, embedding = 3)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     Cash4{
         _unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve), typeof(nlsolve),
@@ -636,7 +636,7 @@ function SFSDIRK4(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         diff_type = Val{:forward}(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :linear)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     SFSDIRK4{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -678,7 +678,7 @@ function SFSDIRK5(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         diff_type = Val{:forward}(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :linear)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     SFSDIRK5{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -720,7 +720,7 @@ function SFSDIRK6(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         diff_type = Val{:forward}(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :linear)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     SFSDIRK6{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -762,7 +762,7 @@ function SFSDIRK7(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         diff_type = Val{:forward}(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :linear)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     SFSDIRK7{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -804,7 +804,7 @@ function SFSDIRK8(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         diff_type = Val{:forward}(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :linear)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     SFSDIRK8{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -846,7 +846,7 @@ function Hairer4(;
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         smooth_est = true, extrapolant = :linear,
         controller = :PI)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     Hairer4{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -885,7 +885,7 @@ function Hairer42(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         smooth_est = true, extrapolant = :linear,
         controller = :PI)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     Hairer42{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -933,7 +933,7 @@ function Kvaerno4(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         smooth_est = true, extrapolant = :linear,
         controller = :PI, step_limiter! = trivial_limiter!)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     Kvaerno4{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -981,7 +981,7 @@ function Kvaerno5(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         smooth_est = true, extrapolant = :linear,
         controller = :PI, step_limiter! = trivial_limiter!)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     Kvaerno5{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -1026,7 +1026,7 @@ function KenCarp4(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         smooth_est = true, extrapolant = :linear,
         controller = :PI, step_limiter! = trivial_limiter!)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     KenCarp4{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -1073,7 +1073,7 @@ function KenCarp47(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         smooth_est = true, extrapolant = :linear,
         controller = :PI)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     KenCarp47{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -1118,7 +1118,7 @@ function KenCarp5(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         smooth_est = true, extrapolant = :linear,
         controller = :PI, step_limiter! = trivial_limiter!)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     KenCarp5{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -1163,7 +1163,7 @@ function KenCarp58(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         smooth_est = true, extrapolant = :linear,
         controller = :PI)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     KenCarp58{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -1207,7 +1207,7 @@ function ESDIRK54I8L2SA(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         diff_type = Val{:forward}(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :linear, controller = :PI)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     ESDIRK54I8L2SA{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -1250,7 +1250,7 @@ function ESDIRK436L2SA2(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         diff_type = Val{:forward}(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :linear, controller = :PI)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     ESDIRK436L2SA2{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -1293,7 +1293,7 @@ function ESDIRK437L2SA(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         diff_type = Val{:forward}(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :linear, controller = :PI)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     ESDIRK437L2SA{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -1336,7 +1336,7 @@ function ESDIRK547L2SA2(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         diff_type = Val{:forward}(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :linear, controller = :PI)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     ESDIRK547L2SA2{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
@@ -1381,7 +1381,7 @@ function ESDIRK659L2SA(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         diff_type = Val{:forward}(),
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :linear, controller = :PI)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     ESDIRK659L2SA{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
         typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),

--- a/lib/OrdinaryDiffEqStabilizedIRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqStabilizedIRK/src/algorithms.jl
@@ -26,7 +26,7 @@ function IRKC(;
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(), κ = nothing,
         tol = nothing,
         extrapolant = :linear, controller = :Standard, eigen_est = nothing)
-    AD_choice = _process_AD_choice(autodiff, chunk_size, diff_type)
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
 
     IRKC{_unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve), typeof(nlsolve),
         typeof(precs), diff_type, _unwrap_val(standardtag), _unwrap_val(concrete_jac),


### PR DESCRIPTION
I'm aware of the work on #2567, but for a downstream application (Pumas, to be precise) I'd like a hotfix release with a bugfix for #2613: We see severe CI time regressions with the latest version of the SciML stack, and the most likely culprit is #2613 - and in particular the fact that it implies that fine-tuned chunksize heuristics are not applied anymore.

I inspected the OrdinaryDiffEq code and it seems that the change to AD types lead to an inconsistency of the type parameters of the AD-dependent algorithms: The chunksize type parameter is set based on `chunk_size`, the AD type parameter based on `autodiff`, and the finitediff type parameter based on `diff_type`. However, the default chunksize (0) and diff type (Val{:forward}) parameters are used even if an AD type with differing chunksize or diff type is specified. This PR fixes this inconsistency by instead using the chunksize and diff type of the AD type (unless non-default values are used for those, in which case the AD type is considered just as a proxy for the previous `Val{true}`/`Val{false}` scheme - this is already the design policy on the master branch).

Fixes #2613.