### PR TITLE
fix deprecated HSLDDRK64 constructor

### DIFF
--- a/lib/OrdinaryDiffEqLowStorageRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/algorithms.jl
@@ -1002,8 +1002,7 @@ struct HSLDDRK64{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqAlgorithm
     function HSLDDRK64(stage_limiter! = trivial_limiter!, step_limiter! = trivial_limiter!;
             williamson_condition = true, thread = False())
         Base.depwarn("HSLDDRK64 is deprecated, use SHLDDRK64 instead.", :HSLDDRK64)
-        SHLDDRK64(stage_limiter!, step_limiter!, thread;
-            williamson_condition = williamson_condition)
+        SHLDDRK64(; stage_limiter!, step_limiter!, thread, williamson_condition)
     end
 end
 

--- a/lib/OrdinaryDiffEqLowStorageRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/algorithms.jl
@@ -1000,7 +1000,7 @@ struct HSLDDRK64{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqAlgorithm
     thread::Thread
     williamson_condition::Bool
     function HSLDDRK64(stage_limiter! = trivial_limiter!, step_limiter! = trivial_limiter!;
-            williamson_condition = true)
+            williamson_condition = true, thread = False())
         Base.depwarn("HSLDDRK64 is deprecated, use SHLDDRK64 instead.", :HSLDDRK64)
         SHLDDRK64(stage_limiter!, step_limiter!, thread;
             williamson_condition = williamson_condition)

--- a/lib/OrdinaryDiffEqLowStorageRK/test/ode_low_storage_rk_tests.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/test/ode_low_storage_rk_tests.jl
@@ -165,6 +165,12 @@ end
     @test sol_old[end] ≈ sol_new[end]
 end
 
+@testset "HSLDDRK64" begin
+    # this method is deprecated
+    alg = HSLDDRK64()
+    @test alg isa SHLDDRK64
+end
+
 @testset "SHLDDRK64" begin
     alg = SHLDDRK64()
     alg2 = SHLDDRK64(; williamson_condition = true)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Without this fix, the inner constructor throws

```julia
julia> HSLDDRK64()
ERROR: UndefVarError: `thread` not defined
Stacktrace:
 [1] HSLDDRK64(stage_limiter!::Function, step_limiter!::Function; williamson_condition::Bool)
   @ OrdinaryDiffEqLowStorageRK ~/.julia/packages/OrdinaryDiffEqLowStorageRK/FzXwO/src/algorithms.jl:1005
 [2] HSLDDRK64(stage_limiter!::Function, step_limiter!::Function)
   @ OrdinaryDiffEqLowStorageRK ~/.julia/packages/OrdinaryDiffEqLowStorageRK/FzXwO/src/algorithms.jl:1002
 [3] top-level scope
   @ REPL[92]:1
```