### PR TITLE
ImplicitDiscreteSolve: handle case where u is nothing

### DIFF
--- a/lib/ImplicitDiscreteSolve/src/cache.jl
+++ b/lib/ImplicitDiscreteSolve/src/cache.jl
@@ -1,5 +1,5 @@
 mutable struct ImplicitDiscreteState{uType, pType, tType}
-    u::Vector{uType}
+    u::uType
     p::pType
     t_next::tType
 end
@@ -16,7 +16,7 @@ function alg_cache(alg::SimpleIDSolve, u, rate_prototype, ::Type{uEltypeNoUnits}
         dt, reltol, p, calck,
         ::Val{true}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
 
-    state = ImplicitDiscreteState(similar(u), p, t)
+    state = ImplicitDiscreteState(isnothing(u) ? nothing : similar(u), p, t)
     SimpleIDSolveCache(u, uprev, state, nothing)
 end
 
@@ -31,7 +31,7 @@ function alg_cache(alg::SimpleIDSolve, u, rate_prototype, ::Type{uEltypeNoUnits}
         dt, reltol, p, calck,
         ::Val{false}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
 
-    state = ImplicitDiscreteState(similar(u), p, t)
+    state = ImplicitDiscreteState(isnothing(u) ? nothing : similar(u), p, t)
     SimpleIDSolveCache(u, uprev, state, nothing)
 end
 

--- a/lib/ImplicitDiscreteSolve/src/solve.jl
+++ b/lib/ImplicitDiscreteSolve/src/solve.jl
@@ -12,7 +12,7 @@ function perform_step!(integrator, cache::SimpleIDSolveCache, repeat_step = fals
 end
 
 function initialize!(integrator, cache::SimpleIDSolveCache)
-    cache.state.u .= integrator.u
+    integrator.u isa AbstractVector && (cache.state.u .= integrator.u)
     cache.state.p = integrator.p
     cache.state.t_next = integrator.t
     f = integrator.f


### PR DESCRIPTION
Sometimes there will be no unknowns in the implicit system (e.g. callbacks where all the updates are explicit), and u is nothing. This handles this case. 