### PR TITLE
bump version of OrdinaryDiffEqSSPRK

### DIFF
--- a/lib/OrdinaryDiffEqSSPRK/Project.toml
+++ b/lib/OrdinaryDiffEqSSPRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSSPRK"
 uuid = "669c94d9-1f4b-4b64-b377-1aa079aa2388"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"


### PR DESCRIPTION
It would be great to get a new release including https://github.com/SciML/OrdinaryDiffEq.jl/pull/2628. To make it easier for you, I bumped the corresponding version.