### PR TITLE
remove deprecated indexing from test

### DIFF
--- a/test/interface/mass_matrix_tests.jl
+++ b/test/interface/mass_matrix_tests.jl
@@ -247,7 +247,7 @@ end
 function _norm_dsol2(alg, prob, prob2; kwargs...)
     sol = solve(prob, alg; kwargs...)
     sol2 = solve(prob2, alg; kwargs...)
-    norm(sol[end] .- sol2[end])
+    norm(sol.u[end] .- sol2.u[end])
 end
 @testset "Dependent Mass Matrix Tests" for mm in (dependent_M1, dependent_M2)
     # test each method for exactness


### PR DESCRIPTION
NFC. Was running some tests and getting annoyed by lots of warnings, so this fixes them.