### PR TITLE
AutoSparse Detection Fix for BDF etc.

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -181,7 +181,6 @@ function build_nlsolver(
 
     if nlalg isa Union{NLNewton, NonlinearSolveAlg}
         nf = nlsolve_f(f, alg)
-        J, W = build_J_W(alg, u, uprev, p, t, dt, f, nothing, uEltypeNoUnits, Val(true))
 
         # TODO: check if the solver is iterative
         weight = zero(u)
@@ -199,6 +198,7 @@ function build_nlsolver(
             end
             jac_config = build_jac_config(alg, nf, uf, du1, uprev, u, ztmp, dz)
         end
+        J, W = build_J_W(alg, u, uprev, p, t, dt, f, jac_config, uEltypeNoUnits, Val(true))
         linprob = LinearProblem(W, _vec(k); u0 = _vec(dz))
         Pl, Pr = wrapprecs(
             alg.precs(W, nothing, u, p, t, nothing, nothing, nothing,

--- a/test/interface/autosparse_detection_tests.jl
+++ b/test/interface/autosparse_detection_tests.jl
@@ -11,6 +11,8 @@ prob = prob_ode_2Dlinear
 
 @test_nowarn solve(prob, Rodas5P(autodiff = ad, linsolve = LinearSolve.KrylovJL_GMRES()))
 
+@test_nowarn solve(prob, FBDF(autodiff = ad))
+
 # Test that no dense matrices are made sparse
 diag_prob = ODEProblem((du, u, p, t) -> du .= -1.0 .* u, rand(Int(1e7)), (0, 1.0))
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

This should fix the case where a user wants to use `AutoSparse` with automatic sparsity detection for `autodiff` with BDF, SDIRK, and a few others. 

The issue was basically that the sparsity pattern from `build_jac_config` wasn't being passed to `build_J_W`.