### PR TITLE
Fix some tests

### DIFF
--- a/lib/OrdinaryDiffEqBDF/test/dae_ad_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/dae_ad_tests.jl
@@ -19,10 +19,11 @@ differential_vars = [true, true, false]
 prob = DAEProblem(f, du₀, u₀, tspan, p, differential_vars = differential_vars)
 prob_oop = DAEProblem{false}(f, du₀, u₀, tspan, p, differential_vars = differential_vars)
 sol1 = solve(prob, DFBDF(), dt = 1e-5, abstol = 1e-8, reltol = 1e-8)
+sol2 = solve(prob_oop, DFBDF(), dt = 1e-5, abstol = 1e-8, reltol = 1e-8)
 
 # These tests flex differentiation of the solver and through the initialization
 # To only test the solver part and isolate potential issues, set the initialization to consistent
-@testset "Inplace: $(isinplace(_prob)), DAEProblem: $(_prob isa DAEProblem), BrownBasic: $(initalg isa BrownFullBasicInit), Autodiff: $autodiff" for _prob in [
+ @testset "Inplace: $(isinplace(_prob)), DAEProblem: $(_prob isa DAEProblem), BrownBasic: $(initalg isa BrownFullBasicInit), Autodiff: $autodiff" for _prob in [
         prob, prob_oop],
     initalg in [BrownFullBasicInit(), ShampineCollocationInit()], autodiff in [true, false]
 

--- a/lib/OrdinaryDiffEqBDF/test/runtests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/runtests.jl
@@ -1,9 +1,9 @@
 using SafeTestsets
 
-@time @safetestset "BDF Convergence Tests" include("bdf_convergence_tests.jl")
-@time @safetestset "BDF Regression Tests" include("bdf_regression_tests.jl")
-
 @time @safetestset "DAE Convergence Tests" include("dae_convergence_tests.jl")
 @time @safetestset "DAE AD Tests" include("dae_ad_tests.jl")
 @time @safetestset "DAE Event Tests" include("dae_event.jl")
 @time @safetestset "DAE Initialization Tests" include("dae_initialization_tests.jl")
+
+@time @safetestset "BDF Convergence Tests" include("bdf_convergence_tests.jl")
+@time @safetestset "BDF Regression Tests" include("bdf_regression_tests.jl")

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/initialize_dae.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/initialize_dae.jl
@@ -616,15 +616,17 @@ function _initialize_dae!(integrator, prob::DAEProblem,
     end
 
     nlequation = @closure (x, _) -> begin
-        du = ifelse.(differential_vars, x, du)
-        u = ifelse.(differential_vars, u, x)
-        f(du, u, p, t)
+        du_ = ifelse.(differential_vars, x, du)
+        u_ = ifelse.(differential_vars, u, x)
+        f.f(du_, u_, p, t)
     end
 
     nlfunc = NonlinearFunction(nlequation; jac_prototype = f.jac_prototype)
     nlprob = NonlinearProblem(nlfunc, ifelse.(differential_vars, du, u))
 
     nlsolve = default_nlsolve(alg.nlsolve, isinplace, nlprob, integrator.u)
+
+    @show nlsolve
 
     nlsol = solve(nlprob, nlsolve)
 

--- a/lib/OrdinaryDiffEqRosenbrock/test/runtests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/runtests.jl
@@ -1,4 +1,4 @@
 using SafeTestsets
 
-@time @safetestset "Rosenbrock Convergence Tests" include("ode_rosenbrock_tests.jl")
 @time @safetestset "DAE Rosenbrock AD Tests" include("dae_rosenbrock_ad_tests.jl")
+@time @safetestset "Rosenbrock Convergence Tests" include("ode_rosenbrock_tests.jl")


### PR DESCRIPTION
The justification for this flip is rather deep... it's documented in https://github.com/EnzymeAD/Enzyme.jl/issues/2360 . Basically `using Enzyme` first causes some behavioral changes in the nonlinear solver. The fact that it matters is almost random here, so I am just isolating the solver tests from this for now.
