### PR TITLE
Support SciMLOperators 0.4 in subpackages

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "1.24.0"
+version = "1.25.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -72,7 +72,7 @@ RecursiveArrayTools = "2.36, 3"
 Reexport = "1.0"
 SafeTestsets = "0.1.0"
 SciMLBase = "2.68"
-SciMLOperators = "0.3"
+SciMLOperators = "0.3, 0.4"
 SciMLStructures = "1"
 SimpleUnPack = "1"
 Static = "0.8, 1"

--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqDifferentiation"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "1.7.0"
+version = "1.8.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -42,7 +42,7 @@ OrdinaryDiffEqCore = "1.21"
 Random = "<0.0.1, 1"
 SafeTestsets = "0.1.0"
 SciMLBase = "2"
-SciMLOperators = "0.3.13"
+SciMLOperators = "0.3.13, 0.4"
 SparseArrays = "1"
 SparseMatrixColorings = "0.4.14"
 StaticArrayInterface = "1"

--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFIRK"
 uuid = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "1.10.0"
+version = "1.11.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -42,7 +42,7 @@ RecursiveArrayTools = "3.27.0"
 Reexport = "1.2.2"
 SafeTestsets = "0.1.0"
 SciMLBase = "2.60.0"
-SciMLOperators = "0.3.9"
+SciMLOperators = "0.3.9, 0.4"
 Test = "<0.0.1, 1"
 julia = "1.10"
 JET = "0.9.18, 0.10.4"

--- a/lib/OrdinaryDiffEqLinear/Project.toml
+++ b/lib/OrdinaryDiffEqLinear/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqLinear"
 uuid = "521117fe-8c41-49f8-b3b6-30780b3f0fb5"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -27,7 +27,7 @@ RecursiveArrayTools = "3.27.0"
 Reexport = "1.2.2"
 SafeTestsets = "0.1.0"
 SciMLBase = "2.48.1"
-SciMLOperators = "0.3.9"
+SciMLOperators = "0.3.9, 0.4"
 Test = "<0.0.1, 1"
 julia = "1.10"
 JET = "0.9.18, 0.10.4"

--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "1.7.0"
+version = "1.8.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -46,7 +46,7 @@ Random = "<0.0.1, 1"
 RecursiveArrayTools = "3.27.0"
 SafeTestsets = "0.1.0"
 SciMLBase = "2.48.1"
-SciMLOperators = "0.3.9"
+SciMLOperators = "0.3.9, 0.4"
 SciMLStructures = "1.4.2"
 SimpleNonlinearSolve = "1.12.0, 2"
 StaticArrays = "1.9.7"


### PR DESCRIPTION
CompatHelper only updated OrdinaryDiffEq but it seems it missed OrdinaryDiffEqCore: #2702 

This should have been caught by CI but it seems CI doesn't run on CompatHelper PRs.

Edit: It seems there are many more subpackages suffering from the same problem.