### PR TITLE
Bump SciMLOperators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEq"
 uuid = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "6.96.0"
+version = "6.97.0"
 
 [sources]
 OrdinaryDiffEqAdamsBashforthMoulton = {path = "lib/OrdinaryDiffEqAdamsBashforthMoulton"}
@@ -165,7 +165,7 @@ Preferences = "1.3"
 RecursiveArrayTools = "2.36, 3"
 Reexport = "1.0"
 SciMLBase = "2.78"
-SciMLOperators = "0.3, 0.4"
+SciMLOperators = "0.3, 0.4, 1"
 SciMLStructures = "1"
 SimpleNonlinearSolve = "1, 2"
 SimpleUnPack = "1"

--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "1.25.0"
+version = "1.26.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -72,7 +72,7 @@ RecursiveArrayTools = "2.36, 3"
 Reexport = "1.0"
 SafeTestsets = "0.1.0"
 SciMLBase = "2.68"
-SciMLOperators = "0.3, 0.4"
+SciMLOperators = "0.3, 0.4, 1"
 SciMLStructures = "1"
 SimpleUnPack = "1"
 Static = "0.8, 1"

--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqDifferentiation"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "1.8.0"
+version = "1.9.0"
 
 [sources]
 OrdinaryDiffEqCore = {path = "../OrdinaryDiffEqCore"}
@@ -45,7 +45,7 @@ OrdinaryDiffEqCore = "1.21"
 Random = "<0.0.1, 1"
 SafeTestsets = "0.1.0"
 SciMLBase = "2"
-SciMLOperators = "0.3.13, 0.4"
+SciMLOperators = "0.3.13, 0.4, 1"
 SparseArrays = "1"
 SparseMatrixColorings = "0.4.14"
 StaticArrayInterface = "1"

--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFIRK"
 uuid = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "1.11.0"
+version = "1.12.0"
 
 [sources]
 OrdinaryDiffEqCore = {path = "../OrdinaryDiffEqCore"}
@@ -47,7 +47,7 @@ RecursiveArrayTools = "3.27.0"
 Reexport = "1.2.2"
 SafeTestsets = "0.1.0"
 SciMLBase = "2.60.0"
-SciMLOperators = "0.3.9, 0.4"
+SciMLOperators = "0.3.9, 0.4, 1"
 Test = "<0.0.1, 1"
 julia = "1.10"
 JET = "0.9.18, 0.10.4"

--- a/lib/OrdinaryDiffEqLinear/Project.toml
+++ b/lib/OrdinaryDiffEqLinear/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqLinear"
 uuid = "521117fe-8c41-49f8-b3b6-30780b3f0fb5"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "1.2.0"
+version = "1.3.0"
 
 [sources]
 OrdinaryDiffEqCore = {path = "../OrdinaryDiffEqCore"}
@@ -32,7 +32,7 @@ RecursiveArrayTools = "3.27.0"
 Reexport = "1.2.2"
 SafeTestsets = "0.1.0"
 SciMLBase = "2.48.1"
-SciMLOperators = "0.3.9, 0.4"
+SciMLOperators = "0.3.9, 0.4, 1"
 Test = "<0.0.1, 1"
 julia = "1.10"
 JET = "0.9.18, 0.10.4"

--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "1.8.0"
+version = "1.9.0"
 
 [sources]
 OrdinaryDiffEqCore = {path = "../OrdinaryDiffEqCore"}
@@ -50,7 +50,7 @@ Random = "<0.0.1, 1"
 RecursiveArrayTools = "3.27.0"
 SafeTestsets = "0.1.0"
 SciMLBase = "2.48.1"
-SciMLOperators = "0.3.9, 0.4"
+SciMLOperators = "0.3.9, 0.4, 1"
 SciMLStructures = "1.4.2"
 SimpleNonlinearSolve = "1.12.0, 2"
 StaticArrays = "1.9.7"


### PR DESCRIPTION
The way OrdinaryDiffEq.jl uses SciMLOperators is unchanged by the v1, which is on purpose because we knew we wanted to do this interface change for years. While this isn't the end of the story, we should make WOperator an AbstractSciMLOperator to simplify code, this is at least a valid bump so we should do it now.
