### PR TITLE
fix `sources` in Ci for 1.11 and up

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,7 @@ steps:
           pre-command: |
             julia --project=. -e '
               using Pkg;
-              Pkg.develop(map(path ->Pkg.PackageSpec.(;path="$(@__DIR__)/lib/$(path)"), readdir("./lib")));
+              VERSION < v"1.11" && Pkg.develop(map(path ->Pkg.PackageSpec.(;path="$(@__DIR__)/lib/$(path)"), readdir("./lib")));
               Pkg.instantiate();
             '
       - JuliaCI/julia-test#v1:
@@ -45,7 +45,7 @@ steps:
           pre-command: |
             julia --project=. -e '
               using Pkg;
-              Pkg.develop(map(path ->Pkg.PackageSpec.(;path="$(@__DIR__)/lib/$(path)"), readdir("./lib")));
+              VERSION < v"1.11" && Pkg.develop(map(path ->Pkg.PackageSpec.(;path="$(@__DIR__)/lib/$(path)"), readdir("./lib")));
               Pkg.instantiate();
             '
       - JuliaCI/julia-test#v1:


### PR DESCRIPTION
Why do we have both `.buildkite` and `.github` ci?
