### PR TITLE
fix NonlinearSolve tests (broken by #2573)

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -427,7 +427,7 @@ function relax!(dz, nlsolver::AbstractNLSolver, integrator::DEIntegrator, f::TF,
 
         @unpack uprev, t, p, dt, opts, isdae = integrator
         @unpack z, tmp, ztmp, γ, iter, α, cache, method = nlsolver
-        @unpack ustep, atmp, tstep, k, invγdt, tstep, k, invγdt = cache
+        @unpack ustep, atmp, tstep, k, invγdt = cache
         function resid(z)
             # recompute residual (rhs)
             if isdae
@@ -484,7 +484,8 @@ function relax(dz, nlsolver::AbstractNLSolver, integrator::DEIntegrator, f::TF,
         linesearch = linesearch
 
         @unpack uprev, t, p, dt, opts = integrator
-        @unpack z, tmp, ztmp, γ, iter, cache = nlsolver
+        @unpack z, tmp, ztmp, γ, iter, cache, method = nlsolver
+        @unpack ustep, atmp, tstep, k, invγdt = cache
         function resid(z)
             # recompute residual (rhs)
             if f isa DAEFunction

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -305,7 +305,7 @@ function build_nlsolver(
                     tmp, α, tstep, invγdt, _p, dt, uprev, f = p
                     _compute_rhs(tmp, α, tstep, invγdt, p, dt, uprev, f, z)[1]
                 end
-                nlp_params = (tmp, α, tstep, invγdt, _p, dt, uprev, f)
+                nlp_params = (tmp, α, tstep, invγdt, p, dt, uprev, f)
             else
                 nlf = (z, p) -> begin
                     tmp, γ, α, tstep, invγdt, method, _p, dt, f = p

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/newton_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/newton_tests.jl
@@ -6,7 +6,7 @@ using DiffEqBase
 using LineSearches
 using Test
 
-import ODEProblemLibrary: prob_ode_orego, prob_ode_rober, prob_ode_lorenz
+using ODEProblemLibrary: prob_ode_lorenz, prob_ode_orego
 
 for prob in (prob_ode_lorenz, prob_ode_orego)
     sol1 = solve(prob, Trapezoid(), reltol = 1e-12, abstol = 1e-12)
@@ -14,5 +14,5 @@ for prob in (prob_ode_lorenz, prob_ode_orego)
     sol2 = solve(prob, Trapezoid(nlsolve = NLNewton(relax = BackTracking())),
         reltol = 1e-12, abstol = 1e-12)
     @test sol2.retcode == DiffEqBase.ReturnCode.Success
-    @test abs(sol2.stats.nf - sol1.stats.nf) <= 20
+    @test sol2.stats.nf <= sol1.stats.nf + 20
 end


### PR DESCRIPTION
https://github.com/SciML/OrdinaryDiffEq.jl/pull/2573 added an `abs` that wasn't supposed to be there. Removing it fixes the test.