### PR TITLE
DRAFT: use the SciML verbosity system

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
+++ b/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
@@ -61,7 +61,7 @@ using DiffEqBase: check_error!, @def, _vec, _reshape
 using FastBroadcast: @.., True, False
 
 using SciMLBase: NoInit, CheckInit, OverrideInit, AbstractDEProblem, _unwrap_val,
-                 ODEAliasSpecifier
+                 ODEAliasSpecifier, @SciMLMessage, ODEVerbosity, Verbosity
 
 import SciMLBase: AbstractNonlinearProblem, alg_order, LinearAliasSpecifier
 

--- a/lib/OrdinaryDiffEqCore/src/composite_algs.jl
+++ b/lib/OrdinaryDiffEqCore/src/composite_algs.jl
@@ -52,8 +52,12 @@ function (AS::AutoSwitchCache)(integrator)
     if (!AS.is_stiffalg && AS.count > AS.maxstiffstep)
         integrator.dt = dt * AS.dtfac
         AS.is_stiffalg = true
+        SciMLBase.@SciMLMessage("Algorithm was switched to $(nameof(typeof(integrator.alg.algs[Int(AS.current) + 1]))) at t = $(integrator.t).",
+            integrator.opts.verbose, :alg_switch, :performance)
     elseif (AS.is_stiffalg && AS.count < -AS.maxnonstiffstep)
         integrator.dt = dt / AS.dtfac
+        SciMLBase.@SciMLMessage("Algorithm was switched to $(nameof(typeof(integrator.alg.algs[1]))) at t = $(integrator.t).",
+            integrator.opts.verbose, :alg_switch, :performance)
         AS.is_stiffalg = false
     end
     AS.current = Int(AS.is_stiffalg) + 1

--- a/lib/OrdinaryDiffEqCore/src/initdt.jl
+++ b/lib/OrdinaryDiffEqCore/src/initdt.jl
@@ -128,9 +128,8 @@
     # because it also checks if partials are NaN
     # https://discourse.julialang.org/t/incorporating-forcing-functions-in-the-ode-model/70133/26
     if isnan(d₁)
-        if integrator.opts.verbose
-            @warn("First function call produced NaNs. Exiting. Double check that none of the initial conditions, parameters, or timespan values are NaN.")
-        end
+        @SciMLMessage("First function call produced NaNs. Exiting. Double check that none of the initial conditions, parameters, or timespan values are NaN.",
+        integrator.opts.verbose, :init_NaN, :error_control)
         
         return tdir * dtmin
     end
@@ -249,8 +248,10 @@ end
     d₀ = internalnorm(u0 ./ sk, t)
 
     f₀ = f(u0, p, t)
-    if integrator.opts.verbose && any(x -> any(isnan, x), f₀)
-        @warn("First function call produced NaNs. Exiting. Double check that none of the initial conditions, parameters, or timespan values are NaN.")
+
+    if any(x -> any(isnan, x), f₀)
+        @SciMLMessage("First function call produced NaNs. Exiting. Double check that none of the initial conditions, parameters, or timespan values are NaN.",
+        integrator.opts.verbose, :init_NaN, :error_control)
     end
 
     inferredtype = Base.promote_op(/, typeof(u0), typeof(oneunit(t)))

--- a/lib/OrdinaryDiffEqCore/src/integrators/type.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/type.jl
@@ -41,7 +41,7 @@ mutable struct DEOptions{absType, relType, QT, tType, Controller, F1, F2, F3, F4
     callback::F4
     isoutofdomain::F5
     unstable_check::F7
-    verbose::Bool
+    verbose::ODEVerbosity
     calck::Bool
     force_dtmin::Bool
     advance_to_tstop::Bool


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

In conjuction with https://github.com/SciML/SciMLBase.jl/pull/1014, will make use of the verbosity system described in https://github.com/SciML/SciMLBase.jl/issues/962. 

Right now this just makes use of the `@SciMLMessage` macro where before there were warning messages. I want to add more toggles, I just need to know where more should go.
