### PR TITLE
bump OrdinaryDiffEqStabilizedRK

### DIFF
--- a/lib/OrdinaryDiffEqStabilizedRK/Project.toml
+++ b/lib/OrdinaryDiffEqStabilizedRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqStabilizedRK"
 uuid = "358294b1-0aab-51c3-aafe-ad5ab194a2ad"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "1.1.0"
+version = "1.1.1"
 
 [sources]
 OrdinaryDiffEqCore = {path = "../OrdinaryDiffEqCore"}


### PR DESCRIPTION
What is the current policy for releasing new versions of the `lib` packages? I just prepared this PR as a reminder to create a new release, given https://github.com/SciML/OrdinaryDiffEq.jl/pull/2753 has been merged (thanks!).