### PR TITLE
Add JET.jl static analysis tests to SimpleImplicitDiscreteSolve

### DIFF
--- a/lib/SimpleImplicitDiscreteSolve/Project.toml
+++ b/lib/SimpleImplicitDiscreteSolve/Project.toml
@@ -11,6 +11,7 @@ SimpleNonlinearSolve = "727e6d20-b764-4bd8-a329-72de5adea6c7"
 
 [compat]
 DiffEqBase = "6.164.1"
+JET = "0.9.18, 0.10.4"
 OrdinaryDiffEqSDIRK = "1.2.0"
 Reexport = "1.2.2"
 SciMLBase = "2.74.1"
@@ -19,8 +20,9 @@ Test = "1.10"
 julia = "1.10"
 
 [extras]
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["OrdinaryDiffEqSDIRK", "Test"]
+test = ["JET", "OrdinaryDiffEqSDIRK", "Test"]

--- a/lib/SimpleImplicitDiscreteSolve/test/jet.jl
+++ b/lib/SimpleImplicitDiscreteSolve/test/jet.jl
@@ -1,0 +1,7 @@
+import SimpleImplicitDiscreteSolve
+using JET
+
+@testset "JET Tests" begin
+    test_package(
+        SimpleImplicitDiscreteSolve, target_defined_modules = true, mode = :typo)
+end

--- a/lib/SimpleImplicitDiscreteSolve/test/runtests.jl
+++ b/lib/SimpleImplicitDiscreteSolve/test/runtests.jl
@@ -68,3 +68,5 @@ end
         @test step[1]^2 + step[2]^2 ≈ 16
     end
 end
+
+include("jet.jl")

--- a/lib/SimpleImplicitDiscreteSolve/test/runtests.jl
+++ b/lib/SimpleImplicitDiscreteSolve/test/runtests.jl
@@ -69,4 +69,6 @@ end
     end
 end
 
-include("jet.jl")
+if isempty(VERSION.prerelease)
+    include("jet.jl")
+end


### PR DESCRIPTION
## Summary
- Add JET.jl static analysis tests to SimpleImplicitDiscreteSolve package
- Follows the existing pattern from ImplicitDiscreteSolve and other packages

## Changes
- Created `jet.jl` test file with `test_package` call
- Added `include("jet.jl")` to `runtests.jl`
- Added JET to test dependencies in Project.toml with compatibility bounds

## Test plan
- [x] Run tests locally with `julia --project=lib/SimpleImplicitDiscreteSolve -e 'using Pkg; Pkg.test()'`
- [x] Verify JET tests pass without issues

Fixes #2663

🤖 Generated with [Claude Code](https://claude.ai/code)