### PR TITLE
Remove outdated Julia version checks for v1.8 and v1.9

### DIFF
--- a/test/interface/norecompile.jl
+++ b/test/interface/norecompile.jl
@@ -28,12 +28,10 @@ t4 = @elapsed sol4 = solve(lorenzprob2, Rosenbrock23(autodiff = AutoFiniteDiff()
 @test sol3.retcode === ReturnCode.Success
 @test sol4.retcode === ReturnCode.Success
 
-if VERSION >= v"1.8"
-    @test t1 < t3
-    @test t2 < t4
-    integ = init(lorenzprob, Rosenbrock23())
-    @test integ.f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper
-end
+@test t1 < t3
+@test t2 < t4
+integ = init(lorenzprob, Rosenbrock23())
+@test integ.f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper
 
 solve(prob, EPIRK4s3A(), dt = 1e-1)
 

--- a/test/interface/sized_matrix_tests.jl
+++ b/test/interface/sized_matrix_tests.jl
@@ -14,23 +14,21 @@ p_giesekus = [η0, τ, α]
 
 prob_giesekus = ODEProblem(dudt!, σ0, (0.0, 2.0), p_giesekus)
 
-if VERSION >= v"1.9"
-    solve_giesekus = solve(prob_giesekus, Rodas4(), saveat = 0.2, abstol = 1e-14,
-        reltol = 1e-14)
-    for alg in [
-        Rosenbrock23(),
-        Rodas4(),
-        Rodas4P(),
-        Rodas5(),
-        Rodas5P(),
-        Tsit5(),
-        Vern6(),
-        Vern7(),
-        Vern8(),
-        Vern9(),
-        DP5()
-    ]
-        sol = solve(prob_giesekus, alg, saveat = 0.2, abstol = 1e-14, reltol = 1e-14)
-        @test Array(sol) ≈ Array(solve_giesekus)
-    end
+solve_giesekus = solve(prob_giesekus, Rodas4(), saveat = 0.2, abstol = 1e-14,
+    reltol = 1e-14)
+for alg in [
+    Rosenbrock23(),
+    Rodas4(),
+    Rodas4P(),
+    Rodas5(),
+    Rodas5P(),
+    Tsit5(),
+    Vern6(),
+    Vern7(),
+    Vern8(),
+    Vern9(),
+    DP5()
+]
+    sol = solve(prob_giesekus, alg, saveat = 0.2, abstol = 1e-14, reltol = 1e-14)
+    @test Array(sol) ≈ Array(solve_giesekus)
 end


### PR DESCRIPTION
## Summary
This PR removes outdated Julia version checks since the current LTS is v1.10.

## Changes
- Removed `if VERSION >= v"1.8"` check in `test/interface/norecompile.jl` (line 31)
- Removed `if VERSION >= v"1.9"` check in `test/interface/sized_matrix_tests.jl` (line 17)

## Test plan
- [ ] All existing tests should continue to pass
- [ ] No functionality changes, only removal of conditional branches that are always true

🤖 Generated with [Claude Code](https://claude.ai/code)