### PR TITLE
Make verbose be LinearVerbosity for Linsolves

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -857,10 +857,10 @@ build_uf(alg, nf, t, p, ::Val{false}) = UDerivativeWrapper(nf, t, p)
 function LinearSolve.init_cacheval(
         alg::LinearSolve.DefaultLinearSolver, A::WOperator, b, u,
         Pl, Pr,
-        maxiters::Int, abstol, reltol, verbose::Bool,
+        maxiters::Int, abstol, reltol, verbose::LinearSolve.LinearVerbosity,
         assumptions::OperatorAssumptions)
     LinearSolve.init_cacheval(alg, A.J, b, u, Pl, Pr,
-        maxiters::Int, abstol, reltol, verbose::Bool,
+        maxiters::Int, abstol, reltol, verbose::LinearSolve.LinearVerbosity,
         assumptions::OperatorAssumptions)
 end
 
@@ -888,10 +888,10 @@ for alg in [LinearSolve.AppleAccelerateLUFactorization,
     LinearSolve.SparspakFactorization,
     LinearSolve.UMFPACKFactorization]
     @eval function LinearSolve.init_cacheval(alg::$alg, A::WOperator, b, u, Pl, Pr,
-            maxiters::Int, abstol, reltol, verbose::Bool,
+            maxiters::Int, abstol, reltol, verbose::LinearSolve.LinearVerbosity,
             assumptions::OperatorAssumptions)
         LinearSolve.init_cacheval(alg, A.J, b, u, Pl, Pr,
-            maxiters::Int, abstol, reltol, verbose::Bool,
+            maxiters::Int, abstol, reltol, verbose::LinearSolve.LinearVerbosity,
             assumptions::OperatorAssumptions)
     end
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Forgot to put this up earlier: 

This is so that https://github.com/SciML/LinearSolve.jl/pull/622 can work, and so that the linear solves will get the correct verbosity type. Probably we'll have to merge that and release it, then we can update the compat bounds so that OrdinaryDiffEq can use LinearVerbosity. 
