### PR TITLE
Fix unnecessary line splits following Catalyst.jl PR #1306

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
@@ -370,8 +370,7 @@ the following logic is applied:
 ```julia
 if integrator.success_iter > 0
     expo = 1 / (alg_adaptive_order(integrator.alg) + 1)
-    qgus = (integrator.dtacc / integrator.dt) *
-           (((integrator.EEst^2) / integrator.erracc)^expo)
+    qgus = (integrator.dtacc / integrator.dt) * (((integrator.EEst^2) / integrator.erracc)^expo)
     qgus = max(inv(integrator.opts.qmax),
         min(inv(integrator.opts.qmin), qgus / integrator.opts.gamma))
     qacc = max(q, qgus)
@@ -433,8 +432,7 @@ function step_accept_controller!(integrator, controller::PredictiveController, a
 
     if integrator.success_iter > 0
         expo = 1 / (get_current_adaptive_order(alg, integrator.cache) + 1)
-        qgus = (integrator.dtacc / integrator.dt) *
-               FastPower.fastpower((EEst^2) / integrator.erracc, expo)
+        qgus = (integrator.dtacc / integrator.dt) * FastPower.fastpower((EEst^2) / integrator.erracc, expo)
         qgus = max(inv(qmax), min(inv(qmin), qgus / gamma))
         qacc = max(q, qgus)
     else

--- a/lib/OrdinaryDiffEqFIRK/src/controllers.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/controllers.jl
@@ -8,8 +8,7 @@ function step_accept_controller!(
 
     if integrator.success_iter > 0
         expo = 1 / (get_current_adaptive_order(alg, integrator.cache) + 1)
-        qgus = (integrator.dtacc / integrator.dt) *
-               DiffEqBase.fastpow((EEst^2) / integrator.erracc, expo)
+        qgus = (integrator.dtacc / integrator.dt) * DiffEqBase.fastpow((EEst^2) / integrator.erracc, expo)
         qgus = max(inv(qmax), min(inv(qmin), qgus / gamma))
         qacc = max(q, qgus)
     else


### PR DESCRIPTION
## Summary

Fix unnecessary line splits in Julia code following the guidelines established in [Catalyst.jl PR #1306](https://github.com/SciML/Catalyst.jl/pull/1306). This PR improves code readability by consolidating short expressions that were unnecessarily split across multiple lines.

## Background

These formatting issues are being addressed upstream in [JuliaFormatter.jl PR #934](https://github.com/domluna/JuliaFormatter.jl/pull/934), which implements algorithmic fixes to prevent these unnecessary line splits. However, since that PR is not yet merged, manual fixes are needed in the meantime to improve code readability.

## Changes Made

Fixed **3 instances** of problematic line splits in controller files:

- **lib/OrdinaryDiffEqFIRK/src/controllers.jl**: 1 arithmetic expression
- **lib/OrdinaryDiffEqCore/src/integrators/controllers.jl**: 2 arithmetic expressions

## Example Fix

### Before:
```julia
qgus = (integrator.dtacc / integrator.dt) *
       DiffEqBase.fastpow((EEst^2) / integrator.erracc, expo)
```

### After:
```julia
qgus = (integrator.dtacc / integrator.dt) * DiffEqBase.fastpow((EEst^2) / integrator.erracc, expo)
```

## Rationale

Following Catalyst.jl PR #1306's approach:
- **Prioritize readability** over strict formatter rules for short expressions
- **Keep semantically related code units together**
- **All modified lines stay well under 120 characters** (typically 95-110 chars)
- **Use JuliaFormatter as a helpful tool** rather than a strict rule enforcer

## Note

This is part of a systematic effort to apply the same formatting improvements across multiple SciML repositories including JumpProcesses.jl, LinearSolve.jl, NonlinearSolve.jl, and ModelingToolkit.jl.

🤖 Generated with [Claude Code](https://claude.ai/code)