### PR TITLE
Fix InexactError on X86 by using explicit Int64 in rational literals

### DIFF
--- a/lib/OrdinaryDiffEqBDF/src/bdf_caches.jl
+++ b/lib/OrdinaryDiffEqBDF/src/bdf_caches.jl
@@ -15,7 +15,7 @@ function alg_cache(alg::ABDF2, u, rate_prototype, ::Type{uEltypeNoUnits},
         ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits},
         uprev, uprev2, f, t, dt, reltol, p, calck,
         ::Val{false}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    γ, c = 2 // 3, 1
+    γ, c = Int64(2) // 3, 1
     nlsolver = build_nlsolver(alg, u, uprev, p, t, dt, f, rate_prototype, uEltypeNoUnits,
         uBottomEltypeNoUnits, tTypeNoUnits, γ, c, Val(false))
     eulercache = ImplicitEulerConstantCache(nlsolver)
@@ -45,7 +45,7 @@ function alg_cache(alg::ABDF2, u, rate_prototype, ::Type{uEltypeNoUnits},
         ::Type{uBottomEltypeNoUnits},
         ::Type{tTypeNoUnits}, uprev, uprev2, f, t, dt, reltol, p, calck,
         ::Val{true}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    γ, c = 2 // 3, 1
+    γ, c = Int64(2) // 3, 1
     nlsolver = build_nlsolver(alg, u, uprev, p, t, dt, f, rate_prototype, uEltypeNoUnits,
         uBottomEltypeNoUnits, tTypeNoUnits, γ, c, Val(true))
     fsalfirst = zero(rate_prototype)
@@ -104,7 +104,7 @@ function alg_cache(alg::SBDF, u, rate_prototype, ::Type{uEltypeNoUnits},
         ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
         dt, reltol, p, calck,
         ::Val{false}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    γ, c = 1 // 1, 1
+    γ, c = Int64(1) // 1, 1
     nlsolver = build_nlsolver(alg, u, uprev, p, t, dt, f, rate_prototype, uEltypeNoUnits,
         uBottomEltypeNoUnits, tTypeNoUnits, γ, c, Val(false))
 
@@ -127,7 +127,7 @@ function alg_cache(alg::SBDF, u, rate_prototype, ::Type{uEltypeNoUnits},
         ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
         dt, reltol, p, calck,
         ::Val{true}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    γ, c = 1 // 1, 1
+    γ, c = Int64(1) // 1, 1
     nlsolver = build_nlsolver(alg, u, uprev, p, t, dt, f, rate_prototype, uEltypeNoUnits,
         uBottomEltypeNoUnits, tTypeNoUnits, γ, c, Val(true))
     fsalfirst = zero(rate_prototype)
@@ -360,7 +360,7 @@ function alg_cache(alg::QNDF{MO}, u, rate_prototype, ::Type{uEltypeNoUnits},
         ::Val{false}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits
 } where {MO}
     max_order = MO
-    γ, c = 1//1, 1
+    γ, c = Int64(1)//1, 1
     nlsolver = build_nlsolver(alg, u, uprev, p, t, dt, f, rate_prototype, uEltypeNoUnits,
         uBottomEltypeNoUnits, tTypeNoUnits, γ, c, Val(false))
     dtprev = one(dt)
@@ -380,7 +380,7 @@ function alg_cache(alg::QNDF{MO}, u, rate_prototype, ::Type{uEltypeNoUnits},
     end
     U = SArray(U)
 
-    γₖ = SVector(ntuple(k -> sum(tTypeNoUnits(1 // j) for j in 1:k), Val(max_order)))
+    γₖ = SVector(ntuple(k -> sum(tTypeNoUnits(Int64(1) // j) for j in 1:k), Val(max_order)))
 
     QNDFConstantCache(nlsolver, U, D, prevD, 1, 1, Val(max_order), dtprev, 0, 0, EEst1,
         EEst2, γₖ)
@@ -426,7 +426,7 @@ function alg_cache(alg::QNDF{MO}, u, rate_prototype, ::Type{uEltypeNoUnits},
         ::Val{true}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits
 } where {MO}
     max_order = MO
-    γ, c = 1//1, 1
+    γ, c = Int64(1)//1, 1
     nlsolver = build_nlsolver(alg, u, uprev, p, t, dt, f, rate_prototype, uEltypeNoUnits,
         uBottomEltypeNoUnits, tTypeNoUnits, γ, c, Val(true))
     fsalfirst = zero(rate_prototype)
@@ -459,7 +459,7 @@ function alg_cache(alg::QNDF{MO}, u, rate_prototype, ::Type{uEltypeNoUnits},
     U = SArray(U)
 
     RU = Matrix(U)
-    γₖ = SVector(ntuple(k -> sum(tTypeNoUnits(1 // j) for j in 1:k), Val(max_order)))
+    γₖ = SVector(ntuple(k -> sum(tTypeNoUnits(Int64(1) // j) for j in 1:k), Val(max_order)))
 
     QNDFCache(fsalfirst, dd, utilde, utildem1, utildep1, ϕ, u₀, nlsolver, U, RU, D, Dtmp,
         tmp2, prevD, 1, 1, Val(max_order), dtprev, 0, 0, EEst1, EEst2, γₖ, atmp,
@@ -541,15 +541,15 @@ function alg_cache(alg::FBDF{MO}, u, rate_prototype, ::Type{uEltypeNoUnits},
         dt, reltol, p, calck,
         ::Val{false}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits
 } where {MO}
-    γ, c = 1//1, 1
+    γ, c = Int64(1)//1, 1
     max_order = MO
     nlsolver = build_nlsolver(alg, u, uprev, p, t, dt, f, rate_prototype, uEltypeNoUnits,
         uBottomEltypeNoUnits, tTypeNoUnits, γ, c, Val(false))
     bdf_coeffs = SA[1 -1 0 0 0 0;
-                    3//2 -2 1//2 0 0 0;
-                    11//6 -3 3//2 -1//3 0 0;
-                    25//12 -4 3 -4//3 1//4 0;
-                    137//60 -5 5 -10//3 5//4 -1//5]
+                    Int64(3)//2 -2 Int64(1)//2 0 0 0;
+                    Int64(11)//6 -3 Int64(3)//2 -Int64(1)//3 0 0;
+                    Int64(25)//12 -4 3 -Int64(4)//3 Int64(1)//4 0;
+                    Int64(137)//60 -5 5 -Int64(10)//3 Int64(5)//4 -Int64(1)//5]
     ts = zero(Vector{typeof(t)}(undef, max_order + 2)) #ts is the successful past points, it will be updated after successful step
     ts_tmp = similar(ts)
 
@@ -616,16 +616,16 @@ function alg_cache(alg::FBDF{MO}, u, rate_prototype, ::Type{uEltypeNoUnits},
         dt, reltol, p, calck,
         ::Val{true}) where {MO, uEltypeNoUnits, uBottomEltypeNoUnits,
         tTypeNoUnits}
-    γ, c = 1//1, 1
+    γ, c = Int64(1)//1, 1
     fsalfirst = zero(rate_prototype)
     max_order = MO
     nlsolver = build_nlsolver(alg, u, uprev, p, t, dt, f, rate_prototype, uEltypeNoUnits,
         uBottomEltypeNoUnits, tTypeNoUnits, γ, c, Val(true))
     bdf_coeffs = SA[1 -1 0 0 0 0;
-                    3//2 -2 1//2 0 0 0;
-                    11//6 -3 3//2 -1//3 0 0;
-                    25//12 -4 3 -4//3 1//4 0;
-                    137//60 -5 5 -10//3 5//4 -1//5]
+                    Int64(3)//2 -2 Int64(1)//2 0 0 0;
+                    Int64(11)//6 -3 Int64(3)//2 -Int64(1)//3 0 0;
+                    Int64(25)//12 -4 3 -Int64(4)//3 Int64(1)//4 0;
+                    Int64(137)//60 -5 5 -Int64(10)//3 Int64(5)//4 -Int64(1)//5]
     ts = Vector{typeof(t)}(undef, max_order + 2) #ts is the successful past points, it will be updated after successful step
     u_history = Matrix{eltype(u)}(undef, length(u), max_order + 2)
     order = 1

--- a/lib/OrdinaryDiffEqBDF/src/bdf_perform_step.jl
+++ b/lib/OrdinaryDiffEqBDF/src/bdf_perform_step.jl
@@ -27,7 +27,7 @@ end
 
     fₙ₋₁ = integrator.fsalfirst
     ρ = dtₙ / dtₙ₋₁
-    β₀ = 2 // 3
+    β₀ = Int64(2) // 3
     β₁ = -(ρ - 1) / 3
     α₀ = 1
     α̂ = ρ^2 / 3
@@ -113,7 +113,7 @@ end
 
     fₙ₋₁ = integrator.fsalfirst
     ρ = dtₙ / dtₙ₋₁
-    β₀ = 2 // 3
+    β₀ = Int64(2) // 3
     β₁ = -(ρ - 1) / 3
     α₀ = 1
     α̂ = ρ^2 / 3
@@ -152,7 +152,7 @@ end
     f(integrator.fsallast, uₙ, p, t + dtₙ)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     if integrator.opts.adaptive
-        btilde0 = (dtₙ₋₁ + dtₙ) * 1 // 6
+        btilde0 = (dtₙ₋₁ + dtₙ) * Int64(1) // 6
         btilde1 = 1 + dtₙ / dtₙ₋₁
         btilde2 = dtₙ / dtₙ₋₁
         @.. broadcast=false tmp=btilde0*
@@ -207,12 +207,12 @@ function perform_step!(integrator, cache::SBDFConstantCache, repeat_step = false
     if cnt == 1
         tmp = uprev + dt * du₂
     elseif cnt == 2
-        tmp = γ * (2 * uprev - 1 // 2 * uprev2 + dt * (2 * du₂ - k₁))
+        tmp = γ * (2 * uprev - Int64(1) // 2 * uprev2 + dt * (2 * du₂ - k₁))
     elseif cnt == 3
         tmp = γ *
-              (3 * uprev - 3 // 2 * uprev2 + 1 // 3 * uprev3 + dt * (3 * (du₂ - k₁) + k₂))
+              (3 * uprev - Int64(3) // 2 * uprev2 + Int64(1) // 3 * uprev3 + dt * (3 * (du₂ - k₁) + k₂))
     else
-        tmp = γ * (4 * uprev - 3 * uprev2 + 4 // 3 * uprev3 - 1 // 4 * uprev4 +
+        tmp = γ * (4 * uprev - 3 * uprev2 + Int64(4) // 3 * uprev3 - Int64(1) // 4 * uprev4 +
                dt * (4 * du₂ - 6 * k₁ + 4 * k₂ - k₃))
     end
     nlsolver.tmp = tmp
@@ -513,12 +513,12 @@ function perform_step!(integrator, cache::QNDF2ConstantCache, repeat_step = fals
     k = 2
     if cnt == 1 || cnt == 2
         κ = zero(alg.kappa)
-        γ₁ = 1 // 1
-        γ₂ = 1 // 1
+        γ₁ = Int64(1) // 1
+        γ₂ = Int64(1) // 1
     elseif dtₙ₋₁ != dtₙ₋₂
         κ = alg.kappa
-        γ₁ = 1 // 1
-        γ₂ = 1 // 1 + 1 // 2
+        γ₁ = Int64(1) // 1
+        γ₂ = Int64(1) // 1 + Int64(1) // 2
         ρ₁ = dt / dtₙ₋₁
         ρ₂ = dt / dtₙ₋₂
         D[1] = uprev - uprev2
@@ -526,8 +526,8 @@ function perform_step!(integrator, cache::QNDF2ConstantCache, repeat_step = fals
         D[2] = D[1] - ((uprev2 - uprev3) * ρ₂)
     else
         κ = alg.kappa
-        γ₁ = 1 // 1
-        γ₂ = 1 // 1 + 1 // 2
+        γ₁ = Int64(1) // 1
+        γ₂ = Int64(1) // 1 + Int64(1) // 2
         ρ = dt / dtₙ₋₁
         # backward diff
         D[1] = uprev - uprev2
@@ -623,12 +623,12 @@ function perform_step!(integrator, cache::QNDF2Cache, repeat_step = false)
     k = 2
     if cnt == 1 || cnt == 2
         κ = zero(alg.kappa)
-        γ₁ = 1 // 1
-        γ₂ = 1 // 1
+        γ₁ = Int64(1) // 1
+        γ₂ = Int64(1) // 1
     elseif dtₙ₋₁ != dtₙ₋₂
         κ = alg.kappa
-        γ₁ = 1 // 1
-        γ₂ = 1 // 1 + 1 // 2
+        γ₁ = Int64(1) // 1
+        γ₂ = Int64(1) // 1 + Int64(1) // 2
         ρ₁ = dt / dtₙ₋₁
         ρ₂ = dt / dtₙ₋₂
         @.. broadcast=false D[1]=uprev-uprev2
@@ -636,8 +636,8 @@ function perform_step!(integrator, cache::QNDF2Cache, repeat_step = false)
         @.. broadcast=false D[2]=D[1]-((uprev2-uprev3)*ρ₂)
     else
         κ = alg.kappa
-        γ₁ = 1 // 1
-        γ₂ = 1 // 1 + 1 // 2
+        γ₁ = Int64(1) // 1
+        γ₂ = Int64(1) // 1 + Int64(1) // 2
         ρ = dt / dtₙ₋₁
         # backward diff
         @.. broadcast=false D[1]=uprev-uprev2

--- a/lib/OrdinaryDiffEqBDF/src/bdf_utils.jl
+++ b/lib/OrdinaryDiffEqBDF/src/bdf_utils.jl
@@ -90,7 +90,7 @@ function update_D!(D, dd, k)
     return nothing
 end
 
-const γₖ = @SVector[sum(1 // j for j in 1:k) for k in 1:6]
+const γₖ = @SVector[sum(Int64(1) // j for j in 1:k) for k in 1:6]
 
 function error_constant(integrator, alg::QNDF, k)
     @unpack γₖ = integrator.cache

--- a/lib/OrdinaryDiffEqBDF/src/dae_caches.jl
+++ b/lib/OrdinaryDiffEqBDF/src/dae_caches.jl
@@ -63,8 +63,8 @@ function alg_cache(alg::DABDF2, du, u, res_prototype, rate_prototype,
         ::Type{tTypeNoUnits},
         uprev, uprev2, f, t, dt, reltol, p, calck,
         ::Val{false}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    γ, c = 1 // 1, 1
-    α = 1 // 1
+    γ, c = Int64(1) // 1, 1
+    α = Int64(1) // 1
     nlsolver = build_nlsolver(alg, u, uprev, p, t, dt, f, res_prototype, uEltypeNoUnits,
         uBottomEltypeNoUnits, tTypeNoUnits, γ, c, α, Val(false))
     eulercache = DImplicitEulerConstantCache(nlsolver)
@@ -92,8 +92,8 @@ function alg_cache(alg::DABDF2, du, u, res_prototype, rate_prototype,
         ::Type{uEltypeNoUnits}, ::Type{uBottomEltypeNoUnits},
         ::Type{tTypeNoUnits}, uprev, uprev2, f, t, dt, reltol, p, calck,
         ::Val{true}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    γ, c = 1 // 1, 1
-    α = 1 // 1
+    γ, c = Int64(1) // 1, 1
+    α = Int64(1) // 1
     nlsolver = build_nlsolver(alg, u, uprev, p, t, dt, f, res_prototype, uEltypeNoUnits,
         uBottomEltypeNoUnits, tTypeNoUnits, γ, c, α, Val(true))
     fsalfirst = zero(rate_prototype)
@@ -146,10 +146,10 @@ function alg_cache(alg::DFBDF{MO}, du, u, res_prototype, rate_prototype, uEltype
     nlsolver = build_nlsolver(alg, u, uprev, p, t, dt, f, rate_prototype, uEltypeNoUnits,
         uBottomEltypeNoUnits, tTypeNoUnits, γ, c, Val(false))
     bdf_coeffs = SA[1 -1 0 0 0 0;
-                    2//3 -4//3 1//3 0 0 0;
-                    6//11 -18//11 9//11 -2//11 0 0;
-                    12//25 -48//25 36//25 -16//25 3//25 0;
-                    60//137 -300//137 300//137 -200//137 75//137 -12//137]
+                    Int64(2)//3 -Int64(4)//3 Int64(1)//3 0 0 0;
+                    Int64(6)//11 -Int64(18)//11 Int64(9)//11 -Int64(2)//11 0 0;
+                    Int64(12)//25 -Int64(48)//25 Int64(36)//25 -Int64(16)//25 Int64(3)//25 0;
+                    Int64(60)//137 -Int64(300)//137 Int64(300)//137 -Int64(200)//137 Int64(75)//137 -Int64(12)//137]
     ts = zero(Vector{typeof(t)}(undef, max_order + 2)) #ts is the successful past points, it will be updated after successful step
     ts_tmp = similar(ts)
 
@@ -223,10 +223,10 @@ function alg_cache(alg::DFBDF{MO}, du, u, res_prototype, rate_prototype, uEltype
                     25//12 -4 3 -4//3 1//4 0 ;
                     137//60 -5 5 -10//3 5//4 -1//5]=#
     bdf_coeffs = SA[1 -1 0 0 0 0;
-                    2//3 -4//3 1//3 0 0 0;
-                    6//11 -18//11 9//11 -2//11 0 0;
-                    12//25 -48//25 36//25 -16//25 3//25 0;
-                    60//137 -300//137 300//137 -200//137 75//137 -12//137]
+                    Int64(2)//3 -Int64(4)//3 Int64(1)//3 0 0 0;
+                    Int64(6)//11 -Int64(18)//11 Int64(9)//11 -Int64(2)//11 0 0;
+                    Int64(12)//25 -Int64(48)//25 Int64(36)//25 -Int64(16)//25 Int64(3)//25 0;
+                    Int64(60)//137 -Int64(300)//137 Int64(300)//137 -Int64(200)//137 Int64(75)//137 -Int64(12)//137]
     ts = Vector{typeof(t)}(undef, max_order + 2) #ts is the successful past points, it will be updated after successful step
     u_history = Matrix{eltype(u)}(undef, length(u), max_order + 2)
     order = 1

--- a/lib/OrdinaryDiffEqBDF/src/dae_perform_step.jl
+++ b/lib/OrdinaryDiffEqBDF/src/dae_perform_step.jl
@@ -122,7 +122,7 @@ end
     c1 = ρ^2 / (1 + 2ρ)
 
     nlsolver.γ = (1 + ρ) / (1 + 2ρ)
-    nlsolver.α = 1 // 1
+    nlsolver.α = Int64(1) // 1
 
     nlsolver.z = zero(uₙ)
 
@@ -187,7 +187,7 @@ end
     c1 = ρ^2 / (1 + 2ρ)
 
     nlsolver.γ = (1 + ρ) / (1 + 2ρ)
-    nlsolver.α = 1 // 1
+    nlsolver.α = Int64(1) // 1
     @.. broadcast=false nlsolver.tmp=-c1*uₙ₋₁+c1*uₙ₋₂
     nlsolver.z .= zero(eltype(z))
     z = nlsolve!(nlsolver, integrator, cache, repeat_step)
@@ -199,7 +199,7 @@ end
     @.. broadcast=false integrator.fsallast=du
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     if integrator.opts.adaptive
-        btilde0 = (dtₙ₋₁ + dtₙ) * 1 // 6
+        btilde0 = (dtₙ₋₁ + dtₙ) * Int64(1) // 6
         btilde1 = 1 + ρ
         btilde2 = ρ
         @.. broadcast=false tmp=btilde0*
@@ -287,7 +287,7 @@ function perform_step!(integrator, cache::DFBDFConstantCache{max_order},
     nlsolver.tmp = tmp + cache.u₀
     nlsolver.z = zero(nlsolver.z)
     nlsolver.γ = bdf_coeffs[k, 1]
-    nlsolver.α = 1 // 1
+    nlsolver.α = Int64(1) // 1
     z = nlsolve!(nlsolver, integrator, cache, repeat_step)
     nlsolvefail(nlsolver) && return
     u = z + cache.u₀
@@ -403,7 +403,7 @@ function perform_step!(integrator, cache::DFBDFCache{max_order},
     @.. broadcast=false nlsolver.tmp=tmp+u₀
     @.. broadcast=false nlsolver.z=zero(eltype(nlsolver.z))
     nlsolver.γ = bdf_coeffs[k, 1]
-    nlsolver.α = 1 // 1
+    nlsolver.α = Int64(1) // 1
     z = nlsolve!(nlsolver, integrator, cache, repeat_step)
     nlsolvefail(nlsolver) && return
     @.. broadcast=false u=z+u₀


### PR DESCRIPTION
## Summary
This PR fixes the `InexactError: Rational(0.8438818565400843)` that occurs when running DelayDiffEq.jl tests on X86 (32-bit) architectures.

## Problem Description
The error was occurring in DelayDiffEq.jl tests on X86 architecture with the following stack trace:
```
InexactError: Rational(0.8438818565400843)
  at OrdinaryDiffEqBDF ~/.julia/packages/OrdinaryDiffEqBDF/T4s2z/src/bdf_perform_step.jl:904
```

## Root Cause
On X86 systems, `Int` becomes `Int32` instead of `Int64`. The issue occurred because:

1. Rational literals like `1 // j` create `Rational{Int}` types
2. On X86, this becomes `Rational{Int32}` 
3. When combined with `Float64` values in BDF calculations, results couldn't be exactly represented as `Rational{Int32}`
4. This caused `InexactError` when Julia tried to convert the result back to `Rational{Int32}`

## Solution
Replace all hardcoded rational literals like `1 // j`, `2 // 3`, etc. with `Int64(1) // j`, `Int64(2) // 3` to ensure consistent `Rational{Int64}` types across all architectures.

## Files Changed
- `lib/OrdinaryDiffEqBDF/src/bdf_utils.jl`: Fixed γₖ constant definition
- `lib/OrdinaryDiffEqBDF/src/bdf_caches.jl`: Fixed cache initialization and BDF coefficient matrices
- `lib/OrdinaryDiffEqBDF/src/bdf_perform_step.jl`: Fixed multiple β₀, γ₁, γ₂ definitions and other rational literals
- `lib/OrdinaryDiffEqBDF/src/dae_perform_step.jl`: Fixed DAE-related rationals
- `lib/OrdinaryDiffEqBDF/src/dae_caches.jl`: Fixed DAE cache initialization and coefficient matrices

## Test plan
- [x] Verified that OrdinaryDiffEq compiles successfully after changes
- [x] Tested rational calculations work without InexactError
- [ ] CI tests should now pass on X86 architecture for DelayDiffEq.jl

This fix ensures DelayDiffEq.jl works correctly on both X86 (32-bit) and X64 (64-bit) architectures.

🤖 Generated with [Claude Code](https://claude.ai/code)