### PR TITLE
Fix duplicate docstring warnings in OrdinaryDiffEqRosenbrock

### DIFF
--- a/lib/OrdinaryDiffEqRosenbrock/src/generic_rosenbrock.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/generic_rosenbrock.jl
@@ -913,303 +913,46 @@ function ROS2Tableau() # 2nd order
     RosenbrockAdaptiveTableau(a,C,b,btilde,gamma,d,c)
 end
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-An Order 2/3 L-Stable Rosenbrock-W method which is good for very stiff equations with oscillations at low tolerances. 2nd order stiff-aware interpolation.
-""",
-"Rosenbrock23",
-references = """
-- Shampine L.F. and Reichelt M., (1997) The MATLAB ODE Suite, SIAM Journal of
-Scientific Computing, 18 (1), pp. 1-22.
-""",
-with_step_limiter = true) Rosenbrock23
+# Rosenbrock23 and Rosenbrock32 are now documented in algorithms.jl
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-An Order 3/2 A-Stable Rosenbrock-W method which is good for mildly stiff equations without oscillations at low tolerances. Note that this method is prone to instability in the presence of oscillations, so use with caution. 2nd order stiff-aware interpolation.
-""",
-"Rosenbrock32",
-references = """
-- Shampine L.F. and Reichelt M., (1997) The MATLAB ODE Suite, SIAM Journal of
-Scientific Computing, 18 (1), pp. 1-22.
-""",
-with_step_limiter = true) Rosenbrock32
+# ROS3P is now documented in algorithms.jl
 
-@doc rosenbrock_docstring(
-"""
-3rd order A-stable and stiffly stable Rosenbrock method. Keeps high accuracy on discretizations of nonlinear parabolic PDEs.
-""",
-"ROS3P",
-references = """
-- Lang, J. & Verwer, ROS3P—An Accurate Third-Order Rosenbrock Solver Designed for
-  Parabolic Problems J. BIT Numerical Mathematics (2001) 41: 731. doi:10.1023/A:1021900219772
-""",
-with_step_limiter = true) ROS3P
+# Rodas23W is now documented in algorithms.jl
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-An Order 2/3 L-Stable Rosenbrock-W method for stiff ODEs and DAEs in mass matrix form. 2nd order stiff-aware interpolation and additional error test for interpolation.
-""",
-"Rodas23W",
-references = """
-- Steinebach G., Rosenbrock methods within OrdinaryDiffEq.jl - Overview, recent developments and applications -
-  Preprint 2024
-  https://github.com/hbrs-cse/RosenbrockMethods/blob/main/paper/JuliaPaper.pdf
-""",
-with_step_limiter = true) Rodas23W
+# ROS34PW1a, ROS34PW1b, ROS34PW2, ROS34PW3 are now documented in algorithms.jl
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-A 4th order L-stable Rosenbrock-W method.
-""",
-"ROS34PW1a",
-references = """
-@article{rang2005new,
-  title={New Rosenbrock W-methods of order 3 for partial differential algebraic equations of index 1},
-  author={Rang, Joachim and Angermann, L},
-  journal={BIT Numerical Mathematics},
-  volume={45},
-  pages={761--787},
-  year={2005},
-  publisher={Springer}}
-""") ROS34PW1a
+# RosShamp4 is now documented in algorithms.jl
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-A 4th order L-stable Rosenbrock-W method.
-""",
-"ROS34PW1b",
-references = """
-@article{rang2005new,
-  title={New Rosenbrock W-methods of order 3 for partial differential algebraic equations of index 1},
-  author={Rang, Joachim and Angermann, L},
-  journal={BIT Numerical Mathematics},
-  volume={45},
-  pages={761--787},
-  year={2005},
-  publisher={Springer}}
-""") ROS34PW1b
+# Rodas3 is now documented in algorithms.jl
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-A 4th order stiffy accurate Rosenbrock-W method for PDAEs.
-""",
-"ROS34PW2",
-references = """
-@article{rang2005new,
-  title={New Rosenbrock W-methods of order 3 for partial differential algebraic equations of index 1},
-  author={Rang, Joachim and Angermann, L},
-  journal={BIT Numerical Mathematics},
-  volume={45},
-  pages={761--787},
-  year={2005},
-  publisher={Springer}}
-""") ROS34PW2
+# Rodas3P is now documented in algorithms.jl
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-A 4th order strongly A-stable (Rinf~0.63) Rosenbrock-W method.
-""",
-"ROS34PW3",
-references = """
-@article{rang2005new,
-  title={New Rosenbrock W-methods of order 3 for partial differential algebraic equations of index 1},
-  author={Rang, Joachim and Angermann, L},
-  journal={BIT Numerical Mathematics},
-  volume={45},
-  pages={761--787},
-  year={2005},
-  publisher={Springer}}
-""") ROS34PW3
+# Rodas4 is now documented in algorithms.jl
 
-@doc rosenbrock_docstring(
-"""
-An A-stable 4th order Rosenbrock method.
-""",
-"RosShamp4",
-references = """
-- L. F. Shampine, Implementation of Rosenbrock Methods, ACM Transactions on
-  Mathematical Software (TOMS), 8: 2, 93-113. doi:10.1145/355993.355994
-""") RosShamp4
-
-@doc rosenbrock_docstring(
-"""
-3rd order A-stable and stiffly stable Rosenbrock method.
-""",
-"Rodas3",
-references = """
-- Sandu, Verwer, Van Loon, Carmichael, Potra, Dabdub, Seinfeld, Benchmarking stiff ode solvers for atmospheric chemistry problems-I. 
-    implicit vs explicit, Atmospheric Environment, 31(19), 3151-3166, 1997.
-""",
-with_step_limiter=true) Rodas3
-
-@doc rosenbrock_docstring(
-"""
-3rd order A-stable and stiffly stable Rosenbrock method with a stiff-aware 3rd order interpolant
-and additional error test for interpolation. Keeps accuracy on discretizations of linear parabolic PDEs.
-""",
-"Rodas3P",
-references = """
-- Steinebach G., Rosenbrock methods within OrdinaryDiffEq.jl - Overview, recent developments and applications -
-  Preprint 2024
-  https://github.com/hbrs-cse/RosenbrockMethods/blob/main/paper/JuliaPaper.pdf
-""",
-with_step_limiter=true) Rodas3P
-
-@doc rosenbrock_docstring(
-"""
-A 4th order A-stable stiffly stable Rosenbrock method with a stiff-aware 3rd order interpolant
-""",
-"Rodas4",
-references = """
-- E. Hairer, G. Wanner, Solving ordinary differential equations II, stiff and
-  differential-algebraic problems. Computational mathematics (2nd revised ed.), Springer (1996)
-""",
-with_step_limiter=true) Rodas4
-
-@doc rosenbrock_docstring(
-"""
-A 4th order A-stable stiffly stable Rosenbrock method with a stiff-aware 3rd order interpolant
-""",
-"Ros4LStab",
-references = """
-- E. Hairer, G. Wanner, Solving ordinary differential equations II, stiff and
-  differential-algebraic problems. Computational mathematics (2nd revised ed.), Springer (1996)
-""",
-with_step_limiter=true) Ros4LStab
+# Ros4LStab is now documented in algorithms.jl
 
 
-@doc rosenbrock_docstring(
-"""
-A 4th order A-stable stiffly stable Rosenbrock method with a stiff-aware 3rd order interpolant
-""",
-"Rodas42",
-references = """
-- E. Hairer, G. Wanner, Solving ordinary differential equations II, stiff and
-  differential-algebraic problems. Computational mathematics (2nd revised ed.), Springer (1996)
-""",
-with_step_limiter=true) Rodas42
+# Rodas42 is now documented in algorithms.jl
 
-@doc rosenbrock_docstring(
-"""
-4th order A-stable stiffly stable Rosenbrock method with a stiff-aware 3rd order interpolant. 4th order
-on linear parabolic problems and 3rd order accurate on nonlinear parabolic problems (as opposed to
-lower if not corrected).
-""",
-"Rodas4P",
-references = """
-- Steinebach, G., Rentrop, P., An adaptive method of lines approach for modelling flow and transport in rivers. 
-    Adaptive method of lines , Wouver, A. Vande, Sauces, Ph., Schiesser, W.E. (ed.),S. 181-205,Chapman & Hall/CRC, 2001,
-- Steinebach, G., Oder-reduction of ROW-methods for DAEs and method of lines  applications. 
-    Preprint-Nr. 1741, FB Mathematik, TH Darmstadt, 1995.
-""",
-with_step_limiter=true) Rodas4P
+# Rodas4P is now documented in algorithms.jl
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-A 4th order L-stable stiffly stable Rosenbrock method with a stiff-aware 3rd order interpolant. 4th order
-on linear parabolic problems and 3rd order accurate on nonlinear parabolic problems. It is an improvement
-of Roadas4P and in case of inexact Jacobians a second order W method.
-""",
-"Rodas4P2",
-references = """
-- Steinebach G., Improvement of Rosenbrock-Wanner Method RODASP, In: Reis T., Grundel S., Schöps S. (eds) 
-    Progress in Differential-Algebraic Equations II. Differential-Algebraic Equations Forum. Springer, Cham., 165-184, 2020.
-""",
-with_step_limiter=true) Rodas4P2
+# Rodas4P2 is now documented in algorithms.jl
 
-@doc rosenbrock_docstring(
-"""
-A 5th order A-stable stiffly stable Rosenbrock method with a stiff-aware 4th order interpolant.
-""",
-"Rodas5",
-references = """
-- Di Marzo G. RODAS5(4) – Méthodes de Rosenbrock d’ordre 5(4) adaptées aux problemes
-  différentiels-algébriques. MSc mathematics thesis, Faculty of Science,
-  University of Geneva, Switzerland.
-""",
-with_step_limiter=true) Rodas5
+# Rodas5 is now documented in algorithms.jl
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-A 5th order A-stable stiffly stable Rosenbrock method with a stiff-aware 4th order interpolant.
-Has improved stability in the adaptive time stepping embedding.
-""",
-"Rodas5P",
-references = """
-- Steinebach G. Construction of Rosenbrock–Wanner method Rodas5P and numerical benchmarks
-  within the Julia Differential Equations package.
-  In: BIT Numerical Mathematics, 63(2), 2023
-""",
-with_step_limiter=true) Rodas5P
+# Rodas5P is now documented in algorithms.jl
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-Variant of Ropdas5P with additional residual control.
-""",
-"Rodas5Pr",
-references = """
-- Steinebach G. Rosenbrock methods within OrdinaryDiffEq.jl - Overview, recent developments and applications -
-  Preprint 2024
-  https://github.com/hbrs-cse/RosenbrockMethods/blob/main/paper/JuliaPaper.pdf
-""",
-with_step_limiter=true) Rodas5Pr
+# Rodas5Pr is now documented in algorithms.jl
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-Variant of Ropdas5P with modified embedded scheme.
-""",
-"Rodas5Pe",
-references = """
-- Steinebach G. Rosenbrock methods within OrdinaryDiffEq.jl - Overview, recent developments and applications -
-  Preprint 2024
-  https://github.com/hbrs-cse/RosenbrockMethods/blob/main/paper/JuliaPaper.pdf
-""",
-with_step_limiter=true) Rodas5Pe
+# Rodas5Pe is now documented in algorithms.jl
 
-@doc rosenbrock_docstring(
-"""
-An efficient 4th order Rosenbrock method.
-""",
-"GRK4T",
-references = """
-- Kaps, P. & Rentrop, Generalized Runge-Kutta methods of order four with stepsize control
-  for stiff ordinary differential equations. P. Numer. Math. (1979) 33: 55. doi:10.1007/BF01396495
-""",
-with_step_limiter=true) GRK4T
+# GRK4T is now documented in algorithms.jl
 
-@doc rosenbrock_docstring(
-"""
-An A-stable 4th order Rosenbrock method. Essentially "anti-L-stable" but efficient.
-""",
-"GRK4A",
-references = """
-- Kaps, P. & Rentrop, Generalized Runge-Kutta methods of order four with stepsize control
-  for stiff ordinary differential equations. P. Numer. Math. (1979) 33: 55. doi:10.1007/BF01396495
-""",
-with_step_limiter=true) GRK4A
+# GRK4A is now documented in algorithms.jl
 
-@doc rosenbrock_docstring(
-"""
-A 4th order D-stable Rosenbrock method.
-""",
-"Veldd4",
-references = """
-- van Veldhuizen, D-stability and Kaps-Rentrop-methods, M. Computing (1984) 32: 229.
-  doi:10.1007/BF02243574
-""",
-with_step_limiter=true) Veldd4
+# Veldd4 is now documented in algorithms.jl
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-A 4th order A-stable Rosenbrock method.
-""",
-"Velds4",
-references = """
-- van Veldhuizen, D-stability and Kaps-Rentrop-methods, M. Computing (1984) 32: 229.
-  doi:10.1007/BF02243574
-""",
-with_step_limiter=true) Velds4
+# Velds4 is now documented in algorithms.jl
 
 """
     @ROS2(part)
@@ -1250,15 +993,7 @@ macro ROS2(part)
     end
 end
 
-@doc rosenbrock_docstring(
-"""
-A 2nd order L-stable Rosenbrock method with 2 internal stages.
-""",
-"ROS2",
-references = """
-- J. G. Verwer et al. (1999): A second-order Rosenbrock method applied to photochemical dispersion problems
-  https://doi.org/10.1137/S1064827597326651
-""") ROS2
+# ROS2 is now documented in algorithms.jl
 
 # 3 step ROS Methods
 """
@@ -1285,19 +1020,7 @@ function ROS2PRTableau() # 2nd order
     RosenbrockAdaptiveTableau(a,C,b,btilde,gamma,d,c)
 end
 
-@doc rosenbrock_docstring(
-"""
-2nd order stiffly accurate Rosenbrock method with 3 internal stages with (Rinf=0).
-For problems with medium stiffness the convergence behaviour is very poor and it is recommended to use
-[`ROS2S`](@ref) instead.
-""",
-"ROS2PR",
-references = """
-- Rang, Joachim (2014): The Prothero and Robinson example:
-  Convergence studies for Runge-Kutta and Rosenbrock-Wanner methods.
-  https://doi.org/10.24355/dbbs.084-201408121139-0
-""")
-ROS2PR
+# ROS2PR is now documented in algorithms.jl
 
 
 
@@ -1324,17 +1047,7 @@ function ROS2STableau() # 2nd order
     RosenbrockAdaptiveTableau(a,C,b,btilde,gamma,d,c)
 end
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-2nd order stiffly accurate Rosenbrock-Wanner W-method with 3 internal stages with B_PR consistent of order 2 with (Rinf=0).
-""",
-"ROS2S",
-references = """
-- Rang, Joachim (2014): The Prothero and Robinson example:
-  Convergence studies for Runge-Kutta and Rosenbrock-Wanner methods.
-  https://doi.org/10.24355/dbbs.084-201408121139-0
-""")
-ROS2S
+# ROS2S is now documented in algorithms.jl
 
 
 """
@@ -1358,16 +1071,7 @@ function ROS3Tableau() # 3rd order
     RosenbrockAdaptiveTableau(a,C,b,btilde,gamma,d,c)
 end
 
-@doc rosenbrock_docstring(
-"""
-3rd order L-stable Rosenbrock method with 3 internal stages with an embedded strongly
-A-stable 2nd order method.
-""",
-"ROS3",
-references = """
-- E. Hairer, G. Wanner, Solving ordinary differential equations II, stiff and
-  differential-algebraic problems. Computational mathematics (2nd revised ed.), Springer (1996)
-""") ROS3
+# ROS3 is now documented in algorithms.jl
 
 
 """
@@ -1392,16 +1096,7 @@ function ROS3PRTableau() # 3rd order
     RosenbrockAdaptiveTableau(a,C,b,btilde,gamma,d,c)
 end
 
-@doc rosenbrock_docstring(
-"""
-3nd order stiffly accurate Rosenbrock method with 3 internal stages with B_PR consistent of order 3, which is strongly A-stable with Rinf~=-0.73.
-""",
-"ROS3PR",
-references = """
-- Rang, Joachim (2014): The Prothero and Robinson example:
-  Convergence studies for Runge-Kutta and Rosenbrock-Wanner methods.
-  https://doi.org/10.24355/dbbs.084-201408121139-0
-""") ROS3PR
+# ROS3PR is now documented in algorithms.jl
 
 
 
@@ -1428,17 +1123,7 @@ function Scholz4_7Tableau() # 3rd order
     RosenbrockAdaptiveTableau(a,C,b,btilde,gamma,d,c)
 end
 
-@doc rosenbrock_docstring(
-"""
-3nd order stiffly accurate Rosenbrock method with 3 internal stages with B_PR consistent of order 3, which is strongly A-stable with Rinf~=-0.73.
-Convergence with order 4 for the stiff case, but has a poor accuracy.
-""",
-"Scholz4_7",
-references = """
-- Rang, Joachim (2014): The Prothero and Robinson example:
-  Convergence studies for Runge-Kutta and Rosenbrock-Wanner methods.
-  https://doi.org/10.24355/dbbs.084-201408121139-0
-""") Scholz4_7
+# Scholz4_7 is now documented in algorithms.jl
 
 
 """
@@ -1619,18 +1304,7 @@ function ROS34PRwTableau() # 3rd order
     RosenbrockAdaptiveTableau(a,C,b,btilde,gamma,d,c)
 end
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-3rd order stiffly accurate Rosenbrock-Wanner W-method with 4 internal stages,
-B_PR consistent of order 2.
-The order of convergence decreases if medium stiff problems are considered.
-""",
-"ROS34PRw",
-references = """
-- Joachim Rang, Improved traditional Rosenbrock–Wanner methods for stiff ODEs and DAEs,
-  Journal of Computational and Applied Mathematics,
-  https://doi.org/10.1016/j.cam.2015.03.010
-""") ROS34PRw
+# ROS34PRw is now documented in algorithms.jl
 
 """
     ROS3PRLTableau()
@@ -1658,18 +1332,7 @@ function ROS3PRLTableau() # 3rd order
     RosenbrockAdaptiveTableau(a,C,b,btilde,gamma,d,c)
 end
 
-@doc rosenbrock_docstring(
-"""
-3rd order stiffly accurate Rosenbrock method with 4 internal stages,
-B_PR consistent of order 2 with Rinf=0.
-The order of convergence decreases if medium stiff problems are considered, but it has good results for very stiff cases.
-""",
-"ROS3PRL",
-references = """
-- Rang, Joachim (2014): The Prothero and Robinson example:
-  Convergence studies for Runge-Kutta and Rosenbrock-Wanner methods.
-  https://doi.org/10.24355/dbbs.084-201408121139-0
-""") ROS3PRL
+# ROS3PRL is now documented in algorithms.jl
 
 
 """
@@ -1698,18 +1361,7 @@ function ROS3PRL2Tableau() # 3rd order
     RosenbrockAdaptiveTableau(a,C,b,btilde,gamma,d,c)
 end
 
-@doc rosenbrock_docstring(
-"""
-3rd order stiffly accurate Rosenbrock method with 4 internal stages,
-B_PR consistent of order 3.
-The order of convergence does NOT decreases if medium stiff problems are considered as it does for [`ROS3PRL`](@ref).
-""",
-"ROS3PRL2",
-references = """
-- Rang, Joachim (2014): The Prothero and Robinson example:
-  Convergence studies for Runge-Kutta and Rosenbrock-Wanner methods.
-  https://doi.org/10.24355/dbbs.084-201408121139-0
-""") ROS3PRL2
+# ROS3PRL2 is now documented in algorithms.jl
 
 
 """
@@ -1736,17 +1388,7 @@ function ROK4aTableau() # 4rd order
     RosenbrockAdaptiveTableau(a,C,b,btilde,gamma,d,c)
 end
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-4rd order L-stable Rosenbrock-Krylov method with 4 internal stages,
-with a 3rd order embedded method which is strongly A-stable with Rinf~=0.55. (when using exact Jacobians)
-""",
-"ROK4a",
-references = """
-- Tranquilli, Paul and Sandu, Adrian (2014):
-  Rosenbrock--Krylov Methods for Large Systems of Differential Equations
-  https://doi.org/10.1137/130923336
-""") ROK4a
+# ROK4a is now documented in algorithms.jl
 
 """
     @ROS34PW(part)


### PR DESCRIPTION
## Summary
- Removes duplicate `@doc` annotations for 30+ Rosenbrock algorithms that were causing "Replacing docs" warnings
- Centralizes documentation in `algorithms.jl` where these structs are defined with docstrings
- Eliminates all duplicate documentation warnings when loading OrdinaryDiffEqRosenbrock module

## Problem
When loading OrdinaryDiffEqRosenbrock, Julia emits warnings like:
```
┌ Warning: Replacing docs for `OrdinaryDiffEqRosenbrock.Rosenbrock23 :: Union{}` in module `OrdinaryDiffEqRosenbrock`
└ @ Base.Docs docs/Docs.jl:243
```

This happens because algorithms were being documented twice:
1. In `algorithms.jl` through macro-generated loops with `Base.@__doc__`
2. In `generic_rosenbrock.jl` with explicit `@doc` annotations

## Solution
Removed the duplicate `@doc` annotations from `generic_rosenbrock.jl` for all affected algorithms. The documentation is now solely in `algorithms.jl` where the structs are defined.

## Affected Algorithms
Rosenbrock23, Rosenbrock32, ROS3P, Rodas23W, ROS34PW1a, ROS34PW1b, ROS34PW2, ROS34PW3, RosShamp4, Rodas3, Rodas3P, Rodas4, Ros4LStab, Rodas42, Rodas4P, Rodas4P2, Rodas5, Rodas5P, Rodas5Pr, Rodas5Pe, GRK4T, GRK4A, Veldd4, Velds4, ROS2, ROS2PR, ROS2S, ROS3, ROS3PR, Scholz4_7, ROS34PRw, ROS3PRL, ROS3PRL2, ROK4a

## Testing
- Module loads without any duplicate documentation warnings
- Tests pass (verified with `Pkg.test()`)

🤖 Generated with [Claude Code](https://claude.ai/code)