### PR TITLE
Fix reltol type instability in Newton solver

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -246,10 +246,10 @@ end
         update_coefficients!(W, ustep, p, tstep; dtgamma = γW, transform = true)
     end
 
-    if integrator.opts.adaptive
-        reltol = integrator.opts.reltol
-    else
+    if !integrator.opts.adaptive && !(integrator.opts.reltol isa AbstractArray)
         reltol = eps(eltype(dz))
+    else
+        reltol = integrator.opts.reltol
     end
 
     if is_always_new(nlsolver) || (iter == 1 && new_W)


### PR DESCRIPTION
## Summary
- Fixes type instability in the Newton solver when handling `reltol` parameter
- Addresses performance issue identified in #2819

## Problem
The Newton solver had a type instability where `reltol` could be either:
- A scalar (`eps(eltype(dz))`) when `adaptive=false`
- A scalar or vector (`integrator.opts.reltol`) when `adaptive=true`

Since `adaptive` is checked at runtime, Julia couldn't determine the type at compile time, causing performance degradation visible in profiling.

## Solution
Changed the condition from:
```julia
if integrator.opts.adaptive
    reltol = integrator.opts.reltol
else
    reltol = eps(eltype(dz))
end
```

To:
```julia
if \!integrator.opts.adaptive && \!(integrator.opts.reltol isa AbstractArray)
    reltol = eps(eltype(dz))
else
    reltol = integrator.opts.reltol
end
```

This ensures `reltol` is only set to `eps(eltype(dz))` when it would be type-compatible (i.e., when the original reltol is not an array), avoiding the type instability.

## Test plan
- [x] Tested with the Robertson equation example from issue #2819
- [x] Verified the solution works with both `adaptive=true` and `adaptive=false`
- [x] Code runs without errors and produces correct results

Fixes part of #2819

🤖 Generated with [Claude Code](https://claude.ai/code)