### PR TITLE
Fix precompilation warnings

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
+++ b/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
@@ -39,7 +39,7 @@ import SciMLOperators: AbstractSciMLOperator, AbstractSciMLScalarOperator,
 
 using DiffEqBase: DEIntegrator
 
-import RecursiveArrayTools: chain, recursivecopy!, recursivecopy, recursive_bottom_eltype, recursive_unitless_bottom_eltype, recursive_unitless_eltype, copyat_or_push!, DiffEqArray
+import RecursiveArrayTools: chain, recursivecopy!, recursivecopy, recursive_bottom_eltype, recursive_unitless_bottom_eltype, recursive_unitless_eltype, copyat_or_push!, DiffEqArray, recursivefill!
 
 using SimpleUnPack: @unpack
 import RecursiveArrayTools

--- a/lib/OrdinaryDiffEqRosenbrock/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/algorithms.jl
@@ -123,8 +123,7 @@ for (Alg, desc) in [
     (:Rodas5Pr, ROSENBROCK_STEPL_DOCS[:Rodas5Pr])
 ]
     @eval begin
-        """$($desc)"""
-        Base.@__doc__ struct $Alg{CS, AD, F, P, FDT, ST, CJ, StepLimiter, StageLimiter} <:
+        @doc $desc struct $Alg{CS, AD, F, P, FDT, ST, CJ, StepLimiter, StageLimiter} <:
                OrdinaryDiffEqRosenbrockAdaptiveAlgorithm{CS, AD, FDT, ST, CJ}
             linsolve::F
             precs::P
@@ -243,8 +242,7 @@ for (Alg, desc) in [
     (:Ros4LStab, ROSENBROCK_DOCS[:Ros4LStab])
 ]
     @eval begin
-        """$($desc)"""
-        Base.@__doc__ struct $Alg{CS, AD, F, P, FDT, ST, CJ} <:
+        @doc $desc struct $Alg{CS, AD, F, P, FDT, ST, CJ} <:
                OrdinaryDiffEqRosenbrockAdaptiveAlgorithm{CS, AD, FDT, ST, CJ}
             linsolve::F
             precs::P


### PR DESCRIPTION
## Summary

This PR fixes two types of precompilation warnings:

1. **Duplicate documentation warnings in OrdinaryDiffEqRosenbrock**: Replaced  with  macro to avoid duplicate documentation attachment during macro expansion
2. **Missing  import in OrdinaryDiffEqCore**: Added import of  from RecursiveArrayTools

## Test Output

Before the fix:
- Multiple "Replacing docs for..." warnings from OrdinaryDiffEqRosenbrock
- "WARNING: could not import OrdinaryDiffEqCore.recursivefill\! into OrdinaryDiffEq"

After the fix:
- Clean precompilation without warnings

## Context

These warnings were benign and didn't affect functionality, but they created unnecessary noise during package precompilation that could confuse users.

🤖 Generated with [Claude Code](https://claude.ai/code)