### PR TITLE
Fix Rosenbrock docstrings and add proper citations

### DIFF
--- a/lib/OrdinaryDiffEqRosenbrock/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/algorithms.jl
@@ -88,42 +88,194 @@ University of Geneva, Switzerland.
 =#
 
 # Documentation for Rosenbrock methods with step_limiter
-const ROSENBROCK_STEPL_DOCS = Dict(
-    :Rosenbrock23 => "An Order 2/3 L-Stable Rosenbrock-W method which is good for very stiff equations with oscillations at low tolerances. 2nd order stiff-aware interpolation. Strong stability for highly stiff systems. Good at high tolerances (>1e-2) for stiff problems. Recommended for highly stiff problems, systems with significant oscillations, low tolerance requirements.",
-    :Rosenbrock32 => "A 3/2-order L-stable Rosenbrock-W method optimized for stiff problems. Good balance of accuracy and computational efficiency.",
-    :ROS3P => "A 3rd-order accurate L-stable Rosenbrock method designed for parabolic problems. Particularly effective for reaction-diffusion equations.",
-    :Rodas3 => "A 3rd-order accurate L-stable Rosenbrock method from Hairer and Wanner. Good general-purpose stiff ODE solver with moderate computational cost.",
-    :Rodas23W => "A 2nd/3rd-order accurate L-stable Rosenbrock-Wanner method with enhanced error estimation. Good for stiff problems with discontinuities.",
-    :Rodas3P => "A 3rd-order accurate L-stable Rosenbrock method optimized for DAE problems. Enhanced version of Rodas3 for differential-algebraic equations.",
-    :Rodas4 => "A 4th-order accurate L-stable Rosenbrock method. Well-suited for moderately stiff problems with good efficiency.",
-    :Rodas42 => "A 4th-order accurate L-stable Rosenbrock method with improved error estimation. Enhanced version of Rodas4 for better step size control.",
-    :Rodas4P => "A 4th-order accurate L-stable Rosenbrock method designed for differential-algebraic equations (DAEs). Optimized for index-1 DAE problems.",
-    :Rodas4P2 => "An improved 4th-order accurate L-stable Rosenbrock method for DAEs with enhanced stability properties.",
-    :Rodas5 => "A 5th-order accurate L-stable Rosenbrock method for differential-algebraic problems. Higher accuracy but increased computational cost.",
-    :Rodas5P => "Efficient for medium tolerance stiff problems. A 5th order A-stable and stiffly stable embedded Rosenbrock method for differential-algebraic problems.",
-    :Rodas5Pe => "A 5th-order accurate L-stable Rosenbrock method with enhanced error estimation. Variant of Rodas5P with improved error control.",
-    :Rodas5Pr => "A 5th-order accurate L-stable Rosenbrock method with relaxed error estimation. Variant of Rodas5P for less stringent error control."
-)
+
+@doc rosenbrock_wolfbrandt_docstring(
+"""
+An Order 2/3 L-Stable Rosenbrock-W method which is good for very stiff equations with oscillations at low tolerances. 2nd order stiff-aware interpolation.
+""",
+"Rosenbrock23",
+references = """
+- Shampine L.F. and Reichelt M., (1997) The MATLAB ODE Suite, SIAM Journal of
+  Scientific Computing, 18 (1), pp. 1-22.
+""",
+with_step_limiter = true) Rosenbrock23
+
+@doc rosenbrock_wolfbrandt_docstring(
+"""
+An Order 3/2 A-Stable Rosenbrock-W method which is good for mildly stiff equations without oscillations at low tolerances. Note that this method is prone to instability in the presence of oscillations, so use with caution. 2nd order stiff-aware interpolation.
+""",
+"Rosenbrock32",
+references = """
+- Shampine L.F. and Reichelt M., (1997) The MATLAB ODE Suite, SIAM Journal of
+  Scientific Computing, 18 (1), pp. 1-22.
+""",
+with_step_limiter = true) Rosenbrock32
+
+@doc rosenbrock_docstring(
+"""
+3rd order A-stable and stiffly stable Rosenbrock method. Keeps high accuracy on discretizations of nonlinear parabolic PDEs.
+""",
+"ROS3P",
+references = """
+- Lang, J. & Verwer, ROS3P—An Accurate Third-Order Rosenbrock Solver Designed for
+  Parabolic Problems J. BIT Numerical Mathematics (2001) 41: 731. doi:10.1023/A:1021900219772
+""",
+with_step_limiter = true) ROS3P
+
+@doc rosenbrock_docstring(
+"""
+3rd order A-stable and stiffly stable Rosenbrock method.
+""",
+"Rodas3",
+references = """
+- Sandu, Verwer, Van Loon, Carmichael, Potra, Dabdub, Seinfeld, Benchmarking stiff ode solvers for atmospheric chemistry problems-I. 
+  implicit vs explicit, Atmospheric Environment, 31(19), 3151-3166, 1997.
+""",
+with_step_limiter=true) Rodas3
+
+@doc rosenbrock_wolfbrandt_docstring(
+"""
+An Order 2/3 L-Stable Rosenbrock-W method for stiff ODEs and DAEs in mass matrix form. 2nd order stiff-aware interpolation and additional error test for interpolation.
+""",
+"Rodas23W",
+references = """
+- Steinebach G., Rosenbrock methods within OrdinaryDiffEq.jl - Overview, recent developments and applications -
+  Preprint 2024. Proceedings of the JuliaCon Conferences.
+  https://proceedings.juliacon.org/papers/eb04326e1de8fa819a3595b376508a40
+""",
+with_step_limiter = true) Rodas23W
+
+@doc rosenbrock_docstring(
+"""
+3rd order A-stable and stiffly stable Rosenbrock method with a stiff-aware 3rd order interpolant
+and additional error test for interpolation. Keeps accuracy on discretizations of linear parabolic PDEs.
+""",
+"Rodas3P",
+references = """
+- Steinebach G., Rosenbrock methods within OrdinaryDiffEq.jl - Overview, recent developments and applications -
+  Preprint 2024. Proceedings of the JuliaCon Conferences.
+  https://proceedings.juliacon.org/papers/eb04326e1de8fa819a3595b376508a40
+""",
+with_step_limiter=true) Rodas3P
+
+@doc rosenbrock_docstring(
+"""
+A 4th order A-stable stiffly stable Rosenbrock method with a stiff-aware 3rd order interpolant
+""",
+"Rodas4",
+references = """
+- E. Hairer, G. Wanner, Solving ordinary differential equations II, stiff and
+  differential-algebraic problems. Computational mathematics (2nd revised ed.), Springer (1996)
+""",
+with_step_limiter=true) Rodas4
+
+@doc rosenbrock_docstring(
+"""
+A 4th order A-stable stiffly stable Rosenbrock method with a stiff-aware 3rd order interpolant
+""",
+"Rodas42",
+references = """
+- E. Hairer, G. Wanner, Solving ordinary differential equations II, stiff and
+  differential-algebraic problems. Computational mathematics (2nd revised ed.), Springer (1996)
+""",
+with_step_limiter=true) Rodas42
+
+@doc rosenbrock_docstring(
+"""
+4th order A-stable stiffly stable Rosenbrock method with a stiff-aware 3rd order interpolant. 4th order
+on linear parabolic problems and 3rd order accurate on nonlinear parabolic problems (as opposed to
+lower if not corrected).
+""",
+"Rodas4P",
+references = """
+- Steinebach, G., Rentrop, P., An adaptive method of lines approach for modelling flow and transport in rivers. 
+  Adaptive method of lines , Wouver, A. Vande, Sauces, Ph., Schiesser, W.E. (ed.),S. 181-205,Chapman & Hall/CRC, 2001,
+- Steinebach, G., Order-reduction of ROW-methods for DAEs and method of lines  applications. 
+  Preprint-Nr. 1741, FB Mathematik, TH Darmstadt, 1995.
+""",
+with_step_limiter=true) Rodas4P
+
+@doc rosenbrock_wolfbrandt_docstring(
+"""
+A 4th order L-stable stiffly stable Rosenbrock method with a stiff-aware 3rd order interpolant. 4th order
+on linear parabolic problems and 3rd order accurate on nonlinear parabolic problems. It is an improvement
+of Rodas4P and in case of inexact Jacobians a second order W method.
+""",
+"Rodas4P2",
+references = """
+- Steinebach G., Improvement of Rosenbrock-Wanner Method RODASP, In: Reis T., Grundel S., Schöps S. (eds) 
+  Progress in Differential-Algebraic Equations II. Differential-Algebraic Equations Forum. Springer, Cham., 165-184, 2020.
+""",
+with_step_limiter=true) Rodas4P2
+
+@doc rosenbrock_docstring(
+"""
+A 5th order A-stable stiffly stable Rosenbrock method with a stiff-aware 4th order interpolant.
+""",
+"Rodas5",
+references = """
+- Di Marzo G. RODAS5(4) – Méthodes de Rosenbrock d'ordre 5(4) adaptées aux problèmes
+  différentiels-algébriques. MSc mathematics thesis, Faculty of Science,
+  University of Geneva, Switzerland.
+""",
+with_step_limiter=true) Rodas5
+
+@doc rosenbrock_wolfbrandt_docstring(
+"""
+A 5th order A-stable stiffly stable Rosenbrock method with a stiff-aware 4th order interpolant.
+Has improved stability in the adaptive time stepping embedding.
+""",
+"Rodas5P",
+references = """
+- Steinebach G. Construction of Rosenbrock–Wanner method Rodas5P and numerical benchmarks
+  within the Julia Differential Equations package.
+  In: BIT Numerical Mathematics, 63(2), 2023. doi:10.1007/s10543-023-00967-x
+""",
+with_step_limiter=true) Rodas5P
+
+@doc rosenbrock_wolfbrandt_docstring(
+"""
+Variant of Rodas5P with additional residual control.
+""",
+"Rodas5Pr",
+references = """
+- Steinebach G. Rosenbrock methods within OrdinaryDiffEq.jl - Overview, recent developments and applications -
+  Preprint 2024. Proceedings of the JuliaCon Conferences.
+  https://proceedings.juliacon.org/papers/eb04326e1de8fa819a3595b376508a40
+""",
+with_step_limiter=true) Rodas5Pr
+
+@doc rosenbrock_wolfbrandt_docstring(
+"""
+Variant of Rodas5P with modified embedded scheme.
+""",
+"Rodas5Pe",
+references = """
+- Steinebach G. Rosenbrock methods within OrdinaryDiffEq.jl - Overview, recent developments and applications -
+  Preprint 2024. Proceedings of the JuliaCon Conferences.
+  https://proceedings.juliacon.org/papers/eb04326e1de8fa819a3595b376508a40
+""",
+with_step_limiter=true) Rodas5Pe
 
 # for Rosenbrock methods with step_limiter
-for (Alg, desc) in [
-    (:Rosenbrock23, ROSENBROCK_STEPL_DOCS[:Rosenbrock23]),
-    (:Rosenbrock32, ROSENBROCK_STEPL_DOCS[:Rosenbrock32]),
-    (:ROS3P, ROSENBROCK_STEPL_DOCS[:ROS3P]),
-    (:Rodas3, ROSENBROCK_STEPL_DOCS[:Rodas3]),
-    (:Rodas23W, ROSENBROCK_STEPL_DOCS[:Rodas23W]),
-    (:Rodas3P, ROSENBROCK_STEPL_DOCS[:Rodas3P]),
-    (:Rodas4, ROSENBROCK_STEPL_DOCS[:Rodas4]),
-    (:Rodas42, ROSENBROCK_STEPL_DOCS[:Rodas42]),
-    (:Rodas4P, ROSENBROCK_STEPL_DOCS[:Rodas4P]),
-    (:Rodas4P2, ROSENBROCK_STEPL_DOCS[:Rodas4P2]),
-    (:Rodas5, ROSENBROCK_STEPL_DOCS[:Rodas5]),
-    (:Rodas5P, ROSENBROCK_STEPL_DOCS[:Rodas5P]),
-    (:Rodas5Pe, ROSENBROCK_STEPL_DOCS[:Rodas5Pe]),
-    (:Rodas5Pr, ROSENBROCK_STEPL_DOCS[:Rodas5Pr])
+for Alg in [
+    :Rosenbrock23,
+    :Rosenbrock32,
+    :ROS3P,
+    :Rodas3,
+    :Rodas23W,
+    :Rodas3P,
+    :Rodas4,
+    :Rodas42,
+    :Rodas4P,
+    :Rodas4P2,
+    :Rodas5,
+    :Rodas5P,
+    :Rodas5Pe,
+    :Rodas5Pr
 ]
     @eval begin
-        @doc $desc struct $Alg{CS, AD, F, P, FDT, ST, CJ, StepLimiter, StageLimiter} <:
+        struct $Alg{CS, AD, F, P, FDT, ST, CJ, StepLimiter, StageLimiter} <:
                OrdinaryDiffEqRosenbrockAdaptiveAlgorithm{CS, AD, FDT, ST, CJ}
             linsolve::F
             precs::P
@@ -177,53 +329,250 @@ function RosenbrockW6S4OS(; chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
 end
 
 # Documentation for Rosenbrock methods without step_limiter
-const ROSENBROCK_DOCS = Dict(
-    :ROS2 => "A 2nd-order accurate L-stable Rosenbrock method. Simple and robust for moderately stiff problems with lower accuracy requirements.",
-    :ROS2PR => "A 2nd-order accurate L-stable Rosenbrock method optimized for the Prothero-Robinson test problem. Good for oscillatory stiff problems.",
-    :ROS2S => "A 2nd-order accurate L-stable Rosenbrock method with enhanced stability properties. Variant of ROS2 with improved behavior.",
-    :ROS3 => "A 3rd-order accurate L-stable Rosenbrock method from Hairer and Wanner. Well-established method for general stiff ODEs.",
-    :ROS3PR => "A 3rd-order accurate L-stable Rosenbrock method optimized for the Prothero-Robinson test problem. Good for stiff oscillatory systems.",
-    :Scholz4_7 => "A 4th-order accurate L-stable Rosenbrock method with optimized stability function. Enhanced performance for certain stiff problem classes.",
-    :ROS34PW1a => "A 4th-order accurate L-stable Rosenbrock method with improved embedded error estimator. Part of the ROS34PW family of methods.",
-    :ROS34PW1b => "A 4th-order accurate L-stable Rosenbrock method with alternative embedded error estimator. Variant in the ROS34PW family.",
-    :ROS34PW2 => "A 4th-order accurate L-stable Rosenbrock method with enhanced embedded error estimation. Second variant in the ROS34PW family.",
-    :ROS34PW3 => "A 4th-order accurate L-stable Rosenbrock method with optimized embedded error estimator. Third variant in the ROS34PW family.",
-    :ROS34PRw => "A 4th-order accurate L-stable Rosenbrock method designed for improved traditional Rosenbrock-Wanner methods for stiff ODEs and DAEs.",
-    :ROS3PRL => "A 3rd-order accurate L-stable Rosenbrock method optimized for the Prothero-Robinson test with additional local error control.",
-    :ROS3PRL2 => "A 3rd-order accurate L-stable Rosenbrock method. Second variant optimized for the Prothero-Robinson test with enhanced local error control.",
-    :ROK4a => "A 4th-order accurate L-stable Rosenbrock-Krylov method for large systems of differential equations. Combines Rosenbrock methods with Krylov subspace techniques.",
-    :RosShamp4 => "A 4th-order accurate L-stable Rosenbrock method implemented by Shampine. Classical implementation of a 4th-order Rosenbrock method.",
-    :Veldd4 => "A 4th-order accurate L-stable Rosenbrock method by van Veldhuizen. Optimized for D-stability properties.",
-    :Velds4 => "A 4th-order accurate L-stable Rosenbrock method by van Veldhuizen. Variant with enhanced stability for stiff problems.",
-    :GRK4T => "A 4th-order accurate generalized Runge-Kutta method with time-derivative. Part of the GRK family by Kaps and Rentrop.",
-    :GRK4A => "A 4th-order accurate generalized Runge-Kutta method with enhanced accuracy. Part of the GRK family by Kaps and Rentrop.",
-    :Ros4LStab => "A 4th-order accurate L-stable Rosenbrock method optimized for L-stability. Enhanced stability properties from Hairer and Wanner."
-)
 
-for (Alg, desc) in [
-    (:ROS2, ROSENBROCK_DOCS[:ROS2]),
-    (:ROS2PR, ROSENBROCK_DOCS[:ROS2PR]),
-    (:ROS2S, ROSENBROCK_DOCS[:ROS2S]),
-    (:ROS3, ROSENBROCK_DOCS[:ROS3]),
-    (:ROS3PR, ROSENBROCK_DOCS[:ROS3PR]),
-    (:Scholz4_7, ROSENBROCK_DOCS[:Scholz4_7]),
-    (:ROS34PW1a, ROSENBROCK_DOCS[:ROS34PW1a]),
-    (:ROS34PW1b, ROSENBROCK_DOCS[:ROS34PW1b]),
-    (:ROS34PW2, ROSENBROCK_DOCS[:ROS34PW2]),
-    (:ROS34PW3, ROSENBROCK_DOCS[:ROS34PW3]),
-    (:ROS34PRw, ROSENBROCK_DOCS[:ROS34PRw]),
-    (:ROS3PRL, ROSENBROCK_DOCS[:ROS3PRL]),
-    (:ROS3PRL2, ROSENBROCK_DOCS[:ROS3PRL2]),
-    (:ROK4a, ROSENBROCK_DOCS[:ROK4a]),
-    (:RosShamp4, ROSENBROCK_DOCS[:RosShamp4]),
-    (:Veldd4, ROSENBROCK_DOCS[:Veldd4]),
-    (:Velds4, ROSENBROCK_DOCS[:Velds4]),
-    (:GRK4T, ROSENBROCK_DOCS[:GRK4T]),
-    (:GRK4A, ROSENBROCK_DOCS[:GRK4A]),
-    (:Ros4LStab, ROSENBROCK_DOCS[:Ros4LStab])
+@doc rosenbrock_docstring(
+"""
+A 2nd order L-stable Rosenbrock method with 2 internal stages.
+""",
+"ROS2",
+references = """
+- J. G. Verwer et al. (1999): A second-order Rosenbrock method applied to photochemical dispersion problems
+  https://doi.org/10.1137/S1064827597326651
+""") ROS2
+
+@doc rosenbrock_docstring(
+"""
+2nd order stiffly accurate Rosenbrock method with 3 internal stages with (Rinf=0).
+For problems with medium stiffness the convergence behaviour is very poor and it is recommended to use
+[`ROS2S`](@ref) instead.
+""",
+"ROS2PR",
+references = """
+- Rang, Joachim (2014): The Prothero and Robinson example:
+  Convergence studies for Runge-Kutta and Rosenbrock-Wanner methods.
+  https://doi.org/10.24355/dbbs.084-201408121139-0
+""") ROS2PR
+
+@doc rosenbrock_wolfbrandt_docstring(
+"""
+2nd order stiffly accurate Rosenbrock-Wanner W-method with 3 internal stages with B_PR consistent of order 2 with (Rinf=0).
+""",
+"ROS2S",
+references = """
+- Rang, Joachim (2014): The Prothero and Robinson example:
+  Convergence studies for Runge-Kutta and Rosenbrock-Wanner methods.
+  https://doi.org/10.24355/dbbs.084-201408121139-0
+""") ROS2S
+
+@doc rosenbrock_docstring(
+"""
+3rd order L-stable Rosenbrock method with 3 internal stages with an embedded strongly
+A-stable 2nd order method.
+""",
+"ROS3",
+references = """
+- E. Hairer, G. Wanner, Solving ordinary differential equations II, stiff and
+  differential-algebraic problems. Computational mathematics (2nd revised ed.), Springer (1996)
+""") ROS3
+
+@doc rosenbrock_docstring(
+"""
+3nd order stiffly accurate Rosenbrock method with 3 internal stages with B_PR consistent of order 3, which is strongly A-stable with Rinf~=-0.73.
+""",
+"ROS3PR",
+references = """
+- Rang, Joachim (2014): The Prothero and Robinson example:
+  Convergence studies for Runge-Kutta and Rosenbrock-Wanner methods.
+  https://doi.org/10.24355/dbbs.084-201408121139-0
+""") ROS3PR
+
+@doc rosenbrock_docstring(
+"""
+3nd order stiffly accurate Rosenbrock method with 3 internal stages with B_PR consistent of order 3, which is strongly A-stable with Rinf~=-0.73.
+Convergence with order 4 for the stiff case, but has a poor accuracy.
+""",
+"Scholz4_7",
+references = """
+- Rang, Joachim (2014): The Prothero and Robinson example:
+  Convergence studies for Runge-Kutta and Rosenbrock-Wanner methods.
+  https://doi.org/10.24355/dbbs.084-201408121139-0
+""") Scholz4_7
+
+@doc rosenbrock_wolfbrandt_docstring(
+"""
+A 4th order L-stable Rosenbrock-W method.
+""",
+"ROS34PW1a",
+references = """
+- Rang, Joachim and Angermann, L (2005): New Rosenbrock W-methods of order 3 for partial differential algebraic equations of index 1.
+  BIT Numerical Mathematics, 45, 761--787.
+""") ROS34PW1a
+
+@doc rosenbrock_wolfbrandt_docstring(
+"""
+A 4th order L-stable Rosenbrock-W method.
+""",
+"ROS34PW1b",
+references = """
+- Rang, Joachim and Angermann, L (2005): New Rosenbrock W-methods of order 3 for partial differential algebraic equations of index 1.
+  BIT Numerical Mathematics, 45, 761--787.
+""") ROS34PW1b
+
+@doc rosenbrock_wolfbrandt_docstring(
+"""
+A 4th order stiffy accurate Rosenbrock-W method for PDAEs.
+""",
+"ROS34PW2",
+references = """
+- Rang, Joachim and Angermann, L (2005): New Rosenbrock W-methods of order 3 for partial differential algebraic equations of index 1.
+  BIT Numerical Mathematics, 45, 761--787.
+""") ROS34PW2
+
+@doc rosenbrock_wolfbrandt_docstring(
+"""
+A 4th order strongly A-stable (Rinf~0.63) Rosenbrock-W method.
+""",
+"ROS34PW3",
+references = """
+- Rang, Joachim and Angermann, L (2005): New Rosenbrock W-methods of order 3 for partial differential algebraic equations of index 1.
+  BIT Numerical Mathematics, 45, 761--787.
+""") ROS34PW3
+
+@doc rosenbrock_wolfbrandt_docstring(
+"""
+3rd order stiffly accurate Rosenbrock-Wanner W-method with 4 internal stages,
+B_PR consistent of order 2.
+The order of convergence decreases if medium stiff problems are considered.
+""",
+"ROS34PRw",
+references = """
+- Joachim Rang, Improved traditional Rosenbrock–Wanner methods for stiff ODEs and DAEs,
+  Journal of Computational and Applied Mathematics,
+  https://doi.org/10.1016/j.cam.2015.03.010
+""") ROS34PRw
+
+@doc rosenbrock_docstring(
+"""
+3rd order stiffly accurate Rosenbrock method with 4 internal stages,
+B_PR consistent of order 2 with Rinf=0.
+The order of convergence decreases if medium stiff problems are considered, but it has good results for very stiff cases.
+""",
+"ROS3PRL",
+references = """
+- Rang, Joachim (2014): The Prothero and Robinson example:
+  Convergence studies for Runge-Kutta and Rosenbrock-Wanner methods.
+  https://doi.org/10.24355/dbbs.084-201408121139-0
+""") ROS3PRL
+
+@doc rosenbrock_docstring(
+"""
+3rd order stiffly accurate Rosenbrock method with 4 internal stages,
+B_PR consistent of order 3.
+The order of convergence does NOT decreases if medium stiff problems are considered as it does for [`ROS3PRL`](@ref).
+""",
+"ROS3PRL2",
+references = """
+- Rang, Joachim (2014): The Prothero and Robinson example:
+  Convergence studies for Runge-Kutta and Rosenbrock-Wanner methods.
+  https://doi.org/10.24355/dbbs.084-201408121139-0
+""") ROS3PRL2
+
+@doc rosenbrock_wolfbrandt_docstring(
+"""
+4rd order L-stable Rosenbrock-Krylov method with 4 internal stages,
+with a 3rd order embedded method which is strongly A-stable with Rinf~=0.55. (when using exact Jacobians)
+""",
+"ROK4a",
+references = """
+- Tranquilli, Paul and Sandu, Adrian (2014):
+  Rosenbrock--Krylov Methods for Large Systems of Differential Equations
+  https://doi.org/10.1137/130923336
+""") ROK4a
+
+@doc rosenbrock_docstring(
+"""
+An A-stable 4th order Rosenbrock method.
+""",
+"RosShamp4",
+references = """
+- L. F. Shampine, Implementation of Rosenbrock Methods, ACM Transactions on
+  Mathematical Software (TOMS), 8: 2, 93-113. doi:10.1145/355993.355994
+""") RosShamp4
+
+@doc rosenbrock_docstring(
+"""
+A 4th order D-stable Rosenbrock method.
+""",
+"Veldd4",
+references = """
+- van Veldhuizen, D-stability and Kaps-Rentrop-methods, M. Computing (1984) 32: 229.
+  doi:10.1007/BF02243574
+""") Veldd4
+
+@doc rosenbrock_wolfbrandt_docstring(
+"""
+A 4th order A-stable Rosenbrock method.
+""",
+"Velds4",
+references = """
+- van Veldhuizen, D-stability and Kaps-Rentrop-methods, M. Computing (1984) 32: 229.
+  doi:10.1007/BF02243574
+""") Velds4
+
+@doc rosenbrock_docstring(
+"""
+An efficient 4th order Rosenbrock method.
+""",
+"GRK4T",
+references = """
+- Kaps, P. & Rentrop, Generalized Runge-Kutta methods of order four with stepsize control
+  for stiff ordinary differential equations. P. Numer. Math. (1979) 33: 55. doi:10.1007/BF01396495
+""") GRK4T
+
+@doc rosenbrock_docstring(
+"""
+An A-stable 4th order Rosenbrock method. Essentially "anti-L-stable" but efficient.
+""",
+"GRK4A",
+references = """
+- Kaps, P. & Rentrop, Generalized Runge-Kutta methods of order four with stepsize control
+  for stiff ordinary differential equations. P. Numer. Math. (1979) 33: 55. doi:10.1007/BF01396495
+""") GRK4A
+
+@doc rosenbrock_docstring(
+"""
+A 4th order A-stable stiffly stable Rosenbrock method with a stiff-aware 3rd order interpolant
+""",
+"Ros4LStab",
+references = """
+- E. Hairer, G. Wanner, Solving ordinary differential equations II, stiff and
+  differential-algebraic problems. Computational mathematics (2nd revised ed.), Springer (1996)
+""") Ros4LStab
+
+for Alg in [
+    :ROS2,
+    :ROS2PR,
+    :ROS2S,
+    :ROS3,
+    :ROS3PR,
+    :Scholz4_7,
+    :ROS34PW1a,
+    :ROS34PW1b,
+    :ROS34PW2,
+    :ROS34PW3,
+    :ROS34PRw,
+    :ROS3PRL,
+    :ROS3PRL2,
+    :ROK4a,
+    :RosShamp4,
+    :Veldd4,
+    :Velds4,
+    :GRK4T,
+    :GRK4A,
+    :Ros4LStab
 ]
     @eval begin
-        @doc $desc struct $Alg{CS, AD, F, P, FDT, ST, CJ} <:
+        struct $Alg{CS, AD, F, P, FDT, ST, CJ} <:
                OrdinaryDiffEqRosenbrockAdaptiveAlgorithm{CS, AD, FDT, ST, CJ}
             linsolve::F
             precs::P

--- a/lib/OrdinaryDiffEqRosenbrock/src/generic_rosenbrock.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/generic_rosenbrock.jl
@@ -913,303 +913,54 @@ function ROS2Tableau() # 2nd order
     RosenbrockAdaptiveTableau(a,C,b,btilde,gamma,d,c)
 end
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-An Order 2/3 L-Stable Rosenbrock-W method which is good for very stiff equations with oscillations at low tolerances. 2nd order stiff-aware interpolation.
-""",
-"Rosenbrock23",
-references = """
-- Shampine L.F. and Reichelt M., (1997) The MATLAB ODE Suite, SIAM Journal of
-Scientific Computing, 18 (1), pp. 1-22.
-""",
-with_step_limiter = true) Rosenbrock23
+Rosenbrock23
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-An Order 3/2 A-Stable Rosenbrock-W method which is good for mildly stiff equations without oscillations at low tolerances. Note that this method is prone to instability in the presence of oscillations, so use with caution. 2nd order stiff-aware interpolation.
-""",
-"Rosenbrock32",
-references = """
-- Shampine L.F. and Reichelt M., (1997) The MATLAB ODE Suite, SIAM Journal of
-Scientific Computing, 18 (1), pp. 1-22.
-""",
-with_step_limiter = true) Rosenbrock32
+Rosenbrock32
 
-@doc rosenbrock_docstring(
-"""
-3rd order A-stable and stiffly stable Rosenbrock method. Keeps high accuracy on discretizations of nonlinear parabolic PDEs.
-""",
-"ROS3P",
-references = """
-- Lang, J. & Verwer, ROS3P—An Accurate Third-Order Rosenbrock Solver Designed for
-  Parabolic Problems J. BIT Numerical Mathematics (2001) 41: 731. doi:10.1023/A:1021900219772
-""",
-with_step_limiter = true) ROS3P
+ROS3P
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-An Order 2/3 L-Stable Rosenbrock-W method for stiff ODEs and DAEs in mass matrix form. 2nd order stiff-aware interpolation and additional error test for interpolation.
-""",
-"Rodas23W",
-references = """
-- Steinebach G., Rosenbrock methods within OrdinaryDiffEq.jl - Overview, recent developments and applications -
-  Preprint 2024
-  https://github.com/hbrs-cse/RosenbrockMethods/blob/main/paper/JuliaPaper.pdf
-""",
-with_step_limiter = true) Rodas23W
+Rodas23W
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-A 4th order L-stable Rosenbrock-W method.
-""",
-"ROS34PW1a",
-references = """
-@article{rang2005new,
-  title={New Rosenbrock W-methods of order 3 for partial differential algebraic equations of index 1},
-  author={Rang, Joachim and Angermann, L},
-  journal={BIT Numerical Mathematics},
-  volume={45},
-  pages={761--787},
-  year={2005},
-  publisher={Springer}}
-""") ROS34PW1a
+ROS34PW1a
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-A 4th order L-stable Rosenbrock-W method.
-""",
-"ROS34PW1b",
-references = """
-@article{rang2005new,
-  title={New Rosenbrock W-methods of order 3 for partial differential algebraic equations of index 1},
-  author={Rang, Joachim and Angermann, L},
-  journal={BIT Numerical Mathematics},
-  volume={45},
-  pages={761--787},
-  year={2005},
-  publisher={Springer}}
-""") ROS34PW1b
+ROS34PW1b
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-A 4th order stiffy accurate Rosenbrock-W method for PDAEs.
-""",
-"ROS34PW2",
-references = """
-@article{rang2005new,
-  title={New Rosenbrock W-methods of order 3 for partial differential algebraic equations of index 1},
-  author={Rang, Joachim and Angermann, L},
-  journal={BIT Numerical Mathematics},
-  volume={45},
-  pages={761--787},
-  year={2005},
-  publisher={Springer}}
-""") ROS34PW2
+ROS34PW2
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-A 4th order strongly A-stable (Rinf~0.63) Rosenbrock-W method.
-""",
-"ROS34PW3",
-references = """
-@article{rang2005new,
-  title={New Rosenbrock W-methods of order 3 for partial differential algebraic equations of index 1},
-  author={Rang, Joachim and Angermann, L},
-  journal={BIT Numerical Mathematics},
-  volume={45},
-  pages={761--787},
-  year={2005},
-  publisher={Springer}}
-""") ROS34PW3
+ROS34PW3
 
-@doc rosenbrock_docstring(
-"""
-An A-stable 4th order Rosenbrock method.
-""",
-"RosShamp4",
-references = """
-- L. F. Shampine, Implementation of Rosenbrock Methods, ACM Transactions on
-  Mathematical Software (TOMS), 8: 2, 93-113. doi:10.1145/355993.355994
-""") RosShamp4
+RosShamp4
 
-@doc rosenbrock_docstring(
-"""
-3rd order A-stable and stiffly stable Rosenbrock method.
-""",
-"Rodas3",
-references = """
-- Sandu, Verwer, Van Loon, Carmichael, Potra, Dabdub, Seinfeld, Benchmarking stiff ode solvers for atmospheric chemistry problems-I. 
-    implicit vs explicit, Atmospheric Environment, 31(19), 3151-3166, 1997.
-""",
-with_step_limiter=true) Rodas3
+Rodas3
 
-@doc rosenbrock_docstring(
-"""
-3rd order A-stable and stiffly stable Rosenbrock method with a stiff-aware 3rd order interpolant
-and additional error test for interpolation. Keeps accuracy on discretizations of linear parabolic PDEs.
-""",
-"Rodas3P",
-references = """
-- Steinebach G., Rosenbrock methods within OrdinaryDiffEq.jl - Overview, recent developments and applications -
-  Preprint 2024
-  https://github.com/hbrs-cse/RosenbrockMethods/blob/main/paper/JuliaPaper.pdf
-""",
-with_step_limiter=true) Rodas3P
+Rodas3P
 
-@doc rosenbrock_docstring(
-"""
-A 4th order A-stable stiffly stable Rosenbrock method with a stiff-aware 3rd order interpolant
-""",
-"Rodas4",
-references = """
-- E. Hairer, G. Wanner, Solving ordinary differential equations II, stiff and
-  differential-algebraic problems. Computational mathematics (2nd revised ed.), Springer (1996)
-""",
-with_step_limiter=true) Rodas4
+Rodas4
 
-@doc rosenbrock_docstring(
-"""
-A 4th order A-stable stiffly stable Rosenbrock method with a stiff-aware 3rd order interpolant
-""",
-"Ros4LStab",
-references = """
-- E. Hairer, G. Wanner, Solving ordinary differential equations II, stiff and
-  differential-algebraic problems. Computational mathematics (2nd revised ed.), Springer (1996)
-""",
-with_step_limiter=true) Ros4LStab
+Ros4LStab
 
 
-@doc rosenbrock_docstring(
-"""
-A 4th order A-stable stiffly stable Rosenbrock method with a stiff-aware 3rd order interpolant
-""",
-"Rodas42",
-references = """
-- E. Hairer, G. Wanner, Solving ordinary differential equations II, stiff and
-  differential-algebraic problems. Computational mathematics (2nd revised ed.), Springer (1996)
-""",
-with_step_limiter=true) Rodas42
+Rodas42
 
-@doc rosenbrock_docstring(
-"""
-4th order A-stable stiffly stable Rosenbrock method with a stiff-aware 3rd order interpolant. 4th order
-on linear parabolic problems and 3rd order accurate on nonlinear parabolic problems (as opposed to
-lower if not corrected).
-""",
-"Rodas4P",
-references = """
-- Steinebach, G., Rentrop, P., An adaptive method of lines approach for modelling flow and transport in rivers. 
-    Adaptive method of lines , Wouver, A. Vande, Sauces, Ph., Schiesser, W.E. (ed.),S. 181-205,Chapman & Hall/CRC, 2001,
-- Steinebach, G., Order-reduction of ROW-methods for DAEs and method of lines  applications. 
-    Preprint-Nr. 1741, FB Mathematik, TH Darmstadt, 1995.
-""",
-with_step_limiter=true) Rodas4P
+Rodas4P
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-A 4th order L-stable stiffly stable Rosenbrock method with a stiff-aware 3rd order interpolant. 4th order
-on linear parabolic problems and 3rd order accurate on nonlinear parabolic problems. It is an improvement
-of Roadas4P and in case of inexact Jacobians a second order W method.
-""",
-"Rodas4P2",
-references = """
-- Steinebach G., Improvement of Rosenbrock-Wanner Method RODASP, In: Reis T., Grundel S., Schöps S. (eds) 
-    Progress in Differential-Algebraic Equations II. Differential-Algebraic Equations Forum. Springer, Cham., 165-184, 2020.
-""",
-with_step_limiter=true) Rodas4P2
+Rodas4P2
 
-@doc rosenbrock_docstring(
-"""
-A 5th order A-stable stiffly stable Rosenbrock method with a stiff-aware 4th order interpolant.
-""",
-"Rodas5",
-references = """
-- Di Marzo G. RODAS5(4) – Méthodes de Rosenbrock d'ordre 5(4) adaptées aux problèmes
-  différentiels-algébriques. MSc mathematics thesis, Faculty of Science,
-  University of Geneva, Switzerland.
-""",
-with_step_limiter=true) Rodas5
+Rodas5
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-A 5th order A-stable stiffly stable Rosenbrock method with a stiff-aware 4th order interpolant.
-Has improved stability in the adaptive time stepping embedding.
-""",
-"Rodas5P",
-references = """
-- Steinebach G. Construction of Rosenbrock–Wanner method Rodas5P and numerical benchmarks
-  within the Julia Differential Equations package.
-  In: BIT Numerical Mathematics, 63(2), 2023
-""",
-with_step_limiter=true) Rodas5P
+Rodas5P
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-Variant of Ropdas5P with additional residual control.
-""",
-"Rodas5Pr",
-references = """
-- Steinebach G. Rosenbrock methods within OrdinaryDiffEq.jl - Overview, recent developments and applications -
-  Preprint 2024
-  https://github.com/hbrs-cse/RosenbrockMethods/blob/main/paper/JuliaPaper.pdf
-""",
-with_step_limiter=true) Rodas5Pr
+Rodas5Pr
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-Variant of Ropdas5P with modified embedded scheme.
-""",
-"Rodas5Pe",
-references = """
-- Steinebach G. Rosenbrock methods within OrdinaryDiffEq.jl - Overview, recent developments and applications -
-  Preprint 2024
-  https://github.com/hbrs-cse/RosenbrockMethods/blob/main/paper/JuliaPaper.pdf
-""",
-with_step_limiter=true) Rodas5Pe
+Rodas5Pe
 
-@doc rosenbrock_docstring(
-"""
-An efficient 4th order Rosenbrock method.
-""",
-"GRK4T",
-references = """
-- Kaps, P. & Rentrop, Generalized Runge-Kutta methods of order four with stepsize control
-  for stiff ordinary differential equations. P. Numer. Math. (1979) 33: 55. doi:10.1007/BF01396495
-""",
-with_step_limiter=true) GRK4T
+GRK4T
 
-@doc rosenbrock_docstring(
-"""
-An A-stable 4th order Rosenbrock method. Essentially "anti-L-stable" but efficient.
-""",
-"GRK4A",
-references = """
-- Kaps, P. & Rentrop, Generalized Runge-Kutta methods of order four with stepsize control
-  for stiff ordinary differential equations. P. Numer. Math. (1979) 33: 55. doi:10.1007/BF01396495
-""",
-with_step_limiter=true) GRK4A
+GRK4A
 
-@doc rosenbrock_docstring(
-"""
-A 4th order D-stable Rosenbrock method.
-""",
-"Veldd4",
-references = """
-- van Veldhuizen, D-stability and Kaps-Rentrop-methods, M. Computing (1984) 32: 229.
-  doi:10.1007/BF02243574
-""",
-with_step_limiter=true) Veldd4
+Veldd4
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-A 4th order A-stable Rosenbrock method.
-""",
-"Velds4",
-references = """
-- van Veldhuizen, D-stability and Kaps-Rentrop-methods, M. Computing (1984) 32: 229.
-  doi:10.1007/BF02243574
-""",
-with_step_limiter=true) Velds4
+Velds4
 
 """
     @ROS2(part)
@@ -1250,15 +1001,7 @@ macro ROS2(part)
     end
 end
 
-@doc rosenbrock_docstring(
-"""
-A 2nd order L-stable Rosenbrock method with 2 internal stages.
-""",
-"ROS2",
-references = """
-- J. G. Verwer et al. (1999): A second-order Rosenbrock method applied to photochemical dispersion problems
-  https://doi.org/10.1137/S1064827597326651
-""") ROS2
+ROS2
 
 # 3 step ROS Methods
 """
@@ -1285,18 +1028,6 @@ function ROS2PRTableau() # 2nd order
     RosenbrockAdaptiveTableau(a,C,b,btilde,gamma,d,c)
 end
 
-@doc rosenbrock_docstring(
-"""
-2nd order stiffly accurate Rosenbrock method with 3 internal stages with (Rinf=0).
-For problems with medium stiffness the convergence behaviour is very poor and it is recommended to use
-[`ROS2S`](@ref) instead.
-""",
-"ROS2PR",
-references = """
-- Rang, Joachim (2014): The Prothero and Robinson example:
-  Convergence studies for Runge-Kutta and Rosenbrock-Wanner methods.
-  https://doi.org/10.24355/dbbs.084-201408121139-0
-""")
 ROS2PR
 
 
@@ -1324,16 +1055,6 @@ function ROS2STableau() # 2nd order
     RosenbrockAdaptiveTableau(a,C,b,btilde,gamma,d,c)
 end
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-2nd order stiffly accurate Rosenbrock-Wanner W-method with 3 internal stages with B_PR consistent of order 2 with (Rinf=0).
-""",
-"ROS2S",
-references = """
-- Rang, Joachim (2014): The Prothero and Robinson example:
-  Convergence studies for Runge-Kutta and Rosenbrock-Wanner methods.
-  https://doi.org/10.24355/dbbs.084-201408121139-0
-""")
 ROS2S
 
 
@@ -1358,16 +1079,7 @@ function ROS3Tableau() # 3rd order
     RosenbrockAdaptiveTableau(a,C,b,btilde,gamma,d,c)
 end
 
-@doc rosenbrock_docstring(
-"""
-3rd order L-stable Rosenbrock method with 3 internal stages with an embedded strongly
-A-stable 2nd order method.
-""",
-"ROS3",
-references = """
-- E. Hairer, G. Wanner, Solving ordinary differential equations II, stiff and
-  differential-algebraic problems. Computational mathematics (2nd revised ed.), Springer (1996)
-""") ROS3
+ROS3
 
 
 """
@@ -1392,16 +1104,7 @@ function ROS3PRTableau() # 3rd order
     RosenbrockAdaptiveTableau(a,C,b,btilde,gamma,d,c)
 end
 
-@doc rosenbrock_docstring(
-"""
-3nd order stiffly accurate Rosenbrock method with 3 internal stages with B_PR consistent of order 3, which is strongly A-stable with Rinf~=-0.73.
-""",
-"ROS3PR",
-references = """
-- Rang, Joachim (2014): The Prothero and Robinson example:
-  Convergence studies for Runge-Kutta and Rosenbrock-Wanner methods.
-  https://doi.org/10.24355/dbbs.084-201408121139-0
-""") ROS3PR
+ROS3PR
 
 
 
@@ -1428,17 +1131,7 @@ function Scholz4_7Tableau() # 3rd order
     RosenbrockAdaptiveTableau(a,C,b,btilde,gamma,d,c)
 end
 
-@doc rosenbrock_docstring(
-"""
-3nd order stiffly accurate Rosenbrock method with 3 internal stages with B_PR consistent of order 3, which is strongly A-stable with Rinf~=-0.73.
-Convergence with order 4 for the stiff case, but has a poor accuracy.
-""",
-"Scholz4_7",
-references = """
-- Rang, Joachim (2014): The Prothero and Robinson example:
-  Convergence studies for Runge-Kutta and Rosenbrock-Wanner methods.
-  https://doi.org/10.24355/dbbs.084-201408121139-0
-""") Scholz4_7
+Scholz4_7
 
 
 """
@@ -1619,18 +1312,7 @@ function ROS34PRwTableau() # 3rd order
     RosenbrockAdaptiveTableau(a,C,b,btilde,gamma,d,c)
 end
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-3rd order stiffly accurate Rosenbrock-Wanner W-method with 4 internal stages,
-B_PR consistent of order 2.
-The order of convergence decreases if medium stiff problems are considered.
-""",
-"ROS34PRw",
-references = """
-- Joachim Rang, Improved traditional Rosenbrock–Wanner methods for stiff ODEs and DAEs,
-  Journal of Computational and Applied Mathematics,
-  https://doi.org/10.1016/j.cam.2015.03.010
-""") ROS34PRw
+ROS34PRw
 
 """
     ROS3PRLTableau()
@@ -1658,18 +1340,7 @@ function ROS3PRLTableau() # 3rd order
     RosenbrockAdaptiveTableau(a,C,b,btilde,gamma,d,c)
 end
 
-@doc rosenbrock_docstring(
-"""
-3rd order stiffly accurate Rosenbrock method with 4 internal stages,
-B_PR consistent of order 2 with Rinf=0.
-The order of convergence decreases if medium stiff problems are considered, but it has good results for very stiff cases.
-""",
-"ROS3PRL",
-references = """
-- Rang, Joachim (2014): The Prothero and Robinson example:
-  Convergence studies for Runge-Kutta and Rosenbrock-Wanner methods.
-  https://doi.org/10.24355/dbbs.084-201408121139-0
-""") ROS3PRL
+ROS3PRL
 
 
 """
@@ -1698,18 +1369,7 @@ function ROS3PRL2Tableau() # 3rd order
     RosenbrockAdaptiveTableau(a,C,b,btilde,gamma,d,c)
 end
 
-@doc rosenbrock_docstring(
-"""
-3rd order stiffly accurate Rosenbrock method with 4 internal stages,
-B_PR consistent of order 3.
-The order of convergence does NOT decreases if medium stiff problems are considered as it does for [`ROS3PRL`](@ref).
-""",
-"ROS3PRL2",
-references = """
-- Rang, Joachim (2014): The Prothero and Robinson example:
-  Convergence studies for Runge-Kutta and Rosenbrock-Wanner methods.
-  https://doi.org/10.24355/dbbs.084-201408121139-0
-""") ROS3PRL2
+ROS3PRL2
 
 
 """
@@ -1736,17 +1396,7 @@ function ROK4aTableau() # 4rd order
     RosenbrockAdaptiveTableau(a,C,b,btilde,gamma,d,c)
 end
 
-@doc rosenbrock_wolfbrandt_docstring(
-"""
-4rd order L-stable Rosenbrock-Krylov method with 4 internal stages,
-with a 3rd order embedded method which is strongly A-stable with Rinf~=0.55. (when using exact Jacobians)
-""",
-"ROK4a",
-references = """
-- Tranquilli, Paul and Sandu, Adrian (2014):
-  Rosenbrock--Krylov Methods for Large Systems of Differential Equations
-  https://doi.org/10.1137/130923336
-""") ROK4a
+ROK4a
 
 """
     @ROS34PW(part)


### PR DESCRIPTION
## Summary

This PR fixes the Rosenbrock method docstrings in OrdinaryDiffEq.jl by:
- Removing duplicate docstrings from `generic_rosenbrock.jl` 
- Consolidating all docstrings in `algorithms.jl` where they belong
- Adding proper citation information to all methods

## Details

Previously, Rosenbrock method docstrings were duplicated between:
- `lib/OrdinaryDiffEqRosenbrock/src/generic_rosenbrock.jl` (lines 916-1300)
- `lib/OrdinaryDiffEqRosenbrock/src/algorithms.jl` (lines 1-244)

The algorithms.jl file had the docstrings but was missing citation information, while generic_rosenbrock.jl had citation information in the docstrings but shouldn't have had docstrings at all.

This PR:
1. Removes all `@doc` macros from generic_rosenbrock.jl (keeping only the algorithm symbols)
2. Updates algorithms.jl to include proper citations using the `rosenbrock_docstring` and `rosenbrock_wolfbrandt_docstring` helper functions
3. Adds specific citations for:
   - Rodas5P: BIT Numerical Mathematics paper (2023) with DOI
   - Rodas5Pr, Rodas5Pe, Rodas23W, Rodas3P: JuliaCon proceedings paper
   - All other methods: Their respective original papers

## Test plan

- [x] Package compiles successfully with `julia -e "using Pkg; Pkg.activate(\".\"); Pkg.instantiate()"`
- [ ] CI tests pass
- [ ] Documentation builds correctly

🤖 Generated with [Claude Code](https://claude.ai/code)