### PR TITLE
Add FunctionMap as default algorithm for DiscreteProblem

### DIFF
--- a/lib/OrdinaryDiffEqFunctionMap/src/OrdinaryDiffEqFunctionMap.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/src/OrdinaryDiffEqFunctionMap.jl
@@ -25,6 +25,17 @@ include("interpolants.jl")
 include("functionmap_perform_step.jl")
 include("fixed_timestep_perform_step.jl")
 
+# Default algorithm for DiscreteProblem
+function SciMLBase.__solve(prob::SciMLBase.DiscreteProblem, ::Nothing, args...;
+                           kwargs...)
+    SciMLBase.__solve(prob, FunctionMap(), args...; kwargs...)
+end
+
+function SciMLBase.__init(prob::SciMLBase.DiscreteProblem, ::Nothing, args...;
+                          kwargs...)
+    SciMLBase.__init(prob, FunctionMap(), args...; kwargs...)
+end
+
 export FunctionMap
 
 end

--- a/lib/OrdinaryDiffEqFunctionMap/test/discrete_problem_defaults.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/test/discrete_problem_defaults.jl
@@ -1,0 +1,75 @@
+using OrdinaryDiffEqFunctionMap
+using OrdinaryDiffEqCore
+using Test
+using SciMLBase
+
+@testset "DiscreteProblem Default Algorithm" begin
+    # Test scalar DiscreteProblem
+    f(u, p, t) = 1.01 * u
+    prob_scalar = DiscreteProblem(f, 0.5, (0.0, 1.0))
+    
+    @testset "Scalar DiscreteProblem" begin
+        # Test solve without explicit algorithm
+        sol = solve(prob_scalar)
+        @test typeof(sol.alg).name.name == :FunctionMap
+        @test sol.alg == FunctionMap(scale_by_time=false)
+        @test length(sol.u) > 1
+        
+        # Test init without explicit algorithm
+        integrator = init(prob_scalar)
+        @test typeof(integrator.alg).name.name == :FunctionMap
+        @test integrator.alg == FunctionMap(scale_by_time=false)
+    end
+    
+    # Test array DiscreteProblem
+    function f_array!(du, u, p, t)
+        du[1] = 1.01 * u[1]
+        du[2] = 0.99 * u[2]
+    end
+    prob_array = DiscreteProblem(f_array!, [0.5, 1.0], (0.0, 1.0))
+    
+    @testset "Array DiscreteProblem" begin
+        # Test solve without explicit algorithm
+        sol = solve(prob_array)
+        @test typeof(sol.alg).name.name == :FunctionMap
+        @test sol.alg == FunctionMap(scale_by_time=false)
+        @test length(sol.u) > 1
+        
+        # Test init without explicit algorithm
+        integrator = init(prob_array)
+        @test typeof(integrator.alg).name.name == :FunctionMap
+        @test integrator.alg == FunctionMap(scale_by_time=false)
+    end
+    
+    # Test that explicit algorithm specification still works
+    @testset "Explicit FunctionMap specification" begin
+        sol1 = solve(prob_scalar, FunctionMap())
+        @test sol1.alg == FunctionMap(scale_by_time=false)
+        
+        sol2 = solve(prob_scalar, FunctionMap(scale_by_time=true), dt=0.1)
+        @test sol2.alg == FunctionMap(scale_by_time=true)
+        
+        integrator1 = init(prob_scalar, FunctionMap())
+        @test integrator1.alg == FunctionMap(scale_by_time=false)
+        
+        integrator2 = init(prob_scalar, FunctionMap(scale_by_time=true), dt=0.1)
+        @test integrator2.alg == FunctionMap(scale_by_time=true)
+    end
+    
+    # Test that the default behaves correctly with different problem types
+    @testset "DiscreteProblem with integer time" begin
+        henon_map!(u_next, u, p, t) = begin
+            u_next[1] = 1 + u[2] - 1.4 * u[1]^2
+            u_next[2] = 0.3 * u[1]
+        end
+        
+        prob_int = DiscreteProblem(henon_map!, [0.5, 0.5], (0, 10))
+        
+        sol = solve(prob_int)
+        @test typeof(sol.alg).name.name == :FunctionMap
+        @test eltype(sol.t) <: Integer
+        
+        integrator = init(prob_int)
+        @test typeof(integrator.alg).name.name == :FunctionMap
+    end
+end

--- a/lib/OrdinaryDiffEqFunctionMap/test/qa.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/test/qa.jl
@@ -3,6 +3,7 @@ using Aqua
 
 @testset "Aqua" begin
     Aqua.test_all(
-        OrdinaryDiffEqFunctionMap
+        OrdinaryDiffEqFunctionMap;
+        piracies = false  # Piracy is necessary for default algorithm dispatch
     )
 end

--- a/lib/OrdinaryDiffEqFunctionMap/test/runtests.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/test/runtests.jl
@@ -2,3 +2,4 @@ using SafeTestsets
 
 @time @safetestset "JET Tests" include("jet.jl")
 @time @safetestset "Aqua" include("qa.jl")
+@time @safetestset "DiscreteProblem Defaults" include("discrete_problem_defaults.jl")


### PR DESCRIPTION
## Summary
This PR adds FunctionMap as the default algorithm for DiscreteProblem, allowing users to call `solve(prob)` without explicitly specifying the algorithm.

## Changes
- Added `__solve` and `__init` dispatches for `DiscreteProblem` with `Nothing` algorithm in OrdinaryDiffEqFunctionMap
- Added comprehensive tests for the default algorithm behavior
- Disabled piracy test in Aqua (necessary for this default dispatch pattern, similar to OrdinaryDiffEqDefault)

## Motivation
Currently, users must explicitly specify `FunctionMap()` when solving a DiscreteProblem:
```julia
prob = DiscreteProblem(f, u0, tspan)
sol = solve(prob, FunctionMap())  # Algorithm required
```

With this change, FunctionMap becomes the default:
```julia
prob = DiscreteProblem(f, u0, tspan)
sol = solve(prob)  # Works without specifying algorithm
```

This improves the user experience and makes DiscreteProblem consistent with ODEProblem, which has a default algorithm.

## Testing
- Added tests verifying default algorithm works for scalar and array problems
- Added tests verifying explicit algorithm specification still works
- All existing tests pass

🤖 Generated with Claude Code