### PR TITLE
Remove ParameterizedFunctions.jl dependency from tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -75,95 +75,37 @@ StaticArrayInterface = "0d7ed370-da01-4f52-bd93-41d350b8b718"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TruncatedStacktraces = "781d530d-4396-4725-bb49-402e4bee1e77"
 
-[sources.OrdinaryDiffEqAdamsBashforthMoulton]
-path = "lib/OrdinaryDiffEqAdamsBashforthMoulton"
-
-[sources.OrdinaryDiffEqBDF]
-path = "lib/OrdinaryDiffEqBDF"
-
-[sources.OrdinaryDiffEqCore]
-path = "lib/OrdinaryDiffEqCore"
-
-[sources.OrdinaryDiffEqDefault]
-path = "lib/OrdinaryDiffEqDefault"
-
-[sources.OrdinaryDiffEqDifferentiation]
-path = "lib/OrdinaryDiffEqDifferentiation"
-
-[sources.OrdinaryDiffEqExplicitRK]
-path = "lib/OrdinaryDiffEqExplicitRK"
-
-[sources.OrdinaryDiffEqExponentialRK]
-path = "lib/OrdinaryDiffEqExponentialRK"
-
-[sources.OrdinaryDiffEqExtrapolation]
-path = "lib/OrdinaryDiffEqExtrapolation"
-
-[sources.OrdinaryDiffEqFIRK]
-path = "lib/OrdinaryDiffEqFIRK"
-
-[sources.OrdinaryDiffEqFeagin]
-path = "lib/OrdinaryDiffEqFeagin"
-
-[sources.OrdinaryDiffEqFunctionMap]
-path = "lib/OrdinaryDiffEqFunctionMap"
-
-[sources.OrdinaryDiffEqHighOrderRK]
-path = "lib/OrdinaryDiffEqHighOrderRK"
-
-[sources.OrdinaryDiffEqIMEXMultistep]
-path = "lib/OrdinaryDiffEqIMEXMultistep"
-
-[sources.OrdinaryDiffEqLinear]
-path = "lib/OrdinaryDiffEqLinear"
-
-[sources.OrdinaryDiffEqLowOrderRK]
-path = "lib/OrdinaryDiffEqLowOrderRK"
-
-[sources.OrdinaryDiffEqLowStorageRK]
-path = "lib/OrdinaryDiffEqLowStorageRK"
-
-[sources.OrdinaryDiffEqNonlinearSolve]
-path = "lib/OrdinaryDiffEqNonlinearSolve"
-
-[sources.OrdinaryDiffEqNordsieck]
-path = "lib/OrdinaryDiffEqNordsieck"
-
-[sources.OrdinaryDiffEqPDIRK]
-path = "lib/OrdinaryDiffEqPDIRK"
-
-[sources.OrdinaryDiffEqPRK]
-path = "lib/OrdinaryDiffEqPRK"
-
-[sources.OrdinaryDiffEqQPRK]
-path = "lib/OrdinaryDiffEqQPRK"
-
-[sources.OrdinaryDiffEqRKN]
-path = "lib/OrdinaryDiffEqRKN"
-
-[sources.OrdinaryDiffEqRosenbrock]
-path = "lib/OrdinaryDiffEqRosenbrock"
-
-[sources.OrdinaryDiffEqSDIRK]
-path = "lib/OrdinaryDiffEqSDIRK"
-
-[sources.OrdinaryDiffEqSSPRK]
-path = "lib/OrdinaryDiffEqSSPRK"
-
-[sources.OrdinaryDiffEqStabilizedIRK]
-path = "lib/OrdinaryDiffEqStabilizedIRK"
-
-[sources.OrdinaryDiffEqStabilizedRK]
-path = "lib/OrdinaryDiffEqStabilizedRK"
-
-[sources.OrdinaryDiffEqSymplecticRK]
-path = "lib/OrdinaryDiffEqSymplecticRK"
-
-[sources.OrdinaryDiffEqTsit5]
-path = "lib/OrdinaryDiffEqTsit5"
-
-[sources.OrdinaryDiffEqVerner]
-path = "lib/OrdinaryDiffEqVerner"
+[sources]
+OrdinaryDiffEqAdamsBashforthMoulton = {path = "lib/OrdinaryDiffEqAdamsBashforthMoulton"}
+OrdinaryDiffEqBDF = {path = "lib/OrdinaryDiffEqBDF"}
+OrdinaryDiffEqCore = {path = "lib/OrdinaryDiffEqCore"}
+OrdinaryDiffEqDefault = {path = "lib/OrdinaryDiffEqDefault"}
+OrdinaryDiffEqDifferentiation = {path = "lib/OrdinaryDiffEqDifferentiation"}
+OrdinaryDiffEqExplicitRK = {path = "lib/OrdinaryDiffEqExplicitRK"}
+OrdinaryDiffEqExponentialRK = {path = "lib/OrdinaryDiffEqExponentialRK"}
+OrdinaryDiffEqExtrapolation = {path = "lib/OrdinaryDiffEqExtrapolation"}
+OrdinaryDiffEqFIRK = {path = "lib/OrdinaryDiffEqFIRK"}
+OrdinaryDiffEqFeagin = {path = "lib/OrdinaryDiffEqFeagin"}
+OrdinaryDiffEqFunctionMap = {path = "lib/OrdinaryDiffEqFunctionMap"}
+OrdinaryDiffEqHighOrderRK = {path = "lib/OrdinaryDiffEqHighOrderRK"}
+OrdinaryDiffEqIMEXMultistep = {path = "lib/OrdinaryDiffEqIMEXMultistep"}
+OrdinaryDiffEqLinear = {path = "lib/OrdinaryDiffEqLinear"}
+OrdinaryDiffEqLowOrderRK = {path = "lib/OrdinaryDiffEqLowOrderRK"}
+OrdinaryDiffEqLowStorageRK = {path = "lib/OrdinaryDiffEqLowStorageRK"}
+OrdinaryDiffEqNonlinearSolve = {path = "lib/OrdinaryDiffEqNonlinearSolve"}
+OrdinaryDiffEqNordsieck = {path = "lib/OrdinaryDiffEqNordsieck"}
+OrdinaryDiffEqPDIRK = {path = "lib/OrdinaryDiffEqPDIRK"}
+OrdinaryDiffEqPRK = {path = "lib/OrdinaryDiffEqPRK"}
+OrdinaryDiffEqQPRK = {path = "lib/OrdinaryDiffEqQPRK"}
+OrdinaryDiffEqRKN = {path = "lib/OrdinaryDiffEqRKN"}
+OrdinaryDiffEqRosenbrock = {path = "lib/OrdinaryDiffEqRosenbrock"}
+OrdinaryDiffEqSDIRK = {path = "lib/OrdinaryDiffEqSDIRK"}
+OrdinaryDiffEqSSPRK = {path = "lib/OrdinaryDiffEqSSPRK"}
+OrdinaryDiffEqStabilizedIRK = {path = "lib/OrdinaryDiffEqStabilizedIRK"}
+OrdinaryDiffEqStabilizedRK = {path = "lib/OrdinaryDiffEqStabilizedRK"}
+OrdinaryDiffEqSymplecticRK = {path = "lib/OrdinaryDiffEqSymplecticRK"}
+OrdinaryDiffEqTsit5 = {path = "lib/OrdinaryDiffEqTsit5"}
+OrdinaryDiffEqVerner = {path = "lib/OrdinaryDiffEqVerner"}
 
 [compat]
 ADTypes = "1.16"
@@ -255,7 +197,6 @@ JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
 ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
-ParameterizedFunctions = "65888b18-ceab-5e60-b2b9-181511a3b968"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PoissonRandom = "e409e4f3-bfea-5376-8464-e040bb5c01ab"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -273,4 +214,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Calculus", "ComponentArrays", "Symbolics", "AlgebraicMultigrid", "IncompleteLU", "DiffEqCallbacks", "DifferentiationInterface", "DiffEqDevTools", "ODEProblemLibrary", "ElasticArrays", "ExplicitImports", "InteractiveUtils", "ParameterizedFunctions", "JLArrays", "PoissonRandom", "Printf", "Random", "ReverseDiff", "SafeTestsets", "SparseArrays", "Statistics", "StructArrays", "Test", "Unitful", "ModelingToolkit", "Pkg", "NLsolve", "RecursiveFactorization", "SparseConnectivityTracer", "SparseMatrixColorings"]
+test = ["Calculus", "ComponentArrays", "Symbolics", "AlgebraicMultigrid", "IncompleteLU", "DiffEqCallbacks", "DifferentiationInterface", "DiffEqDevTools", "ODEProblemLibrary", "ElasticArrays", "ExplicitImports", "InteractiveUtils", "JLArrays", "PoissonRandom", "Printf", "Random", "ReverseDiff", "SafeTestsets", "SparseArrays", "Statistics", "StructArrays", "Test", "Unitful", "ModelingToolkit", "Pkg", "NLsolve", "RecursiveFactorization", "SparseConnectivityTracer", "SparseMatrixColorings"]


### PR DESCRIPTION
## Summary
- Removes the ParameterizedFunctions.jl dependency from OrdinaryDiffEq.jl tests
- Replaces the `@ode_def` macro with standard Julia function definitions
- Maintains compatibility with both in-place and out-of-place ODE problems

## Changes
1. Replaced the `@ode_def Hires` macro in `test/interface/linear_solver_test.jl` with:
   - `hires!` function for in-place operations
   - `hires` function for out-of-place operations
2. Updated the functions to handle both Float64 and Float32 types properly
3. Removed ParameterizedFunctions from Project.toml dependencies and test targets

## Test plan
- [x] Verified the new functions work with FBDF solver
- [x] Tests pass for the Hires system with various solvers (QNDF, FBDF, Rodas5P)
- [x] Both Float64 and Float32 versions work correctly
- [x] Code formatted with JuliaFormatter using SciMLStyle

🤖 Generated with [Claude Code](https://claude.ai/code)