### PR TITLE
Remove PoissonRandom dependency from tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -257,7 +257,6 @@ NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
 ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
 ParameterizedFunctions = "65888b18-ceab-5e60-b2b9-181511a3b968"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-PoissonRandom = "e409e4f3-bfea-5376-8464-e040bb5c01ab"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecursiveFactorization = "f2c3362d-daeb-58d1-803e-2bc74f2840b4"
@@ -273,4 +272,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Calculus", "ComponentArrays", "Symbolics", "AlgebraicMultigrid", "IncompleteLU", "DiffEqCallbacks", "DifferentiationInterface", "DiffEqDevTools", "ODEProblemLibrary", "ElasticArrays", "ExplicitImports", "InteractiveUtils", "ParameterizedFunctions", "JLArrays", "PoissonRandom", "Printf", "Random", "ReverseDiff", "SafeTestsets", "SparseArrays", "Statistics", "StructArrays", "Test", "Unitful", "ModelingToolkit", "Pkg", "NLsolve", "RecursiveFactorization", "SparseConnectivityTracer", "SparseMatrixColorings"]
+test = ["Calculus", "ComponentArrays", "Symbolics", "AlgebraicMultigrid", "IncompleteLU", "DiffEqCallbacks", "DifferentiationInterface", "DiffEqDevTools", "ODEProblemLibrary", "ElasticArrays", "ExplicitImports", "InteractiveUtils", "ParameterizedFunctions", "JLArrays", "Printf", "Random", "ReverseDiff", "SafeTestsets", "SparseArrays", "Statistics", "StructArrays", "Test", "Unitful", "ModelingToolkit", "Pkg", "NLsolve", "RecursiveFactorization", "SparseConnectivityTracer", "SparseMatrixColorings"]

--- a/test/interface/enums.jl
+++ b/test/interface/enums.jl
@@ -1,4 +1,16 @@
-using OrdinaryDiffEq, PoissonRandom
+using OrdinaryDiffEq, Random
+
+# Simple Poisson random number generator using Knuth's algorithm
+function pois_rand(λ::Float64)
+    L = exp(-λ)
+    k = 0
+    p = 1.0
+    while p > L
+        k += 1
+        p *= rand()
+    end
+    return k - 1
+end
 
 function rate_to_proportion(r::Float64, t::Float64)
     1 - exp(-r * t)


### PR DESCRIPTION
## Summary
Removes the PoissonRandom.jl dependency from OrdinaryDiffEq.jl tests by replacing it with a simple built-in implementation.

## Changes
- Replaced `PoissonRandom.pois_rand` with a simple implementation using Knuth's algorithm
- Removed PoissonRandom from Project.toml dependencies and test targets
- Changed import from `using PoissonRandom` to `using Random` (standard library)

## Implementation Details
The replacement `pois_rand` function uses Knuth's algorithm, which is a standard method for generating Poisson-distributed random numbers:
- Simple and efficient for small to moderate λ values
- Uses only Julia's built-in `rand()` function
- Maintains the same interface as the original function

## Test Status
- [x] The modified test file runs without errors
- [x] No other files in the test suite use PoissonRandom

🤖 Generated with [Claude Code](https://claude.ai/code)