### PR TITLE
Remove Printf dependency from tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -258,7 +258,6 @@ ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
 ParameterizedFunctions = "65888b18-ceab-5e60-b2b9-181511a3b968"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PoissonRandom = "e409e4f3-bfea-5376-8464-e040bb5c01ab"
-Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecursiveFactorization = "f2c3362d-daeb-58d1-803e-2bc74f2840b4"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
@@ -273,4 +272,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Calculus", "ComponentArrays", "Symbolics", "AlgebraicMultigrid", "IncompleteLU", "DiffEqCallbacks", "DifferentiationInterface", "DiffEqDevTools", "ODEProblemLibrary", "ElasticArrays", "ExplicitImports", "InteractiveUtils", "ParameterizedFunctions", "JLArrays", "PoissonRandom", "Printf", "Random", "ReverseDiff", "SafeTestsets", "SparseArrays", "Statistics", "StructArrays", "Test", "Unitful", "ModelingToolkit", "Pkg", "NLsolve", "RecursiveFactorization", "SparseConnectivityTracer", "SparseMatrixColorings"]
+test = ["Calculus", "ComponentArrays", "Symbolics", "AlgebraicMultigrid", "IncompleteLU", "DiffEqCallbacks", "DifferentiationInterface", "DiffEqDevTools", "ODEProblemLibrary", "ElasticArrays", "ExplicitImports", "InteractiveUtils", "ParameterizedFunctions", "JLArrays", "PoissonRandom", "Random", "ReverseDiff", "SafeTestsets", "SparseArrays", "Statistics", "StructArrays", "Test", "Unitful", "ModelingToolkit", "Pkg", "NLsolve", "RecursiveFactorization", "SparseConnectivityTracer", "SparseMatrixColorings"]

--- a/test/regression/ode_dense_tests.jl
+++ b/test/regression/ode_dense_tests.jl
@@ -1,6 +1,6 @@
 using OrdinaryDiffEq, Test, DiffEqBase
 using OrdinaryDiffEqCore
-using ForwardDiff, Printf
+using ForwardDiff
 import ODEProblemLibrary: prob_ode_linear,
                           prob_ode_2Dlinear,
                           prob_ode_bigfloatlinear, prob_ode_bigfloat2Dlinear
@@ -8,7 +8,7 @@ import ODEProblemLibrary: prob_ode_linear,
 const PRINT_TESTS = false
 print_results(x) =
     if PRINT_TESTS
-        @printf("%s \n", x)
+        println(x)
     end
 
 # points and storage arrays used in the interpolation tests


### PR DESCRIPTION
## Summary
Removes the Printf standard library dependency from tests by replacing it with the built-in println function.

## Changes
- Replaced `@printf("%s \n", x)` with `println(x)` in test/regression/ode_dense_tests.jl
- Removed `using Printf` import
- Removed Printf from Project.toml test dependencies

## Rationale
Printf was only used in one location for conditional debug printing. The built-in println function provides the same functionality without requiring an additional dependency.

## Test Status
- [x] The modified function works identically to the original
- [x] Only affects debug output that is disabled by default (PRINT_TESTS = false)

🤖 Generated with [Claude Code](https://claude.ai/code)