### PR TITLE
Remove Calculus dependency from tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -242,7 +242,6 @@ julia = "1.10"
 
 [extras]
 AlgebraicMultigrid = "2169fc97-5a83-5252-b627-83903c6c433c"
-Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
@@ -273,4 +272,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Calculus", "ComponentArrays", "Symbolics", "AlgebraicMultigrid", "IncompleteLU", "DiffEqCallbacks", "DifferentiationInterface", "DiffEqDevTools", "ODEProblemLibrary", "ElasticArrays", "ExplicitImports", "InteractiveUtils", "ParameterizedFunctions", "JLArrays", "PoissonRandom", "Printf", "Random", "ReverseDiff", "SafeTestsets", "SparseArrays", "Statistics", "StructArrays", "Test", "Unitful", "ModelingToolkit", "Pkg", "NLsolve", "RecursiveFactorization", "SparseConnectivityTracer", "SparseMatrixColorings"]
+test = ["ComponentArrays", "Symbolics", "AlgebraicMultigrid", "IncompleteLU", "DiffEqCallbacks", "DifferentiationInterface", "DiffEqDevTools", "ODEProblemLibrary", "ElasticArrays", "ExplicitImports", "InteractiveUtils", "ParameterizedFunctions", "JLArrays", "PoissonRandom", "Printf", "Random", "ReverseDiff", "SafeTestsets", "SparseArrays", "Statistics", "StructArrays", "Test", "Unitful", "ModelingToolkit", "Pkg", "NLsolve", "RecursiveFactorization", "SparseConnectivityTracer", "SparseMatrixColorings"]

--- a/test/enzyme/autodiff_events.jl
+++ b/test/enzyme/autodiff_events.jl
@@ -1,5 +1,5 @@
 using SciMLSensitivity
-using OrdinaryDiffEq, OrdinaryDiffEqCore, Calculus, Test
+using OrdinaryDiffEq, OrdinaryDiffEqCore, FiniteDiff, Test
 using Zygote
 
 function f(du, u, p, t)
@@ -26,7 +26,7 @@ function test_f(p)
     solve(_prob, Tsit5(), abstol = 1e-14, reltol = 1e-14, callback = cb,
     save_everystep = false).u[end]
 end
-findiff = Calculus.finite_difference_jacobian(test_f, p)
+findiff = FiniteDiff.finite_difference_jacobian(test_f, p)
 findiff
 
 using ForwardDiff

--- a/test/interface/ad_tests.jl
+++ b/test/interface/ad_tests.jl
@@ -1,5 +1,5 @@
 using Test
-using OrdinaryDiffEq, OrdinaryDiffEqCore, Calculus, ForwardDiff, FiniteDiff, LinearAlgebra, ADTypes, DifferentiationInterface
+using OrdinaryDiffEq, OrdinaryDiffEqCore, ForwardDiff, FiniteDiff, LinearAlgebra, ADTypes, DifferentiationInterface
 
 function f(du, u, p, t)
     du[1] = -p[1]
@@ -21,7 +21,7 @@ for x in 0:0.001:5
     end
     p = [2.0, x]
     called = false
-    findiff = Calculus.finite_difference_jacobian(test_f, p)
+    findiff = FiniteDiff.finite_difference_jacobian(test_f, p)
     @test called
     called = false
     fordiff = ForwardDiff.jacobian(test_f, p)
@@ -48,7 +48,7 @@ for x in 2.1:0.001:5
         solve!(integrator).u[end]
     end
     p = [2.0, x]
-    findiff = Calculus.finite_difference_jacobian(test_f2, p)
+    findiff = FiniteDiff.finite_difference_jacobian(test_f2, p)
     @test called
     called = false
     fordiff = ForwardDiff.jacobian(test_f2, p)
@@ -70,7 +70,7 @@ function test_f2(p)
 end
 
 p = [2.0, x]
-findiff = Calculus.finite_difference_jacobian(test_f2,p)
+findiff = FiniteDiff.finite_difference_jacobian(test_f2,p)
 @test called
 called = false
 fordiff = ForwardDiff.jacobian(test_f2,p)
@@ -106,7 +106,7 @@ for x in 1.0:0.001:2.5
         solve!(integrator).u[end]
     end
 
-    findiff = Calculus.finite_difference_jacobian(test_lotka, p)
+    findiff = FiniteDiff.finite_difference_jacobian(test_lotka, p)
     @test called
     called = false
     fordiff = ForwardDiff.jacobian(test_lotka, p)


### PR DESCRIPTION
## Summary
Removes the Calculus.jl test dependency by replacing it with FiniteDiff.jl, which is already a main dependency of OrdinaryDiffEq.

## Changes
- Replaced `Calculus.finite_difference_jacobian` with `FiniteDiff.finite_difference_jacobian` in:
  - test/interface/ad_tests.jl
  - test/enzyme/autodiff_events.jl
- Removed Calculus from Project.toml test dependencies

## Rationale
- FiniteDiff is already a main dependency of OrdinaryDiffEq (used internally)
- Both packages provide finite difference Jacobian functionality
- Removing Calculus reduces the number of test-only dependencies

## Test Status
- [x] The functions are drop-in replacements with the same interface
- [x] Both test files use the same pattern for finite difference Jacobian calculation

🤖 Generated with [Claude Code](https://claude.ai/code)