### PR TITLE
Move ModelingToolkit to test group specific dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -131,7 +131,6 @@ LinearAlgebra = "1.9"
 LinearSolve = "3.27"
 Logging = "1.9"
 MacroTools = "0.5.16"
-ModelingToolkit = "10.10"
 MuladdMacro = "0.2.4"
 NonlinearSolve = "4.10"
 OrdinaryDiffEqAdamsBashforthMoulton = "1.4.0"
@@ -211,4 +210,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["ComponentArrays", "Symbolics", "AlgebraicMultigrid", "IncompleteLU", "DiffEqCallbacks", "DifferentiationInterface", "DiffEqDevTools", "ODEProblemLibrary", "ElasticArrays", "ExplicitImports", "InteractiveUtils", "JLArrays", "Random", "ReverseDiff", "SafeTestsets", "SparseArrays", "Statistics", "StructArrays", "Test", "Unitful", "ModelingToolkit", "Pkg", "NLsolve", "RecursiveFactorization", "SparseConnectivityTracer", "SparseMatrixColorings"]
+test = ["ComponentArrays", "Symbolics", "AlgebraicMultigrid", "IncompleteLU", "DiffEqCallbacks", "DifferentiationInterface", "DiffEqDevTools", "ODEProblemLibrary", "ElasticArrays", "ExplicitImports", "InteractiveUtils", "JLArrays", "Random", "ReverseDiff", "SafeTestsets", "SparseArrays", "Statistics", "StructArrays", "Test", "Unitful", "Pkg", "NLsolve", "RecursiveFactorization", "SparseConnectivityTracer", "SparseMatrixColorings"]

--- a/test/modelingtoolkit/Project.toml
+++ b/test/modelingtoolkit/Project.toml
@@ -1,0 +1,17 @@
+[deps]
+DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
+ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
+NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+OrdinaryDiffEqBDF = "6ad6398a-0878-4a85-9266-38940aa047c8"
+OrdinaryDiffEqNonlinearSolve = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
+OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+DiffEqDevTools = "2"
+ModelingToolkit = "10.10"
+NonlinearSolve = "4.10"
+OrdinaryDiffEqBDF = "1"
+OrdinaryDiffEqNonlinearSolve = "1"
+OrdinaryDiffEqSDIRK = "1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,12 @@ function activate_enzyme_env()
     Pkg.instantiate()
 end
 
+function activate_modelingtoolkit_env()
+    Pkg.activate("modelingtoolkit")
+    Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    Pkg.instantiate()
+end
+
 #Start Test Script
 
 @time begin
@@ -151,6 +157,7 @@ end
     end
 
     if !is_APPVEYOR && GROUP == "ModelingToolkit"
+        activate_modelingtoolkit_env()
         @time @safetestset "NLStep Tests" include("modelingtoolkit/nlstep_tests.jl")
         @time @safetestset "Jacobian Tests" include("modelingtoolkit/jacobian_tests.jl")
         @time @safetestset "Preconditioner Tests" include("modelingtoolkit/preconditioners.jl")


### PR DESCRIPTION
## Summary
This PR moves ModelingToolkit from being a general test dependency to a test group specific dependency, following the pattern used by other test groups like `downstream`, `gpu`, `enzyme`, and `odeinterface`.

## Changes
- Removed ModelingToolkit from main `Project.toml` test targets
- Removed ModelingToolkit from main `Project.toml` compat section  
- Created `test/modelingtoolkit/Project.toml` with ModelingToolkit as a dependency
- Added `activate_modelingtoolkit_env()` function to `test/runtests.jl`
- Updated ModelingToolkit test group to use the activation function

## Motivation
This change reduces the dependency load for general test runs while maintaining ModelingToolkit availability for its specific test group. This follows the established pattern in OrdinaryDiffEq.jl where test groups with heavy dependencies have their own Project.toml files.

## Test plan
- [x] Verified ModelingToolkit test group runs successfully with the new structure
- [ ] CI tests should pass for all test groups

🤖 Generated with [Claude Code](https://claude.ai/code)