### PR TITLE
Remove redundant test dependencies from sublibraries

### DIFF
--- a/lib/OrdinaryDiffEqAdamsBashforthMoulton/Project.toml
+++ b/lib/OrdinaryDiffEqAdamsBashforthMoulton/Project.toml
@@ -23,7 +23,6 @@ DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
-DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [compat]

--- a/lib/OrdinaryDiffEqBDF/Project.toml
+++ b/lib/OrdinaryDiffEqBDF/Project.toml
@@ -33,7 +33,6 @@ LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
@@ -72,7 +71,7 @@ Reexport = "1.2"
 SafeTestsets = "0.1.0"
 
 [targets]
-test = ["DiffEqDevTools", "ForwardDiff", "Random", "SafeTestsets", "Test", "ODEProblemLibrary", "NonlinearSolve", "StaticArrays", "Enzyme", "LinearSolve", "JET", "Aqua", "AllocCheck"]
+test = ["DiffEqDevTools", "ForwardDiff", "Random", "SafeTestsets", "Test", "ODEProblemLibrary", "NonlinearSolve", "Enzyme", "LinearSolve", "JET", "Aqua", "AllocCheck"]
 
 [sources.OrdinaryDiffEqSDIRK]
 path = "../OrdinaryDiffEqSDIRK"

--- a/lib/OrdinaryDiffEqExtrapolation/Project.toml
+++ b/lib/OrdinaryDiffEqExtrapolation/Project.toml
@@ -24,7 +24,6 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
-DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [compat]

--- a/lib/OrdinaryDiffEqRosenbrock/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrock/Project.toml
@@ -25,12 +25,9 @@ DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [extras]
-ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
-LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
@@ -72,7 +69,7 @@ Reexport = "1.2"
 SafeTestsets = "0.1.0"
 
 [targets]
-test = ["DiffEqDevTools", "Random", "OrdinaryDiffEqNonlinearSolve", "SafeTestsets", "Test", "LinearAlgebra", "LinearSolve", "ForwardDiff", "ODEProblemLibrary", "Enzyme", "JET", "Aqua", "AllocCheck"]
+test = ["DiffEqDevTools", "Random", "OrdinaryDiffEqNonlinearSolve", "SafeTestsets", "Test", "ODEProblemLibrary", "Enzyme", "JET", "Aqua", "AllocCheck"]
 
 [sources.OrdinaryDiffEqDifferentiation]
 path = "../OrdinaryDiffEqDifferentiation"


### PR DESCRIPTION
## Summary
This PR removes test dependencies from lib/ subpackages that are redundantly listed in the `[extras]` section when they are already present in the main `[deps]` section.

## Changes
Removed redundant test dependencies from the following sublibraries:

### OrdinaryDiffEqAdamsBashforthMoulton
- Removed `DiffEqBase` from extras (already in deps)

### OrdinaryDiffEqBDF  
- Removed `StaticArrays` from extras (already in deps)

### OrdinaryDiffEqExtrapolation
- Removed `DiffEqBase` from extras (already in deps)

### OrdinaryDiffEqRosenbrock
- Removed `ForwardDiff` from extras (already in deps)
- Removed `LinearSolve` from extras (already in deps)
- Removed `LinearAlgebra` from extras (already in deps)

## Rationale
Packages that are already in the `[deps]` section are automatically available during testing and don't need to be duplicated in `[extras]`. This simplifies dependency management and reduces potential version conflicts.

## Related
This follows up on #2849 which did similar cleanup for the main OrdinaryDiffEq.jl package.

## Test plan
- [ ] Tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)