### PR TITLE
Remove Symbolics from test dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -206,4 +206,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["ComponentArrays", "Symbolics", "AlgebraicMultigrid", "IncompleteLU", "DiffEqCallbacks", "DifferentiationInterface", "DiffEqDevTools", "ODEProblemLibrary", "ElasticArrays", "JLArrays", "Random", "SafeTestsets", "StructArrays", "Test", "Unitful", "Pkg", "NLsolve", "RecursiveFactorization", "SparseConnectivityTracer", "SparseMatrixColorings", "Statistics"]
+test = ["ComponentArrays", "AlgebraicMultigrid", "IncompleteLU", "DiffEqCallbacks", "DifferentiationInterface", "DiffEqDevTools", "ODEProblemLibrary", "ElasticArrays", "JLArrays", "Random", "SafeTestsets", "StructArrays", "Test", "Unitful", "Pkg", "NLsolve", "RecursiveFactorization", "SparseConnectivityTracer", "SparseMatrixColorings", "Statistics"]


### PR DESCRIPTION
## Summary
- Removes Symbolics from the main test target to avoid dependency conflicts
- Replaces `Symbolics.jacobian_sparsity` with a hardcoded sparsity pattern in the one test that used it

## Motivation
The symbolic stack (Symbolics/DynamicPolynomials/MultivariatePolynomials) creates dependency conflicts when trying to use newer versions of DataStructures (v0.19) and other packages. This is blocking updates across the ecosystem.

## Changes
1. Removed `Symbolics` from the test target in Project.toml
2. Modified `test/interface/nonfulldiagonal_sparse.jl` to use a hardcoded sparsity pattern instead of computing it with `Symbolics.jacobian_sparsity`

The hardcoded sparsity pattern was pre-computed using the exact same `Symbolics.jacobian_sparsity` function, so the test behavior is identical.

## Test plan
- [x] Verified the modified test runs successfully without Symbolics
- [x] Package dependencies resolve without conflicts
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)