### PR TITLE
Specialize more functions on f parameter for trim compatibility

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/dense/generic_dense.jl
+++ b/lib/OrdinaryDiffEqCore/src/dense/generic_dense.jl
@@ -477,17 +477,17 @@ end
     return expr
 end
 
-function _evaluate_interpolant(f, Θ, dt, timeseries, i₋, i₊,
+function _evaluate_interpolant(f::F, Θ, dt, timeseries, i₋, i₊,
         cache, idxs,
-        deriv, ks, ts, p, differential_vars)
+        deriv, ks, ts, p, differential_vars) where F
     _ode_addsteps!(ks[i₊], ts[i₋], timeseries[i₋], timeseries[i₊], dt, f, p,
         cache) # update the kcurrent
     return ode_interpolant(Θ, dt, timeseries[i₋], timeseries[i₊], ks[i₊],
         cache, idxs, deriv, differential_vars)
 end
-function evaluate_composite_cache(f, Θ, dt, timeseries, i₋, i₊,
+function evaluate_composite_cache(f::F, Θ, dt, timeseries, i₋, i₊,
         caches::Tuple{C1, C2, Vararg}, idxs,
-        deriv, ks, ts, p, cacheid, differential_vars) where {C1, C2}
+        deriv, ks, ts, p, cacheid, differential_vars) where {F, C1, C2}
     if (cacheid -= 1) != 0
         return evaluate_composite_cache(f, Θ, dt, timeseries, i₋, i₊, Base.tail(caches),
             idxs,
@@ -497,16 +497,16 @@ function evaluate_composite_cache(f, Θ, dt, timeseries, i₋, i₊,
         first(caches), idxs,
         deriv, ks, ts, p, differential_vars)
 end
-function evaluate_composite_cache(f, Θ, dt, timeseries, i₋, i₊,
+function evaluate_composite_cache(f::F, Θ, dt, timeseries, i₋, i₊,
         caches::Tuple{C}, idxs,
-        deriv, ks, ts, p, _, differential_vars) where {C}
+        deriv, ks, ts, p, _, differential_vars) where {F, C}
     _evaluate_interpolant(f, Θ, dt, timeseries, i₋, i₊,
         only(caches), idxs,
         deriv, ks, ts, p, differential_vars)
 end
 
-function evaluate_default_cache(f, Θ, dt, timeseries, i₋, i₊,
-        cache::DefaultCache, idxs, deriv, ks, ts, p, cacheid, differential_vars)
+function evaluate_default_cache(f::F, Θ, dt, timeseries, i₋, i₊,
+        cache::DefaultCache, idxs, deriv, ks, ts, p, cacheid, differential_vars) where F
     if cacheid == 1
         return _evaluate_interpolant(f, Θ, dt, timeseries, i₋, i₊,
             cache.cache1, idxs, deriv, ks, ts, p, differential_vars)
@@ -528,8 +528,8 @@ function evaluate_default_cache(f, Θ, dt, timeseries, i₋, i₊,
     end
 end
 
-function evaluate_interpolant(f, Θ, dt, timeseries, i₋, i₊, cache, idxs,
-        deriv, ks, ts, id, p, differential_vars)
+function evaluate_interpolant(f::F, Θ, dt, timeseries, i₋, i₊, cache, idxs,
+        deriv, ks, ts, id, p, differential_vars) where F
     if isdiscretecache(cache)
         return ode_interpolant(Θ, dt, timeseries[i₋], timeseries[i₊], 0, cache, idxs,
             deriv, differential_vars)

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -324,7 +324,7 @@ mutable struct WOperator{IIP, T,
             jacvec)
     end
 end
-function WOperator{IIP}(f, u, gamma) where {IIP}
+function WOperator{IIP}(f::F, u, gamma) where {IIP, F}
     if isa(f, Union{SplitFunction, DynamicalODEFunction})
         error("WOperator does not support $(typeof(f)) yet")
     end
@@ -440,7 +440,7 @@ islinearfunction(integrator) = islinearfunction(integrator.f, integrator.alg)
 
 return the tuple `(is_linear_wrt_odealg, islinearodefunction)`.
 """
-function islinearfunction(f, alg)::Tuple{Bool, Bool}
+function islinearfunction(f::F, alg)::Tuple{Bool, Bool} where F
     isode = f isa ODEFunction && islinear(f.f)
     islin = isode || (issplit(alg) && f isa SplitFunction && islinear(f.f1.f))
     return islin, isode

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_wrappers.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_wrappers.jl
@@ -136,7 +136,7 @@ function jacobian(f::F, x::AbstractArray{<:Number}, integrator) where F
 end
 
 # fallback for scalar x, is needed for calc_J to work
-function jacobian(f, x, integrator)
+function jacobian(f::F, x, integrator) where F
     alg = unwrap_alg(integrator, true)
 
     dense = ADTypes.dense_ad(alg_autodiff(alg))
@@ -393,7 +393,7 @@ function build_grad_config(alg, f::F1, tf::F2, du1, t) where {F1, F2}
     end
 end
 
-function sparsity_colorvec(f, x)
+function sparsity_colorvec(f::F, x) where F
     sparsity = f.sparsity
 
     if is_sparse_csc(sparsity)

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -330,7 +330,7 @@ function compute_ustep!(ustep, tmp, γ, z, method)
     ustep
 end
 
-function _compute_rhs(tmp, γ, α, tstep, invγdt, method::MethodType, p, dt, f, z)
+function _compute_rhs(tmp, γ, α, tstep, invγdt, method::MethodType, p, dt, f::F, z) where F
     mass_matrix = f.mass_matrix
     ustep = compute_ustep(tmp, γ, z, method)
     if method === COEFFICIENT_MULTISTEP

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -71,7 +71,7 @@ mutable struct DAEResidualJacobianWrapper{isAD, F, pType, duType, uType, alphaTy
     tmp::tmpType
     uprev::uprevType
     t::tType
-    function DAEResidualJacobianWrapper(alg, f, p, α, invγdt, tmp, uprev, t)
+    function DAEResidualJacobianWrapper(alg, f::F, p, α, invγdt, tmp, uprev, t) where F
         ad = ADTypes.dense_ad(alg_autodiff(alg)) 
         isautodiff = ad isa AutoForwardDiff 
         if isautodiff

--- a/lib/OrdinaryDiffEqSymplecticRK/src/symplectic_perform_step.jl
+++ b/lib/OrdinaryDiffEqSymplecticRK/src/symplectic_perform_step.jl
@@ -77,22 +77,22 @@ end
 # f.f2(p, q, pa, t) = p which is the Newton/Lagrange equations
 # If called with different functions (which are possible in the Hamiltonian case)
 # an exception is thrown to avoid silently calculate wrong results.
-function verify_f2(f, p, q, pa, t, ::Any,
-        ::C) where {C <: Union{HamiltonConstantCache, VerletLeapfrogConstantCache,
+function verify_f2(f::F, p, q, pa, t, ::Any,
+        ::C) where {F, C <: Union{HamiltonConstantCache, VerletLeapfrogConstantCache,
         LeapfrogDriftKickDriftConstantCache}}
     f(p, q, pa, t)
 end
-function verify_f2(f, res, p, q, pa, t, ::Any,
-        ::C) where {C <: Union{HamiltonMutableCache, VerletLeapfrogCache,
+function verify_f2(f::F, res, p, q, pa, t, ::Any,
+        ::C) where {F, C <: Union{HamiltonMutableCache, VerletLeapfrogCache,
         LeapfrogDriftKickDriftCache}}
     f(res, p, q, pa, t)
 end
 
-function verify_f2(f, p, q, pa, t, integrator, ::C) where {C <: VelocityVerletConstantCache}
+function verify_f2(f::F, p, q, pa, t, integrator, ::C) where {F, C <: VelocityVerletConstantCache}
     res = f(p, q, pa, t)
     res == p ? p : throwex(integrator)
 end
-function verify_f2(f, res, p, q, pa, t, integrator, ::C) where {C <: VelocityVerletCache}
+function verify_f2(f::F, res, p, q, pa, t, integrator, ::C) where {F, C <: VelocityVerletCache}
     f(res, p, q, pa, t)
     res == p ? res : throwex(integrator)
 end


### PR DESCRIPTION
## Summary

Similar to #2854, this PR adds type specialization for the `f` parameter in several functions across OrdinaryDiffEq.jl to improve compatibility with `--trim` and reduce dynamic dispatch.

## Functions specialized

- `jacobian` scalar fallback in `derivative_wrappers.jl:139`
- `sparsity_colorvec` in `derivative_wrappers.jl:396`  
- `WOperator` constructor in `derivative_utils.jl:327`
- `islinearfunction` in `derivative_utils.jl:443`
- `_compute_rhs` in `newton.jl:333`
- `DAEResidualJacobianWrapper` constructor in `utils.jl:74`
- Interpolation functions in `generic_dense.jl`:
  - `_evaluate_interpolant` (line 480)
  - `evaluate_composite_cache` (lines 488, 500)
  - `evaluate_default_cache` (line 508)
  - `evaluate_interpolant` (line 531)
- `verify_f2` functions in `symplectic_perform_step.jl` (lines 80, 85, 91, 95)

## Rationale

These functions all either:
- Call `f` directly as a function
- Access fields of `f` 
- Pass `f` to other functions
- Perform type checks on `f`

Adding `where F` type parameters enables better compiler optimizations and reduces dynamic dispatch, similar to what was done in PR #2854.

## Testing

The package compiles and loads successfully with these changes.