### PR TITLE
Bump OrdinaryDiffEqCore to v1.36.1 to fix CI cache invalidation

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "1.36.0"
+version = "1.36.1"
 
 [deps]
 SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"


### PR DESCRIPTION
## Summary

Bumps OrdinaryDiffEqCore version from 1.36.0 to 1.36.1 to resolve CI test failures caused by stale precompilation cache.

## Problem

Multiple CI workflows (CI, Downgrade, IntegrationTest) are failing with:
```
ERROR: UndefVarError: `OverrideInit` not defined in `OrdinaryDiffEqCore`
```

Investigation showed this is due to stale precompilation cache in CI. Recent changes in PR #2885 modified `initialize_dae.jl` type signatures but did not bump the package version, causing Julia's precompilation system to use cached versions that don't reflect the current code state.

## Solution

Version bump from 1.36.0 to 1.36.1 will:
- Invalidate the CI cache (keyed on `hashFiles('**/Project.toml')`)
- Force recompilation of OrdinaryDiffEqCore with latest changes
- Resolve the `OverrideInit` undefined errors

## Verification

Local testing after clearing cache (`rm -rf ~/.julia/compiled/v1.11/OrdinaryDiffEqCore`) confirmed all tests pass with fresh compilation.

## Related

- Fixes failures in workflows: CI, Downgrade, Downgrade Sublibraries, IntegrationTest
- Related to PR #2885 (Expand integrators for _initialize_dae!)
- Related to PR #2884 (Update accepted_kwargs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)