### PR TITLE
Fix codecov action parameter deprecation warning

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,5 +92,5 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: lcov.info
+          files: lcov.info
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary

This PR fixes a deprecation warning in the GitHub Actions workflow for codecov.

## Changes

- Changed deprecated `file` parameter to `files` in `codecov-action@v5` configuration

## Details

The codecov-action@v5 no longer accepts `file` as a parameter name. The correct parameter is `files`. This was causing warnings in all CI test jobs:

```
##[warning]Unexpected input(s) 'file', valid inputs are [...'files'...]
```

## Testing

This change is purely a configuration update and doesn't affect code functionality. The CI will validate that codecov still works correctly with the updated parameter.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>