### PR TITLE
Update link targets to minimize redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ prob = ODEProblem(lorenz, u0, tspan)
 sol = solve(prob, Tsit5())
 ```
 
-For "refined ODEs", like dynamical equations and `SecondOrderODEProblem`s, refer to the [DiffEqDocs](https://diffeq.sciml.ai/dev/types/ode_types/). For example, in [DiffEqTutorials.jl](https://github.com/SciML/DiffEqTutorials.jl) we show how to solve equations of motion using symplectic methods:
+For "refined ODEs", like dynamical equations and `SecondOrderODEProblem`s, refer to the [DiffEqDocs](https://diffeq.sciml.ai/dev/types/ode_types/). For example, in [DiffEqTutorials.jl](https://github.com/SciML/SciMLTutorials.jl) we show how to solve equations of motion using symplectic methods:
 
 ```julia
 function HH_acceleration!(dv, v, u, p, t)
@@ -91,4 +91,4 @@ Other refined forms are IMEX and semi-linear ODEs (for exponential integrators).
 
 ## Available Solvers
 
-For the list of available solvers, please refer to the [DifferentialEquations.jl ODE Solvers](https://diffeq.sciml.ai/dev/solvers/ode_solve/), [Dynamical ODE Solvers](http://diffeq.sciml.ai/dev/solvers/dynamical_solve/), and the [Split ODE Solvers](http://diffeq.sciml.ai/dev/solvers/split_ode_solve/) pages.
+For the list of available solvers, please refer to the [DifferentialEquations.jl ODE Solvers](https://diffeq.sciml.ai/dev/solvers/ode_solve/), [Dynamical ODE Solvers](https://diffeq.sciml.ai/dev/solvers/dynamical_solve/), and the [Split ODE Solvers](https://diffeq.sciml.ai/dev/solvers/split_ode_solve/) pages.

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -45,7 +45,7 @@ prob = ODEProblem(lorenz, u0, tspan)
 sol = solve(prob, Tsit5())
 ```
 
-For “refined ODEs”, like dynamical equations and `SecondOrderODEProblem`s, refer to the [DiffEqDocs](https://diffeq.sciml.ai/dev/types/ode_types/). For example, in [DiffEqTutorials.jl](https://github.com/SciML/DiffEqTutorials.jl) we show how to solve equations of motion using symplectic methods:
+For “refined ODEs”, like dynamical equations and `SecondOrderODEProblem`s, refer to the [DiffEqDocs](https://diffeq.sciml.ai/dev/types/ode_types/). For example, in [DiffEqTutorials.jl](https://github.com/SciML/SciMLTutorials.jl) we show how to solve equations of motion using symplectic methods:
 
 ```julia
 function HH_acceleration(dv, v, u, p, t)
@@ -64,4 +64,4 @@ Other refined forms are IMEX and semi-linear ODEs (for exponential integrators).
 
 ## Available Solvers
 
-For the list of available solvers, please refer to the [DifferentialEquations.jl ODE Solvers](https://diffeq.sciml.ai/dev/solvers/ode_solve/), [Dynamical ODE Solvers](http://diffeq.sciml.ai/dev/solvers/dynamical_solve/), and the [Split ODE Solvers](http://diffeq.sciml.ai/dev/solvers/split_ode_solve/) pages.
+For the list of available solvers, please refer to the [DifferentialEquations.jl ODE Solvers](https://diffeq.sciml.ai/dev/solvers/ode_solve/), [Dynamical ODE Solvers](https://diffeq.sciml.ai/dev/solvers/dynamical_solve/), and the [Split ODE Solvers](https://diffeq.sciml.ai/dev/solvers/split_ode_solve/) pages.


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

- Reflect name change of DiffEqTutorials → SciMLTutorials
- Use 'https://' instead of 'http://'

This isn't any sort of urgent thing, it's just a byproduct of trying to debug a build in DiffEqDocs.jl