### PR TITLE
Prevent rationalization in QNDF

### DIFF
--- a/lib/OrdinaryDiffEqBDF/src/bdf_caches.jl
+++ b/lib/OrdinaryDiffEqBDF/src/bdf_caches.jl
@@ -380,7 +380,7 @@ function alg_cache(alg::QNDF{MO}, u, rate_prototype, ::Type{uEltypeNoUnits},
     end
     U = SArray(U)
 
-    γₖ = SVector(ntuple(k -> sum(tTypeNoUnits(Int64(1) // j) for j in 1:k), Val(max_order)))
+    γₖ = SVector(ntuple(k -> sum(Int64(1) // j for j in 1:k), Val(max_order)))
 
     QNDFConstantCache(nlsolver, U, D, prevD, 1, 1, Val(max_order), dtprev, 0, 0, EEst1,
         EEst2, γₖ)
@@ -459,7 +459,7 @@ function alg_cache(alg::QNDF{MO}, u, rate_prototype, ::Type{uEltypeNoUnits},
     U = SArray(U)
 
     RU = Matrix(U)
-    γₖ = SVector(ntuple(k -> sum(tTypeNoUnits(Int64(1) // j) for j in 1:k), Val(max_order)))
+    γₖ = SVector(ntuple(k -> sum(Int64(1) // j for j in 1:k), Val(max_order)))
 
     QNDFCache(fsalfirst, dd, utilde, utildem1, utildep1, ϕ, u₀, nlsolver, U, RU, D, Dtmp,
         tmp2, prevD, 1, 1, Val(max_order), dtprev, 0, 0, EEst1, EEst2, γₖ, atmp,


### PR DESCRIPTION
This fixes https://github.com/SciML/OrdinaryDiffEq.jl/issues/2921 because `γₖ` now remain rational, and are not converted to floats due to the `tTypeNoUnits` conversion.

I don't know whether this is ok. Why do only BDF/NDF methods do this `tTypeNoUnits` conversion when constructing their cache? Can I also remove all the other `tTypeNoUnits` conversions in the same file?