### PR TITLE
Fix JET version resolution in CI tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,7 +40,7 @@ end
 @time begin
     if contains(GROUP, "OrdinaryDiffEq") || GROUP == "ImplicitDiscreteSolve" || GROUP == "SimpleImplicitDiscreteSolve"
         Pkg.activate(joinpath(dirname(@__DIR__), "lib", GROUP))
-        Pkg.test(GROUP, julia_args=["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version=false, allow_reresolve=true)
+        Pkg.test(GROUP, julia_args=["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version=true, allow_reresolve=true)
     elseif GROUP == "All" || GROUP == "InterfaceI" || GROUP == "Interface"
         @time @safetestset "Discrete Algorithm Tests" include("interface/discrete_algorithm_test.jl")
         @time @safetestset "Tstops Tests" include("interface/ode_tstops_tests.jl")


### PR DESCRIPTION
## Summary

Fix JET test failures on Julia 1.12 by changing `force_latest_compatible_version=false` to `true` in `Pkg.test()` calls.

## Problem

CI tests on Julia 1.12 are failing with:
```
ERROR: LoadError: UndefVarError: `LineInfoNode` not defined in `JET`
@ ~/.julia/packages/JET/sABei/src/JETBase.jl:202
```

This occurs because:
1. JET v0.9.20 is incompatible with Julia 1.12 (has `LineInfoNode` error)
2. JET v0.11+ is required for Julia 1.12
3. CI runners have cached Manifest.toml files with JET v0.9.20 locked
4. `Pkg.test(; force_latest_compatible_version=false)` respects these old Manifest locks

## Solution

Change `force_latest_compatible_version=false` to `force_latest_compatible_version=true` in test/runtests.jl:43.

This ensures CI always uses the latest compatible versions of test dependencies, preventing stale Manifest locks from causing incompatibility errors.

## Testing

Local testing confirms:
- With fresh environment: `Pkg.test(; force_latest_compatible_version=false)` correctly selects JET v0.11.2
- With `force_latest_compatible_version=true`: Always uses latest compatible versions regardless of cached Manifests
- JET v0.11.2 installs and works correctly on Julia 1.12

## Related

- PR #2940 revealed this issue by testing master with Julia 1.12
- Compat entries are correct: `JET = "0.9, 0.11"` allows both versions
- The issue is purely with cached Manifest resolution, not package compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)