### PR TITLE
Add disable_safe_directory to codecov action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -100,3 +100,4 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: false
+          disable_safe_directory: true

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -28,3 +28,4 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: lcov.info
           fail_ci_if_error: true
+          disable_safe_directory: true

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -70,3 +70,4 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: false
+          disable_safe_directory: true


### PR DESCRIPTION
## Summary
- Adds `disable_safe_directory: true` to codecov-action in CI.yml, Downstream.yml, and Documentation.yml
- Prevents codecov from running `git config --global --add safe.directory` which causes lock file errors on self-hosted runners

## Problem
The CI was failing with:
```
error: could not lock config file /home/chrisrackauckas/.gitconfig: File exists
Error: Process completed with exit code 255.
```

This happens when multiple jobs run concurrently on self-hosted runners and compete for the global gitconfig lock file.

## Test plan
- [ ] CI passes without gitconfig lock errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)