### PR TITLE
docs: clarify ESDIRK methods do not support SplitODEProblem

### DIFF
--- a/docs/src/implicit/SDIRK.md
+++ b/docs/src/implicit/SDIRK.md
@@ -80,11 +80,26 @@ Kvaerno5
 
 ### IMEX SDIRK
 
+These methods support `SplitODEProblem` for implicit-explicit (IMEX) integration,
+where the stiff part is treated implicitly and the non-stiff part is treated explicitly.
+
 ```@docs
 KenCarp4
 KenCarp47
 KenCarp5
 KenCarp58
+```
+
+### Higher-Order ESDIRK
+
+Higher-order ESDIRK (Explicit first stage Singly Diagonally Implicit Runge-Kutta) methods.
+These are high-order L-stable implicit methods where the first stage is explicit.
+
+!!! note
+    These methods do not support `SplitODEProblem`. For IMEX integration with split
+    problems, use the KenCarp methods above instead.
+
+```@docs
 ESDIRK54I8L2SA
 ESDIRK436L2SA2
 ESDIRK437L2SA


### PR DESCRIPTION
## Summary

- Move ESDIRK methods out of the "IMEX SDIRK" section into a separate "Higher-Order ESDIRK" section
- Add explicit note that ESDIRK methods do not support `SplitODEProblem`
- Clarify that KenCarp methods are the ones that support IMEX via `SplitODEProblem`

## Problem

The documentation lists ESDIRK methods (ESDIRK54I8L2SA, ESDIRK436L2SA2, ESDIRK437L2SA, ESDIRK547L2SA2, ESDIRK659L2SA) under the "IMEX SDIRK" section, implying they support split ODE problems. However, the implementations in `sdirk_perform_step.jl` do not have `SplitFunction` handling - they treat the entire RHS implicitly.

In contrast, KenCarp methods in `kencarp_kvaerno_perform_step.jl` explicitly check for `integrator.f isa SplitFunction` and apply the explicit coefficients to the explicit part.

This was identified in practical usage when users at Trixi.jl noticed that ESDIRK methods had far more RHS evaluations than expected for IMEX problems, revealing that the entire problem was being treated implicitly rather than as a split IMEX problem.

See discussion at https://github.com/trixi-framework/Trixi.jl/pull/2518#discussion_r2544853826

## Test plan

- [ ] Verify documentation builds correctly
- [ ] Review rendered documentation to ensure clarity

Fixes #2910

🤖 Generated with [Claude Code](https://claude.com/claude-code)