### PR TITLE
Optimize sparse mass matrix algebraic detection from O(n²) to O(nnz)

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -23,6 +23,7 @@ PreallocationTools = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 SciMLStructures = "53ae85a6-f571-4167-b2af-e1d143709226"
 SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [extras]
 LineSearches = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
@@ -67,6 +68,7 @@ DiffEqBase = "6.190.2"
 SafeTestsets = "0.1.0"
 SciMLOperators = "1.4"
 SciMLStructures = "1.7"
+SparseArrays = "1"
 
 [targets]
 test = ["DiffEqDevTools", "LineSearches", "ODEProblemLibrary", "OrdinaryDiffEqSDIRK", "Random", "SafeTestsets", "Test", "JET", "Aqua", "AllocCheck"]

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
@@ -18,6 +18,7 @@ using FastBroadcast: @..
 import FastClosures: @closure
 using LinearAlgebra: UniformScaling, UpperTriangular, givens, cond, dot, lmul!, axpy!
 import LinearAlgebra
+using SparseArrays: SparseMatrixCSC
 import ArrayInterface: ArrayInterface, ismutable, restructure
 import LinearSolve: OperatorAssumptions
 import LinearSolve

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
@@ -1,5 +1,6 @@
 using SafeTestsets
 
 @time @safetestset "Newton Tests" include("newton_tests.jl")
+@time @safetestset "Sparse Algebraic Detection" include("sparse_algebraic_detection_tests.jl")
 @time @safetestset "JET Tests" include("jet.jl")
 @time @safetestset "Aqua" include("qa.jl")

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/sparse_algebraic_detection_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/sparse_algebraic_detection_tests.jl
@@ -1,0 +1,82 @@
+using Test
+using SparseArrays
+using OrdinaryDiffEqNonlinearSolve: find_algebraic_vars_eqs
+
+@testset "Sparse Algebraic Detection Performance" begin
+    # Test 1: Correctness - results should match between sparse and dense methods
+    @testset "Correctness" begin
+        # Small mixed matrix
+        M1 = sparse([1.0 0.0 0.0; 0.0 0.0 0.0; 0.0 0.0 2.0])
+        vars1, eqs1 = find_algebraic_vars_eqs(M1)
+        @test vars1 == [false, true, false]  # col 2 is zero (algebraic)
+        @test eqs1 == [false, true, false]   # row 2 is zero (algebraic)
+
+        # Diagonal matrix (no algebraic)
+        M2 = sparse(1:10, 1:10, ones(10))
+        vars2, eqs2 = find_algebraic_vars_eqs(M2)
+        @test all(.!vars2)  # no algebraic vars
+        @test all(.!eqs2)   # no algebraic eqs
+
+        # Zero matrix (all algebraic)
+        M3 = spzeros(5, 5)
+        vars3, eqs3 = find_algebraic_vars_eqs(M3)
+        @test all(vars3)  # all algebraic vars
+        @test all(eqs3)   # all algebraic eqs
+
+        # Matrix with explicit zeros in sparsity pattern
+        M4 = sparse([1, 2], [1, 2], [1.0, 0.0], 3, 3)  # (2,2) is stored but zero
+        vars4, eqs4 = find_algebraic_vars_eqs(M4)
+        @test vars4 == [false, true, true]   # cols 2,3 are effectively zero
+        @test eqs4 == [false, true, true]    # rows 2,3 are effectively zero
+    end
+
+    # Test 2: Complexity verification
+    # For sparse matrices, time should scale with nnz, not n²
+    # We verify this by checking that processing a large sparse diagonal matrix
+    # is much faster than it would be with O(n²) complexity
+    @testset "Complexity O(nnz) not O(n²)" begin
+        # Create diagonal matrices of increasing size
+        # For a diagonal matrix: nnz = n, so O(nnz) = O(n)
+        # If algorithm were O(n²), doubling n would 4x the time
+        # With O(nnz) = O(n), doubling n should ~2x the time
+
+        n_small = 10_000
+        n_large = 40_000
+
+        M_small = sparse(1:n_small, 1:n_small, ones(n_small))
+        M_large = sparse(1:n_large, 1:n_large, ones(n_large))
+
+        # Warmup
+        find_algebraic_vars_eqs(M_small)
+        find_algebraic_vars_eqs(M_large)
+
+        # Measure
+        t_small = @elapsed for _ in 1:10
+            find_algebraic_vars_eqs(M_small)
+        end
+
+        t_large = @elapsed for _ in 1:10
+            find_algebraic_vars_eqs(M_large)
+        end
+
+        ratio = t_large / t_small
+        size_ratio = n_large / n_small  # 4x size increase
+
+        # With O(n²), ratio would be ~16
+        # With O(nnz) = O(n), ratio should be ~4
+        # Allow some tolerance for measurement noise
+        @test ratio < size_ratio * 2  # Should be closer to linear than quadratic
+
+        # Absolute sanity check: processing 40k diagonal shouldn't take > 100ms
+        t_single = @elapsed find_algebraic_vars_eqs(M_large)
+        @test t_single < 0.1  # Should be < 100ms, typically < 1ms
+    end
+
+    # Test 3: Verify fallback for dense matrices still works
+    @testset "Dense matrix fallback" begin
+        M_dense = [1.0 0.0; 0.0 0.0]
+        vars, eqs = find_algebraic_vars_eqs(M_dense)
+        @test vars == [false, true]
+        @test eqs == [false, true]
+    end
+end


### PR DESCRIPTION
Add `find_algebraic_vars_eqs` function that efficiently detects algebraic variables and equations from sparse mass matrices by traversing the CSC structure directly, reducing complexity from O(n²) to O(nnz).

For a 259k x 259k sparse diagonal mass matrix, this reduces DAE initialization time from ~67 seconds to <1 second.

Changes:
- Add SparseArrays dependency for SparseMatrixCSC type dispatch
- Add find_algebraic_vars_eqs with sparse specialization and dense fallback
- Replace 4 instances of O(n^2) column/row iteration in _initialize_dae!
- Add performance regression tests verifying O(nnz) complexity

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [X] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
