### PR TITLE
Use convert(AbstractMatrix, M) for AbstractSciMLOperator in find_algebraic_vars_eqs

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/initialize_dae.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/initialize_dae.jl
@@ -36,9 +36,9 @@ function find_algebraic_vars_eqs(M::AbstractMatrix)
     return algebraic_vars, algebraic_eqs
 end
 
-# Handle SciMLOperators (e.g., MatrixOperator) by extracting the underlying matrix
+# Handle SciMLOperators (e.g., MatrixOperator) by converting to matrix
 function find_algebraic_vars_eqs(M::AbstractSciMLOperator)
-    return find_algebraic_vars_eqs(M.A)
+    return find_algebraic_vars_eqs(convert(AbstractMatrix, M))
 end
 
 # Optimized tolerance checking that avoids allocations


### PR DESCRIPTION
## Summary
Use `convert(AbstractMatrix, M)` instead of `M.A` for the `AbstractSciMLOperator` dispatch in `find_algebraic_vars_eqs`.

Using `convert()` is more robust:
- ✅ Works for `MatrixOperator` (sparse and dense) 
- ✅ Works for `IdentityOperator` (returns all false - no algebraic vars)
- ✅ Works for `NullOperator` (returns all true - all algebraic vars)
- ✅ Throws clear error for operators that can't be converted to matrix

`M.A` only works for operators that have an `.A` field (`MatrixOperator`, `AffineOperator`), but would crash on `IdentityOperator`, `NullOperator`, `FunctionOperator`, etc.

This matches the existing pattern in `derivative_utils.jl:279-280`.

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)