### PR TITLE
Skip Enzyme tests on Julia 1.12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,6 +72,8 @@ jobs:
           - 'pre'
         exclude:
           - group: Enzyme
+            version: '1'
+          - group: Enzyme
             version: 'pre'
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Skip Enzyme tests on Julia 1.12 (version `'1'` in CI matrix)
- Enzyme is not yet compatible with Julia 1.12

This is a simple CI fix to unblock PRs like #2951.

## Test plan
- [ ] CI passes (Enzyme tests will be skipped on Julia 1.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)