### PR TITLE
Add JET tests for Newmark, RKIP, and SIMDRK packages

### DIFF
--- a/lib/OrdinaryDiffEqNewmark/Project.toml
+++ b/lib/OrdinaryDiffEqNewmark/Project.toml
@@ -23,6 +23,7 @@ ConcreteStructs = "0.2.3"
 DiffEqBase = "6.152.2"
 DiffEqDevTools = "2.44.4"
 FastBroadcast = "0.3.5"
+JET = "0.9, 0.11"
 LinearAlgebra = "<0.0.1, 1"
 MacroTools = "0.5.13"
 MuladdMacro = "0.2.4"
@@ -40,9 +41,10 @@ julia = "1.10"
 
 [extras]
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DiffEqDevTools", "Random", "SafeTestsets", "Test"]
+test = ["DiffEqDevTools", "JET", "Random", "SafeTestsets", "Test"]

--- a/lib/OrdinaryDiffEqNewmark/test/jet.jl
+++ b/lib/OrdinaryDiffEqNewmark/test/jet.jl
@@ -1,0 +1,11 @@
+import OrdinaryDiffEqNewmark
+using OrdinaryDiffEqNewmark
+using OrdinaryDiffEqCore
+using JET
+using Test
+
+@testset "JET Tests" begin
+    # Test package for typos
+    test_package(
+        OrdinaryDiffEqNewmark, target_modules = (OrdinaryDiffEqNewmark,), mode = :typo)
+end

--- a/lib/OrdinaryDiffEqNewmark/test/runtests.jl
+++ b/lib/OrdinaryDiffEqNewmark/test/runtests.jl
@@ -1,4 +1,5 @@
 using OrdinaryDiffEqNewmark, Test, RecursiveArrayTools, DiffEqDevTools
+using SafeTestsets
 
 # Newmark methods with harmonic oscillator
 @testset "Harmonic Oscillator" begin
@@ -92,4 +93,9 @@ end
 
     sim = test_convergence(dts, prob, NewmarkBeta(), dense_errors = true)
     @test sim.𝒪est[:l2]≈2 rtol=1e-1
+end
+
+# Only run JET tests on stable Julia versions
+if isempty(VERSION.prerelease)
+    @time @safetestset "JET Tests" include("jet.jl")
 end

--- a/lib/OrdinaryDiffEqRKIP/Project.toml
+++ b/lib/OrdinaryDiffEqRKIP/Project.toml
@@ -23,6 +23,7 @@ Compat = "4.16"
 DiffEqBase = "6.175"
 DiffEqDevTools = "2.48"
 FFTW = "1.8.0"
+JET = "0.9, 0.11"
 MaybeInplace = "0.1.4"
 OrdinaryDiffEqCore = "2"
 SafeTestsets = "0.1.0"
@@ -33,8 +34,9 @@ julia = "1.10"
 
 [extras]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["FFTW", "Test", "SafeTestsets"]
+test = ["FFTW", "JET", "Test", "SafeTestsets"]

--- a/lib/OrdinaryDiffEqRKIP/test/jet.jl
+++ b/lib/OrdinaryDiffEqRKIP/test/jet.jl
@@ -1,0 +1,11 @@
+import OrdinaryDiffEqRKIP
+using OrdinaryDiffEqRKIP
+using OrdinaryDiffEqCore
+using JET
+using Test
+
+@testset "JET Tests" begin
+    # Test package for typos
+    test_package(
+        OrdinaryDiffEqRKIP, target_modules = (OrdinaryDiffEqRKIP,), mode = :typo)
+end

--- a/lib/OrdinaryDiffEqRKIP/test/runtests.jl
+++ b/lib/OrdinaryDiffEqRKIP/test/runtests.jl
@@ -4,3 +4,8 @@ using SafeTestsets
 @safetestset "Cache Test" include("cache_recycling_test.jl")
 @safetestset "Fourier Semilinear PDE Tests" include("semilinear_pde_test_cpu.jl")
 # GPU tests moved to test/gpu/rkip_semilinear_pde.jl for Buildkite GPU CI
+
+# Only run JET tests on stable Julia versions
+if isempty(VERSION.prerelease)
+    @time @safetestset "JET Tests" include("jet.jl")
+end

--- a/lib/OrdinaryDiffEqSIMDRK/Project.toml
+++ b/lib/OrdinaryDiffEqSIMDRK/Project.toml
@@ -4,34 +4,36 @@ authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Elrod <elrodc@gmail.com>"]
 version = "1.4.0"
 
 [deps]
-Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
-VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
-Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
-SLEEFPirates = "476501e8-09a2-5ece-8869-fb82de89a1fa"
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
-
-[extras]
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+SLEEFPirates = "476501e8-09a2-5ece-8869-fb82de89a1fa"
+Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
+VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 
 [compat]
-Test = "<0.0.1, 1"
 DiffEqDevTools = "2.44.4"
+JET = "0.9, 0.11"
 MuladdMacro = "0.2"
 OrdinaryDiffEqCore = "2"
-Static = "0.7, 0.8, 1"
-SLEEFPirates = "0.6"
-VectorizationBase = "0.21"
-StaticArrays = "1.9"
-SafeTestsets = "0.1.0"
 Reexport = "1"
+SLEEFPirates = "0.6"
+SafeTestsets = "0.1.0"
+Static = "0.7, 0.8, 1"
+StaticArrays = "1.9"
+Test = "<0.0.1, 1"
+VectorizationBase = "0.21"
 julia = "1.10"
 
-[targets]
-test = ["DiffEqDevTools", "SafeTestsets", "StaticArrays", "Test"]
+[extras]
+DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources.OrdinaryDiffEqCore]
 path = "../OrdinaryDiffEqCore"
+
+[targets]
+test = ["DiffEqDevTools", "JET", "SafeTestsets", "StaticArrays", "Test"]

--- a/lib/OrdinaryDiffEqSIMDRK/test/jet.jl
+++ b/lib/OrdinaryDiffEqSIMDRK/test/jet.jl
@@ -1,0 +1,11 @@
+import OrdinaryDiffEqSIMDRK
+using OrdinaryDiffEqSIMDRK
+using OrdinaryDiffEqCore
+using JET
+using Test
+
+@testset "JET Tests" begin
+    # Test package for typos
+    test_package(
+        OrdinaryDiffEqSIMDRK, target_modules = (OrdinaryDiffEqSIMDRK,), mode = :typo)
+end

--- a/lib/OrdinaryDiffEqSIMDRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqSIMDRK/test/runtests.jl
@@ -6,3 +6,8 @@ end
 @time @safetestset "Adaptivity Tests" begin
     include("adaptivity_tests.jl")
 end
+
+# Only run JET tests on stable Julia versions
+if isempty(VERSION.prerelease)
+    @time @safetestset "JET Tests" include("jet.jl")
+end


### PR DESCRIPTION
## Summary

This PR adds JET.jl static analysis tests to the three OrdinaryDiffEq sub-packages that were missing them:

- **OrdinaryDiffEqNewmark** - Second-order ODE solvers using Newmark-Beta method
- **OrdinaryDiffEqRKIP** - Runge-Kutta-like integrating factor methods
- **OrdinaryDiffEqSIMDRK** - SIMD-optimized Runge-Kutta methods

### Changes for each package:
- Created `test/jet.jl` with `test_package` typo checking using `target_modules` (the new API)
- Updated `test/runtests.jl` to include JET tests (only on stable Julia versions)
- Added JET to `[extras]`, `[compat]`, and `[targets]` sections in `Project.toml`
- JET compat is set to `0.9, 0.11` to match OrdinaryDiffEqCore

### Testing
All JET tests pass locally with JET.jl v0.11:
- OrdinaryDiffEqSIMDRK: ✅ Convergence Tests (3/3), Adaptivity Tests (3/3), JET Tests (1/1)
- OrdinaryDiffEqRKIP: ✅ Type Safety Tests (105/105 + 45 broken), Cache Test (1/1), Fourier Semilinear PDE Tests (4/4), JET Tests (1/1)
- OrdinaryDiffEqNewmark: ✅ Harmonic Oscillator (2/2), Damped Oscillator (2/2), JET Tests (1/1)

## Test plan
- [ ] CI passes for all three packages
- [ ] JET tests run successfully on Julia stable releases

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)