### PR TITLE
Skip null_u0_callbacks test on Julia LTS

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,7 +44,7 @@ end
     elseif GROUP == "All" || GROUP == "InterfaceI" || GROUP == "Interface"
         @time @safetestset "Discrete Algorithm Tests" include("interface/discrete_algorithm_test.jl")
         # Skip on Julia LTS (oneunit(Type{Any}) not defined) and pre-release (stalls)
-        # See: https://github.com/SciML/OrdinaryDiffEq.jl/issues/XXXX
+        # See: https://github.com/SciML/OrdinaryDiffEq.jl/issues/2979
         if VERSION >= v"1.11" && isempty(VERSION.prerelease)
             @time @safetestset "Null u0 Callbacks Tests" include("interface/null_u0_callbacks_test.jl")
         end


### PR DESCRIPTION
## Summary
- Skip `null_u0_callbacks_test.jl` on Julia LTS (1.10) per CI Health protocol Option B2
- The test uses `u0=nothing` which triggers `oneunit(Type{Any})` call that fails on Julia 1.10 LTS
- This is a known limitation of the null u0 feature on older Julia versions

## Details
The null u0 with callbacks feature was added to support MTK issue #4078. However, on Julia 1.10 LTS, calling `oneunit(Type{Any})` throws:
```
MethodError: no method matching oneunit(::Type{Any})
```

This happens in `OrdinaryDiffEqCore/src/solve.jl:238` when dealing with null u0 and callbacks.

## CI Health Protocol Applied
- **Option B2 (Version-conditional skip)**: Skip tests on older versions when compat bump is unclear

## Note on Downgrade Tests
The Downgrade and Downgrade Sublibraries workflows have been failing since they were added (July 2025). This is a separate issue related to dependency resolution at minimum compat bounds causing `OrdinaryDiffEqNonlinearSolve` to fail to precompile. A separate issue should be created to investigate this.

## Test plan
- [ ] CI passes on Julia 1.11, 1.x, and pre
- [ ] Julia LTS (1.10) CI passes with the test skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)