### PR TITLE
Add get_mass_matrix helper to support functions without mass_matrix field

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/functional.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/functional.jl
@@ -119,7 +119,7 @@ end
         dz = f(dustep, ustep, p, t)
         ztmp = @.. broadcast = false z + dz
     else
-        mass_matrix = integrator.f.mass_matrix
+        mass_matrix = get_mass_matrix(integrator.f)
         if nlsolver.method === COEFFICIENT_MULTISTEP
             ustep = z
             if mass_matrix === I
@@ -186,7 +186,7 @@ end
         @.. broadcast = false dz = k
         @.. broadcast = false ztmp = z + dz
     else
-        mass_matrix = integrator.f.mass_matrix
+        mass_matrix = get_mass_matrix(integrator.f)
         if nlsolver.method === COEFFICIENT_MULTISTEP
             ustep = z
             f(k, ustep, p, tstep)

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -355,7 +355,7 @@ function compute_ustep!(ustep, tmp, γ, z, method)
 end
 
 function _compute_rhs(tmp, γ, α, tstep, invγdt, method::MethodType, p, dt, f::F, z) where {F}
-    mass_matrix = f.mass_matrix
+    mass_matrix = get_mass_matrix(f)
     ustep = compute_ustep(tmp, γ, z, method)
     if method === COEFFICIENT_MULTISTEP
         # tmp = outertmp ./ hγ
@@ -390,7 +390,7 @@ function _compute_rhs!(
         tmp, ztmp, ustep, γ, α, tstep, k,
         invγdt, method::MethodType, p, dt, f, z
     )
-    mass_matrix = f.mass_matrix
+    mass_matrix = get_mass_matrix(f)
     ustep = compute_ustep!(ustep, tmp, γ, z, method)
     if method === COEFFICIENT_MULTISTEP
         f(k, z, p, tstep)
@@ -433,7 +433,7 @@ function _compute_rhs!(
         tmp::Array, ztmp::Array, ustep::Array, γ, α, tstep, k,
         invγdt, method::MethodType, p, dt, f, z
     )
-    mass_matrix = f.mass_matrix
+    mass_matrix = get_mass_matrix(f)
     ustep = compute_ustep!(ustep, tmp, γ, z, method)
     if method === COEFFICIENT_MULTISTEP
         f(k, z, p, tstep)

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -1,3 +1,7 @@
+# Get mass_matrix from function, defaulting to I if field doesn't exist
+# This allows nlsolver to work with DiscreteFunction which lacks mass_matrix
+get_mass_matrix(f) = hasproperty(f, :mass_matrix) ? f.mass_matrix : I
+
 get_status(nlsolver::AbstractNLSolver) = nlsolver.status
 get_new_W_γdt_cutoff(nlsolver::AbstractNLSolver) = nlsolver.cache.new_W_γdt_cutoff
 # handle FIRK


### PR DESCRIPTION
## Summary
- Adds `get_mass_matrix(f)` helper function that safely retrieves mass_matrix from a function
- Defaults to `I` (identity matrix) if the field doesn't exist
- Updates `functional.jl` and `newton.jl` to use the helper instead of direct field access

## Motivation
The nlsolver infrastructure currently accesses `integrator.f.mass_matrix` directly, which fails with a `FieldError` when used with function types that don't have a mass_matrix field, such as `DiscreteFunction` used by `DiscreteProblem`.

This came up when implementing implicit tau-leaping methods in StochasticDiffEq.jl (see https://github.com/SciML/StochasticDiffEq.jl/pull/658). The `ThetaTrapezoidalTauLeaping` method solves an implicit equation using fixed-point iteration, and we wanted to reuse the nlsolver infrastructure. However, tau-leaping uses `DiscreteProblem` internally, and `DiscreteFunction` lacks the `mass_matrix` field that standard ODE functions have.

## Changes
```julia
# New helper function in utils.jl
get_mass_matrix(f) = hasproperty(f, :mass_matrix) ? f.mass_matrix : I
```

All direct accesses to `f.mass_matrix` or `integrator.f.mass_matrix` in the nlsolver code are replaced with calls to `get_mass_matrix(f)` or `get_mass_matrix(integrator.f)`.

## Test plan
- [x] All existing OrdinaryDiffEqNonlinearSolve tests pass
- [x] Newton tests pass
- [x] JET tests pass
- [x] Aqua tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)