### PR TITLE
Skip ODEInterfaceRegression tests on Julia v1 and pre

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,6 +75,12 @@ jobs:
             version: '1'
           - group: Enzyme
             version: 'pre'
+          # Skip ODEInterfaceRegression until ODEInterface.jl is fixed upstream
+          # See: https://github.com/SciML/OrdinaryDiffEq.jl/issues/2987
+          - group: ODEInterfaceRegression
+            version: '1'
+          - group: ODEInterfaceRegression
+            version: 'pre'
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
## Summary

- Skip ODEInterfaceRegression test group on Julia `1` (latest stable) and `pre` (pre-release) versions
- Tests continue to run on `lts` and `1.11`

## Motivation

ODEInterface.jl has upstream compatibility issues with recent Julia versions that cause the ODEInterfaceRegression tests to fail.

## Changes

Added exclusions in CI.yml for ODEInterfaceRegression on Julia v1 and pre, following the same pattern used for Enzyme tests.

## Test plan

- [x] Verify CI configuration syntax is correct
- [ ] CI will skip ODEInterfaceRegression on v1 and pre versions

Fixes #2987

🤖 Generated with [Claude Code](https://claude.com/claude-code)