### PR TITLE
Remove JET/Aqua/AllocCheck from OrdinaryDiffEqTaylorSeries test targets

### DIFF
--- a/lib/OrdinaryDiffEqTaylorSeries/Project.toml
+++ b/lib/OrdinaryDiffEqTaylorSeries/Project.toml
@@ -62,4 +62,4 @@ julia = "1.10"
 path = "../OrdinaryDiffEqCore"
 
 [targets]
-test = ["DiffEqDevTools", "Random", "SafeTestsets", "Test", "ODEProblemLibrary", "Pkg", "JET", "Aqua", "AllocCheck"]
+test = ["DiffEqDevTools", "Random", "SafeTestsets", "Test", "ODEProblemLibrary", "Pkg"]


### PR DESCRIPTION
## Summary
Remove JET, Aqua, and AllocCheck from `[targets] test` in OrdinaryDiffEqTaylorSeries Project.toml while keeping them in `[extras]` and `[compat]` for QA test group usage.

## Problem
JET is not compatible with Julia 1.13 beta, and having it in `[targets] test` causes `Pkg.test()` to fail when trying to resolve dependencies:
```
restricted by julia compatibility requirements to versions: uninstalled — no versions left
```

## Solution
Keep JET/Aqua/AllocCheck in `[extras]` and `[compat]` so they're available for the QA test group, but remove them from `[targets] test` so they don't get installed during regular `Pkg.test()`.

## Test plan
- [x] JET, Aqua, AllocCheck remain in [extras] for QA tests
- [x] JET, Aqua, AllocCheck remain in [compat] 
- [x] JET, Aqua, AllocCheck removed from [targets] test

🤖 Generated with [Claude Code](https://claude.com/claude-code)