### PR TITLE
Fix runic formatting issues

### DIFF
--- a/lib/OrdinaryDiffEqRosenbrock/test/allocation_tests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/allocation_tests.jl
@@ -40,8 +40,10 @@ operations that will naturally allocate. The core numerical stepping should be a
                 # Test perform_step! directly - this is the core stepping function
                 # that should be allocation-free (unlike step! which includes saving)
                 cache = integrator.cache
-                allocs = check_allocs(OrdinaryDiffEqCore.perform_step!,
-                    (typeof(integrator), typeof(cache)))
+                allocs = check_allocs(
+                    OrdinaryDiffEqCore.perform_step!,
+                    (typeof(integrator), typeof(cache))
+                )
 
                 # These solvers should be allocation-free in perform_step!
                 @test_broken length(allocs) == 0

--- a/lib/OrdinaryDiffEqTaylorSeries/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/src/alg_utils.jl
@@ -81,16 +81,18 @@ function build_jet(f, ::Val{iip}, p, order::Val{P}, length = nothing) where {P, 
         # Array case: build function for matrix of coefficients
         # Each row is the coefficients of one TaylorScalar
         n = Base.length(u)
-        coeffs_matrix = [TaylorDiff.flatten(u[i])[j] for i in 1:n, j in 1:(P+1)]
+        coeffs_matrix = [TaylorDiff.flatten(u[i])[j] for i in 1:n, j in 1:(P + 1)]
         jet_coeffs = build_function(coeffs_matrix, u0, t0; expression = Val(false), cse = true)
         # Wrap to return array of TaylorScalars
-        jet = (jet_coeffs[1], (out, u0_val, t0_val) -> begin
-            coeffs_out = jet_coeffs[2](similar(coeffs_matrix, eltype(u0_val)), u0_val, t0_val)
-            for i in 1:n
-                out[i] = TaylorScalar(Tuple(coeffs_out[i, :]))
-            end
-            return out
-        end)
+        jet = (
+            jet_coeffs[1], (out, u0_val, t0_val) -> begin
+                coeffs_out = jet_coeffs[2](similar(coeffs_matrix, eltype(u0_val)), u0_val, t0_val)
+                for i in 1:n
+                    out[i] = TaylorScalar(Tuple(coeffs_out[i, :]))
+                end
+                return out
+            end,
+        )
     else
         # Fallback (shouldn't happen normally)
         jet = build_function(u, u0, t0; expression = Val(false), cse = true)


### PR DESCRIPTION
## Summary
- Fix formatting in `lib/OrdinaryDiffEqRosenbrock/test/allocation_tests.jl`
- Fix formatting in `lib/OrdinaryDiffEqTaylorSeries/src/alg_utils.jl`

These files were flagged by the runic CI check.

## Test plan
- [x] Run runic locally to verify formatting
- [ ] CI runic check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)