### PR TITLE
Rename ODEVerbosity to DEVerbosity

### DIFF
--- a/docs/src/verbosity.md
+++ b/docs/src/verbosity.md
@@ -5,5 +5,5 @@ through the `verbose` keyword argument for `solve`. The verbosity system allows 
 information is displayed during the solve process. See [SciMLLogging.jl](https://docs.sciml.ai/SciMLLogging/dev/) for more details. 
 
 ```@docs
-ODEVerbosity
+DEVerbosity
 ```

--- a/lib/OrdinaryDiffEqBDF/test/inference_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/inference_tests.jl
@@ -1,7 +1,7 @@
 using OrdinaryDiffEqBDF, ADTypes, Test
 using NonlinearSolve: TrustRegion
 import OrdinaryDiffEqCore.SciMLLogging as SciMLLogging
-using OrdinaryDiffEqCore: ODEVerbosity
+using OrdinaryDiffEqCore: DEVerbosity
 
 prob = ODEProblem((du, u, p, t) -> du .= u, zeros(1), (0.0, 1.0))
 nlalg = FBDF(
@@ -13,13 +13,13 @@ basicalgad = FBDF()
 
 nlsolver = @inferred OrdinaryDiffEqBDF.build_nlsolver(
     basicalg, prob.u0, prob.u0, prob.p, 0.0, 0.0, prob.f, prob.u0, Float64,
-    Float64, Float64, 0.0, 0.0, Val(true), ODEVerbosity()
+    Float64, Float64, 0.0, 0.0, Val(true), DEVerbosity()
 )
 nlsolver = @inferred OrdinaryDiffEqBDF.build_nlsolver(
     nlalg, prob.u0, prob.u0, prob.p, 0.0, 0.0, prob.f, prob.u0, Float64,
-    Float64, Float64, 0.0, 0.0, Val(true), ODEVerbosity()
+    Float64, Float64, 0.0, 0.0, Val(true), DEVerbosity()
 )
 nlsolver = @test_throws Any @inferred OrdinaryDiffEqBDF.build_nlsolver(
     basicalgad, prob.u0, prob.u0, prob.p, 0.0, 0.0, prob.f, prob.u0, Float64,
-    Float64, Float64, 0.0, 0.0, Val(true), ODEVerbosity()
+    Float64, Float64, 0.0, 0.0, Val(true), DEVerbosity()
 )

--- a/lib/OrdinaryDiffEqCore/src/verbosity.jl
+++ b/lib/OrdinaryDiffEqCore/src/verbosity.jl
@@ -1,4 +1,4 @@
-@verbosity_specifier ODEVerbosity begin
+@verbosity_specifier DEVerbosity begin
     toggles = (
         :linear_verbosity, :nonlinear_verbosity,
         :dt_NaN, :init_NaN, :dense_output_saveat, :max_iters, :dt_min_unstable, :instability,
@@ -233,7 +233,7 @@
 end
 
 """
-    ODEVerbosity <: AbstractVerbositySpecifier
+    DEVerbosity <: AbstractVerbositySpecifier
 
 Verbosity configuration for OrdinaryDiffEq.jl solvers, providing fine-grained control over
 diagnostic messages, warnings, and errors during ODE solution.
@@ -288,54 +288,54 @@ diagnostic messages, warnings, and errors during ODE solution.
 
 # Constructors
 
-    ODEVerbosity(preset::AbstractVerbosityPreset)
+    DEVerbosity(preset::AbstractVerbosityPreset)
 
-Create an `ODEVerbosity` using a preset configuration:
+Create an `DEVerbosity` using a preset configuration:
 - `SciMLLogging.None()`: All messages disabled
 - `SciMLLogging.Minimal()`: Only critical errors and fatal issues
 - `SciMLLogging.Standard()`: Balanced verbosity (default)
 - `SciMLLogging.Detailed()`: Comprehensive debugging information
 - `SciMLLogging.All()`: Maximum verbosity
 
-    ODEVerbosity(; preset=nothing, error_control=nothing, performance=nothing, numerical=nothing, sde_specific=nothing, dde_specific=nothing, kwargs...)
+    DEVerbosity(; preset=nothing, error_control=nothing, performance=nothing, numerical=nothing, sde_specific=nothing, dde_specific=nothing, kwargs...)
 
-Create an `ODEVerbosity` with group-level or individual field control.
+Create an `DEVerbosity` with group-level or individual field control.
 
 # Examples
 
 ```julia
 # Use a preset
-verbose = ODEVerbosity(SciMLLogging.Standard())
+verbose = DEVerbosity(SciMLLogging.Standard())
 
 # Set entire groups
-verbose = ODEVerbosity(
+verbose = DEVerbosity(
     error_control = SciMLLogging.WarnLevel(),
     numerical = SciMLLogging.InfoLevel()
 )
 
 # Set individual fields
-verbose = ODEVerbosity(
+verbose = DEVerbosity(
     dt_NaN = SciMLLogging.ErrorLevel(),
     alg_switch = SciMLLogging.InfoLevel()
 )
 
 # Mix group and individual settings
-verbose = ODEVerbosity(
+verbose = DEVerbosity(
     numerical = SciMLLogging.InfoLevel(),  # Set all numerical to InfoLevel
     unlimited_dt = SciMLLogging.ErrorLevel()  # Override specific field
 )
 ```
 """
-function ODEVerbosity end
+function DEVerbosity end
 
-const DEFAULT_VERBOSE = ODEVerbosity()
+const DEFAULT_VERBOSE = DEVerbosity()
 
 @inline function _process_verbose_param(verbose::SciMLLogging.AbstractVerbosityPreset)
-    return ODEVerbosity(verbose)
+    return DEVerbosity(verbose)
 end
 
 @inline function _process_verbose_param(verbose::Bool)
-    return verbose ? DEFAULT_VERBOSE : ODEVerbosity(SciMLLogging.None())
+    return verbose ? DEFAULT_VERBOSE : DEVerbosity(SciMLLogging.None())
 end
 
-@inline _process_verbose_param(verbose::ODEVerbosity) = verbose
+@inline _process_verbose_param(verbose::DEVerbosity) = verbose

--- a/lib/OrdinaryDiffEqCore/test/jet.jl
+++ b/lib/OrdinaryDiffEqCore/test/jet.jl
@@ -2,7 +2,7 @@ using Pkg
 Pkg.add("JET")
 
 import OrdinaryDiffEqCore
-using OrdinaryDiffEqCore: ODEVerbosity
+using OrdinaryDiffEqCore: DEVerbosity
 import OrdinaryDiffEqCore.SciMLLogging as SciMLLogging
 using JET, Test
 
@@ -12,73 +12,73 @@ using JET, Test
     ) === nothing broken = true
 end
 
-@testset "JET Test ODEVerbosity Constructors" begin
+@testset "JET Test DEVerbosity Constructors" begin
     @testset "Default constructor" begin
-        @test_opt ODEVerbosity()
+        @test_opt DEVerbosity()
     end
 
     @testset "Preset constructors" begin
-        @test_opt ODEVerbosity(SciMLLogging.None())
-        @test_opt ODEVerbosity(SciMLLogging.Minimal())
-        @test_opt ODEVerbosity(SciMLLogging.Standard())
-        @test_opt ODEVerbosity(SciMLLogging.Detailed())
-        @test_opt ODEVerbosity(SciMLLogging.All())
+        @test_opt DEVerbosity(SciMLLogging.None())
+        @test_opt DEVerbosity(SciMLLogging.Minimal())
+        @test_opt DEVerbosity(SciMLLogging.Standard())
+        @test_opt DEVerbosity(SciMLLogging.Detailed())
+        @test_opt DEVerbosity(SciMLLogging.All())
     end
 
     @testset "Group-level keyword constructors" begin
-        @test_opt ODEVerbosity(error_control = SciMLLogging.ErrorLevel())
-        @test_opt ODEVerbosity(numerical = SciMLLogging.Silent())
-        @test_opt ODEVerbosity(performance = SciMLLogging.InfoLevel())
-        @test_opt ODEVerbosity(error_control = SciMLLogging.WarnLevel())
-        @test_opt ODEVerbosity(numerical = SciMLLogging.WarnLevel())
-        @test_opt ODEVerbosity(performance = SciMLLogging.Silent())
+        @test_opt DEVerbosity(error_control = SciMLLogging.ErrorLevel())
+        @test_opt DEVerbosity(numerical = SciMLLogging.Silent())
+        @test_opt DEVerbosity(performance = SciMLLogging.InfoLevel())
+        @test_opt DEVerbosity(error_control = SciMLLogging.WarnLevel())
+        @test_opt DEVerbosity(numerical = SciMLLogging.WarnLevel())
+        @test_opt DEVerbosity(performance = SciMLLogging.Silent())
     end
 
     @testset "Individual keyword arguments" begin
-        @test_opt ODEVerbosity(dt_NaN = SciMLLogging.ErrorLevel())
-        @test_opt ODEVerbosity(alg_switch = SciMLLogging.InfoLevel())
-        @test_opt ODEVerbosity(shampine_dt = SciMLLogging.Silent())
-        @test_opt ODEVerbosity(init_NaN = SciMLLogging.WarnLevel())
+        @test_opt DEVerbosity(dt_NaN = SciMLLogging.ErrorLevel())
+        @test_opt DEVerbosity(alg_switch = SciMLLogging.InfoLevel())
+        @test_opt DEVerbosity(shampine_dt = SciMLLogging.Silent())
+        @test_opt DEVerbosity(init_NaN = SciMLLogging.WarnLevel())
     end
 
     @testset "Linear and nonlinear verbosity" begin
-        @test_opt ODEVerbosity(linear_verbosity = SciMLLogging.Detailed())
-        @test_opt ODEVerbosity(nonlinear_verbosity = SciMLLogging.Minimal())
-        @test_opt ODEVerbosity(linear_verbosity = SciMLLogging.None())
-        @test_opt ODEVerbosity(nonlinear_verbosity = SciMLLogging.All())
-        @test_opt ODEVerbosity(
+        @test_opt DEVerbosity(linear_verbosity = SciMLLogging.Detailed())
+        @test_opt DEVerbosity(nonlinear_verbosity = SciMLLogging.Minimal())
+        @test_opt DEVerbosity(linear_verbosity = SciMLLogging.None())
+        @test_opt DEVerbosity(nonlinear_verbosity = SciMLLogging.All())
+        @test_opt DEVerbosity(
             linear_verbosity = SciMLLogging.Detailed(),
             nonlinear_verbosity = SciMLLogging.Minimal()
         )
-        @test_opt ODEVerbosity(
+        @test_opt DEVerbosity(
             linear_verbosity = SciMLLogging.None(),
             nonlinear_verbosity = SciMLLogging.All()
         )
     end
 
     @testset "Mixed group and individual settings" begin
-        @test_opt ODEVerbosity(
+        @test_opt DEVerbosity(
             numerical = SciMLLogging.Silent(),
             shampine_dt = SciMLLogging.WarnLevel()
         )
-        @test_opt ODEVerbosity(
+        @test_opt DEVerbosity(
             numerical = SciMLLogging.Silent(),
             shampine_dt = SciMLLogging.WarnLevel(),
             performance = SciMLLogging.InfoLevel()
         )
-        @test_opt ODEVerbosity(
+        @test_opt DEVerbosity(
             error_control = SciMLLogging.WarnLevel(),
             dt_NaN = SciMLLogging.ErrorLevel()
         )
     end
 
     @testset "Multiple group settings" begin
-        @test_opt ODEVerbosity(
+        @test_opt DEVerbosity(
             error_control = SciMLLogging.ErrorLevel(),
             performance = SciMLLogging.InfoLevel(),
             numerical = SciMLLogging.Silent()
         )
-        @test_opt ODEVerbosity(
+        @test_opt DEVerbosity(
             error_control = SciMLLogging.WarnLevel(),
             performance = SciMLLogging.Silent(),
             numerical = SciMLLogging.WarnLevel()
@@ -86,7 +86,7 @@ end
     end
 
     @testset "Complex mixed settings" begin
-        @test_opt ODEVerbosity(
+        @test_opt DEVerbosity(
             error_control = SciMLLogging.WarnLevel(),
             performance = SciMLLogging.InfoLevel(),
             numerical = SciMLLogging.Silent(),
@@ -95,7 +95,7 @@ end
             dt_NaN = SciMLLogging.ErrorLevel(),
             shampine_dt = SciMLLogging.WarnLevel()
         )
-        @test_opt ODEVerbosity(
+        @test_opt DEVerbosity(
             error_control = SciMLLogging.ErrorLevel(),
             performance = SciMLLogging.Silent(),
             numerical = SciMLLogging.WarnLevel(),

--- a/test/interface/verbosity.jl
+++ b/test/interface/verbosity.jl
@@ -1,5 +1,5 @@
 using OrdinaryDiffEqCore
-using OrdinaryDiffEqCore: ODEVerbosity
+using OrdinaryDiffEqCore: DEVerbosity
 using OrdinaryDiffEq
 using OrdinaryDiffEqNonlinearSolve: NonlinearSolveAlg
 using ODEProblemLibrary: prob_ode_vanderpol_stiff
@@ -8,10 +8,10 @@ import OrdinaryDiffEqCore.SciMLLogging as SciMLLogging
 using LinearSolve: LinearVerbosity
 using NonlinearSolve: NonlinearVerbosity
 
-@testset "ODEVerbosity Tests" begin
+@testset "DEVerbosity Tests" begin
     @testset "Default constructor" begin
-        v1 = ODEVerbosity()
-        @test v1 isa ODEVerbosity
+        v1 = DEVerbosity()
+        @test v1 isa DEVerbosity
 
         # Test solver verbosity
         @test v1.linear_verbosity isa SciMLLogging.Minimal
@@ -46,12 +46,12 @@ using NonlinearSolve: NonlinearVerbosity
         @test v1.near_singular isa SciMLLogging.Silent
     end
 
-    @testset "ODEVerbosity preset constructors" begin
-        v_none = ODEVerbosity(SciMLLogging.None())
-        v_minimal = ODEVerbosity(SciMLLogging.Minimal())
-        v_standard = ODEVerbosity(SciMLLogging.Standard())
-        v_detailed = ODEVerbosity(SciMLLogging.Detailed())
-        v_all = ODEVerbosity(SciMLLogging.All())
+    @testset "DEVerbosity preset constructors" begin
+        v_none = DEVerbosity(SciMLLogging.None())
+        v_minimal = DEVerbosity(SciMLLogging.Minimal())
+        v_standard = DEVerbosity(SciMLLogging.Standard())
+        v_detailed = DEVerbosity(SciMLLogging.Detailed())
+        v_all = DEVerbosity(SciMLLogging.All())
 
         # Test None - everything Silent
         @test v_none.linear_verbosity isa SciMLLogging.None
@@ -102,7 +102,7 @@ using NonlinearSolve: NonlinearVerbosity
     end
 
     @testset "Group-level keyword constructors" begin
-        v_error = ODEVerbosity(error_control = SciMLLogging.ErrorLevel())
+        v_error = DEVerbosity(error_control = SciMLLogging.ErrorLevel())
         # Test all error_control fields
         @test v_error.dt_NaN isa SciMLLogging.ErrorLevel
         @test v_error.init_NaN isa SciMLLogging.ErrorLevel
@@ -115,7 +115,7 @@ using NonlinearSolve: NonlinearVerbosity
         @test v_error.step_accepted isa SciMLLogging.ErrorLevel
         @test v_error.convergence_limit isa SciMLLogging.ErrorLevel
 
-        v_numerical = ODEVerbosity(numerical = SciMLLogging.Silent())
+        v_numerical = DEVerbosity(numerical = SciMLLogging.Silent())
         # Test all numerical fields
         @test v_numerical.rosenbrock_no_differential_states isa SciMLLogging.Silent
         @test v_numerical.shampine_dt isa SciMLLogging.Silent
@@ -124,7 +124,7 @@ using NonlinearSolve: NonlinearVerbosity
         @test v_numerical.stability_check isa SciMLLogging.Silent
         @test v_numerical.near_singular isa SciMLLogging.Silent
 
-        v_performance = ODEVerbosity(performance = SciMLLogging.InfoLevel())
+        v_performance = DEVerbosity(performance = SciMLLogging.InfoLevel())
         # Test all performance fields
         @test v_performance.alg_switch isa SciMLLogging.InfoLevel
         @test v_performance.stiff_detection isa SciMLLogging.InfoLevel
@@ -135,7 +135,7 @@ using NonlinearSolve: NonlinearVerbosity
     end
 
     @testset "Mixed group and individual settings" begin
-        v_mixed = ODEVerbosity(
+        v_mixed = DEVerbosity(
             numerical = SciMLLogging.Silent(),
             shampine_dt = SciMLLogging.WarnLevel(),
             performance = SciMLLogging.InfoLevel()
@@ -151,7 +151,7 @@ using NonlinearSolve: NonlinearVerbosity
     end
 
     @testset "Individual keyword arguments" begin
-        v_individual = ODEVerbosity(
+        v_individual = DEVerbosity(
             dt_NaN = SciMLLogging.ErrorLevel(),
             alg_switch = SciMLLogging.InfoLevel(),
             shampine_dt = SciMLLogging.Silent()
@@ -165,14 +165,14 @@ using NonlinearSolve: NonlinearVerbosity
     end
 
     @testset "Linear and nonlinear verbosity passthrough" begin
-        v_with_solvers = ODEVerbosity(
+        v_with_solvers = DEVerbosity(
             linear_verbosity = SciMLLogging.Detailed(),
             nonlinear_verbosity = SciMLLogging.Minimal()
         )
         @test v_with_solvers.linear_verbosity isa SciMLLogging.Detailed
         @test v_with_solvers.nonlinear_verbosity isa SciMLLogging.Minimal
 
-        v_with_solvers2 = ODEVerbosity(
+        v_with_solvers2 = DEVerbosity(
             linear_verbosity = SciMLLogging.None(),
             nonlinear_verbosity = SciMLLogging.All()
         )
@@ -182,17 +182,17 @@ using NonlinearSolve: NonlinearVerbosity
 
     @testset "Validation tests" begin
         # Test that invalid group arguments throw errors
-        @test_throws ArgumentError ODEVerbosity(error_control = "invalid")
-        @test_throws ArgumentError ODEVerbosity(performance = 123)
-        @test_throws ArgumentError ODEVerbosity(numerical = :wrong)
+        @test_throws ArgumentError DEVerbosity(error_control = "invalid")
+        @test_throws ArgumentError DEVerbosity(performance = 123)
+        @test_throws ArgumentError DEVerbosity(numerical = :wrong)
 
         # Test that invalid individual fields throw errors
-        @test_throws ArgumentError ODEVerbosity(dt_NaN = "invalid")
-        @test_throws ArgumentError ODEVerbosity(unknown_field = SciMLLogging.InfoLevel())
+        @test_throws ArgumentError DEVerbosity(dt_NaN = "invalid")
+        @test_throws ArgumentError DEVerbosity(unknown_field = SciMLLogging.InfoLevel())
     end
 
     @testset "Multiple group settings" begin
-        v = ODEVerbosity(
+        v = DEVerbosity(
             error_control = SciMLLogging.ErrorLevel(),
             performance = SciMLLogging.InfoLevel(),
             numerical = SciMLLogging.Silent()
@@ -203,7 +203,7 @@ using NonlinearSolve: NonlinearVerbosity
     end
 
     @testset "Complex mixed settings" begin
-        v = ODEVerbosity(
+        v = DEVerbosity(
             error_control = SciMLLogging.WarnLevel(),
             performance = SciMLLogging.InfoLevel(),
             numerical = SciMLLogging.Silent(),
@@ -225,7 +225,7 @@ using NonlinearSolve: NonlinearVerbosity
     end
 
     @testset "Stiff Switching Message" begin
-        verb = ODEVerbosity(alg_switch = SciMLLogging.InfoLevel())
+        verb = DEVerbosity(alg_switch = SciMLLogging.InfoLevel())
         solve(prob_ode_vanderpol_stiff, AutoTsit5(Rodas5()), verbose = verb)
     end
 
@@ -246,7 +246,7 @@ using NonlinearSolve: NonlinearVerbosity
 
         @testset "Rosenbrock Solvers" begin
             @testset "Rosenbrock23 with Detailed LinearVerbosity" begin
-                verbose = ODEVerbosity(linear_verbosity = SciMLLogging.Detailed())
+                verbose = DEVerbosity(linear_verbosity = SciMLLogging.Detailed())
                 integrator = init(prob, Rosenbrock23(), verbose = verbose, dt = 1.0e-3)
 
                 # Check that the cache has a linsolve field
@@ -260,28 +260,28 @@ using NonlinearSolve: NonlinearVerbosity
             end
 
             @testset "Rosenbrock23 with Minimal LinearVerbosity" begin
-                verbose = ODEVerbosity(linear_verbosity = SciMLLogging.Minimal())
+                verbose = DEVerbosity(linear_verbosity = SciMLLogging.Minimal())
                 integrator = init(prob, Rosenbrock23(), verbose = verbose, dt = 1.0e-3)
 
                 @test integrator.cache.linsolve.verbose == LinearVerbosity(SciMLLogging.Minimal())
             end
 
             @testset "Rosenbrock23 with None LinearVerbosity" begin
-                verbose = ODEVerbosity(linear_verbosity = SciMLLogging.None())
+                verbose = DEVerbosity(linear_verbosity = SciMLLogging.None())
                 integrator = init(prob, Rosenbrock23(), verbose = verbose, dt = 1.0e-3)
 
                 @test integrator.cache.linsolve.verbose == LinearVerbosity(SciMLLogging.None())
             end
 
             @testset "Rosenbrock32 with Detailed LinearVerbosity" begin
-                verbose = ODEVerbosity(linear_verbosity = SciMLLogging.Detailed())
+                verbose = DEVerbosity(linear_verbosity = SciMLLogging.Detailed())
                 integrator = init(prob, Rosenbrock32(), verbose = verbose, dt = 1.0e-3)
 
                 @test integrator.cache.linsolve.verbose == LinearVerbosity(SciMLLogging.Detailed())
             end
 
             @testset "Rodas4 with All LinearVerbosity" begin
-                verbose = ODEVerbosity(linear_verbosity = SciMLLogging.All())
+                verbose = DEVerbosity(linear_verbosity = SciMLLogging.All())
                 integrator = init(prob, Rodas4(), verbose = verbose, dt = 1.0e-3)
 
                 @test integrator.cache.linsolve.verbose == LinearVerbosity(SciMLLogging.All())
@@ -290,7 +290,7 @@ using NonlinearSolve: NonlinearVerbosity
 
         @testset "FIRK Solvers (Radau Methods)" begin
             @testset "RadauIIA3 with Detailed LinearVerbosity" begin
-                verbose = ODEVerbosity(linear_verbosity = SciMLLogging.Detailed())
+                verbose = DEVerbosity(linear_verbosity = SciMLLogging.Detailed())
                 integrator = init(prob, RadauIIA3(), verbose = verbose, dt = 1.0e-3)
 
                 # RadauIIA3 has a linsolve field
@@ -298,14 +298,14 @@ using NonlinearSolve: NonlinearVerbosity
             end
 
             @testset "RadauIIA3 with Minimal LinearVerbosity" begin
-                verbose = ODEVerbosity(linear_verbosity = SciMLLogging.Minimal())
+                verbose = DEVerbosity(linear_verbosity = SciMLLogging.Minimal())
                 integrator = init(prob, RadauIIA3(), verbose = verbose, dt = 1.0e-3)
 
                 @test integrator.cache.linsolve.verbose == LinearVerbosity(SciMLLogging.Minimal())
             end
 
             @testset "RadauIIA5 with Detailed LinearVerbosity (two linear solvers)" begin
-                verbose = ODEVerbosity(linear_verbosity = SciMLLogging.Detailed())
+                verbose = DEVerbosity(linear_verbosity = SciMLLogging.Detailed())
                 integrator = init(prob, RadauIIA5(), verbose = verbose, dt = 1.0e-3)
 
                 @test integrator.cache.linsolve1.verbose == LinearVerbosity(SciMLLogging.Detailed())
@@ -313,7 +313,7 @@ using NonlinearSolve: NonlinearVerbosity
             end
 
             @testset "RadauIIA5 with None LinearVerbosity" begin
-                verbose = ODEVerbosity(linear_verbosity = SciMLLogging.None())
+                verbose = DEVerbosity(linear_verbosity = SciMLLogging.None())
                 integrator = init(prob, RadauIIA5(), verbose = verbose, dt = 1.0e-3)
 
                 @test integrator.cache.linsolve1.verbose == LinearVerbosity(SciMLLogging.None())
@@ -321,7 +321,7 @@ using NonlinearSolve: NonlinearVerbosity
             end
 
             @testset "RadauIIA9 with All LinearVerbosity (three linear solvers)" begin
-                verbose = ODEVerbosity(linear_verbosity = SciMLLogging.All())
+                verbose = DEVerbosity(linear_verbosity = SciMLLogging.All())
                 integrator = init(prob, RadauIIA9(), verbose = verbose, dt = 1.0e-3)
 
                 # Check all three linear solvers have the correct verbosity
@@ -335,7 +335,7 @@ using NonlinearSolve: NonlinearVerbosity
 
         @testset "Extrapolation Solvers" begin
             @testset "ImplicitEulerExtrapolation with Detailed LinearVerbosity" begin
-                verbose = ODEVerbosity(linear_verbosity = SciMLLogging.Detailed())
+                verbose = DEVerbosity(linear_verbosity = SciMLLogging.Detailed())
                 integrator = init(prob, ImplicitEulerExtrapolation(), verbose = verbose, dt = 1.0e-3)
 
                 # Check that all linear solvers in the array have the correct verbosity
@@ -345,7 +345,7 @@ using NonlinearSolve: NonlinearVerbosity
             end
 
             @testset "ImplicitEulerExtrapolation with Minimal LinearVerbosity" begin
-                verbose = ODEVerbosity(linear_verbosity = SciMLLogging.Minimal())
+                verbose = DEVerbosity(linear_verbosity = SciMLLogging.Minimal())
                 integrator = init(prob, ImplicitEulerExtrapolation(), verbose = verbose, dt = 1.0e-3)
 
                 for ls in integrator.cache.linsolve
@@ -354,7 +354,7 @@ using NonlinearSolve: NonlinearVerbosity
             end
 
             @testset "ImplicitDeuflhardExtrapolation with None LinearVerbosity" begin
-                verbose = ODEVerbosity(linear_verbosity = SciMLLogging.None())
+                verbose = DEVerbosity(linear_verbosity = SciMLLogging.None())
                 integrator = init(prob, ImplicitDeuflhardExtrapolation(), verbose = verbose, dt = 1.0e-3)
 
                 for ls in integrator.cache.linsolve
@@ -363,7 +363,7 @@ using NonlinearSolve: NonlinearVerbosity
             end
 
             @testset "ImplicitHairerWannerExtrapolation with All LinearVerbosity" begin
-                verbose = ODEVerbosity(linear_verbosity = SciMLLogging.All())
+                verbose = DEVerbosity(linear_verbosity = SciMLLogging.All())
                 integrator = init(prob, ImplicitHairerWannerExtrapolation(), verbose = verbose, dt = 1.0e-3)
 
                 for ls in integrator.cache.linsolve
@@ -374,7 +374,7 @@ using NonlinearSolve: NonlinearVerbosity
 
         @testset "Preset Verbosity Levels" begin
             @testset "Rosenbrock23 with Standard() preset (default linear_verbosity = Minimal)" begin
-                verbose = ODEVerbosity(SciMLLogging.Standard())
+                verbose = DEVerbosity(SciMLLogging.Standard())
                 integrator = init(prob, Rosenbrock23(), verbose = verbose, dt = 1.0e-3)
 
                 # Standard() uses Minimal() for linear_verbosity
@@ -382,7 +382,7 @@ using NonlinearSolve: NonlinearVerbosity
             end
 
             @testset "RadauIIA3 with Detailed() preset" begin
-                verbose = ODEVerbosity(SciMLLogging.Detailed())
+                verbose = DEVerbosity(SciMLLogging.Detailed())
                 integrator = init(prob, RadauIIA3(), verbose = verbose, dt = 1.0e-3)
 
                 # Detailed() uses Detailed() for linear_verbosity
@@ -408,7 +408,7 @@ using NonlinearSolve: NonlinearVerbosity
         prob = ODEProblem(rober, u0, tspan, p)
 
         @testset "ImplicitEuler with Detailed NonlinearVerbosity" begin
-            verbose = ODEVerbosity(nonlinear_verbosity = SciMLLogging.Detailed())
+            verbose = DEVerbosity(nonlinear_verbosity = SciMLLogging.Detailed())
             integrator = init(prob, ImplicitEuler(nlsolve = NonlinearSolveAlg()), verbose = verbose, dt = 1.0e-3)
 
             # Check that the cache has an nlsolver field

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -103,7 +103,7 @@ end
         @time @safetestset "No Jac Tests" include("interface/nojac.jl")
         @time @safetestset "Units Tests" include("interface/units_tests.jl")
         @time @safetestset "Non-Full Diagonal Sparsity Tests" include("interface/nonfulldiagonal_sparse.jl")
-        @time @safetestset "ODEVerbosity Tests" include("interface/verbosity.jl")
+        @time @safetestset "DEVerbosity Tests" include("interface/verbosity.jl")
     end
 
     if !is_APPVEYOR && (GROUP == "All" || GROUP == "InterfaceIV" || GROUP == "Interface")


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

It now holds verbosity for SDEs, DDEs, etc. so this is a more appropriate name 
