### PR TITLE
Fix `@verbosity_specifier` usage for DEVerbosity

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/verbosity.jl
+++ b/lib/OrdinaryDiffEqCore/src/verbosity.jl
@@ -16,7 +16,7 @@
         :constrained_step,
         :residual_control,
         :neutral_delay,
-        :state_dependent_delay
+        :state_dependent_delay,
     )
 
     presets = (
@@ -219,7 +219,7 @@
             :sensitivity_vjp_choice,
         ),
         sde_specific = (
-            :noise_evaluation
+            :noise_evaluation,
         ),
         dde_specific = (
             :discontinuity_tracking,
@@ -227,7 +227,7 @@
             :constrained_step,
             :residual_control,
             :neutral_delay,
-            :state_dependent_delay
+            :state_dependent_delay,
         ),
     )
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

~~Looks like the macro needs to be more flexible w/ regards to trailing commas? This should fix it for now though.~~ That's just how single value tuples work. 