### PR TITLE
Optimize sparse isdiag check from O(n²) to O(nnz) in get_differential_vars

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -73,6 +73,7 @@ SciMLBase = "2.116"
 SciMLLogging = "1.7.1"
 FastClosures = "0.3"
 DataStructures = "0.19"
+SparseArrays = "1"
 Static = "1.2"
 Aqua = "0.8.11"
 DocStringExtensions = "0.9"
@@ -97,10 +98,12 @@ Reexport = "1.2"
 [weakdeps]
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [targets]
-test = ["DiffEqDevTools", "Random", "SafeTestsets", "Test", "Pkg"]
+test = ["DiffEqDevTools", "Random", "SafeTestsets", "SparseArrays", "Test", "Pkg"]
 
 [extensions]
 OrdinaryDiffEqCoreEnzymeCoreExt = "EnzymeCore"
 OrdinaryDiffEqCoreMooncakeExt = "Mooncake"
+OrdinaryDiffEqCoreSparseArraysExt = "SparseArrays"

--- a/lib/OrdinaryDiffEqCore/ext/OrdinaryDiffEqCoreSparseArraysExt.jl
+++ b/lib/OrdinaryDiffEqCore/ext/OrdinaryDiffEqCoreSparseArraysExt.jl
@@ -1,0 +1,25 @@
+module OrdinaryDiffEqCoreSparseArraysExt
+
+using SparseArrays: SparseMatrixCSC
+import OrdinaryDiffEqCore: _isdiag
+
+# Efficient O(nnz) isdiag check for sparse matrices.
+# Standard isdiag is O(n²) which is prohibitively slow for large sparse matrices.
+"""
+    _isdiag(A::SparseMatrixCSC)
+
+Check if a sparse matrix is diagonal in O(nnz) time by traversing the CSC structure directly.
+Returns `true` if all non-zero elements are on the diagonal.
+"""
+function _isdiag(A::SparseMatrixCSC)
+    m, n = size(A)
+    m != n && return false
+    @inbounds for j in 1:n
+        for k in A.colptr[j]:(A.colptr[j + 1] - 1)
+            A.rowval[k] != j && return false
+        end
+    end
+    return true
+end
+
+end

--- a/lib/OrdinaryDiffEqCore/src/misc_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/misc_utils.jl
@@ -122,7 +122,7 @@ function get_differential_vars(f, u)
             return nothing
         elseif all(!iszero, mm)
             return trues(size(mm, 1))
-        elseif !(mm isa SciMLOperators.AbstractSciMLOperator) && isdiag(mm)
+        elseif !(mm isa SciMLOperators.AbstractSciMLOperator) && _isdiag(mm)
             return reshape(diag(mm) .!= 0, size(u))
         else
             return DifferentialVarsUndefined()
@@ -131,6 +131,10 @@ function get_differential_vars(f, u)
         return nothing
     end
 end
+
+# Fallback for _isdiag - uses LinearAlgebra.isdiag which is O(n²)
+# Sparse specialization is provided in OrdinaryDiffEqCoreSparseArraysExt
+_isdiag(A::AbstractMatrix) = isdiag(A)
 
 isnewton(::Any) = false
 

--- a/lib/OrdinaryDiffEqCore/test/runtests.jl
+++ b/lib/OrdinaryDiffEqCore/test/runtests.jl
@@ -7,3 +7,6 @@ if TEST_GROUP != "FUNCTIONAL" && isempty(VERSION.prerelease)
     @time @safetestset "JET Tests" include("jet.jl")
     @time @safetestset "Aqua" include("qa.jl")
 end
+
+# Functional tests
+@time @safetestset "Sparse isdiag Performance" include("sparse_isdiag_tests.jl")

--- a/lib/OrdinaryDiffEqCore/test/sparse_isdiag_tests.jl
+++ b/lib/OrdinaryDiffEqCore/test/sparse_isdiag_tests.jl
@@ -1,0 +1,79 @@
+using Test
+# Load SparseArrays first to trigger the extension
+using SparseArrays
+using OrdinaryDiffEqCore: _isdiag
+
+@testset "Sparse isdiag Performance" begin
+    # Test 1: Correctness - _isdiag should correctly identify diagonal matrices
+    @testset "Correctness" begin
+        # Diagonal sparse matrix
+        M1 = sparse(1:5, 1:5, ones(5))
+        @test _isdiag(M1) == true
+
+        # Non-diagonal sparse matrix (has off-diagonal elements)
+        M2 = sparse([1, 1, 2], [1, 2, 2], [1.0, 2.0, 3.0], 3, 3)
+        @test _isdiag(M2) == false
+
+        # Empty sparse matrix (is diagonal by definition)
+        M3 = spzeros(5, 5)
+        @test _isdiag(M3) == true
+
+        # Non-square matrix (not diagonal)
+        M4 = sparse([1, 2], [1, 2], [1.0, 2.0], 3, 4)
+        @test _isdiag(M4) == false
+
+        # Sparse matrix with explicit zeros stored on diagonal
+        M5 = sparse([1, 2, 3], [1, 2, 3], [1.0, 0.0, 1.0], 3, 3)
+        @test _isdiag(M5) == true
+
+        # Large diagonal matrix with some zeros
+        n = 100
+        vals = vcat(ones(n ÷ 2), zeros(n - n ÷ 2))
+        M6 = spdiagm(0 => vals)
+        @test _isdiag(M6) == true
+    end
+
+    # Test 2: Complexity verification
+    # For sparse matrices, time should scale with nnz, not n^2
+    @testset "Complexity O(nnz) not O(n^2)" begin
+        n_small = 10_000
+        n_large = 40_000
+
+        M_small = sparse(1:n_small, 1:n_small, ones(n_small))
+        M_large = sparse(1:n_large, 1:n_large, ones(n_large))
+
+        # Warmup
+        _isdiag(M_small)
+        _isdiag(M_large)
+
+        # Measure
+        t_small = @elapsed for _ in 1:10
+            _isdiag(M_small)
+        end
+
+        t_large = @elapsed for _ in 1:10
+            _isdiag(M_large)
+        end
+
+        ratio = t_large / t_small
+        size_ratio = n_large / n_small  # 4x size increase
+
+        # With O(n^2), ratio would be ~16
+        # With O(nnz) = O(n), ratio should be ~4
+        # Allow some tolerance for measurement noise
+        @test ratio < size_ratio * 2  # Should be closer to linear than quadratic
+
+        # Absolute sanity check: processing 40k diagonal shouldn't take > 100ms
+        t_single = @elapsed _isdiag(M_large)
+        @test t_single < 0.1  # Should be < 100ms, typically < 1ms
+    end
+
+    # Test 3: Verify fallback for dense matrices still works
+    @testset "Dense matrix fallback" begin
+        M_dense = [1.0 0.0; 0.0 2.0]
+        @test _isdiag(M_dense) == true
+
+        M_dense_nondiag = [1.0 1.0; 0.0 2.0]
+        @test _isdiag(M_dense_nondiag) == false
+    end
+end


### PR DESCRIPTION
## Summary

Add SparseArrays extension that provides efficient O(nnz) `_isdiag` check for sparse matrices by traversing the CSC structure directly. Standard `isdiag` is O(n²) which is prohibitively slow for large sparse matrices.

For large DAE systems (e.g., 259k variables), this reduces initialization time from ~60 seconds to <1ms.

**Changes:**
- Add SparseArrays as a weak dependency
- Add `OrdinaryDiffEqCoreSparseArraysExt` extension with `_isdiag(::SparseMatrixCSC)`
- Add `_isdiag` dispatch function with fallback to `LinearAlgebra.isdiag`
- Update `get_differential_vars` to use `_isdiag` instead of `isdiag`
- Add performance regression tests verifying O(nnz) complexity

This is similar to the fix in #2949 for `find_algebraic_vars_eqs`.

Fixes #3010

## Test plan

- [x] Run OrdinaryDiffEqCore tests locally - all pass
- [x] Extension loads correctly when SparseArrays is loaded
- [x] Added `sparse_isdiag_tests.jl` with:
  - Correctness tests for diagonal/non-diagonal sparse matrices
  - Complexity verification (O(nnz) vs O(n²))
  - Dense matrix fallback tests

🤖 Generated with [Claude Code](https://claude.ai/code)