### PR TITLE
Call `final_progress`

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
@@ -227,8 +227,10 @@ function _postamble!(integrator)
     if !(integrator.sol isa DAESolution)
         resize!(integrator.sol.k, integrator.saveiter_dense)
     end
-    return if integrator.opts.progress
+    if integrator.opts.progress
+        final_progress(integrator)
     end
+    return nothing
 end
 
 function final_progress(integrator)


### PR DESCRIPTION
To make sure the progress bar reaches 100%.

Came up in https://github.com/Deltares/Ribasim/issues/2663

Looks like this slipped in in https://github.com/SciML/OrdinaryDiffEq.jl/pull/2742/changes#diff-fc30bb14472d1ad90bcef722e155cd494891c98618f299c6a690be2a262eb7a9

