### PR TITLE
Fix broken diffeq.sciml.ai URLs in docs

### DIFF
--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -45,7 +45,7 @@ prob = ODEProblem(lorenz, u0, tspan)
 sol = solve(prob, Tsit5())
 ```
 
-For “refined ODEs”, like dynamical equations and `SecondOrderODEProblem`s, refer to the [DiffEqDocs](https://diffeq.sciml.ai/dev/types/ode_types/). For example, in [DiffEqTutorials.jl](https://github.com/SciML/SciMLTutorials.jl) we show how to solve equations of motion using symplectic methods:
+For “refined ODEs”, like dynamical equations and `SecondOrderODEProblem`s, refer to the [DiffEqDocs](https://docs.sciml.ai/DiffEqDocs/stable/types/ode_types/). For example, in [DiffEqTutorials.jl](https://github.com/SciML/SciMLTutorials.jl) we show how to solve equations of motion using symplectic methods:
 
 ```julia
 function HH_acceleration!(dv, v, u, p, t)
@@ -64,4 +64,4 @@ Other refined forms are IMEX and semi-linear ODEs (for exponential integrators).
 
 ## Available Solvers
 
-For the list of available solvers, please refer to the [DifferentialEquations.jl ODE Solvers](https://diffeq.sciml.ai/dev/solvers/ode_solve/), [Dynamical ODE Solvers](https://diffeq.sciml.ai/dev/solvers/dynamical_solve/), and the [Split ODE Solvers](https://diffeq.sciml.ai/dev/solvers/split_ode_solve/) pages.
+For the list of available solvers, please refer to the [DifferentialEquations.jl ODE Solvers](https://docs.sciml.ai/DiffEqDocs/stable/solvers/ode_solve/), [Dynamical ODE Solvers](https://docs.sciml.ai/DiffEqDocs/stable/solvers/dynamical_solve/), and the [Split ODE Solvers](https://docs.sciml.ai/DiffEqDocs/stable/solvers/split_ode_solve/) pages.


### PR DESCRIPTION
## Summary
- Replace deprecated `diffeq.sciml.ai` URLs in `docs/src/usage.md` with `docs.sciml.ai/DiffEqDocs/stable/` equivalents
- These docs are copied into DiffEqDocs.jl at build time, and the old URLs timeout causing CI linkcheck failures

### URLs fixed:
| Old URL | New URL |
|---------|---------|
| `diffeq.sciml.ai/dev/types/ode_types/` | `docs.sciml.ai/DiffEqDocs/stable/types/ode_types/` |
| `diffeq.sciml.ai/dev/solvers/ode_solve/` | `docs.sciml.ai/DiffEqDocs/stable/solvers/ode_solve/` |
| `diffeq.sciml.ai/dev/solvers/dynamical_solve/` | `docs.sciml.ai/DiffEqDocs/stable/solvers/dynamical_solve/` |
| `diffeq.sciml.ai/dev/solvers/split_ode_solve/` | `docs.sciml.ai/DiffEqDocs/stable/solvers/split_ode_solve/` |

Related: SciML/DiffEqDocs.jl#841

## Test plan
- [ ] DiffEqDocs.jl CI linkcheck passes after both PRs are merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)