### PR TITLE
Fix broken DiffEqDocs links and ignore ForwardDiff.jl in linkcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ prob = ODEProblem(lorenz, u0, tspan)
 sol = solve(prob, Tsit5())
 ```
 
-For "refined ODEs", like dynamical equations and `SecondOrderODEProblem`s, refer to the [DiffEqDocs](https://diffeq.sciml.ai/dev/types/ode_types/). For example, the harmonic oscillator equations can be solved using symplectic methods. The harmonic oscillator is described by:
+For "refined ODEs", like dynamical equations and `SecondOrderODEProblem`s, refer to the [DiffEqDocs](https://docs.sciml.ai/DiffEqDocs/stable/types/ode_types/). For example, the harmonic oscillator equations can be solved using symplectic methods. The harmonic oscillator is described by:
 
 $$\ddot{x} + \omega^2 x = 0$$
 
@@ -116,4 +116,4 @@ Other refined forms are IMEX and semi-linear ODEs (for exponential integrators).
 
 ## Available Solvers
 
-For the list of available solvers, please refer to the [DifferentialEquations.jl ODE Solvers](https://diffeq.sciml.ai/dev/solvers/ode_solve/), [Dynamical ODE Solvers](https://diffeq.sciml.ai/dev/solvers/dynamical_solve/), and the [Split ODE Solvers](https://diffeq.sciml.ai/dev/solvers/split_ode_solve/) pages.
+For the list of available solvers, please refer to the [DifferentialEquations.jl ODE Solvers](https://docs.sciml.ai/DiffEqDocs/stable/solvers/ode_solve/), [Dynamical ODE Solvers](https://docs.sciml.ai/DiffEqDocs/stable/solvers/dynamical_solve/), and the [Split ODE Solvers](https://docs.sciml.ai/DiffEqDocs/stable/solvers/split_ode_solve/) pages.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -40,6 +40,7 @@ makedocs(
         OrdinaryDiffEq.OrdinaryDiffEqTsit5,
         OrdinaryDiffEq.OrdinaryDiffEqVerner,
     ],
+    linkcheck_ignore = [r"https://github.com/JuliaDiff/ForwardDiff.jl"],
     warnonly = [:docs_block, :missing_docs, :eval_block],
     format = Documenter.HTML(
         analytics = "UA-90474609-3",

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -45,7 +45,7 @@ prob = ODEProblem(lorenz, u0, tspan)
 sol = solve(prob, Tsit5())
 ```
 
-For “refined ODEs”, like dynamical equations and `SecondOrderODEProblem`s, refer to the [DiffEqDocs](https://diffeq.sciml.ai/dev/types/ode_types/). For example, in [DiffEqTutorials.jl](https://github.com/SciML/SciMLTutorials.jl) we show how to solve equations of motion using symplectic methods:
+For “refined ODEs”, like dynamical equations and `SecondOrderODEProblem`s, refer to the [DiffEqDocs](https://docs.sciml.ai/DiffEqDocs/stable/types/ode_types/). For example, in [DiffEqTutorials.jl](https://github.com/SciML/SciMLTutorials.jl) we show how to solve equations of motion using symplectic methods:
 
 ```julia
 function HH_acceleration!(dv, v, u, p, t)
@@ -64,4 +64,4 @@ Other refined forms are IMEX and semi-linear ODEs (for exponential integrators).
 
 ## Available Solvers
 
-For the list of available solvers, please refer to the [DifferentialEquations.jl ODE Solvers](https://diffeq.sciml.ai/dev/solvers/ode_solve/), [Dynamical ODE Solvers](https://diffeq.sciml.ai/dev/solvers/dynamical_solve/), and the [Split ODE Solvers](https://diffeq.sciml.ai/dev/solvers/split_ode_solve/) pages.
+For the list of available solvers, please refer to the [DifferentialEquations.jl ODE Solvers](https://docs.sciml.ai/DiffEqDocs/stable/solvers/ode_solve/), [Dynamical ODE Solvers](https://docs.sciml.ai/DiffEqDocs/stable/solvers/dynamical_solve/), and the [Split ODE Solvers](https://docs.sciml.ai/DiffEqDocs/stable/solvers/split_ode_solve/) pages.

--- a/lib/OrdinaryDiffEqCore/src/integrators/type.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/type.jl
@@ -56,11 +56,11 @@ end
 
 Fundamental `struct` allowing interactively stepping through the numerical solving of a differential equation.
 The full documentation is hosted here:
-[https://diffeq.sciml.ai/latest/basics/integrator/](https://diffeq.sciml.ai/latest/basics/integrator/).
+[https://docs.sciml.ai/DiffEqDocs/stable/basics/integrator/](https://docs.sciml.ai/DiffEqDocs/stable/basics/integrator/).
 This docstring describes basic functionality only!
 
 Initialize using `integrator = init(prob::ODEProblem, alg; kwargs...)`. The keyword args which are accepted are the same
-[common solver options](https://diffeq.sciml.ai/latest/basics/common_solver_opts/)
+[common solver options](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
 used by `solve`.
 
 For reference, relevant fields of the `ODEIntegrator` are:


### PR DESCRIPTION
## Summary
- Replace defunct `diffeq.sciml.ai` URLs with `docs.sciml.ai/DiffEqDocs/stable/` in `README.md`, `docs/src/usage.md`, and `lib/OrdinaryDiffEqCore/src/integrators/type.jl`
- Add `ForwardDiff.jl` GitHub URL to `linkcheck_ignore` in `docs/make.jl`

## Files changed
- `README.md` — updated 2 links
- `docs/src/usage.md` — updated 4 links
- `lib/OrdinaryDiffEqCore/src/integrators/type.jl` — updated 2 links
- `docs/make.jl` — added `linkcheck_ignore` for ForwardDiff.jl

## Test plan
- [ ] CI linkcheck should pass without the previous curl timeout errors
- [ ] All new URLs verified to return HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)