### PR TITLE
Fix CI matrix: remove duplicate Multithreading and fix SimpleImplicitDiscreteSolve_QA exclude

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,6 @@ jobs:
           - QA
           - Regression_I
           - Regression_II
-          - Multithreading
 
           # Functional tests for sublibraries (run on all Julia versions)
           - OrdinaryDiffEqAdamsBashforthMoulton
@@ -343,6 +342,7 @@ jobs:
           - group: SimpleImplicitDiscreteSolve_QA
             version: '1.11'
           - group: SimpleImplicitDiscreteSolve_QA
+            version: 'pre'
           # Skip OrdinaryDiffEqBDF on pre-release Julia (JET resolution fails)
           # See: https://github.com/SciML/OrdinaryDiffEq.jl/issues/2977
           - group: OrdinaryDiffEqBDF


### PR DESCRIPTION
## Summary
- Remove duplicate `Multithreading` entry in CI matrix that caused it to run twice per Julia version (wasting CI resources)
- Add missing `version: 'pre'` to `SimpleImplicitDiscreteSolve_QA` exclude entry — it was excluding all versions instead of just `pre`, meaning the QA test never ran on any Julia version

## Context
The master CI failure (run 21560135721) was caused by a permission denied error on the self-hosted runner's precompile cache (`deepsea4-7`), not a code issue. Both failing jobs (`AlgConvergence_II, pre` and `OrdinaryDiffEqQPRK, pre`) hit the same error:
```
SystemError: opening file ".julia/compiled/v1.13/OrdinaryDiffEqAdamsBashforthMoulton/iK9eS_ovd2T.ji": Permission denied
```
This PR will also trigger a fresh CI run to confirm master is green.

## Test plan
- [ ] CI passes on all Julia versions
- [ ] Multithreading test group runs exactly once per version (not twice)
- [ ] SimpleImplicitDiscreteSolve_QA runs on Julia `1` (latest stable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)