### PR TITLE
Bump subpackages to require OrdinaryDiffEqDifferentiation v2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEq"
 uuid = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "6.107.0"
+version = "6.108.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -136,7 +136,7 @@ OrdinaryDiffEqAdamsBashforthMoulton = "1.4.0"
 OrdinaryDiffEqBDF = "1.9.0"
 OrdinaryDiffEqCore = "3"
 OrdinaryDiffEqDefault = "1.7.0"
-OrdinaryDiffEqDifferentiation = "1.12.0"
+OrdinaryDiffEqDifferentiation = "2"
 OrdinaryDiffEqExplicitRK = "1.3.0"
 OrdinaryDiffEqExponentialRK = "1.7.0"
 OrdinaryDiffEqExtrapolation = "1.7.0"

--- a/lib/OrdinaryDiffEqBDF/Project.toml
+++ b/lib/OrdinaryDiffEqBDF/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqBDF"
 uuid = "6ad6398a-0878-4a85-9266-38940aa047c8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "1.14.0"
+version = "1.15.0"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -52,7 +52,7 @@ MuladdMacro = "0.2"
 LinearSolve = "3.46"
 PrecompileTools = "1.2, 1.3"
 LinearAlgebra = "1.10"
-OrdinaryDiffEqDifferentiation = "1.12.0"
+OrdinaryDiffEqDifferentiation = "2"
 OrdinaryDiffEqSDIRK = "1.6.0"
 TruncatedStacktraces = "1.4"
 SciMLBase = "2.116"

--- a/lib/OrdinaryDiffEqExponentialRK/Project.toml
+++ b/lib/OrdinaryDiffEqExponentialRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExponentialRK"
 uuid = "e0540318-69ee-4070-8777-9e2de6de23de"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "1.12.0"
+version = "1.13.0"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -43,7 +43,7 @@ OrdinaryDiffEqVerner = "1.5.0"
 LinearSolve = "3.46"
 ExponentialUtilities = "1.27"
 LinearAlgebra = "1.10"
-OrdinaryDiffEqDifferentiation = "1.12.0"
+OrdinaryDiffEqDifferentiation = "2"
 OrdinaryDiffEqSDIRK = "1.6.0"
 SciMLBase = "2.116"
 OrdinaryDiffEqCore = "3"

--- a/lib/OrdinaryDiffEqExtrapolation/Project.toml
+++ b/lib/OrdinaryDiffEqExtrapolation/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExtrapolation"
 uuid = "becaefa8-8ca2-5cf9-886d-c06f3d2bd2c4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "1.13.0"
+version = "1.14.0"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -36,7 +36,7 @@ DiffEqDevTools = "2.44.4"
 MuladdMacro = "0.2"
 LinearSolve = "3.46"
 Polyester = "0.7"
-OrdinaryDiffEqDifferentiation = "1.12.0"
+OrdinaryDiffEqDifferentiation = "2"
 SciMLBase = "2.116"
 OrdinaryDiffEqCore = "3"
 Aqua = "0.8.11"

--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFIRK"
 uuid = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "1.20.0"
+version = "1.21.0"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -44,7 +44,7 @@ MuladdMacro = "0.2"
 LinearSolve = "3.46"
 Polyester = "0.7"
 LinearAlgebra = "1.10"
-OrdinaryDiffEqDifferentiation = "1.12.0"
+OrdinaryDiffEqDifferentiation = "2"
 SciMLBase = "2.116"
 OrdinaryDiffEqCore = "3"
 Aqua = "0.8.11"

--- a/lib/OrdinaryDiffEqIMEXMultistep/Project.toml
+++ b/lib/OrdinaryDiffEqIMEXMultistep/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqIMEXMultistep"
 uuid = "9f002381-b378-40b7-97a6-27a27c83f129"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "1.11.0"
+version = "1.12.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -29,7 +29,7 @@ Test = "<0.0.1, 1"
 FastBroadcast = "0.3"
 Random = "<0.0.1, 1"
 DiffEqDevTools = "2.44.4"
-OrdinaryDiffEqDifferentiation = "1.12.0"
+OrdinaryDiffEqDifferentiation = "2"
 SciMLBase = "2.116"
 OrdinaryDiffEqCore = "3"
 Aqua = "0.8.11"

--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "1.19.0"
+version = "1.20.0"
 
 [deps]
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
@@ -50,7 +50,7 @@ MuladdMacro = "0.2"
 LinearSolve = "3.46"
 LineSearches = "7.4"
 LinearAlgebra = "1.10"
-OrdinaryDiffEqDifferentiation = "1.12.0"
+OrdinaryDiffEqDifferentiation = "2"
 OrdinaryDiffEqSDIRK = "1.6.0"
 SciMLBase = "2.116"
 OrdinaryDiffEqCore = "3"

--- a/lib/OrdinaryDiffEqPDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqPDIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqPDIRK"
 uuid = "5dd0a6cf-3d4b-4314-aa06-06d4e299bc89"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "1.10.0"
+version = "1.11.0"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -34,7 +34,7 @@ Random = "<0.0.1, 1"
 DiffEqDevTools = "2.44.4"
 MuladdMacro = "0.2"
 Polyester = "0.7"
-OrdinaryDiffEqDifferentiation = "1.12.0"
+OrdinaryDiffEqDifferentiation = "2"
 SciMLBase = "2.116"
 OrdinaryDiffEqCore = "3"
 Aqua = "0.8.11"

--- a/lib/OrdinaryDiffEqRosenbrock/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrock/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqRosenbrock"
 uuid = "43230ef6-c299-4910-a778-202eb28ce4ce"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "1.22.0"
+version = "1.23.0"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -51,7 +51,7 @@ LinearSolve = "3.46"
 Polyester = "0.7"
 PrecompileTools = "1.2, 1.3"
 LinearAlgebra = "1.10"
-OrdinaryDiffEqDifferentiation = "1.12.0"
+OrdinaryDiffEqDifferentiation = "2"
 SciMLBase = "2.116"
 OrdinaryDiffEqCore = "3"
 Static = "1.2"

--- a/lib/OrdinaryDiffEqSDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqSDIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSDIRK"
 uuid = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "1.11.0"
+version = "1.12.0"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -36,7 +36,7 @@ Random = "<0.0.1, 1"
 DiffEqDevTools = "2.44.4"
 MuladdMacro = "0.2"
 LinearAlgebra = "1.10"
-OrdinaryDiffEqDifferentiation = "1.12.0"
+OrdinaryDiffEqDifferentiation = "2"
 TruncatedStacktraces = "1.4"
 SciMLBase = "2.116"
 OrdinaryDiffEqCore = "3"

--- a/lib/OrdinaryDiffEqStabilizedIRK/Project.toml
+++ b/lib/OrdinaryDiffEqStabilizedIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqStabilizedIRK"
 uuid = "e3e12d00-db14-5390-b879-ac3dd2ef6296"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "1.10.0"
+version = "1.11.0"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -36,7 +36,7 @@ Random = "<0.0.1, 1"
 DiffEqDevTools = "2.44.4"
 MuladdMacro = "0.2"
 LinearAlgebra = "1.10"
-OrdinaryDiffEqDifferentiation = "1.12.0"
+OrdinaryDiffEqDifferentiation = "2"
 SciMLBase = "2.116"
 OrdinaryDiffEqCore = "3"
 Aqua = "0.8.11"


### PR DESCRIPTION
## Summary
- Update `OrdinaryDiffEqDifferentiation` compat from `"1.12.0"` to `"2"` in all 10 dependent subpackages and the main package
- Minor version bump for each affected subpackage

### Version bumps

| Package | Old | New |
|---------|-----|-----|
| OrdinaryDiffEq | 6.107.0 | 6.108.0 |
| OrdinaryDiffEqBDF | 1.14.0 | 1.15.0 |
| OrdinaryDiffEqExponentialRK | 1.12.0 | 1.13.0 |
| OrdinaryDiffEqExtrapolation | 1.13.0 | 1.14.0 |
| OrdinaryDiffEqFIRK | 1.20.0 | 1.21.0 |
| OrdinaryDiffEqIMEXMultistep | 1.11.0 | 1.12.0 |
| OrdinaryDiffEqNonlinearSolve | 1.19.0 | 1.20.0 |
| OrdinaryDiffEqPDIRK | 1.10.0 | 1.11.0 |
| OrdinaryDiffEqRosenbrock | 1.22.0 | 1.23.0 |
| OrdinaryDiffEqSDIRK | 1.11.0 | 1.12.0 |
| OrdinaryDiffEqStabilizedIRK | 1.10.0 | 1.11.0 |

### Registration commands

After merge:

```
@JuliaRegistrator register subdir=lib/OrdinaryDiffEqBDF
@JuliaRegistrator register subdir=lib/OrdinaryDiffEqExponentialRK
@JuliaRegistrator register subdir=lib/OrdinaryDiffEqExtrapolation
@JuliaRegistrator register subdir=lib/OrdinaryDiffEqFIRK
@JuliaRegistrator register subdir=lib/OrdinaryDiffEqIMEXMultistep
@JuliaRegistrator register subdir=lib/OrdinaryDiffEqNonlinearSolve
@JuliaRegistrator register subdir=lib/OrdinaryDiffEqPDIRK
@JuliaRegistrator register subdir=lib/OrdinaryDiffEqRosenbrock
@JuliaRegistrator register subdir=lib/OrdinaryDiffEqSDIRK
@JuliaRegistrator register subdir=lib/OrdinaryDiffEqStabilizedIRK
@JuliaRegistrator register
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)