### PR TITLE
Make EnzymeCore.jl a strong dependency of OrdinaryDiffEqCore.jl

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -4,6 +4,7 @@ authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 version = "3.4.0"
 
 [deps]
+EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
 SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 SciMLStructures = "53ae85a6-f571-4167-b2af-e1d143709226"
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
@@ -97,13 +98,11 @@ Reexport = "1.2"
 
 [weakdeps]
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
-EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [targets]
 test = ["DiffEqDevTools", "Random", "SafeTestsets", "SparseArrays", "Test", "Pkg"]
 
 [extensions]
-OrdinaryDiffEqCoreEnzymeCoreExt = "EnzymeCore"
 OrdinaryDiffEqCoreMooncakeExt = "Mooncake"
 OrdinaryDiffEqCoreSparseArraysExt = "SparseArrays"

--- a/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
+++ b/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
@@ -97,6 +97,8 @@ using SymbolicIndexingInterface: state_values, parameter_values
 
 using ConcreteStructs: @concrete
 
+import EnzymeCore
+
 const CompiledFloats = Union{Float32, Float64}
 import Preferences
 
@@ -165,6 +167,8 @@ include("iterator_interface.jl")
 include("solve.jl")
 include("initdt.jl")
 include("interp_func.jl")
+
+include("enzyme_rules.jl")
 
 include("precompilation_setup.jl")
 

--- a/lib/OrdinaryDiffEqCore/src/enzyme_rules.jl
+++ b/lib/OrdinaryDiffEqCore/src/enzyme_rules.jl
@@ -1,47 +1,47 @@
-module OrdinaryDiffEqCoreEnzymeCoreExt
-import OrdinaryDiffEqCore, EnzymeCore
-
 function EnzymeCore.EnzymeRules.inactive_noinl(
-        ::typeof(OrdinaryDiffEqCore.increment_nf!), args...
-    )
-    return true
-end
-function EnzymeCore.EnzymeRules.inactive_noinl(
-        ::typeof(OrdinaryDiffEqCore.fixed_t_for_floatingpoint_error!), args...
-    )
-    return true
-end
-function EnzymeCore.EnzymeRules.inactive_noinl(
-        ::typeof(OrdinaryDiffEqCore.increment_accept!), args...
-    )
-    return true
-end
-function EnzymeCore.EnzymeRules.inactive_noinl(
-        ::typeof(OrdinaryDiffEqCore.increment_reject!), args...
-    )
-    return true
-end
-function EnzymeCore.EnzymeRules.inactive_noinl(
-        ::typeof(OrdinaryDiffEqCore.check_error!), args...
-    )
-    return true
-end
-function EnzymeCore.EnzymeRules.inactive_noinl(
-        ::typeof(OrdinaryDiffEqCore.log_step!), args...
+        ::typeof(increment_nf!), args...
     )
     return true
 end
 
 function EnzymeCore.EnzymeRules.inactive_noinl(
-        ::typeof(OrdinaryDiffEqCore.final_progress), args...
+        ::typeof(fixed_t_for_floatingpoint_error!), args...
     )
     return true
 end
 
 function EnzymeCore.EnzymeRules.inactive_noinl(
-        ::typeof(OrdinaryDiffEqCore.ode_determine_initdt), args...
+        ::typeof(increment_accept!), args...
     )
     return true
 end
 
+function EnzymeCore.EnzymeRules.inactive_noinl(
+        ::typeof(increment_reject!), args...
+    )
+    return true
+end
+
+function EnzymeCore.EnzymeRules.inactive_noinl(
+        ::typeof(check_error!), args...
+    )
+    return true
+end
+
+function EnzymeCore.EnzymeRules.inactive_noinl(
+        ::typeof(log_step!), args...
+    )
+    return true
+end
+
+function EnzymeCore.EnzymeRules.inactive_noinl(
+        ::typeof(final_progress), args...
+    )
+    return true
+end
+
+function EnzymeCore.EnzymeRules.inactive_noinl(
+        ::typeof(ode_determine_initdt), args...
+    )
+    return true
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

This fixes #3025 and closes #3031. As noted by @devmotion (edit: https://github.com/SciML/OrdinaryDiffEq.jl/pull/3031#issuecomment-3840927936), it does not make sense to make EnzymeCore.jl only a weak dependency of OrdinaryDiffEqCore.jl because OrdinaryDiffEqCore.jl depends on EnzymeCore.jl via DiffEqBase.jl. I verified locally that this also fixes the circular dependency issue on Julia v1.10.
