### PR TITLE
Add missing post newton controller dispatch for non-default algorithms

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
@@ -1002,6 +1002,13 @@ end
 @inline step_reject_controller!(integrator, controller::DummyController, alg) = default_step_reject_controller!(integrator, integrator.cache, alg)
 @inline post_newton_controller!(integrator, controller::DummyController, alg) = default_post_newton_controller!(integrator, integrator.cache, alg)
 
+# TODO remove this for OrdinaryDiffEq v7 . Right now the integrator is expected to carry a controller. Therefore algorithms coming with a custom controller default to a DummyController too.
+# Instead of scattering this function across all subpackages we add the default dispatch here.
+function default_post_newton_controller!(integrator, cache, alg)
+    integrator.dt = integrator.dt / integrator.opts.failfactor
+    return nothing
+end
+
 # Default alg with dummy controller
 function default_stepsize_controller!(integrator, cache::DefaultCache, alg)
     return if cache.current == 1


### PR DESCRIPTION
Fixes https://github.com/SciML/OrdinaryDiffEq.jl/issues/3035 