### PR TITLE
Replace deprecated alias_u0 keyword with ODEAliasSpecifier in test

### DIFF
--- a/test/interface/aliasing_tests.jl
+++ b/test/interface/aliasing_tests.jl
@@ -2,10 +2,10 @@ using OrdinaryDiffEq, Test
 
 import ODEProblemLibrary: prob_ode_linear
 
-# Test that the old keyword works, and that the new AliasSpecier works.
-u0_old_alias_kwarg_sol = solve(prob_ode_linear, Tsit5(), alias_u0 = true)
-u0_new_alias_kwarg_sol = solve(
+# Test that ODEAliasSpecifier works for alias_u0
+u0_alias_sol = solve(
     prob_ode_linear, Tsit5(), alias = ODEAliasSpecifier(alias_u0 = true)
 )
+u0_no_alias_sol = solve(prob_ode_linear, Tsit5())
 
-@test u0_old_alias_kwarg_sol == u0_new_alias_kwarg_sol
+@test u0_alias_sol.u == u0_no_alias_sol.u


### PR DESCRIPTION
## Summary
- Update `test/interface/aliasing_tests.jl` to use `ODEAliasSpecifier` instead of the deprecated bare `alias_u0` keyword

The bare `alias_u0` keyword argument to `solve()` was deprecated in favor of `ODEAliasSpecifier`. On Julia 1.12, this deprecation is promoted to an error (when `--depwarn=error` is active), causing the aliasing integration tests to fail. This was surfacing as a downstream failure in CommonSolve.jl's integration tests.

The test now verifies that `ODEAliasSpecifier(alias_u0 = true)` produces correct solutions by comparing against a standard (non-aliased) solve.

## Test plan
- [ ] CI aliasing tests pass on Julia 1.12+
- [ ] CommonSolve.jl integration tests should stop failing on this test

🤖 Generated with [Claude Code](https://claude.com/claude-code)