### PR TITLE
Fix deprecation warnings

### DIFF
--- a/lib/ImplicitDiscreteSolve/test/runtests.jl
+++ b/lib/ImplicitDiscreteSolve/test/runtests.jl
@@ -160,7 +160,7 @@ if TEST_GROUP != "FUNCTIONAL" && isempty(VERSION.prerelease)
     using JET
     @testset "JET Tests" begin
         test_package(
-            ImplicitDiscreteSolve, target_defined_modules = true, mode = :typo
+            ImplicitDiscreteSolve, target_modules = (ImplicitDiscreteSolve,), mode = :typo
         )
     end
 

--- a/lib/OrdinaryDiffEqAdamsBashforthMoulton/test/jet.jl
+++ b/lib/OrdinaryDiffEqAdamsBashforthMoulton/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqAdamsBashforthMoulton, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqAdamsBashforthMoulton, target_modules = (OrdinaryDiffEqAdamsBashforthMoulton,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqBDF/test/jet.jl
+++ b/lib/OrdinaryDiffEqBDF/test/jet.jl
@@ -11,7 +11,7 @@ using Test
 @testset "JET Tests" begin
     # Test package for typos - now passing
     test_package(
-        OrdinaryDiffEqBDF, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqBDF, target_modules = (OrdinaryDiffEqBDF,), mode = :typo
     )
 
     # Test individual solver type stability

--- a/lib/OrdinaryDiffEqCore/src/misc_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/misc_utils.jl
@@ -95,12 +95,7 @@ macro OnDemandTableauExtract(S_T, T)
 end
 
 macro fold(arg)
-    # https://github.com/JuliaLang/julia/pull/43852
-    return if VERSION < v"1.8.0-DEV.1484"
-        esc(:(@generated $arg))
-    else
-        esc(:(Base.@assume_effects :foldable $arg))
-    end
+    return esc(:(Base.@assume_effects :foldable $arg))
 end
 
 struct DifferentialVarsUndefined end

--- a/lib/OrdinaryDiffEqCore/test/jet.jl
+++ b/lib/OrdinaryDiffEqCore/test/jet.jl
@@ -8,7 +8,7 @@ using JET, Test
 
 @testset "JET Tests" begin
     @test test_package(
-        OrdinaryDiffEqCore, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqCore, target_modules = (OrdinaryDiffEqCore,), mode = :typo
     ) === nothing broken = true
 end
 

--- a/lib/OrdinaryDiffEqDefault/test/jet.jl
+++ b/lib/OrdinaryDiffEqDefault/test/jet.jl
@@ -7,7 +7,7 @@ using JET
 if isempty(VERSION.prerelease)
     @testset "JET Tests" begin
         test_package(
-            OrdinaryDiffEqDefault, target_defined_modules = true, mode = :typo
+            OrdinaryDiffEqDefault, target_modules = (OrdinaryDiffEqDefault,), mode = :typo
         )
     end
 end

--- a/lib/OrdinaryDiffEqDifferentiation/test/jet.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqDifferentiation, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqDifferentiation, target_modules = (OrdinaryDiffEqDifferentiation,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqExplicitRK/test/jet.jl
+++ b/lib/OrdinaryDiffEqExplicitRK/test/jet.jl
@@ -10,7 +10,7 @@ using Test
 @testset "JET Tests" begin
     # Test package for typos - now passing
     test_package(
-        OrdinaryDiffEqExplicitRK, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqExplicitRK, target_modules = (OrdinaryDiffEqExplicitRK,), mode = :typo
     )
 
     # Test individual solver type stability

--- a/lib/OrdinaryDiffEqExponentialRK/test/jet.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqExponentialRK, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqExponentialRK, target_modules = (OrdinaryDiffEqExponentialRK,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqExtrapolation/test/jet.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqExtrapolation, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqExtrapolation, target_modules = (OrdinaryDiffEqExtrapolation,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqFIRK/test/jet.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqFIRK, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqFIRK, target_modules = (OrdinaryDiffEqFIRK,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqFeagin/test/jet.jl
+++ b/lib/OrdinaryDiffEqFeagin/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqFeagin, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqFeagin, target_modules = (OrdinaryDiffEqFeagin,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqFunctionMap/test/jet.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqFunctionMap, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqFunctionMap, target_modules = (OrdinaryDiffEqFunctionMap,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqHighOrderRK/test/jet.jl
+++ b/lib/OrdinaryDiffEqHighOrderRK/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqHighOrderRK, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqHighOrderRK, target_modules = (OrdinaryDiffEqHighOrderRK,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqIMEXMultistep/test/jet.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqIMEXMultistep, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqIMEXMultistep, target_modules = (OrdinaryDiffEqIMEXMultistep,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqLinear/test/jet.jl
+++ b/lib/OrdinaryDiffEqLinear/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqLinear, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqLinear, target_modules = (OrdinaryDiffEqLinear,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqLowOrderRK/test/jet.jl
+++ b/lib/OrdinaryDiffEqLowOrderRK/test/jet.jl
@@ -10,7 +10,7 @@ using Test
 @testset "JET Tests" begin
     # Test package for typos (commented out due to false positive)
     # test_package(
-    #     OrdinaryDiffEqLowOrderRK, target_defined_modules = true, mode = :typo)
+    #     OrdinaryDiffEqLowOrderRK, target_modules = (OrdinaryDiffEqLowOrderRK,), mode = :typo)
 
     # Test individual solver type stability
     @testset "Solver Type Stability Tests" begin

--- a/lib/OrdinaryDiffEqLowStorageRK/test/jet.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqLowStorageRK, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqLowStorageRK, target_modules = (OrdinaryDiffEqLowStorageRK,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/jet.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqNonlinearSolve, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqNonlinearSolve, target_modules = (OrdinaryDiffEqNonlinearSolve,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqNordsieck/test/jet.jl
+++ b/lib/OrdinaryDiffEqNordsieck/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqNordsieck, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqNordsieck, target_modules = (OrdinaryDiffEqNordsieck,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqPDIRK/test/jet.jl
+++ b/lib/OrdinaryDiffEqPDIRK/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqPDIRK, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqPDIRK, target_modules = (OrdinaryDiffEqPDIRK,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqPRK/test/jet.jl
+++ b/lib/OrdinaryDiffEqPRK/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqPRK, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqPRK, target_modules = (OrdinaryDiffEqPRK,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqQPRK/test/jet.jl
+++ b/lib/OrdinaryDiffEqQPRK/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqQPRK, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqQPRK, target_modules = (OrdinaryDiffEqQPRK,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqRKN/test/jet.jl
+++ b/lib/OrdinaryDiffEqRKN/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqRKN, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqRKN, target_modules = (OrdinaryDiffEqRKN,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqRosenbrock/test/jet.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqRosenbrock, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqRosenbrock, target_modules = (OrdinaryDiffEqRosenbrock,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqSDIRK/test/jet.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqSDIRK, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqSDIRK, target_modules = (OrdinaryDiffEqSDIRK,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqSSPRK/test/jet.jl
+++ b/lib/OrdinaryDiffEqSSPRK/test/jet.jl
@@ -10,7 +10,7 @@ using Test
 @testset "JET Tests" begin
     # Test package for typos - now passing
     test_package(
-        OrdinaryDiffEqSSPRK, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqSSPRK, target_modules = (OrdinaryDiffEqSSPRK,), mode = :typo
     )
 
     # Test individual solver type stability

--- a/lib/OrdinaryDiffEqStabilizedIRK/test/jet.jl
+++ b/lib/OrdinaryDiffEqStabilizedIRK/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqStabilizedIRK, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqStabilizedIRK, target_modules = (OrdinaryDiffEqStabilizedIRK,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqStabilizedRK/test/jet.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqStabilizedRK, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqStabilizedRK, target_modules = (OrdinaryDiffEqStabilizedRK,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqSymplecticRK/test/jet.jl
+++ b/lib/OrdinaryDiffEqSymplecticRK/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqSymplecticRK, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqSymplecticRK, target_modules = (OrdinaryDiffEqSymplecticRK,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqTaylorSeries/test/jet.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqTaylorSeries, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqTaylorSeries, target_modules = (OrdinaryDiffEqTaylorSeries,), mode = :typo
     )
 end

--- a/lib/OrdinaryDiffEqTsit5/test/jet.jl
+++ b/lib/OrdinaryDiffEqTsit5/test/jet.jl
@@ -10,7 +10,7 @@ using Test
 @testset "JET Tests" begin
     # Test package for typos - now passing
     test_package(
-        OrdinaryDiffEqTsit5, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqTsit5, target_modules = (OrdinaryDiffEqTsit5,), mode = :typo
     )
 
     # Test individual solver type stability

--- a/lib/OrdinaryDiffEqVerner/test/jet.jl
+++ b/lib/OrdinaryDiffEqVerner/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        OrdinaryDiffEqVerner, target_defined_modules = true, mode = :typo
+        OrdinaryDiffEqVerner, target_modules = (OrdinaryDiffEqVerner,), mode = :typo
     )
 end

--- a/lib/SimpleImplicitDiscreteSolve/test/jet.jl
+++ b/lib/SimpleImplicitDiscreteSolve/test/jet.jl
@@ -6,6 +6,6 @@ using JET
 
 @testset "JET Tests" begin
     test_package(
-        SimpleImplicitDiscreteSolve, target_defined_modules = true, mode = :typo
+        SimpleImplicitDiscreteSolve, target_modules = (SimpleImplicitDiscreteSolve,), mode = :typo
     )
 end


### PR DESCRIPTION
## Summary

- Replace deprecated JET.jl `target_defined_modules` parameter with `target_modules` across all 33 test files. JET.jl deprecated `target_defined_modules::Bool` in favor of `target_modules` tuple (scheduled for removal in JET v0.12).
- Remove dead `VERSION` check in `@fold` macro (`lib/OrdinaryDiffEqCore/src/misc_utils.jl`). The package requires Julia 1.10+, so the `VERSION < v"1.8.0-DEV.1484"` branch was unreachable dead code. Now unconditionally uses `Base.@assume_effects :foldable`.

## Notes on intentional deprecation shims (NOT removed)

The following deprecation warnings exist intentionally as backward-compatibility shims for users during API transitions:
- `alias_u0`/`alias_du0` kwargs → `ODEAliasSpecifier` (solve.jl)
- `beta1`/`beta2`/`qmin`/`qmax`/`qsteady_min`/`qsteady_max`/`qoldinit` → `controller` kwarg (solve.jl)
- `autodiff::Bool` → `ADType` specifier (misc_utils.jl)
- `chunk_size`/`diff_type` kwargs → `ADType` specifier (misc_utils.jl)
- `alg_cache` old `Type{Val{iip}}` signature → `Val(iip)` (cache_utils.jl)

These should be kept until the next breaking version.

## Test plan

- [x] OrdinaryDiffEqCore `Pkg.test()` passes with `--depwarn=error`
- [x] JET Tests: 30 Pass, 1 Broken (pre-existing)
- [x] Aqua: 9 Pass
- [x] Sparse isdiag Performance: 10 Pass
- [x] No more `target_defined_modules` deprecation warning from JET

🤖 Generated with [Claude Code](https://claude.com/claude-code)