### PR TITLE
Default lazy to Val type parameter in BS5, Vern6-9, RKV76IIa

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
@@ -58,7 +58,7 @@ function SciMLBase.reeval_internals_due_to_modification!(
         resize!(integrator.k, integrator.kshortsize) # Reset k for next step!
         alg = unwrap_alg(integrator, false)
         if SciMLBase.has_lazy_interpolation(alg)
-            ode_addsteps!(integrator, integrator.f, true, false, !alg.lazy)
+            ode_addsteps!(integrator, integrator.f, true, false, !_unwrap_val(alg.lazy))
         else
             ode_addsteps!(integrator, integrator.f, true, false)
         end

--- a/lib/OrdinaryDiffEqLowOrderRK/src/OrdinaryDiffEqLowOrderRK.jl
+++ b/lib/OrdinaryDiffEqLowOrderRK/src/OrdinaryDiffEqLowOrderRK.jl
@@ -16,7 +16,7 @@ import OrdinaryDiffEqCore: alg_order, isfsal, beta2_default, beta1_default,
     @cache, CompiledFloats, alg_cache, CompositeAlgorithm,
     AutoAlgSwitch, _ode_interpolant, _ode_interpolant!, full_cache,
     accept_step_controller, DerivativeOrderNotPossibleError,
-    du_cache, u_cache, get_fsalfirstlast, copyat_or_push!
+    du_cache, u_cache, get_fsalfirstlast, copyat_or_push!, _unwrap_val
 using SciMLBase
 import MuladdMacro: @muladd
 import FastBroadcast: @..

--- a/lib/OrdinaryDiffEqLowOrderRK/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqLowOrderRK/src/alg_utils.jl
@@ -25,7 +25,7 @@ alg_order(alg::Alshina2) = 2
 alg_order(alg::Alshina3) = 3
 alg_order(alg::Alshina6) = 6
 
-SciMLBase.has_lazy_interpolation(alg::BS5) = true
+SciMLBase.has_lazy_interpolation(alg::BS5) = _unwrap_val(alg.lazy)
 
 isfsal(alg::FRK65) = true
 isfsal(alg::RKO65) = false

--- a/lib/OrdinaryDiffEqLowOrderRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqLowOrderRK/src/algorithms.jl
@@ -210,11 +210,15 @@ end
     extra_keyword_description = """- `lazy`: determines if the lazy interpolant is used.""",
     extra_keyword_default = "lazy = true"
 )
-Base.@kwdef struct BS5{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqAdaptiveAlgorithm
+Base.@kwdef struct BS5{StageLimiter, StepLimiter, Thread, L} <: OrdinaryDiffEqAdaptiveAlgorithm
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = False()
-    lazy::Bool = true
+    lazy::L = Val{true}()
+end
+# Convert Bool lazy to Val for backwards compatibility
+function BS5(stage_limiter!::StageLimiter, step_limiter!::StepLimiter, thread::Thread, lazy::Bool) where {StageLimiter, StepLimiter, Thread}
+    BS5{StageLimiter, StepLimiter, Thread, Val{lazy}}(stage_limiter!, step_limiter!, thread, Val{lazy}())
 end
 # for backwards compatibility
 function BS5(stage_limiter!, step_limiter! = trivial_limiter!; lazy = true)

--- a/lib/OrdinaryDiffEqLowOrderRK/src/low_order_rk_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowOrderRK/src/low_order_rk_perform_step.jl
@@ -407,7 +407,7 @@ end
 
 function initialize!(integrator, cache::BS5ConstantCache)
     alg = unwrap_alg(integrator, false)
-    alg.lazy ? (integrator.kshortsize = 8) : (integrator.kshortsize = 11)
+    _unwrap_val(alg.lazy) ? (integrator.kshortsize = 8) : (integrator.kshortsize = 11)
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
     integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
@@ -420,7 +420,7 @@ function initialize!(integrator, cache::BS5ConstantCache)
     end
     integrator.k[integrator.kshortsize] = integrator.fsallast
 
-    return if !alg.lazy
+    return if !_unwrap_val(alg.lazy)
         @inbounds for i in 9:11
             integrator.k[i] = zero(integrator.fsalfirst)
         end
@@ -479,7 +479,7 @@ end
     integrator.u = u
 
     alg = unwrap_alg(integrator, false)
-    if !alg.lazy && (
+    if !_unwrap_val(alg.lazy) && (
             integrator.opts.adaptive == false ||
                 accept_step_controller(integrator, integrator.opts.controller)
         )
@@ -520,7 +520,7 @@ end
 get_fsalfirstlast(cache::BS5Cache, u) = (cache.k1, cache.k8)
 function initialize!(integrator, cache::BS5Cache)
     alg = unwrap_alg(integrator, false)
-    alg.lazy ? (integrator.kshortsize = 8) : (integrator.kshortsize = 11)
+    _unwrap_val(alg.lazy) ? (integrator.kshortsize = 8) : (integrator.kshortsize = 11)
     resize!(integrator.k, integrator.kshortsize)
     integrator.k[1] = cache.k1
     integrator.k[2] = cache.k2
@@ -531,7 +531,7 @@ function initialize!(integrator, cache::BS5Cache)
     integrator.k[7] = cache.k7
     integrator.k[8] = cache.k8
 
-    if !alg.lazy
+    if !_unwrap_val(alg.lazy)
         integrator.k[9] = similar(cache.k1)
         integrator.k[10] = similar(cache.k1)
         integrator.k[11] = similar(cache.k1)
@@ -612,7 +612,7 @@ end
         integrator.EEst = max(EEst1, EEst2)
     end
     alg = unwrap_alg(integrator, false)
-    if !alg.lazy && (
+    if !_unwrap_val(alg.lazy) && (
             integrator.opts.adaptive == false ||
                 accept_step_controller(integrator, integrator.opts.controller)
         )

--- a/lib/OrdinaryDiffEqVerner/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqVerner/src/alg_utils.jl
@@ -15,4 +15,4 @@ alg_stability_size(alg::Vern8) = 5.8641
 alg_stability_size(alg::Vern9) = 4.4762
 alg_stability_size(alg::RKV76IIa) = 4.910807773  # From the file: Real Stability Interval is nearly [ -4.910807773, 0]
 
-SciMLBase.has_lazy_interpolation(alg::Union{Vern6, Vern7, Vern8, Vern9, RKV76IIa}) = true
+SciMLBase.has_lazy_interpolation(alg::Union{Vern6, Vern7, Vern8, Vern9, RKV76IIa}) = _unwrap_val(alg.lazy)

--- a/lib/OrdinaryDiffEqVerner/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqVerner/src/algorithms.jl
@@ -15,14 +15,18 @@
     """,
     extra_keyword_default = "lazy = true"
 )
-Base.@kwdef struct Vern6{StageLimiter, StepLimiter, Thread} <:
+Base.@kwdef struct Vern6{StageLimiter, StepLimiter, Thread, L} <:
     OrdinaryDiffEqAdaptiveAlgorithm
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = False()
-    lazy::Bool = true
+    lazy::L = Val{true}()
 end
 @truncate_stacktrace Vern6 3
+# Convert Bool lazy to Val for backwards compatibility
+function Vern6(sl::SL, stl::STL, th::TH, lazy::Bool) where {SL, STL, TH}
+    Vern6{SL, STL, TH, Val{lazy}}(sl, stl, th, Val{lazy}())
+end
 # for backwards compatibility
 function Vern6(stage_limiter!, step_limiter! = trivial_limiter!; lazy = true)
     return Vern6(stage_limiter!, step_limiter!, False(), lazy)
@@ -45,14 +49,18 @@ end
     """,
     extra_keyword_default = "lazy = true"
 )
-Base.@kwdef struct Vern7{StageLimiter, StepLimiter, Thread} <:
+Base.@kwdef struct Vern7{StageLimiter, StepLimiter, Thread, L} <:
     OrdinaryDiffEqAdaptiveAlgorithm
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = False()
-    lazy::Bool = true
+    lazy::L = Val{true}()
 end
 @truncate_stacktrace Vern7 3
+# Convert Bool lazy to Val for backwards compatibility
+function Vern7(sl::SL, stl::STL, th::TH, lazy::Bool) where {SL, STL, TH}
+    Vern7{SL, STL, TH, Val{lazy}}(sl, stl, th, Val{lazy}())
+end
 # for backwards compatibility
 function Vern7(stage_limiter!, step_limiter! = trivial_limiter!; lazy = true)
     return Vern7(stage_limiter!, step_limiter!, False(), lazy)
@@ -75,14 +83,18 @@ end
     """,
     extra_keyword_default = "lazy = true"
 )
-Base.@kwdef struct Vern8{StageLimiter, StepLimiter, Thread} <:
+Base.@kwdef struct Vern8{StageLimiter, StepLimiter, Thread, L} <:
     OrdinaryDiffEqAdaptiveAlgorithm
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = False()
-    lazy::Bool = true
+    lazy::L = Val{true}()
 end
 @truncate_stacktrace Vern8 3
+# Convert Bool lazy to Val for backwards compatibility
+function Vern8(sl::SL, stl::STL, th::TH, lazy::Bool) where {SL, STL, TH}
+    Vern8{SL, STL, TH, Val{lazy}}(sl, stl, th, Val{lazy}())
+end
 # for backwards compatibility
 function Vern8(stage_limiter!, step_limiter! = trivial_limiter!; lazy = true)
     return Vern8(stage_limiter!, step_limiter!, False(), lazy)
@@ -104,14 +116,18 @@ end
     extra_keyword_description = """- `lazy`: determines if the lazy interpolant is used.
     """, extra_keyword_default = "lazy = true"
 )
-Base.@kwdef struct Vern9{StageLimiter, StepLimiter, Thread} <:
+Base.@kwdef struct Vern9{StageLimiter, StepLimiter, Thread, L} <:
     OrdinaryDiffEqAdaptiveAlgorithm
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = False()
-    lazy::Bool = true
+    lazy::L = Val{true}()
 end
 @truncate_stacktrace Vern9 3
+# Convert Bool lazy to Val for backwards compatibility
+function Vern9(sl::SL, stl::STL, th::TH, lazy::Bool) where {SL, STL, TH}
+    Vern9{SL, STL, TH, Val{lazy}}(sl, stl, th, Val{lazy}())
+end
 # for backwards compatibility
 function Vern9(stage_limiter!, step_limiter! = trivial_limiter!; lazy = true)
     return Vern9(stage_limiter!, step_limiter!, False(), lazy)
@@ -172,14 +188,18 @@ AutoVern9(alg; lazy = true, kwargs...) = AutoAlgSwitch(Vern9(lazy = lazy), alg; 
     """,
     extra_keyword_default = "lazy = true"
 )
-Base.@kwdef struct RKV76IIa{StageLimiter, StepLimiter, Thread} <:
+Base.@kwdef struct RKV76IIa{StageLimiter, StepLimiter, Thread, L} <:
     OrdinaryDiffEqAdaptiveAlgorithm
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = False()
-    lazy::Bool = true
+    lazy::L = Val{true}()
 end
 @truncate_stacktrace RKV76IIa 3
+# Convert Bool lazy to Val for backwards compatibility
+function RKV76IIa(sl::SL, stl::STL, th::TH, lazy::Bool) where {SL, STL, TH}
+    RKV76IIa{SL, STL, TH, Val{lazy}}(sl, stl, th, Val{lazy}())
+end
 # for backwards compatibility
 function RKV76IIa(stage_limiter!, step_limiter! = trivial_limiter!; lazy = true)
     return RKV76IIa(stage_limiter!, step_limiter!, False(), lazy)

--- a/lib/OrdinaryDiffEqVerner/src/verner_caches.jl
+++ b/lib/OrdinaryDiffEqVerner/src/verner_caches.jl
@@ -1,6 +1,6 @@
 @cache struct Vern6Cache{
         uType, rateType, uNoUnitsType, TabType, StageLimiter, StepLimiter,
-        Thread,
+        Thread, L,
     } <:
     OrdinaryDiffEqMutableCache
     u::uType
@@ -22,7 +22,7 @@
     stage_limiter!::StageLimiter
     step_limiter!::StepLimiter
     thread::Thread
-    lazy::Bool
+    lazy::L
 end
 
 get_fsalfirstlast(cache::Vern6Cache, u) = (cache.k1, cache.k9)
@@ -54,9 +54,9 @@ function alg_cache(
     )
 end
 
-struct Vern6ConstantCache{TabType} <: OrdinaryDiffEqConstantCache
+struct Vern6ConstantCache{TabType, L} <: OrdinaryDiffEqConstantCache
     tab::TabType
-    lazy::Bool
+    lazy::L
 end
 
 function alg_cache(
@@ -71,7 +71,7 @@ end
 
 @cache struct Vern7Cache{
         uType, rateType, uNoUnitsType, StageLimiter, StepLimiter,
-        Thread,
+        Thread, L,
     } <:
     OrdinaryDiffEqMutableCache
     u::uType
@@ -93,7 +93,7 @@ end
     stage_limiter!::StageLimiter
     step_limiter!::StepLimiter
     thread::Thread
-    lazy::Bool
+    lazy::L
 end
 
 # fake values since non-FSAL method
@@ -126,8 +126,8 @@ function alg_cache(
     )
 end
 
-struct Vern7ConstantCache <: OrdinaryDiffEqConstantCache
-    lazy::Bool
+struct Vern7ConstantCache{L} <: OrdinaryDiffEqConstantCache
+    lazy::L
 end
 
 function alg_cache(
@@ -141,7 +141,7 @@ end
 
 @cache struct Vern8Cache{
         uType, rateType, uNoUnitsType, TabType, StageLimiter, StepLimiter,
-        Thread,
+        Thread, L,
     } <:
     OrdinaryDiffEqMutableCache
     u::uType
@@ -167,7 +167,7 @@ end
     stage_limiter!::StageLimiter
     step_limiter!::StepLimiter
     thread::Thread
-    lazy::Bool
+    lazy::L
 end
 
 # fake values since non-FSAL method
@@ -204,9 +204,9 @@ function alg_cache(
     )
 end
 
-struct Vern8ConstantCache{TabType} <: OrdinaryDiffEqConstantCache
+struct Vern8ConstantCache{TabType, L} <: OrdinaryDiffEqConstantCache
     tab::TabType
-    lazy::Bool
+    lazy::L
 end
 
 function alg_cache(
@@ -221,7 +221,7 @@ end
 
 @cache struct Vern9Cache{
         uType, rateType, uNoUnitsType, StageLimiter, StepLimiter,
-        Thread,
+        Thread, L,
     } <:
     OrdinaryDiffEqMutableCache
     u::uType
@@ -249,7 +249,7 @@ end
     stage_limiter!::StageLimiter
     step_limiter!::StepLimiter
     thread::Thread
-    lazy::Bool
+    lazy::L
 end
 
 # fake values since non-FSAL method
@@ -289,8 +289,8 @@ function alg_cache(
     )
 end
 
-struct Vern9ConstantCache <: OrdinaryDiffEqConstantCache
-    lazy::Bool
+struct Vern9ConstantCache{L} <: OrdinaryDiffEqConstantCache
+    lazy::L
 end
 
 function alg_cache(
@@ -304,7 +304,7 @@ end
 
 @cache struct RKV76IIaCache{
         uType, rateType, uNoUnitsType, TabType, StageLimiter, StepLimiter,
-        Thread,
+        Thread, L,
     } <:
     OrdinaryDiffEqMutableCache
     u::uType
@@ -327,7 +327,7 @@ end
     stage_limiter!::StageLimiter
     step_limiter!::StepLimiter
     thread::Thread
-    lazy::Bool
+    lazy::L
 end
 
 # fake values since non-FSAL method
@@ -361,9 +361,9 @@ function alg_cache(
     )
 end
 
-struct RKV76IIaConstantCache{TabType} <: OrdinaryDiffEqConstantCache
+struct RKV76IIaConstantCache{TabType, L} <: OrdinaryDiffEqConstantCache
     tab::TabType
-    lazy::Bool
+    lazy::L
 end
 
 function alg_cache(

--- a/lib/OrdinaryDiffEqVerner/src/verner_rk_perform_step.jl
+++ b/lib/OrdinaryDiffEqVerner/src/verner_rk_perform_step.jl
@@ -2,7 +2,7 @@ function initialize!(integrator, cache::Vern6ConstantCache)
     integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     alg = unwrap_alg(integrator, false)
-    cache.lazy ? (integrator.kshortsize = 9) : (integrator.kshortsize = 12)
+    _unwrap_val(cache.lazy) ? (integrator.kshortsize = 9) : (integrator.kshortsize = 12)
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
 
     # Avoid undefined entries if k is an array of arrays
@@ -13,7 +13,7 @@ function initialize!(integrator, cache::Vern6ConstantCache)
     end
     integrator.k[integrator.kshortsize] = integrator.fsallast
 
-    return if !cache.lazy
+    return if !_unwrap_val(cache.lazy)
         @inbounds for i in 10:12
             integrator.k[i] = zero(integrator.fsalfirst)
         end
@@ -69,7 +69,7 @@ end
     integrator.k[9] = k9
 
     alg = unwrap_alg(integrator, false)
-    if !cache.lazy && (
+    if !_unwrap_val(cache.lazy) && (
             integrator.opts.adaptive == false ||
                 accept_step_controller(integrator, integrator.opts.controller)
         )
@@ -111,7 +111,7 @@ end
 
 function initialize!(integrator, cache::Vern6Cache)
     alg = unwrap_alg(integrator, false)
-    cache.lazy ? (integrator.kshortsize = 9) : (integrator.kshortsize = 12)
+    _unwrap_val(cache.lazy) ? (integrator.kshortsize = 9) : (integrator.kshortsize = 12)
     (; k) = integrator
     resize!(k, integrator.kshortsize)
     k[1] = cache.k1
@@ -124,7 +124,7 @@ function initialize!(integrator, cache::Vern6Cache)
     k[8] = cache.k8
     k[9] = cache.k9 # Set the pointers
 
-    if !cache.lazy
+    if !_unwrap_val(cache.lazy)
         k[10] = similar(cache.k1)
         k[11] = similar(cache.k1)
         k[12] = similar(cache.k1)
@@ -204,7 +204,7 @@ end
     end
 
     alg = unwrap_alg(integrator, false)
-    if !cache.lazy && (
+    if !_unwrap_val(cache.lazy) && (
             integrator.opts.adaptive == false ||
                 accept_step_controller(integrator, integrator.opts.controller)
         )
@@ -244,7 +244,7 @@ end
 
 function initialize!(integrator, cache::Vern7ConstantCache)
     alg = unwrap_alg(integrator, false)
-    cache.lazy ? (integrator.kshortsize = 10) : (integrator.kshortsize = 16)
+    _unwrap_val(cache.lazy) ? (integrator.kshortsize = 10) : (integrator.kshortsize = 16)
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
 
     # Avoid undefined entries if k is an array of arrays
@@ -314,7 +314,7 @@ end
     integrator.u = u
 
     alg = unwrap_alg(integrator, false)
-    if !cache.lazy && (
+    if !_unwrap_val(cache.lazy) && (
             integrator.opts.adaptive == false ||
                 accept_step_controller(integrator, integrator.opts.controller)
         )
@@ -386,7 +386,7 @@ function initialize!(integrator, cache::Vern7Cache)
     (; k1, k2, k3, k4, k5, k6, k7, k8, k9, k10) = cache
     (; k) = integrator
     alg = unwrap_alg(integrator, false)
-    cache.lazy ? (integrator.kshortsize = 10) : (integrator.kshortsize = 16)
+    _unwrap_val(cache.lazy) ? (integrator.kshortsize = 10) : (integrator.kshortsize = 16)
     resize!(k, integrator.kshortsize)
     k[1] = k1
     k[2] = k2
@@ -399,7 +399,7 @@ function initialize!(integrator, cache::Vern7Cache)
     k[9] = k9
     k[10] = k10 # Setup pointers
 
-    return if !cache.lazy
+    return if !_unwrap_val(cache.lazy)
         k[11] = similar(cache.k1)
         k[12] = similar(cache.k1)
         k[13] = similar(cache.k1)
@@ -501,7 +501,7 @@ end
         integrator.EEst = integrator.opts.internalnorm(atmp, t)
     end
     alg = unwrap_alg(integrator, false)
-    if !cache.lazy && (
+    if !_unwrap_val(cache.lazy) && (
             integrator.opts.adaptive == false ||
                 accept_step_controller(integrator, integrator.opts.controller)
         )
@@ -571,7 +571,7 @@ end
 
 function initialize!(integrator, cache::Vern8ConstantCache)
     alg = unwrap_alg(integrator, false)
-    cache.lazy ? (integrator.kshortsize = 13) : (integrator.kshortsize = 21)
+    _unwrap_val(cache.lazy) ? (integrator.kshortsize = 13) : (integrator.kshortsize = 21)
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
 
     # Avoid undefined entries if k is an array of arrays
@@ -675,7 +675,7 @@ end
     integrator.u = u
 
     alg = unwrap_alg(integrator, false)
-    if !cache.lazy && (
+    if !_unwrap_val(cache.lazy) && (
             integrator.opts.adaptive == false ||
                 accept_step_controller(integrator, integrator.opts.controller)
         )
@@ -768,7 +768,7 @@ function initialize!(integrator, cache::Vern8Cache)
     (; k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12, k13) = cache
     (; k) = integrator
     alg = unwrap_alg(integrator, false)
-    cache.lazy ? (integrator.kshortsize = 13) : (integrator.kshortsize = 21)
+    _unwrap_val(cache.lazy) ? (integrator.kshortsize = 13) : (integrator.kshortsize = 21)
     resize!(k, integrator.kshortsize)
     k[1] = k1
     k[2] = k2
@@ -784,7 +784,7 @@ function initialize!(integrator, cache::Vern8Cache)
     k[12] = k12
     k[13] = k13 # Setup pointers
 
-    return if !cache.lazy
+    return if !_unwrap_val(cache.lazy)
         for i in 14:21
             k[i] = similar(cache.k1)
         end
@@ -907,7 +907,7 @@ end
     end
 
     alg = unwrap_alg(integrator, false)
-    if !cache.lazy && (
+    if !_unwrap_val(cache.lazy) && (
             integrator.opts.adaptive == false ||
                 accept_step_controller(integrator, integrator.opts.controller)
         )
@@ -1012,7 +1012,7 @@ end
 
 function initialize!(integrator, cache::Vern9ConstantCache)
     alg = unwrap_alg(integrator, false)
-    cache.lazy ? (integrator.kshortsize = 10) : (integrator.kshortsize = 20)
+    _unwrap_val(cache.lazy) ? (integrator.kshortsize = 10) : (integrator.kshortsize = 20)
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
 
     # Avoid undefined entries if k is an array of arrays
@@ -1128,7 +1128,7 @@ end
     integrator.u = u
 
     alg = unwrap_alg(integrator, false)
-    if !cache.lazy && (
+    if !_unwrap_val(cache.lazy) && (
             integrator.opts.adaptive == false ||
                 accept_step_controller(integrator, integrator.opts.controller)
         )
@@ -1247,7 +1247,7 @@ function initialize!(integrator, cache::Vern9Cache)
     (; k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12, k13, k14, k15, k16) = cache
     (; k) = integrator
     alg = unwrap_alg(integrator, false)
-    cache.lazy ? (integrator.kshortsize = 10) : (integrator.kshortsize = 20)
+    _unwrap_val(cache.lazy) ? (integrator.kshortsize = 10) : (integrator.kshortsize = 20)
     resize!(k, integrator.kshortsize)
     # k2, k3,k4,k5,k6,k7 are not used in the code (not even in interpolations), we don't need their pointers.
     # So we mapped k[2] (from integrator) with k8 (from cache), k[3] with k9 and so on.
@@ -1262,7 +1262,7 @@ function initialize!(integrator, cache::Vern9Cache)
     k[9] = k15
     k[10] = k16 # Setup pointers
 
-    return if !cache.lazy
+    return if !_unwrap_val(cache.lazy)
         for i in 11:20
             k[i] = similar(cache.k1)
         end
@@ -1410,7 +1410,7 @@ end
     end
 
     alg = unwrap_alg(integrator, false)
-    if !cache.lazy && (
+    if !_unwrap_val(cache.lazy) && (
             integrator.opts.adaptive == false ||
                 accept_step_controller(integrator, integrator.opts.controller)
         )
@@ -1545,7 +1545,7 @@ function initialize!(integrator, cache::RKV76IIaConstantCache)
     integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     alg = unwrap_alg(integrator, false)
-    cache.lazy ? (integrator.kshortsize = 10) : (integrator.kshortsize = 10)
+    _unwrap_val(cache.lazy) ? (integrator.kshortsize = 10) : (integrator.kshortsize = 10)
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
 
     # Avoid undefined entries if k is an array of arrays
@@ -1610,7 +1610,7 @@ end
 
 function initialize!(integrator, cache::RKV76IIaCache)
     alg = unwrap_alg(integrator, false)
-    cache.lazy ? (integrator.kshortsize = 10) : (integrator.kshortsize = 10)
+    _unwrap_val(cache.lazy) ? (integrator.kshortsize = 10) : (integrator.kshortsize = 10)
     (; k) = integrator
     resize!(k, integrator.kshortsize)
     k[1] = cache.k1


### PR DESCRIPTION
## Summary

- Change `lazy::Bool = true` to `lazy::L = Val{true}()` in algorithm structs (BS5, Vern6-9, RKV76IIa), cache structs, and constant cache structs so that laziness is a compile-time type parameter
- The compiler can now eliminate dead branches in `perform_step!` and `initialize!` functions
- `has_lazy_interpolation` returns the actual `_unwrap_val(alg.lazy)` instead of unconditionally `true`, enabling `strip_solution`/`strip_interpolation` to work when `lazy=false` (SciMLBase.jl#629)
- Bool→Val conversion constructors added for full backwards compatibility: `BS5(lazy=false)`, `Vern6(lazy=true)` etc. still work

## Files changed

- **Algorithm structs**: `BS5`, `Vern6`, `Vern7`, `Vern8`, `Vern9`, `RKV76IIa` — added `L` type param, `lazy::L = Val{true}()`, Bool converter
- **Cache structs**: All Verner mutable and constant caches — `lazy::Bool` → `lazy::L` with type param
- **`has_lazy_interpolation`**: Returns `_unwrap_val(alg.lazy)` for both LowOrderRK and Verner
- **`perform_step!`/`initialize!`**: All `alg.lazy` and `cache.lazy` usage sites wrapped with `_unwrap_val()`
- **`integrator_interface.jl`**: `alg.lazy` → `_unwrap_val(alg.lazy)` in `ode_addsteps!` call
- **Module imports**: Added `_unwrap_val` to OrdinaryDiffEqLowOrderRK imports

## Test plan

- [x] `Pkg.test()` OrdinaryDiffEqCore — passed
- [x] `Pkg.test()` OrdinaryDiffEqLowOrderRK — passed
- [x] `Pkg.test()` OrdinaryDiffEqVerner — passed
- [x] Verified backwards compat: `BS5(lazy=true)`, `BS5(lazy=false)`, `Vern6(lazy=true)`, `Vern6(lazy=false)` all construct correctly
- [x] Verified `typeof(BS5().lazy) == Val{true}`, `typeof(BS5(lazy=false).lazy) == Val{false}`
- [x] Verified `has_lazy_interpolation` returns `true` for default, `false` for `lazy=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)