### PR TITLE
Fix DEVerbosity docstring reference

### DIFF
--- a/docs/src/verbosity.md
+++ b/docs/src/verbosity.md
@@ -5,5 +5,5 @@ through the `verbose` keyword argument for `solve`. The verbosity system allows 
 information is displayed during the solve process. See [SciMLLogging.jl](https://docs.sciml.ai/SciMLLogging/dev/) for more details. 
 
 ```@docs
-DEVerbosity
+OrdinaryDiffEqCore.DEVerbosity
 ```


### PR DESCRIPTION
In DiffEqDevDocs the documenter can't find the docstring for DEVerbosity. I think this should fix it? 