### PR TITLE
Trigger DAE initialization on u_modified!

### DIFF
--- a/lib/OrdinaryDiffEqBDF/test/dae_u_modified_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/dae_u_modified_tests.jl
@@ -1,0 +1,30 @@
+using OrdinaryDiffEqBDF, DiffEqBase, Test
+
+# Test that u_modified! triggers DAE initialization
+# Regression test for https://github.com/SciML/DifferentialEquations.jl/issues/1127
+
+function f(out, du, u, _, _)
+    out[1] = -0.04u[1] + 1.0e4 * u[2] * u[3] - du[1]
+    out[2] = +0.04u[1] - 3.0e7 * u[2]^2 - 1.0e4 * u[2] * u[3] - du[2]
+    return out[3] = u[1] + u[2] + u[3] - 1.0
+end
+
+u₀ = [1.0, 0, 0]
+du₀ = [-0.04, 0.04, 0.0]
+
+prob = DAEProblem(f, du₀, u₀, (0.0, 1.0), differential_vars = [true, true, false])
+
+# With CheckInit, modifying u to break constraints and calling u_modified!
+# should trigger the initialization check and error
+int = init(prob, DFBDF(), initializealg = DiffEqBase.CheckInit())
+int.u[1] = 2.0 # Breaks algebraic constraint u[1] + u[2] + u[3] = 1
+u_modified!(int, true)
+@test_throws SciMLBase.CheckInitFailureError step!(int)
+
+# With default init, modifying u and calling u_modified! should
+# reinitialize the algebraic variables to satisfy constraints
+int2 = init(prob, DFBDF())
+int2.u[1] = 2.0 # Breaks algebraic constraint
+u_modified!(int2, true)
+step!(int2)
+@test int2.u[1] + int2.u[2] + int2.u[3] ≈ 1.0 atol = 1.0e-10

--- a/lib/OrdinaryDiffEqBDF/test/runtests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/runtests.jl
@@ -7,6 +7,7 @@ if TEST_GROUP != "QA"
     @time @safetestset "DAE Convergence Tests" include("dae_convergence_tests.jl")
     @time @safetestset "DAE AD Tests" include("dae_ad_tests.jl")
     @time @safetestset "DAE Event Tests" include("dae_event.jl")
+    @time @safetestset "DAE u_modified! Tests" include("dae_u_modified_tests.jl")
     @time @safetestset "DAE Initialization Tests" include("dae_initialization_tests.jl")
 
     @time @safetestset "BDF Inference Tests" include("inference_tests.jl")

--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
@@ -30,6 +30,9 @@ function loopheader!(integrator)
             apply_step!(integrator)
         end
     elseif integrator.u_modified # && integrator.iter == 0
+        if integrator.isdae
+            DiffEqBase.initialize_dae!(integrator)
+        end
         update_uprev!(integrator)
         update_fsal!(integrator)
     end


### PR DESCRIPTION
## Summary

- Fixes `loopheader!` in OrdinaryDiffEqCore to call `initialize_dae!` when `u_modified` is true and the integrator is a DAE
- Adds regression test in OrdinaryDiffEqBDF verifying both `CheckInit` error and default initialization after `u_modified!`

## Problem

When a user manually modifies the state of a DAE integrator and calls `u_modified!(integrator, true)`, the DAE initialization algorithm is not triggered on the next `step!()`. This means algebraic constraints are silently violated.

The callback path correctly triggers DAE initialization via `reeval_internals_due_to_modification!` → `initialize_dae!`, but the `loopheader!` path (which handles `u_modified` for manual modifications) only calls `update_uprev!` and `update_fsal!`, missing the `initialize_dae!` call.

This was a branch missed by PR #1586 which added DAE reinitialization for callbacks.

## Fix

Added `initialize_dae!` call in `loopheader!` when `integrator.u_modified && integrator.isdae`:

```julia
elseif integrator.u_modified # && integrator.iter == 0
    if integrator.isdae
        DiffEqBase.initialize_dae!(integrator)
    end
    update_uprev!(integrator)
    update_fsal!(integrator)
end
```

Fixes https://github.com/SciML/DifferentialEquations.jl/issues/1127

## Test plan

- [x] New test `dae_u_modified_tests.jl` verifies `CheckInit` throws on constraint violation after `u_modified!`
- [x] New test verifies default init correctly re-satisfies algebraic constraints after `u_modified!`
- [x] Full OrdinaryDiffEqBDF test suite passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)