### PR TITLE
Add tests verifying no double DAE initialization

### DIFF
--- a/lib/OrdinaryDiffEqBDF/test/dae_u_modified_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/dae_u_modified_tests.jl
@@ -1,7 +1,19 @@
 using OrdinaryDiffEqBDF, DiffEqBase, Test
+import OrdinaryDiffEqCore: _initialize_dae!
 
 # Test that u_modified! triggers DAE initialization
 # Regression test for https://github.com/SciML/DifferentialEquations.jl/issues/1127
+
+# Custom init algorithm that counts how many times initialize_dae! is called
+struct CountingInit{T} <: SciMLBase.DAEInitializationAlgorithm
+    alg::T
+    count::Ref{Int}
+end
+
+function _initialize_dae!(integrator, prob, alg::CountingInit, isinplace)
+    alg.count[] += 1
+    return _initialize_dae!(integrator, prob, alg.alg, isinplace)
+end
 
 function f(out, du, u, _, _)
     out[1] = -0.04u[1] + 1.0e4 * u[2] * u[3] - du[1]
@@ -28,3 +40,32 @@ int2.u[1] = 2.0 # Breaks algebraic constraint
 u_modified!(int2, true)
 step!(int2)
 @test int2.u[1] + int2.u[2] + int2.u[3] ≈ 1.0 atol = 1.0e-10
+
+# Test that u_modified! calls initialize_dae! exactly once
+counter = CountingInit(DiffEqBase.CheckInit(), Ref(0))
+int3 = init(prob, DFBDF(), initializealg = counter)
+init_after_init = counter.count[]  # init() calls initialize_dae! once
+@test init_after_init == 1
+# Modify u without breaking constraints (just set same values)
+int3.u .= u₀
+u_modified!(int3, true)
+step!(int3)
+@test counter.count[] == init_after_init + 1  # exactly one more init call
+
+# Test that callbacks don't trigger double initialization.
+# A callback that modifies u should trigger initialize_dae! exactly once
+# (via reeval_internals_due_to_modification!, NOT again in loopheader!)
+prob2 = DAEProblem(
+    f, du₀, u₀, (0.0, 100.0),
+    differential_vars = [true, true, false]
+)
+counter2 = CountingInit(DiffEqBase.CheckInit(), Ref(0))
+condition(u, t, integrator) = true  # fire every step
+affect!(integrator) = (integrator.u .= integrator.u)  # no-op modification
+cb = DiscreteCallback(condition, affect!)
+int4 = init(prob2, DFBDF(), initializealg = counter2, callback = cb)
+init_count_before = counter2.count[]
+step!(int4)
+# Callback fires once → reeval_internals_due_to_modification! → initialize_dae! once
+# If double-init existed, this would be 2
+@test counter2.count[] == init_count_before + 1


### PR DESCRIPTION
## Summary

- Adds `CountingInit` wrapper to count `initialize_dae!` calls in tests
- Verifies `u_modified!` + `step!` path triggers exactly 1 init call
- Verifies callback path triggers exactly 1 init call (no double-init from loopheader!)

Follow-up to #3051 which fixed DAE initialization on `u_modified!`. These tests guard against accidental double-initialization in future changes.

## Test plan

- [x] All new tests pass locally
- [x] Runic formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)