### PR TITLE
Replace applicable() with Ref{Bool} flag to eliminate _initialize_dae! invalidation

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
@@ -69,6 +69,10 @@ include("functional.jl")
 include("newton.jl")
 include("initialize_dae.jl")
 
+function __init__()
+    OrdinaryDiffEqCore._nonlinearsolve_loaded[] = true
+end
+
 export BrownFullBasicInit, ShampineCollocationInit
 
 end


### PR DESCRIPTION
## Summary

- Replace `applicable()` calls in `_initialize_dae!` (DefaultInit dispatch for ODEProblem and DAEProblem) with a `Ref{Bool}` flag (`_nonlinearsolve_loaded`) set by OrdinaryDiffEqNonlinearSolve's `__init__()`
- Wrap `BrownFullBasicInit`/`ShampineCollocationInit` dispatch calls in `Base.invokelatest()` to prevent the compiler from creating method table backedges

## Problem

The `applicable()` calls in `_initialize_dae!` created "negative" method table backedges: the compiler recorded "if any method matching `_initialize_dae!(integrator, prob, BrownFullBasicInit(...), Val{true})` is defined, invalidate me." When OrdinaryDiffEqNonlinearSolve loaded and defined that exact method, the invalidation cascaded through:

```
_initialize_dae! → initialize_dae! → reeval_internals_due_to_modification!
→ handle_tstop! → loopheader! → solve! → __init → __solve → solve_up → solve
```

This destroyed **282 precompiled solve-path method instances** in OrdinaryDiffEqCore, OrdinaryDiffEqTsit5, and OrdinaryDiffEqVerner — all packages that load *before* NonlinearSolve in the dependency graph. This is a major contributor to why `solve(prob, Tsit5())` takes ~3s despite having precompile workloads (the precompiled code is destroyed before the user calls `solve`).

## Results (verified with SnoopCompile)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| `_initialize_dae!` invalidation tree | 268 children | 0 children | Eliminated |
| OrdinaryDiffEqCore invalidated MIs | 274 | 0 | -100% |
| Total solve-path invalidated MIs | 827 | 472 | -43% |

## Test plan

- [x] OrdinaryDiffEqCore tests pass
- [x] OrdinaryDiffEqNonlinearSolve tests pass (Newton, Sparse Algebraic Detection, JET, Aqua)
- [x] OrdinaryDiffEqDefault tests pass (Default Solver Tests, JET, Aqua)
- [x] Runic formatting passes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)