### PR TITLE
Fix forwarddiffs_model to handle AutoSparse-wrapped autodiff

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
+++ b/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
@@ -83,7 +83,7 @@ import DiffEqBase: calculate_residuals,
 import Polyester
 # MacroTools and Adapt imported but not directly used in OrdinaryDiffEqCore
 # using MacroTools, Adapt
-import ADTypes: AutoFiniteDiff, AutoForwardDiff, AbstractADType, AutoSparse
+import ADTypes: AutoFiniteDiff, AutoForwardDiff, AbstractADType, AutoSparse, dense_ad
 import Accessors: @reset
 
 # SciMLStructures symbols imported but not directly used in OrdinaryDiffEqCore

--- a/lib/OrdinaryDiffEqCore/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/alg_utils.jl
@@ -19,7 +19,7 @@ function SciMLBase.forwarddiffs_model(
             OrdinaryDiffEqImplicitAlgorithm, ExponentialAlgorithm,
         }
     )
-    return alg_autodiff(alg) isa AutoForwardDiff
+    return dense_ad(alg_autodiff(alg)) isa AutoForwardDiff
 end
 
 SciMLBase.forwarddiffs_model_time(alg::RosenbrockAlgorithm) = true


### PR DESCRIPTION
## Summary

- `forwarddiffs_model` checks `alg_autodiff(alg) isa AutoForwardDiff` to determine if an implicit algorithm uses ForwardDiff on the model function
- With `AutoSparse(AutoForwardDiff())`, `alg_autodiff` returns `AutoSparse(...)` which is NOT `isa AutoForwardDiff`, so the trait incorrectly returns `false`
- Fix: use `dense_ad(alg_autodiff(alg)) isa AutoForwardDiff` to unwrap AutoSparse before the check

## Context

This is needed for DiffEqBase PR #1281 (trait-gated `promote_f` to reduce method invalidations). That PR uses `forwarddiffs_model(alg)` to decide which function wrapping path to take. Without this fix, AutoSparse algorithms take the non-dual wrapping path and fail with "No matching function wrapper was found!" when Rosenbrock methods try to call the model with `ForwardDiff.Dual` arguments.

`dense_ad` is already used extensively in OrdinaryDiffEqDifferentiation and OrdinaryDiffEqNonlinearSolve for the same purpose of unwrapping AutoSparse.

## Test plan

- [x] Verified locally: `Rodas5P(autodiff=AutoSparse(AutoForwardDiff()))` now returns `forwarddiffs_model = true`
- [x] `Rodas5P(autodiff=AutoSparse(AutoFiniteDiff()))` correctly returns `false`
- [x] Plain `Rodas5P()` and `Rodas5P(autodiff=AutoFiniteDiff())` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)