### PR TITLE
Fix forwarddiffs_model and has_autodiff for algorithms without autodiff field

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/alg_utils.jl
@@ -33,6 +33,9 @@ function SciMLBase.forwarddiffs_model(
     )
     return _autodiff_is_forward(alg)
 end
+function SciMLBase.forwarddiffs_model(alg::CompositeAlgorithm)
+    return any(_autodiff_is_forward, alg.algs)
+end
 
 SciMLBase.forwarddiffs_model_time(alg::RosenbrockAlgorithm) = true
 


### PR DESCRIPTION
## Summary

- Fixed `forwarddiffs_model` in OrdinaryDiffEqCore to not call `alg_autodiff` (which requires OrdinaryDiffEqDifferentiation)
- Fixed `has_autodiff` to correctly handle `ExponentialAlgorithm` subtypes that lack an `autodiff` field
- Added `_autodiff_is_forward` helper that safely checks the `autodiff` field using `hasfield`

## Problem

DiffEqBase PR #1281 now calls `forwarddiffs_model(alg)` from `promote_f` for every `solve` call. The existing implementation in OrdinaryDiffEqCore called `alg_autodiff(alg)`, which is only a bare stub (`function alg_autodiff end`) in OrdinaryDiffEqCore — actual methods are defined in OrdinaryDiffEqDifferentiation. This caused two failure modes:

**Failure Mode 1 (MethodError):** Packages that don't depend on OrdinaryDiffEqDifferentiation (OrdinaryDiffEqLinear, OrdinaryDiffEqLowOrderRK, OrdinaryDiffEqNewmark) hit `MethodError: no method matching alg_autodiff`.

**Failure Mode 2 (FieldError):** `ExponentialAlgorithm` subtypes without an `autodiff` field (ETD2, SplitEuler, LinearExponential, all 15 Magnus/Lie/CG/RKMK algorithms) hit `FieldError: type ETD2 has no field autodiff`.

**19 algorithms affected total:**
- ETD2 (OrdinaryDiffEqExponentialRK) — Mode 2
- SplitEuler (OrdinaryDiffEqLowOrderRK) — Mode 1 + 2
- LinearExponential + 15 LinearExponentialAlgorithm subtypes (OrdinaryDiffEqLinear) — Mode 1 + 2
- NewmarkBeta (OrdinaryDiffEqNewmark) — Mode 1

Additionally, `has_autodiff` incorrectly returned `true` for all `OrdinaryDiffEqExponentialAlgorithm` types (including those without an `autodiff` field) and was missing `OrdinaryDiffEqAdaptiveExponentialAlgorithm` from its union.

## Fix

Replaced `alg_autodiff(alg)` in `forwarddiffs_model` with a new `_autodiff_is_forward(alg)` helper that:
1. Uses `hasfield(typeof(alg), :autodiff)` to guard field access
2. Handles `Val{true}()` (legacy), `AutoForwardDiff()`, and `AutoSparse(AutoForwardDiff())`
3. Returns `false` for types without the field
4. Lives entirely in OrdinaryDiffEqCore with no dependency on OrdinaryDiffEqDifferentiation

Fixed `has_autodiff` to use `hasfield` for `ExponentialAlgorithm` types instead of unconditionally returning `true`.

## Test plan

- [x] OrdinaryDiffEqCore tests pass
- [x] OrdinaryDiffEqLinear tests pass
- [x] OrdinaryDiffEqNewmark tests pass
- [x] OrdinaryDiffEqLowOrderRK tests pass
- [x] OrdinaryDiffEqExponentialRK tests pass
- [x] OrdinaryDiffEqSDIRK tests pass (regression check for implicit solvers)
- [x] Verified `forwarddiffs_model` returns correct `Bool` for all affected algorithm types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>