### PR TITLE
Unwrap FunctionWrappersWrapper in DAE init closures

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/initialize_dae.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/initialize_dae.jl
@@ -148,6 +148,10 @@ function _initialize_dae!(
         isinplace::Val{true}
     )
     (; p, t, f) = integrator
+    # Unwrap FunctionWrappersWrapper from f for DAE initialization closures.
+    # NonlinearSolve's internal ForwardDiff uses different tags/chunk sizes than
+    # the pre-compiled FunctionWrapper variants, causing NoFunctionWrapperFoundError.
+    f = SciMLBase.unwrapped_f(f)
     M = integrator.f.mass_matrix
     dtmax = integrator.opts.dtmax
     tmp = first(get_tmp_cache(integrator))
@@ -275,6 +279,7 @@ function _initialize_dae!(
         isinplace::Val{false}
     )
     (; p, t, f) = integrator
+    f = SciMLBase.unwrapped_f(f)
     u0 = integrator.u
     M = integrator.f.mass_matrix
     dtmax = integrator.opts.dtmax
@@ -529,6 +534,7 @@ function _initialize_dae!(
         alg::DiffEqBase.BrownFullBasicInit, isinplace::Val{true}
     )
     (; p, t, f) = integrator
+    f = SciMLBase.unwrapped_f(f)
     u = integrator.u
     M = integrator.f.mass_matrix
     M isa UniformScaling && return
@@ -617,6 +623,7 @@ function _initialize_dae!(
         alg::DiffEqBase.BrownFullBasicInit, isinplace::Val{false}
     )
     (; p, t, f) = integrator
+    f = SciMLBase.unwrapped_f(f)
 
     u0 = integrator.u
     M = integrator.f.mass_matrix


### PR DESCRIPTION
## Summary

- Unwrap `FunctionWrappersWrapper` from `f` at the top of each `ODEProblem` `_initialize_dae!` method via `SciMLBase.unwrapped_f(f)`

## Problem

DiffEqBase #1284 (v6.208.0) enabled AutoSpecialize for mass matrix ODEProblems by removing the `f.mass_matrix isa UniformScaling` guard from `promote_f`. This wraps `f.f` in a `FunctionWrappersWrapper` with 4 pre-compiled variants coordinated with the ODE solver's ForwardDiff (tag = `OrdinaryDiffEqTag`, chunk size = 1).

However, `_initialize_dae!` (both `BrownFullBasicInit` and `ShampineCollocationInit`) passes `f` into closures that NonlinearSolve differentiates through with its own ForwardDiff. NonlinearSolve's duals have a different tag and chunk size, so none of the 4 pre-compiled variants match, causing `NoFunctionWrapperFoundError`.

This breaks the `OrdinaryDiffEqRosenbrock` DAE AD tests (`dae_rosenbrock_ad_tests.jl`) on all Julia versions.

## Fix

Call `SciMLBase.unwrapped_f(f)` after destructuring `(; p, t, f) = integrator` in the 4 `ODEProblem` methods of `_initialize_dae!`. This replaces the `FunctionWrappersWrapper` with the raw function for DAE initialization only. The solver's hot path in `perform_step!` still uses the wrapped version from `integrator.f`.

This is a no-op when AutoSpecialize is not active (i.e., when `f.f` is not a `FunctionWrappersWrapper`).

## Test plan

- [ ] `OrdinaryDiffEqRosenbrock` tests pass (specifically `dae_rosenbrock_ad_tests.jl` with `AutoForwardDiff`)
- [ ] No regression in other subpackage tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)