### PR TITLE
Pass OrdinaryDiffEqTag to NonlinearSolve in DAE initialization

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
@@ -65,6 +65,14 @@ import OrdinaryDiffEqDifferentiation: update_W!, is_always_new, build_uf, build_
 import StaticArrays: SArray, MVector, SVector, @SVector, StaticArray, MMatrix, SA,
     StaticMatrix
 
+@static if isdefined(SciMLBase, :OrdinaryDiffEqTag)
+    import SciMLBase: OrdinaryDiffEqTag
+elseif isdefined(DiffEqBase, :OrdinaryDiffEqTag)
+    import DiffEqBase: OrdinaryDiffEqTag
+else
+    struct OrdinaryDiffEqTag end
+end
+
 include("type.jl")
 include("utils.jl")
 include("deprecated.jl")

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/initialize_dae.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/initialize_dae.jl
@@ -59,41 +59,45 @@ end
     end
 end
 
+function _tagged_autodiff(u)
+    AutoForwardDiff{1}(ForwardDiff.Tag(OrdinaryDiffEqTag(), eltype(u)))
+end
+
 function default_nlsolve(
         ::Nothing, isinplace::Val{true}, u, ::AbstractNonlinearProblem, autodiff = false
     )
     return FastShortcutNonlinearPolyalg(;
-        autodiff = autodiff ? AutoForwardDiff() : AutoFiniteDiff()
+        autodiff = autodiff ? _tagged_autodiff(u) : AutoFiniteDiff()
     )
 end
 function default_nlsolve(
         ::Nothing, isinplace::Val{true}, u, ::NonlinearLeastSquaresProblem, autodiff = false
     )
-    return FastShortcutNLLSPolyalg(; autodiff = autodiff ? AutoForwardDiff() : AutoFiniteDiff())
+    return FastShortcutNLLSPolyalg(; autodiff = autodiff ? _tagged_autodiff(u) : AutoFiniteDiff())
 end
 function default_nlsolve(
         ::Nothing, isinplace::Val{false}, u, ::AbstractNonlinearProblem, autodiff = false
     )
     return FastShortcutNonlinearPolyalg(;
-        autodiff = autodiff ? AutoForwardDiff() : AutoFiniteDiff()
+        autodiff = autodiff ? _tagged_autodiff(u) : AutoFiniteDiff()
     )
 end
 function default_nlsolve(
         ::Nothing, isinplace::Val{false}, u, ::NonlinearLeastSquaresProblem, autodiff = false
     )
-    return FastShortcutNLLSPolyalg(; autodiff = autodiff ? AutoForwardDiff() : AutoFiniteDiff())
+    return FastShortcutNLLSPolyalg(; autodiff = autodiff ? _tagged_autodiff(u) : AutoFiniteDiff())
 end
 function default_nlsolve(
         ::Nothing, isinplace::Val{false}, u::StaticArray,
         ::AbstractNonlinearProblem, autodiff = false
     )
-    return SimpleTrustRegion(autodiff = autodiff ? AutoForwardDiff() : AutoFiniteDiff())
+    return SimpleTrustRegion(autodiff = autodiff ? _tagged_autodiff(u) : AutoFiniteDiff())
 end
 function default_nlsolve(
         ::Nothing, isinplace::Val{false}, u::StaticArray,
         ::NonlinearLeastSquaresProblem, autodiff = false
     )
-    return SimpleGaussNewton(autodiff = autodiff ? AutoForwardDiff() : AutoFiniteDiff())
+    return SimpleGaussNewton(autodiff = autodiff ? _tagged_autodiff(u) : AutoFiniteDiff())
 end
 
 ## DefaultInit resolution for DAE-capable algorithms
@@ -148,9 +152,9 @@ function _initialize_dae!(
         isinplace::Val{true}
     )
     (; p, t, f) = integrator
-    # Unwrap FunctionWrappersWrapper from f for DAE initialization closures.
-    # NonlinearSolve's internal ForwardDiff uses different tags/chunk sizes than
-    # the pre-compiled FunctionWrapper variants, causing NoFunctionWrapperFoundError.
+    # Unwrap FunctionWrappersWrapper so the closure works with any argument types.
+    # NonlinearSolve may call the closure with types that don't match the
+    # pre-compiled FunctionWrapper variants (e.g., during nested AD).
     f = SciMLBase.unwrapped_f(f)
     M = integrator.f.mass_matrix
     dtmax = integrator.opts.dtmax
@@ -279,7 +283,6 @@ function _initialize_dae!(
         isinplace::Val{false}
     )
     (; p, t, f) = integrator
-    f = SciMLBase.unwrapped_f(f)
     u0 = integrator.u
     M = integrator.f.mass_matrix
     dtmax = integrator.opts.dtmax
@@ -336,7 +339,8 @@ function _initialize_dae!(
             jac = jac
         )
         nlprob = NonlinearProblem(nlfunc, u0)
-        nlsolve = default_nlsolve(alg.nlsolve, isinplace, nlprob, u0)
+        isAD = alg_autodiff(integrator.alg) isa AutoForwardDiff
+        nlsolve = default_nlsolve(alg.nlsolve, isinplace, u0, nlprob, isAD)
 
         nlsol = solve(
             nlprob, nlsolve; abstol = integrator.opts.abstol,
@@ -483,7 +487,8 @@ function _initialize_dae!(
         jac = jac
     )
     nlprob = NonlinearProblem(nlfunc, u0)
-    nlsolve = default_nlsolve(alg.nlsolve, isinplace, nlprob, u0)
+    isAD = alg_autodiff(integrator.alg) isa AutoForwardDiff
+    nlsolve = default_nlsolve(alg.nlsolve, isinplace, u0, nlprob, isAD)
 
     nlfunc = NonlinearFunction(nlequation; jac_prototype = f.jac_prototype)
     nlprob = NonlinearProblem(nlfunc, u0)
@@ -623,7 +628,6 @@ function _initialize_dae!(
         alg::DiffEqBase.BrownFullBasicInit, isinplace::Val{false}
     )
     (; p, t, f) = integrator
-    f = SciMLBase.unwrapped_f(f)
 
     u0 = integrator.u
     M = integrator.f.mass_matrix
@@ -812,7 +816,8 @@ function _initialize_dae!(
     nlfunc = NonlinearFunction(nlequation; jac_prototype = f.jac_prototype)
     nlprob = NonlinearProblem(nlfunc, ifelse.(differential_vars, du, u))
 
-    nlsolve = default_nlsolve(alg.nlsolve, isinplace, nlprob, integrator.u)
+    isAD = alg_autodiff(integrator.alg) isa AutoForwardDiff
+    nlsolve = default_nlsolve(alg.nlsolve, isinplace, integrator.u, nlprob, isAD)
 
     nlsol = solve(nlprob, nlsolve, verbose = integrator.opts.verbose.nonlinear_verbosity)
 


### PR DESCRIPTION
## Summary

- Pass `AutoForwardDiff{1}(ForwardDiff.Tag(OrdinaryDiffEqTag(), eltype(u)))` instead of bare `AutoForwardDiff()` in all 6 `default_nlsolve` overloads, so NonlinearSolve's internal ForwardDiff uses a tag matching the pre-compiled `FunctionWrapper` variants
- Fix 3 OOP `default_nlsolve` call sites that had swapped arguments (`nlprob, u0` instead of `u0, nlprob`) and missing `isAD` parameter
- Remove unnecessary `unwrapped_f` from 2 OOP ODEProblem methods (OOP functions don't use `FunctionWrappersWrapper`)
- Keep `unwrapped_f` for 2 IIP ODEProblem methods where FunctionWrapper type mismatches still occur during nested AD

Closes #3067

## Context

PR #3066 fixed `NoFunctionWrapperFoundError` by unwrapping `FunctionWrappersWrapper`, which introduced type-instabilities. This PR addresses that by passing the correct ForwardDiff tag to NonlinearSolve so it matches the pre-compiled variants, reducing the need for unwrapping.

The `unwrapped_f` calls remain for IIP ODEProblem methods because NonlinearSolve may evaluate the closure with types (e.g., stripped `Float64` during internal line search) that don't match any pre-compiled `FunctionWrapper` variant, regardless of the tag. For OOP methods, `FunctionWrappersWrapper` is not used so unwrapping was unnecessary.

## Test plan

- [x] OrdinaryDiffEqNonlinearSolve tests pass (29/29)
- [x] OrdinaryDiffEqRosenbrock `dae_rosenbrock_ad_tests.jl`: 6 pass, 3 error — identical to baseline (pre-existing IIP+AutoForwardDiff failures in main solver's `jacobian!`, not in DAE initialization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)