### PR TITLE
Store FBDF/DFBDF Lagrange thetas as scalars in cache.k_thetas

### DIFF
--- a/lib/OrdinaryDiffEqBDF/src/bdf_caches.jl
+++ b/lib/OrdinaryDiffEqBDF/src/bdf_caches.jl
@@ -610,6 +610,7 @@ end
     r::rType
     weights::wType
     iters_from_event::Int
+    k_thetas::tsType
 end
 
 function alg_cache(
@@ -657,11 +658,12 @@ function alg_cache(
     qwait = 3 # order + 2, matching nconsteps >= order + 2 for failure-free runs
     t_old = zero(t)
     iters_from_event = 0
+    k_thetas = zeros(typeof(t), max_order + 1)
 
     return FBDFConstantCache(
         nlsolver, ts, ts_tmp, t_old, u_history, order, prev_order,
         u_corrector, bdf_coeffs, Val(MO), nconsteps, consfailcnt, qwait, terkm2,
-        terkm1, terk, terkp1, r, weights, iters_from_event
+        terkm1, terk, terkp1, r, weights, iters_from_event, k_thetas
     )
 end
 
@@ -698,6 +700,7 @@ end
     equi_ts::tsType
     iters_from_event::Int
     dense::Vector{uType}
+    k_thetas::tsType
     step_limiter!::StepLimiter
 end
 
@@ -755,12 +758,13 @@ function alg_cache(
     ts_tmp = similar(ts)
     iters_from_event = 0
 
-    dense = [zero(u) for _ in 1:(2 * (max_order + 1))]
+    dense = [zero(u) for _ in 1:(max_order + 1)]
+    k_thetas = zeros(typeof(t), max_order + 1)
 
     return FBDFCache(
         fsalfirst, nlsolver, ts, ts_tmp, t_old, u_history, order, prev_order,
         u_corrector, u₀, bdf_coeffs, Val(MO), nconsteps, consfailcnt, qwait, tmp, atmp,
         terkm2, terkm1, terk, terkp1, terk_tmp, terkp1_tmp, r, weights, equi_ts,
-        iters_from_event, dense, alg.step_limiter!
+        iters_from_event, dense, k_thetas, alg.step_limiter!
     )
 end

--- a/lib/OrdinaryDiffEqBDF/src/bdf_perform_step.jl
+++ b/lib/OrdinaryDiffEqBDF/src/bdf_perform_step.jl
@@ -1156,15 +1156,14 @@ end
 end
 
 function initialize!(integrator, cache::FBDFConstantCache{max_order}) where {max_order}
-    integrator.kshortsize = 2 * (max_order + 1)
+    integrator.kshortsize = max_order + 1
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
     integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 
-    # k[1..half] = solution values, k[half+1..2*half] = Θ positions
-    # where half = max_order + 1
+    # k[1..max_order+1] = solution values; Θ positions stored in cache.k_thetas
     integrator.fsallast = zero(integrator.fsalfirst)
-    for i in 1:(2 * (max_order + 1))
+    for i in 1:(max_order + 1)
         integrator.k[i] = zero(integrator.fsalfirst)
     end
 
@@ -1190,20 +1189,14 @@ function perform_step!(
 
     # Rebuild integrator.k from u_history/ts for predictor/corrector
     # k+1 data points: u_history[:,1..k+1] at Θ = (ts[j]-t)/dt
-    half = max_order + 1
     if iters_from_event >= 1
         for j in 1:(max_order + 1)
             if j <= k + 1
-                if u isa Number
-                    integrator.k[j] = u_history[j]
-                    integrator.k[half + j] = (ts[j] - t) / dt
-                else
-                    integrator.k[j] = copy(u_history[j])
-                    integrator.k[half + j] = fill((ts[j] - t) / dt, size(u))
-                end
+                integrator.k[j] = u isa Number ? u_history[j] : copy(u_history[j])
+                cache.k_thetas[j] = (ts[j] - t) / dt
             else
                 integrator.k[j] = zero(u)
-                integrator.k[half + j] = zero(u)
+                cache.k_thetas[j] = zero(t)
             end
         end
     end
@@ -1357,27 +1350,15 @@ function perform_step!(
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     if integrator.opts.calck
         # Store dense output data: k[1]=u_new at Θ=1, k[1+j]=u_history[:,j]
-        half = max_order + 1
-        if u isa Number
-            integrator.k[1] = u
-            integrator.k[half + 1] = one(t)
-        else
-            integrator.k[1] = copy(u)
-            integrator.k[half + 1] = fill(one(t), size(u))
-        end
+        integrator.k[1] = u isa Number ? u : copy(u)
+        cache.k_thetas[1] = one(t)
         for j in 1:max_order
             if j <= k
-                if u isa Number
-                    integrator.k[1 + j] = u_history[j]
-                else
-                    integrator.k[1 + j] = copy(u_history[j])
-                end
-                integrator.k[half + 1 + j] = (u isa Number) ?
-                    (ts[j] - t) / dt :
-                    fill((ts[j] - t) / dt, size(u))
+                integrator.k[1 + j] = u isa Number ? u_history[j] : copy(u_history[j])
+                cache.k_thetas[1 + j] = (ts[j] - t) / dt
             else
                 integrator.k[1 + j] = zero(u)
-                integrator.k[half + 1 + j] = zero(u)
+                cache.k_thetas[1 + j] = zero(t)
             end
         end
     end
@@ -1385,10 +1366,10 @@ function perform_step!(
 end
 
 function initialize!(integrator, cache::FBDFCache{max_order}) where {max_order}
-    integrator.kshortsize = 2 * (max_order + 1)
+    integrator.kshortsize = max_order + 1
 
     resize!(integrator.k, integrator.kshortsize)
-    for i in 1:(2 * (max_order + 1))
+    for i in 1:(max_order + 1)
         integrator.k[i] = cache.dense[i]
     end
     integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t)
@@ -1415,15 +1396,14 @@ function perform_step!(
     tdt = t + dt
 
     # Rebuild integrator.k from u_history/ts for predictor/corrector
-    half = max_order + 1
     if cache.iters_from_event >= 1
         for j in 1:(max_order + 1)
             if j <= k + 1
                 copyto!(integrator.k[j], u_history[j])
-                fill!(integrator.k[half + j], (ts[j] - t) / dt)
+                cache.k_thetas[j] = (ts[j] - t) / dt
             else
                 fill!(integrator.k[j], zero(eltype(u)))
-                fill!(integrator.k[half + j], zero(eltype(u)))
+                cache.k_thetas[j] = zero(t)
             end
         end
     end
@@ -1546,16 +1526,15 @@ function perform_step!(
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     if integrator.opts.calck
         # Store dense output data: k[1]=u_new at Θ=1, k[1+j]=u_history[:,j]
-        half = max_order + 1
         @.. broadcast = false integrator.k[1] = u
-        fill!(integrator.k[half + 1], one(eltype(u)))
+        cache.k_thetas[1] = one(eltype(u))
         for j in 1:max_order
             if j <= k
                 copyto!(integrator.k[1 + j], u_history[j])
-                fill!(integrator.k[half + 1 + j], (ts[j] - t) / dt)
+                cache.k_thetas[1 + j] = (ts[j] - t) / dt
             else
                 fill!(integrator.k[1 + j], zero(eltype(u)))
-                fill!(integrator.k[half + 1 + j], zero(eltype(u)))
+                cache.k_thetas[1 + j] = zero(t)
             end
         end
     end

--- a/lib/OrdinaryDiffEqBDF/src/dae_caches.jl
+++ b/lib/OrdinaryDiffEqBDF/src/dae_caches.jl
@@ -157,6 +157,7 @@ end
     r::rType
     weights::wType
     iters_from_event::Int
+    k_thetas::tsType
 end
 
 function alg_cache(
@@ -202,11 +203,12 @@ function alg_cache(
     t_old = zero(t)
     iters_from_event = 0
     u₀ = zero(u)
+    k_thetas = zeros(typeof(t), max_order + 1)
 
     return DFBDFConstantCache(
         nlsolver, ts, ts_tmp, t_old, u_history, order, prev_order, u₀,
         u_corrector, bdf_coeffs, Val(MO), nconsteps, consfailcnt, qwait, terkm2,
-        terkm1, terk, terkp1, r, weights, iters_from_event
+        terkm1, terk, terkp1, r, weights, iters_from_event, k_thetas
     )
 end
 
@@ -243,6 +245,7 @@ end
     equi_ts::tsType
     iters_from_event::Int
     dense::Vector{uType}
+    k_thetas::tsType
 end
 
 function alg_cache(
@@ -299,12 +302,13 @@ function alg_cache(
     ts_tmp = similar(ts)
     iters_from_event = 0
 
-    dense = [zero(u) for _ in 1:(2 * (max_order + 1))]
+    dense = [zero(u) for _ in 1:(max_order + 1)]
+    k_thetas = zeros(typeof(t), max_order + 1)
 
     return DFBDFCache(
         fsalfirst, nlsolver, ts, ts_tmp, t_old, u_history, order, prev_order,
         u_corrector, u₀, bdf_coeffs, Val(MO), nconsteps, consfailcnt, qwait, tmp, atmp,
         terkm2, terkm1, terk, terkp1, terk_tmp, terkp1_tmp, r, weights, equi_ts,
-        iters_from_event, dense
+        iters_from_event, dense, k_thetas
     )
 end


### PR DESCRIPTION
## Summary

- Stores FBDF/DFBDF Lagrange interpolation theta positions as scalar values in a new `cache.k_thetas::Vector{typeof(t)}` field instead of as `fill(scalar, size(u))` arrays packed into `integrator.k`
- Eliminates `_get_theta(x) = first(x)` which caused GPU scalar indexing failures and wasted memory by duplicating a single scalar across u-sized arrays
- Halves `kshortsize` (and `dense` array size for mutable caches) since theta entries are no longer stored in `k`

## Files changed

- `bdf_caches.jl` / `dae_caches.jl` — Added `k_thetas` field to FBDF/DFBDF cache structs and constructors
- `bdf_perform_step.jl` / `dae_perform_step.jl` — Store thetas in `cache.k_thetas[j]` instead of `fill(scalar, size(u))` in `k[half+j]`; halved `kshortsize`
- `stiff_addsteps.jl` — Rebuild thetas in `cache.k_thetas` after callbacks instead of in k entries
- `bdf_interpolants.jl` — Read thetas from `cache.k_thetas` instead of `_get_theta(k[half+j])`; removed `_get_theta` helper and `half = length(k) ÷ 2` splitting

## Test plan

- [ ] CI passes on all existing BDF tests (QNDF, FBDF, DFBDF)
- [ ] Interpolation correctness verified through existing convergence and regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)