### PR TITLE
Fix FBDF GPU scalar indexing in step interpolation path

### DIFF
--- a/test/gpu/bdf_solvers.jl
+++ b/test/gpu/bdf_solvers.jl
@@ -22,9 +22,8 @@ prob_gpu = ODEProblem(f_gpu!, copy(u0_gpu), tspan, p_gpu)
     @test isapprox(Array(sol_gpu.u[end]), sol_cpu.u[end], rtol = 1.0e-5)
 end
 
-# FBDF GPU requires fixing scalar indexing in bdf_interpolants.jl (_get_theta)
 @testset "FBDF GPU" begin
-    @test_broken begin
+    @test begin
         sol_gpu = solve(prob_gpu, FBDF(), abstol = 1.0e-8, reltol = 1.0e-8)
         sol_cpu = solve(prob_cpu, FBDF(), abstol = 1.0e-8, reltol = 1.0e-8)
         isapprox(Array(sol_gpu.u[end]), sol_cpu.u[end], rtol = 1.0e-5)


### PR DESCRIPTION
## Summary
- remove FBDF predictor/corrector dependence on `_ode_interpolant` in `perform_step!` paths
- add history-based Lagrange interpolation helpers that use scalar `ts` nodes (`calc_history_lagrange_interp` / `calc_history_lagrange_interp!`)
- keep `sol.k` as `Vector{uType}` and unbreak the FBDF GPU test

## Why
FBDF GPU failures were caused by scalar indexing from `_get_theta(first(x))` through `_ode_interpolant` on CuArray-backed `k` entries. This patch avoids that solve-time path while preserving output layout and behavior.

## Validation
- `using OrdinaryDiffEqBDF` precompiles successfully
- CPU sanity solve with `FBDF()` succeeds
- `include("lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl")` passes
- GPU test file updated from `@test_broken` to `@test` for FBDF (`test/gpu/bdf_solvers.jl`)

## Note
GPU execution could not be run in this environment because CUDA driver is unavailable (`CUDA driver not functional`).
