### PR TITLE
Set OrdinaryDiffEqCore back from 3.11 to 3.10

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "3.11.0"
+version = "3.10.0"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"


### PR DESCRIPTION
3.10 was never registered, and now 3.11 registration is failing since it skipped over 3.10.

https://github.com/JuliaRegistries/General/pull/149063
