### PR TITLE
Run Runic.jl formatting on entire repository

### DIFF
--- a/lib/OrdinaryDiffEqBDF/test/dae_convergence_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/dae_convergence_tests.jl
@@ -69,13 +69,13 @@ function f_dae_linear_jac_u_iip(J, du, u, p, t)
     fill!(J, 0)
     J[1, 1] = -1.0
     J[2, 2] = -1.0
-    nothing
+    return nothing
 end
 function f_dae_linear_jac_du_iip(J, du, u, p, t)
     fill!(J, 0)
     J[1, 1] = 1.0
     J[2, 2] = 1.0
-    nothing
+    return nothing
 end
 prob_dae_linear_iip_sep = DAEProblem(
     DAEFunction(

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -773,7 +773,8 @@ function update_W!(
                     cj = nlsolver.α * inv(dtgamma)
                     if lcache.W isa StaticWOperator
                         W = StaticWOperator(
-                            dae_jacobian2W(lcache.J, dae_jac.J_du, cj))
+                            dae_jacobian2W(lcache.J, dae_jac.J_du, cj)
+                        )
                     else
                         W = dae_jacobian2W(lcache.J, dae_jac.J_du, cj)
                         if !isa(W, Number)

--- a/lib/OrdinaryDiffEqRosenbrock/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/algorithms.jl
@@ -155,7 +155,8 @@ struct HybridExplicitImplicitRK{TabType, CS, AD, F, P, FDT, ST, CJ, StepLimiter,
     autodiff::AD
 end
 
-function HybridExplicitImplicitRK(tab;
+function HybridExplicitImplicitRK(
+        tab;
         order,
         chunk_size = Val{0}(), autodiff = AutoForwardDiff(),
         standardtag = Val{true}(), concrete_jac = nothing,
@@ -187,7 +188,8 @@ function HybridExplicitImplicitRK(;
         precs = DEFAULT_PRECS, step_limiter! = trivial_limiter!,
         stage_limiter! = trivial_limiter!
     )
-    return HybridExplicitImplicitRK(tab;
+    return HybridExplicitImplicitRK(
+        tab;
         order, chunk_size, autodiff, standardtag, concrete_jac,
         diff_type, linsolve, precs, step_limiter!, stage_limiter!
     )

--- a/lib/OrdinaryDiffEqTaylorSeries/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/src/alg_utils.jl
@@ -93,7 +93,8 @@ function build_jet(f, ::Val{iip}, p, order::Val{P}, length = nothing) where {P, 
             end,
             (out, u0_val, t0_val) -> begin
                 coeffs_out = jet_coeffs[2](
-                    similar(coeffs_matrix, eltype(u0_val)), u0_val, t0_val)
+                    similar(coeffs_matrix, eltype(u0_val)), u0_val, t0_val
+                )
                 for i in 1:n
                     out[i] = TaylorScalar(Tuple(coeffs_out[i, :]))
                 end

--- a/lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl
@@ -58,18 +58,24 @@ if TEST_GROUP != "QA"
             @test SciMLBase.successful_retcode(sol2)
             @test length(sol2) > 1
 
-            sol8 = solve(prob, ExplicitTaylor(order = Val(8)),
-                abstol = 1e-12, reltol = 1e-12)
+            sol8 = solve(
+                prob, ExplicitTaylor(order = Val(8)),
+                abstol = 1.0e-12, reltol = 1.0e-12
+            )
             @test SciMLBase.successful_retcode(sol8)
             @test length(sol8) > 1
         end
 
         # Verify both give similar results
-        sol_auto = solve(prob_auto, ExplicitTaylor(order = Val(8)),
-            abstol = 1e-12, reltol = 1e-12)
-        sol_full = solve(prob_full, ExplicitTaylor(order = Val(8)),
-            abstol = 1e-12, reltol = 1e-12)
-        @test sol_auto.u[end] ≈ sol_full.u[end] atol = 1e-10
+        sol_auto = solve(
+            prob_auto, ExplicitTaylor(order = Val(8)),
+            abstol = 1.0e-12, reltol = 1.0e-12
+        )
+        sol_full = solve(
+            prob_full, ExplicitTaylor(order = Val(8)),
+            abstol = 1.0e-12, reltol = 1.0e-12
+        )
+        @test sol_auto.u[end] ≈ sol_full.u[end] atol = 1.0e-10
     end
 
     # Test OOP (out-of-place) with array state
@@ -86,14 +92,16 @@ if TEST_GROUP != "QA"
         @test SciMLBase.successful_retcode(sol2)
         @test length(sol2) > 1
 
-        sol8 = solve(prob_oop, ExplicitTaylor(order = Val(8)),
-            abstol = 1e-12, reltol = 1e-12)
+        sol8 = solve(
+            prob_oop, ExplicitTaylor(order = Val(8)),
+            abstol = 1.0e-12, reltol = 1.0e-12
+        )
         @test SciMLBase.successful_retcode(sol8)
         @test length(sol8) > 1
 
         # Check solution accuracy (harmonic oscillator: u1=cos(t), u2=sin(t))
-        @test sol8.u[end][1] ≈ cos(1.0) atol = 1e-10
-        @test sol8.u[end][2] ≈ sin(1.0) atol = 1e-10
+        @test sol8.u[end][1] ≈ cos(1.0) atol = 1.0e-10
+        @test sol8.u[end][2] ≈ sin(1.0) atol = 1.0e-10
     end
 
     # Test IIP with a nonlinear system (Henon-Heiles-style)
@@ -109,17 +117,21 @@ if TEST_GROUP != "QA"
         tspan = (0.0, 10.0)
 
         prob = ODEProblem{true, SciMLBase.FullSpecialize}(henon_heiles!, u0, tspan)
-        sol = solve(prob, ExplicitTaylor(order = Val(8)),
-            abstol = 1e-14, reltol = 1e-14)
+        sol = solve(
+            prob, ExplicitTaylor(order = Val(8)),
+            abstol = 1.0e-14, reltol = 1.0e-14
+        )
         @test SciMLBase.successful_retcode(sol)
         @test length(sol) > 1
 
         # Also test with AutoSpecialize
         prob_auto = ODEProblem(henon_heiles!, u0, tspan)
-        sol_auto = solve(prob_auto, ExplicitTaylor(order = Val(8)),
-            abstol = 1e-14, reltol = 1e-14)
+        sol_auto = solve(
+            prob_auto, ExplicitTaylor(order = Val(8)),
+            abstol = 1.0e-14, reltol = 1.0e-14
+        )
         @test SciMLBase.successful_retcode(sol_auto)
-        @test sol_auto.u[end] ≈ sol.u[end] atol = 1e-10
+        @test sol_auto.u[end] ≈ sol.u[end] atol = 1.0e-10
     end
 end
 


### PR DESCRIPTION
## Summary
- Run Runic.jl v1.5.1 formatting across all 538 Julia source files in the repository
- Only 5 files required changes, indicating the codebase was already well-formatted

## Changes
- **Explicit `return` keywords**: Added `return` before bare `nothing` statements in functions
- **Canonical float literals**: `1e-12` → `1.0e-12` for consistency
- **Multi-argument formatting**: Trailing `)` placed on new lines for long function calls, first argument of multi-line calls moved to its own line

## Files changed
- `lib/OrdinaryDiffEqBDF/test/dae_convergence_tests.jl`
- `lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl`
- `lib/OrdinaryDiffEqRosenbrock/src/algorithms.jl`
- `lib/OrdinaryDiffEqTaylorSeries/src/alg_utils.jl`
- `lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl`

## Test plan
- [ ] CI passes — changes are purely formatting, no behavioral changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)