### PR TITLE
Refactor generic Rosenbrock perform_step! to converge with RosenbrockCache

### DIFF
--- a/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_caches.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_caches.jl
@@ -1,6 +1,7 @@
 abstract type RosenbrockMutableCache <: OrdinaryDiffEqMutableCache end
 abstract type GenericRosenbrockMutableCache <: RosenbrockMutableCache end
 abstract type RosenbrockConstantCache <: OrdinaryDiffEqConstantCache end
+abstract type GenericRosenbrockConstantCache <: RosenbrockConstantCache end
 
 # Fake values since non-FSAL
 get_fsalfirstlast(cache::RosenbrockMutableCache, u) = (nothing, nothing)
@@ -947,7 +948,6 @@ function get_fsalfirstlast(
         cache::Union{
             Rosenbrock23Cache, Rosenbrock32Cache, Rosenbrock33Cache,
             Rosenbrock34Cache,
-            Rosenbrock4Cache,
         },
         u
     )
@@ -959,6 +959,13 @@ end
 ### RosenbrockW6S4O
 
 @RosenbrockW6S4OS(:cache)
+
+# Accessors to get stage vectors as a tuple from generic caches
+@inline _ks(c::ROS2Cache) = (c.k1, c.k2)
+@inline _ks(c::ROS23Cache) = (c.k1, c.k2, c.k3)
+@inline _ks(c::ROS34PWCache) = (c.k1, c.k2, c.k3, c.k4)
+@inline _ks(c::Rosenbrock4Cache) = (c.k1, c.k2, c.k3, c.k4)
+@inline _ks(c::RosenbrockW6SCache) = (c.k1, c.k2, c.k3, c.k4, c.k5, c.k6)
 
 ################################################################################
 


### PR DESCRIPTION
## Summary

- Replace macro-generated `perform_step!` code (`gen_perform_step`, `gen_constant_perform_step`, `gen_initialize`) with a shared loop function `_rosenbrock_stage_loop!()` used by both `GenericRosenbrockMutableCache` and `RosenbrockCache`
- Add `GenericRosenbrockConstantCache` abstract type and `_ks()` accessors for dispatch on generic caches
- Store array-based tableaus via `_make_rosenbrock_tableau()` instead of named-field structs, enabling uniform `tab.a[i,j]` access across all methods
- Fix existing bug where generated code never persisted `cache.linsolve = linres.cache`
- Net -60 lines: eliminates ~230 lines of code generation while converging two independent implementations into one shared loop

## Details

The generic Rosenbrock (W) methods previously used macro-based code generation to produce specialized `perform_step!` for 21 algorithms across 5 macro families (`@ROS2`, `@ROS23`, `@ROS34PW`, `@Rosenbrock4`, `@RosenbrockW6S4OS`). Meanwhile, `RosenbrockCache` (Rodas4/5/6P) already had a clean loop-based `perform_step!` with an identical inner loop structure. This PR converges them.

**Key design decisions:**
- `_rosenbrock_stage_loop!` handles stages 2..s, parameterized by `tab_a`, `dtC`, `dtd`, and `stage_limiter!` to accommodate differences between generic (no stage limiter, locally allocated dtC) and Rodas (stage limiter, pre-allocated dtC)
- Stage 1 stays in each `perform_step!` because the first `dolinsolve` call has different kwargs
- Accepts one extra `f` evaluation per step for 6 Rosenbrock4 algorithms (previously the `a4j=a3j` optimization avoided this), since the linear solve dominates cost
- Only the inplace (mutable cache) version shares the loop; the non-inplace version remains separate due to fundamentally different APIs (`dolinsolve` vs `W\b`)

## Test plan

- [x] All 26 algorithms pass smoke tests (both inplace and out-of-place)
- [x] `Pkg.test("OrdinaryDiffEqRosenbrock")` passes — convergence tests for all 21 generic + all Rodas methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)