### PR TITLE
Fix OOP J_t tracking in update_W! to prevent infinite REDO loop

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -4,7 +4,7 @@ uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 
 [targets]
-test = ["DiffEqDevTools", "Random", "SafeTestsets", "Test", "SparseArrays", "Pkg"]
+test = ["DiffEqDevTools", "OrdinaryDiffEqSDIRK", "Random", "SafeTestsets", "Test", "SparseArrays", "Pkg"]
 
 [compat]
 Pkg = "1"
@@ -22,6 +22,7 @@ ConstructionBase = "1.5.8"
 LinearAlgebra = "1.10"
 SciMLBase = "2.141"
 OrdinaryDiffEqCore = "3"
+OrdinaryDiffEqSDIRK = "1"
 SparseArrays = "1.10"
 ConcreteStructs = "0.2"
 Aqua = "0.8.11"
@@ -68,10 +69,14 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
+OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources.OrdinaryDiffEqCore]
 path = "../OrdinaryDiffEqCore"
+
+[sources.OrdinaryDiffEqSDIRK]
+path = "../OrdinaryDiffEqSDIRK"
 
 [extensions]
 OrdinaryDiffEqDifferentiationSparseArraysExt = "SparseArrays"

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -792,7 +792,13 @@ function update_W!(
                 lcache.W = calc_W(integrator, nlsolver, dtgamma, repeat_step)
             end
         end
-        new_jac && (lcache.J_t = integrator.t)
+        if isdae
+            new_jac && (lcache.J_t = integrator.t)
+        else
+            # OOP calc_W always recomputes J via calc_J (no mutable J to reuse),
+            # so J_t should be updated whenever calc_W is called (i.e., new_W).
+            (new_jac || new_W) && (lcache.J_t = integrator.t)
+        end
         set_new_W!(nlsolver, new_W)
         if isdae && new_W
             set_W_γdt!(nlsolver, nlsolver.α * inv(dtgamma))

--- a/lib/OrdinaryDiffEqDifferentiation/test/oop_jt_tracking_test.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/oop_jt_tracking_test.jl
@@ -1,0 +1,24 @@
+# Test that OOP update_W! correctly tracks J_t when new_W=true but new_jac=false.
+# Without the fix, OOP TRBDF2 can hang in an infinite @goto REDO loop because
+# isJcurrent() returns false even after J was freshly computed by calc_W.
+using OrdinaryDiffEqSDIRK, Test
+
+# Stiff OOP scalar problem: du/dt = -1000*u
+# The extreme stiffness forces step retries where new_W=true, new_jac=false can occur.
+f_oop(u, p, t) = -1000 * u
+prob = ODEProblem(f_oop, 1.0, (0.0, 1.0))
+
+# This should complete without hanging. The bug causes an infinite loop in nlsolve.
+sol = solve(prob, TRBDF2(); adaptive = true)
+@test sol.retcode == ReturnCode.Success
+@test sol.t[end] == 1.0
+@test abs(sol.u[end]) < 1.0e-6  # Should decay to near zero
+
+# Also test with a vector OOP problem (StaticArrays-style)
+using StaticArrays
+f_oop_sa(u, p, t) = SA[-1000.0 * u[1], -500.0 * u[2]]
+prob_sa = ODEProblem(f_oop_sa, SA[1.0, 1.0], (0.0, 1.0))
+
+sol_sa = solve(prob_sa, TRBDF2(); adaptive = true)
+@test sol_sa.retcode == ReturnCode.Success
+@test sol_sa.t[end] == 1.0

--- a/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
@@ -7,3 +7,8 @@ if TEST_GROUP != "FUNCTIONAL" && isempty(VERSION.prerelease)
     @time @safetestset "JET Tests" include("jet.jl")
     @time @safetestset "Aqua" include("qa.jl")
 end
+
+# Run functional tests
+if TEST_GROUP != "QA"
+    @time @safetestset "OOP J_t Tracking" include("oop_jt_tracking_test.jl")
+end


### PR DESCRIPTION
## Summary

- Fix a bug in OOP `update_W!` where `J_t` was only updated when `new_jac=true`, but OOP `calc_W` always recomputes J via `calc_J` (no mutable J to reuse)
- When `do_newJW` returned `(new_jac=false, new_W=true)`, J was freshly computed but `J_t` remained stale, causing `isJcurrent()` to return false and triggering an infinite `@goto REDO` loop in `nlsolve.jl`
- This was exposed by OrdinaryDiffEqCore 3.10.0's `qmax_first_step=10000`, which allows large first step growth that triggers step retries with `new_W=true` but `new_jac=false`

## Root Cause

In `derivative_utils.jl`, the OOP `update_W!` function had:
```julia
new_jac && (lcache.J_t = integrator.t)
```

This is correct for IIP (where `calc_J!` is only called when `new_jac=true`), but wrong for OOP where `calc_W` → `calc_J` always recomputes J regardless of `new_jac`.

## Fix

Update `J_t` whenever `new_jac || new_W` for non-DAE OOP problems. DAE is left unchanged because its `dae_jacobians` path reuses stored `lcache.J` without recomputing when only `new_W=true`.

## Test Plan

- [x] Added `oop_jt_tracking_test.jl` that verifies OOP TRBDF2 solve completes without hanging (scalar and StaticArray problems)
- [x] `Pkg.test("OrdinaryDiffEqDifferentiation")` passes (JET, Aqua, and new functional test)
- [x] Runic formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)