### PR TITLE
Accept SDE/RODE kwargs in __init for unified integrator construction

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/solve.jl
+++ b/lib/OrdinaryDiffEqCore/src/solve.jl
@@ -80,6 +80,13 @@ function SciMLBase.__init(
         alias = ODEAliasSpecifier(),
         initializealg = DefaultInit(),
         rng = nothing,
+        # SDE/RODE fields: accepted here so that SDE packages can delegate to
+        # this __init and construct an ODEIntegrator with noise populated.
+        save_noise = false,
+        delta = nothing,
+        W = nothing,
+        P = nothing,
+        sqdt = nothing,
         kwargs...
     )
     if prob isa SciMLBase.AbstractDAEProblem && alg isa OrdinaryDiffEqAlgorithm
@@ -558,7 +565,7 @@ function SciMLBase.__init(
         typeof(save_idxs),
         typeof(maxiters), typeof(tstops),
         typeof(saveat), typeof(d_discontinuities), typeof(verbose_spec),
-        typeof(nothing),
+        typeof(delta),
     }(
         maxiters, save_everystep,
         adaptive, abstol_internal,
@@ -590,9 +597,9 @@ function SciMLBase.__init(
         progress_message,
         progress_id,
         timeseries_errors,
-        dense_errors, nothing, dense,
+        dense_errors, delta, dense,
         save_on, save_start,
-        save_end, false, save_discretes, save_end_user,
+        save_end, save_noise, save_discretes, save_end_user,
         callbacks_internal,
         isoutofdomain,
         unstable_check,
@@ -666,7 +673,7 @@ function SciMLBase.__init(
         typeof(last_event_error), typeof(callback_cache),
         typeof(initializealg), typeof(differential_vars),
         typeof(controller_cache), typeof(_rng),
-        Nothing, Nothing, Nothing,
+        typeof(W), typeof(P), typeof(sqdt),
     }(
         sol, u, du, k, t, tType(_dt), f, p,
         uprev, uprev2, duprev, tprev,
@@ -690,7 +697,7 @@ function SciMLBase.__init(
         u_modified, reinitiailize, isdae,
         opts, stats, initializealg, differential_vars,
         fsalfirst, fsallast, _rng,
-        nothing, nothing, nothing
+        W, P, sqdt
     )
 
     if initialize_integrator


### PR DESCRIPTION
## Summary

- Adds `save_noise`, `delta`, `W`, `P`, and `sqdt` keyword arguments to `OrdinaryDiffEqCore.__init`
- These default to `false`/`nothing` so existing ODE behavior is unchanged
- Wires `delta` and `save_noise` into `DEOptions` construction (previously hardcoded to `nothing`/`false`)
- Wires `W`, `P`, `sqdt` into `ODEIntegrator` construction (previously hardcoded to `nothing`)

This enables StochasticDiffEq to eventually delegate integrator construction to ODE's `__init` by passing pre-constructed noise fields, rather than maintaining a separate `SDEIntegrator` constructor.

Part of the SDE/ODE unification effort (companion to SciML/StochasticDiffEq.jl#682).

## Test plan

- [x] OrdinaryDiffEqCore tests pass locally
- [x] No behavior change for ODE solvers (all kwargs default to previous hardcoded values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>