### PR TITLE
Add noise, c, rate_constants, q fields to ODEIntegrator

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/integrators/type.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/type.jl
@@ -133,6 +133,7 @@ mutable struct ODEIntegrator{
         uType, duType, tType, pType, eigenType, EEstT, QT, tdirType,
         ksEltype, SolType, F, CacheType, O, FSALType, EventErrorType,
         CallbackCacheType, IA, DV, CC, RNGType, WType, PType, SqdtType,
+        NoiseType, CType, RCType,
     } <:
     SciMLBase.AbstractODEIntegrator{algType, IIP, uType, tType}
     sol::SolType
@@ -193,4 +194,9 @@ mutable struct ODEIntegrator{
     W::WType
     P::PType
     sqdt::SqdtType
+    # SDE/RODE fields: populated by SDE packages, Nothing for pure ODE.
+    noise::NoiseType
+    c::CType
+    rate_constants::RCType
+    q::QT
 end

--- a/lib/OrdinaryDiffEqCore/src/solve.jl
+++ b/lib/OrdinaryDiffEqCore/src/solve.jl
@@ -87,6 +87,9 @@ function SciMLBase.__init(
         W = nothing,
         P = nothing,
         sqdt = nothing,
+        noise = nothing,
+        c = nothing,
+        rate_constants = nothing,
         kwargs...
     )
     if prob isa SciMLBase.AbstractDAEProblem && alg isa OrdinaryDiffEqAlgorithm
@@ -674,6 +677,7 @@ function SciMLBase.__init(
         typeof(initializealg), typeof(differential_vars),
         typeof(controller_cache), typeof(_rng),
         typeof(W), typeof(P), typeof(sqdt),
+        typeof(noise), typeof(c), typeof(rate_constants),
     }(
         sol, u, du, k, t, tType(_dt), f, p,
         uprev, uprev2, duprev, tprev,
@@ -697,7 +701,8 @@ function SciMLBase.__init(
         u_modified, reinitiailize, isdae,
         opts, stats, initializealg, differential_vars,
         fsalfirst, fsallast, _rng,
-        W, P, sqdt
+        W, P, sqdt,
+        noise, c, rate_constants, QT(1)
     )
 
     if initialize_integrator


### PR DESCRIPTION
## Summary

Adds SDE-specific fields to `ODEIntegrator` so that SDE packages can eventually construct an `ODEIntegrator` directly, eliminating the need for a separate `SDEIntegrator` struct.

New fields (all `Nothing`/default for pure ODE):
- `noise` — original noise process from `prob.noise`
- `c` — stoichiometry function from `regular_jump`
- `rate_constants` — initial rate values for tau-leaping adaptive error estimation
- `q` — stepsize control ratio (`QT(1)` default)

New `__init` kwargs: `noise`, `c`, `rate_constants` (`q` is always initialized to `QT(1)`).

This follows the same pattern used for `W`, `P`, `sqdt`, `delta`, `save_noise` in earlier PRs (#3095, #3108, #3113).

## Test plan
- [x] OrdinaryDiffEqCore precompiles
- [x] Full OrdinaryDiffEq precompiles (33 sub-packages)
- [x] `solve(prob, Tsit5())` works correctly
- [x] New fields present on integrator with `nothing` defaults
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)