### PR TITLE
Fix callable tstops, DiscreteProblem abstol, and composite SDE algs

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
@@ -435,13 +435,8 @@ function SciMLBase.reinit!(
 
     tType = typeof(integrator.t)
     tspan = (tType(t0), tType(tf))
-    # Evaluate callable tstops with current parameters
-    _tstops = if tstops isa AbstractArray || tstops isa Tuple || tstops isa Number
-        tstops
-    else
-        tstops(parameter_values(integrator), tspan)
-    end
-    reinit_tstops!(tType, integrator.opts.tstops, _tstops, d_discontinuities, tspan)
+    reinit_tstops!(tType, integrator.opts.tstops, tstops, d_discontinuities, tspan;
+        p = parameter_values(integrator))
     reinit_saveat!(tType, integrator.opts.saveat, saveat, tspan)
     reinit_d_discontinuities!(tType, integrator.opts.d_discontinuities, d_discontinuities, tspan)
     if erase_sol

--- a/lib/OrdinaryDiffEqCore/src/solve.jl
+++ b/lib/OrdinaryDiffEqCore/src/solve.jl
@@ -930,15 +930,26 @@ end
     return tstops_internal
 end
 
-function reinit_tstops!(::Type{T}, tstops_internal, tstops, d_discontinuities, tspan) where {T}
+function reinit_tstops!(
+        ::Type{T}, tstops_internal, tstops, d_discontinuities, tspan; p = nothing
+) where {T}
     empty!(tstops_internal)
+
+    # Evaluate callable tstops
+    _tstops = if tstops isa AbstractArray || tstops isa Tuple || tstops isa Number
+        tstops
+    elseif p !== nothing
+        tstops(p, tspan)
+    else
+        ()
+    end
 
     t0, tf = tspan
     tdir = sign(tf - t0)
     tdir_t0 = tdir * t0
     tdir_tf = tdir * tf
 
-    for t in tstops
+    for t in _tstops
         tdir_t = tdir * t
         tdir_t0 < tdir_t < tdir_tf && push!(tstops_internal, tdir_t)
     end


### PR DESCRIPTION
## Summary
- Fix callable tstops storage in `tstops_cache` — was storing empty tuple `()` instead of the callable function, breaking `reinit!`
- Evaluate callable tstops in `reinit!` with current parameters via `parameter_values(integrator)`
- Only override `abstol/reltol` to `false` for `AbstractDiscreteProblem` when user didn't explicitly provide them — fixes implicit tau-leaping `nlsolver` convergence failure when SDE passes computed tolerances for JumpProblem{DiscreteProblem}
- Initialize `alg_choice` for `StochasticDiffEqCompositeAlgorithm` and `StochasticDiffEqRODECompositeAlgorithm` — fixes `copyat_or_push!(::Nothing, ...)` error in `_savevalues!`

## Context
Follow-up to #3122 (SDE init delegation support). These issues were discovered during CI testing of StochasticDiffEq PR #685 which delegates `__init` to ODE's `_ode_init`.

## Test plan
- [x] Normal tstops (array) still work for both ODE and SDE
- [x] Callable tstops work for ODE and SDE (basic, reinit!, parameter-dependent)
- [x] Tau-leaping (ThetaTrapezoidalTauLeaping) converges correctly
- [x] Composite SDE algorithms (AutoSOSRI2) produce correct `alg_choice`
- [x] All standard SDE solvers (EM, SRIW1, ImplicitEM, LambaEM, RandomEM) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)