### PR TITLE
multiply initial dt by random number to prevent numerical coincendences

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/initdt.jl
+++ b/lib/OrdinaryDiffEqCore/src/initdt.jl
@@ -10,7 +10,7 @@
     p = integrator.p
     oneunit_tType = oneunit(_tType)
     # a number that's about 1 that we multiply by to prevent numerical coincedences
-    arbitrary_const = oneunit_tType*(84//83)
+    arbitrary_const = oneunit_tType*(93//83)
     dtmax_tdir = tdir * dtmax
 
     dtmin = nextfloat(max(integrator.opts.dtmin, eps(t)))
@@ -275,7 +275,7 @@ end
     p = prob.p
     oneunit_tType = oneunit(_tType)
     # a number that's about 1 that we multiply by to prevent numerical coincedences
-    arbitrary_const = oneunit_tType*(84//83)
+    arbitrary_const = oneunit_tType*(93//83)
     dtmax_tdir = tdir * dtmax
 
     dtmin = nextfloat(max(integrator.opts.dtmin, eps(t)))


### PR DESCRIPTION
Previously our initial dt was very likely to be a power of 10 which can cause odd numerical issues (e.g. if it lines up exactly with the period of a sign wave). This is exacerbated dramatically with the inital_qmax raise to 10000 since a dt of 1e-4 amplifys to a dt of 1.0 after an inital step (if the inital step had no error) and something like ~30% of ODEs have something special happen at t=1
