### PR TITLE
Fix dtpropose sign loss in modify_dt_for_tstops! for backward solves

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
@@ -179,7 +179,7 @@ function modify_dt_for_tstops!(integrator)
 
         if integrator.opts.adaptive
             original_dt = abs(integrator.dt)
-            integrator.dtpropose = original_dt
+            integrator.dtpropose = integrator.tdir * original_dt
             if original_dt < distance_to_tstop
                 _set_tstop_flag!(integrator, false)
             else

--- a/lib/OrdinaryDiffEqVerner/test/ode_verner_tests.jl
+++ b/lib/OrdinaryDiffEqVerner/test/ode_verner_tests.jl
@@ -128,3 +128,50 @@ println("RKV76IIa")
 dts = [2, 1, 0.5, 0.25]
 
 check_convergence(dts, prob_oop, RKV76IIa(), 7)
+
+# -------------------------------------------------------------
+### Backward solve lazy interpolation dt sign regression test
+# Tests that lazy interpolation during a backward solve produces correct results.
+# Previously, modify_dt_for_tstops! stored dtpropose without the sign, causing
+# addsteps! to evaluate at times outside the step interval on the last step.
+println("Backward solve lazy interpolation")
+
+function backward_ode!(du, u, p, t)
+    du[1] = -u[1]
+    du[2] = -2 * u[2]
+end
+
+prob_back = ODEProblem(backward_ode!, [1.0, 1.0], (1.0, 0.0))
+
+interp_lazy = Float64[]
+interp_nolazy = Float64[]
+
+cb_lazy = DiscreteCallback(
+    (u, t, int) -> true,
+    integrator -> begin
+        t_mid = (integrator.tprev + integrator.t) / 2
+        curu = similar(integrator.u)
+        integrator(curu, t_mid)
+        push!(interp_lazy, curu[1])
+        u_modified!(integrator, false)
+    end,
+    save_positions = (false, false))
+
+cb_nolazy = DiscreteCallback(
+    (u, t, int) -> true,
+    integrator -> begin
+        t_mid = (integrator.tprev + integrator.t) / 2
+        curu = similar(integrator.u)
+        integrator(curu, t_mid)
+        push!(interp_nolazy, curu[1])
+        u_modified!(integrator, false)
+    end,
+    save_positions = (false, false))
+
+solve(prob_back, Vern9(lazy = true), abstol = 1e-12, reltol = 1e-12,
+    callback = cb_lazy, save_everystep = false)
+solve(prob_back, Vern9(lazy = false), abstol = 1e-12, reltol = 1e-12,
+    callback = cb_nolazy, save_everystep = false)
+
+@test length(interp_lazy) == length(interp_nolazy)
+@test maximum(abs.(interp_lazy .- interp_nolazy)) < 1e-10


### PR DESCRIPTION
## Summary

- **Bug**: `modify_dt_for_tstops!` stored `dtpropose = abs(integrator.dt)`, losing the sign for backward solves. When `_loopfooter!` later restores `integrator.dt = integrator.dtpropose` before firing callbacks, lazy interpolation solvers (e.g., Vern9 with `lazy=true`) would compute `addsteps!` stages at `t + c*dt` with a positive dt during a backward solve, evaluating at times outside the step interval.
- **Impact**: Catastrophically wrong interpolation on the last step (tstop step) of backward solves with lazy Vern solvers. This caused GaussAdjoint sensitivity analysis with Vern9 to produce relative errors of ~34x instead of ~1e-12.
- **Fix**: One-line change — apply `integrator.tdir` to preserve the sign: `integrator.dtpropose = integrator.tdir * original_dt`

## Root cause analysis

In `modify_dt_for_tstops!` (`integrator_utils.jl:182`):
```julia
original_dt = abs(integrator.dt)
integrator.dtpropose = original_dt  # BUG: loses sign for backward solves
```

The flow on a tstop step:
1. `modify_dt_for_tstops!` shrinks `dt` to hit the tstop exactly, stores unsigned `dtpropose`
2. The step is accepted
3. `_loopfooter!` restores `integrator.dt = integrator.dtpropose` (now positive) **before** `handle_callbacks!`
4. Callbacks fire with wrong-sign `dt`
5. Lazy `addsteps!` computes extra RK stages at `t + c*dt` — with positive `dt` these are outside `[t_current, t_prev]` for a backward solve
6. Interpolation using these wrong stages returns garbage

## Verification

| Test | Before fix | After fix |
|------|-----------|-----------|
| Vern9 lazy GaussAdjoint rel error | 34.4 | 9.4e-12 |
| Backward solve lazy vs non-lazy interp diff | 50.2 | 0.0 |
| Tsit5 GaussAdjoint rel error | 2.8e-12 | 2.8e-12 (unchanged, not affected) |

## Test plan

- [x] OrdinaryDiffEqCore `Pkg.test()` passes
- [x] OrdinaryDiffEqVerner functional tests pass (31/31)
- [x] New regression test: backward solve Vern9 lazy vs non-lazy callback interpolation
- [x] Runic formatting check passes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)