### PR TITLE
Fix DAE reinit test: Rosenbrock methods don't fail on violated constraints

### DIFF
--- a/test/interface/dae_initialization_tests.jl
+++ b/test/interface/dae_initialization_tests.jl
@@ -164,8 +164,10 @@ integrator = init(
     @test SciMLBase.successful_retcode(integ.sol.retcode)
     reinit!(integ, reinit_dae = false)
     @test integ.u ≈ [2.0, 0.0]
-    # @test_warn doesn't properly capture LazyString warnings from SciMLBase
-    # Just verify that step! runs (it will fail with Unstable retcode due to violated DAE constraint)
+    # With reinit_dae=false the algebraic constraint u[1]^2 - u[2]^2 = 0 is violated.
+    # Rosenbrock methods (Rodas5P) linearize and don't iterate, so the step succeeds
+    # but the constraint remains violated — u[2] stays near 0 instead of tracking u[1].
     step!(integ, 0.01, true)
-    @test integ.sol.retcode == ReturnCode.Unstable
+    @test abs(integ.u[2]) < 1e-10  # u[2] stuck near 0, not reinitialized
+    @test abs(integ.u[1]) > 1.5    # u[1] still evolving
 end


### PR DESCRIPTION
## Summary

- The test at `test/interface/dae_initialization_tests.jl:170` expected `ReturnCode.Unstable` after `reinit!(integ, reinit_dae=false)` + `step!`, but the step returns `ReturnCode.Success`
- **Root cause**: Rosenbrock methods (Rodas5P) linearize the system and solve a single linear system per stage — they don't use Newton iteration, so they don't detect DAE constraint violations. The algebraic variable `u[2]` stays at 0 (a stable fixed point of the linearized system) while `u[1]` evolves normally.
- The original test used `@test_warn ["dt", "forced below floating point epsilon"]` which also wasn't triggering properly (commit 97c5fcc41 changed it to check `ReturnCode.Unstable` instead)
- **Fix**: Changed the test to verify the actual intended behavior — that `reinit_dae=false` skips initialization, leaving the constraint violated (`u[2] ≈ 0` instead of tracking `u[1]`)

## Test plan

- [x] New test assertions pass locally (6/6)
- [x] Runic formatting check passes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)