### PR TITLE
Use traits for composite algorithm checks to support SDE dispatch unification

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/alg_utils.jl
@@ -546,7 +546,7 @@ alg_can_repeat_jac(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm}) = false
 alg_can_repeat_jac(alg::OrdinaryDiffEqNewtonAdaptiveAlgorithm) = true
 
 function unwrap_alg(alg::SciMLBase.DEAlgorithm, is_stiff)
-    if !(alg isa CompositeAlgorithm)
+    if !is_composite_algorithm(alg)
         return alg
     elseif alg.choice_function isa AutoSwitchCache
         if length(alg.algs) > 2
@@ -568,7 +568,7 @@ end
 
 function unwrap_alg(integrator, is_stiff)
     alg = integrator.alg
-    if !(alg isa CompositeAlgorithm)
+    if !is_composite_algorithm(alg)
         return alg
     elseif alg.choice_function isa AutoSwitchCache
         if length(alg.algs) > 2

--- a/lib/OrdinaryDiffEqCore/src/cache_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/cache_utils.jl
@@ -8,8 +8,7 @@ end
 function SciMLBase.unwrap_cache(integrator::ODEIntegrator, is_stiff)
     alg = integrator.alg
     cache = integrator.cache
-    iscomp = alg isa CompositeAlgorithm
-    if !iscomp
+    if !is_composite_algorithm(alg)
         return cache
     elseif cache isa DefaultCache
         current = integrator.cache.current

--- a/lib/OrdinaryDiffEqCore/src/perform_step/composite_perform_step.jl
+++ b/lib/OrdinaryDiffEqCore/src/perform_step/composite_perform_step.jl
@@ -280,6 +280,29 @@ function choose_algorithm!(integrator, cache::DefaultCache)
 end
 
 """
+Generic fallback for composite caches that are not CompositeCache or DefaultCache
+(e.g. StochasticCompositeCache). Uses the `is_composite_cache` trait.
+Non-composite caches that don't match any more-specific method get the no-op.
+"""
+function choose_algorithm!(integrator, cache)
+    is_composite_cache(cache) || return nothing
+    new_current = cache.choice_function(integrator)
+    old_current = cache.current
+    new_current == old_current && return nothing
+    initialize!(integrator, @inbounds(cache.caches[new_current]))
+    reset_alg_dependent_opts!(
+        integrator, integrator.alg.algs[old_current],
+        integrator.alg.algs[new_current]
+    )
+    transfer_cache!(
+        integrator, cache.caches[old_current],
+        cache.caches[new_current]
+    )
+    cache.current = new_current
+    return nothing
+end
+
+"""
 If no user default, then this will change the default to the defaults
 for the second algorithm.
 Except if the user default turns out to be the default for the current alg,
@@ -289,6 +312,18 @@ function reset_alg_dependent_opts!(integrator, alg1, alg2)
     integrator.dtchangeable = isdtchangeable(alg2)
     if integrator.opts.adaptive == isadaptive(alg1)
         integrator.opts.adaptive = isadaptive(alg2)
+    end
+    if integrator.opts.qmin == qmin_default(alg1)
+        integrator.opts.qmin = qmin_default(alg2)
+    end
+    if integrator.opts.qmax == qmax_default(alg1)
+        integrator.opts.qmax = qmax_default(alg2)
+    end
+    if integrator.opts.qsteady_min == qsteady_min_default(alg1)
+        integrator.opts.qsteady_min = qsteady_min_default(alg2)
+    end
+    if integrator.opts.qsteady_max == qsteady_max_default(alg1)
+        integrator.opts.qsteady_max = qsteady_max_default(alg2)
     end
     reset_alg_dependent_opts!(integrator.opts.controller, alg1, alg2)
     return nothing

--- a/lib/OrdinaryDiffEqCore/src/solve.jl
+++ b/lib/OrdinaryDiffEqCore/src/solve.jl
@@ -855,6 +855,8 @@ function SciMLBase.solve!(integrator::ODEIntegrator)
     postamble!(integrator)
 
     f = integrator.sol.prob.f
+    # SDE split problems may store f as a Tuple; unwrap to check for analytic solution
+    f = f isa Tuple ? f[1] : f
 
     if SciMLBase.has_analytic(f)
         SciMLBase.calculate_solution_errors!(
@@ -932,7 +934,7 @@ end
 
 function reinit_tstops!(
         ::Type{T}, tstops_internal, tstops, d_discontinuities, tspan; p = nothing
-) where {T}
+    ) where {T}
     empty!(tstops_internal)
 
     # Evaluate callable tstops


### PR DESCRIPTION
## Summary

- `unwrap_alg`: use `is_composite_algorithm(alg)` trait instead of `isa CompositeAlgorithm`, so SDE composite algorithms are handled without requiring a separate override
- `unwrap_cache`: use `is_composite_algorithm(alg)` trait instead of `isa CompositeAlgorithm`
- Add generic `choose_algorithm!(integrator, cache)` fallback that uses `is_composite_cache` trait for composite caches outside the ODE hierarchy (e.g. `StochasticCompositeCache`)
- Add `qmin`/`qmax`/`qsteady_min`/`qsteady_max` handling to `reset_alg_dependent_opts!` (previously only in SDE's copy)
- Handle `f isa Tuple` in `solve!` for SDE split problem analytic solutions

These changes enable StochasticDiffEq to reuse ODE's composite algorithm infrastructure (`choose_algorithm!`, `reset_alg_dependent_opts!`, `transfer_cache!`, `unwrap_alg`, `unwrap_cache`, `solve!`) instead of maintaining separate copies, eliminating ~130 lines of duplicated code in the companion SDE PR.

## Files changed

| File | Changes |
|------|---------|
| `OrdinaryDiffEqCore/src/alg_utils.jl` | `unwrap_alg`: `isa CompositeAlgorithm` → `is_composite_algorithm(alg)` |
| `OrdinaryDiffEqCore/src/cache_utils.jl` | `unwrap_cache`: `isa CompositeAlgorithm` → `is_composite_algorithm(alg)` |
| `OrdinaryDiffEqCore/src/perform_step/composite_perform_step.jl` | Generic `choose_algorithm!` fallback + qmin/qmax/qsteady in `reset_alg_dependent_opts!` |
| `OrdinaryDiffEqCore/src/solve.jl` | Tuple f unwrap for `has_analytic` check |

## Test plan

- [x] `Pkg.test("OrdinaryDiffEqCore")` passes
- [x] StochasticDiffEq Interface1/2/3 tests pass with companion SDE changes
- [x] Composite SDE algorithm solve + `unwrap_cache` verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)