### PR TITLE
Add isempty(k) linear interpolation fallback in _ode_interpolant

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/dense/generic_dense.jl
+++ b/lib/OrdinaryDiffEqCore/src/dense/generic_dense.jl
@@ -1321,11 +1321,16 @@ function interpolation_differential_vars(differential_vars, y₀, idxs)
     end
 end
 
-# If no dispatch found, assume Hermite
+# If no dispatch found, assume Hermite (or linear when k is empty, e.g. SDE)
 function _ode_interpolant(
         Θ, dt, y₀, y₁, k, cache, idxs, T::Type{Val{TI}}, differential_vars
     ) where {TI}
     TI > 3 && throw(DerivativeOrderNotPossibleError())
+
+    # Linear fallback when no dense output vectors (e.g. SDE)
+    if isempty(k)
+        return linear_interpolant(Θ, dt, y₀, y₁, idxs, T)
+    end
 
     differential_vars = interpolation_differential_vars(differential_vars, y₀, idxs)
     return hermite_interpolant(
@@ -1338,6 +1343,10 @@ function _ode_interpolant!(
         out, Θ, dt, y₀, y₁, k, cache, idxs, T::Type{Val{TI}}, differential_vars
     ) where {TI}
     TI > 3 && throw(DerivativeOrderNotPossibleError())
+
+    if isempty(k)
+        return linear_interpolant!(out, Θ, dt, y₀, y₁, idxs, T)
+    end
 
     differential_vars = interpolation_differential_vars(differential_vars, y₀, idxs)
     return hermite_interpolant!(out, Θ, dt, y₀, y₁, k, idxs, T, differential_vars)


### PR DESCRIPTION
## Summary

- Add `isempty(k)` check in `_ode_interpolant` and `_ode_interpolant!` that falls back to `linear_interpolant` when the dense output vector `k` is empty
- This enables SDE integrators (which use linear interpolation and never populate `k`) to use ODE's interpolation infrastructure directly

## Motivation

`SDEIntegrator` is a type alias for `ODEIntegrator{<:SDEAlgTypes}`. SDE currently maintains its own entire interpolation layer (~320 lines in `dense.jl` + `interp_func.jl`) because ODE's `_ode_interpolant` unconditionally calls `hermite_interpolant`, which crashes when `k` is empty.

SDE's `sde_interpolant` is identical to ODE's `linear_interpolant`. The only missing piece was this 2-line fallback.

**Why `isempty(k)` works**: SDE's `_ode_init` initializes `k = rateType[]` (empty vector). SDE's `_ode_addsteps!` is a no-op for `StochasticDiffEqCache`, so `k` stays empty throughout. ODE caches always populate `k` during `initialize!`, so this fallback is never triggered for ODE solvers.

## Changes

| File | Change |
|------|--------|
| `lib/OrdinaryDiffEqCore/src/dense/generic_dense.jl` | Add `isempty(k)` → `linear_interpolant` fallback in both `_ode_interpolant` and `_ode_interpolant!` |

## Test plan

- [x] OrdinaryDiffEqCore tests pass (JET, Aqua, sparse)
- [x] SDE smoke test: `sol(t)`, `integrator(t)`, `get_du(integrator)` all work correctly
- [x] StochasticDiffEq Interface1/2/3 tests pass

## Part of SDE/ODE unification

This is the ODE-side prerequisite for the companion SDE PR (SciML/StochasticDiffEq.jl#TBD) which deletes ~320 lines of SDE interpolation code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)