### PR TITLE
Move SDE cache abstract types & dispatch fallbacks to OrdinaryDiffEqCore

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "3.20.0"
+version = "3.21.0"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/lib/OrdinaryDiffEqCore/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/alg_utils.jl
@@ -114,6 +114,7 @@ all_fsal(alg::CompositeAlgorithm, cache) = _all_fsal(alg.algs)
 end
 
 issplit(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm}) = false
+issplit(alg::StochasticDiffEqAlgorithm) = false
 
 function _composite_beta1_default(
         algs::Tuple{T1, T2}, current, ::Val{QT},

--- a/lib/OrdinaryDiffEqCore/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqCore/src/algorithms.jl
@@ -11,6 +11,11 @@ abstract type StochasticDiffEqRODEAlgorithm <: SciMLBase.AbstractRODEAlgorithm e
 abstract type StochasticDiffEqRODEAdaptiveAlgorithm <: StochasticDiffEqRODEAlgorithm end
 abstract type StochasticDiffEqRODECompositeAlgorithm <: StochasticDiffEqRODEAlgorithm end
 
+# SDE/RODE cache type hierarchy (used by StochasticDiffEq)
+abstract type StochasticDiffEqCache <: SciMLBase.DECache end
+abstract type StochasticDiffEqConstantCache <: StochasticDiffEqCache end
+abstract type StochasticDiffEqMutableCache <: StochasticDiffEqCache end
+
 abstract type OrdinaryDiffEqAdaptiveImplicitAlgorithm{CS, AD, FDT, ST, CJ} <:
 OrdinaryDiffEqAdaptiveAlgorithm end
 abstract type OrdinaryDiffEqNewtonAdaptiveAlgorithm{CS, AD, FDT, ST, CJ} <:

--- a/lib/OrdinaryDiffEqCore/src/dense/generic_dense.jl
+++ b/lib/OrdinaryDiffEqCore/src/dense/generic_dense.jl
@@ -1224,6 +1224,14 @@ function ode_interpolation!(
     return out
 end
 
+# No-op: SDE uses linear interpolation, not Hermite, so no k values needed.
+@inline function _ode_addsteps!(
+        k, t, uprev, u, dt, f, p, cache::StochasticDiffEqCache,
+        always_calc_begin = false, allow_calc_end = true, force_calc_end = false
+    )
+    return nothing
+end
+
 """
 By default, Hermite interpolant so update the derivative at the two ends
 """

--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
@@ -221,6 +221,22 @@ end
     return (cache.nlsolver.cache.dz, cache.atmp)
 end
 
+# SDE cache fallbacks — mirror ODE's pattern for SDE types
+for AlgType in (StochasticDiffEqAlgorithm, StochasticDiffEqRODEAlgorithm)
+    @eval @inline function SciMLBase.get_tmp_cache(
+            integrator, alg::$AlgType,
+            cache::StochasticDiffEqConstantCache
+        )
+        return nothing
+    end
+    @eval @inline function SciMLBase.get_tmp_cache(
+            integrator, alg::$AlgType,
+            cache::StochasticDiffEqMutableCache
+        )
+        return (cache.tmp,)
+    end
+end
+
 function full_cache(integrator::ODEIntegrator)
     # for DefaultCache, we need to make sure to initialize all the caches in case they get switched to later
     if integrator.cache isa DefaultCache

--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
@@ -801,6 +801,9 @@ function nlsolve_f(f, alg::OrdinaryDiffEqAlgorithm)
     return f isa SplitFunction && issplit(alg) ? f.f1 : f
 end
 nlsolve_f(f, alg::DAEAlgorithm) = f
+function nlsolve_f(f, alg::StochasticDiffEqAlgorithm)
+    return f isa SplitSDEFunction && issplit(alg) ? f.f1 : f
+end
 function nlsolve_f(integrator::ODEIntegrator)
     return nlsolve_f(integrator.f, unwrap_alg(integrator, true))
 end


### PR DESCRIPTION
## Summary

- Add `StochasticDiffEqCache`, `StochasticDiffEqConstantCache`, `StochasticDiffEqMutableCache` abstract type hierarchy to `algorithms.jl` (alongside existing SDE algorithm types)
- Add `get_tmp_cache` fallbacks for SDE cache types in `integrator_interface.jl`
- Add `nlsolve_f(f, alg::StochasticDiffEqAlgorithm)` in `integrator_utils.jl`
- Add `issplit(alg::StochasticDiffEqAlgorithm) = false` in `alg_utils.jl`
- Add `_ode_addsteps!` no-op for `StochasticDiffEqCache` in `generic_dense.jl`
- Bump OrdinaryDiffEqCore to v3.21.0

This makes OrdinaryDiffEqCore the single source of truth for all SDE abstract type hierarchies (both algorithm types from PR #3122 and now cache types). The companion StochasticDiffEq PR deletes the corresponding definitions and imports them from OrdinaryDiffEqCore.

## Test plan

- [x] OrdinaryDiffEqCore tests pass
- [x] StochasticDiffEq Interface1 tests pass
- [x] StochasticDiffEq Interface2 tests pass
- [x] StochasticDiffEq Interface3 tests pass
- [x] Runic formatting check passes

## Part of SDE/ODE unification (Phase 14)

Stacked on #3132 (unify-sde-integrator-methods).
Companion SDE PR: ChrisRackauckas-Claude/StochasticDiffEq.jl

🤖 Generated with [Claude Code](https://claude.com/claude-code)