### PR TITLE
Use CuArray instead of cu() in BDF GPU tests to preserve Float64

### DIFF
--- a/test/gpu/bdf_solvers.jl
+++ b/test/gpu/bdf_solvers.jl
@@ -8,8 +8,8 @@ end
 
 u0_cpu = [1.0, 2.0]
 p_cpu = [-0.5, -1.5]
-u0_gpu = cu(u0_cpu)
-p_gpu = cu(p_cpu)
+u0_gpu = CuArray(u0_cpu)
+p_gpu = CuArray(p_cpu)
 tspan = (0.0, 1.0)
 
 prob_cpu = ODEProblem(f_gpu!, copy(u0_cpu), tspan, p_cpu)


### PR DESCRIPTION
## Summary
- Replace `cu()` with `CuArray()` in `test/gpu/bdf_solvers.jl` to preserve Float64 element type
- `cu()` converts arrays to Float32, making the `abstol=1e-8, reltol=1e-8` tolerances unreachable (Float32 eps ≈ 1.2e-7)
- The solver fails to converge at every step, producing wrong results after ~30 minutes of struggling
- `CuArray()` preserves Float64, matching the CPU solve and making the tolerances achievable

## Test plan
- [ ] QNDF GPU test should pass with correct results
- [ ] FBDF GPU test remains `@test_broken` (separate scalar indexing issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)