### PR TITLE
fix: SublibraryCI fetch depth causes merge base failure on fork PRs

### DIFF
--- a/.github/workflows/SublibraryCI.yml
+++ b/.github/workflows/SublibraryCI.yml
@@ -33,7 +33,7 @@ jobs:
             CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} 2>/dev/null || git diff --name-only HEAD~1 HEAD)
           else
             # For pull requests, compare against the base branch
-            git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
+            git fetch origin ${{ github.event.pull_request.base.ref }}
             CHANGED=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD)
           fi
 


### PR DESCRIPTION
## Summary
- The `detect-changes` job in `SublibraryCI.yml` fails with `fatal: origin/master...HEAD: no merge base` on PRs from forks (e.g. #3126)
- Root cause: `git fetch origin master --depth=1` fetches only 1 commit of the base branch, which is insufficient for Git to compute the merge base needed by the three-dot diff (`origin/master...HEAD`)
- Fix: remove `--depth=1` so the full base branch history is fetched, consistent with the `fetch-depth: 0` already configured on the checkout step

## Test plan
- [x] Verified the error in CI logs: `fatal: origin/master...HEAD: no merge base` at https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/23211895755/job/67492965893
- [ ] Once merged, re-run CI on #3126 to confirm the detect-changes job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)