### PR TITLE
Apply Runic.jl formatting

### DIFF
--- a/.github/scripts/compute_affected_sublibraries.jl
+++ b/.github/scripts/compute_affected_sublibraries.jl
@@ -84,6 +84,7 @@ function compute_reverse_deps(graph::Dict{String, Vector{String}})
         for rdep in get(rev, pkg, Set{String}())
             get_all_rdeps!(visited, rdep)
         end
+        return
     end
 
     transitive = Dict{String, Set{String}}()
@@ -110,9 +111,11 @@ function load_test_groups(lib_dir::String, pkg::String)
     return DEFAULT_TEST_GROUPS
 end
 
-function compute_affected(changed_files::Vector{String},
-                          graph::Dict{String, Vector{String}},
-                          reverse_deps::Dict{String, Set{String}})
+function compute_affected(
+        changed_files::Vector{String},
+        graph::Dict{String, Vector{String}},
+        reverse_deps::Dict{String, Set{String}}
+    )
     affected = Set{String}()
     for filepath in changed_files
         filepath = strip(filepath)
@@ -131,9 +134,11 @@ end
 # Entries to exclude from the matrix.
 # Each entry is (group, version) where group is the CI GROUP string.
 # See: https://github.com/SciML/OrdinaryDiffEq.jl/issues/2977
-const EXCLUDES = Set([
-    ("OrdinaryDiffEqBDF", "pre"),  # JET resolution fails on pre-release Julia
-])
+const EXCLUDES = Set(
+    [
+        ("OrdinaryDiffEqBDF", "pre"),  # JET resolution fails on pre-release Julia
+    ]
+)
 
 function build_matrix(affected::Set{String}, lib_dir::String)
     entries = Vector{@NamedTuple{group::String, version::String}}()
@@ -159,7 +164,7 @@ function print_json(entries)
         i > 1 && print(",")
         print("{\"group\":\"", entry.group, "\",\"version\":\"", entry.version, "\"}")
     end
-    println("]")
+    return println("]")
 end
 
 function main()
@@ -183,7 +188,7 @@ function main()
     affected = compute_affected(collect(String, changed_files), graph, reverse_deps)
 
     matrix = build_matrix(affected, lib_dir)
-    print_json(matrix)
+    return print_json(matrix)
 end
 
 main()

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/dae_initialization_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/dae_initialization_tests.jl
@@ -169,6 +169,6 @@ integrator = init(
     # Rosenbrock methods (Rodas5P) linearize and don't iterate, so the step succeeds
     # but the constraint remains violated — u[2] stays near 0 instead of tracking u[1].
     step!(integ, 0.01, true)
-    @test abs(integ.u[2]) < 1e-10  # u[2] stuck near 0, not reinitialized
+    @test abs(integ.u[2]) < 1.0e-10  # u[2] stuck near 0, not reinitialized
     @test abs(integ.u[1]) > 1.5    # u[1] still evolving
 end

--- a/lib/OrdinaryDiffEqVerner/test/ode_verner_tests.jl
+++ b/lib/OrdinaryDiffEqVerner/test/ode_verner_tests.jl
@@ -138,7 +138,7 @@ println("Backward solve lazy interpolation")
 
 function backward_ode!(du, u, p, t)
     du[1] = -u[1]
-    du[2] = -2 * u[2]
+    return du[2] = -2 * u[2]
 end
 
 prob_back = ODEProblem(backward_ode!, [1.0, 1.0], (1.0, 0.0))
@@ -155,7 +155,8 @@ cb_lazy = DiscreteCallback(
         push!(interp_lazy, curu[1])
         u_modified!(integrator, false)
     end,
-    save_positions = (false, false))
+    save_positions = (false, false)
+)
 
 cb_nolazy = DiscreteCallback(
     (u, t, int) -> true,
@@ -166,12 +167,17 @@ cb_nolazy = DiscreteCallback(
         push!(interp_nolazy, curu[1])
         u_modified!(integrator, false)
     end,
-    save_positions = (false, false))
+    save_positions = (false, false)
+)
 
-solve(prob_back, Vern9(lazy = true), abstol = 1e-12, reltol = 1e-12,
-    callback = cb_lazy, save_everystep = false)
-solve(prob_back, Vern9(lazy = false), abstol = 1e-12, reltol = 1e-12,
-    callback = cb_nolazy, save_everystep = false)
+solve(
+    prob_back, Vern9(lazy = true), abstol = 1.0e-12, reltol = 1.0e-12,
+    callback = cb_lazy, save_everystep = false
+)
+solve(
+    prob_back, Vern9(lazy = false), abstol = 1.0e-12, reltol = 1.0e-12,
+    callback = cb_nolazy, save_everystep = false
+)
 
 @test length(interp_lazy) == length(interp_nolazy)
-@test maximum(abs.(interp_lazy .- interp_nolazy)) < 1e-10
+@test maximum(abs.(interp_lazy .- interp_nolazy)) < 1.0e-10

--- a/test/gpu/simple_dae.jl
+++ b/test/gpu/simple_dae.jl
@@ -62,6 +62,6 @@ end
 
 @testset "Compare GPU to CPU solution" begin
     for t in tspan[begin]:0.1:tspan[end]
-        @test isapprox(Vector(sol_d(t)), sol(t); rtol = 1e-4)
+        @test isapprox(Vector(sol_d(t)), sol(t); rtol = 1.0e-4)
     end
 end

--- a/test/interface/dae_initialization_tests.jl
+++ b/test/interface/dae_initialization_tests.jl
@@ -168,6 +168,6 @@ integrator = init(
     # Rosenbrock methods (Rodas5P) linearize and don't iterate, so the step succeeds
     # but the constraint remains violated — u[2] stays near 0 instead of tracking u[1].
     step!(integ, 0.01, true)
-    @test abs(integ.u[2]) < 1e-10  # u[2] stuck near 0, not reinitialized
+    @test abs(integ.u[2]) < 1.0e-10  # u[2] stuck near 0, not reinitialized
     @test abs(integ.u[1]) > 1.5    # u[1] still evolving
 end


### PR DESCRIPTION
## Summary
- Run Runic.jl formatter on the entire repository
- Fixes function argument alignment, closing paren placement, and explicit `return` statements in `.github/scripts/compute_affected_sublibraries.jl` and `lib/OrdinaryDiffEqVerner/test/ode_verner_tests.jl`
- Normalizes float literals (`1e-10` → `1.0e-10`) in test files

## Test plan
- [ ] CI passes — formatting-only changes, no behavioral impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)