### PR TITLE
Fix type inference for AutoVern7+Rodas5P with autodiff and linsolve

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/alg_utils.jl
@@ -304,8 +304,22 @@ function DiffEqBase.prepare_alg(
 end
 
 function DiffEqBase.prepare_alg(alg::CompositeAlgorithm, u0, p, prob)
-    algs = map(alg -> DiffEqBase.prepare_alg(alg, u0, p, prob), alg.algs)
-    return CompositeAlgorithm(algs, alg.choice_function)
+    algs = map(a -> DiffEqBase.prepare_alg(a, u0, p, prob), alg.algs)
+    cf = alg.choice_function
+    if cf isa AutoSwitch
+        nonstiffalg = _prepare_autoswitch_alg(cf.nonstiffalg, u0, p, prob)
+        stiffalg = _prepare_autoswitch_alg(cf.stiffalg, u0, p, prob)
+        cf = AutoSwitch(nonstiffalg, stiffalg,
+            cf.maxstiffstep, cf.maxnonstiffstep,
+            cf.nonstifftol, cf.stifftol,
+            cf.dtfac, cf.stiffalgfirst, cf.switch_max)
+    end
+    return CompositeAlgorithm(algs, cf)
+end
+
+_prepare_autoswitch_alg(alg, u0, p, prob) = DiffEqBase.prepare_alg(alg, u0, p, prob)
+function _prepare_autoswitch_alg(algs::Tuple, u0, p, prob)
+    map(a -> DiffEqBase.prepare_alg(a, u0, p, prob), algs)
 end
 
 has_autodiff(alg::OrdinaryDiffEqAlgorithm) = false

--- a/lib/OrdinaryDiffEqCore/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqCore/src/algorithms.jl
@@ -83,7 +83,7 @@ function SciMLBase.remake(thing::OrdinaryDiffEqAlgorithm; kwargs...)
     return T(; SciMLBase.struct_as_namedtuple(thing)..., kwargs...)
 end
 
-function SciMLBase.remake(
+@inline function SciMLBase.remake(
         thing::Union{
             OrdinaryDiffEqAdaptiveImplicitAlgorithm{
                 CS, AD, FDT,

--- a/lib/OrdinaryDiffEqDifferentiation/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/alg_utils.jl
@@ -46,16 +46,16 @@ function DiffEqBase.prepare_alg(
         alg::Union{
             OrdinaryDiffEqAdaptiveImplicitAlgorithm{
                 CS, AD,
-                FDT,
+                FDT, ST,
             },
-            OrdinaryDiffEqImplicitAlgorithm{CS, AD, FDT},
-            DAEAlgorithm{CS, AD, FDT},
-            OrdinaryDiffEqExponentialAlgorithm{CS, AD, FDT},
+            OrdinaryDiffEqImplicitAlgorithm{CS, AD, FDT, ST},
+            DAEAlgorithm{CS, AD, FDT, ST},
+            OrdinaryDiffEqExponentialAlgorithm{CS, AD, FDT, ST},
         },
         u0::AbstractArray{T},
         p, prob
-    ) where {CS, AD, FDT, T}
-    prepped_AD = prepare_ADType(alg_autodiff(alg), prob, u0, p, standardtag(alg))
+    ) where {CS, AD, FDT, ST, T}
+    prepped_AD = prepare_ADType(alg_autodiff(alg), prob, u0, p, Val{ST}())
 
     sparse_prepped_AD = prepare_user_sparsity(prepped_AD, prob)
 
@@ -82,13 +82,11 @@ function prepare_ADType(autodiff_alg::AutoSparse, prob, u0, p, standardtag)
     )
 end
 
-function prepare_ADType(autodiff_alg::AutoForwardDiff, prob, u0, p, standardtag)
-    tag = if standardtag
-        ForwardDiff.Tag(OrdinaryDiffEqTag(), eltype(u0))
-    else
-        nothing
-    end
+function prepare_ADType(autodiff_alg::AutoForwardDiff, prob, u0, p, standardtag::Bool)
+    prepare_ADType(autodiff_alg, prob, u0, p, Val(standardtag))
+end
 
+function _prepare_ADType_fwd(autodiff_alg::AutoForwardDiff, prob, u0, tag)
     T = eltype(u0)
 
     fwd_cs = OrdinaryDiffEqCore._get_fwd_chunksize_int(autodiff_alg)
@@ -106,6 +104,15 @@ function prepare_ADType(autodiff_alg::AutoForwardDiff, prob, u0, p, standardtag)
     else
         return AutoForwardDiff{cs}(tag)
     end
+end
+
+function prepare_ADType(autodiff_alg::AutoForwardDiff, prob, u0, p, ::Val{true})
+    tag = ForwardDiff.Tag(OrdinaryDiffEqTag(), eltype(u0))
+    return _prepare_ADType_fwd(autodiff_alg, prob, u0, tag)
+end
+
+function prepare_ADType(autodiff_alg::AutoForwardDiff, prob, u0, p, ::Val{false})
+    return _prepare_ADType_fwd(autodiff_alg, prob, u0, nothing)
 end
 
 function prepare_ADType(alg::AutoFiniteDiff, prob, u0, p, standardtag)

--- a/test/regression/inference.jl
+++ b/test/regression/inference.jl
@@ -17,3 +17,20 @@ using Test
     #    @test_broken @inferred init(prob2D, alg)
     #end
 end
+
+# Regression test for https://github.com/SciML/OrdinaryDiffEq.jl/issues/3200
+# AutoVern7 + Rodas5P with both autodiff and linsolve should be inferrable
+@testset "AutoVern7 + Rodas5P inference with autodiff and linsolve (#3200)" begin
+    using StaticArrays, ADTypes, LinearSolve
+    f(u, p, t) = SVector(-p.Ka * u[1], p.Ka * u[1] - p.CL * u[2] / p.Vc)
+    u0 = SVector(0.0, 0.0)
+    prob = ODEProblem(f, u0, (0.0, 10.0), (Ka = 1.0, CL = 1.0, Vc = 1.0))
+
+    @inferred solve(
+        prob,
+        AutoVern7(Rodas5P(
+            autodiff = AutoForwardDiff(chunksize = 1),
+            linsolve = GenericLUFactorization()
+        ))
+    )
+end


### PR DESCRIPTION
## Summary

Fixes #3200 — `@inferred solve(prob, AutoVern7(Rodas5P(autodiff=AutoForwardDiff(chunksize=1), linsolve=GenericLUFactorization())))` now passes on Julia 1.11.

The root cause was a combination of three inference barriers:

- **`SciMLBase.remake` for implicit algorithms** used kwargs splatting (`struct_as_namedtuple(thing)...` + `kwargs...`) that exceeded Julia 1.11's inference budget when the algorithm had many type parameters (custom autodiff + custom linsolve). Adding `@inline` lets the compiler track through the merging.
- **`prepare_ADType` for `AutoForwardDiff`** branched on `standardtag::Bool`, producing a `Union{AutoForwardDiff{CS,Nothing}, AutoForwardDiff{CS,Tag}}` return type. Splitting into `Val{true}`/`Val{false}` dispatch eliminates the union.
- **`prepare_alg` for `CompositeAlgorithm`** updated the algorithm tuple but left the `AutoSwitch` choice function with unprepped (stale) algorithm types, causing a type mismatch in `AutoSwitchCache`.

## Changes

- `lib/OrdinaryDiffEqCore/src/algorithms.jl`: Add `@inline` to `SciMLBase.remake` for implicit/DAE algorithms
- `lib/OrdinaryDiffEqDifferentiation/src/alg_utils.jl`: Extract `ST` type parameter in `prepare_alg`, use `Val{ST}()` dispatch; split `prepare_ADType` for `AutoForwardDiff` into `Val{true}`/`Val{false}` methods
- `lib/OrdinaryDiffEqCore/src/alg_utils.jl`: Update `prepare_alg` for `CompositeAlgorithm` to also prepare algorithms stored in `AutoSwitch`
- `test/regression/inference.jl`: Add regression test

## Test plan

- [x] `@inferred solve(prob, AutoVern7(Rodas5P(autodiff=AutoForwardDiff(chunksize=1), linsolve=GenericLUFactorization())))` passes on Julia 1.11.9
- [x] All previously-passing inference cases still pass (Tsit5, Rodas5P, AutoVern7+Rodas5P, etc.)
- [x] No regression on Julia 1.12
- [x] OrdinaryDiffEqCore tests pass
- [ ] OrdinaryDiffEqRosenbrock tests (running)
- [ ] OrdinaryDiffEqDifferentiation tests (running)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)