### PR TITLE
Run Runic.jl formatter on codebase

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/alg_utils.jl
@@ -309,17 +309,19 @@ function DiffEqBase.prepare_alg(alg::CompositeAlgorithm, u0, p, prob)
     if cf isa AutoSwitch
         nonstiffalg = _prepare_autoswitch_alg(cf.nonstiffalg, u0, p, prob)
         stiffalg = _prepare_autoswitch_alg(cf.stiffalg, u0, p, prob)
-        cf = AutoSwitch(nonstiffalg, stiffalg,
+        cf = AutoSwitch(
+            nonstiffalg, stiffalg,
             cf.maxstiffstep, cf.maxnonstiffstep,
             cf.nonstifftol, cf.stifftol,
-            cf.dtfac, cf.stiffalgfirst, cf.switch_max)
+            cf.dtfac, cf.stiffalgfirst, cf.switch_max
+        )
     end
     return CompositeAlgorithm(algs, cf)
 end
 
 _prepare_autoswitch_alg(alg, u0, p, prob) = DiffEqBase.prepare_alg(alg, u0, p, prob)
 function _prepare_autoswitch_alg(algs::Tuple, u0, p, prob)
-    map(a -> DiffEqBase.prepare_alg(a, u0, p, prob), algs)
+    return map(a -> DiffEqBase.prepare_alg(a, u0, p, prob), algs)
 end
 
 has_autodiff(alg::OrdinaryDiffEqAlgorithm) = false

--- a/lib/OrdinaryDiffEqDifferentiation/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/alg_utils.jl
@@ -83,7 +83,7 @@ function prepare_ADType(autodiff_alg::AutoSparse, prob, u0, p, standardtag)
 end
 
 function prepare_ADType(autodiff_alg::AutoForwardDiff, prob, u0, p, standardtag::Bool)
-    prepare_ADType(autodiff_alg, prob, u0, p, Val(standardtag))
+    return prepare_ADType(autodiff_alg, prob, u0, p, Val(standardtag))
 end
 
 function _prepare_ADType_fwd(autodiff_alg::AutoForwardDiff, prob, u0, tag)

--- a/lib/OrdinaryDiffEqSDIRK/test/dae_esdirk_test.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/dae_esdirk_test.jl
@@ -48,4 +48,3 @@ sol = @inferred solve(prob_mm_oop, KenCarp47(), reltol = 1.0e-8, abstol = 1.0e-8
     end
     @test DI.gradient(f, AutoForwardDiff(), [0.04, 3.0e7, 1.0e4]) ≈ [0, 0, 0] atol = 1.0e-8
 end
-

--- a/test/regression/inference.jl
+++ b/test/regression/inference.jl
@@ -28,9 +28,11 @@ end
 
     @inferred solve(
         prob,
-        AutoVern7(Rodas5P(
-            autodiff = AutoForwardDiff(chunksize = 1),
-            linsolve = GenericLUFactorization()
-        ))
+        AutoVern7(
+            Rodas5P(
+                autodiff = AutoForwardDiff(chunksize = 1),
+                linsolve = GenericLUFactorization()
+            )
+        )
     )
 end


### PR DESCRIPTION
## Summary
- Run Runic.jl formatter across the entire codebase
- Fixes minor style issues: explicit `return` keywords, multi-line argument indentation, trailing blank lines
- Only 4 files required changes — the codebase was already very clean

## Files changed
- `lib/OrdinaryDiffEqCore/src/alg_utils.jl` — indentation + explicit return
- `lib/OrdinaryDiffEqDifferentiation/src/alg_utils.jl` — explicit return
- `lib/OrdinaryDiffEqSDIRK/test/dae_esdirk_test.jl` — trailing newline
- `test/regression/inference.jl` — indentation

## Test plan
- [x] Ran `Runic.jl` formatter with `--inplace` flag
- [ ] CI should pass — changes are formatting-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)