### PR TITLE
Remove V100 CUDA compatibility workarounds

### DIFF
--- a/lib/OrdinaryDiffEqBDF/test/gpu/LocalPreferences.toml
+++ b/lib/OrdinaryDiffEqBDF/test/gpu/LocalPreferences.toml
@@ -1,7 +1,0 @@
-[CUDA_Runtime_jll]
-version = "12.6"
-
-[CUDA_Driver_jll]
-# Disable forward-compat driver — V100 runners need the system driver
-# since CUDA_Driver_jll v13+ drops compute capability 7.0 support
-compat = "false"

--- a/lib/OrdinaryDiffEqBDF/test/gpu/Project.toml
+++ b/lib/OrdinaryDiffEqBDF/test/gpu/Project.toml
@@ -1,7 +1,5 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-CUDA_Driver_jll = "4ee394cb-3365-5eb0-8335-949819d2adfc"
-CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
 OrdinaryDiffEqBDF = "6ad6398a-0878-4a85-9266-38940aa047c8"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/lib/OrdinaryDiffEqCore/test/gpu/LocalPreferences.toml
+++ b/lib/OrdinaryDiffEqCore/test/gpu/LocalPreferences.toml
@@ -1,7 +1,0 @@
-[CUDA_Runtime_jll]
-version = "12.6"
-
-[CUDA_Driver_jll]
-# Disable forward-compat driver — V100 runners need the system driver
-# since CUDA_Driver_jll v13+ drops compute capability 7.0 support
-compat = "false"

--- a/lib/OrdinaryDiffEqCore/test/gpu/Project.toml
+++ b/lib/OrdinaryDiffEqCore/test/gpu/Project.toml
@@ -2,8 +2,6 @@
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-CUDA_Driver_jll = "4ee394cb-3365-5eb0-8335-949819d2adfc"
-CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqDefault/test/gpu/LocalPreferences.toml
+++ b/lib/OrdinaryDiffEqDefault/test/gpu/LocalPreferences.toml
@@ -1,7 +1,0 @@
-[CUDA_Runtime_jll]
-version = "12.6"
-
-[CUDA_Driver_jll]
-# Disable forward-compat driver — V100 runners need the system driver
-# since CUDA_Driver_jll v13+ drops compute capability 7.0 support
-compat = "false"

--- a/lib/OrdinaryDiffEqDefault/test/gpu/Project.toml
+++ b/lib/OrdinaryDiffEqDefault/test/gpu/Project.toml
@@ -1,7 +1,5 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-CUDA_Driver_jll = "4ee394cb-3365-5eb0-8335-949819d2adfc"
-CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/lib/OrdinaryDiffEqLinear/test/gpu/LocalPreferences.toml
+++ b/lib/OrdinaryDiffEqLinear/test/gpu/LocalPreferences.toml
@@ -1,7 +1,0 @@
-[CUDA_Runtime_jll]
-version = "12.6"
-
-[CUDA_Driver_jll]
-# Disable forward-compat driver — V100 runners need the system driver
-# since CUDA_Driver_jll v13+ drops compute capability 7.0 support
-compat = "false"

--- a/lib/OrdinaryDiffEqLinear/test/gpu/Project.toml
+++ b/lib/OrdinaryDiffEqLinear/test/gpu/Project.toml
@@ -1,7 +1,5 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-CUDA_Driver_jll = "4ee394cb-3365-5eb0-8335-949819d2adfc"
-CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/lib/OrdinaryDiffEqLowStorageRK/test/gpu/LocalPreferences.toml
+++ b/lib/OrdinaryDiffEqLowStorageRK/test/gpu/LocalPreferences.toml
@@ -1,7 +1,0 @@
-[CUDA_Runtime_jll]
-version = "12.6"
-
-[CUDA_Driver_jll]
-# Disable forward-compat driver — V100 runners need the system driver
-# since CUDA_Driver_jll v13+ drops compute capability 7.0 support
-compat = "false"

--- a/lib/OrdinaryDiffEqLowStorageRK/test/gpu/Project.toml
+++ b/lib/OrdinaryDiffEqLowStorageRK/test/gpu/Project.toml
@@ -1,7 +1,5 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-CUDA_Driver_jll = "4ee394cb-3365-5eb0-8335-949819d2adfc"
-CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/lib/OrdinaryDiffEqRKIP/test/gpu/LocalPreferences.toml
+++ b/lib/OrdinaryDiffEqRKIP/test/gpu/LocalPreferences.toml
@@ -1,7 +1,0 @@
-[CUDA_Runtime_jll]
-version = "12.6"
-
-[CUDA_Driver_jll]
-# Disable forward-compat driver — V100 runners need the system driver
-# since CUDA_Driver_jll v13+ drops compute capability 7.0 support
-compat = "false"

--- a/lib/OrdinaryDiffEqRKIP/test/gpu/Project.toml
+++ b/lib/OrdinaryDiffEqRKIP/test/gpu/Project.toml
@@ -1,7 +1,5 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-CUDA_Driver_jll = "4ee394cb-3365-5eb0-8335-949819d2adfc"
-CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrdinaryDiffEqRKIP = "a4daff8c-1d43-4ff3-8eff-f78720aeecdc"

--- a/lib/OrdinaryDiffEqRosenbrock/test/gpu/LocalPreferences.toml
+++ b/lib/OrdinaryDiffEqRosenbrock/test/gpu/LocalPreferences.toml
@@ -1,7 +1,0 @@
-[CUDA_Runtime_jll]
-version = "12.6"
-
-[CUDA_Driver_jll]
-# Disable forward-compat driver — V100 runners need the system driver
-# since CUDA_Driver_jll v13+ drops compute capability 7.0 support
-compat = "false"

--- a/lib/OrdinaryDiffEqRosenbrock/test/gpu/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrock/test/gpu/Project.toml
@@ -1,8 +1,6 @@
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-CUDA_Driver_jll = "4ee394cb-3365-5eb0-8335-949819d2adfc"
-CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrdinaryDiffEqNonlinearSolve = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"

--- a/lib/OrdinaryDiffEqStabilizedRK/test/gpu/LocalPreferences.toml
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/gpu/LocalPreferences.toml
@@ -1,7 +1,0 @@
-[CUDA_Runtime_jll]
-version = "12.6"
-
-[CUDA_Driver_jll]
-# Disable forward-compat driver — V100 runners need the system driver
-# since CUDA_Driver_jll v13+ drops compute capability 7.0 support
-compat = "false"

--- a/lib/OrdinaryDiffEqStabilizedRK/test/gpu/Project.toml
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/gpu/Project.toml
@@ -1,7 +1,5 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-CUDA_Driver_jll = "4ee394cb-3365-5eb0-8335-949819d2adfc"
-CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"

--- a/lib/StochasticDiffEq/test/gpu/LocalPreferences.toml
+++ b/lib/StochasticDiffEq/test/gpu/LocalPreferences.toml
@@ -1,7 +1,0 @@
-[CUDA_Runtime_jll]
-version = "12.6"
-
-[CUDA_Driver_jll]
-# Disable forward-compat driver — V100 runners need the system driver
-# since CUDA_Driver_jll v13+ drops compute capability 7.0 support
-compat = "false"

--- a/lib/StochasticDiffEq/test/gpu/Project.toml
+++ b/lib/StochasticDiffEq/test/gpu/Project.toml
@@ -1,7 +1,5 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-CUDA_Driver_jll = "4ee394cb-3365-5eb0-8335-949819d2adfc"
-CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
 DiffEqGPU = "071ae1c0-96b5-11e9-1965-c90190d839ea"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/gpu/LocalPreferences.toml
+++ b/test/gpu/LocalPreferences.toml
@@ -1,7 +1,0 @@
-[CUDA_Runtime_jll]
-version = "12.6"
-
-[CUDA_Driver_jll]
-# Disable forward-compat driver — V100 runners need the system driver
-# since CUDA_Driver_jll v13+ drops compute capability 7.0 support
-compat = "false"

--- a/test/gpu/Project.toml
+++ b/test/gpu/Project.toml
@@ -1,8 +1,6 @@
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-CUDA_Driver_jll = "4ee394cb-3365-5eb0-8335-949819d2adfc"
-CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"


### PR DESCRIPTION
## Summary
- Remove all `LocalPreferences.toml` files that pinned CUDA runtime to 12.6 for V100 compatibility
- Remove `CUDA_Driver_jll` and `CUDA_Runtime_jll` dependency additions from test/gpu/Project.toml files across sub-libraries

demeter4's driver has been downgraded to CUDA 12.9 (from 13.x), so these workarounds are no longer needed. The CUDA 12.x driver will automatically select a compatible toolkit for the V100s.

Reverts the workaround parts of #3162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)