### PR TITLE
Fix FIRK methods with KLUFactorization and sparse Jacobians

### DIFF
--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -20,9 +20,11 @@ OrdinaryDiffEqNonlinearSolve = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [extras]
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+KLU = "ef3ab10e-7fda-4108-b977-705223b18434"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -51,6 +53,7 @@ Aqua = "0.8.11"
 GenericSchur = "0.5"
 julia = "1.10"
 JET = "0.9, 0.11"
+KLU = "0.6"
 ADTypes = "1.16"
 RecursiveArrayTools = "3.36"
 FastPower = "1.1"
@@ -61,9 +64,10 @@ DiffEqBase = "6.194"
 Reexport = "1.2"
 SafeTestsets = "0.1.0"
 SciMLOperators = "1.4"
+SparseArrays = "1.10"
 
 [targets]
-test = ["DiffEqDevTools", "GenericSchur", "Random", "SafeTestsets", "Test", "ODEProblemLibrary", "Pkg"]
+test = ["DiffEqDevTools", "GenericSchur", "KLU", "Random", "SafeTestsets", "Test", "ODEProblemLibrary", "Pkg"]
 
 [sources.OrdinaryDiffEqDifferentiation]
 path = "../OrdinaryDiffEqDifferentiation"

--- a/lib/OrdinaryDiffEqFIRK/src/OrdinaryDiffEqFIRK.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/OrdinaryDiffEqFIRK.jl
@@ -23,6 +23,7 @@ using MuladdMacro, DiffEqBase, RecursiveArrayTools, Polyester
 isfirk, generic_solver_docstring
 using SciMLOperators: AbstractSciMLOperator
 using LinearAlgebra: I, UniformScaling, mul!, lu
+using SparseArrays: AbstractSparseMatrix, nonzeros
 import LinearSolve
 import FastBroadcast: @..
 import OrdinaryDiffEqCore

--- a/lib/OrdinaryDiffEqFIRK/src/firk_caches.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_caches.jl
@@ -1,4 +1,48 @@
 abstract type FIRKMutableCache <: OrdinaryDiffEqMutableCache end
+
+"""
+    _make_sparse_compatible_W(J, ::Type{CT})
+
+Create a complex-valued W matrix from Jacobian J with element type CT.
+For sparse matrices, fills structural nonzeros with ones to ensure
+factorization-based linear solvers can initialize properly.
+The values are overwritten in perform_step! before any actual solve.
+"""
+function _make_sparse_compatible_W(J, ::Type{CT}) where {CT}
+    W = similar(J, CT)
+    if W isa AbstractSparseMatrix
+        nonzeros(W) .= one(CT)
+    else
+        recursivefill!(W, false)
+    end
+    return W
+end
+
+"""
+    _complex_linsolve(linsolve, W_complex, b, u0, verbose)
+
+Initialize a linear solver for a complex W matrix. If the solver does not
+support complex sparse matrices (e.g., KLU), falls back to the default
+linear solver which uses UMFPACK for sparse matrices.
+"""
+function _complex_linsolve(linsolve, W_complex, b, u0, verbose)
+    linprob = LinearProblem(W_complex, b; u0 = u0)
+    lincache = init(
+        linprob, linsolve,
+        alias = LinearAliasSpecifier(alias_A = true, alias_b = true),
+        assumptions = LinearSolve.OperatorAssumptions(true),
+        verbose = verbose.linear_verbosity
+    )
+    if lincache.cacheval === nothing && W_complex isa AbstractSparseMatrix
+        lincache = init(
+            linprob, nothing,
+            alias = LinearAliasSpecifier(alias_A = true, alias_b = true),
+            assumptions = LinearSolve.OperatorAssumptions(true),
+            verbose = verbose.linear_verbosity
+        )
+    end
+    return lincache
+end
 get_fsalfirstlast(cache::FIRKMutableCache, u) = (cache.fsalfirst, cache.k)
 
 mutable struct RadauIIA3ConstantCache{F, Tab, Tol, Dt, U, JType} <:
@@ -107,16 +151,9 @@ function alg_cache(
     jac_config = build_jac_config(alg, f, uf, du1, uprev, u, tmp, dw12)
 
     J, W1 = build_J_W(alg, u, uprev, p, t, dt, f, jac_config, uEltypeNoUnits, Val(true))
-    W1 = similar(J, Complex{eltype(W1)})
-    recursivefill!(W1, false)
+    W1 = _make_sparse_compatible_W(J, Complex{eltype(W1)})
 
-    linprob = LinearProblem(W1, _vec(cubuff); u0 = _vec(dw12))
-    linsolve = init(
-        linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true),
-        assumptions = LinearSolve.OperatorAssumptions(true), verbose = verbose.linear_verbosity
-    )
-    #Pl = LinearSolve.InvPreconditioner(Diagonal(_vec(weight))),
-    #Pr = Diagonal(_vec(weight)))
+    linsolve = _complex_linsolve(alg.linsolve, W1, _vec(cubuff), _vec(dw12), verbose)
 
     rtol = reltol isa Number ? reltol : zero(reltol)
     atol = reltol isa Number ? reltol : zero(reltol)
@@ -260,8 +297,7 @@ function alg_cache(
     if J isa AbstractSciMLOperator
         error("Non-concrete Jacobian not yet supported by RadauIIA5.")
     end
-    W2 = similar(J, Complex{eltype(W1)})
-    recursivefill!(W2, false)
+    W2 = _make_sparse_compatible_W(J, Complex{eltype(W1)})
 
     linprob = LinearProblem(W1, _vec(ubuff); u0 = _vec(dw1))
     linsolve1 = init(
@@ -270,13 +306,7 @@ function alg_cache(
     )
     #Pl = LinearSolve.InvPreconditioner(Diagonal(_vec(weight))),
     #Pr = Diagonal(_vec(weight)))
-    linprob = LinearProblem(W2, _vec(cubuff); u0 = _vec(dw23))
-    linsolve2 = init(
-        linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true),
-        assumptions = LinearSolve.OperatorAssumptions(true), verbose = verbose.linear_verbosity
-    )
-    #Pl = LinearSolve.InvPreconditioner(Diagonal(_vec(weight))),
-    #Pr = Diagonal(_vec(weight)))
+    linsolve2 = _complex_linsolve(alg.linsolve, W2, _vec(cubuff), _vec(dw23), verbose)
 
     rtol = reltol isa Number ? reltol : zero(reltol)
     atol = reltol isa Number ? reltol : zero(reltol)
@@ -464,10 +494,8 @@ function alg_cache(
     if J isa AbstractSciMLOperator
         error("Non-concrete Jacobian not yet supported by RadauIIA5.")
     end
-    W2 = similar(J, Complex{eltype(W1)})
-    W3 = similar(J, Complex{eltype(W1)})
-    recursivefill!(W2, false)
-    recursivefill!(W3, false)
+    W2 = _make_sparse_compatible_W(J, Complex{eltype(W1)})
+    W3 = _make_sparse_compatible_W(J, Complex{eltype(W1)})
 
     linprob = LinearProblem(W1, _vec(ubuff); u0 = _vec(dw1))
     linsolve1 = init(
@@ -476,20 +504,8 @@ function alg_cache(
     )
     #Pl = LinearSolve.InvPreconditioner(Diagonal(_vec(weight))),
     #Pr = Diagonal(_vec(weight)))
-    linprob = LinearProblem(W2, _vec(cubuff1); u0 = _vec(dw23))
-    linsolve2 = init(
-        linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true),
-        assumptions = LinearSolve.OperatorAssumptions(true), verbose = verbose.linear_verbosity
-    )
-    #Pl = LinearSolve.InvPreconditioner(Diagonal(_vec(weight))),
-    #Pr = Diagonal(_vec(weight)))
-    linprob = LinearProblem(W3, _vec(cubuff2); u0 = _vec(dw45))
-    linsolve3 = init(
-        linprob, alg.linsolve, alias = LinearAliasSpecifier(alias_A = true, alias_b = true),
-        assumptions = LinearSolve.OperatorAssumptions(true), verbose = verbose.linear_verbosity
-    )
-    #Pl = LinearSolve.InvPreconditioner(Diagonal(_vec(weight))),
-    #Pr = Diagonal(_vec(weight)))
+    linsolve2 = _complex_linsolve(alg.linsolve, W2, _vec(cubuff1), _vec(dw23), verbose)
+    linsolve3 = _complex_linsolve(alg.linsolve, W3, _vec(cubuff2), _vec(dw45), verbose)
 
     rtol = reltol isa Number ? reltol : zero(reltol)
     atol = reltol isa Number ? reltol : zero(reltol)
@@ -688,8 +704,7 @@ function alg_cache(
         error("Non-concrete Jacobian not yet supported by AdaptiveRadau.")
     end
 
-    W2 = [similar(J, Complex{eltype(W1)}) for _ in 1:((max_stages - 1) ÷ 2)]
-    recursivefill!.(W2, false)
+    W2 = [_make_sparse_compatible_W(J, Complex{eltype(W1)}) for _ in 1:((max_stages - 1) ÷ 2)]
 
     linprob = LinearProblem(W1, _vec(ubuff); u0 = _vec(dw1))
     linsolve1 = init(
@@ -698,13 +713,7 @@ function alg_cache(
     )
 
     linsolve2 = [
-        init(
-                LinearProblem(W2[i], _vec(cubuff[i]); u0 = _vec(dw2[i])),
-                alg.linsolve, alias = LinearAliasSpecifier(
-                    alias_A = true, alias_b = true
-                ),
-                assumptions = LinearSolve.OperatorAssumptions(true), verbose = verbose.linear_verbosity
-            )
+        _complex_linsolve(alg.linsolve, W2[i], _vec(cubuff[i]), _vec(dw2[i]), verbose)
             for i in 1:((max_stages - 1) ÷ 2)
     ]
 

--- a/lib/OrdinaryDiffEqFIRK/test/ode_firk_tests.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/ode_firk_tests.jl
@@ -117,3 +117,27 @@ for iip in (true, false)
     @test length(sol) < 5000 # the error estimate is not very good
     @test SciMLBase.successful_retcode(sol)
 end
+
+# Test sparse Jacobian with KLUFactorization (issue #2892)
+# KLU does not support complex sparse matrices, so FIRK methods must
+# fall back to a compatible solver for the complex linear systems.
+using SparseArrays, LinearSolve, KLU
+let
+    function f_sparse(du, u, p, t)
+        return du .= u
+    end
+    u0 = [1.0, 2.0]
+    jac_prototype = sparse([1, 2], [1, 2], ones(2))
+    ode_fun = ODEFunction(f_sparse, jac_prototype = jac_prototype)
+    prob = ODEProblem(ode_fun, u0, (0.0, 1.0))
+
+    for alg in (
+            RadauIIA3(linsolve = KLUFactorization()),
+            RadauIIA5(linsolve = KLUFactorization()),
+            RadauIIA9(linsolve = KLUFactorization()),
+            AdaptiveRadau(linsolve = KLUFactorization()),
+        )
+        sol = solve(prob, alg)
+        @test SciMLBase.successful_retcode(sol)
+    end
+end


### PR DESCRIPTION
## Summary

Fixes #2892 - FIRK methods (RadauIIA3, RadauIIA5, RadauIIA9, AdaptiveRadau) error with `KLUFactorization()` when using sparse `jac_prototype`.

**Root cause:** KLU does not support complex sparse matrices. FIRK methods require complex linear systems (W2) for the complex eigenvalue pairs of the Butcher tableau. When `LinearSolve.init` is called with a complex sparse matrix and `KLUFactorization`, the factorization silently fails, setting `cacheval = nothing`. Subsequent `solve!` calls then crash with `type Nothing has no field nzval/colptr`.

**Fix:**
- Added `_complex_linsolve` helper that detects when a solver fails to initialize for complex sparse matrices (`cacheval === nothing`) and automatically falls back to the default solver (UMFPACK), which supports complex sparse matrices
- Added `_make_sparse_compatible_W` to properly initialize complex sparse W matrices with nonzero structural values
- Applied the fix to all 4 FIRK cache initializations: RadauIIA3, RadauIIA5, RadauIIA9, AdaptiveRadau
- Added SparseArrays as a dependency (stdlib, zero cost)

## Test plan

- [x] Reproduced the original bug (AdaptiveRadau + KLUFactorization + sparse jac_prototype)
- [x] Verified fix works for all 4 Radau variants with KLUFactorization
- [x] All 92 existing FIRK tests pass
- [x] JET and Aqua QA tests pass
- [x] Added 4 new tests for sparse KLU with each FIRK solver (96 total tests pass)
- [x] Formatted with Runic.jl

🤖 Generated with [Claude Code](https://claude.com/claude-code)