### PR TITLE
Make calculate_residuals! consistently return nothing

### DIFF
--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.212.0"
+version = "6.212.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/DiffEqBase/src/calculate_residuals.jl
+++ b/lib/DiffEqBase/src/calculate_residuals.jl
@@ -142,7 +142,8 @@ with multiple threads.
         out, u₀, u₁, α, ρ, internalnorm, t,
         thread::Union{False, True} = False()
     )
-    return @.. broadcast = false thread = thread out = calculate_residuals(u₀, u₁, α, ρ, internalnorm, t)
+    @.. broadcast = false thread = thread out = calculate_residuals(u₀, u₁, α, ρ, internalnorm, t)
+    return nothing
 end
 
 """
@@ -166,5 +167,5 @@ with multiple threads.
         E₁, E₂, u₀, u₁, α, ρ, δ,
         scalarnorm, t
     )
-    return out
+    return nothing
 end


### PR DESCRIPTION
## Summary
- Fix return value inconsistency in `calculate_residuals!` methods in DiffEqBase
- Two methods returned `nothing`, one returned the broadcast result, and one returned `out` — now all consistently return `nothing`
- Bump DiffEqBase version to 6.212.1

No callers capture the return value of `calculate_residuals!` anywhere in the monorepo, so this is a safe change.

## Test plan
- [ ] SublibraryCI passes for DiffEqBase and all downstream dependencies
- [ ] CI passes for main test groups
- [ ] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)