### PR TITLE
Remove Bool verbose compatibility path for v7

### DIFF
--- a/lib/DelayDiffEq/src/solve.jl
+++ b/lib/DelayDiffEq/src/solve.jl
@@ -107,13 +107,9 @@ function SciMLBase.__init(
         order_discontinuity_t0 = prob.order_discontinuity_t0
     end
 
-    # Handle verbose argument: convert Bool or AbstractVerbosityPreset to DEVerbosity
+    # Handle verbose argument: convert AbstractVerbosityPreset to DEVerbosity
     if verbose isa Bool
-        if verbose
-            verbose_spec = DEVerbosity()
-        else
-            verbose_spec = DEVerbosity(None())
-        end
+        throw(ArgumentError("Passing a `Bool` for `verbose` is no longer supported in OrdinaryDiffEq v7. Use `DEVerbosity()` or a preset like `Standard()`, `None()`, etc. from SciMLLogging."))
     elseif verbose isa AbstractVerbosityPreset
         verbose_spec = DEVerbosity(verbose)
     else

--- a/lib/DelayDiffEq/test/integrators/retcode.jl
+++ b/lib/DelayDiffEq/test/integrators/retcode.jl
@@ -1,6 +1,8 @@
 using DelayDiffEq, DDEProblemLibrary
 using OrdinaryDiffEqTsit5
 using OrdinaryDiffEqRosenbrock
+using OrdinaryDiffEqCore: DEVerbosity
+using SciMLLogging: None
 using Test
 using SciMLBase: ReturnCode
 
@@ -15,9 +17,9 @@ const prob = prob_dde_constant_1delay_ip
     sol1 = solve(prob, alg)
     @test sol1.retcode == ReturnCode.Success
 
-    sol2 = solve(prob, alg; maxiters = 1, verbose = false)
+    sol2 = solve(prob, alg; maxiters = 1, verbose = DEVerbosity(None()))
     @test sol2.retcode == ReturnCode.MaxIters
 
-    sol3 = solve(prob, alg; dtmin = 5, verbose = false)
+    sol3 = solve(prob, alg; dtmin = 5, verbose = DEVerbosity(None()))
     @test sol3.retcode == ReturnCode.DtLessThanMin
 end

--- a/lib/DelayDiffEq/test/interface/verbosity.jl
+++ b/lib/DelayDiffEq/test/interface/verbosity.jl
@@ -21,16 +21,13 @@ prob = DDEProblem(f_dde, u0, h, tspan; constant_lags = [1.0])
         @test sol.retcode == ReturnCode.Success
     end
 
-    # Test verbose=true (backwards compatible)
-    @testset "verbose=true" begin
-        sol = solve(prob; verbose = true, saveat = 0.1)
-        @test sol.retcode == ReturnCode.Success
+    # Test that Bool verbose is no longer supported (v7 breaking change)
+    @testset "verbose=true throws" begin
+        @test_throws ArgumentError solve(prob; verbose = true, saveat = 0.1)
     end
 
-    # Test verbose=false (backwards compatible)
-    @testset "verbose=false" begin
-        sol = solve(prob; verbose = false, saveat = 0.1)
-        @test sol.retcode == ReturnCode.Success
+    @testset "verbose=false throws" begin
+        @test_throws ArgumentError solve(prob; verbose = false, saveat = 0.1)
     end
 
     # Test with DEVerbosity

--- a/lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl
@@ -1,4 +1,6 @@
 using OrdinaryDiffEqBDF, OrdinaryDiffEqCore, ForwardDiff, Test
+using OrdinaryDiffEqCore: DEVerbosity
+import OrdinaryDiffEqCore.SciMLLogging as SciMLLogging
 
 foop = (u, p, t) -> u * p
 proboop = ODEProblem(foop, ones(2), (0.0, 1000.0), 1.0)
@@ -8,7 +10,7 @@ probiip = ODEProblem(fiip, ones(2), (0.0, 1000.0), 1.0)
 
 @testset "FBDF reinit" begin
     for prob in [proboop, probiip]
-        integ = init(prob, FBDF(), verbose = false) #suppress warning to clean up CI
+        integ = init(prob, FBDF(), verbose = DEVerbosity(SciMLLogging.None())) #suppress warning to clean up CI
         solve!(integ)
         @test integ.sol.retcode != ReturnCode.Success
         @test integ.sol.t[end] >= 700
@@ -41,7 +43,7 @@ end
     # so it reaches fewer time steps on exponential growth problems.
     for MO in 1:5
         for prob in [proboop, probiip]
-            sol = solve(prob, FBDF(max_order = Val{MO}()), verbose = false)
+            sol = solve(prob, FBDF(max_order = Val{MO}()), verbose = DEVerbosity(SciMLLogging.None()))
             @test sol.t[end] >= (MO == 1 ? 250 : 700)
         end
     end

--- a/lib/OrdinaryDiffEqCore/src/verbosity.jl
+++ b/lib/OrdinaryDiffEqCore/src/verbosity.jl
@@ -335,7 +335,7 @@ const DEFAULT_VERBOSE = DEVerbosity()
 end
 
 @inline function _process_verbose_param(verbose::Bool)
-    return verbose ? DEFAULT_VERBOSE : DEVerbosity(SciMLLogging.None())
+    throw(ArgumentError("Passing a `Bool` for `verbose` is no longer supported in OrdinaryDiffEq v7. Use `DEVerbosity()` or a preset like `Standard()`, `None()`, etc. from SciMLLogging."))
 end
 
 @inline _process_verbose_param(verbose::DEVerbosity) = verbose

--- a/lib/StochasticDiffEqCore/src/solve.jl
+++ b/lib/StochasticDiffEqCore/src/solve.jl
@@ -139,7 +139,7 @@ function _sde_init(
         internalnorm = ODE_DEFAULT_NORM,
         isoutofdomain = ODE_DEFAULT_ISOUTOFDOMAIN,
         unstable_check = ODE_DEFAULT_UNSTABLE_CHECK,
-        verbose = true, force_dtmin = false,
+        verbose = Standard(), force_dtmin = false,
         timeseries_errors = true, dense_errors = false,
         advance_to_tstop = false, stop_at_next_tstop = false,
         initialize_save = true,
@@ -509,13 +509,13 @@ function _sde_init(
     dW, dZ = isnothing(W) ? (nothing, nothing) : (W.dW, W.dZ)
 
     verbose_internal = if verbose isa Bool
-        verbose ? DEVerbosity(Standard()) : DEVerbosity(None())
+        throw(ArgumentError("Passing a `Bool` for `verbose` is no longer supported in OrdinaryDiffEq v7. Use `DEVerbosity()` or a preset like `Standard()`, `None()`, etc. from SciMLLogging."))
     elseif verbose isa AbstractVerbosityPreset
         DEVerbosity(verbose)
     elseif verbose isa DEVerbosity
         verbose
     else
-        throw(ArgumentError("verbose must be a Bool, AbstractVerbosityPreset, or DEVerbosity"))
+        throw(ArgumentError("verbose must be an AbstractVerbosityPreset or DEVerbosity"))
     end
 
     cache = alg_cache(

--- a/test/interface/verbosity.jl
+++ b/test/interface/verbosity.jl
@@ -189,6 +189,11 @@ using NonlinearSolve: NonlinearVerbosity
         # Test that invalid individual fields throw errors
         @test_throws ArgumentError DEVerbosity(dt_NaN = "invalid")
         @test_throws ArgumentError DEVerbosity(unknown_field = SciMLLogging.InfoLevel())
+
+        # Test that Bool verbose is no longer supported (v7 breaking change)
+        prob_simple = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 1.0))
+        @test_throws ArgumentError solve(prob_simple, Tsit5(); verbose = true)
+        @test_throws ArgumentError solve(prob_simple, Tsit5(); verbose = false)
     end
 
     @testset "Multiple group settings" begin


### PR DESCRIPTION
## Summary
- Remove the `Bool` compatibility path for the `verbose` keyword argument, making it a v7 breaking change
- `verbose=true` and `verbose=false` now throw `ArgumentError` with a message directing users to use `DEVerbosity()` or SciMLLogging presets (`Standard()`, `None()`, etc.)
- Update default `verbose` in `StochasticDiffEqCore` from `true` to `Standard()`

## Changes
- **`lib/OrdinaryDiffEqCore/src/verbosity.jl`**: `_process_verbose_param(::Bool)` now throws `ArgumentError` instead of silently converting
- **`lib/StochasticDiffEqCore/src/solve.jl`**: Default `verbose` changed from `true` to `Standard()`; Bool branch throws `ArgumentError`
- **`lib/DelayDiffEq/src/solve.jl`**: Bool branch throws `ArgumentError`
- **Tests updated**: All `verbose = false` in solve/init calls replaced with `DEVerbosity(None())`; new tests verify Bool is rejected

Closes #2310

## Test plan
- [x] `test/interface/verbosity.jl` passes (140/140 tests)
- [ ] CI for OrdinaryDiffEqBDF regression tests
- [ ] CI for DelayDiffEq retcode and verbosity tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)