### PR TITLE
Make CheckInit the default for ODEs and DAEs

### DIFF
--- a/lib/OrdinaryDiffEqBDF/test/dae_event.jl
+++ b/lib/OrdinaryDiffEqBDF/test/dae_event.jl
@@ -1,4 +1,5 @@
 using OrdinaryDiffEqBDF, Test
+using OrdinaryDiffEqNonlinearSolve: BrownFullBasicInit
 
 f = function (out, du, u, p, t)
     out[1] = -p[1] * u[1] + p[3] * u[2] * u[3] - du[1]
@@ -23,7 +24,10 @@ sol = solve(prob, IDA(), callback=cb, tstops=[50.0],abstol=1e-14,reltol=1e-14)
 
 p = [0.04, 3.0e7, 1.0e4, 1.0]
 prob = DAEProblem(f, du₀, u₀, tspan, p, differential_vars = differential_vars)
-sol = solve(prob, DFBDF(), callback = cb, tstops = [50.0], abstol = 1.0e-12, reltol = 1.0e-12)
+sol = solve(
+    prob, DFBDF(), callback = cb, tstops = [50.0], abstol = 1.0e-12, reltol = 1.0e-12,
+    initializealg = BrownFullBasicInit()
+)
 @test sol.t[end] == 100.0
 @test sol.u[end][1] ≈ 0.686300529575259 atol = 1.0e-7
 @test sol.u[end][2] ≈ 2.0797982209353813e-6 atol = 1.0e-7

--- a/lib/OrdinaryDiffEqBDF/test/dae_initialization_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/dae_initialization_tests.jl
@@ -13,19 +13,19 @@ du₀ = [0.0, 0.0, 0.0]
 tspan = (0.0, 100000.0)
 differential_vars = [true, true, false]
 prob = DAEProblem(f, du₀, u₀, tspan, differential_vars = differential_vars)
-integrator = init(prob, DABDF2())
+integrator = init(prob, DABDF2(), initializealg = BrownFullBasicInit())
 
 @test integrator.du[1] ≈ -0.04 atol = 1.0e-9
 @test integrator.du[2] ≈ 0.04 atol = 1.0e-9
 @test integrator.u ≈ u₀ atol = 1.0e-9
 
-integrator = init(prob, DImplicitEuler())
+integrator = init(prob, DImplicitEuler(), initializealg = BrownFullBasicInit())
 
 @test integrator.du[1] ≈ -0.04 atol = 1.0e-9
 @test integrator.du[2] ≈ 0.04 atol = 1.0e-9
 @test integrator.u ≈ u₀ atol = 1.0e-9
 
-integrator = init(prob, DFBDF())
+integrator = init(prob, DFBDF(), initializealg = BrownFullBasicInit())
 
 @test integrator.du[1] ≈ -0.04 atol = 1.0e-9
 @test integrator.du[2] ≈ 0.04 atol = 1.0e-9
@@ -33,7 +33,7 @@ integrator = init(prob, DFBDF())
 
 u₀ = [1.0, 0, 0.2]
 prob = DAEProblem(f, du₀, u₀, tspan, differential_vars = differential_vars)
-integrator = init(prob, DABDF2())
+integrator = init(prob, DABDF2(), initializealg = BrownFullBasicInit())
 @test integrator.u ≈ [1.0, 0, 0.0] atol = 1.0e-9
 integrator = init(
     prob, DABDF2(), initializealg = OrdinaryDiffEqNonlinearSolve.ShampineCollocationInit()
@@ -42,7 +42,7 @@ integrator = init(
 
 u₀ = [1.0, 0, 0.2]
 prob = DAEProblem(f, du₀, u₀, tspan)
-integrator = init(prob, DABDF2())
+integrator = init(prob, DABDF2(), initializealg = ShampineCollocationInit())
 @test !(integrator.u ≈ [1.0, 0, 0.0])
 
 f = function (out, du, u, p, t)
@@ -56,8 +56,8 @@ du₀ = [0.0, 0.0, 0.0]
 tspan = (0.0, 100000.0)
 differential_vars = [true, true, false]
 prob = DAEProblem(f, du₀, u₀, tspan, differential_vars = differential_vars)
-integrator = init(prob, DABDF2())
-integrator2 = init(prob, DABDF2(autodiff = AutoFiniteDiff()))
+integrator = init(prob, DABDF2(), initializealg = BrownFullBasicInit())
+integrator2 = init(prob, DABDF2(autodiff = AutoFiniteDiff()), initializealg = BrownFullBasicInit())
 
 @test integrator.du[1] ≈ -0.04 atol = 1.0e-9
 @test integrator.du[2] ≈ 0.04 atol = 1.0e-9
@@ -67,13 +67,13 @@ integrator2 = init(prob, DABDF2(autodiff = AutoFiniteDiff()))
 @test integrator2.du[2] ≈ 0.04 atol = 1.0e-9
 @test integrator2.u ≈ u₀ atol = 1.0e-9
 
-integrator = init(prob, DImplicitEuler())
+integrator = init(prob, DImplicitEuler(), initializealg = BrownFullBasicInit())
 
 @test integrator.du[1] ≈ -0.04 atol = 1.0e-9
 @test integrator.du[2] ≈ 0.04 atol = 1.0e-9
 @test integrator.u ≈ u₀ atol = 1.0e-9
 
-integrator = init(prob, DFBDF())
+integrator = init(prob, DFBDF(), initializealg = BrownFullBasicInit())
 
 @test integrator.du[1] ≈ -0.04 atol = 1.0e-9
 @test integrator.du[2] ≈ 0.04 atol = 1.0e-9
@@ -81,7 +81,7 @@ integrator = init(prob, DFBDF())
 
 u₀ = [1.0, 0, 0.2]
 prob = DAEProblem(f, du₀, u₀, tspan, differential_vars = differential_vars)
-integrator = init(prob, DABDF2())
+integrator = init(prob, DABDF2(), initializealg = BrownFullBasicInit())
 @test integrator.u ≈ [1.0, 0, 0.0] atol = 1.0e-9
 integrator = init(
     prob, DABDF2(), initializealg = OrdinaryDiffEqNonlinearSolve.ShampineCollocationInit()
@@ -90,7 +90,7 @@ integrator = init(
 
 u₀ = [1.0, 0, 0.2]
 prob = DAEProblem(f, du₀, u₀, tspan)
-integrator = init(prob, DABDF2())
+integrator = init(prob, DABDF2(), initializealg = ShampineCollocationInit())
 @test !(integrator.u ≈ [1.0, 0, 0.0])
 
 # Need to be able to find the consistent solution of this problem, broken right now
@@ -140,7 +140,7 @@ du₀ = SVector(0.0)
 tspan = (0.0, 1.0)
 differential_vars = SVector(true)
 prob = DAEProblem(f, du₀, u₀, tspan, differential_vars = differential_vars)
-integrator = init(prob, DABDF2())
+integrator = init(prob, DABDF2(), initializealg = BrownFullBasicInit())
 
 @test integrator.du ≈ [1.0] atol = 1.0e-9
 
@@ -153,7 +153,7 @@ du₀ = SA[0.0, 0.0]
 tspan = (0.0, 1.0)
 differential_vars = [true, true]
 prob = DAEProblem(f, du₀, u₀, tspan, differential_vars = differential_vars)
-integrator = init(prob, DABDF2())
+integrator = init(prob, DABDF2(), initializealg = BrownFullBasicInit())
 
 @test integrator.du[1] ≈ 1.0 atol = 1.0e-9
 @test integrator.du[2] ≈ 1.0 atol = 1.0e-9

--- a/lib/OrdinaryDiffEqBDF/test/dae_u_modified_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/dae_u_modified_tests.jl
@@ -1,4 +1,5 @@
 using OrdinaryDiffEqBDF, DiffEqBase, Test
+using OrdinaryDiffEqNonlinearSolve: BrownFullBasicInit
 import OrdinaryDiffEqCore: _initialize_dae!
 
 # Test that u_modified! triggers DAE initialization
@@ -33,9 +34,9 @@ int.u[1] = 2.0 # Breaks algebraic constraint u[1] + u[2] + u[3] = 1
 u_modified!(int, true)
 @test_throws SciMLBase.CheckInitFailureError step!(int)
 
-# With default init, modifying u and calling u_modified! should
+# With BrownFullBasicInit, modifying u and calling u_modified! should
 # reinitialize the algebraic variables to satisfy constraints
-int2 = init(prob, DFBDF())
+int2 = init(prob, DFBDF(), initializealg = BrownFullBasicInit())
 int2.u[1] = 2.0 # Breaks algebraic constraint
 u_modified!(int2, true)
 step!(int2)

--- a/lib/OrdinaryDiffEqCore/src/initialize_dae.jl
+++ b/lib/OrdinaryDiffEqCore/src/initialize_dae.jl
@@ -24,7 +24,8 @@ function DiffEqBase.initialize_dae!(
     )
 end
 
-## Default algorithms
+## Default algorithm is CheckInit
+## Changed in v7--previously was BrownFullBasicInit or ShampineCollocationInit
 
 function _initialize_dae!(
         integrator::ODEIntegrator, prob::Union{ODEProblem, DAEProblem},
@@ -36,14 +37,11 @@ function _initialize_dae!(
             OverrideInit(integrator.opts.abstol), x
         )
     else
-        _default_dae_init!(integrator, prob, x, integrator.alg)
+        _initialize_dae!(
+            integrator, prob,
+            CheckInit(), x
+        )
     end
-end
-
-# Fallback: algorithm does not support DAE initialization.
-# OrdinaryDiffEqNonlinearSolve extends this for DAE-capable algorithm types.
-function _default_dae_init!(integrator, prob, x, alg)
-    error("`OrdinaryDiffEqNonlinearSolve` is not loaded, which is required for the default initialization algorithm (`BrownFullBasicInit` or `ShampineCollocationInit`). To solve this problem, either do `using OrdinaryDiffEqNonlinearSolve` or pass `initializealg = CheckInit()` to the `solve` function. This second option requires consistent `u0`.")
 end
 
 function _initialize_dae!(

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
@@ -52,7 +52,7 @@ using OrdinaryDiffEqCore: resize_nlsolver!, _initialize_dae!,
     MethodType, alg_order, error_constant,
     alg_extrapolates, resize_J_W!, has_autodiff
 
-import OrdinaryDiffEqCore: _initialize_dae!, _default_dae_init!,
+import OrdinaryDiffEqCore: _initialize_dae!,
     isnewton, get_W, isfirstcall, isfirststage,
     isJcurrent, get_new_W_γdt_cutoff, resize_nlsolver!, apply_step!,
     postamble!, @SciMLMessage

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/initialize_dae.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/initialize_dae.jl
@@ -114,42 +114,6 @@ function default_nlsolve(
     )
 end
 
-## DefaultInit resolution for DAE-capable algorithms
-
-const DAECapableAlgorithm = Union{
-    OrdinaryDiffEqAdaptiveImplicitAlgorithm,
-    OrdinaryDiffEqImplicitAlgorithm,
-    DAEAlgorithm,
-    OrdinaryDiffEqCompositeAlgorithm,
-}
-
-function _default_dae_init!(
-        integrator, prob::ODEProblem, x,
-        alg::DAECapableAlgorithm
-    )
-    return _initialize_dae!(
-        integrator, prob,
-        BrownFullBasicInit(integrator.opts.abstol), x
-    )
-end
-
-function _default_dae_init!(
-        integrator, prob::DAEProblem, x,
-        alg::DAECapableAlgorithm
-    )
-    return if prob.differential_vars === nothing
-        _initialize_dae!(
-            integrator, prob,
-            ShampineCollocationInit(), x
-        )
-    else
-        _initialize_dae!(
-            integrator, prob,
-            BrownFullBasicInit(integrator.opts.abstol), x
-        )
-    end
-end
-
 ## ShampineCollocationInit
 
 #=

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/dae_initialization_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/dae_initialization_tests.jl
@@ -30,7 +30,10 @@ integrator = @inferred init(prob_mm, Rodas5(autodiff = AutoForwardDiff(chunksize
 @inferred SciMLBase.initialize_dae!(integrator)
 
 prob_mm = ODEProblem(f_oop, [1.0, 0.0, 0.2], (0.0, 1.0e5), (0.04, 3.0e7, 1.0e4))
-sol = solve(prob_mm, Rosenbrock23(), reltol = 1.0e-8, abstol = 1.0e-8)
+sol = solve(
+    prob_mm, Rosenbrock23(), reltol = 1.0e-8, abstol = 1.0e-8,
+    initializealg = BrownFullBasicInit()
+)
 @test sum(sol.u[1]) ≈ 1
 @test sol.u[1] ≈ [1.0, 0.0, 0.0]
 for alg in [Rosenbrock23(autodiff = AutoFiniteDiff()), Trapezoid()]
@@ -67,7 +70,10 @@ integrator = @inferred init(prob_mm, Rodas5(autodiff = AutoForwardDiff(chunksize
 @inferred SciMLBase.initialize_dae!(integrator)
 
 prob_mm = ODEProblem(f, [1.0, 0.0, 1.0], (0.0, 1.0e5), (0.04, 3.0e7, 1.0e4))
-sol = solve(prob_mm, Rodas5(), reltol = 1.0e-8, abstol = 1.0e-8)
+sol = solve(
+    prob_mm, Rodas5(), reltol = 1.0e-8, abstol = 1.0e-8,
+    initializealg = BrownFullBasicInit()
+)
 @test sum(sol.u[1]) ≈ 1
 @test sol.u[1] ≈ [1.0, 0.0, 0.0]
 

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/sparse_dae_initialization_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/sparse_dae_initialization_tests.jl
@@ -2,7 +2,7 @@ using Test
 using SparseArrays
 using LinearAlgebra
 using OrdinaryDiffEqSDIRK
-using OrdinaryDiffEqNonlinearSolve: find_algebraic_vars_eqs, algebraic_jacobian
+using OrdinaryDiffEqNonlinearSolve: find_algebraic_vars_eqs, algebraic_jacobian, BrownFullBasicInit
 using SciMLBase: ReturnCode
 
 @testset "Sparse jac_prototype in BrownFullBasicInit" begin
@@ -53,7 +53,7 @@ using SciMLBase: ReturnCode
         f_ode = ODEFunction(f_small!; mass_matrix = M, jac_prototype = jac_proto)
         prob = ODEProblem(f_ode, u0, (0.0, 1.0))
 
-        sol = solve(prob, Trapezoid())
+        sol = solve(prob, Trapezoid(), initializealg = BrownFullBasicInit())
         @test sol.retcode == ReturnCode.Success
         # Check constraint is satisfied after initialization
         @test abs(sol.u[1][1] - sol.u[1][2]^3) < 1.0e-6
@@ -90,7 +90,7 @@ using SciMLBase: ReturnCode
         f_ode = ODEFunction(rober!; mass_matrix = M, jac_prototype = jac_proto)
         prob = ODEProblem(f_ode, u0, (0.0, 1.0e5), p)
 
-        sol = solve(prob, Trapezoid())
+        sol = solve(prob, Trapezoid(), initializealg = BrownFullBasicInit())
         @test sol.retcode == ReturnCode.Success
         @test sum(sol.u[1]) ≈ 1
         @test sol.u[1] ≈ [1.0, 0.0, 0.0]
@@ -134,7 +134,7 @@ using SciMLBase: ReturnCode
         f_ode = ODEFunction(f_medium!; mass_matrix = M, jac_prototype = jac_proto)
         prob = ODEProblem(f_ode, u0, (0.0, 1.0))
 
-        sol = solve(prob, Trapezoid(); save_everystep = false)
+        sol = solve(prob, Trapezoid(); save_everystep = false, initializealg = BrownFullBasicInit())
         @test sol.retcode == ReturnCode.Success
         # Algebraic constraint u[i] = u[N+i]^2 should be satisfied at t=0
         max_violation = maximum(abs.(sol.u[1][1:N] .- sol.u[1][(N + 1):(2N)] .^ 2))
@@ -176,8 +176,8 @@ using SciMLBase: ReturnCode
         prob_dense = ODEProblem(f_dense, u0, (0.0, 1.0))
         prob_sparse = ODEProblem(f_sparse, u0, (0.0, 1.0))
 
-        sol_dense = solve(prob_dense, Trapezoid(); save_everystep = false)
-        sol_sparse = solve(prob_sparse, Trapezoid(); save_everystep = false)
+        sol_dense = solve(prob_dense, Trapezoid(); save_everystep = false, initializealg = BrownFullBasicInit())
+        sol_sparse = solve(prob_sparse, Trapezoid(); save_everystep = false, initializealg = BrownFullBasicInit())
 
         @test sol_dense.retcode == ReturnCode.Success
         @test sol_sparse.retcode == ReturnCode.Success
@@ -255,7 +255,7 @@ using SciMLBase: ReturnCode
         @test size(J_sub) == (N, N)
         @test nnz(J_sub) == N  # diagonal only for algebraic block
 
-        sol = solve(prob, Trapezoid(); save_everystep = false)
+        sol = solve(prob, Trapezoid(); save_everystep = false, initializealg = BrownFullBasicInit())
         @test sol.retcode == ReturnCode.Success
         # Verify algebraic constraint P = phi^3 after initialization
         max_violation = maximum(

--- a/lib/OrdinaryDiffEqRosenbrock/test/dae_rosenbrock_ad_tests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/dae_rosenbrock_ad_tests.jl
@@ -27,8 +27,14 @@ roberf_oop = ODEFunction{false, SciMLBase.AutoSpecialize}(rober, mass_matrix = M
 prob_mm = ODEProblem(roberf, [1.0, 0.0, 0.2], (0.0, 1.0e5), (0.04, 3.0e7, 1.0e4))
 prob_mm_oop = ODEProblem(roberf_oop, [1.0, 0.0, 0.2], (0.0, 1.0e5), (0.04, 3.0e7, 1.0e4))
 # Both should be inferable so long as AutoSpecialize is used...
-sol = @inferred solve(prob_mm, Rodas5P(), reltol = 1.0e-8, abstol = 1.0e-8)
-sol = @inferred solve(prob_mm_oop, Rodas5P(), reltol = 1.0e-8, abstol = 1.0e-8)
+sol = @inferred solve(
+    prob_mm, Rodas5P(), reltol = 1.0e-8, abstol = 1.0e-8,
+    initializealg = BrownFullBasicInit()
+)
+sol = @inferred solve(
+    prob_mm_oop, Rodas5P(), reltol = 1.0e-8, abstol = 1.0e-8,
+    initializealg = BrownFullBasicInit()
+)
 
 # These tests flex differentiation of the solver and through the initialization
 # To only test the solver part and isolate potential issues, set the initialization to consistent

--- a/lib/OrdinaryDiffEqSDIRK/test/dae_esdirk_test.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/dae_esdirk_test.jl
@@ -27,8 +27,14 @@ roberf_oop = ODEFunction{false, SciMLBase.AutoSpecialize}(rober, mass_matrix = M
 prob_mm = ODEProblem(roberf, [1.0, 0.0, 0.2], (0.0, 1.0e5), (0.04, 3.0e7, 1.0e4))
 prob_mm_oop = ODEProblem(roberf_oop, [1.0, 0.0, 0.2], (0.0, 1.0e5), (0.04, 3.0e7, 1.0e4))
 # Both should be inferable so long as AutoSpecialize is used...
-sol = @inferred solve(prob_mm, KenCarp47(), reltol = 1.0e-8, abstol = 1.0e-8)
-sol = @inferred solve(prob_mm_oop, KenCarp47(), reltol = 1.0e-8, abstol = 1.0e-8)
+sol = @inferred solve(
+    prob_mm, KenCarp47(), reltol = 1.0e-8, abstol = 1.0e-8,
+    initializealg = BrownFullBasicInit()
+)
+sol = @inferred solve(
+    prob_mm_oop, KenCarp47(), reltol = 1.0e-8, abstol = 1.0e-8,
+    initializealg = BrownFullBasicInit()
+)
 
 # These tests flex differentiation of the solver and through the initialization
 # To only test the solver part and isolate potential issues, set the initialization to consistent


### PR DESCRIPTION
## Summary

- Makes `CheckInit` the default initialization algorithm for ODEs and DAEs (previously `BrownFullBasicInit` / `ShampineCollocationInit`)
- Removes the `_default_dae_init!` dispatch mechanism from `OrdinaryDiffEqCore` and `OrdinaryDiffEqNonlinearSolve` since it's no longer needed
- Updates tests across NonlinearSolve, BDF, SDIRK, and Rosenbrock subpackages to use explicit `initializealg` where they relied on the old default

This is a **breaking change** for v7. Users with inconsistent initial conditions who relied on automatic correction must now explicitly pass `initializealg = BrownFullBasicInit()` or `initializealg = ShampineCollocationInit()`.

Rebased from #2602 (by @Ickaser) onto the v7 branch. See also #2514 and #2554 for prior discussion.

## Test plan

- [x] `OrdinaryDiffEqNonlinearSolve` tests pass locally (Julia 1.11, `Pkg.test()`)
- [ ] CI passes for all subpackages

🤖 Generated with [Claude Code](https://claude.com/claude-code)