### PR TITLE
Change default lazy interpolation to false for v7

### DIFF
--- a/lib/OrdinaryDiffEqLowOrderRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqLowOrderRK/src/algorithms.jl
@@ -208,20 +208,20 @@ end
     publisher={Elsevier}
     }",
     extra_keyword_description = """- `lazy`: determines if the lazy interpolant is used.""",
-    extra_keyword_default = "lazy = true"
+    extra_keyword_default = "lazy = false"
 )
 Base.@kwdef struct BS5{StageLimiter, StepLimiter, Thread, L} <: OrdinaryDiffEqAdaptiveAlgorithm
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = False()
-    lazy::L = Val{true}()
+    lazy::L = Val{false}()
 end
 # Convert Bool lazy to Val for backwards compatibility
 function BS5(stage_limiter!::StageLimiter, step_limiter!::StepLimiter, thread::Thread, lazy::Bool) where {StageLimiter, StepLimiter, Thread}
     return BS5{StageLimiter, StepLimiter, Thread, Val{lazy}}(stage_limiter!, step_limiter!, thread, Val{lazy}())
 end
 # for backwards compatibility
-function BS5(stage_limiter!, step_limiter! = trivial_limiter!; lazy = true)
+function BS5(stage_limiter!, step_limiter! = trivial_limiter!; lazy = false)
     return BS5(stage_limiter!, step_limiter!, False(), lazy)
 end
 

--- a/lib/OrdinaryDiffEqVerner/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqVerner/src/algorithms.jl
@@ -13,14 +13,14 @@
     }",
     extra_keyword_description = """- `lazy`: determines if the lazy interpolant is used.
     """,
-    extra_keyword_default = "lazy = true"
+    extra_keyword_default = "lazy = false"
 )
 Base.@kwdef struct Vern6{StageLimiter, StepLimiter, Thread, L} <:
     OrdinaryDiffEqAdaptiveAlgorithm
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = False()
-    lazy::L = Val{true}()
+    lazy::L = Val{false}()
 end
 @truncate_stacktrace Vern6 3
 # Convert Bool lazy to Val for backwards compatibility
@@ -28,7 +28,7 @@ function Vern6(sl::SL, stl::STL, th::TH, lazy::Bool) where {SL, STL, TH}
     return Vern6{SL, STL, TH, Val{lazy}}(sl, stl, th, Val{lazy}())
 end
 # for backwards compatibility
-function Vern6(stage_limiter!, step_limiter! = trivial_limiter!; lazy = true)
+function Vern6(stage_limiter!, step_limiter! = trivial_limiter!; lazy = false)
     return Vern6(stage_limiter!, step_limiter!, False(), lazy)
 end
 
@@ -47,14 +47,14 @@ end
     }",
     extra_keyword_description = """- `lazy`: determines if the lazy interpolant is used.
     """,
-    extra_keyword_default = "lazy = true"
+    extra_keyword_default = "lazy = false"
 )
 Base.@kwdef struct Vern7{StageLimiter, StepLimiter, Thread, L} <:
     OrdinaryDiffEqAdaptiveAlgorithm
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = False()
-    lazy::L = Val{true}()
+    lazy::L = Val{false}()
 end
 @truncate_stacktrace Vern7 3
 # Convert Bool lazy to Val for backwards compatibility
@@ -62,7 +62,7 @@ function Vern7(sl::SL, stl::STL, th::TH, lazy::Bool) where {SL, STL, TH}
     return Vern7{SL, STL, TH, Val{lazy}}(sl, stl, th, Val{lazy}())
 end
 # for backwards compatibility
-function Vern7(stage_limiter!, step_limiter! = trivial_limiter!; lazy = true)
+function Vern7(stage_limiter!, step_limiter! = trivial_limiter!; lazy = false)
     return Vern7(stage_limiter!, step_limiter!, False(), lazy)
 end
 
@@ -81,14 +81,14 @@ end
     }",
     extra_keyword_description = """- `lazy`: determines if the lazy interpolant is used.
     """,
-    extra_keyword_default = "lazy = true"
+    extra_keyword_default = "lazy = false"
 )
 Base.@kwdef struct Vern8{StageLimiter, StepLimiter, Thread, L} <:
     OrdinaryDiffEqAdaptiveAlgorithm
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = False()
-    lazy::L = Val{true}()
+    lazy::L = Val{false}()
 end
 @truncate_stacktrace Vern8 3
 # Convert Bool lazy to Val for backwards compatibility
@@ -96,7 +96,7 @@ function Vern8(sl::SL, stl::STL, th::TH, lazy::Bool) where {SL, STL, TH}
     return Vern8{SL, STL, TH, Val{lazy}}(sl, stl, th, Val{lazy}())
 end
 # for backwards compatibility
-function Vern8(stage_limiter!, step_limiter! = trivial_limiter!; lazy = true)
+function Vern8(stage_limiter!, step_limiter! = trivial_limiter!; lazy = false)
     return Vern8(stage_limiter!, step_limiter!, False(), lazy)
 end
 
@@ -114,14 +114,14 @@ end
     publisher={Springer}
     }",
     extra_keyword_description = """- `lazy`: determines if the lazy interpolant is used.
-    """, extra_keyword_default = "lazy = true"
+    """, extra_keyword_default = "lazy = false"
 )
 Base.@kwdef struct Vern9{StageLimiter, StepLimiter, Thread, L} <:
     OrdinaryDiffEqAdaptiveAlgorithm
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = False()
-    lazy::L = Val{true}()
+    lazy::L = Val{false}()
 end
 @truncate_stacktrace Vern9 3
 # Convert Bool lazy to Val for backwards compatibility
@@ -129,7 +129,7 @@ function Vern9(sl::SL, stl::STL, th::TH, lazy::Bool) where {SL, STL, TH}
     return Vern9{SL, STL, TH, Val{lazy}}(sl, stl, th, Val{lazy}())
 end
 # for backwards compatibility
-function Vern9(stage_limiter!, step_limiter! = trivial_limiter!; lazy = true)
+function Vern9(stage_limiter!, step_limiter! = trivial_limiter!; lazy = false)
     return Vern9(stage_limiter!, step_limiter!, False(), lazy)
 end
 
@@ -142,7 +142,7 @@ This method is equivalent to `AutoAlgSwitch(Vern6(), stiff_alg; kwargs...)`.
 To gain access to stiff algorithms you might have to install additional libraries,
 such as `OrdinaryDiffEqRosenbrock`.
 """
-AutoVern6(alg; lazy = true, kwargs...) = AutoAlgSwitch(Vern6(lazy = lazy), alg; kwargs...)
+AutoVern6(alg; lazy = false, kwargs...) = AutoAlgSwitch(Vern6(lazy = lazy), alg; kwargs...)
 """
 Automatic switching algorithm that can switch between the (non-stiff) `Vern7()` and `stiff_alg`.
 
@@ -152,7 +152,7 @@ This method is equivalent to `AutoAlgSwitch(Vern7(), stiff_alg; kwargs...)`.
 To gain access to stiff algorithms you might have to install additional libraries,
 such as `OrdinaryDiffEqRosenbrock`.
 """
-AutoVern7(alg; lazy = true, kwargs...) = AutoAlgSwitch(Vern7(lazy = lazy), alg; kwargs...)
+AutoVern7(alg; lazy = false, kwargs...) = AutoAlgSwitch(Vern7(lazy = lazy), alg; kwargs...)
 """
 Automatic switching algorithm that can switch between the (non-stiff) `Vern8()` and `stiff_alg`.
 
@@ -162,7 +162,7 @@ This method is equivalent to `AutoAlgSwitch(Vern8(), stiff_alg; kwargs...)`.
 To gain access to stiff algorithms you might have to install additional libraries,
 such as `OrdinaryDiffEqRosenbrock`.
 """
-AutoVern8(alg; lazy = true, kwargs...) = AutoAlgSwitch(Vern8(lazy = lazy), alg; kwargs...)
+AutoVern8(alg; lazy = false, kwargs...) = AutoAlgSwitch(Vern8(lazy = lazy), alg; kwargs...)
 """
 Automatic switching algorithm that can switch between the (non-stiff) `Vern9()` and `stiff_alg`.
 
@@ -172,7 +172,7 @@ This method is equivalent to `AutoAlgSwitch(Vern9(), stiff_alg; kwargs...)`.
 To gain access to stiff algorithms you might have to install additional libraries,
 such as `OrdinaryDiffEqRosenbrock`.
 """
-AutoVern9(alg; lazy = true, kwargs...) = AutoAlgSwitch(Vern9(lazy = lazy), alg; kwargs...)
+AutoVern9(alg; lazy = false, kwargs...) = AutoAlgSwitch(Vern9(lazy = lazy), alg; kwargs...)
 
 
 @doc explicit_rk_docstring(
@@ -186,14 +186,14 @@ AutoVern9(alg; lazy = true, kwargs...) = AutoAlgSwitch(Vern9(lazy = lazy), alg; 
     }",
     extra_keyword_description = """- `lazy`: determines if the lazy interpolant is used.
     """,
-    extra_keyword_default = "lazy = true"
+    extra_keyword_default = "lazy = false"
 )
 Base.@kwdef struct RKV76IIa{StageLimiter, StepLimiter, Thread, L} <:
     OrdinaryDiffEqAdaptiveAlgorithm
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = False()
-    lazy::L = Val{true}()
+    lazy::L = Val{false}()
 end
 @truncate_stacktrace RKV76IIa 3
 # Convert Bool lazy to Val for backwards compatibility
@@ -201,6 +201,6 @@ function RKV76IIa(sl::SL, stl::STL, th::TH, lazy::Bool) where {SL, STL, TH}
     return RKV76IIa{SL, STL, TH, Val{lazy}}(sl, stl, th, Val{lazy}())
 end
 # for backwards compatibility
-function RKV76IIa(stage_limiter!, step_limiter! = trivial_limiter!; lazy = true)
+function RKV76IIa(stage_limiter!, step_limiter! = trivial_limiter!; lazy = false)
     return RKV76IIa(stage_limiter!, step_limiter!, False(), lazy)
 end

--- a/test/interface/ode_strip_test.jl
+++ b/test/interface/ode_strip_test.jl
@@ -45,4 +45,14 @@ end
     @test isnothing(stripped_sol.interp.cache.args)
 end
 
-@test_throws SciMLBase.LazyInterpolationException SciMLBase.strip_solution(vern_sol)
+@testset "Vern Solution Stripping (default lazy=false)" begin
+    # With default lazy=false, strip_solution should work
+    stripped_sol = SciMLBase.strip_solution(vern_sol)
+    @test stripped_sol.prob isa NamedTuple
+end
+
+@testset "Vern Solution Stripping (explicit lazy=true)" begin
+    # With explicit lazy=true, strip_solution should throw
+    vern_lazy_sol = solve(prob, Vern7(lazy = true))
+    @test_throws SciMLBase.LazyInterpolationException SciMLBase.strip_solution(vern_lazy_sol)
+end


### PR DESCRIPTION
## Summary
- Changes the default value of `lazy` from `Val{true}()` to `Val{false}()` for all algorithms that support it: BS5, Vern6/7/8/9, RKV76IIa, and AutoVern6/7/8/9
- Updates docstring defaults and Bool compatibility constructors to match
- Updates `ode_strip_test.jl` to verify that `strip_solution` now works for Vern solutions with the new default, and that explicitly passing `lazy=true` still throws `LazyInterpolationException`

## Motivation
When `lazy=true` (old default), the ODE function `f` is needed during interpolation queries, which prevents `strip_interpolation` from working. With `lazy=false`, all intermediate steps are computed eagerly so `f` is not needed for interpolation. This is a breaking change appropriate for v7, making https://github.com/SciML/SciMLBase.jl/issues/629 simpler and more robust.

Relates to #2310.

## Test plan
- [x] OrdinaryDiffEqVerner tests pass
- [x] OrdinaryDiffEqLowOrderRK tests pass
- [x] Strip test verifies `strip_solution` works for default Vern7() (lazy=false)
- [x] Strip test verifies `strip_solution` throws for explicit Vern7(lazy=true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>