### PR TITLE
Remove Bool->Val compat paths for lazy kwarg (v7)

### DIFF
--- a/lib/OrdinaryDiffEqDefault/src/default_alg.jl
+++ b/lib/OrdinaryDiffEqDefault/src/default_alg.jl
@@ -30,7 +30,7 @@ const DEFAULTBETA1S = (
 callbacks_exists(integrator) = !isempty(integrator.opts.callbacks)
 current_nonstiff(current) = ifelse(current <= NUM_NONSTIFF, current, current - NUM_STIFF)
 
-function DefaultODEAlgorithm(; lazy = true, stiffalgfirst = false, kwargs...)
+function DefaultODEAlgorithm(; lazy = Val{true}(), stiffalgfirst = false, kwargs...)
     nonstiff = (Tsit5(), Vern7(lazy = lazy))
     stiff = (
         Rosenbrock23(; kwargs...), Rodas5P(; kwargs...), FBDF(; kwargs...),
@@ -157,7 +157,7 @@ function is_mass_matrix_alg(
     return true
 end
 
-function DefaultImplicitODEAlgorithm(; lazy = true, stol = 0, ntol = Inf, kwargs...)
+function DefaultImplicitODEAlgorithm(; lazy = Val{true}(), stol = 0, ntol = Inf, kwargs...)
     nonstiff = (Tsit5(), Vern7(lazy = lazy))
     stiff = (
         Rosenbrock23(; kwargs...), Rodas5P(; kwargs...),

--- a/lib/OrdinaryDiffEqLowOrderRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqLowOrderRK/src/algorithms.jl
@@ -208,7 +208,7 @@ end
     publisher={Elsevier}
     }",
     extra_keyword_description = """- `lazy`: determines if the lazy interpolant is used.""",
-    extra_keyword_default = "lazy = true"
+    extra_keyword_default = "lazy = Val{true}()"
 )
 Base.@kwdef struct BS5{StageLimiter, StepLimiter, Thread, L} <: OrdinaryDiffEqAdaptiveAlgorithm
     stage_limiter!::StageLimiter = trivial_limiter!
@@ -216,12 +216,8 @@ Base.@kwdef struct BS5{StageLimiter, StepLimiter, Thread, L} <: OrdinaryDiffEqAd
     thread::Thread = False()
     lazy::L = Val{true}()
 end
-# Convert Bool lazy to Val for backwards compatibility
-function BS5(stage_limiter!::StageLimiter, step_limiter!::StepLimiter, thread::Thread, lazy::Bool) where {StageLimiter, StepLimiter, Thread}
-    return BS5{StageLimiter, StepLimiter, Thread, Val{lazy}}(stage_limiter!, step_limiter!, thread, Val{lazy}())
-end
 # for backwards compatibility
-function BS5(stage_limiter!, step_limiter! = trivial_limiter!; lazy = true)
+function BS5(stage_limiter!, step_limiter! = trivial_limiter!; lazy = Val{true}())
     return BS5(stage_limiter!, step_limiter!, False(), lazy)
 end
 

--- a/lib/OrdinaryDiffEqVerner/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqVerner/src/algorithms.jl
@@ -13,7 +13,7 @@
     }",
     extra_keyword_description = """- `lazy`: determines if the lazy interpolant is used.
     """,
-    extra_keyword_default = "lazy = true"
+    extra_keyword_default = "lazy = Val{true}()"
 )
 Base.@kwdef struct Vern6{StageLimiter, StepLimiter, Thread, L} <:
     OrdinaryDiffEqAdaptiveAlgorithm
@@ -23,12 +23,8 @@ Base.@kwdef struct Vern6{StageLimiter, StepLimiter, Thread, L} <:
     lazy::L = Val{true}()
 end
 @truncate_stacktrace Vern6 3
-# Convert Bool lazy to Val for backwards compatibility
-function Vern6(sl::SL, stl::STL, th::TH, lazy::Bool) where {SL, STL, TH}
-    return Vern6{SL, STL, TH, Val{lazy}}(sl, stl, th, Val{lazy}())
-end
 # for backwards compatibility
-function Vern6(stage_limiter!, step_limiter! = trivial_limiter!; lazy = true)
+function Vern6(stage_limiter!, step_limiter! = trivial_limiter!; lazy = Val{true}())
     return Vern6(stage_limiter!, step_limiter!, False(), lazy)
 end
 
@@ -47,7 +43,7 @@ end
     }",
     extra_keyword_description = """- `lazy`: determines if the lazy interpolant is used.
     """,
-    extra_keyword_default = "lazy = true"
+    extra_keyword_default = "lazy = Val{true}()"
 )
 Base.@kwdef struct Vern7{StageLimiter, StepLimiter, Thread, L} <:
     OrdinaryDiffEqAdaptiveAlgorithm
@@ -57,12 +53,8 @@ Base.@kwdef struct Vern7{StageLimiter, StepLimiter, Thread, L} <:
     lazy::L = Val{true}()
 end
 @truncate_stacktrace Vern7 3
-# Convert Bool lazy to Val for backwards compatibility
-function Vern7(sl::SL, stl::STL, th::TH, lazy::Bool) where {SL, STL, TH}
-    return Vern7{SL, STL, TH, Val{lazy}}(sl, stl, th, Val{lazy}())
-end
 # for backwards compatibility
-function Vern7(stage_limiter!, step_limiter! = trivial_limiter!; lazy = true)
+function Vern7(stage_limiter!, step_limiter! = trivial_limiter!; lazy = Val{true}())
     return Vern7(stage_limiter!, step_limiter!, False(), lazy)
 end
 
@@ -81,7 +73,7 @@ end
     }",
     extra_keyword_description = """- `lazy`: determines if the lazy interpolant is used.
     """,
-    extra_keyword_default = "lazy = true"
+    extra_keyword_default = "lazy = Val{true}()"
 )
 Base.@kwdef struct Vern8{StageLimiter, StepLimiter, Thread, L} <:
     OrdinaryDiffEqAdaptiveAlgorithm
@@ -91,12 +83,8 @@ Base.@kwdef struct Vern8{StageLimiter, StepLimiter, Thread, L} <:
     lazy::L = Val{true}()
 end
 @truncate_stacktrace Vern8 3
-# Convert Bool lazy to Val for backwards compatibility
-function Vern8(sl::SL, stl::STL, th::TH, lazy::Bool) where {SL, STL, TH}
-    return Vern8{SL, STL, TH, Val{lazy}}(sl, stl, th, Val{lazy}())
-end
 # for backwards compatibility
-function Vern8(stage_limiter!, step_limiter! = trivial_limiter!; lazy = true)
+function Vern8(stage_limiter!, step_limiter! = trivial_limiter!; lazy = Val{true}())
     return Vern8(stage_limiter!, step_limiter!, False(), lazy)
 end
 
@@ -114,7 +102,7 @@ end
     publisher={Springer}
     }",
     extra_keyword_description = """- `lazy`: determines if the lazy interpolant is used.
-    """, extra_keyword_default = "lazy = true"
+    """, extra_keyword_default = "lazy = Val{true}()"
 )
 Base.@kwdef struct Vern9{StageLimiter, StepLimiter, Thread, L} <:
     OrdinaryDiffEqAdaptiveAlgorithm
@@ -124,12 +112,8 @@ Base.@kwdef struct Vern9{StageLimiter, StepLimiter, Thread, L} <:
     lazy::L = Val{true}()
 end
 @truncate_stacktrace Vern9 3
-# Convert Bool lazy to Val for backwards compatibility
-function Vern9(sl::SL, stl::STL, th::TH, lazy::Bool) where {SL, STL, TH}
-    return Vern9{SL, STL, TH, Val{lazy}}(sl, stl, th, Val{lazy}())
-end
 # for backwards compatibility
-function Vern9(stage_limiter!, step_limiter! = trivial_limiter!; lazy = true)
+function Vern9(stage_limiter!, step_limiter! = trivial_limiter!; lazy = Val{true}())
     return Vern9(stage_limiter!, step_limiter!, False(), lazy)
 end
 
@@ -142,7 +126,7 @@ This method is equivalent to `AutoAlgSwitch(Vern6(), stiff_alg; kwargs...)`.
 To gain access to stiff algorithms you might have to install additional libraries,
 such as `OrdinaryDiffEqRosenbrock`.
 """
-AutoVern6(alg; lazy = true, kwargs...) = AutoAlgSwitch(Vern6(lazy = lazy), alg; kwargs...)
+AutoVern6(alg; lazy = Val{true}(), kwargs...) = AutoAlgSwitch(Vern6(lazy = lazy), alg; kwargs...)
 """
 Automatic switching algorithm that can switch between the (non-stiff) `Vern7()` and `stiff_alg`.
 
@@ -152,7 +136,7 @@ This method is equivalent to `AutoAlgSwitch(Vern7(), stiff_alg; kwargs...)`.
 To gain access to stiff algorithms you might have to install additional libraries,
 such as `OrdinaryDiffEqRosenbrock`.
 """
-AutoVern7(alg; lazy = true, kwargs...) = AutoAlgSwitch(Vern7(lazy = lazy), alg; kwargs...)
+AutoVern7(alg; lazy = Val{true}(), kwargs...) = AutoAlgSwitch(Vern7(lazy = lazy), alg; kwargs...)
 """
 Automatic switching algorithm that can switch between the (non-stiff) `Vern8()` and `stiff_alg`.
 
@@ -162,7 +146,7 @@ This method is equivalent to `AutoAlgSwitch(Vern8(), stiff_alg; kwargs...)`.
 To gain access to stiff algorithms you might have to install additional libraries,
 such as `OrdinaryDiffEqRosenbrock`.
 """
-AutoVern8(alg; lazy = true, kwargs...) = AutoAlgSwitch(Vern8(lazy = lazy), alg; kwargs...)
+AutoVern8(alg; lazy = Val{true}(), kwargs...) = AutoAlgSwitch(Vern8(lazy = lazy), alg; kwargs...)
 """
 Automatic switching algorithm that can switch between the (non-stiff) `Vern9()` and `stiff_alg`.
 
@@ -172,7 +156,7 @@ This method is equivalent to `AutoAlgSwitch(Vern9(), stiff_alg; kwargs...)`.
 To gain access to stiff algorithms you might have to install additional libraries,
 such as `OrdinaryDiffEqRosenbrock`.
 """
-AutoVern9(alg; lazy = true, kwargs...) = AutoAlgSwitch(Vern9(lazy = lazy), alg; kwargs...)
+AutoVern9(alg; lazy = Val{true}(), kwargs...) = AutoAlgSwitch(Vern9(lazy = lazy), alg; kwargs...)
 
 
 @doc explicit_rk_docstring(
@@ -186,7 +170,7 @@ AutoVern9(alg; lazy = true, kwargs...) = AutoAlgSwitch(Vern9(lazy = lazy), alg; 
     }",
     extra_keyword_description = """- `lazy`: determines if the lazy interpolant is used.
     """,
-    extra_keyword_default = "lazy = true"
+    extra_keyword_default = "lazy = Val{true}()"
 )
 Base.@kwdef struct RKV76IIa{StageLimiter, StepLimiter, Thread, L} <:
     OrdinaryDiffEqAdaptiveAlgorithm
@@ -196,11 +180,7 @@ Base.@kwdef struct RKV76IIa{StageLimiter, StepLimiter, Thread, L} <:
     lazy::L = Val{true}()
 end
 @truncate_stacktrace RKV76IIa 3
-# Convert Bool lazy to Val for backwards compatibility
-function RKV76IIa(sl::SL, stl::STL, th::TH, lazy::Bool) where {SL, STL, TH}
-    return RKV76IIa{SL, STL, TH, Val{lazy}}(sl, stl, th, Val{lazy}())
-end
 # for backwards compatibility
-function RKV76IIa(stage_limiter!, step_limiter! = trivial_limiter!; lazy = true)
+function RKV76IIa(stage_limiter!, step_limiter! = trivial_limiter!; lazy = Val{true}())
     return RKV76IIa(stage_limiter!, step_limiter!, False(), lazy)
 end

--- a/lib/OrdinaryDiffEqVerner/test/ode_verner_tests.jl
+++ b/lib/OrdinaryDiffEqVerner/test/ode_verner_tests.jl
@@ -171,11 +171,11 @@ cb_nolazy = DiscreteCallback(
 )
 
 solve(
-    prob_back, Vern9(lazy = true), abstol = 1.0e-12, reltol = 1.0e-12,
+    prob_back, Vern9(lazy = Val{true}()), abstol = 1.0e-12, reltol = 1.0e-12,
     callback = cb_lazy, save_everystep = false
 )
 solve(
-    prob_back, Vern9(lazy = false), abstol = 1.0e-12, reltol = 1.0e-12,
+    prob_back, Vern9(lazy = Val{false}()), abstol = 1.0e-12, reltol = 1.0e-12,
     callback = cb_nolazy, save_everystep = false
 )
 

--- a/test/integrators/ode_add_steps_tests.jl
+++ b/test/integrators/ode_add_steps_tests.jl
@@ -47,7 +47,7 @@ for inplace in [false, true], alg in lazy_alg
     fail = all(isapprox(sol(t)[1], test_solution(t); atol = 0.05) for t in testtimes)
 
     prob = ODEProblem{inplace}(test_ode, [0.0], tspan, [1.0])
-    sol = solve(prob, alg(lazy = false); callback = cb, dt = 0.0013)
+    sol = solve(prob, alg(lazy = Val{false}()); callback = cb, dt = 0.0013)
     pass = all(isapprox(sol(t)[1], test_solution(t); atol = 0.05) for t in testtimes)
 
     cur_itr += 1

--- a/test/regression/ode_dense_tests.jl
+++ b/test/regression/ode_dense_tests.jl
@@ -480,7 +480,7 @@ regression_test(Feagin10(), 6.0e-4, 9.0e-4)
 @test BS5() == BS5(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(BS5(), 4.0e-8, 6.0e-8; test_diff1 = true, nth_der = 1, dertol = 1.0e-12)
 regression_test(
-    BS5(lazy = false), 4.0e-8, 6.0e-8; test_diff1 = true, nth_der = 1,
+    BS5(lazy = Val{false}()), 4.0e-8, 6.0e-8; test_diff1 = true, nth_der = 1,
     dertol = 1.0e-12
 )
 
@@ -506,7 +506,7 @@ println("Verns")
 @test Vern6() == Vern6(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(Vern6(), 7.0e-8, 7.0e-8; test_diff1 = true, nth_der = 1, dertol = 1.0e-9)
 regression_test(
-    Vern6(lazy = false), 7.0e-8, 7.0e-8; test_diff1 = true, nth_der = 1,
+    Vern6(lazy = Val{false}()), 7.0e-8, 7.0e-8; test_diff1 = true, nth_der = 1,
     dertol = 1.0e-9
 )
 
@@ -530,7 +530,7 @@ print_results(@test maximum(map((x) -> maximum(abs.(x)), sol2 - interpd_big)) < 
 # Vern7
 regression_test(Vern7(), 3.0e-9, 5.0e-9; test_diff1 = true, nth_der = 1, dertol = 1.0e-10)
 regression_test(
-    Vern7(lazy = false), 3.0e-9, 5.0e-9; test_diff1 = true, nth_der = 1,
+    Vern7(lazy = Val{false}()), 3.0e-9, 5.0e-9; test_diff1 = true, nth_der = 1,
     dertol = 1.0e-10
 )
 
@@ -538,7 +538,7 @@ regression_test(
 @test Vern8() == Vern8(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(Vern8(), 3.0e-8, 5.0e-8; test_diff1 = true, nth_der = 1, dertol = 1.0e-7)
 regression_test(
-    Vern8(lazy = false), 3.0e-8, 5.0e-8; test_diff1 = true, nth_der = 1,
+    Vern8(lazy = Val{false}()), 3.0e-8, 5.0e-8; test_diff1 = true, nth_der = 1,
     dertol = 1.0e-7
 )
 
@@ -546,7 +546,7 @@ regression_test(
 @test Vern9() == Vern9(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(Vern9(), 1.0e-9, 2.0e-9; test_diff1 = true, nth_der = 4, dertol = 5.0e-2)
 regression_test(
-    Vern9(lazy = false), 1.0e-9, 2.0e-9; test_diff1 = true, nth_der = 4,
+    Vern9(lazy = Val{false}()), 1.0e-9, 2.0e-9; test_diff1 = true, nth_der = 4,
     dertol = 5.0e-2
 )
 


### PR DESCRIPTION
## Summary
- Remove Bool->Val backwards compatibility constructors for `lazy` keyword argument on BS5, Vern6, Vern7, Vern8, Vern9, and RKV76IIa algorithms
- Update all keyword constructor defaults from `lazy = true` (Bool) to `lazy = Val{true}()` to match the @kwdef struct defaults
- Update `AutoVern6/7/8/9` defaults from `lazy = true` to `lazy = Val{true}()`
- Update `DefaultODEAlgorithm` and `DefaultImplicitODEAlgorithm` defaults from `lazy = true` to `lazy = Val{true}()`
- Update docstring defaults to show `lazy = Val{true}()`
- Update tests to use `Val{true}()`/`Val{false}()` instead of Bool

The default `lazy = Val{true}()` is unchanged. This is a breaking change for v7 that removes the Bool compatibility layer.

## Test plan
- [x] OrdinaryDiffEqVerner Core tests pass locally
- [x] OrdinaryDiffEqLowOrderRK Core tests pass locally
- [ ] CI passes on v7 branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)