### PR TITLE
Bump SDE weak convergence test timeouts

### DIFF
--- a/lib/StochasticDiffEq/test/test_groups.toml
+++ b/lib/StochasticDiffEq/test/test_groups.toml
@@ -22,12 +22,12 @@ versions = ["1"]
 [OOPWeakConvergence]
 versions = ["1"]
 runner = ["self-hosted", "Linux", "X64", "high-memory"]
-timeout = 240
+timeout = 300
 
 [IIPWeakConvergence]
 versions = ["1"]
 runner = ["self-hosted", "Linux", "X64", "high-memory"]
-timeout = 240
+timeout = 300
 
 [Multithreaded]
 versions = ["1"]

--- a/lib/StochasticDiffEqWeak/test/test_groups.toml
+++ b/lib/StochasticDiffEqWeak/test/test_groups.toml
@@ -7,7 +7,7 @@ versions = ["1"]
 [WeakConvergence2]
 versions = ["1"]
 runner = ["self-hosted", "Linux", "X64", "high-memory"]
-timeout = 240
+timeout = 300
 
 [W2Ito1WeakConvergence]
 versions = ["1"]
@@ -15,7 +15,7 @@ versions = ["1"]
 [WeakConvergence3]
 versions = ["1"]
 runner = ["self-hosted", "Linux", "X64", "high-memory"]
-timeout = 240
+timeout = 300
 
 [SIESMEWeakConvergence]
 versions = ["1"]
@@ -23,17 +23,17 @@ versions = ["1"]
 [WeakConvergence4]
 versions = ["1"]
 runner = ["self-hosted", "Linux", "X64", "high-memory"]
-timeout = 360
+timeout = 420
 
 [WeakConvergence5]
 versions = ["1"]
 runner = ["self-hosted", "Linux", "X64", "high-memory"]
-timeout = 240
+timeout = 300
 
 [WeakConvergence6]
 versions = ["1"]
 runner = ["self-hosted", "Linux", "X64", "high-memory"]
-timeout = 240
+timeout = 300
 
 [IRI1WeakConvergence]
 versions = ["1"]


### PR DESCRIPTION
## Summary
- Bump StochasticDiffEqWeak WeakConvergence2/3/5/6 timeouts from 240 to 300 minutes
- Bump StochasticDiffEqWeak WeakConvergence4 timeout from 360 to 420 minutes
- Bump StochasticDiffEq OOP/IIP WeakConvergence timeouts from 240 to 300 minutes

These tests were consistently timing out by just a few minutes (e.g. 245 min on a 240 min limit, 365 min on a 360 min limit). The ~25% increase provides adequate headroom.

## Test plan
- [ ] StochasticDiffEqWeak_WeakConvergence2-6 CI passes
- [ ] StochasticDiffEq_OOPWeakConvergence CI passes
- [ ] StochasticDiffEq_IIPWeakConvergence CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)