### PR TITLE
Force dense=false for SDE/RODE solutions in InterpolationData

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/solve.jl
+++ b/lib/OrdinaryDiffEqCore/src/solve.jl
@@ -665,6 +665,14 @@ function _ode_init(
         get_differential_vars(f, u)
     end
 
+    # SDE/RODE solvers never populate derivative stages (ks) — RODESolution has
+    # no .k field, so _has_ks returns false and save_dense_at_t! is a no-op.
+    # Force dense=false so ode_interpolation uses linear interpolation instead
+    # of trying to access the empty ks vector.
+    if !isnothing(W)
+        dense = false
+    end
+
     id = InterpolationData(
         f, timeseries, ts, ks, alg_choice, dense, cache, differential_vars, false
     )


### PR DESCRIPTION
## Summary
SDE/RODE solvers never populate derivative stages (`ks`) because `RODESolution` has no `.k` field (`_has_ks` returns `false`, so `save_dense_at_t!` is a no-op). When a user passes `dense=true` to `solve()`, the `InterpolationData` was created with `dense=true` and empty `ks`, causing `BoundsError` in `ode_interpolation!` when it tries `ks[i]` for high-order interpolation.

**Fix**: Force `dense=false` when `W !== nothing` (SDE/RODE path) in `_ode_init`, right before `InterpolationData` construction. This makes `ode_interpolation` use `linear_interpolant` instead.

This fixes the `BoundsError: attempt to access 0-element Vector{Vector{Vector{Float64}}} at index [50001]` seen in SciMLSensitivity.jl's RODE `InterpolatingAdjoint` tests (SciML/SciMLSensitivity.jl#1398).

## Test plan
- [ ] Existing SDE/RODE tests pass (they already default to `dense=false`)
- [ ] SciMLSensitivity RODE InterpolatingAdjoint tests pass (currently crash with BoundsError)

🤖 Generated with [Claude Code](https://claude.com/claude-code)