### PR TITLE
Fix DelayDiffEq QA test failures

### DIFF
--- a/lib/DelayDiffEq/src/DelayDiffEq.jl
+++ b/lib/DelayDiffEq/src/DelayDiffEq.jl
@@ -21,7 +21,7 @@ import SymbolicIndexingInterface as SII
 
 using SciMLBase: AbstractDDEAlgorithm, AbstractDDEIntegrator, AbstractODEIntegrator,
     DEIntegrator
-using SciMLBase: AbstractSDDEProblem, SDDEProblem, AbstractSDDEAlgorithm
+using SciMLBase: AbstractSDDEProblem, SDDEProblem
 
 using Base: deleteat!
 import FastBroadcast: @..
@@ -29,9 +29,9 @@ import FastBroadcast: @..
 using OrdinaryDiffEqNonlinearSolve: NLAnderson, NLFunctional
 using OrdinaryDiffEqCore: AbstractNLSolverCache, SlowConvergence,
     alg_extrapolates, alg_maximum_order, initialize!, DEVerbosity
-using OrdinaryDiffEqCore: StochasticDiffEqAlgorithm, StochasticDiffEqAdaptiveAlgorithm,
+using OrdinaryDiffEqCore: StochasticDiffEqAlgorithm,
     StochasticDiffEqRODEAlgorithm,
-    StochasticDiffEqCache, StochasticDiffEqConstantCache, StochasticDiffEqMutableCache
+    StochasticDiffEqConstantCache, StochasticDiffEqMutableCache
 using OrdinaryDiffEqRosenbrock: RosenbrockMutableCache
 using OrdinaryDiffEqFunctionMap: FunctionMap
 # using OrdinaryDiffEqDifferentiation: resize_grad_config!, resize_jac_config!

--- a/lib/DelayDiffEq/src/solve.jl
+++ b/lib/DelayDiffEq/src/solve.jl
@@ -732,7 +732,7 @@ function DiffEqBase.check_prob_alg_pairing(prob::SDDEProblem, alg::AbstractMetho
     if !(alg.alg isa SDEAlgUnion)
         throw(SciMLBase.ProblemSolverPairingError(prob, alg))
     end
-    if isdefined(prob, :u0) && DiffEqBase.eltypedual(prob.u0) &&
+    if isdefined(prob, :u0) && SciMLBase.eltypedual(prob.u0) &&
             !SciMLBase.isautodifferentiable(alg)
         throw(SciMLBase.DirectAutodiffError())
     end

--- a/lib/DelayDiffEq/test/qa/qa_tests.jl
+++ b/lib/DelayDiffEq/test/qa/qa_tests.jl
@@ -12,12 +12,14 @@ import SciMLBase
     Aqua.test_stale_deps(DelayDiffEq)
     Aqua.test_deps_compat(DelayDiffEq)
     # Allow piracy for the default solver methods and SDE integration
-    using OrdinaryDiffEqCore: StochasticDiffEqAlgorithm, StochasticDiffEqRODEAlgorithm,
+    using OrdinaryDiffEqCore: OrdinaryDiffEqAlgorithm, StochasticDiffEqAlgorithm,
+        StochasticDiffEqRODEAlgorithm,
         StochasticDiffEqConstantCache, StochasticDiffEqMutableCache
     Aqua.test_piracies(
         DelayDiffEq;
         treat_as_own = [
             SciMLBase.DDEProblem,
+            OrdinaryDiffEqAlgorithm,
             StochasticDiffEqAlgorithm,
             StochasticDiffEqRODEAlgorithm,
             StochasticDiffEqConstantCache,


### PR DESCRIPTION
## Summary
- Remove stale explicit imports (`AbstractSDDEAlgorithm`, `StochasticDiffEqAdaptiveAlgorithm`, `StochasticDiffEqCache`) that were imported but never used
- Fix qualified access: `DiffEqBase.eltypedual` → `SciMLBase.eltypedual` (SciMLBase is the owner module)
- Add `OrdinaryDiffEqAlgorithm` to Aqua piracy `treat_as_own` list for the DDE auto-wrap convenience methods

These are pre-existing failures on master (confirmed failing in run 23688925082).

## Test plan
- [x] ExplicitImports tests pass locally (3/3)
- [x] Aqua piracy test passes locally
- [ ] CI DelayDiffEq_QA job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)