### PR TITLE
Reduce CI cache size to fix upload timeouts

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,6 +13,9 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
+    permissions:
+      actions: write
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 120
     continue-on-error: ${{ matrix.group == 'Downstream' }}
@@ -59,6 +62,8 @@ jobs:
         with:
           version: ${{ matrix.version }}
       - uses: julia-actions/cache@v3
+        with:
+          cache-compiled: 'false'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:

--- a/.github/workflows/SublibraryCI.yml
+++ b/.github/workflows/SublibraryCI.yml
@@ -54,6 +54,9 @@ jobs:
   test:
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true'
+    permissions:
+      actions: write
+      contents: read
     runs-on: ${{ matrix.runner }}
     timeout-minutes: ${{ matrix.timeout }}
     strategy:
@@ -66,6 +69,8 @@ jobs:
         with:
           version: ${{ matrix.version }}
       - uses: julia-actions/cache@v3
+        with:
+          cache-compiled: 'false'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:


### PR DESCRIPTION
## Summary
- Disable `cache-compiled` in `julia-actions/cache@v3` for both CI.yml and SublibraryCI.yml. Self-hosted runners already persist `~/.julia/compiled` on disk, so uploading it to GitHub's cache storage is wasteful. GitHub-hosted runners will just recompile on first use.
- Add `permissions: {actions: write, contents: read}` so `delete-old-caches` (enabled by default) can actually call the cache deletion API and clean up stale entries.

The cache was growing to ~12 GB, causing uploads to take so long that the Azure SAS token would expire mid-upload (~47%), resulting in spurious CI failures in the "Post Run julia-actions/cache@v3" step (e.g. [this run](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/23710055222/job/69072877412?pr=3272)).

## Test plan
- CI workflows will run on this PR itself — verify cache step completes without timeout
- Verify tests still pass (precompilation just happens inline instead of from cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)