### PR TITLE
Add tags, multiple error estimates, best-of-family and autoplot to DiffEqDevTools

### DIFF
--- a/docs/src/devtools/alg_dev/benchmarks.md
+++ b/docs/src/devtools/alg_dev/benchmarks.md
@@ -82,6 +82,48 @@ wp_set = WorkPrecisionSet(prob, abstols, reltols, setups; dt = 1 / 2^4, numruns 
 Both of these types have a plot recipe to produce a work-precision diagram,
 and a print which will show some relevant information.
 
+### Tags and comparison plots
+
+A benchmark usually wants several views of the same data: each family of methods on its
+own, then the best of each family against each other, with a couple of reference methods
+in every plot. Tagging the setups produces all of those from a single run. Add a `:tags`
+entry to each setup, request every error metric the plots need with `error_estimates`,
+and slice the result afterwards:
+
+```julia
+setups = [
+    Dict(:alg => Rosenbrock23(), :tags => [:rosenbrock, :second_order]),
+    Dict(:alg => Rodas5P(), :tags => [:rosenbrock, :fifth_order]),
+    Dict(:alg => TRBDF2(), :tags => [:sdirk, :second_order]),
+    Dict(:alg => KenCarp4(), :tags => [:sdirk, :fourth_order]),
+    Dict(:alg => RadauIIA5(), :tags => [:firk, :reference]),
+]
+wp_set = WorkPrecisionSet(
+    prob, abstols, reltols, setups;
+    error_estimates = [:final, :l2], appxsol = test_sol
+)
+
+plot(wp_set, tags = [:rosenbrock])                     # one family
+plot(best_of_families(wp_set, [:rosenbrock, :sdirk]))  # cross-family comparison
+plot(wp_set, x = :l2)                                  # a second error metric, no re-solve
+
+# a family against the baseline
+plot(
+    wp_set, tags = [:sdirk], include_tags = [:reference],
+    reference_tags = [:reference]
+)
+```
+
+`plot(wp_set; tags)` keeps the entries carrying all of `tags`, `include_tags` adds
+entries back regardless of that filter, and `exclude_tags` drops entries. Entries
+matching `reference_tags` are drawn in a separate, de-emphasized style controlled by
+`reference_style`. [`autoplot`](@ref) returns the whole standard collection of subsets
+at once, keyed by name.
+
+Slow configurations can be capped with `timeout` (seconds per tolerance): a solve is
+never interrupted, but once one exceeds the budget its repeated timing runs are skipped
+and the point is recorded as `NaN`, which the plot recipe drops.
+
 ## API
 
 ```@docs
@@ -90,4 +132,20 @@ DiffEqDevTools.ShootoutSet
 DiffEqDevTools.WorkPrecision
 DiffEqDevTools.WorkPrecisionSet
 DiffEqDevTools.get_sample_errors
+```
+
+### Tagging and comparison helpers
+
+```@docs
+DiffEqDevTools.get_tags
+DiffEqDevTools.unique_tags
+DiffEqDevTools.filter_by_tags
+DiffEqDevTools.exclude_by_tags
+DiffEqDevTools.merge_wp_sets
+DiffEqDevTools.available_errors
+DiffEqDevTools.wp_area
+DiffEqDevTools.best_by_tag
+DiffEqDevTools.best_of_families
+DiffEqDevTools.with_autodiff_variants
+DiffEqDevTools.autoplot
 ```

--- a/lib/DiffEqDevTools/Project.toml
+++ b/lib/DiffEqDevTools/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqDevTools"
 uuid = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "3.3.0"
+version = "3.4.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/DiffEqDevTools/docs/src/index.md
+++ b/lib/DiffEqDevTools/docs/src/index.md
@@ -24,6 +24,22 @@ DiffEqDevTools.WorkPrecisionSet
 DiffEqDevTools.get_sample_errors
 ```
 
+## Tagging and comparison helpers
+
+```@docs
+DiffEqDevTools.get_tags
+DiffEqDevTools.unique_tags
+DiffEqDevTools.filter_by_tags
+DiffEqDevTools.exclude_by_tags
+DiffEqDevTools.merge_wp_sets
+DiffEqDevTools.available_errors
+DiffEqDevTools.wp_area
+DiffEqDevTools.best_by_tag
+DiffEqDevTools.best_of_families
+DiffEqDevTools.with_autodiff_variants
+DiffEqDevTools.autoplot
+```
+
 ## Tableaus
 
 ```@docs

--- a/lib/DiffEqDevTools/src/DiffEqDevTools.jl
+++ b/lib/DiffEqDevTools/src/DiffEqDevTools.jl
@@ -53,6 +53,7 @@ const ALL_ERRORS = union(
 include("benchmark.jl")
 include("convergence.jl")
 include("plotrecipes.jl")
+include("autoplot.jl")
 include("test_solution.jl")
 include("ode_tableaus.jl")
 include("tableau_info.jl")
@@ -65,6 +66,21 @@ export Shootout, ShootoutSet, WorkPrecision, WorkPrecisionSet
 export test_convergence, analyticless_test_convergence, appxtrue
 
 export get_sample_errors
+
+#Tagging and filtering
+export filter_by_tags, exclude_by_tags, get_tags, unique_tags, merge_wp_sets
+
+#Multiple error estimates from one run
+export available_errors
+
+#Best-of-family selection
+export wp_area, best_by_tag, best_of_families
+
+#AutoDiff comparison helpers
+export with_autodiff_variants
+
+#Comparison plot sets
+export autoplot
 
 #Tab Functions
 export stability_region, residual_order_condition, check_tableau, imaginary_stability_interval

--- a/lib/DiffEqDevTools/src/autoplot.jl
+++ b/lib/DiffEqDevTools/src/autoplot.jl
@@ -1,0 +1,52 @@
+"""
+    autoplot(wp_set::WorkPrecisionSet; families = nothing, reference_tags = nothing,
+        best_n = 2) -> Dict{String, WorkPrecisionSet}
+
+Split one tagged [`WorkPrecisionSet`](@ref) into the subsets a benchmark page usually
+plots, without re-solving anything:
+
+  - `"family_<tag>"` for each family in `families`, holding that family's entries plus
+    any entry matching `reference_tags`
+  - `"best_of_families"`, the [`best_of_families`](@ref) selection of the `best_n` best
+    entries per family, again alongside the reference entries
+  - `"all"`, the full input set
+
+Each value plots directly with `plot(subset)`. When `families` is not given it is taken
+from the tags in use, dropping tags carried by more than 80% of the entries, since those
+describe the benchmark as a whole (`:stiff`, `:nonstiff`) rather than a family.
+"""
+function autoplot(
+        wp_set::WorkPrecisionSet;
+        families = nothing,
+        reference_tags = nothing,
+        best_n::Int = 2
+    )
+    families === nothing && (families = _auto_detect_families(wp_set))
+    ref_indices = reference_tags === nothing ? Int[] :
+        findall(wp -> _has_any_tag(wp, _as_tags(reference_tags)), wp_set.wps)
+
+    results = Dict{String, WorkPrecisionSet}()
+    present = Symbol[]
+    for family in families
+        indices = findall(wp -> family in wp.tags, wp_set.wps)
+        isempty(indices) && continue
+        push!(present, family)
+        results["family_$(family)"] = _subset_wps(wp_set, sort!(union(indices, ref_indices)))
+    end
+
+    if !isempty(present)
+        best = _best_family_indices(wp_set, present, best_n, :area)
+        results["best_of_families"] = _subset_wps(wp_set, sort!(union(best, ref_indices)))
+    end
+
+    results["all"] = wp_set
+    return results
+end
+
+function _auto_detect_families(wp_set::WorkPrecisionSet)
+    n_methods = length(wp_set.wps)
+    n_methods == 0 && return Symbol[]
+    return filter(unique_tags(wp_set)) do tag
+        count(wp -> tag in wp.tags, wp_set.wps) <= 0.8 * n_methods
+    end
+end

--- a/lib/DiffEqDevTools/src/benchmark.jl
+++ b/lib/DiffEqDevTools/src/benchmark.jl
@@ -1,5 +1,31 @@
 using Statistics
 
+# Errors recorded for a tolerance whose solve failed or was cut off by `timeout`.
+_nan_errors() = Dict{Symbol, Float64}(:l∞ => NaN, :L2 => NaN, :final => NaN, :l2 => NaN, :L∞ => NaN)
+
+_setup_tags(setup) = Vector{Symbol}(get(setup, :tags, Symbol[]))
+_setup_name(setup) = get(setup, :name, _default_name(setup[:alg]))
+
+function _timed_out(timeout, solve_time, name, abstol)
+    (timeout === nothing || solve_time <= timeout) && return false
+    @warn "$name exceeded the $(timeout)s timeout at abstol=$abstol " *
+        "($(round(solve_time, sigdigits = 3))s); recording this point as NaN."
+    return true
+end
+
+# Build the `errors` StructArray from the per-tolerance error `Dict`s.
+# A failed tolerance records a different key set than a successful one and `Dict`
+# iteration order is unspecified, so `NamedTuple.(dicts)` can yield differently-typed
+# NamedTuples whose element type widens to bare `NamedTuple` — which StructArrays 0.7
+# rejects. Use the union of keys in a fixed order and fill the gaps with NaN.
+function _dicts_to_structarray(dicts)
+    ks = Tuple(sort!(unique!(mapreduce(d -> collect(keys(d)), vcat, dicts))))
+    V = mapreduce(valtype, promote_type, dicts)
+    T = all(d -> length(d) == length(ks), dicts) ? V : promote_type(V, Float64)
+    NT = NamedTuple{ks, NTuple{length(ks), T}}
+    return StructArray([NT(Tuple(get(d, k, NaN) for k in ks)) for d in dicts])
+end
+
 # Default names of algorithms:
 # Workaround for `MethodOfSteps` algorithms, otherwise they are all called "MethodOfSteps"
 # Ideally this would be a trait (in SciMLBase?), so packages could implement it
@@ -193,7 +219,7 @@ Base.lastindex(shoot::ShootoutSet) = lastindex(shoot.shootouts)
     WorkPrecision(
         prob, alg, abstols, reltols, dts = nothing;
         name = nothing, appxsol = nothing, error_estimate = :final,
-        numruns = 20, seconds = 2, kwargs...
+        numruns = 20, seconds = 2, tags = Symbol[], timeout = nothing, kwargs...
     )
 
 Measure error and execution time for `alg` at corresponding absolute and relative
@@ -202,7 +228,9 @@ tolerance pair. The result stores the measured errors, timings, solver statistic
 inputs for plotting a work-precision diagram.
 
 Use `appxsol` as a numerical reference when the problem has no analytic solution.
-Additional keyword arguments are forwarded to `solve`.
+`tags` attaches metadata symbols used by [`filter_by_tags`](@ref) and the plot recipe.
+`timeout` gives a per-tolerance wall-clock budget in seconds; see
+[`WorkPrecisionSet`](@ref). Additional keyword arguments are forwarded to `solve`.
 """
 mutable struct WorkPrecision
     prob::Any
@@ -215,15 +243,38 @@ mutable struct WorkPrecision
     name::Any
     error_estimate::Any
     N::Int
+    tags::Vector{Symbol}
+end
+
+function WorkPrecision(
+        prob, abstols, reltols, errors, times, dts, stats, name, error_estimate, N
+    )
+    return WorkPrecision(
+        prob, abstols, reltols, errors, times, dts, stats, name, error_estimate, N,
+        Symbol[]
+    )
 end
 
 """
-    WorkPrecisionSet(prob, abstols, reltols, setups; kwargs...)
+    WorkPrecisionSet(prob, abstols, reltols, setups; error_estimates = nothing,
+        timeout = nothing, kwargs...)
 
 Build one [`WorkPrecision`](@ref) result for each solver configuration in `setups` so
 their work-precision curves can be compared. Each setup is a dictionary containing an
 `:alg` and may override the shared tolerances or fixed step sizes with `:abstols`,
-`:reltols`, or `:dts`.
+`:reltols`, or `:dts`, or its legend entry with `:name`. A `:tags` entry attaches
+metadata symbols to that setup's curve, which [`filter_by_tags`](@ref),
+[`best_of_families`](@ref), [`autoplot`](@ref) and the plot recipe use to build family
+and cross-family comparisons.
+
+`error_estimates` requests several error metrics from a single run (for example
+`[:final, :l2, :L2]`), so plots for each metric can be drawn without re-solving; the
+computed metrics are reported by [`available_errors`](@ref). `error_estimate` remains
+the metric the plot recipe defaults to.
+
+`timeout` is a per-tolerance wall-clock budget in seconds. A solve is never
+interrupted, but once one exceeds the budget its repeated timing runs are skipped and
+its error and time are recorded as `NaN`, which the plot recipe drops.
 """
 mutable struct WorkPrecisionSet
     wps::Vector{WorkPrecision}
@@ -235,12 +286,37 @@ mutable struct WorkPrecisionSet
     names::Any
     error_estimate::Any
     numruns::Any
+    active_error_estimates::Vector{Symbol}
 end
+
+function WorkPrecisionSet(
+        wps, N, abstols, reltols, prob, setups, names, error_estimate, numruns
+    )
+    return WorkPrecisionSet(
+        wps, N, abstols, reltols, prob, setups, names, error_estimate, numruns,
+        Symbol[error_estimate]
+    )
+end
+
+"""
+    available_errors(wp_set::WorkPrecisionSet) -> Vector{Symbol}
+
+Return the error estimates computed for `wp_set`, i.e. the `error_estimates` requested
+from [`WorkPrecisionSet`](@ref) or, when none were, the single `error_estimate`. Each
+one is a valid `x` for the plot recipe.
+"""
+available_errors(wp_set::WorkPrecisionSet) = wp_set.active_error_estimates
+
+_needs_timeseries(error_estimates) = any(e -> e ∈ TIMESERIES_ERRORS, error_estimates)
+_needs_dense(error_estimates) = any(e -> e ∈ DENSE_ERRORS, error_estimates)
 
 function WorkPrecision(
         prob, alg, abstols, reltols, dts = nothing;
         name = nothing, appxsol = nothing, error_estimate = :final,
-        numruns = 20, seconds = 2, kwargs...
+        numruns = 20, seconds = 2, timeout = nothing,
+        timeseries_errors::Union{Bool, Nothing} = nothing,
+        dense_errors::Union{Bool, Nothing} = nothing,
+        tags::Vector{Symbol} = Symbol[], kwargs...
     )
     N = length(abstols)
     errors = Vector{Dict{Symbol, Float64}}(undef, N)
@@ -259,9 +335,10 @@ function WorkPrecision(
     end
 
     let _prob = _prob
-        timeseries_errors = error_estimate ∈ TIMESERIES_ERRORS
-        dense_errors = error_estimate ∈ DENSE_ERRORS
+        timeseries_errors = something(timeseries_errors, error_estimate ∈ TIMESERIES_ERRORS)
+        dense_errors = something(dense_errors, error_estimate ∈ DENSE_ERRORS)
         for i in 1:N
+            t_start = time()
             if dts === nothing
                 sol = solve(
                     _prob, alg; kwargs..., abstol = abstols[i],
@@ -278,6 +355,12 @@ function WorkPrecision(
             end
 
             stats[i] = sol.stats
+
+            if _timed_out(timeout, time() - t_start, name, abstols[i])
+                errors[i] = _nan_errors()
+                times[i] = NaN
+                continue
+            end
 
             if SciMLBase.successful_retcode(sol)
                 if haskey(kwargs, :prob_choice)
@@ -354,16 +437,14 @@ function WorkPrecision(
                 end
             else
                 # Unsuccessful retcode, give NaN time
-                errors[i] = Dict(
-                    :l∞ => NaN, :L2 => NaN, :final => NaN, :l2 => NaN, :L∞ => NaN
-                )
+                errors[i] = _nan_errors()
                 times[i] = NaN
             end
         end
     end
     return WorkPrecision(
-        prob, abstols, reltols, StructArray(NamedTuple.(errors)),
-        times, dts, stats, name, error_estimate, N
+        prob, abstols, reltols, _dicts_to_structarray(errors),
+        times, dts, stats, name, error_estimate, N, tags
     )
 end
 
@@ -371,7 +452,10 @@ end
 function WorkPrecision(
         prob::AbstractBVProblem, alg, abstols, reltols, dts = nothing;
         name = nothing, appxsol = nothing, error_estimate = :final,
-        numruns = 20, seconds = 2, kwargs...
+        numruns = 20, seconds = 2, timeout = nothing,
+        timeseries_errors::Union{Bool, Nothing} = nothing,
+        dense_errors::Union{Bool, Nothing} = nothing,
+        tags::Vector{Symbol} = Symbol[], kwargs...
     )
     N = length(abstols)
     errors = Vector{Dict{Symbol, Float64}}(undef, N)
@@ -390,9 +474,10 @@ function WorkPrecision(
     end
 
     let _prob = _prob
-        timeseries_errors = error_estimate ∈ TIMESERIES_ERRORS
-        dense_errors = error_estimate ∈ DENSE_ERRORS
+        timeseries_errors = something(timeseries_errors, error_estimate ∈ TIMESERIES_ERRORS)
+        dense_errors = something(dense_errors, error_estimate ∈ DENSE_ERRORS)
         for i in 1:N
+            t_start = time()
             if dts === nothing
                 sol = solve(
                     _prob, alg; kwargs..., abstol = abstols[i],
@@ -409,6 +494,13 @@ function WorkPrecision(
             end
 
             stats[i] = sol.stats
+
+            if _timed_out(timeout, time() - t_start, name, abstols[i])
+                errors[i] = _nan_errors()
+                times[i] = NaN
+                continue
+            end
+
             if SciMLBase.successful_retcode(sol)
                 if haskey(kwargs, :prob_choice)
                     cur_appxsol = appxsol[kwargs[:prob_choice]]
@@ -484,23 +576,22 @@ function WorkPrecision(
                 end
             else
                 # Unsuccessful retcode, give NaN error and time
-                errors[i] = Dict(
-                    :l∞ => NaN, :L2 => NaN, :final => NaN, :l2 => NaN, :L∞ => NaN
-                )
+                errors[i] = _nan_errors()
                 times[i] = NaN
             end
         end
     end
     return WorkPrecision(
-        prob, abstols, reltols, StructArray(NamedTuple.(errors)),
-        times, dts, stats, name, error_estimate, N
+        prob, abstols, reltols, _dicts_to_structarray(errors),
+        times, dts, stats, name, error_estimate, N, tags
     )
 end
 
 # Work precision information for a nonlinear problem.
 function WorkPrecision(
         prob::NonlinearProblem, alg, abstols, reltols, dts = nothing; name = nothing,
-        appxsol = nothing, error_estimate = :l2, numruns = 20, seconds = 2, kwargs...
+        appxsol = nothing, error_estimate = :l2, numruns = 20, seconds = 2,
+        timeout = nothing, tags::Vector{Symbol} = Symbol[], kwargs...
     )
     N = length(abstols)
     errors = Vector{Dict{Symbol, Float64}}(undef, N)
@@ -520,9 +611,16 @@ function WorkPrecision(
 
     let _prob = _prob
         for i in 1:N
+            t_start = time()
             sol = solve(_prob, alg; kwargs..., abstol = abstols[i], reltol = reltols[i])
 
             stats[i] = sol.stats
+
+            if _timed_out(timeout, time() - t_start, name, abstols[i])
+                errors[i] = Dict{Symbol, Float64}(error_estimate => NaN)
+                times[i] = NaN
+                continue
+            end
 
             err = appxsol === nothing ? sol.resid : (sol .- appxsol)
             if error_estimate == :l2
@@ -555,8 +653,8 @@ function WorkPrecision(
     end
 
     return WorkPrecision(
-        prob, abstols, reltols, StructArray(NamedTuple.(errors)),
-        times, dts, stats, name, error_estimate, N
+        prob, abstols, reltols, _dicts_to_structarray(errors),
+        times, dts, stats, name, error_estimate, N, tags
     )
 end
 
@@ -564,15 +662,20 @@ function WorkPrecisionSet(
         prob,
         abstols, reltols, setups;
         print_names = false, names = nothing, appxsol = nothing,
-        error_estimate = :final,
-        test_dt = nothing, kwargs...
+        error_estimate = :final, error_estimates = nothing,
+        test_dt = nothing, timeout = nothing, kwargs...
     )
     N = length(setups)
     @assert names === nothing || length(setups) == length(names)
     wps = Vector{WorkPrecision}(undef, N)
     if names === nothing
-        names = [_default_name(setup[:alg]) for setup in setups]
+        names = [_setup_name(setup) for setup in setups]
     end
+
+    active = error_estimates === nothing ? Symbol[error_estimate] : collect(error_estimates)
+    timeseries_errors = error_estimates === nothing ? nothing : _needs_timeseries(active)
+    dense_errors = error_estimates === nothing ? nothing : _needs_dense(active)
+
     for i in 1:N
         print_names && println(names[i])
         _abstols = get(setups[i], :abstols, abstols)
@@ -584,12 +687,16 @@ function WorkPrecisionSet(
             prob, setups[i][:alg], _abstols, _reltols, _dts;
             appxsol,
             error_estimate,
+            timeout,
+            timeseries_errors,
+            dense_errors,
+            tags = _setup_tags(setups[i]),
             name = names[i], kwargs..., filtered_setup...
         )
     end
     return WorkPrecisionSet(
         wps, N, abstols, reltols, prob, setups, names, error_estimate,
-        nothing
+        nothing, active
     )
 end
 
@@ -658,7 +765,8 @@ function WorkPrecisionSet(
         test_dt = nothing;
         numruns = 20, numruns_error = 20,
         print_names = false, names = nothing, appxsol_setup = nothing,
-        error_estimate = :final, parallel_type = :none,
+        error_estimate = :final, error_estimates = nothing, parallel_type = :none,
+        timeout = nothing,
         kwargs...
     )
     @assert names === nothing || length(setups) == length(names)
@@ -672,7 +780,7 @@ function WorkPrecisionSet(
     times = Array{Float64}(undef, M, N)
     tmp_solutions = Array{Any}(undef, numruns_error, M, N)
     if names === nothing
-        names = [_default_name(setup[:alg]) for setup in setups]
+        names = [_setup_name(setup) for setup in setups]
     end
     time_tmp = Vector{Float64}(undef, numruns)
 
@@ -729,6 +837,7 @@ function WorkPrecisionSet(
         x = isempty(_sol.t) ? 0 : round(Int, mean(_sol.t) - sum(_sol.t) / length(_sol.t))
         GC.gc()
         for j in 1:M
+            timed_out = false
             for i in 1:numruns
                 time_tmp[i] = @elapsed sol = solve(
                     prob, setups[k][:alg];
@@ -738,8 +847,12 @@ function WorkPrecisionSet(
                     timeseries_errors = false,
                     dense_errors = false
                 )
+                if _timed_out(timeout, time_tmp[i], names[k], _abstols[k][j])
+                    timed_out = true
+                    break
+                end
             end
-            times[j, k] = mean(time_tmp) + x
+            times[j, k] = timed_out ? NaN : mean(time_tmp) + x
             GC.gc()
         end
     end
@@ -748,14 +861,16 @@ function WorkPrecisionSet(
     wps = [
         WorkPrecision(
                 prob, _abstols[i], _reltols[i],
-                StructArray(NamedTuple.(errors[i])),
-                times[:, i], _dts[i], stats, names[i], error_estimate, N
+                _dicts_to_structarray(errors[i]),
+                times[:, i], _dts[i], stats, names[i], error_estimate, N,
+                _setup_tags(setups[i])
             )
             for i in 1:N
     ]
     return WorkPrecisionSet(
         wps, N, abstols, reltols, prob, setups, names, error_estimate,
-        numruns_error
+        numruns_error,
+        error_estimates === nothing ? Symbol[error_estimate] : collect(error_estimates)
     )
 end
 
@@ -765,7 +880,8 @@ function WorkPrecisionSet(
         numruns = 5, trajectories = 1000,
         print_names = false, names = nothing, appxsol_setup = nothing,
         expected_value = nothing,
-        error_estimate = :weak_final, ensemblealg = EnsembleThreads(),
+        error_estimate = :weak_final, error_estimates = nothing,
+        ensemblealg = EnsembleThreads(), timeout = nothing,
         kwargs...
     )
     @assert names === nothing || length(setups) == length(names)
@@ -778,7 +894,7 @@ function WorkPrecisionSet(
     times = Array{Float64}(undef, M, N)
     solutions = Array{Any}(undef, M, N)
     if names === nothing
-        names = [_default_name(setup[:alg]) for setup in setups]
+        names = [_setup_name(setup) for setup in setups]
     end
     time_tmp = Vector{Float64}(undef, numruns)
 
@@ -872,6 +988,7 @@ function WorkPrecisionSet(
         #x = isempty(_sol.t) ? 0 : round(Int,mean(_sol.t) - sum(_sol.t)/length(_sol.t))
         GC.gc()
         for j in 1:M
+            timed_out = false
             for i in 1:numruns
                 time_tmp[i] = @elapsed sol = solve(
                     prob, setups[k][:alg], ensemblealg;
@@ -884,8 +1001,12 @@ function WorkPrecisionSet(
                     trajectories = Int(trajectories),
                     kwargs...
                 )
+                if _timed_out(timeout, time_tmp[i], names[k], _abstols[k][j])
+                    timed_out = true
+                    break
+                end
             end
-            times[j, k] = mean(time_tmp) #+ x
+            times[j, k] = timed_out ? NaN : mean(time_tmp) #+ x
             GC.gc()
         end
     end
@@ -893,13 +1014,15 @@ function WorkPrecisionSet(
     wps = [
         WorkPrecision(
                 prob, _abstols[i], _reltols[i], errors[i], times[:, i],
-                _dts[i], stats, names[i], error_estimate, N
+                _dts[i], stats, names[i], error_estimate, N,
+                _setup_tags(setups[i])
             )
             for i in 1:N
     ]
     return WorkPrecisionSet(
         wps, N, abstols, reltols, prob, setups, names, error_estimate,
-        Int(trajectories)
+        Int(trajectories),
+        error_estimates === nothing ? Symbol[error_estimate] : collect(error_estimates)
     )
 end
 
@@ -907,15 +1030,20 @@ function WorkPrecisionSet(
         prob::AbstractBVProblem,
         abstols, reltols, setups;
         print_names = false, names = nothing, appxsol = nothing,
-        error_estimate = :final,
-        test_dt = nothing, kwargs...
+        error_estimate = :final, error_estimates = nothing,
+        test_dt = nothing, timeout = nothing, kwargs...
     )
     N = length(setups)
     @assert names === nothing || length(setups) == length(names)
     wps = Vector{WorkPrecision}(undef, N)
     if names === nothing
-        names = [_default_name(setup[:alg]) for setup in setups]
+        names = [_setup_name(setup) for setup in setups]
     end
+
+    active = error_estimates === nothing ? Symbol[error_estimate] : collect(error_estimates)
+    timeseries_errors = error_estimates === nothing ? nothing : _needs_timeseries(active)
+    dense_errors = error_estimates === nothing ? nothing : _needs_dense(active)
+
     for i in 1:N
         print_names && println(names[i])
         _abstols = get(setups[i], :abstols, abstols)
@@ -927,12 +1055,16 @@ function WorkPrecisionSet(
             prob, setups[i][:alg], _abstols, _reltols, _dts;
             appxsol,
             error_estimate,
+            timeout,
+            timeseries_errors,
+            dense_errors,
+            tags = _setup_tags(setups[i]),
             name = names[i], kwargs..., filtered_setup...
         )
     end
     return WorkPrecisionSet(
         wps, N, abstols, reltols, prob, setups, names, error_estimate,
-        nothing
+        nothing, active
     )
 end
 
@@ -1031,6 +1163,255 @@ function get_sample_errors(
                 sqrt(numruns[i])
         end
     end
+end
+
+## Tagging and filtering
+
+_as_tags(tags) = tags isa Symbol ? (tags,) : Tuple(tags)
+
+"""
+    get_tags(wp_set::WorkPrecisionSet) -> Vector{Vector{Symbol}}
+
+Return the tags of each entry of `wp_set`, in order. Tags come from the `:tags` entry
+of the corresponding setup dictionary.
+"""
+get_tags(wp_set::WorkPrecisionSet) = [wp.tags for wp in wp_set.wps]
+
+"""
+    unique_tags(wp_set::WorkPrecisionSet) -> Vector{Symbol}
+
+Return every tag used by any entry of `wp_set`, sorted and deduplicated.
+"""
+function unique_tags(wp_set::WorkPrecisionSet)
+    alltags = Symbol[]
+    for wp in wp_set.wps
+        append!(alltags, wp.tags)
+    end
+    return unique!(sort!(alltags))
+end
+
+_has_all_tags(wp, tags) = all(t -> t in wp.tags, tags)
+_has_any_tag(wp, tags) = any(t -> t in wp.tags, tags)
+
+"""
+    filter_by_tags(wp_set::WorkPrecisionSet, tags::Symbol...) -> WorkPrecisionSet
+
+Return the entries of `wp_set` tagged with every one of `tags` (AND logic), as a new
+`WorkPrecisionSet`. Passing no tags returns `wp_set` unchanged.
+"""
+function filter_by_tags(wp_set::WorkPrecisionSet, tags::Symbol...)
+    isempty(tags) && return wp_set
+    return _subset_wps(wp_set, findall(wp -> _has_all_tags(wp, tags), wp_set.wps))
+end
+
+"""
+    exclude_by_tags(wp_set::WorkPrecisionSet, tags::Symbol...) -> WorkPrecisionSet
+
+Return the entries of `wp_set` carrying none of `tags` (OR logic on the exclusion), as
+a new `WorkPrecisionSet`. Passing no tags returns `wp_set` unchanged.
+"""
+function exclude_by_tags(wp_set::WorkPrecisionSet, tags::Symbol...)
+    isempty(tags) && return wp_set
+    return _subset_wps(wp_set, findall(wp -> !_has_any_tag(wp, tags), wp_set.wps))
+end
+
+"""
+    merge_wp_sets(sets::WorkPrecisionSet...) -> WorkPrecisionSet
+
+Concatenate the entries of several `WorkPrecisionSet`s into one. The tolerances,
+problem and error estimates are taken from the first set, so merging results computed
+on different problems or tolerance grids gives a set whose metadata describes only the
+first of them.
+"""
+function merge_wp_sets(sets::WorkPrecisionSet...)
+    isempty(sets) && throw(ArgumentError("At least one WorkPrecisionSet is required"))
+    wps = reduce(vcat, [s.wps for s in sets])
+    setups = reduce(vcat, [s.setups for s in sets])
+    names = reduce(vcat, [s.names for s in sets])
+    first_set = first(sets)
+    return WorkPrecisionSet(
+        wps, length(wps), first_set.abstols, first_set.reltols, first_set.prob,
+        setups, names, first_set.error_estimate, first_set.numruns,
+        first_set.active_error_estimates
+    )
+end
+
+function _subset_wps(wp_set::WorkPrecisionSet, indices)
+    isempty(indices) &&
+        @warn "No entries match the requested tags. Returning an empty WorkPrecisionSet."
+    setups = wp_set.setups isa AbstractVector ? wp_set.setups[indices] : wp_set.setups
+    names = wp_set.names isa AbstractVector ? wp_set.names[indices] : wp_set.names
+    return WorkPrecisionSet(
+        wp_set.wps[indices], length(indices), wp_set.abstols, wp_set.reltols,
+        wp_set.prob, setups, names, wp_set.error_estimate, wp_set.numruns,
+        wp_set.active_error_estimates
+    )
+end
+
+# Indices selected by the plot recipe's tag keywords: `tags` narrows (AND), then
+# `include_tags` adds back entries matching all of those tags, then `exclude_tags`
+# drops any entry carrying one of them.
+function _selected_indices(
+        wp_set::WorkPrecisionSet; tags = nothing, include_tags = nothing,
+        exclude_tags = nothing
+    )
+    indices = collect(eachindex(wp_set.wps))
+    if tags !== nothing
+        ts = _as_tags(tags)
+        indices = filter(i -> _has_all_tags(wp_set.wps[i], ts), indices)
+    end
+    if include_tags !== nothing
+        ts = _as_tags(include_tags)
+        extra = findall(wp -> _has_all_tags(wp, ts), wp_set.wps)
+        indices = sort!(union(indices, extra))
+    end
+    if exclude_tags !== nothing
+        ts = _as_tags(exclude_tags)
+        indices = filter(i -> !_has_any_tag(wp_set.wps[i], ts), indices)
+    end
+    return indices
+end
+
+## Best-of-family selection
+
+# (log10(error), log10(time)) for the tolerances that produced a usable measurement,
+# sorted by increasing error.
+function _wp_points(wp::WorkPrecision)
+    errs = getproperty(wp.errors, wp.error_estimate)
+    pts = [
+        (log10(e), log10(t)) for (e, t) in zip(errs, wp.times)
+            if !isnan(e) && !isnan(t) && e > 0 && t > 0
+    ]
+    return sort!(pts; by = first)
+end
+
+function _trapezoid(pts)
+    return sum(
+        0.5 * (pts[i][2] + pts[i - 1][2]) * (pts[i][1] - pts[i - 1][1])
+            for i in 2:length(pts)
+    )
+end
+
+"""
+    wp_area(wp::WorkPrecision) -> Float64
+
+Trapezoidal area under the log₁₀(time)-vs-log₁₀(error) curve of `wp`, using the
+tolerances that produced a usable (positive, non-`NaN`) error and time. Lower is
+better. Returns `Inf` when fewer than two such points exist.
+
+The area grows with the width of the error range covered, so it only compares methods
+that span a similar range; [`best_by_tag`](@ref) normalizes by that width instead.
+"""
+function wp_area(wp::WorkPrecision)
+    pts = _wp_points(wp)
+    length(pts) < 2 && return Inf
+    return _trapezoid(pts)
+end
+
+# Rank key: most usable tolerance points first, then lowest mean log10 time across the
+# error range covered. Ranking on the mean rather than the raw area keeps methods that
+# reach a wider range of accuracies from being penalized for it.
+function _wp_rank(wp::WorkPrecision)
+    pts = _wp_points(wp)
+    length(pts) < 2 && return (-length(pts), Inf)
+    span = pts[end][1] - pts[1][1]
+    span == 0 && return (-length(pts), mean(p[2] for p in pts))
+    return (-length(pts), _trapezoid(pts) / span)
+end
+
+function _best_indices(wp_set::WorkPrecisionSet, tag::Symbol, n::Int, metric::Symbol)
+    metric === :area ||
+        throw(ArgumentError("Unknown metric: $metric. Supported metrics: :area"))
+    candidates = findall(wp -> tag in wp.tags, wp_set.wps)
+    isempty(candidates) && return candidates
+    perm = sortperm([_wp_rank(wp_set.wps[i]) for i in candidates])
+    return candidates[perm[1:min(n, length(perm))]]
+end
+
+"""
+    best_by_tag(wp_set::WorkPrecisionSet, tag::Symbol; n = 1, metric = :area)
+        -> WorkPrecisionSet
+
+Return the `n` best-performing entries of `wp_set` tagged `tag`. With `metric = :area`
+(the only metric currently supported) entries are ranked first by how many tolerances
+produced a usable measurement — so a method that fails at tight tolerances does not win
+on the few points it survived — and then by their mean log₁₀ solve time over the
+log₁₀ error range they cover, i.e. [`wp_area`](@ref) normalized by that range.
+"""
+function best_by_tag(
+        wp_set::WorkPrecisionSet, tag::Symbol; n::Int = 1, metric::Symbol = :area
+    )
+    return _subset_wps(wp_set, _best_indices(wp_set, tag, n, metric))
+end
+
+"""
+    best_of_families(wp_set::WorkPrecisionSet, family_tags; n = 1, metric = :area)
+        -> WorkPrecisionSet
+
+Combine the `n` best entries of each family in `family_tags` (see
+[`best_by_tag`](@ref)) into one `WorkPrecisionSet` for a cross-family comparison. An
+entry belonging to several families is included once. Throws an `ArgumentError` when no
+entry carries any of `family_tags`.
+"""
+function best_of_families(
+        wp_set::WorkPrecisionSet, family_tags; n::Int = 1, metric::Symbol = :area
+    )
+    indices = _best_family_indices(wp_set, family_tags, n, metric)
+    isempty(indices) &&
+        throw(ArgumentError("No entries found for any of the family tags $family_tags"))
+    return _subset_wps(wp_set, indices)
+end
+
+function _best_family_indices(wp_set::WorkPrecisionSet, family_tags, n, metric)
+    indices = Int[]
+    for tag in family_tags
+        append!(indices, _best_indices(wp_set, tag, n, metric))
+    end
+    return sort!(unique!(indices))
+end
+
+## AutoDiff comparison helpers
+
+# Short name of an AD backend, e.g. AutoForwardDiff() -> "ForwardDiff".
+function ad_backend_name(backend)
+    name = string(nameof(typeof(backend)))
+    return startswith(name, "Auto") ? name[5:end] : name
+end
+
+"""
+    with_autodiff_variants(setups; ad_backends, tag_prefix = :autodiff)
+        -> Vector{Dict{Symbol, Any}}
+
+Expand `setups` with one copy per entry of `ad_backends`, each copy replacing `:alg`
+with the same algorithm rebuilt for that backend. Setups whose algorithm takes no
+`autodiff` argument (explicit Runge-Kutta methods, say) are passed through unexpanded.
+
+The originals are kept and tagged `\$(tag_prefix)_default`; each variant is tagged with
+the lowercased backend name, e.g. `:autodiff_forwarddiff` for `AutoForwardDiff()`, and
+named after its backend so the legends stay readable. Existing tags are preserved and
+the input setups are not mutated, so the result plots as an AD comparison via
+`plot(wp_set, tags = [:autodiff_forwarddiff])`.
+"""
+function with_autodiff_variants(setups; ad_backends, tag_prefix::Symbol = :autodiff)
+    result = Vector{Dict{Symbol, Any}}()
+    for setup in setups
+        original = Dict{Symbol, Any}(setup)
+        original[:tags] = [_setup_tags(setup); Symbol(tag_prefix, :_default)]
+        push!(result, original)
+
+        hasfield(typeof(setup[:alg]), :autodiff) || continue
+        for backend in ad_backends
+            variant = Dict{Symbol, Any}(setup)
+            variant[:alg] = remake(setup[:alg]; autodiff = backend)
+            variant[:name] = "$(_setup_name(setup)) ($(ad_backend_name(backend)))"
+            variant[:tags] = [
+                _setup_tags(setup);
+                Symbol(tag_prefix, :_, lowercase(ad_backend_name(backend)))
+            ]
+            push!(result, variant)
+        end
+    end
+    return result
 end
 
 Base.length(wp::WorkPrecision) = wp.N

--- a/lib/DiffEqDevTools/src/plotrecipes.jl
+++ b/lib/DiffEqDevTools/src/plotrecipes.jl
@@ -93,7 +93,7 @@ function key_to_label(key::Symbol)
     elseif key == :maxeig
         return "Maximum eigenvalue recorded"
     else
-        return key
+        return String(key)
     end
 end
 
@@ -102,21 +102,57 @@ end
         x = wp_set.error_estimate,
         y = :times,
         view = :benchmark,
-        color = nothing
+        color = nothing,
+        tags = nothing,
+        include_tags = nothing,
+        exclude_tags = nothing,
+        reference_tags = nothing,
+        reference_style = (linestyle = :dash, linewidth = 1, alpha = 0.5)
     )
+    if tags !== nothing || include_tags !== nothing || exclude_tags !== nothing
+        wp_set = _subset_wps(
+            wp_set,
+            _selected_indices(wp_set; tags, include_tags, exclude_tags)
+        )
+    end
     if view == :benchmark
         seriestype --> :path
-        linewidth --> 3
         xscale --> :log10
         yscale --> :log10
         markershape --> :auto
-        xs = [get_val_from_wp(wp, x) for wp in wp_set.wps]
-        ys = [get_val_from_wp(wp, y) for wp in wp_set.wps]
         xguide --> key_to_label(x)
         yguide --> key_to_label(y)
         legend --> :outerright
-        label --> reshape(wp_set.names, 1, length(wp_set))
-        return xs, ys
+
+        ref_indices = reference_tags === nothing ? Int[] :
+            findall(wp -> _has_any_tag(wp, _as_tags(reference_tags)), wp_set.wps)
+        main_indices = filter(i -> i ∉ ref_indices, eachindex(wp_set.wps))
+        if isempty(ref_indices) || isempty(main_indices)
+            # One uniform group: nothing to contrast the references against.
+            linewidth --> 3
+            label --> reshape([wp.name for wp in wp_set.wps], 1, length(wp_set.wps))
+            return [get_val_from_wp(wp, x) for wp in wp_set.wps],
+                [get_val_from_wp(wp, y) for wp in wp_set.wps]
+        end
+        # One series per curve, references first: a matrix-valued attribute would be
+        # cycled by the plot-wide series index and so would not line up with two
+        # groups of different sizes.
+        for i in ref_indices
+            @series begin
+                linewidth --> get(reference_style, :linewidth, 1)
+                linestyle --> get(reference_style, :linestyle, :dash)
+                seriesalpha --> get(reference_style, :alpha, 0.5)
+                label --> wp_set.wps[i].name
+                get_val_from_wp(wp_set.wps[i], x), get_val_from_wp(wp_set.wps[i], y)
+            end
+        end
+        for i in main_indices
+            @series begin
+                linewidth --> 3
+                label --> wp_set.wps[i].name
+                get_val_from_wp(wp_set.wps[i], x), get_val_from_wp(wp_set.wps[i], y)
+            end
+        end
     elseif view == :dt_convergence
         idts = filter(i -> haskey(wp_set.setups[i], :dts), 1:length(wp_set))
         length(idts) > 0 ||

--- a/lib/DiffEqDevTools/test/multi_error_tests.jl
+++ b/lib/DiffEqDevTools/test/multi_error_tests.jl
@@ -1,0 +1,53 @@
+using OrdinaryDiffEq, DiffEqDevTools, Test
+using OrdinaryDiffEqLowOrderRK: DP5, RK4
+using ODEProblemLibrary: prob_ode_linear
+
+prob = prob_ode_linear
+abstols = 1 ./ 10 .^ (3:6)
+reltols = 1 ./ 10 .^ (3:6)
+setups = [Dict{Symbol, Any}(:alg => DP5())]
+
+@testset "one error estimate (the default)" begin
+    wp_set = WorkPrecisionSet(prob, abstols, reltols, setups; numruns = 2)
+    @test available_errors(wp_set) == [:final]
+    @test propertynames(wp_set[1].errors) == (:final,)
+end
+
+@testset "several error estimates from one run" begin
+    wp_set = WorkPrecisionSet(
+        prob, abstols, reltols, setups; numruns = 2,
+        error_estimates = [:final, :l2, :L2]
+    )
+    @test available_errors(wp_set) == [:final, :l2, :L2]
+    for e in available_errors(wp_set)
+        @test all(isfinite, getproperty(wp_set[1].errors, e))
+    end
+end
+
+@testset "positional constructors without the new fields" begin
+    wp = WorkPrecision(prob, DP5(), abstols, reltols; name = "DP5", numruns = 2)
+    bare = WorkPrecision(
+        prob, abstols, reltols, wp.errors, wp.times, wp.dts, wp.stats, "DP5", :final,
+        length(abstols)
+    )
+    @test isempty(bare.tags)
+
+    wp_set = WorkPrecisionSet(
+        [wp], 1, abstols, reltols, prob, setups, ["DP5"], :final, nothing
+    )
+    @test available_errors(wp_set) == [:final]
+end
+
+@testset "tolerances that fail keep the successful ones plottable" begin
+    # Regression test: a failed solve records every error key while a successful one
+    # records only the requested estimate, which StructArrays 0.7 rejects unless the
+    # key sets are reconciled.
+    wp = WorkPrecision(
+        prob, RK4(), [1.0e-3, 1.0e-14], [1.0e-3, 1.0e-14];
+        name = "RK4", numruns = 2, maxiters = 300
+    )
+    @test !isnan(wp.times[1])
+    @test isnan(wp.times[2])
+    @test isfinite(wp.errors.final[1])
+    @test isnan(wp.errors.final[2])
+end

--- a/lib/DiffEqDevTools/test/plotrecipes_tests.jl
+++ b/lib/DiffEqDevTools/test/plotrecipes_tests.jl
@@ -1,6 +1,10 @@
 using Test
 using OrdinaryDiffEq, StochasticDiffEq, DiffEqDevTools, Plots
 import SDEProblemLibrary: prob_sde_additivesystem
+import ODEProblemLibrary: prob_ode_linear
+using OrdinaryDiffEqLowOrderRK: Euler, Heun, BS3, DP5
+using OrdinaryDiffEqTsit5: Tsit5
+using OrdinaryDiffEqRosenbrock: Rosenbrock23
 
 using Random
 Random.seed!(123)
@@ -85,6 +89,52 @@ gr()
     @test_nowarn plot(
         wp, view = :dt_convergence, color = :lightblue, title = "Δt Convergence"
     )
+end
+
+@testset "Tag-based plotting" begin
+    prob = prob_ode_linear
+    abstols = 1.0 ./ 10.0 .^ (3:6)
+    reltols = 1.0 ./ 10.0 .^ (3:6)
+
+    setups = [
+        Dict{Symbol, Any}(:alg => DP5(), :tags => [:rk, :fifth_order]),
+        Dict{Symbol, Any}(:alg => Tsit5(), :tags => [:rk, :fifth_order]),
+        Dict{Symbol, Any}(:alg => BS3(), :tags => [:rk, :third_order]),
+        Dict{Symbol, Any}(:alg => Rosenbrock23(), :tags => [:rosenbrock, :reference]),
+    ]
+    wp = WorkPrecisionSet(
+        prob, abstols, reltols, setups; numruns = 2, error_estimates = [:final, :l2]
+    )
+    @test available_errors(wp) == [:final, :l2]
+
+    labels(plt) = [series[:label] for series in plt.series_list]
+
+    @test labels(@test_nowarn plot(wp, tags = [:fifth_order])) == ["DP5", "Tsit5"]
+    @test labels(@test_nowarn plot(wp, exclude_tags = [:reference])) ==
+        ["DP5", "Tsit5", "BS3"]
+    @test labels(@test_nowarn plot(wp, tags = [:third_order], include_tags = [:reference])) ==
+        ["BS3", "Rosenbrock23"]
+    @test labels(@test_nowarn plot(wp, tags = :fifth_order)) == ["DP5", "Tsit5"]
+
+    @testset "reference styling" begin
+        plt = @test_nowarn plot(
+            wp, reference_tags = [:reference],
+            reference_style = (linestyle = :dot, linewidth = 2, alpha = 0.25)
+        )
+        # References are drawn first, in their own style
+        @test labels(plt) == ["Rosenbrock23", "DP5", "Tsit5", "BS3"]
+        @test plt[1][1][:linestyle] == :dot
+        @test plt[1][1][:linewidth] == 2
+        @test plt[1][1][:seriesalpha] == 0.25
+        @test plt[1][2][:linewidth] == 3
+        @test plt[1][1][:x] ≈ getproperty(wp[4].errors, wp[4].error_estimate)
+    end
+
+    # With nothing to contrast against, references are still drawn
+    @test labels(@test_nowarn plot(wp, tags = [:reference], reference_tags = [:reference])) ==
+        ["Rosenbrock23"]
+
+    @test labels(@test_nowarn plot(wp, x = :l2, tags = [:rk])) == ["DP5", "Tsit5", "BS3"]
 end
 
 @testset "SDE WorkPrecisionSet" begin

--- a/lib/DiffEqDevTools/test/runtests.jl
+++ b/lib/DiffEqDevTools/test/runtests.jl
@@ -42,4 +42,16 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @testset "Plot Recipes (Nonlinearsolve WP-diagrams)" begin
         include("nonlinearsolve_wpdiagram_tests.jl")
     end
+    @time @testset "Tagging" begin
+        include("tagging_tests.jl")
+    end
+    @time @testset "Multiple Error Estimates" begin
+        include("multi_error_tests.jl")
+    end
+    @time @testset "Best-of-Family Selection" begin
+        include("wp_selection_tests.jl")
+    end
+    @time @testset "Timeout" begin
+        include("timeout_tests.jl")
+    end
 end

--- a/lib/DiffEqDevTools/test/tagging_tests.jl
+++ b/lib/DiffEqDevTools/test/tagging_tests.jl
@@ -1,0 +1,64 @@
+using OrdinaryDiffEq, DiffEqDevTools, Test
+using OrdinaryDiffEqLowOrderRK: Euler, Midpoint, BS3, DP5, RK4
+using ODEProblemLibrary: prob_ode_linear
+
+prob = prob_ode_linear
+abstols = 1 ./ 10 .^ (3:6)
+reltols = 1 ./ 10 .^ (3:6)
+
+setups = [
+    Dict{Symbol, Any}(:alg => RK4(), :tags => [:rk, :fourth_order]),
+    Dict{Symbol, Any}(:alg => DP5(), :tags => [:rk, :fifth_order]),
+    Dict{Symbol, Any}(:alg => BS3(), :tags => [:rk, :third_order]),
+    Dict{Symbol, Any}(:alg => Euler(), :tags => [:euler, :first_order, :reference]),
+    Dict{Symbol, Any}(:alg => Midpoint()),
+]
+wp_set = WorkPrecisionSet(prob, abstols, reltols, setups; dt = 1 / 2^4, numruns = 2)
+
+@testset "tags reach the WorkPrecision entries" begin
+    @test get_tags(wp_set) == [
+        [:rk, :fourth_order], [:rk, :fifth_order], [:rk, :third_order],
+        [:euler, :first_order, :reference], Symbol[],
+    ]
+    @test unique_tags(wp_set) ==
+        sort([:rk, :fourth_order, :fifth_order, :third_order, :euler, :first_order, :reference])
+
+    wp = WorkPrecision(
+        prob, DP5(), abstols, reltols; name = "DP5", numruns = 2,
+        tags = [:rk, :fifth_order]
+    )
+    @test wp.tags == [:rk, :fifth_order]
+    @test isempty(WorkPrecision(prob, DP5(), abstols, reltols; numruns = 2).tags)
+end
+
+@testset "filter_by_tags" begin
+    for (tags, expected) in [
+            ((:rk,), ["RK4", "DP5", "BS3"]),
+            ((:rk, :fifth_order), ["DP5"]),
+            ((:reference,), ["Euler"]),
+        ]
+        subset = filter_by_tags(wp_set, tags...)
+        @test subset.names == expected
+        @test [wp.name for wp in subset.wps] == expected
+        # setups stay aligned with the entries that survived the filter
+        @test [string(nameof(typeof(s[:alg]))) for s in subset.setups] == expected
+    end
+
+    @test length(@test_logs (:warn,) filter_by_tags(wp_set, :nonexistent)) == 0
+    @test length(filter_by_tags(wp_set)) == length(wp_set)
+end
+
+@testset "exclude_by_tags" begin
+    @test exclude_by_tags(wp_set, :reference).names == ["RK4", "DP5", "BS3", "Midpoint"]
+    @test exclude_by_tags(wp_set, :rk, :reference).names == ["Midpoint"]
+    @test length(exclude_by_tags(wp_set)) == length(wp_set)
+end
+
+@testset "merge_wp_sets" begin
+    merged = merge_wp_sets(filter_by_tags(wp_set, :euler), filter_by_tags(wp_set, :rk))
+    @test length(merged) == 4
+    @test merged.names == ["Euler", "RK4", "DP5", "BS3"]
+    @test get_tags(merged)[1] == [:euler, :first_order, :reference]
+    @test available_errors(merged) == available_errors(wp_set)
+    @test_throws ArgumentError merge_wp_sets()
+end

--- a/lib/DiffEqDevTools/test/timeout_tests.jl
+++ b/lib/DiffEqDevTools/test/timeout_tests.jl
@@ -1,0 +1,34 @@
+using OrdinaryDiffEq, DiffEqDevTools, Test
+using OrdinaryDiffEqLowOrderRK: RK4
+using ODEProblemLibrary: prob_ode_linear
+
+prob = prob_ode_linear
+abstols = 1 ./ 10 .^ (3:6)
+reltols = 1 ./ 10 .^ (3:6)
+
+@testset "no timeout leaves every point measured" begin
+    wp = WorkPrecision(
+        prob, RK4(), abstols, reltols; name = "RK4", dt = 1 / 2^4, numruns = 2,
+        timeout = nothing
+    )
+    @test !any(isnan, wp.times)
+end
+
+@testset "an exceeded budget records NaN" begin
+    wp = @test_logs (:warn,) (:warn,) (:warn,) (:warn,) WorkPrecision(
+        prob, RK4(), abstols, reltols; name = "RK4", dt = 1 / 2^4, numruns = 2,
+        timeout = 0.0
+    )
+    @test all(isnan, wp.times)
+    @test all(isnan, wp.errors.final)
+    # the solve that blew the budget still ran, so its statistics are kept
+    @test all(!isnothing, wp.stats)
+end
+
+@testset "WorkPrecisionSet forwards the budget" begin
+    setups = [Dict{Symbol, Any}(:alg => RK4())]
+    wp_set = @test_logs (:warn,) (:warn,) (:warn,) (:warn,) WorkPrecisionSet(
+        prob, abstols, reltols, setups; dt = 1 / 2^4, numruns = 2, timeout = 0.0
+    )
+    @test all(isnan, wp_set[1].times)
+end

--- a/lib/DiffEqDevTools/test/wp_selection_tests.jl
+++ b/lib/DiffEqDevTools/test/wp_selection_tests.jl
@@ -1,0 +1,124 @@
+using OrdinaryDiffEq, DiffEqDevTools, Test
+using OrdinaryDiffEqLowOrderRK: Euler, BS3, DP5, RK4
+using OrdinaryDiffEqTsit5: Tsit5
+using OrdinaryDiffEqRosenbrock: Rosenbrock23
+using OrdinaryDiffEqSDIRK: TRBDF2
+using DiffEqDevTools: _default_name
+using ODEProblemLibrary: prob_ode_linear
+
+prob = prob_ode_linear
+abstols = 1 ./ 10 .^ (3:6)
+reltols = 1 ./ 10 .^ (3:6)
+
+setups = [
+    Dict{Symbol, Any}(:alg => RK4(), :tags => [:rk, :fourth_order]),
+    Dict{Symbol, Any}(:alg => DP5(), :tags => [:rk, :fifth_order]),
+    Dict{Symbol, Any}(:alg => Tsit5(), :tags => [:rk, :fifth_order]),
+    Dict{Symbol, Any}(:alg => BS3(), :tags => [:rk, :third_order]),
+    Dict{Symbol, Any}(:alg => Euler(), :tags => [:euler, :first_order, :reference]),
+]
+wp_set = WorkPrecisionSet(prob, abstols, reltols, setups; dt = 1 / 2^4, numruns = 2)
+
+@testset "wp_area" begin
+    @test all(isfinite, wp_area.(wp_set.wps))
+
+    # A curve with fewer than two usable points has no area to integrate.
+    lonely = deepcopy(wp_set[1])
+    lonely.times = [NaN; fill(NaN, length(lonely.times) - 2); 1.0]
+    @test wp_area(lonely) == Inf
+end
+
+@testset "best_by_tag" begin
+    @test length(best_by_tag(wp_set, :rk; n = 2)) == 2
+    @test best_by_tag(wp_set, :euler).names == ["Euler"]
+    @test length(@test_logs (:warn,) best_by_tag(wp_set, :nonexistent)) == 0
+    @test_throws ArgumentError best_by_tag(wp_set, :rk; metric = :unknown)
+
+    # `n` truncates one ranking rather than re-ranking each time
+    @test best_by_tag(wp_set, :rk; n = 2).names == best_by_tag(wp_set, :rk; n = 4).names[1:2]
+
+    # Ranking prefers the method that produced usable results at every tolerance.
+    crippled = deepcopy(wp_set)
+    crippled.wps[2].times = [crippled.wps[2].times[1]; fill(NaN, length(abstols) - 1)]
+    @test "DP5" ∉ best_by_tag(crippled, :rk; n = 3).names
+end
+
+@testset "best_of_families" begin
+    best = best_of_families(wp_set, [:rk, :euler]; n = 1)
+    @test length(best) == 2
+    @test "Euler" in best.names
+    @test_throws ArgumentError best_of_families(wp_set, [:nonexistent])
+
+    # A method in two families is included once
+    overlapping = best_of_families(wp_set, [:rk, :fifth_order]; n = 5)
+    @test length(overlapping) == 4
+    @test allunique(overlapping.names)
+end
+
+@testset "autoplot" begin
+    plots = autoplot(wp_set; families = [:rk, :euler])
+    @test sort(collect(keys(plots))) == ["all", "best_of_families", "family_euler", "family_rk"]
+    @test length(plots["family_rk"]) == 4
+    @test length(plots["family_euler"]) == 1
+    @test plots["all"] === wp_set
+    @test length(plots["best_of_families"]) == 3  # best 2 of :rk, and the lone :euler
+
+    @testset "reference methods join every family" begin
+        plots = autoplot(wp_set; families = [:rk], reference_tags = :reference)
+        @test plots["family_rk"].names == ["RK4", "DP5", "Tsit5", "BS3", "Euler"]
+        @test "Euler" in plots["best_of_families"].names
+    end
+
+    @testset "auto-detected families" begin
+        # :rk is on 4/5 entries, :fifth_order on 2/5; a tag on every entry is dropped
+        @test DiffEqDevTools._auto_detect_families(wp_set) == unique_tags(wp_set)
+        uniform = filter_by_tags(wp_set, :rk)
+        @test :rk ∉ DiffEqDevTools._auto_detect_families(uniform)
+        @test haskey(autoplot(wp_set), "family_fifth_order")
+    end
+
+    @testset "families with no entries are skipped" begin
+        plots = autoplot(wp_set; families = [:rk, :nonexistent])
+        @test !haskey(plots, "family_nonexistent")
+    end
+end
+
+@testset "with_autodiff_variants" begin
+    original = Dict{Symbol, Any}(:alg => Rosenbrock23(), :tags => [:rosenbrock])
+    expanded = with_autodiff_variants(
+        [original, Dict{Symbol, Any}(:alg => TRBDF2()), Dict{Symbol, Any}(:alg => Tsit5())];
+        ad_backends = [AutoForwardDiff(), AutoFiniteDiff()]
+    )
+
+    @test DiffEqDevTools.ad_backend_name(AutoForwardDiff()) == "ForwardDiff"
+
+    # two implicit setups expand to three entries each, Tsit5 takes no autodiff
+    @test length(expanded) == 7
+    @test expanded[1][:tags] == [:rosenbrock, :autodiff_default]
+    @test expanded[2][:tags] == [:rosenbrock, :autodiff_forwarddiff]
+    @test expanded[2][:alg].autodiff isa AutoForwardDiff
+    @test expanded[3][:alg].autodiff isa AutoFiniteDiff
+    @test expanded[3][:name] == "Rosenbrock23 (FiniteDiff)"
+    @test expanded[7][:tags] == [:autodiff_default]
+    @test _default_name(expanded[7][:alg]) == "Tsit5"
+    @test !haskey(expanded[1], :name)
+
+    @test original[:tags] == [:rosenbrock]  # inputs are not mutated
+
+    @test with_autodiff_variants(
+        [original]; ad_backends = [AutoForwardDiff()], tag_prefix = :ad
+    )[1][:tags] == [:rosenbrock, :ad_default]
+
+    @testset "the variants reach the benchmark" begin
+        ad_set = WorkPrecisionSet(
+            prob, abstols, reltols,
+            with_autodiff_variants(
+                [Dict{Symbol, Any}(:alg => Rosenbrock23())];
+                ad_backends = [AutoFiniteDiff()]
+            ); numruns = 2
+        )
+        @test ad_set.names == ["Rosenbrock23", "Rosenbrock23 (FiniteDiff)"]
+        @test get_tags(ad_set) == [[:autodiff_default], [:autodiff_finitediff]]
+        @test ad_set.setups[2][:alg].autodiff isa AutoFiniteDiff
+    end
+end


### PR DESCRIPTION
> Draft — please ignore until reviewed by @ChrisRackauckas.

## What changed and why

Implements phases 1–7 of https://github.com/SciML/DiffEqDevTools.jl/issues/177 for the
`lib/DiffEqDevTools` sublibrary: setups carry `:tags`, one `WorkPrecisionSet` run can
compute several error metrics, and the tagged result can be sliced into per-family,
cross-family and reference-overlay plots without re-solving anything.

This is a rebase and repair of the original branch, which was written against `master`
from 2026-03-30 and no longer applied. Beyond the mechanical rebase, several parts of it
did not do what they claimed; those are called out under "Corrections" below.

New public API (all keyword-only, all defaults preserve current behavior):

| | |
|---|---|
| `:tags` / `:name` entries in a setup dict | attach metadata and a legend label to one curve |
| `filter_by_tags`, `exclude_by_tags`, `get_tags`, `unique_tags`, `merge_wp_sets` | slice and combine tagged sets |
| `error_estimates = [...]`, `available_errors` | several error metrics from one run |
| `plot(wp_set; tags, include_tags, exclude_tags, reference_tags, reference_style)` | tag-based subsetting and de-emphasized baselines |
| `wp_area`, `best_by_tag`, `best_of_families` | pick the standout methods per family |
| `timeout` | drop points whose solve blew a wall-clock budget |
| `with_autodiff_variants` | build AD-backend comparison setups |
| `autoplot` | all of the standard subsets at once, as `Dict{String, WorkPrecisionSet}` |

`WorkPrecision` gains a `tags` field and `WorkPrecisionSet` an `active_error_estimates`
field; both keep a positional constructor with the old arity, so existing positional
construction still works. `DiffEqDevTools` 3.3.0 → 3.4.0 (3.3.0 was taken by #4298 and
is registered).

## Corrections to the original branch

1. **`with_autodiff_variants` produced variants that were byte-identical to the
   originals.** It set `setup[:autodiff]`, but `WorkPrecisionSet` filters setups through
   `filter(p -> p.first in SciMLBase.allowedkeywords, setup)` and `:autodiff` is not a
   solve keyword — it is an algorithm field. The variants never reached `solve` and the
   plot would have drawn N identical curves. It now rebuilds the algorithm with
   `remake(alg; autodiff = backend)`, passes through setups whose algorithm has no
   `autodiff` field, and names each variant after its backend. The AD plot below shows
   the curves actually separating.
2. **Mixed error keys crashed the `StructArray` build.** A failed tolerance records five
   error keys while a successful one records only the requested estimate, so
   `StructArray(NamedTuple.(errors))` widens to `Vector{NamedTuple}` and StructArrays
   0.7 rejects it. This is a live bug on `master` (compat is `"0.6, 0.7"`); failing/passing
   evidence below.
3. **Reference-method labels were shifted.** Plots cycles a matrix-valued attribute by
   the plot-wide series index, so a reference group of a different size than the main
   group mislabels every curve in the second group (observed: `Rosenbrock23, Tsit5, BS3,
   DP5` for data in the order `Rosenbrock23, DP5, Tsit5, BS3`). The recipe now emits one
   series per curve when `reference_tags` is used.
4. **A recipe with only reference curves, or with none, returned a malformed recipe**;
   both cases now fall back to a single uniform group.
5. **Subsetting kept the parent's `setups`/`names`**, so `wp_set.setups[i]` no longer
   described `wp_set.wps[i]` after filtering (in `autoplot`'s reference merge and the
   recipe's `include_tags`). All subsetting is now index-based through one helper, and
   `active_error_estimates` survives it.
6. **Best-of-family ranked on the raw log–log area**, which grows with the width of the
   error range a method covers, so a method that failed at tight tolerances could win on
   the few points it survived. Ranking is now by usable-point count first, then mean
   log₁₀ time over the covered log₁₀ error range. `wp_area` is kept and documented as the
   raw area.
7. `key_to_label` returned a `Symbol` instead of a `String` for unknown keys.

Rebase-specific: `DiffEqBase.allowedkeywords`/`has_analytic` → `SciMLBase.`, Runic
formatting, and the new tests import algorithms from their sublibraries (the umbrella
`OrdinaryDiffEq` no longer blanket-reexports them). Rebased again onto `6c53eafe2`,
resolving into master's newer style sweeps (#4295 runic docstrings, #4299 keyword
shorthand): the keyword variables are rebound in place so `solve(...; timeseries_errors,
dense_errors)` stays in shorthand form rather than reintroducing `x = x`.

## Example plots

One `WorkPrecisionSet` run over HIRES with 10 tagged methods (82s, `error_estimates =
[:final, :l2, :L2]`) produces every plot below with no further solving.

The script that produced them is
[`example_plots.jl`](https://raw.githubusercontent.com/ChrisRackauckas-Claude/OrdinaryDiffEq.jl/wp-tagging-example-plots/example_plots.jl) on the same branch as the images.

**Everything, in one plot — the thing tags exist to avoid.**

![all methods](https://raw.githubusercontent.com/ChrisRackauckas-Claude/OrdinaryDiffEq.jl/wp-tagging-example-plots/01_all_methods.png)

**`autoplot(wp_set; families = [:rosenbrock, :sdirk, :bdf], reference_tags = :reference)`.**
One subset per family, each with `RadauIIA5` overlaid in the de-emphasized reference
style.

![families](https://raw.githubusercontent.com/ChrisRackauckas-Claude/OrdinaryDiffEq.jl/wp-tagging-example-plots/02_autoplot_families.png)

**`autoplot(...)["best_of_families"]`** — the best two of each family plus the
reference, ranked by usable points then mean log-time.

![best of families](https://raw.githubusercontent.com/ChrisRackauckas-Claude/OrdinaryDiffEq.jl/wp-tagging-example-plots/03_best_of_families.png)

**`error_estimates = [:final, :l2, :L2]`** — three metrics, one run, `plot(wp_set, x = ...)`.

![error estimates](https://raw.githubusercontent.com/ChrisRackauckas-Claude/OrdinaryDiffEq.jl/wp-tagging-example-plots/04_error_estimates.png)

**`with_autodiff_variants(...; ad_backends = [AutoFiniteDiff()])`** with the FiniteDiff
variants tagged as references so they render dashed. The curves separate, which is the
check that the variants now actually reach `solve`.

![autodiff](https://raw.githubusercontent.com/ChrisRackauckas-Claude/OrdinaryDiffEq.jl/wp-tagging-example-plots/05_autodiff_comparison.png)

**`timeout = 0.003`** — Rosenbrock23's two tightest tolerances blew the 3 ms budget and
were recorded as `NaN`, so the curve stops; Rodas5P is unaffected.

![timeout](https://raw.githubusercontent.com/ChrisRackauckas-Claude/OrdinaryDiffEq.jl/wp-tagging-example-plots/06_timeout.png)

## Verification

Everything below was run locally on Julia 1.12.4.

### `GROUP=Core` (`lib/DiffEqDevTools`)

```
Test Summary:   | Pass  Total     Time
Benchmark Tests |   15     15  5m29.4s
Test Summary:      | Pass  Total  Time
ODE AppxTrue Tests |    7      7  6.5s
Test Summary:                  | Pass  Total      Time
Analyticless Convergence Tests |    7      7  11m32.7s
Test Summary:              | Pass  Total      Time
Analyticless Stochastic WP |    2      2  42m19.7s
Test Summary:                | Pass  Total   Time
Convergence retain_solutions |   35     35  15.3s
Test Summary:          | Pass  Total   Time
Stability Region Tests |    7      7  17.9s
Test Summary: | Pass  Total     Time
Plot Recipes  |   56     56  4m56.9s
Test Summary:                             | Pass  Total  Time
Plot Recipes (Nonlinearsolve WP-diagrams) |    6      6  9.9s
Test Summary: | Pass  Total  Time
Tagging       |   24     24  9.4s
Test Summary:            | Pass  Total  Time
Multiple Error Estimates |   12     12  3.4s
Test Summary:            | Pass  Total  Time
Best-of-Family Selection |   40     40  9.4s
Test Summary: | Pass  Total  Time
Timeout       |    7      7  9.6s
     Testing DiffEqDevTools tests passed
```

### `GROUP=QA`

```
Test Summary: | Pass  Total     Time
Aqua          |   15     15  47.2s
     Testing DiffEqDevTools tests passed
```

The QA lane enforces that every exported name has a docstring and a ```@docs``` entry.
I checked the check itself: dropping `DiffEqDevTools.autoplot` from
`docs/src/devtools/alg_dev/benchmarks.md` turns it red.

```
public API is rendered in docs: Test Failed at SciMLTesting.jl:1707
   Evaluated: isempty([:autoplot])
```

Since #4280 dropped the `docs_src` override in `test/qa/qa.jl`, the check resolves the
manual itself; the new entries are in both `docs/src/devtools/alg_dev/benchmarks.md` and
`lib/DiffEqDevTools/docs/src/index.md`, so either resolution covers them.

### Failing before / passing after, for correction 2

```julia
wp = WorkPrecision(prob_ode_linear, RK4(), [1e-3, 1e-14], [1e-3, 1e-14];
                   name = "RK4", numruns = 2, maxiters = 300)
```

On `master`:

```
ERROR: LoadError: MethodError: no method matching strip_params(::Type{NamedTuple})
 [7] WorkPrecision(...)
   @ DiffEqDevTools lib/DiffEqDevTools/src/benchmark.jl:358
```

On this branch:

```
times  = [1.005e-5, NaN]
errors = [1.4612724786866593e-5, NaN]
```

That case is now `lib/DiffEqDevTools/test/multi_error_tests.jl`, "tolerances that fail
keep the successful ones plottable".

### Formatting and spelling

```
$ julia --project=@runic -e 'using Runic; exit(Runic.main(["--check","lib/DiffEqDevTools/"]))'   # clean
$ typos lib/DiffEqDevTools docs/src/devtools/alg_dev/benchmarks.md                               # clean
```

### Docs build

Clean, under the strict `checkdocs = :public` that #4315 turned on:

```
$ julia --project=docs -e 'using Pkg; Pkg.resolve()' && julia --project=docs docs/make.jl
...
[ Info: HTMLWriter: rendering HTML pages.
[ Info: Automatic `version="7.6.0"` for inventory from ../Project.toml
```

Zero `Error:` lines; the only warning is "skipping deployment", expected outside CI. The
`has_global_error` cross-reference that used to break this build was fixed separately in
#4289, which is now on `master`.

Note the `Pkg.resolve()`: with a stale `docs/Manifest.toml` the build reports four
spurious "no docs found" errors for `StochasticDiffEqHighOrder`/`StochasticDiffEqROCK`
names that disappear once the manifest matches the project.

## Not verified

- GPU, downstream and `julia pre` lanes were not run locally.
- The RODE/SDE and ensemble `WorkPrecisionSet` methods got the same `timeout`, `:tags`
  and `error_estimates` plumbing, but only the existing suite
  (`analyticless_stochastic_wp.jl`) exercises them; there is no new test for a weak-error
  timeout.
- `timeout` cannot interrupt a solve in progress. It skips the repeat timing runs for a
  tolerance whose first solve blew the budget and marks the point `NaN`. Issue #177 also
  asks for a hard process-level cutoff via `Distributed`; that is not in this PR.

## Worth pushing back on

- `_auto_detect_families` drops any tag carried by more than 80% of the entries. The
  cutoff is arbitrary; it exists so that a benchmark-wide tag like `:stiff` is not
  treated as a family. Explicit `families = [...]` bypasses it.
- Ranking usable-point count ahead of speed means a slow-but-complete curve beats a
  fast-but-truncated one. That is the right default for "best of family", but it is a
  policy choice.
- `merge_wp_sets` takes tolerances, problem and error estimates from the first set, so
  merging results from different problems yields metadata describing only one of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
