### PR TITLE
Fix DelayDiffEq version to 5.70.0

### DIFF
--- a/lib/DelayDiffEq/Project.toml
+++ b/lib/DelayDiffEq/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "5.71.0"
+version = "5.70.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"


### PR DESCRIPTION
Version was 5.71.0 on master but the last registered version is 5.69.0 — the registry requires sequential versions and rejects the skip to 5.71.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)