### PR TITLE
Fix deprecated AbstractDiffEqArray integer indexing for RecursiveArrayTools v4

### DIFF
--- a/lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl
@@ -23,7 +23,7 @@ function ad_helper(alg, prob)
     return function costoop(p)
         _oprob = remake(prob; p)
         sol = solve(_oprob, alg, saveat = 1:10)
-        return sum(sol)
+        return sum(sum, sol.u)
     end
 end
 

--- a/lib/OrdinaryDiffEqBDF/test/dae_ad_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/dae_ad_tests.jl
@@ -69,7 +69,7 @@ end
             remake(_prob, p = p), alg, abstol = 1.0e-14,
             reltol = 1.0e-14, initializealg = initalg
         )
-        sum(sol)
+        sum(sum, sol.u)
     end
     @test DI.gradient(f_loss, AutoForwardDiff(), [0.04, 3.0e7, 1.0e4]) ≈ [0, 0, 0] atol = 1.0e-8
 end

--- a/lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_krylov_tests.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_krylov_tests.jl
@@ -92,7 +92,7 @@ let N = 20
             sol1(interp_results, interp_points)
             sol2 = solve(prob, alg, dt = 1 / 16, dense = true, adaptive = false)
             for i in eachindex(sol2)
-                err = maximum(abs.(sol2[i] - interp_results[i]))
+                err = maximum(abs.(sol2.u[i] - interp_results[i]))
                 @test err < tol
             end
         end

--- a/lib/OrdinaryDiffEqLinear/test/linear_method_tests.jl
+++ b/lib/OrdinaryDiffEqLinear/test/linear_method_tests.jl
@@ -246,7 +246,7 @@ prob = SplitODEProblem(f, η, tspan)
 sol = solve(prob, CayleyEuler(), dt = 1 / 10)
 
 @test sol.retcode == ReturnCode.Success
-eig_err = [norm(eigvals(sol[i]) - eigvals(η)) for i in eachindex(sol)]
+eig_err = [norm(eigvals(sol.u[i]) - eigvals(η)) for i in eachindex(sol.u)]
 @test all(≈(e, 0, atol = 1.0e-13) for e in eig_err)
 
 test_setup = Dict(:alg => Vern9(), :reltol => 1.0e-14, :abstol => 1.0e-14)
@@ -260,7 +260,7 @@ prob = SplitODEProblem(f, η, tspan)
 sol = solve(prob, CayleyEuler(), dt = 1 / 10)
 
 @test sol.retcode == ReturnCode.Success
-eig_err = [norm(eigvals(sol[i]) - eigvals(η)) for i in eachindex(sol)]
+eig_err = [norm(eigvals(sol.u[i]) - eigvals(η)) for i in eachindex(sol.u)]
 @test all(≈(e, 0, atol = 1.0e-13) for e in eig_err)
 
 test_setup = Dict(:alg => Vern9(), :reltol => 1.0e-14, :abstol => 1.0e-14)

--- a/lib/OrdinaryDiffEqRosenbrock/test/dae_rosenbrock_ad_tests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/dae_rosenbrock_ad_tests.jl
@@ -50,7 +50,7 @@ sol = @inferred solve(prob_mm, Tsit5DA(), reltol = 1.0e-8, abstol = 1.0e-8)
             remake(_prob, p = p), alg, abstol = 1.0e-14,
             reltol = 1.0e-14, initializealg = initalg
         )
-        sum(sol[end])
+        sum(sol.u[end])
     end
     @test DI.gradient(f, AutoForwardDiff(), [0.04, 3.0e7, 1.0e4]) ≈ [0, 0, 0] atol = 1.0e-8
 end

--- a/test/ad/ad_tests.jl
+++ b/test/ad/ad_tests.jl
@@ -448,7 +448,7 @@ x0 = [0.1]
 DI.gradient(AutoForwardDiff(), x0) do x
     prob = ODEProblem{true}((du, u, p, t) -> (du[1] = -u[1]), x, (0.0, 1.0))
     sol = solve(prob, DefaultODEAlgorithm(), reltol = 1.0e-6)
-    sum(sol)
+    sum(sum, sol.u)
 end ≈ [6.765310476296564]
 
 # Test with multiple AD backends

--- a/test/regression/ode_dense_tests.jl
+++ b/test/regression/ode_dense_tests.jl
@@ -67,7 +67,7 @@ function regression_test(
     sol2 = solve(prob_ode_linear, alg, dt = 1 // 2^(4), dense = true, adaptive = false)
     for i in eachindex(sol2)
         print_results(
-            @test maximum(abs.(sol2[i] - interpolation_results_1d[i])) <
+            @test maximum(abs.(sol2.u[i] - interpolation_results_1d[i])) <
                 tol_ode_linear
         )
     end
@@ -112,7 +112,7 @@ function regression_test(
     sol2 = solve(prob_ode_2Dlinear, alg, dt = 1 // 2^(4), dense = true, adaptive = false)
     for i in eachindex(sol2)
         print_results(
-            @test maximum(maximum.(abs.(sol2[i] - interpolation_results_2d[i]))) <
+            @test maximum(maximum.(abs.(sol2.u[i] - interpolation_results_2d[i]))) <
                 tol_ode_2Dlinear
         )
     end


### PR DESCRIPTION
## Summary
- Replace deprecated `sol[i]` with `sol.u[i]` across test files
- Replace deprecated `sol[end]` with `sol.u[end]`  
- Replace deprecated `sum(sol)` with `sum(sum, sol.u)`

RecursiveArrayTools v4 will remove `Base.getindex(VA::AbstractDiffEqArray{T, N, A}, i::Int)`. These changes use `VA.u[i]` directly as recommended by the deprecation warning.

### Files changed
- `test/ad/ad_tests.jl` — `sum(sol)` → `sum(sum, sol.u)`
- `test/regression/ode_dense_tests.jl` — `sol2[i]` → `sol2.u[i]`
- `lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl` — `sum(sol)` → `sum(sum, sol.u)`
- `lib/OrdinaryDiffEqBDF/test/dae_ad_tests.jl` — `sum(sol)` → `sum(sum, sol.u)`
- `lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_krylov_tests.jl` — `sol2[i]` → `sol2.u[i]`
- `lib/OrdinaryDiffEqLinear/test/linear_method_tests.jl` — `sol[i]` → `sol.u[i]`
- `lib/OrdinaryDiffEqRosenbrock/test/dae_rosenbrock_ad_tests.jl` — `sol[end]` → `sol.u[end]`

## Test plan
- [x] Verified `sum(sol.u[end])` produces correct results with no deprecation warnings (Rodas5P DAE AD test)
- [x] Verified `sum(sum, sol.u)` produces identical results to `sum(sol)` with no deprecation warnings (DefaultODEAlgorithm AD test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>