### PR TITLE
test(Rosenbrock): update resize_tests for new cache fields (k₁/k₂/k₃ → ks, f₁ → dense)

### DIFF
--- a/test/integrators/resize_tests.jl
+++ b/test/integrators/resize_tests.jl
@@ -76,12 +76,10 @@ i = init(prob, Rosenbrock23())
 resize!(i, 5)
 @test length(i.cache.u) == 5
 @test length(i.cache.uprev) == 5
-@test length(i.cache.k₁) == 5
-@test length(i.cache.k₂) == 5
-@test length(i.cache.k₃) == 5
+@test all(length.(i.cache.ks) .== 5)
 @test length(i.cache.du1) == 5
 @test length(i.cache.du2) == 5
-@test length(i.cache.f₁) == 5
+@test all(length.(i.cache.dense) .== 5)
 @test length(i.cache.fsalfirst) == 5
 @test length(i.cache.fsallast) == 5
 @test length(i.cache.dT) == 5
@@ -104,12 +102,10 @@ i = init(prob, Rosenbrock23(autodiff = AutoForwardDiff(), linsolve = KrylovJL_GM
 resize!(i, 5)
 @test length(i.cache.u) == 5
 @test length(i.cache.uprev) == 5
-@test length(i.cache.k₁) == 5
-@test length(i.cache.k₂) == 5
-@test length(i.cache.k₃) == 5
+@test all(length.(i.cache.ks) .== 5)
 @test length(i.cache.du1) == 5
 @test length(i.cache.du2) == 5
-@test length(i.cache.f₁) == 5
+@test all(length.(i.cache.dense) .== 5)
 @test length(i.cache.fsalfirst) == 5
 @test length(i.cache.fsallast) == 5
 @test length(i.cache.dT) == 5
@@ -123,12 +119,10 @@ i = init(prob, Rosenbrock23(; autodiff = AutoFiniteDiff()))
 resize!(i, 5)
 @test length(i.cache.u) == 5
 @test length(i.cache.uprev) == 5
-@test length(i.cache.k₁) == 5
-@test length(i.cache.k₂) == 5
-@test length(i.cache.k₃) == 5
+@test all(length.(i.cache.ks) .== 5)
 @test length(i.cache.du1) == 5
 @test length(i.cache.du2) == 5
-@test length(i.cache.f₁) == 5
+@test all(length.(i.cache.dense) .== 5)
 @test length(i.cache.fsalfirst) == 5
 @test length(i.cache.fsallast) == 5
 @test length(i.cache.dT) == 5

--- a/test/integrators/resize_tests.jl
+++ b/test/integrators/resize_tests.jl
@@ -76,6 +76,7 @@ i = init(prob, Rosenbrock23())
 resize!(i, 5)
 @test length(i.cache.u) == 5
 @test length(i.cache.uprev) == 5
+@test length(i.cache.ks) == 3
 @test all(length.(i.cache.ks) .== 5)
 @test length(i.cache.du1) == 5
 @test length(i.cache.du2) == 5
@@ -102,6 +103,7 @@ i = init(prob, Rosenbrock23(autodiff = AutoForwardDiff(), linsolve = KrylovJL_GM
 resize!(i, 5)
 @test length(i.cache.u) == 5
 @test length(i.cache.uprev) == 5
+@test length(i.cache.ks) == 3
 @test all(length.(i.cache.ks) .== 5)
 @test length(i.cache.du1) == 5
 @test length(i.cache.du2) == 5
@@ -119,6 +121,7 @@ i = init(prob, Rosenbrock23(; autodiff = AutoFiniteDiff()))
 resize!(i, 5)
 @test length(i.cache.u) == 5
 @test length(i.cache.uprev) == 5
+@test length(i.cache.ks) == 3
 @test all(length.(i.cache.ks) .== 5)
 @test length(i.cache.du1) == 5
 @test length(i.cache.du2) == 5


### PR DESCRIPTION
## Summary

Updates `resize_tests.jl` to reflect the new `RosenbrockCache` structure introduced in the RodasTableau refactor.

The previous tests accessed fields specific to `Rosenbrock23Cache` / `Rosenbrock32Cache`:

* `k₁`, `k₂`, `k₃`
* `f₁`

These have been replaced in the unified `RosenbrockCache` with:

* `ks` (vector of stage values)
* `dense` (interpolation coefficients)

## Changes

* Replaced:

  * `k₁`, `k₂`, `k₃` → `ks`
  * `f₁` → `dense`
* Updated assertions to validate vectorized structure:

  * `all(length.(cache.ks) .== N)`
  * `all(length.(cache.dense) .== N)`

## Rationale

The cache structure was unified as part of the RodasTableau migration, so tests need to align with the new representation.

No changes to solver behavior — this only updates tests to match the new internal structure.
Test for #3273 
## Checklist

* [x] Appropriate tests were updated
* [x] No public API changes
* [x] Follows SciML style guidelines
* [x] Documentation unaffected (internal change)
