### PR TITLE
Use tight tolerances for convergence tests with KrylovJL

### DIFF
--- a/lib/OrdinaryDiffEqBDF/test/bdf_convergence_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/bdf_convergence_tests.jl
@@ -76,7 +76,8 @@ end
                     function_annotation = Enzyme.Const
                 ),
                 linsolve = LinearSolve.KrylovJL()
-            )
+            ),
+            reltol = 1.0e-14, abstol = 1.0e-14
         )
         @test sim.𝒪est[:final] ≈ 1 atol = testTol
         @test sim.𝒪est[:l2] ≈ 1 atol = testTol

--- a/lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl
@@ -114,7 +114,8 @@ end
                 autodiff = AutoEnzyme(
                     mode = set_runtime_activity(Enzyme.Forward), function_annotation = Enzyme.Const
                 ), linsolve = LinearSolve.KrylovJL()
-            )
+            ),
+            reltol = 1.0e-14, abstol = 1.0e-14
         )
         @test sim.𝒪est[:final] ≈ 3 atol = testTol
 
@@ -160,7 +161,8 @@ end
                     mode = set_runtime_activity(Enzyme.Forward), function_annotation = Enzyme.Const
                 ),
                 linsolve = LinearSolve.KrylovJL()
-            )
+            ),
+            reltol = 1.0e-14, abstol = 1.0e-14
         )
         @test sim.𝒪est[:final] ≈ 3 atol = testTol
 
@@ -208,7 +210,8 @@ end
                     mode = set_runtime_activity(Enzyme.Forward), function_annotation = Enzyme.Const
                 ),
                 linsolve = LinearSolve.KrylovJL()
-            )
+            ),
+            reltol = 1.0e-14, abstol = 1.0e-14
         )
         @test sim.𝒪est[:final] ≈ 3 atol = testTol
 
@@ -669,7 +672,8 @@ end
                     mode = set_runtime_activity(Enzyme.Forward), function_annotation = Enzyme.Const
                 ),
                 linsolve = LinearSolve.KrylovJL()
-            )
+            ),
+            reltol = 1.0e-14, abstol = 1.0e-14
         )
         @test sim.𝒪est[:final] ≈ 2 atol = testTol
 
@@ -717,7 +721,8 @@ end
                     mode = set_runtime_activity(Enzyme.Forward), function_annotation = Enzyme.Const
                 ),
                 linsolve = LinearSolve.KrylovJL()
-            )
+            ),
+            reltol = 1.0e-14, abstol = 1.0e-14
         )
         @test sim.𝒪est[:final] ≈ 3 atol = testTol
 
@@ -1006,7 +1011,8 @@ end
                 ),
                 linsolve = LinearSolve.KrylovJL()
             ),
-            dense_errors = true
+            dense_errors = true,
+            reltol = 1.0e-14, abstol = 1.0e-14
         )
         #@test sim.𝒪est[:final]≈5 atol=testTol #-- observed order > 6
         @test sim.𝒪est[:L2] ≈ 5 atol = testTol
@@ -1019,7 +1025,8 @@ end
                 ),
                 linsolve = LinearSolve.KrylovJL_GMRES()
             ),
-            dense_errors = true
+            dense_errors = true,
+            reltol = 1.0e-14, abstol = 1.0e-14
         )
         #@test sim.𝒪est[:final]≈5 atol=testTol #-- observed order > 6
         @test sim.𝒪est[:L2] ≈ 5 atol = testTol
@@ -1061,7 +1068,8 @@ end
     testTol = 0.2
     # Check convergence of Rodas3 with time-dependent matrix-free Jacobian.
     # Primarily to check that the Jacobian is being updated correctly as t changes.
-    sim = test_convergence(dts, prob, Rodas3(linsolve = LinearSolve.KrylovJL()))
+    sim = test_convergence(dts, prob, Rodas3(linsolve = LinearSolve.KrylovJL()),
+        reltol = 1.0e-14, abstol = 1.0e-14)
     @test sim.𝒪est[:final] ≈ 3 atol = testTol
 end
 


### PR DESCRIPTION
## Summary

Tighten `reltol`/`abstol` to `1e-14` for all `test_convergence` calls that use iterative Krylov linear solvers (`KrylovJL`, `KrylovJL_GMRES`).

## Why

The ODE `reltol` controls how accurately the whole step — including the linear solve — needs to be computed. For iterative linear solvers like `KrylovJL`, that tolerance is also the Krylov inner-iteration convergence target (as it should be: the user is only promised solves to their requested tolerance, and tightening the linear solve beyond that is wasted work).

`test_convergence` drives the step size down by hand and measures how fast the error shrinks. To see the method's actual order you need the step error to be much smaller than any other numerical floor — including the linear solve residual. Normally users control that with `reltol`, but these tests were only passing `dts` and leaving `reltol` at its default (`1e-3`). With a direct LU solve that happened to work because LU gives a near-machine-precision solve regardless of the requested tolerance; with a Krylov solver it (correctly) stops once it hits the user's tolerance, and the Krylov residual floor then dominates the ODE step error — the convergence estimate drops far below the method's true order.

Concretely on master, `Rodas5P + KrylovJL` on `prob_ode_2Dlinear`:

| Config | L2 order |
|---|---|
| `Rodas5P()` (LU) | 5.004 |
| `Rodas5P(linsolve = KrylovJL())`, default `reltol = 1e-3` | 2.83 |
| `Rodas5P(linsolve = KrylovJL())`, `reltol = 1e-14` | 5.004 |

This is expected behavior — the test just needs to ask for the accuracy it's measuring.

## What this PR does

Adds `reltol = 1.0e-14, abstol = 1.0e-14` to 9 `test_convergence` calls:

- `lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl` — 8 blocks covering `Rosenbrock32`, `ROS3P`, `Rodas3`, `Rodas23W`, `Rodas3P`, `Rodas5P` × 2, and the bottom-of-file matrix-free `Rodas3` convergence test
- `lib/OrdinaryDiffEqBDF/test/bdf_convergence_tests.jl` — 1 block (`QNDF1 + Enzyme + KrylovJL`)

`ExponentialRK/test/linear_nonlinear_convergence_tests.jl` already passes `reltol = 1.0e-16` for its `KrylovJL_GMRES` case, so it's untouched.

## Test plan

- [x] Locally verified: `Rodas5P + Enzyme + KrylovJL` reports `L2` order 5.004 (was 2.83)
- [x] Locally verified: `Rodas3 + KrylovJL` reports final order 3.02

🤖 Generated with [Claude Code](https://claude.com/claude-code)
