### PR TITLE
Skip wasted recursivecopy in _ode_init when SDE delegates with prebuilt state

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "3.29.0"
+version = "3.29.1"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/lib/OrdinaryDiffEqCore/src/solve.jl
+++ b/lib/OrdinaryDiffEqCore/src/solve.jl
@@ -358,7 +358,12 @@ function _ode_init(
 
     if !isdae && isinplace(prob) && u isa AbstractArray && eltype(u) <: Number &&
             uBottomEltypeNoUnits == uBottomEltype && tType == tTypeNoUnits # Could this be more efficient for other arrays?
-        rate_prototype = recursivecopy(u)
+        # SDE delegation provides `_cache` and a non-nothing `W`. In that case
+        # `rate_prototype`'s value is unused: only its type is taken downstream,
+        # the alg_cache calls are skipped (cache is provided), get_fsalfirstlast
+        # is short-circuited, and the [rate_prototype] push is gated by
+        # `isnothing(W)` which is false for SDE. Alias instead of allocating.
+        rate_prototype = (_cache !== nothing && W !== nothing) ? u : recursivecopy(u)
     elseif prob isa DAEProblem
         rate_prototype = prob.du0
     else
@@ -489,16 +494,17 @@ function _ode_init(
 
     k = rateType[]
 
-    if uses_uprev(_alg, adaptive) || calck
+    if _uprev !== nothing
+        # SDE delegation provides a pre-built uprev (cache holds references to it).
+        # Use it directly instead of allocating a recursivecopy(u) that would
+        # immediately be discarded.
+        uprev = _uprev
+    elseif uses_uprev(_alg, adaptive) || calck
         uprev = recursivecopy(u)
     else
         # Some algorithms do not use `uprev` explicitly. In that case, we can save
         # some memory by aliasing `uprev = u`, e.g. for "2N" low storage methods.
         uprev = u
-    end
-    # SDE delegation: use pre-built uprev if provided (cache holds references to it)
-    if _uprev !== nothing
-        uprev = _uprev
     end
     if allow_extrapolation
         uprev2 = recursivecopy(u)


### PR DESCRIPTION
## Summary

Eliminates two wasted `recursivecopy(u)` calls in `_ode_init` that fire when `StochasticDiffEqCore._sde_init` delegates through it (the unified-init path introduced in StochasticDiffEq v6.100/6.101). For the ComplexF64 sparse SDE MWE in #3372, this saves **~32 KiB and 4 allocations per init call**, recovering most of the memory regression that landed alongside the SDE delegation refactor.

## Background

@albertomercurio reported in #3372 that the same SDE solve allocates ~9× more on StochasticDiffEq v6.101 than on v6.97. PR #3350 already fixed the dominant `_tType` non-specialization regression in `_ode_initdt_iip`, and that fix is present in the user's resolved `OrdinaryDiffEqCore v3.29.0`. While I could not reproduce the user's full 9101-alloc number from a clean install (likely a stale precompile cache on his side — see [comment](https://github.com/SciML/OrdinaryDiffEq.jl/issues/3372#issuecomment-4222070717)), I did find a smaller but real residual regression that *is* reproducible: **+25 allocs / ~50 KiB** between v6.97.0 and v6.101.0 on Julia 1.12.0 with a deterministic seed.

Tracking it down via `Profile.Allocs` showed two new allocation sites in v6.101 attributable to the new SDE → ODE init delegation path, both in `OrdinaryDiffEqCore/src/solve.jl`:

1. **Line 361** — `rate_prototype = recursivecopy(u)`. When `_cache !== nothing && W !== nothing` (the SDE-delegation marker), `rate_prototype`'s value is dead:
   - Line 372 only takes its `typeof`.
   - The `alg_cache(...)` calls at 519/525 are skipped because `_cache` is provided.
   - `get_fsalfirstlast` at 732 is short-circuited to `(nothing, nothing)`.
   - The `copyat_or_push!(ks, 1, [rate_prototype])` at 790 is gated by `isnothing(W)`, which is false for SDE.

2. **Line 498** — `uprev = recursivecopy(u)` (under `uses_uprev || calck`), then immediately overwritten by `uprev = _uprev` two lines later when `_uprev !== nothing`. The recursivecopy result is allocated and thrown away.

For a 1000-element `ComplexF64` vector, each `recursivecopy(u)` allocates a 16016-byte `Memory` plus an `Array` struct, so the two wasted calls account for ~32 KiB of memory and 4 allocations per init.

## Fix

- **`rate_prototype`**: alias `u` instead of copying when `_cache !== nothing && W !== nothing` (the unique signature of the SDE delegation path).
- **`uprev`**: reorder the `if` to check `_uprev !== nothing` first, falling back to the existing `uses_uprev || calck` and aliasing branches when no pre-built uprev is provided. This is logically equivalent to the original code for every path except the SDE delegation, which now skips the wasted copy entirely.

The fix is strictly opt-in via the SDE-delegation markers — pure ODE callers never hit the new branches, so behavior for `OrdinaryDiffEqTsit5` etc. is unchanged.

## Verification

Reproduction is a deterministically-seeded run of the #3372 MWE (`f!(du,u,p,t)=mul!(du,A,u)`, `g!` similarly, ComplexF64, n=1000, SRIW1, seed=1, naccept=734, nreject=31), measured via `Base.GC_Diff` for exactness:

| Configuration                  | allocs | bytes  |
|---|---|---|
| StochasticDiffEq v6.97.0       | 1097   | 623120 |
| v6.101.0 (registry, unpatched) | 1122   | 673472 |
| **v6.101.0 (this patch)**      | **1118** | **641392** |

The patch saves exactly the predicted **4 allocs / 32080 bytes** (= 2 × `recursivecopy(::Vector{ComplexF64,1000})`). The remaining ~21 alloc / ~18 KiB gap vs. v6.97 is structural overhead from the new ~30-kwarg `_ode_init` delegation call in `StochasticDiffEqCore`, not a one-line fix.

## Test plan

- [x] Pure ODE smoke test (`Tsit5` on `du = -u`): correct result, `integ.uprev !== integ.u` after `step!`.
- [x] SDE smoke test (the #3372 MWE): same trajectory (734 accept + 31 reject), `integ.uprev !== integ.u`, `!(integ.uprev ≈ integ.u)` — confirms the fix preserves uprev independence and does not introduce aliasing.
- [x] **StochasticDiffEq.jl Interface1 group passes** with the patched `OrdinaryDiffEqCore` `Pkg.develop`'d in. Includes the **152-case Solver Reversal Tests** which exercise nearly every SDE solver in the package (~18 minutes).
- [x] **StochasticDiffEq.jl Interface2 group passes** (Tau Leaping, Linear SDE, Element-wise Tolerances, Adaptive SDE Linear, Inplace RODESolution Interpolation, etc.).
- [x] **StochasticDiffEq.jl Interface3 group passes** (Multiple Dimension Linear Adaptive, Stochastic iterated integrals, etc.).
- [x] **Pre-existing failures unrelated to this patch**: SOSRI/SOSRA stepping allocation tests fail on Julia 1.12.0 with `allocs_per_step == 8/7` instead of `0`, both with and without this patch (verified by `Pkg.free`'ing OrdinaryDiffEqCore back to the registry version and re-running). This is a separate issue and not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
