### PR TITLE
ImplicitDiscreteSolve: bypass NonlinearSolve for u0=nothing

### DIFF
--- a/lib/ImplicitDiscreteSolve/src/cache.jl
+++ b/lib/ImplicitDiscreteSolve/src/cache.jl
@@ -12,25 +12,45 @@ mutable struct IDSolveCache{uType, cType, thetaType} <: OrdinaryDiffEqMutableCac
     Θks::thetaType
 end
 
+# u === nothing path: no state to evolve (e.g. MTK systems with only callbacks).
+# Bypass NonlinearSolve entirely — there is nothing to nonlinear-solve, and
+# constructing a NonlinearProblem with empty u would force the nonlinear
+# solver to handle a degenerate case. Returning a cache with `nlcache=nothing`
+# is dispatched on in `perform_step!` below to make stepping a no-op success.
+function alg_cache(
+        alg::IDSolve, ::Nothing, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{true}, verbose
+    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    return IDSolveCache(nothing, nothing, nothing, nothing, uBottomEltypeNoUnits[])
+end
+function alg_cache(
+        alg::IDSolve, ::Nothing, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{false}, verbose
+    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    return IDSolveCache(nothing, nothing, nothing, nothing, uBottomEltypeNoUnits[])
+end
+
 function alg_cache(
         alg::IDSolve, u, rate_prototype, ::Type{uEltypeNoUnits},
         ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
         dt, reltol, p, calck,
         ::Val{true}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    state = ImplicitDiscreteState(isnothing(u) ? nothing : zero(u), p, t)
+    state = ImplicitDiscreteState(zero(u), p, t)
     f_nl = (resid, u_next, p) -> f(resid, u_next, p.u, p.p, p.t)
 
-    u_len = isnothing(u) ? 0 : length(u)
-    nlls = !isnothing(f.resid_prototype) && (length(f.resid_prototype) != u_len)
-    unl = isnothing(u) ? Float64[] : u # FIXME nonlinear solve cannot handle nothing for u
+    nlls = !isnothing(f.resid_prototype) && (length(f.resid_prototype) != length(u))
     prob = if nlls
         NonlinearLeastSquaresProblem{isinplace(f)}(
             NonlinearFunction(f_nl; resid_prototype = f.resid_prototype),
-            unl, state
+            u, state
         )
     else
-        NonlinearProblem{isinplace(f)}(f_nl, unl, state)
+        NonlinearProblem{isinplace(f)}(f_nl, u, state)
     end
 
     nlcache = init(prob, alg.nlsolve)
@@ -46,21 +66,17 @@ function alg_cache(
         dt, reltol, p, calck,
         ::Val{false}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    @assert !isnothing(u) "Empty u not supported with out of place functions yet."
-
-    state = ImplicitDiscreteState(isnothing(u) ? nothing : zero(u), p, t)
+    state = ImplicitDiscreteState(zero(u), p, t)
     f_nl = (u_next, p) -> f(u_next, p.u, p.p, p.t)
 
-    u_len = isnothing(u) ? 0 : length(u)
-    nlls = !isnothing(f.resid_prototype) && (length(f.resid_prototype) != u_len)
-    unl = isnothing(u) ? Float64[] : u # FIXME nonlinear solve cannot handle nothing for u
+    nlls = !isnothing(f.resid_prototype) && (length(f.resid_prototype) != length(u))
     prob = if nlls
         NonlinearLeastSquaresProblem{isinplace(f)}(
             NonlinearFunction(f_nl; resid_prototype = f.resid_prototype),
-            unl, state
+            u, state
         )
     else
-        NonlinearProblem{isinplace(f)}(f_nl, unl, state)
+        NonlinearProblem{isinplace(f)}(f_nl, u, state)
     end
 
     nlcache = init(prob, alg.nlsolve)

--- a/lib/ImplicitDiscreteSolve/src/solve.jl
+++ b/lib/ImplicitDiscreteSolve/src/solve.jl
@@ -1,3 +1,11 @@
+# u === nothing path: nothing to step. The integrator's state is unchanged
+# and the step trivially succeeds.
+function perform_step!(
+        integrator, cache::IDSolveCache{Nothing, Nothing}, repeat_step = false
+    )
+    return nothing
+end
+
 function perform_step!(integrator, cache::IDSolveCache, repeat_step = false)
     (; alg, u, uprev, dt, t, tprev, f, p) = integrator
     (; nlcache, Θks) = cache

--- a/lib/ImplicitDiscreteSolve/test/runtests.jl
+++ b/lib/ImplicitDiscreteSolve/test/runtests.jl
@@ -88,22 +88,19 @@ if TEST_GROUP != "QA"
     end
 
     @testset "Handle nothing in u0" begin
-        function emptyiip(residual, u_next, u, p, t) # TODO OOP variant does not work yet
-            nothing
-        end
-        function emptyoop(u_next, u, p, t) # TODO OOP variant does not work yet
-            nothing
-        end
+        emptyiip(residual, u_next, u, p, t) = nothing
+        emptyoop(u_next, u, p, t) = nothing
 
         tsteps = 5
         u0 = nothing
+
         idprob = ImplicitDiscreteProblem(emptyiip, u0, (0, tsteps), [])
-        @test_nowarn integ = init(idprob, IDSolve())
+        sol = solve(idprob, IDSolve())
+        @test sol.retcode == ReturnCode.Success
 
         idprob2 = ImplicitDiscreteProblem(emptyoop, u0, (0, tsteps), [])
-        # OOP with u0=nothing throws an error (MethodError or AssertionError depending on
-        # how far the initialization proceeds before encountering undefined operations on Nothing)
-        @test_throws Exception integ = init(idprob2, IDSolve())
+        sol2 = solve(idprob2, IDSolve())
+        @test sol2.retcode == ReturnCode.Success
     end
 
     @testset "Create NonlinearLeastSquaresProblem" begin


### PR DESCRIPTION
## Summary

Previously \`alg_cache\` wrapped \`nothing\` u0 by replacing it with an empty \`Float64[]\` (with a \`FIXME\` comment) and constructed a \`NonlinearProblem\` with the empty vector. NonlinearSolveBase then needed a runtime \`length(u) == 0\` early return to avoid passing the empty vector to \`DI.prepare_jacobian\` (which errors). That early return broke type inference: it produced a \`JacobianCache\` parameterization different from the main path, yielding a \`Union\` return type from \`construct_jacobian_cache\` that propagated up through \`init\` and \`build_nlsolver\`.

## Fix

Handle \`u0=nothing\` entirely inside ImplicitDiscreteSolve, analogous to DiffEqBase's \`build_null_solution\` for ODE problems with \`u0=nothing\`:

- Add a dedicated \`alg_cache\` method dispatched on \`::Nothing\` that returns \`IDSolveCache(nothing, nothing, nothing, nothing, ...)\` with no NonlinearSolve cache
- Add a \`perform_step!\` method dispatched on \`IDSolveCache{Nothing, Nothing}\` that is a no-op success
- Remove the \`@assert !isnothing(u)\` from the OOP \`alg_cache\` (now handled by dispatch)
- Update the empty u0 test to call \`solve\` end-to-end and assert success for both IIP and OOP

## Companion PR

The corresponding fix to NonlinearSolveBase removes the runtime \`length(u) == 0\` early return: SciML/NonlinearSolve.jl#896.

🤖 Generated with [Claude Code](https://claude.com/claude-code)