### PR TITLE
ci: write Julia depot cache only from master pushes; PRs restore-only

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,9 +61,36 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-      - uses: julia-actions/cache@v3
+      # Split cache restore/save by event to work around recurring GitHub
+      # Actions cache upload auth failures (Azure SAS "Server failed to
+      # authenticate the request") that show up sporadically across the
+      # ~68-cell matrix. PRs only restore from a recent master push cache;
+      # only master push runs write the cache. continue-on-error keeps a
+      # transient cache backend hiccup from flunking an otherwise green job.
+      - name: Cache Julia depot (push only — read+write)
+        if: github.event_name == 'push'
+        uses: julia-actions/cache@v3
+        continue-on-error: true
         with:
           cache-compiled: 'false'
+      - name: Cache Julia depot (PR — restore only)
+        if: github.event_name != 'push'
+        uses: actions/cache/restore@v4
+        continue-on-error: true
+        with:
+          path: |
+            ~/.julia/artifacts
+            ~/.julia/packages
+            ~/.julia/registries
+            ~/.julia/scratchspaces
+            ~/.julia/logs
+          # Primary key intentionally won't match (run_id is unique); the
+          # restore-keys prefix matches julia-actions/cache's key scheme
+          # `${cache-name};os=${runner.os};${matrix...}` so we pull the most
+          # recent cache from a master push for this same matrix cell.
+          key: julia-cache;workflow=${{ github.workflow }};job=${{ github.job }};os=${{ runner.os }};group=${{ matrix.group }};version=${{ matrix.version }};run_id=${{ github.run_id }};run_attempt=${{ github.run_attempt }}
+          restore-keys: |
+            julia-cache;workflow=${{ github.workflow }};job=${{ github.job }};os=${{ runner.os }};group=${{ matrix.group }};version=${{ matrix.version }};
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:

--- a/.github/workflows/SublibraryCI.yml
+++ b/.github/workflows/SublibraryCI.yml
@@ -68,7 +68,16 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-      - uses: julia-actions/cache@v3
+      # Same workaround as CI.yml: only write the cache from master pushes
+      # to avoid the Azure SAS auth failure storm during PR matrix uploads.
+      # SublibraryCI's matrix shape is dynamic (group/version/runner/timeout/
+      # num_threads), so we don't try to construct a restore-only key for
+      # PRs here — PRs simply skip the cache. This workflow only fires when
+      # files in lib/ change, so the lost cache hit on PRs is small.
+      - name: Cache Julia depot (push only)
+        if: github.event_name == 'push'
+        uses: julia-actions/cache@v3
+        continue-on-error: true
         with:
           cache-compiled: 'false'
       - uses: julia-actions/julia-buildpkg@v1


### PR DESCRIPTION
## Summary

GitHub Actions cache uploads have been intermittently failing across the ~68-cell PR test matrix with Azure SAS auth errors:

```
Failed to save: Server failed to authenticate the request.
RequestId:6a2b0577-a01e-007d-7fef-c87329000000
uploadCacheArchiveSDK: internal error uploading cache archive
```

Even after #(094a3bfdd) dropped the compiled-cache and brought tarballs from ~12 GB down to ~120 MB (so SAS expiry on huge uploads is no longer the cause), this signature failure keeps showing up on a small number of matrix cells per run. With ~17 groups × ~4 Julia versions all uploading at once, even a low per-upload failure rate paints otherwise-green jobs red on a majority of CI runs. The failing call is in `@actions/cache`'s `uploadCacheArchiveSDK` blob upload — there is nothing tunable from the workflow side to fix the upload itself.

This PR removes the *amplifier* (matrix fan-out of cache writes) and stops a flaky cache step from flunking real test results.

### Changes

- **`.github/workflows/CI.yml`**: split `julia-actions/cache@v3` into:
  - a **push-only** step (read+write) — only `master` push runs upload to the cache backend.
  - a **PR-only** step using `actions/cache/restore@v4` (restore only, no upload). The `restore-keys` prefix is constructed to exactly match `julia-actions/cache`'s key scheme (`julia-cache;workflow=...;job=...;os=...;group=...;version=...;`) so PRs still get the most recent master cache for the same matrix cell.
- **`.github/workflows/SublibraryCI.yml`**: gate `julia-actions/cache@v3` on `github.event_name == 'push'`. The matrix here is dynamic (`group`/`version`/`runner`/`timeout`/`num_threads`, with `runner` sometimes an array for self-hosted/GPU jobs), so building a clean restore-only key in YAML isn't worth it. SublibraryCI only fires when files in `lib/` change, so the lost PR cache hit is minor.
- Both cache steps get **`continue-on-error: true`**, so a transient cache backend hiccup in either restore or save no longer flunks an otherwise-passing test job. This is a band-aid for the same Azure auth bug, applied to the right place: the failure is in post-test housekeeping and shouldn't gate CI.

### What this does NOT change

- Compiled cache is still disabled (from 094a3bfdd).
- The full cache (artifacts/packages/registries/scratchspaces/logs) is still saved on every master push, so the master cache stays warm for PRs to restore from.
- Test step behavior, runner permissions, codecov, etc. are unchanged.

### Trade-offs / known issues

- The first PR run after a long quiet period on master may cache-miss if no recent master push has populated a matching key. Subsequent PR runs hit the same warm cache. This is the standard pattern most large SciML repos with this issue have settled on.
- This does not fix the recurring `Implicit solver with lazy W` test failure on `InterfaceIII` (Julia 1, 1.11) — that's a real test failure in `test/interface/utility_tests.jl:87` for the in-place `Rosenbrock23` operator-Jacobian path, currently broken on master. Tracking that separately.

## Test plan

- [ ] PR CI runs `Cache Julia depot (PR — restore only)` step (not the push-only step), with `cache-hit: false` on the primary key but a successful prefix match in `restore-keys`.
- [ ] PR CI runs do not produce `uploadCacheArchiveSDK` errors and do not have a `Post Run julia-actions/cache@v3` step at all.
- [ ] After this PR is merged, the next master push run uploads cache normally.
- [ ] Subsequent PRs see warm restores from the master cache for the same matrix cell.
- [ ] If the cache backend hiccups regardless, the transient failure is non-fatal (`continue-on-error: true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)