### PR TITLE
Fix Multirate FastBroadcast compat and BDF convergence-test KeyError

### DIFF
--- a/lib/OrdinaryDiffEqBDF/test/bdf_convergence_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/bdf_convergence_tests.jl
@@ -67,6 +67,11 @@ end
         @test sim.𝒪est[:l2] ≈ 1 atol = testTol
         @test sim.𝒪est[:l∞] ≈ 1 atol = testTol
 
+        # Note: tight reltol/abstol (1e-14) is unusable for BDF-1 because the
+        # method's local error floor exceeds machine precision, causing Newton
+        # ConvergenceFailure on all but the finest dt. Leave reltol/abstol at the
+        # defaults; without the LinearSolve residual-tolerance coupling described in
+        # #3373, QNDF1's observed order already lands near 1 on prob_ode_2Dlinear.
         sim = test_convergence(
             dts,
             prob,
@@ -76,8 +81,7 @@ end
                     function_annotation = Enzyme.Const
                 ),
                 linsolve = LinearSolve.KrylovJL()
-            ),
-            reltol = 1.0e-14, abstol = 1.0e-14
+            )
         )
         @test sim.𝒪est[:final] ≈ 1 atol = testTol
         @test sim.𝒪est[:l2] ≈ 1 atol = testTol

--- a/lib/OrdinaryDiffEqMultirate/Project.toml
+++ b/lib/OrdinaryDiffEqMultirate/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqMultirate"
 uuid = "d4b830b4-ac80-426b-8507-16693d424963"
 authors = ["singhharsh1708 <hs1663531@gmail.com>"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -17,7 +17,7 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Aqua = "0.8.11"
 DiffEqBase = "6.194"
 DiffEqDevTools = "2.44.4"
-FastBroadcast = "0.3"
+FastBroadcast = "1.3"
 JET = "0.9, 0.11"
 MuladdMacro = "0.2"
 OrdinaryDiffEqCore = "3"


### PR DESCRIPTION
## Summary

Two independent master test failures uncovered by the CI run on #3385. Both trivial, unrelated root causes.

- **OrdinaryDiffEqMultirate: unsatisfiable FastBroadcast compat.** Multirate 1.0.0 pins `FastBroadcast = "0.3"`, but `OrdinaryDiffEqCore` requires `FastBroadcast = "1.3"`, so `Pkg.Resolve` fails immediately. Bump the compat to `"1.3"` and the package version to 1.0.1. Fixes `test (OrdinaryDiffEqMultirate, ...)` and `test (OrdinaryDiffEqMultirate_QA, ...)`.
- **OrdinaryDiffEqBDF: `KeyError: key :l∞ not found` in convergence test.** The `QNDF1 + AutoEnzyme + KrylovJL` test added by #3373 passes `reltol = abstol = 1e-14`. BDF-1's local error floor exceeds double-precision near those tolerances, so Newton hits `ConvergenceFailure` on every dt except the finest. Failed solutions have an empty `sol.errors` dict, which then makes `DiffEqDevTools.ConvergenceSimulation` crash while iterating keys from the one successful solution. Drop the tight-tolerance override for this BDF case — the tightening from #3373 was only needed to stop LinearSolve's residual-tolerance coupling from starving *Rosenbrock* convergence, which is not a concern for BDF-1. Fixes `test (OrdinaryDiffEqBDF, ...)`.

### Not fixed in this PR (investigated, non-trivial)

For anyone auditing the same CI run:

- `test (InterfaceIII, ...)` — `test/interface/utility_tests.jl:87` `Implicit solver with lazy W`. IIP Rosenbrock23/Rodas5 with a `MatrixOperator` `jac_prototype` + time-dependent `update_func!` + mass matrix diverges on the second component. Root cause is that `W._concrete_form` (what `convert(AbstractMatrix, W)` returns for `IIP=true`, consumed by the linsolve path) is never refreshed when `W.J` is a `SciMLOperator`. Patching `calc_W!` to manually `jacobian2W!` the operator branch synces the values but the `LinearSolve` factorization cache still sees a stale reference because the mutation is in-place. Needs a fix in `SciMLOperators.WOperator.convert` for `IIP=true` (or a reference-change shim).
- `test (AD, lts)` — real numerical bug: Mooncake gradient for Lorenz ODE with `SensitivityADPassThrough` disagrees with ForwardDiff (`[-4.07, -6.61, -1.47]` vs `[-5.71, -5.24, 0.96]`).
- `test (DiffEqDevTools, ...)` / `_QA` — `Pkg.Resolve` conflict via `ParameterizedFunctions = "5"` + the `ProblemLibrary = "0.1"` pins cascading through MTK / FunctionWrappersWrappers. Relaxing the `ProblemLibrary` bounds to `"0.1, 1"` unblocks resolution, but the resolver then selects `StochasticDelayDiffEq 1.13` + `StochasticDiffEq 6.101`, and SDDE 1.13 references `StochasticDiffEq.handle_callback_modifiers!`, which 6.101 no longer exports after the StochasticDiffEqCore split. Needs an upstream fix in SDE/SDDE (or compat bounds in the registry), not here.
- `test (StochasticDiffEqROCK_SROCKC2WeakConvergence, ...)` — not a test failure, the self-hosted runner received a shutdown signal mid-job.

## Test plan

- [x] Reproduced BDF `KeyError` locally with `QNDF1 + AutoEnzyme + KrylovJL` on `prob_ode_2Dlinear`; verified root cause via per-`dt` `solve` showing `ReturnCode.ConvergenceFailure` and empty `sol.errors` for all dts except the finest.
- [x] Verified the fix: `test_convergence` with the QNDF1 + KrylovJL config on both `prob_ode_linear` and `prob_ode_2Dlinear` returns `final/l2/l∞` orders 1.02 / 1.02 / 1.02 and 1.16 / 1.17 / 1.16, both within `testTol = 0.2`.
- [x] `OrdinaryDiffEqMultirate` test env resolves cleanly after the FastBroadcast bump (compat check — the actual sublibrary tests weren't otherwise failing).
- [ ] Full CI run (Sublibrary CI for Multirate + Interface/BDF groups).