### PR TITLE
Widen UJacobianWrapper.p for nested ForwardDiff through Rosenbrock (#3381)

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "2.8.0"
+version = "2.8.1"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_wrappers.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_wrappers.jl
@@ -185,6 +185,68 @@ function jacobian(f::F, x, integrator) where {F}
     return jac
 end
 
+# Inner-Dual eltype that the prepared ForwardDiff JacobianConfig will allocate
+# for its xdual buffer. Returns `nothing` if `prep` is not a ForwardDiff
+# JacobianConfig-backed prep (e.g. AutoFiniteDiff path).
+function _jac_prep_inner_dual_eltype(prep)
+    hasfield(typeof(prep), :config) || return nothing
+    cfg = getfield(prep, :config)
+    cfg isa ForwardDiff.JacobianConfig || return nothing
+    duals = cfg.duals
+    duals isa Tuple && length(duals) >= 2 || return nothing
+    return eltype(duals[2])
+end
+
+# When the integrator's stored `p` (held in `f::UJacobianWrapper`) is a
+# `Vector{<:Dual}` because we are *inside* an outer ForwardDiff Jacobian /
+# gradient, the inner Rosenbrock Jacobian widens `u` into a deeper nested-Dual
+# type via the prepared `JacobianConfig`. If the user-facing function is a
+# plain Julia function (the FullSpecialize / NoSpecialize case), then the
+# subsequent `p[i] * u[i]` inside the user body multiplies values at two
+# different Dual nesting levels, which dispatches through ForwardDiff's
+# `tagcount`-based tag precedence. That precedence is unstable across
+# precompile boundaries (the `@generated tagcount` literal is baked at first
+# compile and depends on which package precompiled which tag first), so the
+# result type can come out wrong and crash inside `setindex!(du, ...)` with
+# `Float64(::nested_dual)`.
+#
+# The fix: lift `p` into the inner nested-Dual type so the user body never
+# multiplies across tag levels. The widened `p` carries zero inner partials
+# (which is what we want — `p` does not depend on `u`).
+#
+# We deliberately skip widening when the underlying ODEFunction was
+# AutoSpecialize-wrapped by DiffEqBase into a `FunctionWrappersWrapper`.
+# DiffEqBase already precompiles the `(nested_u, nested_du, outer_p, t)`
+# FunctionWrapper signature, so the unwidened call matches an existing
+# wrapper slot and dispatches normally; widening to a nested `p` would
+# instead produce `(nested_u, nested_du, nested_p, t)` which does not match
+# any precompiled slot and trips FWW v1's `AllowNonIsBits` policy into
+# `NoFunctionWrapperFoundError`.
+_widen_uf_p_for_jac(f, prep) = f
+function _widen_uf_p_for_jac(f::UJacobianWrapper, prep)
+    inner_T = _jac_prep_inner_dual_eltype(prep)
+    inner_T === nothing && return f
+    p = f.p
+    p isa AbstractArray || return f
+    Tp = eltype(p)
+    Tp <: ForwardDiff.Dual || return f
+    Tp === inner_T && return f
+    inner_T <: ForwardDiff.Dual || return f
+    # Skip widening when the user function is FWW-wrapped — DiffEqBase's
+    # AutoSpecialize already precompiles the needed nested-u / outer-p slot.
+    _uf_is_fw_wrapped(f) && return f
+    return UJacobianWrapper{isinplace(f)}(f.f, f.t, convert.(inner_T, p))
+end
+
+# Whether the user function stored in a UJacobianWrapper lives behind a
+# FunctionWrappersWrapper (i.e. was AutoSpecialize-wrapped). Handles the
+# common layer `UJacobianWrapper.f = ODEFunction`, `ODEFunction.f = FWW`.
+function _uf_is_fw_wrapped(f::UJacobianWrapper)
+    ff = f.f
+    hasfield(typeof(ff), :f) || return false
+    return getfield(ff, :f) isa FunctionWrappersWrappers.FunctionWrappersWrapper
+end
+
 function jacobian!(
         J::AbstractMatrix{<:Number}, f::F, x::AbstractArray{<:Number},
         fx::AbstractArray{<:Number}, integrator::SciMLBase.DEIntegrator,
@@ -240,14 +302,16 @@ function jacobian!(
         config = jac_config[1]
     end
 
+    f_eff = _widen_uf_p_for_jac(f, config)
+
     if integrator.iter == 1
         try
-            DI.jacobian!(f, fx, J, config, gpu_safe_autodiff(alg_autodiff(alg), x), x)
+            DI.jacobian!(f_eff, fx, J, config, gpu_safe_autodiff(alg_autodiff(alg), x), x)
         catch e
             throw(FirstAutodiffJacError(e))
         end
     else
-        DI.jacobian!(f, fx, J, config, gpu_safe_autodiff(alg_autodiff(alg), x), x)
+        DI.jacobian!(f_eff, fx, J, config, gpu_safe_autodiff(alg_autodiff(alg), x), x)
     end
 
     return nothing

--- a/lib/OrdinaryDiffEqDifferentiation/test/nested_forwarddiff_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/nested_forwarddiff_tests.jl
@@ -1,0 +1,61 @@
+using Test
+using OrdinaryDiffEqRosenbrock
+using SciMLBase
+using ADTypes
+using ForwardDiff
+
+# Regression test for nested ForwardDiff over an ODE solve (#3381). When a
+# Rosenbrock solver is invoked with a `Vector{<:Dual}` `p` (i.e. we are
+# inside some *outer* ForwardDiff layer), the inner Rosenbrock Jacobian
+# widens `u` to a deeper nested-Dual type via its JacobianConfig. The user
+# `f(du, u, p, t)` body then multiplies `p[i] * u[i]` across two different
+# Dual nesting levels. ForwardDiff's cross-tag multiplication uses
+# `tagcount`-based precedence, which is a `@generated` function whose
+# literal value is baked at first compile. Depending on the order in which
+# tag types are first instantiated (which varies with precompile order),
+# the resulting ordering can invert nesting and produce a triple-nested
+# `Dual` that crashes the eventual `setindex!` with
+#     `Float64(::nested_dual)` MethodError.
+#
+# The fix (`_widen_uf_p_for_jac` in derivative_wrappers.jl) lifts
+# `uf.p` into the inner nested-Dual type ahead of time so the user
+# body never has to cross tag levels.
+#
+# To reliably reproduce the broken precedence without depending on
+# NonlinearSolve's precompile-baked NonlinearSolveTag, we construct the
+# outer Dual manually with a throwaway tag that is *not* a concrete
+# `Tag(f, V)` call. Because the throwaway tag is only used as a type
+# parameter, ForwardDiff does not trigger its `tagcount` until the first
+# cross-tag multiplication — which happens *after* `OrdinaryDiffEqTag` has
+# already had its nested-V `tagcount` triggered via
+# `OrdinaryDiffEqDifferentiation.prepare_ADType`. This matches the
+# precedence inversion that the original issue hits via
+# `NonlinearSolveTag`'s precompile workload.
+
+struct _Nested3381OuterTag end
+
+function _nested3381_ode!(du, u, p, t)
+    du[1] = -p[1] * u[1]
+    du[2] = -u[1] - p[2] * u[2]
+    return nothing
+end
+
+@testset "Nested ForwardDiff through Rosenbrock Jacobian (#3381)" begin
+    OuterTag = ForwardDiff.Tag{_Nested3381OuterTag, Float64}
+    DualT = ForwardDiff.Dual{OuterTag, Float64, 2}
+    pdual = [
+        DualT(1.5, ForwardDiff.Partials((1.0, 0.0))),
+        DualT(2.0, ForwardDiff.Partials((0.0, 1.0))),
+    ]
+
+    ode_f = ODEFunction{true, SciMLBase.FullSpecialize}(_nested3381_ode!)
+    u0 = [1.0, 1.0]
+    tspan = (0.0, 1.0)
+    prob = ODEProblem(ode_f, u0, tspan, pdual)
+
+    sol = solve(prob, Rosenbrock23(autodiff = AutoForwardDiff(chunksize = 2)))
+    @test SciMLBase.successful_retcode(sol.retcode)
+    @test eltype(sol.u[end]) === DualT
+    # Sanity: primal values still reach the target trajectory.
+    @test all(isfinite, ForwardDiff.value.(sol.u[end]))
+end

--- a/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
@@ -27,6 +27,7 @@ if TEST_GROUP ∉ ("QA", "Sparse", "ModelingToolkit")
     @time @safetestset "Differentiation Trait Tests" include("differentiation_traits_tests.jl")
     @time @safetestset "Autodiff Error Tests" include("autodiff_error_tests.jl")
     @time @safetestset "No Jac Tests" include("nojac_tests.jl")
+    @time @safetestset "Nested ForwardDiff" include("nested_forwarddiff_tests.jl")
 end
 
 # Run sparse tests (separate environment due to ComponentArrays dep conflicts)


### PR DESCRIPTION
## Summary

- Fixes SciML/OrdinaryDiffEq.jl#3381. When a Rosenbrock integrator is invoked with a `Vector{<:Dual}` `p` (because we are inside an outer ForwardDiff layer — e.g. a NonlinearLeastSquares parameter fit), the inner Jacobian widens `u` into a deeper nested-Dual type via its `JacobianConfig`, but the stored `p` in `UJacobianWrapper` is still at the *outer* Dual level. The user body then multiplies `p[i] * u[i]` across two different Dual nesting levels, which dispatches through ForwardDiff's `tagcount`-based tag precedence. That precedence is a `@generated` function whose literal value is baked at first compile, so its ordering depends on which package's precompile cache first instantiated each tag type — in this nested-AD scenario it inverts the nesting and produces a triple-nested `Dual` that crashes `setindex!(du, ...)` with `MethodError: no method matching Float64(::Dual{..., Dual{..., Float64, 2}, 2})`.
- `jacobian!` now inspects the prepared `ForwardDiff.JacobianConfig` to recover the inner xdual buffer's element type and lifts `uf.p` into that nested-Dual type via a fresh `UJacobianWrapper` before delegating to `DI.jacobian!`. The widened `p` carries zero inner partials (correct — `p` does not depend on `u`). The fast path (`_widen_uf_p_for_jac(f, prep) = f`) is a single type-stable dispatch so non-nested calls incur no overhead.
- Adds a regression test that builds an outer Dual `p` with a throwaway tag type and solves a Rosenbrock23 ODE, exercising the exact call graph that crashes pre-fix and succeeds post-fix. The test is self-contained within `OrdinaryDiffEqDifferentiation`'s test deps (no NonlinearSolve needed).
- Bumps `OrdinaryDiffEqDifferentiation` patch version 2.8.0 → 2.8.1.

## Root cause (abbreviated)

The user's MWE from SciML/OrdinaryDiffEq.jl#3381:

```julia
using OrdinaryDiffEqRosenbrock, NonlinearSolve
function ode(du, u, p, t)
    du[1] = -p[1]*u[1]
    du[2] = -u[1] - p[2]*u[2]
end
ode_f = ODEFunction{true, SciMLBase.FullSpecialize}(ode)
solve_ode(p) = solve(ODEProblem(ode_f, [1.0, 1.0], (0.0, 10.0), p),
                     Rosenbrock23(autodiff=AutoForwardDiff(chunksize=2)))
experiment = solve_ode([1.5, 2.0])
function resid!(du, p, _)
    du .= sol.(experiment.t, idxs=1) .- experiment[1, :] where sol = solve_ode(p)
end
nls = NonlinearFunction{true, SciMLBase.FullSpecialize}(resid!, resid_prototype=zeros(length(experiment.t)))
solve(NonlinearLeastSquaresProblem(nls, [1.0, 1.0]), LevenbergMarquardt())
```

fails with `FirstAutodiffJacError` wrapping
`MethodError: no method matching Float64(::ForwardDiff.Dual{Tag{OrdinaryDiffEqTag, Dual{NonlinearSolveTag, Float64, 2}}, Dual{NonlinearSolveTag, Float64, 2}, 2})`

The nested dual ends up being assigned into a vector whose eltype is only the outer single-level dual. Bisecting shows the broken `tagcount` literal order for the outer `Tag{NonlinearSolveTag, Float64}` vs. the inner `Tag{OrdinaryDiffEqTag, Dual{NonlinearSolveTag, Float64, 2}}` — the former is baked by `NonlinearSolveBase`'s precompile workload at precompile time while the latter is generated lazily at runtime, which inverts `≺` for the cross-tag `p[i]*u[i]` multiplication inside `ode`. That inversion is what this patch defends against by normalizing `p` on the *inner solver's* side so the cross-tag arithmetic never happens.

The NonlinearSolveBase-side root cause (hardcoded `Tag{NonlinearSolveTag, Float64}` stamped via `isa Vector{Float64}` specialization) is addressed in a companion PR to `SciML/NonlinearSolve.jl`. This OrdinaryDiffEq PR is the robust bug-class fix: it protects any caller that hands `UJacobianWrapper` a `Vector{<:Dual}` `p`, regardless of how that caller's tag was registered.

## Test plan

- [x] Added `lib/OrdinaryDiffEqDifferentiation/test/nested_forwarddiff_tests.jl`. Reproduces the crash pre-fix (`FirstAutodiffJacError` on an unpatched `repro` env) and passes post-fix on the same env with just the `derivative_wrappers.jl` change developed in.
- [x] Existing `Autodiff Error Tests` / `Differentiation Trait Tests` / `No Jac Tests` still pass locally (no behavior change for single-level AD — `_widen_uf_p_for_jac` returns `f` unchanged in that path).
- [ ] CI on `OrdinaryDiffEqDifferentiation` test group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)