### PR TITLE
Add READMEs and docs page for new packages (AMF, Multirate)

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,11 +2,14 @@
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+OrdinaryDiffEqAMF = "08082164-f6a1-4363-b3df-3aa6fcf571ad"
 
 [sources]
 DiffEqDevTools = {path = "../lib/DiffEqDevTools"}
+OrdinaryDiffEqAMF = {path = "../lib/OrdinaryDiffEqAMF"}
 
 [compat]
 DiffEqDevTools = "2"
 Documenter = "0.27, 1"
 OrdinaryDiffEq = "6"
+OrdinaryDiffEqAMF = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,5 @@
 using Documenter, OrdinaryDiffEq, DiffEqDevTools
+using OrdinaryDiffEqAMF
 
 cp(joinpath(@__DIR__, "Manifest.toml"), joinpath(@__DIR__, "src", "assets", "Manifest.toml"), force = true)
 cp(joinpath(@__DIR__, "Project.toml"), joinpath(@__DIR__, "src", "assets", "Project.toml"), force = true)
@@ -39,6 +40,7 @@ makedocs(
         OrdinaryDiffEq.OrdinaryDiffEqSymplecticRK,
         OrdinaryDiffEq.OrdinaryDiffEqTsit5,
         OrdinaryDiffEq.OrdinaryDiffEqVerner,
+        OrdinaryDiffEqAMF,
         DiffEqDevTools,
     ],
     linkcheck_ignore = [r"https://github.com/JuliaDiff/ForwardDiff.jl"],

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -17,6 +17,7 @@ pages = [
     ],
     "Semi-Implicit Solvers" => [
         "semiimplicit/Rosenbrock.md",
+        "semiimplicit/AMF.md",
         "semiimplicit/StabilizedRK.md",
         "semiimplicit/ExponentialRK.md",
     ],

--- a/docs/src/semiimplicit/AMF.md
+++ b/docs/src/semiimplicit/AMF.md
@@ -40,16 +40,36 @@ If your Jacobian is genuinely dense and unstructured, plain Rosenbrock with a st
 
 To use it, the `ODEFunction` must carry a `jac_prototype` (the true Jacobian, as a `SciMLOperator`) *and* a `W_prototype` (the AMF approximation of `-(I - γJ)/γ`, built from the factors). `build_amf_function` assembles both for you.
 
-## Usage
+## Usage: 2D reaction-diffusion with ADI-style splitting
 
-First install the package alongside a Rosenbrock-W subpackage:
+The canonical AMF use case is a PDE whose discrete Laplacian separates along each spatial dimension — the split reduces the dense Rosenbrock-W `W` solve to a pair of Kronecker-structured solves that can be done much faster. This example is a 2D reaction-diffusion problem,
+
+```
+uₜ = A uₓₓ + B u_yy + g(u, t),     g(u, t) = u²(1 − u) + eᵗ,
+```
+
+on the unit square with homogeneous Dirichlet boundary conditions. After second-order finite differencing on an `N × N` grid, the Jacobian of the linear (diffusion) part splits as
+
+```
+J = A (Lx ⊗ I) + B (I ⊗ Lx) = Jx + Jy
+```
+
+where `Lx` is the tridiagonal 1D Laplacian. AMF approximates the stage operator as
+
+```
+W ≈ −(I − γ Jx)(I − γ Jy) / γ,
+```
+
+so each stage does two independent block-diagonal tridiagonal solves instead of one dense solve — the standard ADI preconditioner, applied automatically by `AMF(...)` whenever you hand it the split.
+
+Install the package alongside a Rosenbrock-W subpackage:
 
 ```julia
 using Pkg
 Pkg.add(["OrdinaryDiffEqAMF", "OrdinaryDiffEqRosenbrock"])
 ```
 
-Minimal example with a 2-way split Jacobian:
+Set up the problem:
 
 ```julia
 using OrdinaryDiffEqAMF
@@ -57,45 +77,73 @@ using OrdinaryDiffEqRosenbrock
 using SciMLOperators
 using LinearAlgebra
 
-# Problem: du/dt = f(u, t), with Jacobian J = J_upper + J_lower.
-function f!(du, u, p, t)
-    # ... fill du ...
+function setup_fd2d_problem(; A = 0.1, B = 0.1, N = 40, final_t = 1.0)
+    h = 1 / (N + 1)
+
+    # 1D Laplacian with Dirichlet zero BCs, as a SciMLOperator.
+    D    = (1 / h^2) * Tridiagonal(ones(N - 1), -2 * ones(N), ones(N - 1))
+    D_op = MatrixOperator(D)
+
+    # 2D Jacobian pieces: diffusion in x and in y, via Kronecker products.
+    Jx_op = A * Base.kron(D_op, IdentityOperator(N))
+    Jy_op = B * Base.kron(IdentityOperator(N), D_op)
+    J_op  = cache_operator(Jx_op + Jy_op, zeros(N^2))
+
+    # Nonlinear reaction term.
+    g!(du, u, p, t) = (@. du += u^2 * (1 - u) + exp(t); return nothing)
+
+    # Full RHS: linear diffusion + nonlinear reaction.
+    function f!(du, u, p, t)
+        mul!(du, J_op, u)
+        g!(du, u, p, t)
+        return nothing
+    end
+
+    # Initial condition: a bump that vanishes on the boundary.
+    u0 = [16 * (h * i) * (h * j) * (1 - h * i) * (1 - h * j) for i in 1:N for j in 1:N]
+
+    # Hand the split to build_amf_function so Rosenbrock-W sees the
+    # structured W_prototype instead of a dense one.
+    amf_func = build_amf_function(f!; jac = J_op, split = (Jx_op, Jy_op))
+    return ODEProblem(amf_func, u0, (0.0, final_t))
 end
 
-# Per-part update functions populate the structured operators in place.
-fjac_upper(J, u, p, t) = (# fill upper-triangular J)
-fjac_lower(J, u, p, t) = (# fill lower-triangular J)
-
-N = 20
-J1_op = MatrixOperator(UpperTriangular(zeros(N, N)); update_func! = fjac_upper)
-J2_op = MatrixOperator(LowerTriangular(zeros(N, N)); update_func! = fjac_lower)
-J_op  = cache_operator(J1_op + J2_op, zeros(N))
-
-# Hand the split to build_amf_function so it can build the W_prototype for you.
-func = build_amf_function(f!; jac = J_op, split = (J1_op, J2_op))
-
-u0    = zeros(N)
-tspan = (0.0, 1.0)
-prob  = ODEProblem(func, u0, tspan)
-
-sol = solve(prob, AMF(ROS34PW1a))
+prob = setup_fd2d_problem()
+sol  = solve(prob, AMF(ROS34PW1a); abstol = 1e-8, reltol = 1e-8)
 ```
+
+For this 1600-unknown problem the AMF stage solve is substantially faster than the dense equivalent, and the speedup grows with `N` because the dense `W` solve is `O(N⁶)` while the two Kronecker-structured AMF solves are `O(N³)` total. A regression test inside the package (`lib/OrdinaryDiffEqAMF/test/test_fd2d.jl`) measures the speedup on the same problem against a baseline `solve(..., ROS34PW1a())` without AMF.
 
 ### Supplying AMF factors directly
 
-Sometimes you want to control the factors yourself — for example when the factors aren't just `I - γJᵢ` but have their own structure (pre-factorized banded matrices, FFT plans, etc.). Pass them as `amf_factors`:
+Sometimes you want to control the factors yourself — for instance to pre-factorize each 1D operator with something cheaper than a generic structured solver, or to bake in an FFT plan. Pass the custom factors as `amf_factors`:
 
 ```julia
-func = build_amf_function(f!;
-    jac = J_op,
-    split = (J1_op, J2_op),
-    amf_factors = (F1_op, F2_op),
+using SciMLOperators: ScalarOperator
+
+gamma_op = ScalarOperator(
+    1.0;
+    update_func       = (old, u, p, t; gamma = 1.0) -> gamma,
+    accepted_kwargs   = Val((:gamma,)),
 )
 
-sol = solve(prob, AMF(Rosenbrock23))
+# Each factor is (I − γ Jᵢ), pre-assembled as a Kronecker-structured operator.
+custom_factors = (
+    Base.kron(IdentityOperator(N) - gamma_op * A * D_op, IdentityOperator(N)),
+    Base.kron(IdentityOperator(N), IdentityOperator(N) - gamma_op * B * D_op),
+)
+
+amf_func = build_amf_function(
+    f!;
+    jac         = J_op,
+    split       = (Jx_op, Jy_op),
+    amf_factors = custom_factors,
+)
+
+sol = solve(ODEProblem(amf_func, u0, (0.0, 1.0)), AMF(ROS34PW1a); reltol = 1e-8)
 ```
 
-`split` and `amf_factors` must contain the same number of operators; the split is used to propagate Jacobian updates while the factors determine what `W_prototype` actually looks like.
+`split` and `amf_factors` must contain the same number of operators: the split is used to propagate Jacobian updates, and the factors determine the actual `W_prototype` that the linear solver sees.
 
 ### Forwarding keyword arguments
 

--- a/docs/src/semiimplicit/AMF.md
+++ b/docs/src/semiimplicit/AMF.md
@@ -1,0 +1,114 @@
+```@meta
+CollapsedDocStrings = true
+```
+
+# OrdinaryDiffEqAMF
+
+**Approximate Matrix Factorization (AMF)** is a wrapper around Rosenbrock-W methods that replaces the dense `W = I - γJ` solve at each stage with a product of simpler factors:
+
+```
+W ≈ -∏ᵢ (I - γJᵢ) / γ
+```
+
+where the `Jᵢ` are individually-structured pieces of the Jacobian (e.g. upper and lower triangular parts, directional operators in dimensional splittings, mode blocks in spectral discretizations). Each factor can be solved independently with a cheap structured solver, so the overall per-step work drops from "one dense solve" to "a handful of structured solves".
+
+## Key Properties
+
+AMF methods provide:
+
+  - **Structured linear solves** — each factor is handled by its own `SciMLOperator`-aware solver, so you never materialize a dense `W`.
+  - **Any Rosenbrock-W base method** — `AMF` is an algorithm wrapper, not a fixed integrator; plug in `Rosenbrock23`, `ROS34PW1a`, `Rodas4`, etc.
+  - **Works with the existing SciML split/operator infrastructure** — you describe the Jacobian split as `SciMLOperators` and pass them through `build_amf_function`.
+  - **Preserves the Rosenbrock-W order** under the usual AMF consistency assumptions.
+
+## When to Use AMF
+
+AMF is recommended when:
+
+  - Your Jacobian has **exploitable structure** that a dense LU solve would throw away — e.g. ADI-style dimensional splits, upper+lower triangular decompositions, block-diagonal plus a low-rank coupling, FFT/diagonalizable pieces.
+  - You're using a **Rosenbrock-W method** and the `W` solve is the dominant per-step cost.
+  - You can write the structured factors as `SciMLOperators`.
+
+If your Jacobian is genuinely dense and unstructured, plain Rosenbrock with a standard `LinearSolve` algorithm will be simpler and faster — AMF only helps when the product-of-factors approximation is significantly cheaper than the true `W` solve.
+
+## How It Works
+
+`AMF(AlgType)` wraps a Rosenbrock-W algorithm type. When you call `solve(prob, AMF(ROS34PW1a))`, the wrapper:
+
+ 1. Instantiates the inner algorithm with `linsolve = SciMLOpFactorization()`, a `LinearSolve` backend that respects `SciMLOperator` products and solves them factor-by-factor rather than concretizing them.
+ 2. Delegates the rest of the integration to the inner Rosenbrock-W method unchanged.
+
+To use it, the `ODEFunction` must carry a `jac_prototype` (the true Jacobian, as a `SciMLOperator`) *and* a `W_prototype` (the AMF approximation of `-(I - γJ)/γ`, built from the factors). `build_amf_function` assembles both for you.
+
+## Usage
+
+First install the package alongside a Rosenbrock-W subpackage:
+
+```julia
+using Pkg
+Pkg.add(["OrdinaryDiffEqAMF", "OrdinaryDiffEqRosenbrock"])
+```
+
+Minimal example with a 2-way split Jacobian:
+
+```julia
+using OrdinaryDiffEqAMF
+using OrdinaryDiffEqRosenbrock
+using SciMLOperators
+using LinearAlgebra
+
+# Problem: du/dt = f(u, t), with Jacobian J = J_upper + J_lower.
+function f!(du, u, p, t)
+    # ... fill du ...
+end
+
+# Per-part update functions populate the structured operators in place.
+fjac_upper(J, u, p, t) = (# fill upper-triangular J)
+fjac_lower(J, u, p, t) = (# fill lower-triangular J)
+
+N = 20
+J1_op = MatrixOperator(UpperTriangular(zeros(N, N)); update_func! = fjac_upper)
+J2_op = MatrixOperator(LowerTriangular(zeros(N, N)); update_func! = fjac_lower)
+J_op  = cache_operator(J1_op + J2_op, zeros(N))
+
+# Hand the split to build_amf_function so it can build the W_prototype for you.
+func = build_amf_function(f!; jac = J_op, split = (J1_op, J2_op))
+
+u0    = zeros(N)
+tspan = (0.0, 1.0)
+prob  = ODEProblem(func, u0, tspan)
+
+sol = solve(prob, AMF(ROS34PW1a))
+```
+
+### Supplying AMF factors directly
+
+Sometimes you want to control the factors yourself — for example when the factors aren't just `I - γJᵢ` but have their own structure (pre-factorized banded matrices, FFT plans, etc.). Pass them as `amf_factors`:
+
+```julia
+func = build_amf_function(f!;
+    jac = J_op,
+    split = (J1_op, J2_op),
+    amf_factors = (F1_op, F2_op),
+)
+
+sol = solve(prob, AMF(Rosenbrock23))
+```
+
+`split` and `amf_factors` must contain the same number of operators; the split is used to propagate Jacobian updates while the factors determine what `W_prototype` actually looks like.
+
+### Forwarding keyword arguments
+
+Any extra kwargs passed to `AMF(alg; kwargs...)` are forwarded to the inner algorithm constructor:
+
+```julia
+sol = solve(prob, AMF(ROS34PW1a; autodiff = AutoFiniteDiff()))
+```
+
+## Full list of exports
+
+```@docs
+OrdinaryDiffEqAMF.AMF
+OrdinaryDiffEqAMF.AMFOperator
+OrdinaryDiffEqAMF.build_amf_function
+```

--- a/lib/OrdinaryDiffEqAMF/README.md
+++ b/lib/OrdinaryDiffEqAMF/README.md
@@ -1,0 +1,80 @@
+# OrdinaryDiffEqAMF
+
+[![Join the chat at https://julialang.zulipchat.com #sciml-bridged](https://img.shields.io/static/v1?label=Zulip&message=chat&color=9558b2&labelColor=389826)](https://julialang.zulipchat.com/#narrow/stream/279055-sciml-bridged)
+[![Global Docs](https://img.shields.io/badge/docs-SciML-blue.svg)](https://docs.sciml.ai/OrdinaryDiffEq/stable/)
+
+[![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor%27s%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
+[![SciML Code Style](https://img.shields.io/static/v1?label=code%20style&message=SciML&color=9558b2&labelColor=389826)](https://github.com/SciML/SciMLStyle)
+
+OrdinaryDiffEqAMF is a subpackage of the [OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl) monorepo that provides **Approximate Matrix Factorization (AMF)** wrappers for Rosenbrock-W methods. AMF lets you replace the dense `W = I - γJ` solve at each Rosenbrock-W stage with a product of simpler factors, `W ≈ ∏ᵢ (I - γJᵢ)`, which is often much cheaper for problems whose Jacobian has exploitable structure (e.g. dimensionally-split discretizations of PDEs).
+
+## Installation
+
+```julia
+import Pkg
+Pkg.add("OrdinaryDiffEqAMF")
+```
+
+For targeted dependencies, pair it with a Rosenbrock-W subpackage such as `OrdinaryDiffEqRosenbrock`:
+
+```julia
+Pkg.add(["OrdinaryDiffEqAMF", "OrdinaryDiffEqRosenbrock"])
+```
+
+## How it works
+
+`AMF` is a thin algorithm wrapper around any Rosenbrock-W method (`ROS34PW1a`, `Rosenbrock23`, `Rodas4`, …). When you call `solve(prob, AMF(ROS34PW1a))` it:
+
+1. Configures the inner Rosenbrock-W algorithm with `linsolve = SciMLOpFactorization()`, a linear solver that keeps the `W_prototype` as a `SciMLOperator` product instead of concretizing it to a dense matrix.
+2. Expects the `ODEFunction` to carry a structured `jac_prototype` and `W_prototype` made of `SciMLOperators`. Build them with `build_amf_function`.
+
+The result: each stage's `W` solve is done one factor at a time, typically with structured solves (triangular, banded, FFT-diagonalizable, etc.) that are asymptotically cheaper than a dense factorization.
+
+## Usage
+
+```julia
+using OrdinaryDiffEqAMF
+using OrdinaryDiffEqRosenbrock
+using SciMLOperators
+using LinearAlgebra
+
+# A 20×20 problem whose Jacobian splits into upper + lower triangular parts.
+N = 20
+
+function f!(du, u, p, t)
+    # ... fill du ...
+end
+
+# Per-part Jacobians, expressed as SciMLOperators.
+J1_op = MatrixOperator(UpperTriangular(zeros(N, N)); update_func! = fjac_upper)
+J2_op = MatrixOperator(LowerTriangular(zeros(N, N)); update_func! = fjac_lower)
+J_op  = cache_operator(J1_op + J2_op, zeros(N))
+
+# Build the ODEFunction with AMF-aware jac_prototype / W_prototype.
+func = build_amf_function(f!; jac = J_op, split = (J1_op, J2_op))
+
+u0    = zeros(N)
+tspan = (0.0, 1.0)
+prob  = ODEProblem(func, u0, tspan)
+
+sol = solve(prob, AMF(ROS34PW1a))
+```
+
+If you want to supply custom structured AMF factors directly (rather than letting the wrapper build `I - γJᵢ` for you), pass `amf_factors = (F1, F2, …)` to `build_amf_function`.
+
+Extra keyword arguments given to `AMF(alg; kwargs...)` are forwarded to the inner algorithm constructor, so you can still tune autodiff, step control, etc.:
+
+```julia
+sol = solve(prob, AMF(ROS34PW1a; autodiff = AutoFiniteDiff()))
+```
+
+## Exports
+
+- `AMF` — algorithm wrapper
+- `AMFOperator` — builds the `W_prototype` operator from a Jacobian, a split, or explicit factors
+- `build_amf_function` — helper that assembles the `ODEFunction` with the right `jac_prototype`, `W_prototype`, and sparsity pattern
+- `SciMLOpFactorization` — the `SciMLOperator`-aware linear solver used internally
+
+## Documentation
+
+See the main [OrdinaryDiffEq.jl documentation](https://docs.sciml.ai/OrdinaryDiffEq/stable/) for background on Rosenbrock-W methods and the broader SciML ecosystem.

--- a/lib/OrdinaryDiffEqMultirate/README.md
+++ b/lib/OrdinaryDiffEqMultirate/README.md
@@ -1,0 +1,62 @@
+# OrdinaryDiffEqMultirate
+
+[![Join the chat at https://julialang.zulipchat.com #sciml-bridged](https://img.shields.io/static/v1?label=Zulip&message=chat&color=9558b2&labelColor=389826)](https://julialang.zulipchat.com/#narrow/stream/279055-sciml-bridged)
+[![Global Docs](https://img.shields.io/badge/docs-SciML-blue.svg)](https://docs.sciml.ai/OrdinaryDiffEq/stable/)
+
+[![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor%27s%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
+[![SciML Code Style](https://img.shields.io/static/v1?label=code%20style&message=SciML&color=9558b2&labelColor=389826)](https://github.com/SciML/SciMLStyle)
+
+OrdinaryDiffEqMultirate is a subpackage of the [OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl) monorepo that provides **multirate explicit integrators** for split ODEs of the form
+
+```
+du/dt = f1(u, t) + f2(u, t)
+```
+
+where `f1` is the *fast* component and `f2` is the *slow* component (the standard SciML split-ODE convention). The slow rate is frozen over each macro interval while the fast rate is integrated with many substeps, so you pay the cost of the slow term only once per macro step.
+
+## Installation
+
+```julia
+import Pkg
+Pkg.add("OrdinaryDiffEqMultirate")
+```
+
+## Exports
+
+- `MREEF` — **M**ultirate **R**ichardson **E**xtrapolation with **E**uler as the base **F**ast method. An adaptive explicit integrator that stacks multiple Euler-based fast-slow integrations into an Aitken–Neville Richardson-extrapolation table to boost accuracy.
+
+`MREEF` keyword arguments:
+
+| kwarg | default | meaning |
+| --- | --- | --- |
+| `m` | `4` | number of fast substeps per macro interval |
+| `order` | `4` | extrapolation order (number of base solutions in the Richardson table) |
+| `seq` | `:harmonic` | subdivision sequence used for extrapolation; `:harmonic` or `:romberg` |
+
+## Usage
+
+```julia
+using OrdinaryDiffEqMultirate
+using SciMLBase
+
+# A split ODE: f1 is the fast rate, f2 is the slow rate.
+f1!(du, u, p, t) = (@. du = -50 * u)    # fast, stiff-ish
+f2!(du, u, p, t) = (@. du = -u)         # slow
+
+u0    = [1.0, 2.0, 3.0]
+tspan = (0.0, 1.0)
+
+prob = SplitODEProblem(f1!, f2!, u0, tspan)
+sol  = solve(prob, MREEF())               # defaults: m=4, order=4, :harmonic
+
+# Tune the substep count / extrapolation order explicitly:
+sol = solve(prob, MREEF(m = 8, order = 6, seq = :romberg))
+```
+
+## When to reach for it
+
+Multirate methods pay off when the two halves of your split have very different characteristic timescales and the slow term is expensive to evaluate (so you really want to evaluate it as few times as possible while still resolving the fast dynamics). For problems where both halves cost roughly the same per call, a standard explicit RK on the combined right-hand side is usually simpler and faster.
+
+## Documentation
+
+See the main [OrdinaryDiffEq.jl documentation](https://docs.sciml.ai/OrdinaryDiffEq/stable/) for background on split-ODE solvers and the broader SciML ecosystem.


### PR DESCRIPTION
## Summary

Followup to #3387 / #3388. `OrdinaryDiffEqAMF` and `OrdinaryDiffEqMultirate` are being registered in General for the first time from those two PRs, but the monorepo didn't have:

- A README for either new package
- A docs page explaining what Approximate Matrix Factorization is or when to reach for it

This PR adds all three, so new users hitting the JuliaHub / docs pages after these register have something to read.

## What's in here

### READMEs
- **`lib/OrdinaryDiffEqAMF/README.md`** — overview of AMF as a Rosenbrock-W wrapper, how `SciMLOperators` split + `build_amf_function` interact, usage example with an upper/lower triangular split, list of exports.
- **`lib/OrdinaryDiffEqMultirate/README.md`** — overview of `MREEF` (Multirate Richardson Extrapolation with Euler base), kwargs table, `SplitODEProblem` usage example, guidance on when multirate actually pays off.

### AMF docs page

- **`docs/src/semiimplicit/AMF.md`** — full solver page following the same structure as `semiimplicit/Rosenbrock.md`: key properties, when to use, how it works, usage (including the `amf_factors =` path for custom structured factors), and `@docs` autodoc block for `AMF`, `AMFOperator`, `build_amf_function`.
- **`docs/pages.jl`** — adds the page under *Semi-Implicit Solvers* right after `Rosenbrock.md`.
- **`docs/Project.toml`** — adds `OrdinaryDiffEqAMF` as a dep with a local `[sources]` path so the `@docs` block can resolve the exported symbols.
- **`docs/make.jl`** — `using OrdinaryDiffEqAMF` and adds it to the `modules` list.

No code changes and no version bumps — this PR is docs/READMEs only, so the pending AMF and Multirate Registrator PRs don't need anything new. Once this merges I'll re-fire Registrator for both so the new tree (which now includes READMEs) is what gets registered.

## Test plan

- [ ] Docs build passes (`docs/make.jl`)
- [ ] `@docs` block in `AMF.md` resolves without missing-docstring warnings for `AMF`, `AMFOperator`, `build_amf_function`
- [ ] After merge, re-fire `@JuliaRegistrator register subdir=lib/OrdinaryDiffEqAMF` and `@JuliaRegistrator register subdir=lib/OrdinaryDiffEqMultirate` on the new merge commit so the registered tree includes the READMEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)