### PR TITLE
CI check: d_discontinuities shift-past (master target)

### DIFF
--- a/lib/DelayDiffEq/src/integrators/interface.jl
+++ b/lib/DelayDiffEq/src/integrators/interface.jl
@@ -508,6 +508,9 @@ function DiffEqBase.reinit!(
         DiffEqBase.initialize!(integrator)
     end
 
+    # Starting-time discontinuity handling: mirrors DDE's __init.
+    OrdinaryDiffEqCore.handle_starting_time_discontinuity!(integrator)
+
     return nothing
 end
 

--- a/lib/DelayDiffEq/src/integrators/utils.jl
+++ b/lib/DelayDiffEq/src/integrators/utils.jl
@@ -51,8 +51,9 @@ function advance_ode_integrator!(integrator::DDEIntegrator, always_calc_begin = 
     ode_integrator = integrator.integrator
 
     # algorithm only works if current time of DDE integrator equals final time point
-    # of solution
-    t != ode_integrator.sol.t[end] && error("cannot advance ODE integrator")
+    # of solution (allow one-ULP gap from shift_past_discontinuity!)
+    abs(t - ode_integrator.sol.t[end]) > eps(t) &&
+        error("cannot advance ODE integrator")
 
     # complete interpolation data of DDE integrator for time interval [t, t+dt]
     # and copy it to ODE integrator
@@ -231,31 +232,16 @@ function OrdinaryDiffEqCore.handle_discontinuities!(integrator::DDEIntegrator)
     return nothing
 end
 
-# Override shift_past_discontinuity! for DDEIntegrator: after advancing
-# integrator.t by one ULP, add a new save slot to the history ODE integrator's
-# solution at the shifted time. This keeps the `t == ode_integrator.sol.t[end]`
-# invariant in `advance_ode_integrator!` satisfied, and gives the history
-# interpolant a proper boundary at the discontinuity.
+# Override shift_past_discontinuity! for DDEIntegrator: shift integrator.t
+# and ode_integrator.t by one ULP. We do NOT modify ode_integrator.sol.t
+# (which must stay in lockstep with the outer DDE sol.t). Instead, the
+# one-ULP gap between t and sol.t[end] is tolerated by a relaxed check
+# in advance_ode_integrator!.
 function OrdinaryDiffEqCore.shift_past_discontinuity!(integrator::DDEIntegrator)
     OrdinaryDiffEqCore._shift_past_discontinuity!(
         integrator, integrator.t, integrator.tdir
     )
-    # Add a new save slot at the shifted time. The state u is continuous
-    # across the discontinuity so we copy the current values unchanged.
-    ode_integrator = integrator.integrator
-    ode_integrator.saveiter += 1
-    copyat_or_push!(ode_integrator.sol.t, ode_integrator.saveiter, integrator.t)
-    copyat_or_push!(ode_integrator.sol.u, ode_integrator.saveiter, ode_integrator.u)
-    ode_integrator.saveiter_dense += 1
-    copyat_or_push!(ode_integrator.sol.k, ode_integrator.saveiter_dense, ode_integrator.k)
-    if iscomposite(integrator.alg)
-        copyat_or_push!(
-            ode_integrator.sol.alg_choice, ode_integrator.saveiter,
-            integrator.cache.current
-        )
-    end
-    ode_integrator.t = integrator.t
-    integrator.prev_idx = ode_integrator.saveiter
+    integrator.integrator.t = integrator.t
     return nothing
 end
 

--- a/lib/DelayDiffEq/src/integrators/utils.jl
+++ b/lib/DelayDiffEq/src/integrators/utils.jl
@@ -232,18 +232,24 @@ function OrdinaryDiffEqCore.handle_discontinuities!(integrator::DDEIntegrator)
 end
 
 # Override shift_past_discontinuity! for DDEIntegrator: after advancing
-# integrator.t by one ULP, also update the internal ODE integrator's solution
-# endpoint so that the `t == ode_integrator.sol.t[end]` check in
-# advance_ode_integrator! remains satisfied.
+# integrator.t by one ULP, add a new save slot to the history ODE integrator's
+# solution at the shifted time. This keeps the `t == ode_integrator.sol.t[end]`
+# invariant in `advance_ode_integrator!` satisfied, and gives the history
+# interpolant a proper boundary at the discontinuity.
 function OrdinaryDiffEqCore.shift_past_discontinuity!(integrator::DDEIntegrator)
     OrdinaryDiffEqCore._shift_past_discontinuity!(
         integrator, integrator.t, integrator.tdir
     )
-    # Keep the ODE history integrator's solution endpoint in sync
+    # Add a new save slot at the shifted time. The state u is continuous
+    # across the discontinuity so we copy the current values unchanged.
     ode_integrator = integrator.integrator
-    if !isempty(ode_integrator.sol.t) && length(ode_integrator.sol.t) > 0
-        ode_integrator.sol.t[end] = integrator.t
-    end
+    ode_integrator.saveiter += 1
+    copyat_or_push!(ode_integrator.sol.t, ode_integrator.saveiter, integrator.t)
+    copyat_or_push!(ode_integrator.sol.u, ode_integrator.saveiter, ode_integrator.u)
+    ode_integrator.saveiter_dense += 1
+    copyat_or_push!(ode_integrator.sol.k, ode_integrator.saveiter_dense, ode_integrator.k)
+    ode_integrator.t = integrator.t
+    integrator.prev_idx = ode_integrator.saveiter
     return nothing
 end
 

--- a/lib/DelayDiffEq/src/integrators/utils.jl
+++ b/lib/DelayDiffEq/src/integrators/utils.jl
@@ -248,6 +248,12 @@ function OrdinaryDiffEqCore.shift_past_discontinuity!(integrator::DDEIntegrator)
     copyat_or_push!(ode_integrator.sol.u, ode_integrator.saveiter, ode_integrator.u)
     ode_integrator.saveiter_dense += 1
     copyat_or_push!(ode_integrator.sol.k, ode_integrator.saveiter_dense, ode_integrator.k)
+    if iscomposite(integrator.alg)
+        copyat_or_push!(
+            ode_integrator.sol.alg_choice, ode_integrator.saveiter,
+            integrator.cache.current
+        )
+    end
     ode_integrator.t = integrator.t
     integrator.prev_idx = ode_integrator.saveiter
     return nothing

--- a/lib/DelayDiffEq/src/integrators/utils.jl
+++ b/lib/DelayDiffEq/src/integrators/utils.jl
@@ -231,6 +231,22 @@ function OrdinaryDiffEqCore.handle_discontinuities!(integrator::DDEIntegrator)
     return nothing
 end
 
+# Override shift_past_discontinuity! for DDEIntegrator: after advancing
+# integrator.t by one ULP, also update the internal ODE integrator's solution
+# endpoint so that the `t == ode_integrator.sol.t[end]` check in
+# advance_ode_integrator! remains satisfied.
+function OrdinaryDiffEqCore.shift_past_discontinuity!(integrator::DDEIntegrator)
+    OrdinaryDiffEqCore._shift_past_discontinuity!(
+        integrator, integrator.t, integrator.tdir
+    )
+    # Keep the ODE history integrator's solution endpoint in sync
+    ode_integrator = integrator.integrator
+    if !isempty(ode_integrator.sol.t) && length(ode_integrator.sol.t) > 0
+        ode_integrator.sol.t[end] = integrator.t
+    end
+    return nothing
+end
+
 """
     add_next_discontinuities!(integrator::DDEIntegrator, order[, t=integrator.t])
 

--- a/lib/DelayDiffEq/src/solve.jl
+++ b/lib/DelayDiffEq/src/solve.jl
@@ -594,6 +594,9 @@ function SciMLBase.__init(
         integrator.W.dt = integrator.dt
     end
 
+    # Starting-time discontinuity handling: mirrors OrdinaryDiffEqCore's __init.
+    OrdinaryDiffEqCore.handle_starting_time_discontinuity!(integrator)
+
     return integrator
 end
 

--- a/lib/DiffEqBase/src/solve.jl
+++ b/lib/DiffEqBase/src/solve.jl
@@ -351,9 +351,25 @@ section at the end of this page for some example usage.
   also cannot interpolate, then `tstops` must be a multiple of `dt` or else an
   error will be thrown. `tstops` may also be a function `tstops(p, tspan)`, accepting the parameter
   object and `tspan`, returning the vector of time points to stop at. Default is `[]`.
-* `d_discontinuities:` Denotes locations of discontinuities in low order derivatives.
-  This will force FSAL algorithms which assume derivative continuity to re-evaluate
-  the derivatives at the point of discontinuity. The default is `[]`.
+* `d_discontinuities`: Denotes locations of discontinuities in low-order derivatives
+  of the vector field `f`. Each entry `t_d` is added as a tstop, and when the
+  integrator lands on `t_d` it advances `t` by one ULP in the integration direction
+  and re-evaluates the FSAL cache on the post-discontinuity side. The convention
+  is *right-continuous*: `f` evaluated at `t_d` is the "old" regime and `f` at
+  `nextfloat(t_d)` is the "new" regime, so user code should be written as
+  ```julia
+  if t > t_d
+      # new regime
+  else
+      # old regime
+  end
+  ```
+  Writing `t >= t_d` also works but means the solver takes one step of post-regime
+  integration with a pre-regime-evaluated FSAL, which is less efficient and can
+  reduce step acceptance near the discontinuity. A `d_discontinuities` entry at
+  `tspan[1]` is supported (the starting-time case), in which case the first step
+  begins at `nextfloat(tspan[1])`; this is useful for callbacks that need to
+  activate immediately. The default is `[]`.
 * `save_everystep`: Saves the result at every step.
   Default is true if `isempty(saveat)`.
 * `save_on`: Denotes whether intermediate solutions are saved. This overrides the

--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
@@ -582,6 +582,10 @@ function SciMLBase.reinit!(
     end
 
     reinit_noise!(_get_W(integrator), integrator.dt)
+
+    # Starting-time discontinuity handling: mirrors `__init`.
+    handle_starting_time_discontinuity!(integrator)
+
     return nothing
 end
 

--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
@@ -131,6 +131,7 @@ function update_fsal!(integrator)
     if has_discontinuity(integrator) &&
             first_discontinuity(integrator) == integrator.tdir * integrator.t
         handle_discontinuities!(integrator)
+        shift_past_discontinuity!(integrator)
         get_current_isfsal(integrator.alg, integrator.cache) && reset_fsal!(integrator)
     elseif all_fsal(integrator.alg, integrator.cache) ||
             get_current_isfsal(integrator.alg, integrator.cache)
@@ -722,6 +723,34 @@ function update_uprev!(integrator)
 end
 
 handle_discontinuities!(integrator) = pop_discontinuity!(integrator)
+
+"""
+    shift_past_discontinuity!(integrator)
+
+Advance `integrator.t` by one ULP in the `integrator.tdir` direction. Called
+right after `handle_discontinuities!` so that subsequent RHS evaluations —
+including the FSAL re-evaluation that follows in `update_fsal!` — take place
+on the post-discontinuity side of `t`-dependent branches in the user's `f`.
+
+By convention, a `d_discontinuities` entry at `t_d` marks the vector field as
+right-discontinuous there: `f` evaluated at `t_d` is the "old" regime, and
+`f` at `nextfloat(t_d)` is the "new" regime. This pairs with user code
+written as `if t > t_d; new; else; old; end` and lets starting-time
+discontinuities (`t_d == t0`) work by advancing forward into the tspan.
+
+The state `u` is continuous across `t_d` (only the vector field changes), so
+it is left untouched. For non-`AbstractFloat` time types (e.g. `Rational`),
+there is no ULP to shift to and the call is a no-op.
+"""
+@inline function shift_past_discontinuity!(integrator)
+    _shift_past_discontinuity!(integrator, integrator.t, integrator.tdir)
+    return nothing
+end
+@inline function _shift_past_discontinuity!(integrator, t::AbstractFloat, tdir)
+    integrator.t = tdir > 0 ? nextfloat(t) : prevfloat(t)
+    return nothing
+end
+@inline _shift_past_discontinuity!(integrator, t, tdir) = nothing
 
 function calc_dt_propose!(integrator, dtnew)
     dtnew = if has_dtnew_modification(integrator.alg) &&

--- a/lib/OrdinaryDiffEqCore/src/solve.jl
+++ b/lib/OrdinaryDiffEqCore/src/solve.jl
@@ -838,7 +838,36 @@ function _ode_init(
         !isnothing(integrator.P) && (integrator.P.dt = integrator.dt)
     end
 
+    # Starting-time discontinuity: if `d_discontinuities` names `t0`, advance
+    # past it so the first step's RHS evaluations are on the post-discontinuity
+    # side of `t`-dependent branches in `f` (e.g. `if t > t0`). The regular
+    # `update_fsal!` mechanism only fires at iter > 0, so handle the iter==0
+    # case explicitly here. Interior/end discontinuities are handled normally
+    # via the tstops heap and `update_fsal!`. Gated on `initialize_integrator`
+    # because otherwise the FSAL cache is not yet populated.
+    if initialize_integrator
+        handle_starting_time_discontinuity!(integrator)
+    end
+
     return integrator
+end
+
+"""
+    handle_starting_time_discontinuity!(integrator)
+
+If `integrator.opts.d_discontinuities` has an entry at exactly `integrator.t`
+(i.e. at `t0`), pop it, shift `t` by one ULP in the `tdir` direction, and
+re-evaluate the FSAL cache on the post-discontinuity side. No-op otherwise.
+"""
+function handle_starting_time_discontinuity!(integrator)
+    if has_discontinuity(integrator) &&
+            first_discontinuity(integrator) == integrator.tdir * integrator.t
+        handle_discontinuities!(integrator)
+        shift_past_discontinuity!(integrator)
+        get_current_isfsal(integrator.alg, integrator.cache) &&
+            reset_fsal!(integrator)
+    end
+    return nothing
 end
 
 function SciMLBase.solve!(integrator::ODEIntegrator)

--- a/test/interface/ode_tstops_tests.jl
+++ b/test/interface/ode_tstops_tests.jl
@@ -217,3 +217,74 @@ end
         @test any(abs.(sol.t .- time) .< 1.0e-10)
     end
 end
+
+# Tests for the `t > t_d` convention on `d_discontinuities`:
+# v7 advances `integrator.t` by one ULP past a d_discontinuity so the
+# post-discontinuity side of `t`-dependent branches in `f` is reached.
+@testset "d_discontinuities: interior discontinuity with t > t_d" begin
+    # f has slope 0 for t < 5 and slope 1 for t > 5.
+    # Exact solution: u(t) = 0 for t ≤ 5, u(t) = t - 5 for t > 5. So u(10) = 5.
+    # With a fixed-step non-adaptive integrator, a stale pre-discontinuity FSAL
+    # would cause the first post-discontinuity step to use f(u, 5) = 0 and drop
+    # accumulated value by exactly one step (0.5 with dt = 0.5).
+    f(u, p, t) = t > 5.0 ? 1.0 : 0.0
+    prob = ODEProblem(f, 0.0, (0.0, 10.0))
+    sol = solve(
+        prob, Euler(); dt = 0.5, d_discontinuities = [5.0],
+        adaptive = false
+    )
+    @test sol.u[end] ≈ 5.0 atol = 1.0e-10
+
+    # Same setup with Tsit5 (FSAL, adaptive) at tight tolerance.
+    sol_tsit5 = solve(
+        prob, Tsit5(); d_discontinuities = [5.0],
+        reltol = 1.0e-12, abstol = 1.0e-14
+    )
+    @test sol_tsit5.u[end] ≈ 5.0 atol = 1.0e-10
+    @test 5.0 ∈ sol_tsit5.t
+end
+
+@testset "d_discontinuities: starting-time discontinuity" begin
+    # f has slope 0 at t = 0 and slope 1 for t > 0. Without handling of
+    # t_d == t0, the starting-time discontinuity would be silently dropped
+    # (filtered out of the tstops heap by the strict-inequality tspan check)
+    # and fsalfirst would be stuck at 0.
+    f(u, p, t) = t > 0.0 ? 1.0 : 0.0
+    prob = ODEProblem(f, 0.0, (0.0, 5.0))
+    sol = solve(
+        prob, Euler(); dt = 0.5, d_discontinuities = [0.0],
+        adaptive = false
+    )
+    @test sol.u[end] ≈ 5.0 atol = 1.0e-10
+end
+
+@testset "d_discontinuities: backward integration shifts with prevfloat" begin
+    # Backwards integration with discontinuity at t = 5.
+    # u(10) = 5. For t > 5 the slope is 1, so integrating backward from t = 10
+    # to t = 5 decreases u by 5 → u(5) = 0. For t ≤ 5, slope is 0, so u stays
+    # at 0 back to t = 0. Expected u(0) = 0.
+    f(u, p, t) = t > 5.0 ? 1.0 : 0.0
+    prob = ODEProblem(f, 5.0, (10.0, 0.0))
+    sol = solve(
+        prob, Tsit5(); d_discontinuities = [5.0],
+        reltol = 1.0e-12, abstol = 1.0e-14
+    )
+    @test sol.u[end] ≈ 0.0 atol = 1.0e-10
+end
+
+@testset "d_discontinuities: tprev advanced past discontinuity" begin
+    # Directly verify the shift-past invariant using the integrator interface:
+    # after stepping past the discontinuity, integrator.tprev should be
+    # nextfloat(t_d), not t_d itself.
+    f(u, p, t) = t > 5.0 ? 1.0 : 0.0
+    prob = ODEProblem(f, 0.0, (0.0, 10.0))
+    integrator = init(prob, Tsit5(); d_discontinuities = [5.0])
+    # Advance until we've landed on the tstop at t = 5.
+    while integrator.t < 5.0
+        step!(integrator)
+    end
+    @test integrator.t == 5.0
+    # The next step triggers update_fsal! → shift_past_discontinuity!
+    step!(integrator)
+    @test integrator.tprev == nextfloat(5.0)
+end


### PR DESCRIPTION
**CI-only PR — do not merge.** This is the same change as #3392 (targeting `v7`) cherry-picked onto `master` to verify tests pass on the stable CI infrastructure. Close after CI results are reviewed.

See #3392 for the full description, rationale, and test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)