### PR TITLE
Remove redundant SDE abstract types from StochasticDiffEqCore

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqCore/src/algorithms.jl
@@ -12,22 +12,18 @@ abstract type StochasticDiffEqRODEAdaptiveAlgorithm <: StochasticDiffEqRODEAlgor
 abstract type StochasticDiffEqRODECompositeAlgorithm <: StochasticDiffEqRODEAlgorithm end
 
 # SDE Newton/Jump algorithm subtypes (used by StochasticDiffEq implicit solvers)
-abstract type StochasticDiffEqNewtonAdaptiveAlgorithm{CS, AD, FDT, ST, CJ, Controller} <:
+abstract type StochasticDiffEqNewtonAdaptiveAlgorithm <:
 StochasticDiffEqAdaptiveAlgorithm end
-abstract type StochasticDiffEqNewtonAlgorithm{CS, AD, FDT, ST, CJ, Controller} <:
+abstract type StochasticDiffEqNewtonAlgorithm <:
 StochasticDiffEqAlgorithm end
 
 abstract type StochasticDiffEqJumpAlgorithm <: StochasticDiffEqAlgorithm end
 abstract type StochasticDiffEqJumpAdaptiveAlgorithm <: StochasticDiffEqAlgorithm end
-abstract type StochasticDiffEqJumpNewtonAdaptiveAlgorithm{
-    CS, AD, FDT, ST, CJ, Controller,
-} <: StochasticDiffEqJumpAdaptiveAlgorithm end
+abstract type StochasticDiffEqJumpNewtonAdaptiveAlgorithm <: StochasticDiffEqJumpAdaptiveAlgorithm end
 
 abstract type StochasticDiffEqJumpDiffusionAlgorithm <: StochasticDiffEqAlgorithm end
 abstract type StochasticDiffEqJumpDiffusionAdaptiveAlgorithm <: StochasticDiffEqAlgorithm end
-abstract type StochasticDiffEqJumpNewtonDiffusionAdaptiveAlgorithm{
-    CS, AD, FDT, ST, CJ, Controller,
-} <: StochasticDiffEqJumpDiffusionAdaptiveAlgorithm end
+abstract type StochasticDiffEqJumpNewtonDiffusionAdaptiveAlgorithm <: StochasticDiffEqJumpDiffusionAdaptiveAlgorithm end
 
 # SDE/RODE cache type hierarchy (used by StochasticDiffEq)
 abstract type StochasticDiffEqCache <: SciMLBase.DECache end

--- a/lib/StochasticDiffEqCore/src/algorithms.jl
+++ b/lib/StochasticDiffEqCore/src/algorithms.jl
@@ -1,20 +1,12 @@
 # Abstract types are defined in OrdinaryDiffEqCore and imported via StochasticDiffEqCore.jl:
 # StochasticDiffEqAlgorithm, StochasticDiffEqAdaptiveAlgorithm,
 # StochasticDiffEqCompositeAlgorithm, StochasticDiffEqRODEAlgorithm,
-# StochasticDiffEqRODEAdaptiveAlgorithm, StochasticDiffEqRODECompositeAlgorithm
-
-abstract type StochasticDiffEqNewtonAdaptiveAlgorithm <:
-StochasticDiffEqAdaptiveAlgorithm end
-abstract type StochasticDiffEqNewtonAlgorithm <:
-StochasticDiffEqAlgorithm end
-
-abstract type StochasticDiffEqJumpAlgorithm <: StochasticDiffEqAlgorithm end
-abstract type StochasticDiffEqJumpAdaptiveAlgorithm <: StochasticDiffEqAlgorithm end
-abstract type StochasticDiffEqJumpNewtonAdaptiveAlgorithm <: StochasticDiffEqJumpAdaptiveAlgorithm end
-
-abstract type StochasticDiffEqJumpDiffusionAlgorithm <: StochasticDiffEqAlgorithm end
-abstract type StochasticDiffEqJumpDiffusionAdaptiveAlgorithm <: StochasticDiffEqAlgorithm end
-abstract type StochasticDiffEqJumpNewtonDiffusionAdaptiveAlgorithm <: StochasticDiffEqJumpDiffusionAdaptiveAlgorithm end
+# StochasticDiffEqRODEAdaptiveAlgorithm, StochasticDiffEqRODECompositeAlgorithm,
+# StochasticDiffEqNewtonAdaptiveAlgorithm, StochasticDiffEqNewtonAlgorithm,
+# StochasticDiffEqJumpAlgorithm, StochasticDiffEqJumpAdaptiveAlgorithm,
+# StochasticDiffEqJumpNewtonAdaptiveAlgorithm,
+# StochasticDiffEqJumpDiffusionAlgorithm, StochasticDiffEqJumpDiffusionAdaptiveAlgorithm,
+# StochasticDiffEqJumpNewtonDiffusionAdaptiveAlgorithm
 
 abstract type IteratedIntegralApprox end
 

--- a/lib/StochasticDiffEqCore/src/algorithms.jl
+++ b/lib/StochasticDiffEqCore/src/algorithms.jl
@@ -1,13 +1,3 @@
-# Abstract types are defined in OrdinaryDiffEqCore and imported via StochasticDiffEqCore.jl:
-# StochasticDiffEqAlgorithm, StochasticDiffEqAdaptiveAlgorithm,
-# StochasticDiffEqCompositeAlgorithm, StochasticDiffEqRODEAlgorithm,
-# StochasticDiffEqRODEAdaptiveAlgorithm, StochasticDiffEqRODECompositeAlgorithm,
-# StochasticDiffEqNewtonAdaptiveAlgorithm, StochasticDiffEqNewtonAlgorithm,
-# StochasticDiffEqJumpAlgorithm, StochasticDiffEqJumpAdaptiveAlgorithm,
-# StochasticDiffEqJumpNewtonAdaptiveAlgorithm,
-# StochasticDiffEqJumpDiffusionAlgorithm, StochasticDiffEqJumpDiffusionAdaptiveAlgorithm,
-# StochasticDiffEqJumpNewtonDiffusionAdaptiveAlgorithm
-
 abstract type IteratedIntegralApprox end
 
 struct IICommutative <: IteratedIntegralApprox end


### PR DESCRIPTION
## Summary
- Removes redundant abstract type definitions from `StochasticDiffEqCore/src/algorithms.jl` that were duplicating types already defined in `OrdinaryDiffEqCore/src/algorithms.jl`
- Removes vestigial `{CS, AD, FDT, ST, CJ, Controller}` type parameters from the SDE Newton/Jump abstract types in OrdinaryDiffEqCore, consistent with v7's removal of phantom type parameters
- Types remain in OrdinaryDiffEqCore where they are needed by OrdinaryDiffEqDifferentiation

Addresses review comment from #3380.

## Types affected
- `StochasticDiffEqNewtonAdaptiveAlgorithm`
- `StochasticDiffEqNewtonAlgorithm`
- `StochasticDiffEqJumpAlgorithm`
- `StochasticDiffEqJumpAdaptiveAlgorithm`
- `StochasticDiffEqJumpNewtonAdaptiveAlgorithm`
- `StochasticDiffEqJumpDiffusionAlgorithm`
- `StochasticDiffEqJumpDiffusionAdaptiveAlgorithm`
- `StochasticDiffEqJumpNewtonDiffusionAdaptiveAlgorithm`

## Test plan
- [ ] CI passes on v7 branch
- [ ] StochasticDiffEqCore tests pass (type hierarchy checks)
- [ ] StochasticDiffEqImplicit tests pass (concrete subtypes)
- [ ] StochasticDiffEqLeaping tests pass (jump algorithm subtypes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)