### PR TITLE
Fix @inferred type instability from JacReuseState Union type

### DIFF
--- a/lib/OrdinaryDiffEqRosenbrock/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/algorithms.jl
@@ -96,11 +96,10 @@ for (Alg, desc, refs, is_W) in [
     # Rosenbrock23/32 are low-order methods typically used on small/warm-up
     # problems where J evaluation is cheap and per-step overhead dominates.
     # Default them to max_jac_age = 1 which effectively disables reuse (the
-    # cache allocates `nothing` for jac_reuse and the decision function
-    # short-circuits through do_newJW, matching master behavior). Users can
-    # still opt into reuse with an explicit max_jac_age kwarg. Higher-order
-    # W-methods (Rodas23W, ROS34PW*, Rodas4P2, Rodas5P/Pe/Pr, Rodas6P) keep
-    # the full reuse default which wins on PDE workloads.
+    # age check in _rosenbrock_jac_reuse_decision triggers every step).
+    # Users can still opt into reuse with an explicit max_jac_age kwarg.
+    # Higher-order W-methods (Rodas23W, ROS34PW*, Rodas4P2, Rodas5P/Pe/Pr,
+    # Rodas6P) keep the full reuse default which wins on PDE workloads.
     default_max_jac_age = (Alg === :Rosenbrock23 || Alg === :Rosenbrock32) ? 1 : 20
     @eval begin
         @doc $(

--- a/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_caches.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_caches.jl
@@ -41,13 +41,13 @@ end
 """
     _make_jac_reuse_state(dtgamma, max_jac_age)
 
-Allocate a `JacReuseState` only when reuse is meaningfully enabled
-(`max_jac_age > 1`). When `max_jac_age ≤ 1` every accepted step would
-recompute J anyway, so return `nothing` to let the decision function
-take the master-compatible fast path through `do_newJW`.
+Always allocate a `JacReuseState` to keep cache types concrete and avoid
+Union-type instability that breaks `@inferred` tests. When `max_jac_age ≤ 1`
+the age check in `_rosenbrock_jac_reuse_decision` triggers every step anyway,
+so the overhead is negligible.
 """
 @inline function _make_jac_reuse_state(dtgamma, max_jac_age::Int)
-    return max_jac_age > 1 ? JacReuseState(dtgamma, max_jac_age) : nothing
+    return JacReuseState(dtgamma, max_jac_age)
 end
 
 # Fake values since non-FSAL


### PR DESCRIPTION
## Summary
- `_make_jac_reuse_state` returned `Union{Nothing, JacReuseState{T}}` based on runtime `max_jac_age`, causing type instability in Rosenbrock cache's `JRType` parameter
- This broke `@inferred` tests in OrdinaryDiffEqRosenbrock (`dae_rosenbrock_ad_tests.jl`) and OrdinaryDiffEqNonlinearSolve (`mass_matrix_tests.jl`)
- Fix: always allocate `JacReuseState` — when `max_jac_age ≤ 1` the age check in `_rosenbrock_jac_reuse_decision` triggers every step anyway, so behavior is unchanged

Introduced by #3075.

## Test plan
- [x] OrdinaryDiffEqRosenbrock `Pkg.test` passes locally (was erroring on `DAE Rosenbrock AD Tests`)
- [x] OrdinaryDiffEqNonlinearSolve `Pkg.test` passes locally (was erroring on `Mass Matrix Tests with Singular Mass Matrices`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)