### PR TITLE
Run Runic formatter on files with formatting violations

### DIFF
--- a/lib/OrdinaryDiffEqAMF/test/test_adjoint_fd2d.jl
+++ b/lib/OrdinaryDiffEqAMF/test/test_adjoint_fd2d.jl
@@ -133,7 +133,7 @@ end
 
     # AMF gradient should be close to baseline
     relerr_amf_vs_baseline = norm(dLdu0_amf - dLdu0_baseline) / norm(dLdu0_baseline)
-    @test relerr_amf_vs_baseline < 1e-4
+    @test relerr_amf_vs_baseline < 1.0e-4
     @info "Adjoint AMF vs baseline" relerr = relerr_amf_vs_baseline
 
     # Finite-difference validation on a few components
@@ -141,11 +141,11 @@ end
         f!; jac_prototype = J_op, sparsity = adj_sparsity,
     )
 
-    function fd_gradient_component(idx; ε = 1e-7)
+    function fd_gradient_component(idx; ε = 1.0e-7)
         u_plus = copy(u0); u_plus[idx] += ε
         u_minus = copy(u0); u_minus[idx] -= ε
-        sol_plus = solve(ODEProblem(ref_func, u_plus, tspan), ROS34PW1a(); abstol = 1e-10, reltol = 1e-10)
-        sol_minus = solve(ODEProblem(ref_func, u_minus, tspan), ROS34PW1a(); abstol = 1e-10, reltol = 1e-10)
+        sol_plus = solve(ODEProblem(ref_func, u_plus, tspan), ROS34PW1a(); abstol = 1.0e-10, reltol = 1.0e-10)
+        sol_minus = solve(ODEProblem(ref_func, u_minus, tspan), ROS34PW1a(); abstol = 1.0e-10, reltol = 1.0e-10)
         L_plus = 0.5 * dot(sol_plus.u[end], sol_plus.u[end])
         L_minus = 0.5 * dot(sol_minus.u[end], sol_minus.u[end])
         return (L_plus - L_minus) / (2ε)
@@ -155,7 +155,7 @@ end
     for idx in test_indices
         fd_grad = fd_gradient_component(idx)
         adj_amf = dLdu0_amf[idx]
-        relerr_vs_fd = abs(fd_grad - adj_amf) / max(abs(fd_grad), 1e-12)
+        relerr_vs_fd = abs(fd_grad - adj_amf) / max(abs(fd_grad), 1.0e-12)
         @test relerr_vs_fd < 0.01  # AMF + forward tolerance → ~1e-3
         @info "FD validation idx=$idx" fd = fd_grad adj_amf = adj_amf relerr = relerr_vs_fd
     end

--- a/lib/OrdinaryDiffEqCore/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/alg_utils.jl
@@ -414,9 +414,13 @@ function alg_order(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm})
 end
 alg_order(alg::CompositeAlgorithm) = maximum(alg_order, alg.algs)
 
-function get_current_alg_order(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm,
-        StochasticDiffEqAlgorithm,
-        StochasticDiffEqRODEAlgorithm}, cache)
+function get_current_alg_order(
+        alg::Union{
+            OrdinaryDiffEqAlgorithm, DAEAlgorithm,
+            StochasticDiffEqAlgorithm,
+            StochasticDiffEqRODEAlgorithm,
+        }, cache
+    )
     return alg_order(alg)
 end
 function get_current_alg_order(alg::CompositeAlgorithm, cache)

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/nested_ad_nlsolvealg_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/nested_ad_nlsolvealg_tests.jl
@@ -33,16 +33,18 @@ using ForwardDiff
     function make_loss(alg)
         return function (p)
             prob = ODEProblem(lin!, u0, tspan, p)
-            sol = solve(prob, alg; save_everystep = false, reltol = 1.0e-8,
-                abstol = 1.0e-8)
+            sol = solve(
+                prob, alg; save_everystep = false, reltol = 1.0e-8,
+                abstol = 1.0e-8
+            )
             return sum(sol.u[end])
         end
     end
 
     for alg in (
-        ImplicitEuler(nlsolve = NonlinearSolveAlg()),
-        TRBDF2(nlsolve = NonlinearSolveAlg()),
-    )
+            ImplicitEuler(nlsolve = NonlinearSolveAlg()),
+            TRBDF2(nlsolve = NonlinearSolveAlg()),
+        )
         loss = make_loss(alg)
         # The @test_nowarn just guards against a regression — the important
         # thing is that this does not throw

--- a/lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl
@@ -1068,8 +1068,10 @@ end
     testTol = 0.2
     # Check convergence of Rodas3 with time-dependent matrix-free Jacobian.
     # Primarily to check that the Jacobian is being updated correctly as t changes.
-    sim = test_convergence(dts, prob, Rodas3(linsolve = LinearSolve.KrylovJL()),
-        reltol = 1.0e-14, abstol = 1.0e-14)
+    sim = test_convergence(
+        dts, prob, Rodas3(linsolve = LinearSolve.KrylovJL()),
+        reltol = 1.0e-14, abstol = 1.0e-14
+    )
     @test sim.𝒪est[:final] ≈ 3 atol = testTol
 end
 


### PR DESCRIPTION
## Summary
- Runs Runic on the 4 files that have formatting violations on master
- Fixes the format-check CI failure

Files formatted:
- `lib/OrdinaryDiffEqAMF/test/test_adjoint_fd2d.jl`
- `lib/OrdinaryDiffEqCore/src/alg_utils.jl`
- `lib/OrdinaryDiffEqNonlinearSolve/test/nested_ad_nlsolvealg_tests.jl`
- `lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl`

## Test plan
- [ ] format-check CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)