### PR TITLE
Use BrownFullBasicInit for Hard DAE regression test

### DIFF
--- a/test/regression/hard_dae.jl
+++ b/test/regression/hard_dae.jl
@@ -227,9 +227,11 @@ affect!(integrator) = integrator.p[28] += 0.2
 cb = DiscreteCallback(condition, affect!)
 
 prob = ODEProblem(f, deepcopy(res.zero), (0, 20.0), deepcopy(p_inv))
+# v7 default is CheckInit which rejects nlsolve residuals at tight tolerances;
+# use BrownFullBasicInit to initialize algebraic variables as before v7.
 refsol = solve(
     prob, Rodas4(), saveat = 0.1, callback = cb, tstops = [1.0], reltol = 1.0e-12,
-    abstol = 1.0e-14
+    abstol = 1.0e-17, initializealg = BrownFullBasicInit()
 )
 
 for solver in (Rodas4, Rodas4P, Rodas5, Rodas5P, FBDF, QNDF)
@@ -237,7 +239,7 @@ for solver in (Rodas4, Rodas4P, Rodas5, Rodas5P, FBDF, QNDF)
     prob = ODEProblem(f, deepcopy(res.zero), (0, 20.0), deepcopy(p_inv))
     sol = solve(
         prob, solver(), saveat = 0.1, callback = cb, tstops = [1.0], reltol = 1.0e-14,
-        abstol = 1.0e-14
+        abstol = 1.0e-14, initializealg = BrownFullBasicInit()
     )
     @test sol.retcode == ReturnCode.Success
     @test sol.t[end] == 20.0


### PR DESCRIPTION
## Summary

- Restore original `abstol = 1e-17` for the Hard DAE reference solution (was incorrectly loosened to `1e-14` in #3398)
- Add `initializealg = BrownFullBasicInit()` to both reference and test solves
- v7 changed the default from `BrownFullBasicInit` to `CheckInit`, which rejects nlsolve residuals (~7e-17) at tight tolerances — the correct fix is to explicitly use the old init algorithm, not to loosen tolerances

## Test plan

- [ ] Regression_I Hard DAE Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)