### PR TITLE
Import BrownFullBasicInit from DiffEqBase in Hard DAE test

### DIFF
--- a/test/regression/hard_dae.jl
+++ b/test/regression/hard_dae.jl
@@ -1,4 +1,5 @@
 using OrdinaryDiffEq
+using DiffEqBase: BrownFullBasicInit
 using LinearAlgebra
 using NLsolve
 using Test


### PR DESCRIPTION
## Summary

`BrownFullBasicInit` is no longer exported from the top-level `OrdinaryDiffEq` namespace in v7. Add explicit `using DiffEqBase: BrownFullBasicInit` to the Hard DAE regression test.

Fixes the `UndefVarError: BrownFullBasicInit not defined` from #3402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)