### PR TITLE
Fix nested ForwardDiff tag mismatch 

### DIFF
--- a/lib/DiffEqBase/ext/DiffEqBaseForwardDiffExt.jl
+++ b/lib/DiffEqBase/ext/DiffEqBaseForwardDiffExt.jl
@@ -204,6 +204,24 @@ if !hasmethod(nextfloat, Tuple{ForwardDiff.Dual})
     end
 end
 
+struct WidenedDualArray{T,A} <: AbstractVector{T}
+    parent::A
+end
+Base.size(a::WidenedDualArray) = size(a.parent)
+Base.@propagate_inbounds Base.getindex(a::WidenedDualArray{T}, i::Int) where {T} = convert(T, a.parent[i])
+
+function (ff::SciMLBase.UJacobianWrapper{true})(du1, uprev::AbstractArray{<:ForwardDiff.Dual})
+    p = ff.p
+    if p isa AbstractArray && eltype(p) <: ForwardDiff.Dual
+        DualU = eltype(uprev)
+        if !(eltype(p) <: DualU)
+            hasfield(typeof(ff.f), :f) && getfield(ff.f, :f) isa FunctionWrappersWrappers.FunctionWrappersWrapper && return ff.f(du1, uprev, p, ff.t)
+            return ff.f(du1, uprev, WidenedDualArray{DualU, typeof(p)}(p), ff.t)
+        end
+    end
+    ff.f(du1, uprev, p, ff.t)
+end
+
 import PrecompileTools
 PrecompileTools.@compile_workload begin
     # Scalar operations on Dual numbers (arithmetic, math functions, comparisons)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context
Fix for [SciML/OrdinaryDiffEq.jl#3381](https://github.com/SciML/OrdinaryDiffEq.jl/issues/3381). When NonlinearSolve computes a Jacobian over an ODE solve, `p` enters as `Dual{NLTag}` and Rosenbrock's internal ForwardDiff seeds `u` as `Dual{OrdEqTag, Dual{NLTag}, CS}`. The user function f(du, u, p, t) multiplies across tag levels, producing the wrong outer tag and crashing on `setindex!`.
