### PR TITLE
Minor bumps for subpackages with unreleased changes since #3387

### DIFF
--- a/lib/DelayDiffEq/Project.toml
+++ b/lib/DelayDiffEq/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "5.73.0"
+version = "5.74.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.215.0"
+version = "6.216.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/DiffEqDevTools/Project.toml
+++ b/lib/DiffEqDevTools/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqDevTools"
 uuid = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.52.0"
+version = "2.53.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "3.30.0"
+version = "3.31.0"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "2.8.0"
+version = "2.9.0"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 

--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "1.27.0"
+version = "1.28.0"
 
 [deps]
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"

--- a/lib/OrdinaryDiffEqRosenbrock/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrock/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqRosenbrock"
 uuid = "43230ef6-c299-4910-a778-202eb28ce4ce"
-version = "1.30.0"
+version = "1.31.0"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 
 [deps]

--- a/lib/OrdinaryDiffEqStabilizedRK/Project.toml
+++ b/lib/OrdinaryDiffEqStabilizedRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqStabilizedRK"
 uuid = "358294b1-0aab-51c3-aafe-ad5ab194a2ad"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "1.10.0"
+version = "1.11.0"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqTaylorSeries/Project.toml
+++ b/lib/OrdinaryDiffEqTaylorSeries/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqTaylorSeries"
 uuid = "9c7f1690-dd92-42a3-8318-297ee24d8d39"
 authors = ["Songchen Tan <i@tansongchen.com>"]
-version = "1.13.0"
+version = "1.14.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"


### PR DESCRIPTION
## Summary

Bumps every lib/* subpackage that has accumulated source, compat, or formatting changes on master since #3387. Each entry will be registered via `@JuliaRegistrator register(subdir=\"lib/<pkg>\")` after merge.

| Package | From | To | Driver |
|---|---|---|---|
| DelayDiffEq | 5.73.0 | 5.74.0 | #3394 — alg_choice push in `shift_past_discontinuity!` for composite DDEs |
| DiffEqBase | 6.215.0 | 6.216.0 | #3394 — solve hook for shift-past d_discontinuities |
| DiffEqDevTools | 2.52.0 | 2.53.0 | LICENSE.md added (from #3388) |
| OrdinaryDiffEqCore | 3.30.0 | 3.31.0 | #3394 integrator updates + #3400 formatting |
| OrdinaryDiffEqDifferentiation | 2.8.0 | 2.9.0 | #3405 — StaticArrays → StaticArraysCore |
| OrdinaryDiffEqNonlinearSolve | 1.27.0 | 1.28.0 | #3405 + #3400 formatting |
| OrdinaryDiffEqRosenbrock | 1.30.0 | 1.31.0 | #3399 — JacReuseState `@inferred` fix + #3400 formatting |
| OrdinaryDiffEqStabilizedRK | 1.10.0 | 1.11.0 | #3405 — StaticArrays → StaticArraysCore |
| OrdinaryDiffEqTaylorSeries | 1.13.0 | 1.14.0 | FunctionWrappers compat bound added in #3388 |

## Not bumped

- `OrdinaryDiffEqAMF` and `OrdinaryDiffEqMultirate` remain at `1.0.0` — neither is registered in General yet, so the pending first registration will naturally pick up the subsequent README/LICENSE/compat fixes from #3388, #3390, and #3400 without another bump.

## Test plan

- [ ] CI green across lib/* suites that changed
- [ ] After merge: run Registrator once per bumped subpackage