### PR TITLE
Import NLNewton from OrdinaryDiffEqNonlinearSolve in Hard DAE test

### DIFF
--- a/test/regression/hard_dae.jl
+++ b/test/regression/hard_dae.jl
@@ -4,6 +4,7 @@ using LinearAlgebra
 using NLsolve
 using Test
 using OrdinaryDiffEqBDF, OrdinaryDiffEqRosenbrock, OrdinaryDiffEqSDIRK
+using OrdinaryDiffEqNonlinearSolve: NLNewton
 
 p_inv = [
     500.0


### PR DESCRIPTION
`NLNewton` is defined in `OrdinaryDiffEqNonlinearSolve` but not re-exported from the top-level `OrdinaryDiffEq` namespace in v7. The Hard DAE regression test uses `NLNewton()` bare — this PR imports it explicitly.

Same pattern as #3403 (which imported `BrownFullBasicInit` from DiffEqBase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)