### PR TITLE
Import CompositeAlgorithm from OrdinaryDiffEqCore in Hard DAE test

### DIFF
--- a/test/regression/hard_dae.jl
+++ b/test/regression/hard_dae.jl
@@ -5,6 +5,7 @@ using NLsolve
 using Test
 using OrdinaryDiffEqBDF, OrdinaryDiffEqRosenbrock, OrdinaryDiffEqSDIRK
 using OrdinaryDiffEqNonlinearSolve: NLNewton
+using OrdinaryDiffEqCore: CompositeAlgorithm
 
 p_inv = [
     500.0


### PR DESCRIPTION
Follow-up to #3403 (BrownFullBasicInit) and #3415 (NLNewton). Same pattern: v7 stopped re-exporting internal symbols from the top-level OrdinaryDiffEq namespace; the Hard DAE regression test needs an explicit import.

**Verified locally** that `test/regression/hard_dae.jl` now runs through all 6 solvers (Rodas4, Rodas4P, Rodas5, Rodas5P, FBDF, QNDF) plus the CompositeAlgorithm switching test block.

This time I ran the full file locally to catch all missing imports, not just patch one error at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)