### PR TITLE
fix initialization of MVectors; Bool -> one

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
@@ -547,7 +547,7 @@ function PIDController(
     )
     beta = map(float, promote(beta1, beta2, beta3))
     QT = eltype(beta)
-    err = MVector{3, QT}(true, true, true)
+    err = MVector{3, QT}(one(QT), one(QT), one(QT))
     return PIDController(beta, err, convert(QT, accept_safety), limiter)
 end
 
@@ -685,12 +685,12 @@ mutable struct PIDControllerCache{T, Limiter, UT} <: AbstractControllerCache
 end
 
 function SciMLBase.reinit!(integrator::ODEIntegrator, cache::PIDControllerCache{T}) where {T}
-    cache.err = MVector{3, T}(true, true, true)
+    cache.err = MVector{3, T}(one(T), one(T), one(T))
     return cache.dt_factor = T(1 // 10^4)
 end
 
 function setup_controller_cache(alg, atmp, controller::NewPIDController{QT}) where {QT}
-    err = MVector{3, QT}(true, true, true)
+    err = MVector{3, QT}(one(QT), one(QT), one(QT))
     return PIDControllerCache(
         controller,
         err,


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

This should fix https://github.com/SciML/OrdinaryDiffEq.jl/issues/3384