### PR TITLE
Drop `@test_broken` in inference.jl regression — inference now holds on v7

### DIFF
--- a/test/regression/inference.jl
+++ b/test/regression/inference.jl
@@ -15,11 +15,10 @@ using OrdinaryDiffEqLowOrderRK, OrdinaryDiffEqRosenbrock, OrdinaryDiffEqSDIRK
     end
 
     @testset "stiff default" begin
-        # Stiff solvers are not fully inferable for the 2D problem with the default args
         inferred2 = [SDIRK2(), TRBDF2(), KenCarp4(), Rosenbrock23(), Rodas4()]
         for alg in inferred2
             @inferred init(prob, alg)
-            @test_broken @inferred init(prob2D, alg)
+            @inferred init(prob2D, alg)
         end
     end
 
@@ -33,35 +32,6 @@ using OrdinaryDiffEqLowOrderRK, OrdinaryDiffEqRosenbrock, OrdinaryDiffEqSDIRK
             if VERSION >= v"1.12"
                 @inferred init(prob2D, alg)
             end
-        end
-    end
-
-    @testset "stiff finite diff" begin
-        # FiniteDiff works
-        autodiff = ADTypes.AutoFiniteDiff()
-        inferred4 = [SDIRK2(; autodiff), TRBDF2(; autodiff), KenCarp4(; autodiff), Rosenbrock23(; autodiff), Rodas4(; autodiff)]
-        for alg in inferred4
-            @inferred init(prob, alg)
-            @inferred init(prob2D, alg)
-        end
-    end
-
-    @testset "stiff default" begin
-        # Stiff solvers are not fully inferable for the 2D problem with the default args
-        inferred2 = [SDIRK2(), TRBDF2(), KenCarp4(), Rosenbrock23(), Rodas4()]
-        for alg in inferred2
-            @inferred init(prob, alg)
-            @test_broken @inferred init(prob2D, alg)
-        end
-    end
-
-    @testset "stiff fixed chunksize" begin
-        # When choosing a fixed chunksize it works
-        autodiff = ADTypes.AutoForwardDiff(; chunksize = 10)
-        inferred3 = [SDIRK2(; autodiff), TRBDF2(; autodiff), KenCarp4(; autodiff), Rosenbrock23(; autodiff), Rodas4(; autodiff)]
-        for alg in inferred3
-            @inferred init(prob, alg)
-            @inferred init(prob2D, alg)
         end
     end
 


### PR DESCRIPTION
## Summary

On v7, `@test_broken @inferred init(prob2D, alg)` for the stiff-default solvers (SDIRK2/TRBDF2/KenCarp4/Rosenbrock23/Rodas4) now errors with ``Expression evaluated to non-Boolean`` — `@inferred` succeeds and returns the integrator, so `@test_broken` receives a non-Bool value. Inference got better for the 2D problem on these algorithms on the current v7, so this PR simply drops the `@test_broken` wrapper and lets `@inferred` throw on future regressions.

While there, three testsets (`stiff default`, `stiff fixed chunksize`, `stiff finite diff`) were pasted twice in the file; only the first copies are kept. The duplicated `stiff fixed chunksize` was missing the `VERSION >= v"1.12"` guard on the 2D inferred call, which would keep re-failing on 1.11/lts.

Fixes the `test (Regression_II, 1)` / `test (Regression_II, 1.11)` / `test (Regression_II, pre)` failures on v7 CI.

## Test plan

- [ ] Regression_II passes on v7 CI across 1 / 1.11 / pre

🤖 Generated with [Claude Code](https://claude.com/claude-code)