### PR TITLE
Fix RAT v4 algebraic_interpolation pattern; source StochasticDiffEq from lib/ in downstream test

### DIFF
--- a/test/downstream/Project.toml
+++ b/test/downstream/Project.toml
@@ -41,3 +41,4 @@ OrdinaryDiffEqLowStorageRK = {path = "../../lib/OrdinaryDiffEqLowStorageRK"}
 OrdinaryDiffEqRosenbrock = {path = "../../lib/OrdinaryDiffEqRosenbrock"}
 OrdinaryDiffEqSDIRK = {path = "../../lib/OrdinaryDiffEqSDIRK"}
 OrdinaryDiffEqSSPRK = {path = "../../lib/OrdinaryDiffEqSSPRK"}
+StochasticDiffEq = {path = "../../lib/StochasticDiffEq"}

--- a/test/interface/algebraic_interpolation.jl
+++ b/test/interface/algebraic_interpolation.jl
@@ -122,12 +122,17 @@ abstol = 1.0e-3
     sol_op(tv, Val{1}, idxs = idxsv), rtol = reltol, atol = abstol
 )
 
-# higher derivatives should be zero
+# higher derivatives should be zero.
+# `sol(tv, Val{k})` returns a DiffEqArray; `.== 0` yields a VectorOfArray whose
+# `.u` is Vector{BitVector} (one per timestep). Iterate `.u` to compare each
+# timestep's pattern — `map(==(target), ::VectorOfArray)` broadcasts
+# element-wise over the underlying matrix and collapses the pattern.
+
 # second derivative, no index
 @test (sol_ip(t, Val{2}) .== 0) == [false, false, true]
-@test all(map(==([false, false, true]), sol_ip(tv, Val{2}) .== 0))
+@test all(==([false, false, true]), (sol_ip(tv, Val{2}) .== 0).u)
 @test (sol_op(t, Val{2}) .== 0) == [false, false, true]
-@test all(map(==([false, false, true]), sol_op(tv, Val{2}) .== 0))
+@test all(==([false, false, true]), (sol_op(tv, Val{2}) .== 0).u)
 
 # second derivative, scalar index
 @test sol_ip(t, Val{2}, idxs = idxs) == 0
@@ -137,15 +142,15 @@ abstol = 1.0e-3
 
 # second derivative, vector index
 @test (sol_ip(t, Val{2}, idxs = idxsv) .== 0) == [false, true]
-@test all(map(==([false, true]), sol_ip(tv, Val{2}, idxs = idxsv) .== 0))
+@test all(==([false, true]), (sol_ip(tv, Val{2}, idxs = idxsv) .== 0).u)
 @test (sol_op(t, Val{2}, idxs = idxsv) .== 0) == [false, true]
-@test all(map(==([false, true]), sol_op(tv, Val{2}, idxs = idxsv) .== 0))
+@test all(==([false, true]), (sol_op(tv, Val{2}, idxs = idxsv) .== 0).u)
 
 # third derivative, no index
 @test (sol_ip(t, Val{3}) .== 0) == [false, false, true]
-@test all(map(==([false, false, true]), sol_ip(tv, Val{3}) .== 0))
+@test all(==([false, false, true]), (sol_ip(tv, Val{3}) .== 0).u)
 @test (sol_op(t, Val{3}) .== 0) == [false, false, true]
-@test all(map(==([false, false, true]), sol_op(tv, Val{3}) .== 0))
+@test all(==([false, false, true]), (sol_op(tv, Val{3}) .== 0).u)
 
 # third derivative, scalar index
 @test sol_ip(t, Val{3}, idxs = idxs) == 0
@@ -155,6 +160,6 @@ abstol = 1.0e-3
 
 # third derivative, vector index
 @test (sol_ip(t, Val{3}, idxs = idxsv) .== 0) == [false, true]
-@test all(map(==([false, true]), sol_ip(tv, Val{3}, idxs = idxsv) .== 0))
+@test all(==([false, true]), (sol_ip(tv, Val{3}, idxs = idxsv) .== 0).u)
 @test (sol_op(t, Val{3}, idxs = idxsv) .== 0) == [false, true]
-@test all(map(==([false, true]), sol_op(tv, Val{3}, idxs = idxsv) .== 0))
+@test all(==([false, true]), (sol_op(tv, Val{3}, idxs = idxsv) .== 0).u)


### PR DESCRIPTION
## Summary

Two independent v7 CI fixes, pulled out of PR #3428 per review.

### `test/interface/algebraic_interpolation.jl` (fixes InterfaceI 1 / 1.11)

`sol(tv, Val{k})` returns a `RecursiveArrayTools.DiffEqArray` on RAT v4. Broadcasting `.== 0` over it yields a `VectorOfArray{Bool,2,Vector{BitVector}}` (3 × length(tv)). `map(==([false, false, true]), voa)` used to iterate timestep-wise under RAT v3 and compare each 3-vector to the target. On v4 it iterates element-wise over the underlying `Matrix`, so every element (a `Bool`) is compared to `[false, false, true]` — all false. Reproduced locally:

```
typeof(sol(tv, Val{2}) .== 0) == VectorOfArray{Bool,2,Vector{BitVector}}
map(==([false, false, true]), sol(tv, Val{2}) .== 0) == Bool[0 0 0; 0 0 0; 0 0 0]
```

Fix: iterate `.u` (the underlying `Vector{BitVector}`) and use `all(==(target), _)`. That matches the per-timestep intent and keeps the `idxsv` path (2-element pattern) working too.

### `test/downstream/Project.toml` (fixes Downstream 1 / 1.11 / pre)

Registered `StochasticDiffEq` still pins `SciMLBase < 3`, but v7 requires `SciMLBase = 3` via `OrdinaryDiffEq` / `OrdinaryDiffEqCore`. The local `lib/StochasticDiffEq` already declares `SciMLBase = "3"`, so adding a path `[sources]` entry unblocks the resolve without waiting on the registered release.

## Test plan

- [ ] InterfaceI on 1 and 1.11 passes on v7
- [ ] Downstream on 1 / 1.11 / pre resolves and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)