### PR TITLE
Restore ungated 2D `@inferred` check for stiff fixed chunksize

### DIFF
--- a/test/regression/inference.jl
+++ b/test/regression/inference.jl
@@ -28,10 +28,7 @@ using OrdinaryDiffEqLowOrderRK, OrdinaryDiffEqRosenbrock, OrdinaryDiffEqSDIRK
         inferred3 = [SDIRK2(; autodiff), TRBDF2(; autodiff), KenCarp4(; autodiff), Rosenbrock23(; autodiff), Rodas4(; autodiff)]
         for alg in inferred3
             @inferred init(prob, alg)
-            # In Julia < v1.12 only some of these are inferable
-            if VERSION >= v"1.12"
-                @inferred init(prob2D, alg)
-            end
+            @inferred init(prob2D, alg)
         end
     end
 


### PR DESCRIPTION
## Summary

Follow-up to #3428. The pre-merge `test/regression/inference.jl` had two copies of the `stiff fixed chunksize` testset (same 5 solvers: SDIRK2 / TRBDF2 / KenCarp4 / Rosenbrock23 / Rodas4 with `chunksize = 10`). One copy gated `@inferred init(prob2D, alg)` on `VERSION >= v"1.12"`, the other ran it unconditionally. The dedupe in #3428 kept the gated copy and dropped the ungated one — which was actually providing real coverage on 1.10/1.11 (the line wasn't in the CI failure list before dedupe, so it was passing).

Drop the stale `VERSION >= v"1.12"` guard so the kept testset runs the 2D inferred check across all Julia versions, matching the coverage the dropped duplicate had.

No new solver choices are added or removed; this just restores a per-version check that was inadvertently narrowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)