### PR TITLE
Preserve u0 === nothing for solvers that handle it via allows_null_u0

### DIFF
--- a/lib/ImplicitDiscreteSolve/src/ImplicitDiscreteSolve.jl
+++ b/lib/ImplicitDiscreteSolve/src/ImplicitDiscreteSolve.jl
@@ -10,7 +10,7 @@ import OrdinaryDiffEqCore: OrdinaryDiffEqAlgorithm, alg_cache, OrdinaryDiffEqMut
     alg_order, beta2_default, beta1_default, dt_required,
     _initialize_dae!, DefaultInit, BrownFullBasicInit, OverrideInit,
     @muladd, @.., _unwrap_val, OrdinaryDiffEqCore, isadaptive,
-    AbstractController
+    AbstractController, allows_null_u0
 
 @static if Base.pkgversion(OrdinaryDiffEqCore) >= v"3.4"
     @eval begin

--- a/lib/ImplicitDiscreteSolve/src/alg_utils.jl
+++ b/lib/ImplicitDiscreteSolve/src/alg_utils.jl
@@ -19,3 +19,7 @@ dt_required(alg::IDSolve) = false
 isdiscretealg(alg::IDSolve) = true
 
 isadaptive(alg::IDSolve) = true
+
+# Preserve `u === nothing` through __init so alg_cache(alg, ::Nothing, ...) fires
+# and we skip building a NonlinearProblem over an empty state.
+allows_null_u0(alg::IDSolve) = true

--- a/lib/ImplicitDiscreteSolve/test/runtests.jl
+++ b/lib/ImplicitDiscreteSolve/test/runtests.jl
@@ -135,6 +135,22 @@ if TEST_GROUP != "QA"
         @test integ.cache.nlcache.prob isa NonlinearProblem
     end
 
+    @testset "Null u0 bypasses NonlinearSolve" begin
+        # IDSolve overrides allows_null_u0 so `nothing` reaches alg_cache unchanged
+        # and the `::Nothing` dispatch returns a cache with nlcache=nothing. Without
+        # the opt-in, u0 is coerced to Float64[] and NonlinearSolve fails building
+        # a 0x1 Jacobian for the least-squares branch.
+        fn = ImplicitDiscreteFunction(; resid_prototype = [0.0]) do du, unext, u, p, t
+            du[1] = 1
+        end
+        pr = ImplicitDiscreteProblem(fn, nothing, (0, 1))
+        integ = init(pr, IDSolve())
+        @test integ.cache.u === nothing
+        @test integ.cache.nlcache === nothing
+        sol = solve(pr, IDSolve())
+        @test SciMLBase.successful_retcode(sol)
+    end
+
     @testset "InitialFailure thrown" begin
         function bad(u_next, u, p, t)
             [u_next[1] - u_next[2], u_next[1] - 3, u_next[2] - 4]

--- a/lib/OrdinaryDiffEqCore/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/alg_utils.jl
@@ -211,6 +211,13 @@ anyadaptive(alg) = isadaptive(alg)
 has_dtnew_modification(alg) = false
 dtnew_modification(integrator, alg, dtnew) = dtnew
 
+# Whether the algorithm's alg_cache / perform_step! handle `u === nothing` directly.
+# Default: false, and __init coerces a null u0 to Float64[] so generic cache code
+# (zero(u), similar(u), broadcasts) still works. Solvers that want to preserve the
+# `nothing` signal — e.g., to bypass nonlinear solvers or skip allocation — override
+# to true.
+allows_null_u0(alg) = false
+
 # Whether an algorithm uses a posteriori dt estimates (always accepts, then picks next dt).
 # Default is false. CaoTauLeaping overrides to true.
 isaposteriori(alg) = false

--- a/lib/OrdinaryDiffEqCore/src/solve.jl
+++ b/lib/OrdinaryDiffEqCore/src/solve.jl
@@ -284,9 +284,12 @@ function _ode_init(
         u = recursivecopy(prob.u0)
     end
 
-    # Handle null u0 (e.g., MTK systems with only callbacks and no state variables)
-    # Convert to empty Float64 array to allow initialization to proceed
-    if u === nothing
+    # Null u0 (e.g., MTK systems with only callbacks and no state variables).
+    # Most solvers' caches are built with zero(u)/similar(u) and can't ingest `nothing`,
+    # so coerce to Float64[] to let them limp through. Solvers that can handle the
+    # `nothing` signal directly (e.g., IDSolve bypasses NonlinearSolve entirely)
+    # opt in via allows_null_u0 and keep the richer signal.
+    if u === nothing && !allows_null_u0(_alg)
         u = Float64[]
     end
 


### PR DESCRIPTION
## Summary

- Gates the `u0 === nothing → Float64[]` coercion in `OrdinaryDiffEqCore/_ode_init` behind a new `allows_null_u0(alg)` trait (default `false`).
- `IDSolve` opts in so its purpose-built `::Nothing` `alg_cache` dispatch actually fires — the one that bypasses NonlinearSolve entirely for a no-state problem.
- All other solvers keep the coercion and the MTK #4078 callback-only case still works.

## Motivation

This repro previously crashed inside `NonlinearSolveBase.construct_jacobian_cache` trying to build a 0x1 Jacobian:

```julia
fn = ImplicitDiscreteFunction(; resid_prototype = [0.0]) do du, unext, u, p, t
    du[1] = 1
end
pr = ImplicitDiscreteProblem(fn, nothing, (0, 1))
init(pr, IDSolve())
```

`IDSolve`'s `cache.jl` already has `alg_cache(alg::IDSolve, ::Nothing, ...)` that returns `IDSolveCache(nothing, nothing, nothing, nothing, ...)` with `perform_step!` as a no-op success. That dispatch is the right thing for a discrete problem with no state — there is nothing to nonlinear-solve. But it was unreachable: the blanket coercion in `solve.jl` introduced in d20c3510d turned `nothing` into `Float64[]` before `alg_cache` ran, routing into the generic-vector branch which built a NonlinearLeastSquaresProblem over an empty u.

Rather than unwind the coercion (which would regress the MTK case — Tsit5/Rosenbrock23/FBDF caches can't directly ingest `nothing`), this introduces a trait so solvers that can handle the richer `nothing` signal opt in.

## Design notes

- `allows_null_u0(alg) = false` default in `OrdinaryDiffEqCore/src/alg_utils.jl`.
- `allows_null_u0(::IDSolve) = true` override.
- Gate: `if u === nothing && !allows_null_u0(_alg); u = Float64[]; end`.
- `@code_warntype` confirms the branch is compile-time constant-folded in both directions:
  - `Tsit5()` + `nothing` → `Body::Vector{Float64}` (coercion branch taken as const).
  - `IDSolve()` + `nothing` → `Body::Nothing` (coercion branch is dead code).
  - Any `alg` + non-nothing `u` → the whole block is dead code.

So there is no runtime branch cost and no type instability leaking into the integrator struct.

## Test plan

- [x] New testset `Null u0 bypasses NonlinearSolve` in `lib/ImplicitDiscreteSolve/test/runtests.jl` covering the failing repro — asserts `integ.cache.u === nothing`, `integ.cache.nlcache === nothing`, and `successful_retcode(sol)`.
- [x] Local: `ODEDIFFEQ_TEST_GROUP=Core Pkg.test("ImplicitDiscreteSolve")` — all functional tests pass including the new one.
- [x] Local smoke: Tsit5 / Rosenbrock23 / FBDF on `ODEProblem(f, nothing, tspan)` + `PeriodicCallback` still succeed, callback triggers expected count (the #4078 regression gate).
- [ ] CI green across the full matrix.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>