### PR TITLE
DelayDiffEq 5.74.1: require OrdinaryDiffEqCore 3.31

### DIFF
--- a/lib/DelayDiffEq/Project.toml
+++ b/lib/DelayDiffEq/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "5.74.0"
+version = "5.74.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -73,7 +73,7 @@ LinearAlgebra = "1"
 LinearSolve = "3.54"
 Logging = "1"
 OrdinaryDiffEqBDF = "1.16.0"
-OrdinaryDiffEqCore = "3"
+OrdinaryDiffEqCore = "3.31"
 OrdinaryDiffEqDefault = "1.9"
 OrdinaryDiffEqDifferentiation = "2.2.1"
 OrdinaryDiffEqFeagin = "1.3.0"


### PR DESCRIPTION
## Summary

- Bumps `DelayDiffEq` to `5.74.1`.
- Tightens `OrdinaryDiffEqCore` compat from `"3"` to `"3.31"`.

## Why

`DelayDiffEq 5.74.0` added an `OrdinaryDiffEqCore.shift_past_discontinuity!(::DDEIntegrator)` override in `lib/DelayDiffEq/src/integrators/utils.jl:240` as the DDE-side half of the discontinuity-ULP-shift fix (#3394, paired with #3392). `shift_past_discontinuity!` itself only exists as of `OrdinaryDiffEqCore 3.31.0`. The current compat `"3"` allows `3.0 - 3.30`, where extending the non-existent method throws at load — so any resolver that picks `OrdinaryDiffEqCore < 3.31` alongside `DelayDiffEq >= 5.74` gets a broken install.

A matching registry patch is in JuliaRegistries/General#152940 to tighten the `["5.74 - 5"]` block from `"3"` to `"3.31.0 - 3"` so already-registered installs resolve correctly; this PR fixes the source of truth and triggers a new registered version.

## Test plan

- [ ] CI green on `lib/DelayDiffEq`
- [ ] Register `5.74.1` via JuliaRegistrator once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)