### PR TITLE
DelayDiffEq: don't rewrite sol.t[end] in shift_past_discontinuity!

### DIFF
--- a/lib/DelayDiffEq/src/integrators/utils.jl
+++ b/lib/DelayDiffEq/src/integrators/utils.jl
@@ -51,8 +51,10 @@ function advance_ode_integrator!(integrator::DDEIntegrator, always_calc_begin = 
     ode_integrator = integrator.integrator
 
     # algorithm only works if current time of DDE integrator equals final time point
-    # of solution
-    t != ode_integrator.sol.t[end] && error("cannot advance ODE integrator")
+    # of solution (allow one-ULP gap from shift_past_discontinuity!, which nudges
+    # integrator.t past a propagated discontinuity without rewriting sol.t[end])
+    abs(t - ode_integrator.sol.t[end]) > eps(t) &&
+        error("cannot advance ODE integrator")
 
     # complete interpolation data of DDE integrator for time interval [t, t+dt]
     # and copy it to ODE integrator
@@ -231,19 +233,18 @@ function OrdinaryDiffEqCore.handle_discontinuities!(integrator::DDEIntegrator)
     return nothing
 end
 
-# Override shift_past_discontinuity! for DDEIntegrator: shift the DDE's
-# `integrator.t`, the ODE sub-integrator's `t`, and the last saved endpoint
-# `sol.t[end]` together. `u` is continuous across the propagated derivative-
-# discontinuity so only times move. Keeping the invariant
-# `integrator.t == ode_integrator.sol.t[end]` lets the strict equality check
-# in `advance_ode_integrator!` stay strict.
+# Override shift_past_discontinuity! for DDEIntegrator: nudge the DDE's
+# `integrator.t` and the ODE sub-integrator's `t` by one ULP to cross a
+# propagated derivative-discontinuity. `sol.t[end]` on both sides is left alone:
+# the step completed at the pre-shift time and that is what should appear in
+# the saved history (see `#190` testset and `saveat.jl:18/46/75`). The one-ULP
+# gap between `integrator.t` and `ode_integrator.sol.t[end]` is tolerated by
+# the relaxed equality check in `advance_ode_integrator!`.
 function OrdinaryDiffEqCore.shift_past_discontinuity!(integrator::DDEIntegrator)
     integrator.t isa AbstractFloat || return nothing
     newt = integrator.tdir > 0 ? nextfloat(integrator.t) : prevfloat(integrator.t)
     integrator.t = newt
-    ode_integrator = integrator.integrator
-    ode_integrator.t = newt
-    ode_integrator.sol.t[end] = newt
+    integrator.integrator.t = newt
     return nothing
 end
 


### PR DESCRIPTION
## Summary

Fixes `test (DelayDiffEq_Interface, ...)` on master. Reverts the `sol.t[end]` rewriting introduced in #3427 and restores the one-ULP tolerance in `advance_ode_integrator!`. Both `saveat.jl` and `discontinuities.jl` (including the `#3426` regression test added in #3427) now pass.

## What was broken

`shift_past_discontinuity!` for `DDEIntegrator` was doing three writes per propagated discontinuity — `integrator.t`, `ode_integrator.t`, and `ode_integrator.sol.t[end]` — all set to `nextfloat(t)`. The `sol.t[end]` rewrite broke `lib/DelayDiffEq/test/interface/saveat.jl:18/46/75`:

```julia
@test sol.t == dde_int.integrator.sol.t
```

Reproduced locally on the reference `prob_dde_constant_1delay_long_ip`: 6 divergent indices, each at a discontinuity time (t = n·τ), each exactly one ULP. The outer DDE `sol.t` was unchanged; only the inner ODE sub-integrator's `sol.t[end]` got bumped.

## Why not also bump the outer sol.t[end]

I tried that first. It fixes `saveat.jl` but breaks `discontinuities.jl`'s `#190` testset, which expects `t ∈ sol.t` for each integer discontinuity time — bumping `sol.t[end]` to `nextfloat(t)` replaces the integer value with its successor. It is also wrong when the user has a sparse `saveat`, because `sol.t[end]` there is an older user-requested time, not the current step endpoint.

The `#190` expectation is the semantically correct one: the step **completed** at `t = 5.0` exactly, and `5.0` is what belongs in the saved history. The shift is an integration-state nudge to cross the propagated derivative-discontinuity on the next step — it is not a retroactive amendment to what the integrator computed.

## The fix

- `shift_past_discontinuity!`: move `integrator.t` and `integrator.integrator.t` by one ULP; do not touch either `sol.t[end]`.
- `advance_ode_integrator!`: restore `abs(t - ode_integrator.sol.t[end]) > eps(t) && error(…)` so the one-ULP gap between `integrator.t` and `ode.sol.t[end]` is tolerated.

This is the pre-#3427 behavior for the equality check, combined with #3427's narrower `shift_past_discontinuity!` override (still shifting both `t`s — that part was load-bearing for #3426).

## Test plan

Ran locally in a clean worktree off `upstream/master`:

- [x] `ODEDIFFEQ_TEST_GROUP=Interface Pkg.test("DelayDiffEq")` — all pass. Includes the previously-failing `saveat` (104/104), `discontinuities` (42/42 — the `#3426` regression test from #3427 still passes), AD, Backwards, Callback, Composite, Constrained, Dependent Delays, Export, Fixed-point Iteration, History Function, Jacobian, Mass Matrix, Default Solver, Parameterized Function, save_idxs, Unconstrained, Units, Verbosity, Multi-Algorithm.
- [x] `ODEDIFFEQ_TEST_GROUP=Integrators Pkg.test("DelayDiffEq")` — pass.
- [x] `ODEDIFFEQ_TEST_GROUP=Regression Pkg.test("DelayDiffEq")` — pass (includes Waltman).
- [x] Direct reproducer on `prob_dde_constant_1delay_long_ip`: `sol.t == dde_int.integrator.sol.t` → `true`, 0 divergent indices (vs. 6 on master).
- [ ] CI green across the full matrix.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>