### PR TITLE
Apply Runic: drop stray trailing comma in 1-arg anonymous tuples

### DIFF
--- a/lib/DelayDiffEq/src/functionwrapper.jl
+++ b/lib/DelayDiffEq/src/functionwrapper.jl
@@ -13,11 +13,11 @@ macro wrap_h(signature)
         else
             if isinplace(f)
                 let _f = f.$name, h = h
-                    ($(args_wo_h...),) -> _f($(args...))
+                    ($(args_wo_h...)) -> _f($(args...))
                 end
             else
                 let _f = f.$name, h = h
-                    ($(args_wo_h[2:end]...),) -> _f($(args[2:end]...))
+                    ($(args_wo_h[2:end]...)) -> _f($(args[2:end]...))
                 end
             end
         end

--- a/lib/DiffEqBase/test/downstream/callback_detection.jl
+++ b/lib/DiffEqBase/test/downstream/callback_detection.jl
@@ -42,8 +42,8 @@ using OrdinaryDiffEq
         du[1] = -3sin(3t)
         du[2] = -sin(t)
     end
-    affect1 = (integ,) -> push!(record, 1)
-    affect2 = (integ,) -> push!(record, 2)
+    affect1 = (integ) -> push!(record, 1)
+    affect2 = (integ) -> push!(record, 2)
     cb1 = ContinuousCallback((u, i, integ) -> u[2], affect1, affect1; rootfind = SciMLBase.LeftRootFind, abstol = 0.0)
     cb2 = ContinuousCallback((u, i, integ) -> u[1], affect2, affect2; rootfind = SciMLBase.RightRootFind, abstol = 0.0)
 


### PR DESCRIPTION
## Summary

The `runic` CI check on v7 (`7d76855b9f`) exits 1 because two files still use the `(x,) -> ...` one-arg anonymous tuple syntax that Runic wants as `(x) -> ...`:

- `lib/DelayDiffEq/src/functionwrapper.jl` — `($(args_wo_h...),)` and `($(args_wo_h[2:end]...),)` in the `@wrap_h` macro body
- `lib/DiffEqBase/test/downstream/callback_detection.jl` — `affect1 = (integ,) -> ...` and `affect2 = (integ,) -> ...`

Runic reports all 950 files but flags these two with a `✖` and emits a diff stripping the trailing comma. Apply those diffs.

No semantic change: the splats in `functionwrapper.jl` are the single interpolation expression themselves, so `(splat,)` and `(splat)` produce the same argument form at macro expansion; the `affect*` definitions are straight-forward 1-arg lambdas.

## Test plan

- [ ] `runic` passes on v7 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)