### PR TITLE
Guard TSRKC3 in iipvsoop_tests against older registered StabilizedRK

### DIFF
--- a/test/regression/iipvsoop_tests.jl
+++ b/test/regression/iipvsoop_tests.jl
@@ -145,7 +145,12 @@ rosenbrock_algs = [
     @test sol_ip.t ≈ sol_scalar.t && sol_ip[1, :] ≈ sol_scalar.u
 end
 
-rkc_algs = [RKC(), ROCK2(), ROCK4(), SERK2(), OrdinaryDiffEq.OrdinaryDiffEqStabilizedRK.TSRKC3()]
+rkc_algs = Any[RKC(), ROCK2(), ROCK4(), SERK2()]
+# TSRKC3 was added in OrdinaryDiffEqStabilizedRK 1.11.0; Pkg on Julia 1.10 ignores
+# [sources] and pulls the registered version, which may not have it yet.
+if isdefined(OrdinaryDiffEq.OrdinaryDiffEqStabilizedRK, :TSRKC3)
+    push!(rkc_algs, OrdinaryDiffEq.OrdinaryDiffEqStabilizedRK.TSRKC3())
+end
 
 @testset "Algorithm $(nameof(typeof(alg)))" for alg in rkc_algs
     println(nameof(typeof(alg)))


### PR DESCRIPTION
## Summary

- The IIP vs OOP regression test at `test/regression/iipvsoop_tests.jl:148` unconditionally references `OrdinaryDiffEq.OrdinaryDiffEqStabilizedRK.TSRKC3()`.
- `TSRKC3` was introduced in `OrdinaryDiffEqStabilizedRK` 1.11.0 via #3420 and has not yet been released to the Julia General registry.
- Julia 1.10's Pkg silently ignores the `[sources]` path directive in the main `Project.toml`, so it resolves `OrdinaryDiffEqStabilizedRK` from the registry where `TSRKC3` does not exist. This reliably fails the `Regression_II, lts` matrix entry on master with `UndefVarError: TSRKC3 not defined`, while `1`, `1.11`, and `pre` (which honor `[sources]`) pass. See, e.g., [run 24456085111](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/24456085111).
- Gate the TSRKC3 push with `isdefined(OrdinaryDiffEq.OrdinaryDiffEqStabilizedRK, :TSRKC3)` so the test:
  - continues to exercise `TSRKC3` whenever it is available (new Pkg, or once the sublibrary is released), and
  - gracefully skips it when running against an older registered copy of the sublibrary.

Long-term, releasing `OrdinaryDiffEqStabilizedRK` 1.11.x and bumping `compat` in the main package will make the `isdefined` branch always be true on CI, but this unblocks master in the meantime.

## Test plan

- [ ] `Regression_II, lts` job passes on this PR's CI.
- [ ] `Regression_II, 1.11` / `1` / `pre` continue to pass (TSRKC3 still included).