### PR TITLE
Fix v7 CI: `eachindex(sol.u)` in dense_tests; path-source DiffEqDevTools in DelayDiffEq

### DIFF
--- a/lib/DelayDiffEq/Project.toml
+++ b/lib/DelayDiffEq/Project.toml
@@ -54,6 +54,7 @@ StochasticDiffEqImplicit = {path = "../StochasticDiffEqImplicit"}
 StochasticDiffEqLowOrder = {path = "../StochasticDiffEqLowOrder"}
 StochasticDiffEqROCK = {path = "../StochasticDiffEqROCK"}
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 ADTypes = "1.16"

--- a/test/regression/ode_dense_tests.jl
+++ b/test/regression/ode_dense_tests.jl
@@ -111,7 +111,11 @@ function regression_test(
     sol(interpolation_results_2d, interpolation_points)
     sol(interpolation_points[1])
     sol2 = solve(prob_ode_2Dlinear, alg, dt = 1 // 2^(4), dense = true, adaptive = false)
-    for i in eachindex(sol2)
+    # `eachindex(sol2)` now returns `CartesianIndices` over the full solution
+    # tensor (u_dims..., nsteps) under RecursiveArrayTools v4; iterate the
+    # timestep axis via `sol2.u` so `sol2.u[i]` / `interpolation_results_2d[i]`
+    # index the per-step matrix as the test intends.
+    for i in eachindex(sol2.u)
         print_results(
             @test maximum(maximum.(abs.(sol2.u[i] - interpolation_results_2d[i]))) <
                 tol_ode_2Dlinear


### PR DESCRIPTION
## Summary

Two real (non-runner-flake) v7 failures on `329b3cec36`.

### `test/regression/ode_dense_tests.jl` (fixes Regression_I 1 / 1.11 / pre)

Under RecursiveArrayTools v4 `eachindex(sol2)` returns `CartesianIndices` over the full solution tensor `(u_dims..., nsteps)`, not `1:nsteps` as it did under v3. The follow-up `sol2.u[i]` / `interpolation_results_2d[i]` then tries a 3-index lookup into `Vector{Matrix{Float64}}` and throws:

```
BoundsError: attempt to access 17-element Vector{Matrix{Float64}} at index [1, 2, 1]
```

Iterate `eachindex(sol2.u)` — that still gives `Base.OneTo(nsteps)`, which is what the per-timestep test actually wants. Locally reproduced on v7 HEAD with RAT v4:

```
eachindex(sol2)    = CartesianIndices((4, 2, 17))
eachindex(sol2.u)  = Base.OneTo(17)
```

### `lib/DelayDiffEq/Project.toml` (fixes DelayDiffEq_{Integrators,Interface,QA,Regression} on 1 / 1.11 / pre)

The DelayDiffEq test target develops `StochasticDiffEqLowOrder` from path, which now pins `RecursiveArrayTools = "4"`. Every registered `DiffEqDevTools` version declares `RecursiveArrayTools < 4`, so Pkg errors with:

```
Unsatisfiable requirements detected for package DiffEqDevTools [f3b72e0c]:
  ├─restricted to versions 2.44.4 - 2 by project
  └─restricted by compatibility requirements with RecursiveArrayTools to versions: uninstalled
```

Add `DiffEqDevTools = {path = "../DiffEqDevTools"}` to `lib/DelayDiffEq/Project.toml`'s `[sources]`. The in-repo `lib/DiffEqDevTools` already declares `RecursiveArrayTools = "4"` and `SciMLBase = "3"`, so path-sourcing unblocks the resolve.

Scope intentionally narrow: 38 other sublibraries list `DiffEqDevTools` in `[extras]` without a path source and are still passing CI because their test envs don't pull in a path package that forces RAT v4. Those can migrate as needed when registered SciMLBase-v3 DiffEqDevTools lands.

## Out of scope / upstream-blocked on this v7 tip

- `test (DiffEqBase_Downstream{,2})`, `DiffEqBase_ModelingToolkit`, `DiffEqBase_Sundials` — `Unsatisfiable` on MultiScaleArrays / ModelingToolkit / Sundials / OrdinaryDiffEq restricted by RAT v4; waiting on upstream bumps.
- `benchmark (1/lts)` — AirspeedVelocity-can't-resolve-unregistered-subpackages.
- `test (AD, 1.11 / lts)` — pre-existing Mooncake / DifferentiationInterface conflict.
- lts-only failures — ignoring per discussion.
- `InterfaceIV, pre`, and most of the scattered `*, pre` failures — self-hosted runner registry corruption (`rm General: ENOTEMPTY`, missing `Package.toml`); retry clears.

## Test plan

- [ ] Regression_I passes on 1 / 1.11 / pre
- [ ] DelayDiffEq_* groups resolve and run on 1 / 1.11 / pre

🤖 Generated with [Claude Code](https://claude.com/claude-code)