### PR TITLE
Bump ImplicitDiscreteSolve 1.10.0 → 1.11.0

### DIFF
--- a/lib/ImplicitDiscreteSolve/Project.toml
+++ b/lib/ImplicitDiscreteSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "ImplicitDiscreteSolve"
 uuid = "3263718b-31ed-49cf-8a0f-35a466e8af96"
 authors = ["vyudu <vincent.duyuan@gmail.com>"]
-version = "1.10.0"
+version = "1.11.0"
 
 [deps]
 NonlinearSolveBase = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"


### PR DESCRIPTION
## Summary
- Bump ImplicitDiscreteSolve 1.10.0 → 1.11.0 for unreleased source changes since registration
- Source change: `allows_null_u0` trait to preserve `u0 === nothing` (#3433)

After merge, register ImplicitDiscreteSolve plus the other 5 packages already bumped on master:
- DelayDiffEq 5.74.1
- DiffEqBase 6.217.0
- OrdinaryDiffEqCore 3.32.0
- OrdinaryDiffEqStabilizedRK 1.11.1
- OrdinaryDiffEqTaylorSeries 1.14.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>