### PR TITLE
Fix v7 build: `verbose = DEFAULT_VERBOSE` instead of Bool in solve/init

### DIFF
--- a/lib/DiffEqBase/src/solve.jl
+++ b/lib/DiffEqBase/src/solve.jl
@@ -90,7 +90,7 @@ end
 
 Base.@constprop :aggressive function init(
         prob::AbstractDEProblem, args...; sensealg = nothing,
-        u0 = nothing, p = nothing, verbose = true, kwargs...
+        u0 = nothing, p = nothing, verbose = DEFAULT_VERBOSE, kwargs...
     )
     if sensealg === nothing && has_kwargs(prob) && haskey(prob.kwargs, :sensealg)
         sensealg = prob.kwargs[:sensealg]
@@ -590,7 +590,7 @@ the extension to other types is straightforward.
 """
 Base.@constprop :aggressive function solve(
         prob::AbstractDEProblem, args...; sensealg = nothing,
-        u0 = nothing, p = nothing, wrap = Val(true), verbose = true, kwargs...
+        u0 = nothing, p = nothing, wrap = Val(true), verbose = DEFAULT_VERBOSE, kwargs...
     )
     if sensealg === nothing && haskey(prob.kwargs, :sensealg)
         sensealg = prob.kwargs[:sensealg]


### PR DESCRIPTION
## Summary

The v7 rebase onto master re-introduced `verbose = true` (Bool) as the default kwarg in `DiffEqBase.init` and `DiffEqBase.solve`. But v7's `_process_verbose_param(::Bool)` (from f73c2f5658) throws `ArgumentError: Passing a Bool for verbose is no longer supported in OrdinaryDiffEq v7`.

Every `solve(prob, alg)` call hits this — including the precompile workloads in OrdinaryDiffEqVerner, OrdinaryDiffEqDefault, etc. — so the `build` step itself fails and cascades to all 160+ sublibrary and integration tests.

**Fix:** Replace `verbose = true` with `verbose = DEFAULT_VERBOSE` (`DEVerbosity()`, the Standard preset) in the two function signatures. This is the v7-native equivalent of `verbose = true`.

The pre-rebase v7 DiffEqBase didn't have `verbose` as an explicit kwarg at all (it flowed through `kwargs...`); the rebase brought in master's explicit-kwarg version without updating the default to the v7 type.

## Test plan

- [ ] `build` step passes
- [ ] Sublibrary CI resolves and tests run

🤖 Generated with [Claude Code](https://claude.com/claude-code)