### PR TITLE
Source DiffEqDevTools from lib/ in all 38 sublibraries; fix verbose inference test

### DIFF
--- a/lib/DiffEqBase/test/verbose_inference.jl
+++ b/lib/DiffEqBase/test/verbose_inference.jl
@@ -1,19 +1,16 @@
 using DiffEqBase, Test
 
-# Verify that the Bool path of `_process_verbose_param` is type-stable when
-# the Bool is a compile-time literal (the default `verbose = true` case from
-# `solve`/`init`). Without `Base.@constprop :aggressive`, both branches return
-# different concrete `DEVerbosity{...}` parameterizations and the result is a
-# `Union{...}` that poisons inference all the way through `solve`.
+# Verify that the DEVerbosity paths of `_process_verbose_param` are type-stable
+# and that passing a Bool throws (v7 breaking change).
 
 @testset "_process_verbose_param inference" begin
-    # Val-dispatch is unconditionally type-stable.
-    @inferred DiffEqBase._process_verbose_param(Val(true))
-    @inferred DiffEqBase._process_verbose_param(Val(false))
+    # DEVerbosity passthrough is type-stable.
+    @inferred DiffEqBase._process_verbose_param(DiffEqBase.DEFAULT_VERBOSE)
 
-    # Constprop on literal Bool resolves to a single concrete type.
-    f_true() = DiffEqBase._process_verbose_param(true)
-    f_false() = DiffEqBase._process_verbose_param(false)
-    @test Base.return_types(f_true, ())[1] === typeof(DiffEqBase.DEFAULT_VERBOSE)
-    @test Base.return_types(f_false, ())[1] === typeof(DiffEqBase.NONE_VERBOSE)
+    # Preset dispatch is type-stable.
+    @inferred DiffEqBase._process_verbose_param(DiffEqBase.SciMLLogging.Standard())
+
+    # Bool is no longer accepted — throws ArgumentError.
+    @test_throws ArgumentError DiffEqBase._process_verbose_param(true)
+    @test_throws ArgumentError DiffEqBase._process_verbose_param(false)
 end

--- a/lib/OrdinaryDiffEqAdamsBashforthMoulton/Project.toml
+++ b/lib/OrdinaryDiffEqAdamsBashforthMoulton/Project.toml
@@ -23,6 +23,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqBDF/Project.toml
+++ b/lib/OrdinaryDiffEqBDF/Project.toml
@@ -38,6 +38,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -43,6 +43,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 SafeTestsets = "0.1.0"

--- a/lib/OrdinaryDiffEqDefault/Project.toml
+++ b/lib/OrdinaryDiffEqDefault/Project.toml
@@ -30,6 +30,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -8,6 +8,7 @@ test = ["DiffEqDevTools", "OrdinaryDiffEqBDF", "OrdinaryDiffEqRosenbrock", "Ordi
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqExplicitRK/Project.toml
+++ b/lib/OrdinaryDiffEqExplicitRK/Project.toml
@@ -23,6 +23,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqExponentialRK/Project.toml
+++ b/lib/OrdinaryDiffEqExponentialRK/Project.toml
@@ -30,6 +30,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqExtrapolation/Project.toml
+++ b/lib/OrdinaryDiffEqExtrapolation/Project.toml
@@ -26,6 +26,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -31,6 +31,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqFeagin/Project.toml
+++ b/lib/OrdinaryDiffEqFeagin/Project.toml
@@ -22,6 +22,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqFunctionMap/Project.toml
+++ b/lib/OrdinaryDiffEqFunctionMap/Project.toml
@@ -21,6 +21,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqHighOrderRK/Project.toml
+++ b/lib/OrdinaryDiffEqHighOrderRK/Project.toml
@@ -22,6 +22,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqIMEXMultistep/Project.toml
+++ b/lib/OrdinaryDiffEqIMEXMultistep/Project.toml
@@ -22,6 +22,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqLinear/Project.toml
+++ b/lib/OrdinaryDiffEqLinear/Project.toml
@@ -25,6 +25,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 SciMLOperators = "1.4"

--- a/lib/OrdinaryDiffEqLowOrderRK/Project.toml
+++ b/lib/OrdinaryDiffEqLowOrderRK/Project.toml
@@ -23,6 +23,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqLowStorageRK/Project.toml
+++ b/lib/OrdinaryDiffEqLowStorageRK/Project.toml
@@ -27,6 +27,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqNewmark/Project.toml
+++ b/lib/OrdinaryDiffEqNewmark/Project.toml
@@ -21,6 +21,7 @@ TruncatedStacktraces = "781d530d-4396-4725-bb49-402e4bee1e77"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 OrdinaryDiffEqCore = {path = "../OrdinaryDiffEqCore"}
 
 [compat]

--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -42,6 +42,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqNordsieck/Project.toml
+++ b/lib/OrdinaryDiffEqNordsieck/Project.toml
@@ -24,6 +24,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqPDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqPDIRK/Project.toml
@@ -24,6 +24,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 ADTypes = "1.16"

--- a/lib/OrdinaryDiffEqPRK/Project.toml
+++ b/lib/OrdinaryDiffEqPRK/Project.toml
@@ -20,6 +20,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqQPRK/Project.toml
+++ b/lib/OrdinaryDiffEqQPRK/Project.toml
@@ -22,6 +22,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqRKN/Project.toml
+++ b/lib/OrdinaryDiffEqRKN/Project.toml
@@ -22,6 +22,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Statistics = "<0.0.1, 1"

--- a/lib/OrdinaryDiffEqRosenbrock/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrock/Project.toml
@@ -28,6 +28,7 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 OrdinaryDiffEqBDF = {path = "../OrdinaryDiffEqBDF"}
 OrdinaryDiffEqCore = {path = "../OrdinaryDiffEqCore"}
 OrdinaryDiffEqDifferentiation = {path = "../OrdinaryDiffEqDifferentiation"}

--- a/lib/OrdinaryDiffEqSDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqSDIRK/Project.toml
@@ -31,6 +31,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqSSPRK/Project.toml
+++ b/lib/OrdinaryDiffEqSSPRK/Project.toml
@@ -27,6 +27,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqStabilizedIRK/Project.toml
+++ b/lib/OrdinaryDiffEqStabilizedIRK/Project.toml
@@ -26,6 +26,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqStabilizedRK/Project.toml
+++ b/lib/OrdinaryDiffEqStabilizedRK/Project.toml
@@ -23,6 +23,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqSymplecticRK/Project.toml
+++ b/lib/OrdinaryDiffEqSymplecticRK/Project.toml
@@ -25,6 +25,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Statistics = "<0.0.1, 1"

--- a/lib/OrdinaryDiffEqTaylorSeries/Project.toml
+++ b/lib/OrdinaryDiffEqTaylorSeries/Project.toml
@@ -30,6 +30,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 DiffEqBase = "6.194"

--- a/lib/OrdinaryDiffEqTsit5/Project.toml
+++ b/lib/OrdinaryDiffEqTsit5/Project.toml
@@ -25,6 +25,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/OrdinaryDiffEqVerner/Project.toml
+++ b/lib/OrdinaryDiffEqVerner/Project.toml
@@ -28,6 +28,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 Pkg = "1"

--- a/lib/StochasticDiffEq/Project.toml
+++ b/lib/StochasticDiffEq/Project.toml
@@ -26,6 +26,7 @@ StochasticDiffEqWeak = "af2a2fcd-1c36-4cbe-a6d0-5afda784a085"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 ImplicitDiscreteSolve = {path = "../ImplicitDiscreteSolve"}
 OrdinaryDiffEq = {path = "../../"}
 OrdinaryDiffEqCore = {path = "../OrdinaryDiffEqCore"}

--- a/lib/StochasticDiffEqROCK/Project.toml
+++ b/lib/StochasticDiffEqROCK/Project.toml
@@ -24,6 +24,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 DiffEqBase = "6.187"

--- a/lib/StochasticDiffEqWeak/Project.toml
+++ b/lib/StochasticDiffEqWeak/Project.toml
@@ -29,6 +29,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 ADTypes = "1"


### PR DESCRIPTION
## Summary

Two fixes for the v7 CI after the rebase onto master.

### DiffEqDevTools path source (unblocks ~80 sublibrary test jobs)

Every sublibrary test target has `DiffEqDevTools` in `[extras]`. On v7 the test envs path-source packages pinning `RecursiveArrayTools = "4"` (via `SciMLBase = "3"`), but every registered `DiffEqDevTools` version restricts `RecursiveArrayTools < 4`. So the env fails to resolve:

```
Unsatisfiable requirements detected for package DiffEqDevTools [f3b72e0c]:
  restricted by compatibility requirements with RecursiveArrayTools to versions: uninstalled
```

Adds `DiffEqDevTools = {path = "../DiffEqDevTools"}` to `[sources]` in all 38 sublibraries that list it in `[extras]`. `lib/DiffEqDevTools` already declares `RecursiveArrayTools = "4"` and `SciMLBase = "3"`.

### DiffEqBase verbose inference test

`lib/DiffEqBase/test/verbose_inference.jl` tested that `_process_verbose_param(::Bool)` returns `DEVerbosity` via constprop. But v7's `f73c2f5658` changed that method to `throw(ArgumentError(...))`. Updated the test to assert the throw and verify the `DEVerbosity` / preset paths instead.

### Not in this PR (remaining v7 failures from #3448 CI)

- `Regression_II`: `UndefVarError: OrdinaryDiffEqStabilizedRK not defined in OrdinaryDiffEq` — missing re-export in main module
- `Downstream (1)`: "Time derivative Tests: First call to automatic differentiation for the Jacobian failed" — AD issue in downstream test
- Pre-existing: benchmark, AD/Mooncake, ODEInterfaceRegression

## Test plan

- [ ] Sublibrary CI (all ~80 OrdinaryDiffEq*/StochasticDiffEq*/DelayDiffEq* jobs) resolves and tests run
- [ ] DiffEqBase tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)