### PR TITLE
Fix Regression_II: use bare TSRKC3() instead of OrdinaryDiffEq.OrdinaryDiffEqStabilizedRK.TSRKC3()

### DIFF
--- a/test/regression/iipvsoop_tests.jl
+++ b/test/regression/iipvsoop_tests.jl
@@ -146,7 +146,7 @@ rosenbrock_algs = [
     @test sol_ip.t ≈ sol_scalar.t && sol_ip[1, :] ≈ sol_scalar.u
 end
 
-rkc_algs = [RKC(), ROCK2(), ROCK4(), SERK2(), OrdinaryDiffEq.OrdinaryDiffEqStabilizedRK.TSRKC3()]
+rkc_algs = [RKC(), ROCK2(), ROCK4(), SERK2(), TSRKC3()]
 
 @testset "Algorithm $(nameof(typeof(alg)))" for alg in rkc_algs
     println(nameof(typeof(alg)))


### PR DESCRIPTION
## Summary

`test/regression/iipvsoop_tests.jl:149` accesses `OrdinaryDiffEq.OrdinaryDiffEqStabilizedRK.TSRKC3()`, but on v7 `OrdinaryDiffEqStabilizedRK` is not a submodule of `OrdinaryDiffEq` (the main module only re-exports a small set of algorithms). The test file already imports `OrdinaryDiffEqStabilizedRK` on line 3, and `TSRKC3` is exported from it — just use the bare name.

Fixes Regression_II on 1 / 1.11 / pre.

### Downstream (1) "Time derivative Tests" — investigated, upstream issue

The Enzyme forward-mode rule in `FunctionWrappersWrappersEnzymeExt` doesn't match the installed Enzyme's `FwdConfigWidth` signature (`{1, false, false, false, false}` vs expected `{1, false, true, RA, SZ}`). This is a version mismatch between Enzyme and FunctionWrappersWrappers — not fixable from OrdinaryDiffEq. Needs an upstream bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)