### PR TITLE
Fix verbosity test after dt_epsilon default change

### DIFF
--- a/test/interface/verbosity.jl
+++ b/test/interface/verbosity.jl
@@ -37,11 +37,11 @@ using NonlinearSolve: NonlinearVerbosity
         @test v1.w_factorization isa SciMLLogging.Silent
         @test v1.newton_iterations isa SciMLLogging.Silent
 
-        # Test numerical group (default: WarnLevel except shampine_dt, dt_epsilon, stability_check)
+        # Test numerical group (default: WarnLevel except shampine_dt, stability_check)
         @test v1.rosenbrock_no_differential_states isa SciMLLogging.WarnLevel
         @test v1.shampine_dt isa SciMLLogging.Silent
         @test v1.unlimited_dt isa SciMLLogging.WarnLevel
-        @test v1.dt_epsilon isa SciMLLogging.Silent
+        @test v1.dt_epsilon isa SciMLLogging.WarnLevel
         @test v1.stability_check isa SciMLLogging.Silent
         @test v1.near_singular isa SciMLLogging.Silent
     end


### PR DESCRIPTION
## Summary

PR #3445 changed `dt_epsilon` from `Silent()` to `WarnLevel()` in the Minimal and Standard presets (`lib/DiffEqBase/src/verbosity.jl`) but did not update the corresponding test assertion in `test/interface/verbosity.jl`.

This one-line fix updates the default-constructor test to expect `WarnLevel` instead of `Silent` for `dt_epsilon`, matching the new preset.

## Test plan

- [x] The assertion now matches the actual Standard preset value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)