### PR TITLE
Bump OrdinaryDiffEqCore to v3.33.0

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "3.32.0"
+version = "3.33.0"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"


### PR DESCRIPTION
## Summary

Julia 1.10 (`lts`) doesn't support `[sources]` in Project.toml (added in 1.11), so CI on 1.10 installs OrdinaryDiffEqCore from the registry (v3.32.0) rather than the local checkout. The tstop tolerance fix from #3441 isn't in the registered v3.32.0, causing the new regression test to fail on `lts`.

Bumping to v3.33.0 triggers a release via TagBot so that Julia 1.10 CI picks up the fix.

## Test plan

- [ ] After merge + TagBot release, `test (InterfaceI, lts)` should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)