### PR TITLE
Bump DiffEqBase and OrdinaryDiffEqCore minors for post-#3453 src changes

### DIFF
--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.217.0"
+version = "6.218.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "3.32.0"
+version = "3.33.0"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"


### PR DESCRIPTION
## Summary

Bumps the two subpackages that have accumulated source-code changes on master since their last registered versions.

- **DiffEqBase** `6.217.0 -> 6.218.0` — `dt_epsilon` default raised to `WarnLevel()` in the `Minimal` and `Standard` verbosity presets (#3445, `src/verbosity.jl`). Behavior-visible change.
- **OrdinaryDiffEqCore** `3.32.0 -> 3.33.0` — fix spurious tiny trailing step for fixed-dt methods by adding a floating-point tolerance in `modify_dt_for_tstops!` so the integrator snaps to `tstop` when `dt ≈ distance_to_tstop` (#3441, `src/integrators/integrator_utils.jl`). Bugfix.

## Checked but not bumped

Everything else with post-#3453 activity on master is test-only or already-registered:

- `OrdinaryDiffEqLowOrderRK`, `OrdinaryDiffEqSSPRK` — only `test/qa/jet.jl` touched by #3438
- `OrdinaryDiffEqAMF` — only `test/` touched by #3439 (still at 1.0.0 awaiting initial registration)
- `ImplicitDiscreteSolve` — only `Project.toml` compat bound changed (#3453); no src change, so not included in this PR
- `DelayDiffEq` — unchanged since c2de709ef8
- All other sublibraries — unchanged since #3439 or earlier

Each entry here will be registered via `@JuliaRegistrator` after this merges.

## Test plan

- [ ] `@JuliaRegistrator register subdir=lib/DiffEqBase`
- [ ] `@JuliaRegistrator register subdir=lib/OrdinaryDiffEqCore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)