### PR TITLE
Fix v7: second eachindex(sol) in dense_tests, EEst→set_EEst! in TSRKC3

### DIFF
--- a/lib/OrdinaryDiffEqStabilizedRK/src/rkc_perform_step.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/rkc_perform_step.jl
@@ -1188,7 +1188,7 @@ end
             tmp, uprev, u, integrator.opts.abstol,
             integrator.opts.reltol, integrator.opts.internalnorm, t
         )
-        integrator.EEst = integrator.opts.internalnorm(atmp, t)
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
     end
     integrator.k[1] = integrator.fsalfirst
     integrator.k[2] = integrator.fsallast
@@ -1320,7 +1320,7 @@ end
             atmp, tmp, uprev, u, integrator.opts.abstol,
             integrator.opts.reltol, integrator.opts.internalnorm, t
         )
-        integrator.EEst = integrator.opts.internalnorm(atmp, t)
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
     end
     integrator.k[1] = integrator.fsalfirst
     integrator.k[2] = integrator.fsallast

--- a/test/regression/ode_dense_tests.jl
+++ b/test/regression/ode_dense_tests.jl
@@ -66,7 +66,7 @@ function regression_test(
     @inferred sol(interpolation_results_1d, interpolation_points)
     @inferred sol(interpolation_points[1])
     sol2 = solve(prob_ode_linear, alg, dt = 1 // 2^(4), dense = true, adaptive = false)
-    for i in eachindex(sol2)
+    for i in eachindex(sol2.u)
         print_results(
             @test maximum(abs.(sol2.u[i] - interpolation_results_1d[i])) <
                 tol_ode_linear


### PR DESCRIPTION
## Summary

Two real test failures on the current v7 CI (PR #3242, SHA `428db4a89d`):

### Regression_I — Dense Tests (line 69)

#3446 fixed `eachindex(sol2)` → `eachindex(sol2.u)` at line 118 (2D problem loop) but missed the same pattern at line 69 (1D linear problem loop). Same RAT v4 issue: `eachindex(sol)` returns `CartesianIndices` instead of `1:nsteps`.

### Regression_II — TSRKC3 FieldError

`perform_step!` for TSRKC3 at `rkc_perform_step.jl:1191` and `:1323` writes `integrator.EEst = ...`, but #3422 moved `EEst` from the integrator struct to the controller cache. Every other sublibrary uses `OrdinaryDiffEqCore.set_EEst!(integrator, ...)` — these two sites were missed.

### Other failures on this run

- Self-hosted runner registry flakes (AlgConvergence_I, Integrators_I, InterfaceIII, etc.)
- Downstream (1): upstream Enzyme/FunctionWrappersWrappers version mismatch
- benchmark, AD: pre-existing

🤖 Generated with [Claude Code](https://claude.com/claude-code)