### PR TITLE
Fix duplicate [sources.DiffEqDevTools] TOML key in ImplicitTableaus

### DIFF
--- a/lib/OrdinaryDiffEqImplicitTableaus/Project.toml
+++ b/lib/OrdinaryDiffEqImplicitTableaus/Project.toml
@@ -10,9 +10,6 @@ DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources.DiffEqDevTools]
-path = "../DiffEqDevTools"
-
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
 


### PR DESCRIPTION
#3459 inserted a second `[sources.DiffEqDevTools]` subsection, producing a TOML parse error that cascaded to break `detect-changes` → Sublibrary CI → all IntegrationTest jobs (DiffEqCallbacks, MTK, SciMLSensitivity, PositiveIntegrators, ProbNumDiffEq).

One-line fix: remove the duplicate and keep `[sources]` inline before subsections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)