### PR TITLE
Fix PredictiveController no-arg constructor: add missing qmax_first_step

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
@@ -756,10 +756,11 @@ struct PredictiveController{T} <: AbstractController
     qsteady_max::T
 end
 
-function PredictiveController(; qmin = float(1 // 5), qmax = 10 // 1, gamma = 9 // 10, qsteady_min = 1 // 1, qsteady_max = 6 // 5)
+function PredictiveController(; qmin = float(1 // 5), qmax = 10 // 1, qmax_first_step = 10000 // 1, gamma = 9 // 10, qsteady_min = 1 // 1, qsteady_max = 6 // 5)
     return PredictiveController{typeof(qmin)}( # FIXME combined promoted type
         qmin,
         qmax,
+        qmax_first_step,
         gamma,
         qsteady_min,
         qsteady_max,


### PR DESCRIPTION
## Summary

The `PredictiveController(; ...)` keyword constructor passes 5 positional values to a 6-field struct, omitting `qmax_first_step`:

```julia
# Before (broken):
PredictiveController{T}(qmin, qmax, gamma, qsteady_min, qsteady_max)
#                        ----  ----  ^^^^^  ^^^^^^^^^^^  ^^^^^^^^^^^
# Fields:                qmin  qmax  qmax_first_step(!)  gamma(!)  qsteady_min(!)
# qsteady_max is missing entirely → MethodError
```

This would cause a `MethodError` (5 args for 6 fields) or, if Julia ever allowed it, silently wrong parameters: `gamma = 0.9` landing in `qmax_first_step`, `qsteady_min = 1` in `gamma`, etc.

The `PredictiveController(QT, alg)` constructor used by `default_controller` was already correct. This bug only affects direct `PredictiveController()` calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)