### PR TITLE
Fix FieldError for Magnus/Linear integrators with OrdinaryDiffEqDiffe…

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/src/OrdinaryDiffEqDifferentiation.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/OrdinaryDiffEqDifferentiation.jl
@@ -36,6 +36,7 @@ using OrdinaryDiffEqCore: OrdinaryDiffEqAlgorithm, OrdinaryDiffEqAdaptiveImplici
     OrdinaryDiffEqImplicitAlgorithm, CompositeAlgorithm,
     OrdinaryDiffEqExponentialAlgorithm,
     OrdinaryDiffEqAdaptiveExponentialAlgorithm,
+    OrdinaryDiffEqLinearExponentialAlgorithm,
     StochasticDiffEqNewtonAlgorithm, StochasticDiffEqNewtonAdaptiveAlgorithm,
     StochasticDiffEqJumpNewtonAdaptiveAlgorithm,
     StochasticDiffEqJumpNewtonDiffusionAdaptiveAlgorithm,

--- a/lib/OrdinaryDiffEqDifferentiation/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/alg_utils.jl
@@ -72,8 +72,6 @@ Base.@pure function determine_chunksize(u, CS)
     end
 end
 
-
-
 function DiffEqBase.prepare_alg(
         alg::Union{
             OrdinaryDiffEqAdaptiveImplicitAlgorithm{

--- a/lib/OrdinaryDiffEqDifferentiation/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/alg_utils.jl
@@ -32,6 +32,12 @@ function _alg_autodiff(
     ) where {CS, AD, FDT, ST, CJ, Controller}
     return Val{AD}()
 end
+# OrdinaryDiffEqLinearExponentialAlgorithm subtypes (Magnus integrators, LieEuler,
+# CG methods, etc.) have NO autodiff field — their only fields are krylov, m, iop.
+# They must be excluded before the generic ExponentialAlgorithm dispatch below.
+function _alg_autodiff(::OrdinaryDiffEqLinearExponentialAlgorithm)
+    return Val{false}()
+end
 function _alg_autodiff(
         alg::Union{
             OrdinaryDiffEqExponentialAlgorithm{CS, AD},
@@ -65,6 +71,8 @@ Base.@pure function determine_chunksize(u, CS)
         return ForwardDiff.pickchunksize(length(u))
     end
 end
+
+
 
 function DiffEqBase.prepare_alg(
         alg::Union{

--- a/lib/OrdinaryDiffEqDifferentiation/test/differentiation_traits_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/differentiation_traits_tests.jl
@@ -45,29 +45,24 @@ sol = solve(prob2, Rosenbrock23(autodiff = AutoFiniteDiff()))
 @test ≈(good_sol[:, end], sol[:, end], rtol = 1.0e-2)
 
 # Regression test for issue #3232:
-# OrdinaryDiffEqLinearExponentialAlgorithm subtypes (MagnusGL6, etc.)
-# have no `autodiff` field; _alg_autodiff and prepare_alg must not crash.
-using OrdinaryDiffEqDifferentiation: _alg_autodiff
-using OrdinaryDiffEqCore: OrdinaryDiffEqLinearExponentialAlgorithm
-using DiffEqBase: prepare_alg
+# MagnusGL6 (and all OrdinaryDiffEqLinearExponentialAlgorithm subtypes)
+# have no `autodiff` field. When OrdinaryDiffEqDifferentiation is loaded,
+# _alg_autodiff must not crash by trying to access alg.autodiff.
+using OrdinaryDiffEqLinear
+using SciMLOperators: MatrixOperator
 
-struct MockMagnusAlg <: OrdinaryDiffEqLinearExponentialAlgorithm
-    krylov::Bool
-    m::Int
-    iop::Int
-end
+@testset "MagnusGL6 solve with Differentiation loaded (issue #3232)" begin
+    function update_func!(A, u, p, t)
+        A[1, 1] = cos(t)
+        A[2, 1] = sin(t)
+        A[1, 2] = -sin(t)
+        A[2, 2] = cos(t)
+    end
+    A = MatrixOperator(ones(2, 2), update_func! = update_func!)
+    prob = ODEProblem(A, ones(2), (1.0, 6.0))
 
-@testset "LinearExponentialAlgorithm autodiff traits (issue #3232)" begin
-    mock = MockMagnusAlg(false, 30, 0)
-
-    # _alg_autodiff must return Val{false}() instead of accessing alg.autodiff
-    @test _alg_autodiff(mock) == Val{false}()
-
-    # prepare_alg must return the algorithm unchanged (no AD preparation needed)
-    u0 = ones(2)
-    mock_prob = ODEProblem((du, u, p, t) -> du .= 0, u0, (0.0, 1.0))
-    @test prepare_alg(mock, u0, nothing, mock_prob) === mock
-
-    # forwarddiffs_model must return false
-    @test SciMLBase.forwarddiffs_model(mock) == false
+    # This would crash with FieldError before the fix
+    sol = solve(prob, MagnusGL6(), dt = 1 / 10)
+    @test sol.retcode == ReturnCode.Success
+    @test length(sol.t) > 1
 end

--- a/lib/OrdinaryDiffEqDifferentiation/test/differentiation_traits_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/differentiation_traits_tests.jl
@@ -43,3 +43,31 @@ sol = solve(prob2, Rosenbrock23(autodiff = AutoForwardDiff(chunksize = 1)))
 
 sol = solve(prob2, Rosenbrock23(autodiff = AutoFiniteDiff()))
 @test ≈(good_sol[:, end], sol[:, end], rtol = 1.0e-2)
+
+# Regression test for issue #3232:
+# OrdinaryDiffEqLinearExponentialAlgorithm subtypes (MagnusGL6, etc.)
+# have no `autodiff` field; _alg_autodiff and prepare_alg must not crash.
+using OrdinaryDiffEqDifferentiation: _alg_autodiff
+using OrdinaryDiffEqCore: OrdinaryDiffEqLinearExponentialAlgorithm
+using DiffEqBase: prepare_alg
+
+struct MockMagnusAlg <: OrdinaryDiffEqLinearExponentialAlgorithm
+    krylov::Bool
+    m::Int
+    iop::Int
+end
+
+@testset "LinearExponentialAlgorithm autodiff traits (issue #3232)" begin
+    mock = MockMagnusAlg(false, 30, 0)
+
+    # _alg_autodiff must return Val{false}() instead of accessing alg.autodiff
+    @test _alg_autodiff(mock) == Val{false}()
+
+    # prepare_alg must return the algorithm unchanged (no AD preparation needed)
+    u0 = ones(2)
+    mock_prob = ODEProblem((du, u, p, t) -> du .= 0, u0, (0.0, 1.0))
+    @test prepare_alg(mock, u0, nothing, mock_prob) === mock
+
+    # forwarddiffs_model must return false
+    @test SciMLBase.forwarddiffs_model(mock) == false
+end

--- a/lib/OrdinaryDiffEqLinear/test/linear_method_tests.jl
+++ b/lib/OrdinaryDiffEqLinear/test/linear_method_tests.jl
@@ -267,3 +267,21 @@ test_setup = Dict(:alg => Vern9(), :reltol => 1.0e-14, :abstol => 1.0e-14)
 
 sim = analyticless_test_convergence(dts, prob, CayleyEuler(), test_setup)
 @test sim.𝒪est[:l2] ≈ 1 atol = 0.2
+
+# Regression test for https://github.com/SciML/OrdinaryDiffEq.jl/issues/3232
+# Magnus/Linear integrators must not FieldError when OrdinaryDiffEqDifferentiation
+# is loaded (which happens transitively via DifferentialEquations.jl).
+@testset "Regression #3232: non-autonomous Magnus solve does not FieldError" begin
+    function update_func_3232!(A, u, p, t)
+        A[1, 1] = cos(t)
+        A[2, 1] = sin(t)
+        A[1, 2] = -sin(t)
+        A[2, 2] = cos(t)
+    end
+    A_3232 = MatrixOperator(ones(2, 2), update_func! = update_func_3232!)
+    prob_3232 = ODEProblem(A_3232, ones(2), (1.0, 6.0))
+    for alg in (MagnusGL6(), MagnusGL4(), MagnusGL8(), LieEuler(), CG2(), CG3(), CG4a())
+        sol = solve(prob_3232, alg, dt = 1 / 10)
+        @test sol.retcode == ReturnCode.Success
+    end
+end


### PR DESCRIPTION
## Fix `FieldError` for Magnus/Linear integrators when `OrdinaryDiffEqDifferentiation` is loaded

**Fixes #3232**

### Problem

Solving a non-autonomous linear ODE with any Magnus integrator (e.g. `MagnusGL6`, `MagnusGL8`, `LieEuler`, `CG2`, etc.) crashes with a `FieldError` when `OrdinaryDiffEqDifferentiation` is loaded (which happens automatically via `DifferentialEquations.jl`):

```
FieldError: type OrdinaryDiffEqLinear.MagnusGL6 has no field `autodiff`,
available fields: `krylov`, `m`, `iop`
```

### Root Cause

`MagnusGL6 <: OrdinaryDiffEqLinearExponentialAlgorithm <: OrdinaryDiffEqExponentialAlgorithm{0, false, ...}`

In `OrdinaryDiffEqDifferentiation/src/alg_utils.jl`, the generic dispatch:

```julia
function _alg_autodiff(alg::Union{
        OrdinaryDiffEqExponentialAlgorithm{CS, AD},
        OrdinaryDiffEqAdaptiveExponentialAlgorithm{CS, AD},
    }) where {CS, AD}
    return alg.autodiff  # ← crashes: Magnus types have no autodiff field
end
```

catches all `OrdinaryDiffEqLinearExponentialAlgorithm` subtypes because they inherit from `OrdinaryDiffEqExponentialAlgorithm{0, false, ...}`. These algorithms are matrix-exponential methods that never use ForwardDiff/FiniteDiff — they only have fields `krylov`, `m`, and `iop`.

### Fix

Add a more-specific `_alg_autodiff` override that intercepts `OrdinaryDiffEqLinearExponentialAlgorithm` before the generic `ExponentialAlgorithm` dispatch:

```julia
function _alg_autodiff(::OrdinaryDiffEqLinearExponentialAlgorithm)
    return Val{false}()
end
```

This is consistent with how `OrdinaryDiffEqCore` already handles these types in `prepare_alg` and `has_autodiff`.

### Changes

| File | Change |
|------|--------|
| `OrdinaryDiffEqDifferentiation.jl` | Import `OrdinaryDiffEqLinearExponentialAlgorithm` from Core |
| `alg_utils.jl` | Add `_alg_autodiff` override returning `Val{false}()` |
| `differentiation_traits_tests.jl` | Regression test verifying `_alg_autodiff`, `prepare_alg`, and `forwarddiffs_model` |

### Testing

All 3 regression assertions pass with clean precompilation:
```
✓ _alg_autodiff returns Val{false}()
✓ prepare_alg returns alg unchanged  
✓ forwarddiffs_model returns false
```