### PR TITLE
Fix/nested arraypartition oop initdt

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/initdt.jl
+++ b/lib/OrdinaryDiffEqCore/src/initdt.jl
@@ -367,7 +367,7 @@ end
     dt₀ = min(dt₀, dtmax_tdir)
     dt₀_tdir = tdir * dt₀
 
-    u₁ = @.. broadcast = false u0 + dt₀_tdir * f₀
+    u₁ = u0 + dt₀_tdir * f₀
     f₁ = f(u₁, p, t + dt₀_tdir)
 
     # Constant zone before callback


### PR DESCRIPTION
Summary
Fixes ODE solve failing when u0 is a recursive ArrayPartition (e.g. ArrayPartition([1.], ArrayPartition(1.)))
In _ode_initdt_oop, @.. broadcast = false u0 + dt₀_tdir * f₀ incorrectly flattens nested ArrayPartition partitions into Vector{Float64}, causing the ODE function to be called with the wrong type on the 3rd invocation
Root cause: when an ArrayPartition mixes Vector and ArrayPartition partitions, the combined broadcast style is ArrayPartitionStyle{DefaultArrayStyle{1}}; RecursiveArrayTools' unpack then propagates DefaultArrayStyle{1} to all partitions, so copy allocates a Vector for what should remain an ArrayPartition
Fix: use plain arithmetic (u0 + dt₀_tdir * f₀) which uses RecursiveArrayTools' map-based operators and preserves each partition's type independently
Test plan
 Reproduce with ODEProblem(func, ArrayPartition([1.], ArrayPartition(1.)), (0,1)) |> solve — should no longer throw FieldError: type Array has no field x
 Existing tests pass
Closes #3207