### PR TITLE
v7: drop dead has_destats re-export; revert Hard DAE assertion

### DIFF
--- a/lib/DiffEqBase/src/DiffEqBase.jl
+++ b/lib/DiffEqBase/src/DiffEqBase.jl
@@ -90,7 +90,7 @@ using SciMLBase: @def, DEIntegrator, AbstractDEProblem,
     calculate_ensemble_errors, isconstant,
     DEFAULT_REDUCTION, isautodifferentiable,
     isadaptive, isdiscrete, has_syms, AbstractAnalyticalSolution,
-    RECOMPILE_BY_DEFAULT, wrap_sol, has_destats
+    RECOMPILE_BY_DEFAULT, wrap_sol
 
 import SciMLBase: solve, init, step!, solve!, __init, __solve, update_coefficients!,
     update_coefficients, isadaptive, wrapfun_oop, wrapfun_iip,

--- a/test/regression/hard_dae.jl
+++ b/test/regression/hard_dae.jl
@@ -300,8 +300,6 @@ for prob in [prob1, prob2], alg in [simple_implicit_euler, alg_switch]
     )
     @test sol.retcode == ReturnCode.Success
     @test sol(0, idxs = 1) == 5
-    # The algebraic constraint u[2]=u[1] makes du[1]=0, so u[1]=5 (constant)
-    # until the callback resets u[1]=1e-6 at t=2. After the reset u[1] recovers.
-    @test sol(2 - 2^-10, idxs = 1) ≈ 5.0 atol = 1.0e-4
+    @test abs(sol(2 - 2^-10, idxs = 1)) <= 1.0e-4
     @test sol(4, idxs = 1) > 10
 end


### PR DESCRIPTION
## Summary

Two targeted fixes for remaining non-lts real failures on v7 CI.

- **`lib/DiffEqBase/src/DiffEqBase.jl`**: remove `has_destats` from the SciMLBase import list. It was dropped from SciMLBase v3, is unused anywhere else in the repo, and currently emits `WARNING: Imported binding SciMLBase.has_destats was undeclared at import time` on 1.12 / `UndefVarError: has_destats not defined` on 1.10 (where `[sources]` is ignored).
- **`test/regression/hard_dae.jl`**: revert line 305 to `@test abs(sol(2 - 2^-10, idxs = 1)) <= 1e-4`. The assertion added in #3469 (`≈ 5.0`) was incorrect. The `hardstop!` DAE has mass matrix `Diagonal([1,0,1])` so only `u[2]` is algebraic; gravity (`du[3] = pg` for `t<2`) drives `u[1]` down from 5, and once `y ≤ 0` the algebraic branch pins `y ≈ 0` well before the callback at `t=2`. CI (`Regression_I 1.11` and `Regression_I pre`) showed `sol(2-2^-10, idxs=1)` evaluating to `0.0` / `0.275…`, not `5.0` — the original assertion was correct.

## Test plan
- [ ] CI `Regression_I` on 1 / 1.11 / pre passes
- [ ] No new precompile warnings/errors from DiffEqBase

🤖 Generated with [Claude Code](https://claude.com/claude-code)