### PR TITLE
style: apply Runic formatting to unblock runic CI

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
@@ -184,8 +184,12 @@ function modify_dt_for_tstops!(integrator)
         # just past the last tstop and produce a spurious micro-step.
         tstop_tol = if integrator.t isa AbstractFloat && isfinite(tdir_tstop) &&
                 isfinite(integrator.t)
-            100 * eps(float(max(abs(integrator.t), abs(tdir_tstop)) /
-                            oneunit(integrator.t))) * oneunit(integrator.t)
+            100 * eps(
+                float(
+                    max(abs(integrator.t), abs(tdir_tstop)) /
+                        oneunit(integrator.t)
+                )
+            ) * oneunit(integrator.t)
         else
             zero(distance_to_tstop)
         end

--- a/lib/OrdinaryDiffEqFIRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/algorithms.jl
@@ -9,12 +9,12 @@ year={1999},
 publisher={Elsevier}}"""
 
 AdaptiveRadauPaper = """@article{AdaptiveRadauPaper,
-  author={Ekanathan, Shreyas and Smith, Oscar and Rackauckas, Christopher},
-  booktitle={2025 IEEE High Performance Extreme Computing Conference (HPEC)}, 
-  title={A Fully Adaptive Radau Method for the Efficient Solution of Stiff Ordinary Differential Equations at Low Tolerances}, 
-  year={2025},
-  pages={1-9},
-  doi={10.1109/HPEC67600.2025.11196706}}"""
+author={Ekanathan, Shreyas and Smith, Oscar and Rackauckas, Christopher},
+booktitle={2025 IEEE High Performance Extreme Computing Conference (HPEC)}, 
+title={A Fully Adaptive Radau Method for the Efficient Solution of Stiff Ordinary Differential Equations at Low Tolerances}, 
+year={2025},
+pages={1-9},
+doi={10.1109/HPEC67600.2025.11196706}}"""
 
 extra_keyword_description = """
 - `extrapolant`: TBD

--- a/lib/OrdinaryDiffEqStabilizedRK/src/rkc_perform_step.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/rkc_perform_step.jl
@@ -1212,7 +1212,7 @@ end
     onemq = 1 - q
     onepq = 1 + q
     onepq2 = onepq * onepq
-    
+
     # The first and possibly second steps are calculated via the one-step RKC method.
     rkcstep = q < 0.49
 

--- a/lib/OrdinaryDiffEqSymplecticRK/src/symplectic_caches.jl
+++ b/lib/OrdinaryDiffEqSymplecticRK/src/symplectic_caches.jl
@@ -150,23 +150,23 @@ end
 
 # Mapping from algorithm to tableau constructor
 _symplectic_tableau(::PseudoVerletLeapfrog, ::Type{T}, ::Type{T2}) where {T, T2} = PseudoVerletLeapfrogConstantCache(T, T2)
-_symplectic_tableau(::McAte2, ::Type{T}, ::Type{T2}) where {T,T2} = McAte2ConstantCache(T, T2)
-_symplectic_tableau(::Ruth3, ::Type{T}, ::Type{T2}) where {T,T2} = Ruth3ConstantCache(T, T2)
-_symplectic_tableau(::McAte3, ::Type{T}, ::Type{T2}) where {T,T2} = McAte3ConstantCache(T, T2)
-_symplectic_tableau(::CandyRoz4, ::Type{T}, ::Type{T2}) where {T,T2} = CandyRoz4ConstantCache(T, T2)
-_symplectic_tableau(::McAte4, ::Type{T}, ::Type{T2}) where {T,T2} = McAte4ConstantCache(T, T2)
-_symplectic_tableau(::CalvoSanz4, ::Type{T}, ::Type{T2}) where {T,T2} = CalvoSanz4ConstantCache(T, T2)
-_symplectic_tableau(::McAte42, ::Type{T}, ::Type{T2}) where {T,T2} = McAte42ConstantCache(T, T2)
-_symplectic_tableau(::McAte5, ::Type{T}, ::Type{T2}) where {T,T2}= McAte5ConstantCache(T, T2)
-_symplectic_tableau(::Yoshida6, ::Type{T}, ::Type{T2}) where {T,T2} = Yoshida6ConstantCache(T, T2)
-_symplectic_tableau(::KahanLi6, ::Type{T}, ::Type{T2}) where {T,T2} = KahanLi6ConstantCache(T, T2)
-_symplectic_tableau(::McAte8, ::Type{T}, ::Type{T2}) where {T,T2} = McAte8ConstantCache(T, T2)
-_symplectic_tableau(::KahanLi8, ::Type{T}, ::Type{T2}) where {T,T2} = KahanLi8ConstantCache(T, T2)
-_symplectic_tableau(::SofSpa10, ::Type{T}, ::Type{T2}) where {T,T2} = SofSpa10ConstantCache(T, T2)
+_symplectic_tableau(::McAte2, ::Type{T}, ::Type{T2}) where {T, T2} = McAte2ConstantCache(T, T2)
+_symplectic_tableau(::Ruth3, ::Type{T}, ::Type{T2}) where {T, T2} = Ruth3ConstantCache(T, T2)
+_symplectic_tableau(::McAte3, ::Type{T}, ::Type{T2}) where {T, T2} = McAte3ConstantCache(T, T2)
+_symplectic_tableau(::CandyRoz4, ::Type{T}, ::Type{T2}) where {T, T2} = CandyRoz4ConstantCache(T, T2)
+_symplectic_tableau(::McAte4, ::Type{T}, ::Type{T2}) where {T, T2} = McAte4ConstantCache(T, T2)
+_symplectic_tableau(::CalvoSanz4, ::Type{T}, ::Type{T2}) where {T, T2} = CalvoSanz4ConstantCache(T, T2)
+_symplectic_tableau(::McAte42, ::Type{T}, ::Type{T2}) where {T, T2} = McAte42ConstantCache(T, T2)
+_symplectic_tableau(::McAte5, ::Type{T}, ::Type{T2}) where {T, T2} = McAte5ConstantCache(T, T2)
+_symplectic_tableau(::Yoshida6, ::Type{T}, ::Type{T2}) where {T, T2} = Yoshida6ConstantCache(T, T2)
+_symplectic_tableau(::KahanLi6, ::Type{T}, ::Type{T2}) where {T, T2} = KahanLi6ConstantCache(T, T2)
+_symplectic_tableau(::McAte8, ::Type{T}, ::Type{T2}) where {T, T2} = McAte8ConstantCache(T, T2)
+_symplectic_tableau(::KahanLi8, ::Type{T}, ::Type{T2}) where {T, T2} = KahanLi8ConstantCache(T, T2)
+_symplectic_tableau(::SofSpa10, ::Type{T}, ::Type{T2}) where {T, T2} = SofSpa10ConstantCache(T, T2)
 
 const SymplecticGenericAlgorithm = Union{
     PseudoVerletLeapfrog, McAte2, Ruth3, McAte3, CandyRoz4, McAte4,
-    CalvoSanz4, McAte42, McAte5, Yoshida6, KahanLi6, McAte8, KahanLi8, SofSpa10
+    CalvoSanz4, McAte42, McAte5, Yoshida6, KahanLi6, McAte8, KahanLi8, SofSpa10,
 }
 
 function alg_cache(
@@ -179,7 +179,8 @@ function alg_cache(
     k = zero(rate_prototype)
     fsalfirst = zero(rate_prototype)
     tab = _symplectic_tableau(
-        alg, constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
+        alg, constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits)
+    )
     return SymplecticGenericCache(u, uprev, k, tmp, fsalfirst, tab)
 end
 
@@ -190,7 +191,8 @@ function alg_cache(
         ::Val{false}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
     return _symplectic_tableau(
-        alg, constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
+        alg, constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits)
+    )
 end
 
 function get_fsalfirstlast(

--- a/lib/OrdinaryDiffEqSymplecticRK/src/symplectic_tableaus.jl
+++ b/lib/OrdinaryDiffEqSymplecticRK/src/symplectic_tableaus.jl
@@ -345,10 +345,14 @@ function KahanLi8ConstantCache(T::Type{<:CompiledFloats}, T2::Type{<:CompiledFlo
     b17 = b2
     b18 = b1
     return SymplecticTableau(
-        (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
-            a14, a15, a16, a17, a18),
-        (b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13,
-            b14, b15, b16, b17, b18)
+        (
+            a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+            a14, a15, a16, a17, a18,
+        ),
+        (
+            b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13,
+            b14, b15, b16, b17, b18,
+        )
     )
 end
 
@@ -390,10 +394,14 @@ function KahanLi8ConstantCache(T::Type, T2::Type)
     b17 = b2
     b18 = b1
     return SymplecticTableau(
-        (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
-            a14, a15, a16, a17, a18),
-        (b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13,
-            b14, b15, b16, b17, b18)
+        (
+            a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+            a14, a15, a16, a17, a18,
+        ),
+        (
+            b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13,
+            b14, b15, b16, b17, b18,
+        )
     )
 end
 
@@ -471,14 +479,18 @@ function SofSpa10ConstantCache(T::Type{<:CompiledFloats}, T2::Type{<:CompiledFlo
     b35 = b2
     b36 = b1
     return SymplecticTableau(
-        (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+        (
+            a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
             a14, a15, a16, a17, a18,
             a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30,
-            a31, a32, a33, a34, a35, a36),
-        (b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13,
+            a31, a32, a33, a34, a35, a36,
+        ),
+        (
+            b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13,
             b14, b15, b16, b17, b18,
             b19, b20, b21, b22, b23, b24, b25, b26, b27, b28, b29, b30,
-            b31, b32, b33, b34, b35, b36)
+            b31, b32, b33, b34, b35, b36,
+        )
     )
 end
 
@@ -556,13 +568,17 @@ function SofSpa10ConstantCache(T::Type, T2::Type)
     b35 = b2
     b36 = b1
     return SymplecticTableau(
-        (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+        (
+            a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
             a14, a15, a16, a17, a18,
             a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30,
-            a31, a32, a33, a34, a35, a36),
-        (b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13,
+            a31, a32, a33, a34, a35, a36,
+        ),
+        (
+            b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13,
             b14, b15, b16, b17, b18,
             b19, b20, b21, b22, b23, b24, b25, b26, b27, b28, b29, b30,
-            b31, b32, b33, b34, b35, b36)
+            b31, b32, b33, b34, b35, b36,
+        )
     )
 end


### PR DESCRIPTION
## Summary

Re-runs Runic on the 5 files currently flagged by the \`runic\` format-check job, so that open PRs (including #3480) are no longer blocked by inherited formatting drift.

Flagged files:
- \`lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl\`
- \`lib/OrdinaryDiffEqFIRK/src/algorithms.jl\`
- \`lib/OrdinaryDiffEqStabilizedRK/src/rkc_perform_step.jl\`
- \`lib/OrdinaryDiffEqSymplecticRK/src/symplectic_caches.jl\`
- \`lib/OrdinaryDiffEqSymplecticRK/src/symplectic_tableaus.jl\`

The drift was introduced primarily by #3473 (SymplecticRK refactor).

No semantic changes — purely whitespace / line-break formatting produced by \`Runic.format_file(f, f; inplace = true)\` with Runic v1.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>