### PR TITLE
Add v7 breaking changes documentation (BREAKING_CHANGES_v7.md)

### DIFF
--- a/BREAKING_CHANGES_v7.md
+++ b/BREAKING_CHANGES_v7.md
@@ -1,0 +1,274 @@
+# OrdinaryDiffEq.jl v7 Breaking Changes
+
+This release bumps to **SciMLBase v3**, **RecursiveArrayTools v4**, and includes breaking changes across **DiffEqBase**, **OrdinaryDiffEqCore**, and all solver sublibraries.
+
+---
+
+## RecursiveArrayTools v4
+
+### ODESolution is now an AbstractArray
+
+`AbstractVectorOfArray` (the parent type of `ODESolution`, `RODESolution`, `DAESolution`, etc.) now subtypes `AbstractArray`. This changes the semantics of several common operations:
+
+| Operation | v3 (old) | v4 (new) | Migration |
+|---|---|---|---|
+| `sol[i]` | Returns i-th timestep (`Vector`) | Returns i-th scalar element (column-major) | Use `sol.u[i]` or `sol[:, i]` |
+| `length(sol)` | Number of timesteps | `prod(size(sol))` (total elements) | Use `length(sol.t)` or `length(sol.u)` |
+| `eachindex(sol)` | `1:nsteps` | `CartesianIndices(size(sol))` | Use `eachindex(sol.u)` |
+| `iterate(sol)` | Iterates over timesteps | Iterates over scalar elements | Use `for u in sol.u` |
+| `first(sol)` / `last(sol)` | First/last timestep | First/last scalar element | Use `first(sol.u)` / `last(sol.u)` |
+| `map(f, sol)` | Maps over timesteps | Maps over elements | Use `map(f, sol.u)` |
+| `maximum(sol)` | Maximum over timesteps | Maximum over all elements | Use `maximum(f, sol.u)` |
+
+### Other RAT v4 changes
+
+- `zero(VectorOfArray)` now preserves container type (e.g. `StructVector`) via `rewrap`
+- Ragged arrays: `size(sol)` reports maximum dimensions; out-of-bounds elements return `zero(T)`
+- Removed: custom `length`, `eachindex`, `iterate`, `first`, `last`, `eltype`, `ndims`, `axes`, `any`, `all`, `sum`, `prod`, `mapreduce`, `map` overrides (all inherited from `AbstractArray`)
+- Removed: `convert(::Type{AbstractArray}, ...)` (identity since it IS an AbstractArray)
+- Removed: `==(::AbstractVectorOfArray, ::AbstractArray)` override
+
+---
+
+## SciMLBase v3
+
+### Renamed APIs
+
+| Old (v2) | New (v3) |
+|---|---|
+| `u_modified!(integrator, bool)` | `derivative_discontinuity!(integrator, bool)` |
+| `integrator.u_modified` | `integrator.derivative_discontinuity` |
+| `DEAlgorithm` | `AbstractDEAlgorithm` |
+| `DEProblem` | `AbstractSciMLProblem` |
+| `DESolution` | `AbstractSciMLSolution` |
+| `sol.destats` | `sol.stats` |
+
+### Removed deprecations
+
+- `has_destats` function
+- `symbol_to_ReturnCode` and Symbol-to-ReturnCode conversion
+- `syms`/`paramsyms`/`indepsym` kwargs from all `SciMLFunction` constructors
+- `sol.x` on `AbstractOptimizationSolution` (use `sol.u`)
+- `prob.lb`/`prob.ub` on `IntegralProblem` (use `prob.domain`)
+- `sol.minimizer`/`sol.minimum`
+- `tuples()`, `intervals()` iterator functions
+- `IntegratorTuples`, `IntegratorIntervals`, `TimeChoiceIterator` types
+- `QuadratureProblem` alias
+- `EnsembleProblem` vector-of-problems constructor
+- `IntegralProblem` `nout`/`batch` kwargs
+- `SciMLBaseMLStyleExt` extension (MLStyle dependency removed)
+
+### Changed defaults
+
+- `ODEFunction{iip}(f)` now uses `AutoSpecialize` by default (was `FullSpecialize`)
+- `is_discrete_time_domain(nothing)` now returns `false` (was `true`)
+
+### Ensemble RNG redesign
+
+- `prob_func(prob, i, repeat)` → `prob_func(prob, ctx)` where `ctx::EnsembleContext`
+- `output_func(sol, i)` → `output_func(sol, ctx)`
+- New `seed`/`rng`/`rng_func` kwargs on `solve()` for deterministic, thread-count-independent ensemble solves
+
+### Removed Zygote integer-indexing adjoints for ODESolution
+
+Integer-indexing Zygote adjoints removed; Zygote's generic `AbstractArray` rules handle this under RAT v4.
+
+---
+
+## OrdinaryDiffEq v7
+
+### Package scope reduction
+
+`using OrdinaryDiffEq` now loads only the default solver set:
+
+- **Included**: `DefaultODEAlgorithm`, `Tsit5`, `AutoTsit5`, `Vern6`–`Vern9`, `AutoVern6`–`AutoVern9`, `Rosenbrock23`, `Rodas5P`, `FBDF`
+- **Not included**: All other solvers require explicit import of their sublibrary
+
+```julia
+# v6
+using OrdinaryDiffEq
+solve(prob, KenCarp4())  # worked
+
+# v7
+using OrdinaryDiffEqSDIRK  # explicit import required
+solve(prob, KenCarp4())
+```
+
+### Algorithm struct type parameters removed
+
+All `{CS, AD, FDT, ST, CJ}` type parameters removed from algorithm abstract and concrete types. Over 100 structs affected across BDF, SDIRK, Rosenbrock, FIRK, Extrapolation, ExponentialRK, IMEXMultistep, PDIRK, Newmark, StabilizedIRK, and StochasticDiffEqImplicit.
+
+```julia
+# v6
+ImplicitEuler{0, AutoForwardDiff{nothing, Nothing}, Nothing, NLNewton{...}, typeof(DEFAULT_PRECS), Val{:forward}(), true, nothing, typeof(trivial_limiter!)}
+
+# v7
+ImplicitEuler{AutoForwardDiff{nothing, Nothing}, Nothing, NLNewton{...}, typeof(trivial_limiter!), Nothing}
+```
+
+Any code dispatching on `SomeAlg{CS, AD, FDT, ST, CJ}` will break.
+
+### Removed keyword arguments from algorithm constructors
+
+Across all implicit/Rosenbrock/BDF/SDIRK/FIRK/Exponential constructors:
+
+| Removed kwarg | Migration |
+|---|---|
+| `chunk_size` | Set via `autodiff = AutoForwardDiff(chunksize=N)` |
+| `diff_type` | Set via `autodiff = AutoFiniteDiff(fdtype=Val(:central))` |
+| `standardtag` | Always true; removed |
+| `precs` | Preconditioners now configured via `linsolve` kwarg |
+| `controller` (on individual algs) | Set at `solve()` level via `controller` kwarg |
+
+### autodiff: Bool no longer accepted
+
+```julia
+# v6
+Rosenbrock23(autodiff=true)   # worked
+Rosenbrock23(autodiff=false)  # worked
+
+# v7 — must use ADTypes
+Rosenbrock23(autodiff=AutoForwardDiff())
+Rosenbrock23(autodiff=AutoFiniteDiff())
+```
+
+### verbose: Bool no longer accepted
+
+```julia
+# v6
+solve(prob, alg, verbose=false)
+
+# v7 — must use ODEVerbosity
+solve(prob, alg, verbose=ODEVerbosity(SciMLLogging.None()))
+```
+
+### alias: Bool no longer accepted
+
+```julia
+# v6
+solve(prob, alg, alias=true)
+
+# v7 — must use ODEAliasSpecifier
+solve(prob, alg, alias=ODEAliasSpecifier(alias_u0=true))
+```
+
+Deprecated `alias_u0`/`alias_du0` keyword shortcuts also removed.
+
+### Default DAE initialization changed to CheckInit
+
+```julia
+# v6 — inconsistent initial conditions silently fixed
+solve(prob, Rodas5P())
+
+# v7 — errors on inconsistent initial conditions
+solve(prob, Rodas5P())  # throws if u0 is inconsistent
+
+# v7 — explicit opt-in to automatic fixing
+solve(prob, Rodas5P(), initializealg=BrownFullBasicInit())
+```
+
+### Controller refactor
+
+PID controller parameters removed from `solve()`/`init()`:
+
+| Removed kwarg | Migration |
+|---|---|
+| `gamma` | Pass `controller = PIController(...)` or `PIDController(...)` |
+| `beta1`, `beta2` | Part of controller object |
+| `qmin`, `qmax` | Part of controller object |
+| `qsteady_min`, `qsteady_max` | Part of controller object |
+| `qoldinit` | Part of controller object |
+
+**EEst moved from integrator to controller cache:**
+
+```julia
+# v6
+integrator.EEst
+
+# v7
+OrdinaryDiffEqCore.get_EEst(integrator)
+OrdinaryDiffEqCore.set_EEst!(integrator, val)
+```
+
+Fields `EEst`, `qold`, `q11`, `erracc`, `dtacc` removed from `ODEIntegrator` struct.
+
+### lazy keyword: Bool no longer accepted
+
+`BS5`, `Vern6`–`Vern9`: `lazy` must be `Val{true}()` or `Val{false}()`, not `true`/`false`.
+
+### williamson_condition default changed
+
+All 2N low-storage RK methods: default changed from `williamson_condition=true` to `williamson_condition=false`. This optimization only works for `Array` types and is now opt-in.
+
+### Threading interface changed
+
+| Old (v6) | New (v7) |
+|---|---|
+| `OrdinaryDiffEq.False()` / `Static.False()` | `Serial()` (from FastBroadcast) |
+| `OrdinaryDiffEq.True()` / `Static.True()` | `Threaded()` (from FastBroadcast) |
+
+All `calculate_residuals!` thread argument types changed from `Union{False, True}` to `Union{Serial, Threaded}`.
+
+---
+
+## Removed dependencies
+
+| Package | Replacement |
+|---|---|
+| **Static.jl** | `FastBroadcast.Serial` / `FastBroadcast.Threaded` |
+| **StaticArrayInterface.jl** | `ArrayInterface.ismutable` |
+| **Polyester.jl** (direct dep) | Moved to weak dep `OrdinaryDiffEqCorePolyesterExt`; requires `using Polyester` to activate |
+| **StaticArrays.jl** (direct dep) | `SVector`/`MVector` in tableaus replaced with `NTuple`/`Vector`; SA moved to test-only |
+
+---
+
+## DiffEqBase changes
+
+DiffEqBase is now a sublibrary under `lib/DiffEqBase` (migrated from standalone package). Key changes:
+
+- `has_destats` re-export removed (function removed from SciMLBase v3)
+- `RECOMPILE_BY_DEFAULT` re-export removed (unused)
+- `fastpow` deprecation removed (use `FastPower.fastpower`)
+- `DEStats` deprecation removed (use `SciMLBase.DEStats`)
+- `concrete_solve` deprecation removed
+- `FunctionWrappersWrapper` wrapping updated for new LinearSolve precs interface
+
+---
+
+## OrdinaryDiffEqCore changes
+
+- `DEOptions` struct: removed `gamma`, `qmax`, `qmin`, `qsteady_max`, `qsteady_min`, `qoldinit`, `controller` fields and the `Controller` type parameter
+- `ODEIntegrator` struct: removed `EEst`, `qold`, `q11`, `erracc`, `dtacc`, `q` fields and `EEstT`, `QT` type parameters; added `controller_cache` field
+- `u_modified` field → `derivative_discontinuity`
+- `DEFAULT_PRECS` removed
+- `ispredictive`/`isstandard` controller traits removed — algorithms now override `default_controller` directly
+- `has_chunksize` removed (dead code)
+- Backwards-compat positional constructors removed from LowStorageRK (44 constructors) and Tsit5
+
+---
+
+## Tableau changes
+
+Tableau functions in `OrdinaryDiffEqExplicitTableaus` / `OrdinaryDiffEqImplicitTableaus` dropped the `construct` prefix:
+
+```julia
+# v6
+constructDormandPrince()
+
+# v7
+OrdinaryDiffEqExplicitTableaus.DormandPrince()
+```
+
+~80+ functions renamed. Functions are no longer exported.
+
+---
+
+## StochasticDiffEq / DelayDiffEq
+
+- Same `verbose`, `alias`, `autodiff` changes as ODE solvers
+- `alias_u0`/`alias_jumps`/`alias_noise` deprecated kwargs removed
+- `beta1`/`beta2` PID parameter deprecation warnings removed
+- `initial_order` deprecated kwarg removed from DelayDiffEq
+- SDDE (StochasticDDE) code paths removed from DelayDiffEq
+- `ispredictive`/`isstandard` trait definitions removed; direct `default_controller` overrides used
+- `@static if isdefined` version guards removed (always true on v7)

--- a/BREAKING_CHANGES_v7.md
+++ b/BREAKING_CHANGES_v7.md
@@ -269,6 +269,5 @@ OrdinaryDiffEqExplicitTableaus.DormandPrince()
 - `alias_u0`/`alias_jumps`/`alias_noise` deprecated kwargs removed
 - `beta1`/`beta2` PID parameter deprecation warnings removed
 - `initial_order` deprecated kwarg removed from DelayDiffEq
-- SDDE (StochasticDDE) code paths removed from DelayDiffEq
 - `ispredictive`/`isstandard` trait definitions removed; direct `default_controller` overrides used
 - `@static if isdefined` version guards removed (always true on v7)

--- a/BREAKING_CHANGES_v7.md
+++ b/BREAKING_CHANGES_v7.md
@@ -313,7 +313,7 @@ DiffEqBase is now a sublibrary under `lib/DiffEqBase` (migrated from standalone 
 - `concrete_solve` deprecation removed — use `solve` directly
 - `FunctionWrappersWrapper` wrapping updated for new LinearSolve precs interface
 
-**Why migrate DiffEqBase into the monorepo:** it's tightly coupled to OrdinaryDiffEq's internals and was never consumed independently of it; keeping them in lockstep releases eliminates a compatibility-bound class of bugs.
+**Why migrate DiffEqBase into the monorepo:** it's tightly coupled to OrdinaryDiffEq's internals and most features were only available through OrdinaryDiffEq; keeping them in lockstep releases eliminates a compatibility-bound class of bugs.
 
 ---
 

--- a/BREAKING_CHANGES_v7.md
+++ b/BREAKING_CHANGES_v7.md
@@ -2,6 +2,37 @@
 
 This release bumps to **SciMLBase v3**, **RecursiveArrayTools v4**, and includes breaking changes across **DiffEqBase**, **OrdinaryDiffEqCore**, and all solver sublibraries.
 
+## Themes of the v7 release
+
+Most of the breaking changes fall into a small set of recurring themes. Keep these in mind while reading the migration table — they explain why an individual change exists and often suggest the right migration direction:
+
+- **Time to first solve (TTFS) reduction.** Direct deps on `Static.jl`, `StaticArrayInterface.jl`, `Polyester.jl`, and `StaticArrays.jl` were dropped; `using OrdinaryDiffEq` now loads only the default solver set; `ODEFunction` switched to `AutoSpecialize`. All of this means less code loaded and more precompilation caching on first `solve`.
+- **Type stability everywhere.** All `Bool` solver/`solve` keyword arguments (`autodiff`, `verbose`, `alias`, `lazy`, …) were replaced by typed objects. Passing a `Bool` no longer changes dispatch in ways the compiler cannot specialize on, and the reverse is no longer allowed to silently fall back through slow generic paths.
+- **Generality beyond ForwardDiff.** `chunk_size`, `diff_type`, `standardtag`, etc. encoded ForwardDiff-specific or FiniteDiff-specific knobs on every solver. They are replaced by the `ADTypes` interface (`AutoForwardDiff`, `AutoFiniteDiff`, `AutoEnzyme`, `AutoZygote`, …) so every solver automatically generalizes to any AD backend.
+- **Controller is now an object, not a pile of `solve` kwargs.** `gamma`, `beta1`, `beta2`, `qmin`, `qmax`, `qsteady_min`, `qsteady_max`, `qoldinit` were moved onto concrete `PIController` / `PIDController` / `IController` / `PredictiveController` structs, and `EEst` moved to the controller cache. This is prep work for pluggable controllers and removes a large amount of dead state from the integrator struct.
+- **Cleanup of old re-exports / deprecations.** Functions like `has_destats` (now `has_stats`), `sol.destats` (now `sol.stats`), `DEAlgorithm`/`DEProblem`/`DESolution` abstract types, `tuples()`/`intervals()`, `QuadratureProblem`, `fastpow`, `concrete_solve`, etc. were on a deprecation path for one or more minor releases. v7 removes them.
+
+## Recommended upgrade path
+
+The cleanest path is **not** to jump straight from an old environment onto v7. Most renamed APIs (e.g. `DEAlgorithm` → `AbstractDEAlgorithm`, `u_modified!` → `derivative_discontinuity!`, `has_destats` → `has_stats`, `sol.destats` → `sol.stats`, the `construct*` tableau functions, `alias_u0`/`alias_du0`, `beta1`/`beta2`, PID kwargs) already exist under their new names in **SciMLBase v2** / **OrdinaryDiffEq v6** with deprecation warnings. The recommended sequence is:
+
+1. **Stay on SciMLBase v2 / OrdinaryDiffEq v6.** Update your code to the new names (`has_stats`, `sol.stats`, `AbstractDEAlgorithm`, `derivative_discontinuity!`, `ODEAliasSpecifier`, `ODEVerbosity`, `ADTypes`-based `autodiff`, explicit `controller = …` objects, new tableau names) while the deprecation shims still exist.
+2. **Verify your tests pass on v6 with no deprecation warnings.**
+3. **Then bump to v7.** At this point your code should compile and run against v7 without further changes aside from the genuinely new breakage (RAT v4 array semantics, ensemble `prob_func`/`output_func` signature, struct type parameter removals, kwargs that truly no longer exist, default changes like `CheckInit` and `williamson_condition=false`).
+
+Doing it in two steps keeps the diff small per step and lets the deprecation warnings on v6 point you at the exact call sites that will break on v7.
+
+## Fallback for RAT v4 indexing
+
+If you cannot update `sol[i]` / `length(sol)` / `eachindex(sol)` call sites yet (see the RAT v4 table below), you can opt back into v3 semantics on a per-solution basis by converting the container type to the ragged variant:
+
+```julia
+using RecursiveArrayToolsRaggedArrays
+sol_old = RaggedVectorOfArray(sol)   # indexes like v3: sol_old[i] is the i-th timestep
+```
+
+`RecursiveArrayToolsRaggedArrays.jl` preserves the previous `AbstractVectorOfArray` indexing behavior (timestep-first, not element-first). This is the escape hatch for code that assumes `sol[i]` returns the i-th timestep. It is, however, recommended that you update to the `sol.u[i]` / `sol[:, i]` style — the ragged wrapper is a compatibility layer, not the canonical API going forward.
+
 ---
 
 ## RecursiveArrayTools v4
@@ -20,6 +51,12 @@ This release bumps to **SciMLBase v3**, **RecursiveArrayTools v4**, and includes
 | `map(f, sol)` | Maps over timesteps | Maps over elements | Use `map(f, sol.u)` |
 | `maximum(sol)` | Maximum over timesteps | Maximum over all elements | Use `maximum(f, sol.u)` |
 
+**Why:** making `AbstractVectorOfArray <: AbstractArray` lets every generic `AbstractArray` consumer (LinearAlgebra, broadcasting, Zygote adjoints, `StructArrays`, etc.) work on solutions without any special casing in SciMLBase, and deletes a large pile of manual method overrides.
+
+**Migration shortcut:** `sol.u[i]` is the forward-compatible form under both v3 and v4 — if you change every `sol[i]` → `sol.u[i]` in your code base now, it works on both versions.
+
+**Full fallback:** see the "Fallback for RAT v4 indexing" section above — wrapping with `RaggedVectorOfArray` from `RecursiveArrayToolsRaggedArrays.jl` restores v3 indexing.
+
 ### Other RAT v4 changes
 
 - `zero(VectorOfArray)` now preserves container type (e.g. `StructVector`) via `rewrap`
@@ -34,44 +71,63 @@ This release bumps to **SciMLBase v3**, **RecursiveArrayTools v4**, and includes
 
 ### Renamed APIs
 
-| Old (v2) | New (v3) |
-|---|---|
-| `u_modified!(integrator, bool)` | `derivative_discontinuity!(integrator, bool)` |
-| `integrator.u_modified` | `integrator.derivative_discontinuity` |
-| `DEAlgorithm` | `AbstractDEAlgorithm` |
-| `DEProblem` | `AbstractSciMLProblem` |
-| `DESolution` | `AbstractSciMLSolution` |
-| `sol.destats` | `sol.stats` |
+The new names already exist under SciMLBase v2 with deprecation warnings. Update to the v3 names while still on v2 before bumping.
+
+| Old (v2, removed in v3) | New (v2 + v3) | Migration |
+|---|---|---|
+| `u_modified!(integrator, bool)` | `derivative_discontinuity!(integrator, bool)` | Search-and-replace. `u_modified!` was misleading — the callback system doesn't care whether `u` changed, it cares whether the derivative is discontinuous. |
+| `integrator.u_modified` | `integrator.derivative_discontinuity` | Field access rename. |
+| `DEAlgorithm` | `AbstractDEAlgorithm` | Abstract type name aligned with SciML-wide `Abstract…` convention. |
+| `DEProblem` | `AbstractSciMLProblem` | Same. |
+| `DESolution` | `AbstractSciMLSolution` | Same. |
+| `sol.destats` | `sol.stats` | Drop the `de` prefix. |
+| `has_destats(alg)` | `has_stats(alg)` | Same renaming applied to the trait function. |
 
 ### Removed deprecations
 
-- `has_destats` function
-- `symbol_to_ReturnCode` and Symbol-to-ReturnCode conversion
-- `syms`/`paramsyms`/`indepsym` kwargs from all `SciMLFunction` constructors
-- `sol.x` on `AbstractOptimizationSolution` (use `sol.u`)
-- `prob.lb`/`prob.ub` on `IntegralProblem` (use `prob.domain`)
-- `sol.minimizer`/`sol.minimum`
-- `tuples()`, `intervals()` iterator functions
+All of these printed a deprecation warning under SciMLBase v2. They are gone in v3:
+
+- `has_destats` function → use `has_stats`
+- `symbol_to_ReturnCode` and Symbol-to-ReturnCode conversion → construct `ReturnCode.*` directly
+- `syms`/`paramsyms`/`indepsym` kwargs on all `SciMLFunction` constructors → use the problem's `sys` / MTK symbolic interface
+- `sol.x` on `AbstractOptimizationSolution` → use `sol.u`
+- `prob.lb`/`prob.ub` on `IntegralProblem` → use `prob.domain`
+- `sol.minimizer`/`sol.minimum` → use `sol.u` / `sol.objective`
+- `tuples()`, `intervals()` iterator functions → iterate over `sol.u` / `sol.t` directly
 - `IntegratorTuples`, `IntegratorIntervals`, `TimeChoiceIterator` types
-- `QuadratureProblem` alias
-- `EnsembleProblem` vector-of-problems constructor
-- `IntegralProblem` `nout`/`batch` kwargs
-- `SciMLBaseMLStyleExt` extension (MLStyle dependency removed)
+- `QuadratureProblem` alias → use `IntegralProblem`
+- `EnsembleProblem` vector-of-problems constructor → use a `prob_func`
+- `IntegralProblem` `nout`/`batch` kwargs → set on the integrand function directly
+- `SciMLBaseMLStyleExt` extension (`MLStyle` dependency removed)
 
 ### Changed defaults
 
-- `ODEFunction{iip}(f)` now uses `AutoSpecialize` by default (was `FullSpecialize`)
-- `is_discrete_time_domain(nothing)` now returns `false` (was `true`)
+- `ODEFunction{iip}(f)` now uses `AutoSpecialize` by default (was `FullSpecialize`).
+  **Why:** drastically more precompilation caching now "works" out of the box — `AutoSpecialize` stores a lightly-specialized method that can be reused across different right-hand side function types instead of baking a fresh specialization per-user. Combined with the default-solver-set reduction (below), this is the single biggest TTFS improvement in v7.
+  **Migration:** if you *want* the old behavior (e.g. you are benchmarking and need maximum inlining of `f`), write `ODEFunction{iip, FullSpecialize}(f)` explicitly.
+- `is_discrete_time_domain(nothing)` now returns `false` (was `true`). Affects only code that called this trait with `nothing` — replace with an explicit domain.
 
 ### Ensemble RNG redesign
 
 - `prob_func(prob, i, repeat)` → `prob_func(prob, ctx)` where `ctx::EnsembleContext`
 - `output_func(sol, i)` → `output_func(sol, ctx)`
-- New `seed`/`rng`/`rng_func` kwargs on `solve()` for deterministic, thread-count-independent ensemble solves
+- New `seed` / `rng` / `rng_func` kwargs on `solve()` for deterministic, thread-count-independent ensemble solves
+
+**Why:** the old `(i, repeat)` signature had no way to plumb a reproducible per-trajectory RNG through, so ensemble results depended on thread count and scheduling. `EnsembleContext` carries an RNG derived from a single top-level seed, so results are reproducible regardless of how many workers run in parallel.
+
+**Migration:**
+```julia
+# v6
+prob_func = (prob, i, repeat) -> remake(prob, u0 = rand(length(prob.u0)))
+
+# v7
+prob_func = (prob, ctx) -> remake(prob, u0 = rand(ctx.rng, length(prob.u0)))
+```
+Within the new signature, `ctx.i` is the trajectory index and `ctx.repeat` is the retry counter if you need them. Pass `solve(ensemble_prob, alg; seed=42, trajectories=N)` for a reproducible run.
 
 ### Removed Zygote integer-indexing adjoints for ODESolution
 
-Integer-indexing Zygote adjoints removed; Zygote's generic `AbstractArray` rules handle this under RAT v4.
+Integer-indexing Zygote adjoints removed; Zygote's generic `AbstractArray` rules handle this under RAT v4. **Migration:** nothing to do if you were using `sol[i]` for AD — the generic path produces the same gradient. Code that explicitly called the `ChainRulesCore`/`Zygote` rule by name should delete those references.
 
 ---
 
@@ -82,7 +138,7 @@ Integer-indexing Zygote adjoints removed; Zygote's generic `AbstractArray` rules
 `using OrdinaryDiffEq` now loads only the default solver set:
 
 - **Included**: `DefaultODEAlgorithm`, `Tsit5`, `AutoTsit5`, `Vern6`–`Vern9`, `AutoVern6`–`AutoVern9`, `Rosenbrock23`, `Rodas5P`, `FBDF`
-- **Not included**: All other solvers require explicit import of their sublibrary
+- **Not included**: all other solvers require explicit import of their sublibrary
 
 ```julia
 # v6
@@ -93,6 +149,10 @@ solve(prob, KenCarp4())  # worked
 using OrdinaryDiffEqSDIRK  # explicit import required
 solve(prob, KenCarp4())
 ```
+
+**Why:** TTFS. The old umbrella package loaded every solver family (exponential integrators, symplectic RK, stabilized methods, multirate, Taylor series, …) whether you used them or not. The solver you actually care about, plus its precompilation cache, is now a small fraction of what gets loaded.
+
+**Migration:** add `using OrdinaryDiffEq<Family>` for any non-default solver you use. The sublibrary name is predictable — `KenCarp*`/`TRBDF2` → `OrdinaryDiffEqSDIRK`, `Rosenbrock*`/`Rodas*` except `Rosenbrock23`/`Rodas5P` → `OrdinaryDiffEqRosenbrock`, `RadauIIA*` → `OrdinaryDiffEqFIRK`, etc. Every family has its own `lib/OrdinaryDiffEq<X>` directory in the repo.
 
 ### Algorithm struct type parameters removed
 
@@ -106,7 +166,9 @@ ImplicitEuler{0, AutoForwardDiff{nothing, Nothing}, Nothing, NLNewton{...}, type
 ImplicitEuler{AutoForwardDiff{nothing, Nothing}, Nothing, NLNewton{...}, typeof(trivial_limiter!), Nothing}
 ```
 
-Any code dispatching on `SomeAlg{CS, AD, FDT, ST, CJ}` will break.
+**Why:** the removed parameters (`CS` = chunk size, `FDT` = finite diff type, `ST` = standard tag, `CJ` = concrete Jacobian) are all now carried by the `ADTypes` object on the `autodiff` field, not baked into the algorithm's type. This shrinks the method table, improves compile time, and means a single `autodiff = AutoForwardDiff(chunksize=12)` now communicates what used to take five type parameters.
+
+**Migration:** any code dispatching on `SomeAlg{CS, AD, FDT, ST, CJ}` will break. Most call sites want either `SomeAlg` (no parameters at all) or dispatch on the autodiff type via `alg.autodiff`. If you genuinely need to specialize on chunksize, inspect the `ADTypes` object at runtime.
 
 ### Removed keyword arguments from algorithm constructors
 
@@ -116,9 +178,11 @@ Across all implicit/Rosenbrock/BDF/SDIRK/FIRK/Exponential constructors:
 |---|---|
 | `chunk_size` | Set via `autodiff = AutoForwardDiff(chunksize=N)` |
 | `diff_type` | Set via `autodiff = AutoFiniteDiff(fdtype=Val(:central))` |
-| `standardtag` | Always true; removed |
-| `precs` | Preconditioners now configured via `linsolve` kwarg |
-| `controller` (on individual algs) | Set at `solve()` level via `controller` kwarg |
+| `standardtag` | Always true; remove the kwarg |
+| `precs` | Preconditioners now configured via `linsolve` kwarg (see LinearSolve.jl docs on the `Pl`/`Pr` interface) |
+| `controller` (on individual algs) | Set at `solve()` level via `controller = PIController(...)` etc. |
+
+**Why:** `chunk_size` and `diff_type` only meant anything to ForwardDiff and FiniteDiff respectively. Hoisting them onto the `ADTypes` object means every solver now works with **any** AD backend (Enzyme, Zygote, ReverseDiff, Mooncake, …) by just swapping `autodiff=AutoEnzyme()` — no per-solver kwarg surface needed. `standardtag` was always the right default. `precs` moved under `linsolve` because LinearSolve now owns the preconditioner abstraction.
 
 ### autodiff: Bool no longer accepted
 
@@ -132,6 +196,8 @@ Rosenbrock23(autodiff=AutoForwardDiff())
 Rosenbrock23(autodiff=AutoFiniteDiff())
 ```
 
+**Why:** type stability. `autodiff::Bool` forced a runtime branch between AD backends that the compiler couldn't specialize through; `autodiff::AbstractADType` dispatches at compile time. This is also what enables the "generalizes beyond ForwardDiff" story — you can now pass `AutoEnzyme()`, `AutoZygote()`, `AutoMooncake()`, etc., and the solver specializes correctly.
+
 ### verbose: Bool no longer accepted
 
 ```julia
@@ -141,6 +207,8 @@ solve(prob, alg, verbose=false)
 # v7 — must use ODEVerbosity
 solve(prob, alg, verbose=ODEVerbosity(SciMLLogging.None()))
 ```
+
+**Why:** same type-stability reason, plus `ODEVerbosity` exposes fine-grained control (separate levels for nonlinear solver, linear solver, initialization, etc.) that a single `Bool` can't express.
 
 ### alias: Bool no longer accepted
 
@@ -152,7 +220,9 @@ solve(prob, alg, alias=true)
 solve(prob, alg, alias=ODEAliasSpecifier(alias_u0=true))
 ```
 
-Deprecated `alias_u0`/`alias_du0` keyword shortcuts also removed.
+Deprecated `alias_u0` / `alias_du0` keyword shortcuts also removed — they already printed warnings on v6. Update to `alias = ODEAliasSpecifier(alias_u0=…, alias_du0=…)` on v6 first, then upgrade.
+
+**Why:** type stability + finer control. `alias=true` used to mean "alias everything that can be aliased," which was ambiguous when some things could be safely aliased and others couldn't. `ODEAliasSpecifier` makes each aliasable buffer an explicit opt-in.
 
 ### Default DAE initialization changed to CheckInit
 
@@ -167,17 +237,19 @@ solve(prob, Rodas5P())  # throws if u0 is inconsistent
 solve(prob, Rodas5P(), initializealg=BrownFullBasicInit())
 ```
 
+**Why:** silently fixing an inconsistent DAE initial condition produced wrong answers when the user's `u0` was actually correct but a modeling bug elsewhere made the system look inconsistent. The new default errors loudly; users who want the old "just fix it" behavior opt in explicitly via `initializealg=BrownFullBasicInit()`.
+
 ### Controller refactor
 
 PID controller parameters removed from `solve()`/`init()`:
 
 | Removed kwarg | Migration |
 |---|---|
-| `gamma` | Pass `controller = PIController(...)` or `PIDController(...)` |
-| `beta1`, `beta2` | Part of controller object |
-| `qmin`, `qmax` | Part of controller object |
-| `qsteady_min`, `qsteady_max` | Part of controller object |
-| `qoldinit` | Part of controller object |
+| `gamma` | Pass `controller = PIController(gamma=…)` or `PIDController(...)` |
+| `beta1`, `beta2` | Constructor args on `PIController` / `PIDController` |
+| `qmin`, `qmax` | Same — on the controller object |
+| `qsteady_min`, `qsteady_max` | Same |
+| `qoldinit` | Same |
 
 **EEst moved from integrator to controller cache:**
 
@@ -192,13 +264,17 @@ OrdinaryDiffEqCore.set_EEst!(integrator, val)
 
 Fields `EEst`, `qold`, `q11`, `erracc`, `dtacc` removed from `ODEIntegrator` struct.
 
+**Why:** controllers are now real, pluggable objects rather than a collection of loose numeric knobs on `solve`. This makes it possible to write a custom controller and just pass `controller = MyController(…)` without adding yet more kwargs to `solve`, and keeps controller state (including `EEst`) inside the controller where it belongs instead of on the integrator.
+
+**Migration:** if you only ever set `gamma`, just write `controller = PIController(gamma=0.9)` (or whatever value). The default controller per algorithm is unchanged; the kwargs are what moved.
+
 ### lazy keyword: Bool no longer accepted
 
-`BS5`, `Vern6`–`Vern9`: `lazy` must be `Val{true}()` or `Val{false}()`, not `true`/`false`.
+`BS5`, `Vern6`–`Vern9`: `lazy` must be `Val{true}()` or `Val{false}()`, not `true`/`false`. **Why:** type stability — same story as `autodiff` / `verbose` / `alias`.
 
 ### williamson_condition default changed
 
-All 2N low-storage RK methods: default changed from `williamson_condition=true` to `williamson_condition=false`. This optimization only works for `Array` types and is now opt-in.
+All 2N low-storage RK methods: default changed from `williamson_condition=true` to `williamson_condition=false`. **Why:** this optimization only works for mutable `Array`-style state. Having it on by default silently made the method wrong (or errored) for `StaticArrays`, GPU arrays, `ComponentArrays`, etc. Off-by-default is the safe choice; opt in with `williamson_condition=true` when you know your state is a plain `Array`.
 
 ### Threading interface changed
 
@@ -209,16 +285,20 @@ All 2N low-storage RK methods: default changed from `williamson_condition=true` 
 
 All `calculate_residuals!` thread argument types changed from `Union{False, True}` to `Union{Serial, Threaded}`.
 
+**Why:** this change is what makes the `Static.jl` dependency removal possible, and `Static.jl` removal is one of the largest single contributions to v7's TTFS reduction. The `Serial`/`Threaded` types from `FastBroadcast` are semantically identical for this purpose and FastBroadcast is already a transitive dep. **Migration:** if your code pattern-matched on `Static.True`/`Static.False` for threading dispatch, swap to `FastBroadcast.Threaded`/`FastBroadcast.Serial`.
+
 ---
 
 ## Removed dependencies
 
-| Package | Replacement |
-|---|---|
-| **Static.jl** | `FastBroadcast.Serial` / `FastBroadcast.Threaded` |
-| **StaticArrayInterface.jl** | `ArrayInterface.ismutable` |
-| **Polyester.jl** (direct dep) | Moved to weak dep `OrdinaryDiffEqCorePolyesterExt`; requires `using Polyester` to activate |
-| **StaticArrays.jl** (direct dep) | `SVector`/`MVector` in tableaus replaced with `NTuple`/`Vector`; SA moved to test-only |
+All four removals are driven by TTFS.
+
+| Package | Replacement | Why |
+|---|---|---|
+| **Static.jl** | `FastBroadcast.Serial` / `FastBroadcast.Threaded` | Removing Static slashes load time and eliminates a wide surface of `StaticInt`/`StaticBool` specialization that the compiler was re-running for every user |
+| **StaticArrayInterface.jl** | `ArrayInterface.ismutable` | The only thing OrdinaryDiffEq actually used from StaticArrayInterface was the mutability query, which ArrayInterface already provides |
+| **Polyester.jl** (direct dep) | Moved to weak dep `OrdinaryDiffEqCorePolyesterExt`; requires `using Polyester` to activate | Polyester loads a nontrivial amount of threading infrastructure. Users who don't enable Polyester-threaded solvers no longer pay for it |
+| **StaticArrays.jl** (direct dep) | `SVector`/`MVector` in tableaus replaced with `NTuple`/`Vector`; SA moved to test-only | Loading StaticArrays forces compilation of a large generated-function surface for every solver that mentions an `SVector`. Tableaus used them for constants, which `NTuple` expresses just as statically |
 
 ---
 
@@ -226,24 +306,26 @@ All `calculate_residuals!` thread argument types changed from `Union{False, True
 
 DiffEqBase is now a sublibrary under `lib/DiffEqBase` (migrated from standalone package). Key changes:
 
-- `has_destats` re-export removed (function removed from SciMLBase v3)
+- `has_destats` re-export removed (function removed from SciMLBase v3 — use `has_stats`)
 - `RECOMPILE_BY_DEFAULT` re-export removed (unused)
-- `fastpow` deprecation removed (use `FastPower.fastpower`)
-- `DEStats` deprecation removed (use `SciMLBase.DEStats`)
-- `concrete_solve` deprecation removed
+- `fastpow` deprecation removed — use `FastPower.fastpower`
+- `DEStats` deprecation removed — use `SciMLBase.DEStats`
+- `concrete_solve` deprecation removed — use `solve` directly
 - `FunctionWrappersWrapper` wrapping updated for new LinearSolve precs interface
+
+**Why migrate DiffEqBase into the monorepo:** it's tightly coupled to OrdinaryDiffEq's internals and was never consumed independently of it; keeping them in lockstep releases eliminates a compatibility-bound class of bugs.
 
 ---
 
 ## OrdinaryDiffEqCore changes
 
-- `DEOptions` struct: removed `gamma`, `qmax`, `qmin`, `qsteady_max`, `qsteady_min`, `qoldinit`, `controller` fields and the `Controller` type parameter
-- `ODEIntegrator` struct: removed `EEst`, `qold`, `q11`, `erracc`, `dtacc`, `q` fields and `EEstT`, `QT` type parameters; added `controller_cache` field
+- `DEOptions` struct: removed `gamma`, `qmax`, `qmin`, `qsteady_max`, `qsteady_min`, `qoldinit`, `controller` fields and the `Controller` type parameter (moved to controller object; see Controller refactor above)
+- `ODEIntegrator` struct: removed `EEst`, `qold`, `q11`, `erracc`, `dtacc`, `q` fields and `EEstT`, `QT` type parameters; added `controller_cache` field. **Migration:** `integrator.EEst` → `OrdinaryDiffEqCore.get_EEst(integrator)`; the rest live on `integrator.controller_cache`
 - `u_modified` field → `derivative_discontinuity`
-- `DEFAULT_PRECS` removed
-- `ispredictive`/`isstandard` controller traits removed — algorithms now override `default_controller` directly
-- `has_chunksize` removed (dead code)
-- Backwards-compat positional constructors removed from LowStorageRK (44 constructors) and Tsit5
+- `DEFAULT_PRECS` removed (preconditioners now configured via `linsolve`)
+- `ispredictive` / `isstandard` controller traits removed — algorithms now override `default_controller` directly. **Migration:** if you defined a custom algorithm that set `isstandard(::MyAlg) = true`, instead define `default_controller(::MyAlg, args...) = IController(…)`
+- `has_chunksize` removed (dead code — chunksize is on the ADTypes object now)
+- Backwards-compat positional constructors removed from LowStorageRK (44 constructors) and Tsit5 — use keyword form
 
 ---
 
@@ -259,15 +341,17 @@ constructDormandPrince()
 OrdinaryDiffEqExplicitTableaus.DormandPrince()
 ```
 
-~80+ functions renamed. Functions are no longer exported.
+~80+ functions renamed. Functions are no longer exported — qualify explicitly with the sublibrary name. The new names also exist on v6 as deprecations, so you can rename first and bump later.
 
 ---
 
 ## StochasticDiffEq / DelayDiffEq
 
-- Same `verbose`, `alias`, `autodiff` changes as ODE solvers
-- `alias_u0`/`alias_jumps`/`alias_noise` deprecated kwargs removed
-- `beta1`/`beta2` PID parameter deprecation warnings removed
+Same theme as the ODE side — all of the following break identically to the ODE versions, with identical migrations:
+
+- Same `verbose`, `alias`, `autodiff` Bool-to-typed-object changes as ODE solvers
+- `alias_u0` / `alias_jumps` / `alias_noise` deprecated kwargs removed → use `ODEAliasSpecifier` (for SDE: `SDEAliasSpecifier`)
+- `beta1` / `beta2` PID parameter deprecation warnings removed → set on the controller object
 - `initial_order` deprecated kwarg removed from DelayDiffEq
-- `ispredictive`/`isstandard` trait definitions removed; direct `default_controller` overrides used
+- `ispredictive` / `isstandard` trait definitions removed; algorithms now override `default_controller` directly
 - `@static if isdefined` version guards removed (always true on v7)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ import Pkg;
 Pkg.add("OrdinaryDiffEq");
 ```
 
+## v7 Breaking Changes
+
+OrdinaryDiffEq v7 bumps to **SciMLBase v3** and **RecursiveArrayTools v4** with breaking changes across all sublibraries. See [BREAKING_CHANGES_v7.md](BREAKING_CHANGES_v7.md) for the full migration guide.
+
 ## API
 
 OrdinaryDiffEq.jl is part of the SciML common interface, but can be used independently of DifferentialEquations.jl. The only requirement is that the user passes an OrdinaryDiffEq.jl algorithm to `solve`. For example, we can solve the [ODE tutorial from the docs](https://docs.sciml.ai/DiffEqDocs/stable/getting_started/#ode_example) using the `Tsit5()` algorithm:
@@ -117,7 +121,3 @@ Other refined forms are IMEX and semi-linear ODEs (for exponential integrators).
 ## Available Solvers
 
 For the list of available solvers, please refer to the [DifferentialEquations.jl ODE Solvers](https://docs.sciml.ai/DiffEqDocs/stable/solvers/ode_solve/), [Dynamical ODE Solvers](https://docs.sciml.ai/DiffEqDocs/stable/solvers/dynamical_solve/), and the [Split ODE Solvers](https://docs.sciml.ai/DiffEqDocs/stable/solvers/split_ode_solve/) pages.
-
-## v7 Breaking Changes
-
-OrdinaryDiffEq v7 bumps to **SciMLBase v3** and **RecursiveArrayTools v4** with breaking changes across all sublibraries. See [BREAKING_CHANGES_v7.md](BREAKING_CHANGES_v7.md) for the full migration guide.

--- a/README.md
+++ b/README.md
@@ -117,3 +117,7 @@ Other refined forms are IMEX and semi-linear ODEs (for exponential integrators).
 ## Available Solvers
 
 For the list of available solvers, please refer to the [DifferentialEquations.jl ODE Solvers](https://docs.sciml.ai/DiffEqDocs/stable/solvers/ode_solve/), [Dynamical ODE Solvers](https://docs.sciml.ai/DiffEqDocs/stable/solvers/dynamical_solve/), and the [Split ODE Solvers](https://docs.sciml.ai/DiffEqDocs/stable/solvers/split_ode_solve/) pages.
+
+## v7 Breaking Changes
+
+OrdinaryDiffEq v7 bumps to **SciMLBase v3** and **RecursiveArrayTools v4** with breaking changes across all sublibraries. See [BREAKING_CHANGES_v7.md](BREAKING_CHANGES_v7.md) for the full migration guide.


### PR DESCRIPTION
Adds `BREAKING_CHANGES_v7.md` with the full v7 migration guide and links it from the README.

## What this document now covers

### High-level themes
Each breaking change is tied back to one of the recurring themes of the v7 release, so readers understand *why* each item exists:

- **Time to first solve (TTFS) reduction** — `using OrdinaryDiffEq` now loads only the default solver set; `ODEFunction` defaults to `AutoSpecialize` (much more precompilation caching); direct deps on `Static.jl`, `StaticArrayInterface.jl`, `Polyester.jl`, and `StaticArrays.jl` dropped.
- **Type stability everywhere** — `Bool` keyword args (`autodiff`, `verbose`, `alias`, `lazy`) replaced by typed objects (`AutoForwardDiff`, `ODEVerbosity`, `ODEAliasSpecifier`, `Val{true/false}()`).
- **Generality beyond ForwardDiff** — `chunk_size`, `diff_type`, `standardtag` all moved onto the `ADTypes` object, so every solver generalizes to any AD backend (Enzyme, Zygote, Mooncake, …) with no per-solver kwarg surface.
- **Controller is an object now** — `gamma`, `beta1`/`beta2`, `qmin`/`qmax`, `qsteady_*`, `qoldinit` all moved onto `PIController`/`PIDController`/`IController`; `EEst` moved to controller cache.
- **Threading interface changed** — `Static.True`/`Static.False` → `FastBroadcast.Threaded`/`FastBroadcast.Serial`. This is what makes Static.jl removal possible.

### Recommended upgrade path
Most renamed APIs already exist under SciMLBase v2 / OrdinaryDiffEq v6 with deprecation warnings (`has_destats` → `has_stats`, `DEAlgorithm` → `AbstractDEAlgorithm`, `u_modified!` → `derivative_discontinuity!`, `sol.destats` → `sol.stats`, `construct*` tableaus, `alias_u0`/`alias_du0`, `beta1`/`beta2`, PID kwargs, etc.). The recommended sequence is to **update names while still on v2/v6 using the deprecation shims, verify no warnings, then bump to v7** — so the v7 bump only has to deal with the truly-new breakage.

### Fallback for RAT v4 indexing
Users who can't immediately migrate `sol[i]` / `length(sol)` / `eachindex(sol)` call sites can use `RecursiveArrayToolsRaggedArrays.RaggedVectorOfArray(sol)` as an explicit escape hatch — it preserves the previous (v3) timestep-first indexing behavior. Updating to `sol.u[i]` remains the recommended path.

### Migration paths on every change
Every removed kwarg, renamed API, and changed default has both a **Why:** rationale (so readers can evaluate edge cases) and an explicit migration snippet (so they know exactly what to change).

## Full breakdown
- **RecursiveArrayTools v4**: `ODESolution <: AbstractArray` — `length(sol)`, `sol[i]`, `eachindex(sol)` semantics changed; ragged-array fallback documented
- **SciMLBase v3**: `u_modified!` → `derivative_discontinuity!`, `has_destats` → `has_stats`, `sol.destats` → `sol.stats`, `DEAlgorithm`/`DEProblem`/`DESolution` → `Abstract…`, removed deprecations, ensemble `prob_func`/`output_func` ctx redesign (reproducible across thread counts), `AutoSpecialize` default
- **Algorithm structs**: `{CS, AD, FDT, ST, CJ}` type parameters removed from 100+ structs (info now on the `ADTypes` object)
- **Removed kwargs**: `chunk_size`, `diff_type`, `standardtag`, `precs`, per-algorithm `controller`, PID params
- **Bool kwargs banned** (for type stability): `autodiff`, `verbose`, `alias`, `lazy` must use typed alternatives
- **Default changes**: `CheckInit` for DAE init (was silent fix), `williamson_condition=false` (was `true`), `AutoSpecialize` for `ODEFunction` (was `FullSpecialize`)
- **Controller refactor**: `EEst` moved to controller cache; PID params moved to controller objects
- **Removed deps**: Static.jl, StaticArrayInterface.jl, Polyester.jl (→ weak dep), StaticArrays.jl (direct)
- **DiffEqBase**: migrated as sublibrary, removed deprecations
- **OrdinaryDiffEqCore**: struct field removals, trait removals, dead code cleanup
- **Tableau renames**: `constructDormandPrince` → `DormandPrince` (~80 functions)
- **SDE/DDE**: parallel changes to ODE

🤖 Generated with [Claude Code](https://claude.com/claude-code)
