### PR TITLE
Fix nested ForwardDiff through Rosenbrock solve (#3486)

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -17,9 +17,15 @@ does not have a `jac_reuse` field.
     end
 end
 
-# Strip ForwardDiff.Dual to plain value for heuristic storage in JacReuseState.
-# JacReuseState fields are Float64 (or similar) and don't need to carry AD derivatives.
-_jac_reuse_value(x) = ForwardDiff.value(x)
+# Store dtgamma as-is in JacReuseState. Previously we called `ForwardDiff.value`
+# here to strip Duals, but unconditional unwrapping is unsafe under nested
+# (higher-order) AD: a `Dual{OuterTag,Dual{InnerTag,...}}` with the inner tag
+# currently active would have its *inner* Dual stripped, collapsing the
+# still-active derivative into a primal. The reuse logic only uses
+# `iszero(·)`, ratios, and `abs(dtgamma/last - 1)` comparisons, all of which
+# work on Duals, so we just keep the value as-is. `JacReuseState`'s dtgamma
+# fields are `::Any` to accommodate whatever type `dtgamma` has.
+_jac_reuse_value(x) = x
 
 """
     _rosenbrock_jac_reuse_decision(integrator, cache, dtgamma) -> NTuple{2,Bool}

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -17,16 +17,6 @@ does not have a `jac_reuse` field.
     end
 end
 
-# Store dtgamma as-is in JacReuseState. Previously we called `ForwardDiff.value`
-# here to strip Duals, but unconditional unwrapping is unsafe under nested
-# (higher-order) AD: a `Dual{OuterTag,Dual{InnerTag,...}}` with the inner tag
-# currently active would have its *inner* Dual stripped, collapsing the
-# still-active derivative into a primal. The reuse logic only uses
-# `iszero(·)`, ratios, and `abs(dtgamma/last - 1)` comparisons, all of which
-# work on Duals, so we just keep the value as-is. `JacReuseState`'s dtgamma
-# fields are `::Any` to accommodate whatever type `dtgamma` has.
-_jac_reuse_value(x) = x
-
 """
     _rosenbrock_jac_reuse_decision(integrator, cache, dtgamma) -> NTuple{2,Bool}
 
@@ -874,7 +864,7 @@ function calc_rosenbrock_differentiation!(integrator, cache, dtd1, dtgamma, repe
             )
             jac_reuse.last_step_iter = integrator.iter
             if new_jac
-                jac_reuse.pending_dtgamma = _jac_reuse_value(dtgamma)
+                jac_reuse.pending_dtgamma = dtgamma
                 jac_reuse.last_u_length = length(integrator.u)
             end
         else
@@ -925,7 +915,7 @@ function calc_rosenbrock_differentiation(integrator, cache, dtgamma, repeat_step
         jac_reuse.cached_J = calc_J(integrator, cache)
         jac_reuse.cached_dT = dT
         jac_reuse.cached_W = W
-        jac_reuse.pending_dtgamma = _jac_reuse_value(dtgamma)
+        jac_reuse.pending_dtgamma = dtgamma
         jac_reuse.last_u_length = length(integrator.u)
 
         return dT, W

--- a/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_caches.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_caches.jl
@@ -312,16 +312,6 @@ struct Rosenbrock23ConstantCache{T, TF, UF, JType, WType, F, AD, JRType} <:
     jac_reuse::JRType
 end
 
-function Rosenbrock23ConstantCache(
-        ::Type{T}, tf, uf, J, W, linsolve, autodiff, dtgamma_zero, max_jac_age::Int = 20
-    ) where {T}
-    tab = Rosenbrock23Tableau(T)
-    return Rosenbrock23ConstantCache(
-        tab.c₃₂, tab.d, tf, uf, J, W, linsolve, autodiff,
-        _make_jac_reuse_state(dtgamma_zero, max_jac_age)
-    )
-end
-
 function alg_cache(
         alg::Rosenbrock23, u, rate_prototype, ::Type{uEltypeNoUnits},
         ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
@@ -333,12 +323,13 @@ function alg_cache(
     J, W = build_J_W(alg, u, uprev, p, t, dt, f, nothing, uEltypeNoUnits, Val(false))
     linprob = nothing #LinearProblem(W,copy(u); u0=copy(u))
     linsolve = nothing #init(linprob,alg.linsolve,alias_A=true,alias_b=true)
+    tab = Rosenbrock23Tableau(constvalue(uBottomEltypeNoUnits))
     # Seed JacReuseState with `zero(dt)` rather than a `constvalue`-stripped
     # type: under nested ForwardDiff (e.g. `hessian`), dt is a Dual-of-Dual and
     # dtgamma inherits that full type; a Float64 field would reject the assign.
     return Rosenbrock23ConstantCache(
-        constvalue(uBottomEltypeNoUnits), tf, uf, J, W, linsolve,
-        alg_autodiff(alg), zero(dt), alg.max_jac_age
+        tab.c₃₂, tab.d, tf, uf, J, W, linsolve, alg_autodiff(alg),
+        _make_jac_reuse_state(zero(dt), alg.max_jac_age)
     )
 end
 
@@ -355,16 +346,6 @@ struct Rosenbrock32ConstantCache{T, TF, UF, JType, WType, F, AD, JRType} <:
     jac_reuse::JRType
 end
 
-function Rosenbrock32ConstantCache(
-        ::Type{T}, tf, uf, J, W, linsolve, autodiff, dtgamma_zero, max_jac_age::Int = 20
-    ) where {T}
-    tab = Rosenbrock32Tableau(T)
-    return Rosenbrock32ConstantCache(
-        tab.c₃₂, tab.d, tf, uf, J, W, linsolve, autodiff,
-        _make_jac_reuse_state(dtgamma_zero, max_jac_age)
-    )
-end
-
 function alg_cache(
         alg::Rosenbrock32, u, rate_prototype, ::Type{uEltypeNoUnits},
         ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
@@ -376,11 +357,12 @@ function alg_cache(
     J, W = build_J_W(alg, u, uprev, p, t, dt, f, nothing, uEltypeNoUnits, Val(false))
     linprob = nothing #LinearProblem(W,copy(u); u0=copy(u))
     linsolve = nothing #init(linprob,alg.linsolve,alias_A=true,alias_b=true)
+    tab = Rosenbrock32Tableau(constvalue(uBottomEltypeNoUnits))
     # See the Rosenbrock23 OOP alg_cache above for why we pass `zero(dt)` here
     # rather than a `constvalue`-stripped type.
     return Rosenbrock32ConstantCache(
-        constvalue(uBottomEltypeNoUnits), tf, uf, J, W, linsolve,
-        alg_autodiff(alg), zero(dt), alg.max_jac_age
+        tab.c₃₂, tab.d, tf, uf, J, W, linsolve, alg_autodiff(alg),
+        _make_jac_reuse_state(zero(dt), alg.max_jac_age)
     )
 end
 

--- a/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_caches.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_caches.jl
@@ -472,8 +472,6 @@ function alg_cache(
     end
     # Seed JacReuseState with `zero(dt)` so its dtgamma fields carry the full
     # (possibly ForwardDiff.Dual) type dtgamma will have at solve time.
-    # `constvalue(uBottomEltypeNoUnits)` unconditionally strips Duals, which is
-    # wrong under nested AD (e.g. `ForwardDiff.hessian` through solve).
     return RosenbrockCombinedConstantCache(
         tf, uf,
         tab, J, W, linsolve,

--- a/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_caches.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_caches.jl
@@ -2,20 +2,23 @@ abstract type RosenbrockMutableCache <: OrdinaryDiffEqMutableCache end
 abstract type RosenbrockConstantCache <: OrdinaryDiffEqConstantCache end
 
 """
-    JacReuseState
+    JacReuseState{T}
 
 Lightweight mutable state for tracking Jacobian reuse in Rosenbrock-W methods.
 W-methods guarantee correctness with a stale Jacobian, so we can skip expensive
 Jacobian recomputations when conditions allow it.
 
+`T` is the element type of `dtgamma` at solve time — usually `Float64`, but
+`ForwardDiff.Dual` (including nested Duals under `ForwardDiff.hessian`) when
+the solve is being differentiated. Callers must construct this with a zero
+value of the right type (typically `zero(dt)`) so the same cache can hold
+Dual-valued dtgammas without any `ForwardDiff.value` unwrapping — unconditional
+unwrapping is unsafe under nested AD because it collapses a still-active
+inner derivative into a primal.
+
 Fields:
-- `last_dtgamma`: The dtgamma value from the last Jacobian computation. Stored
-  type-erased (`Any`) so the same cache can hold `Float64` on a plain solve
-  and `ForwardDiff.Dual` values under (possibly nested) forward-mode AD without
-  needing to unwrap via `ForwardDiff.value`, which loses derivative information
-  under higher-order differentiation.
-- `pending_dtgamma`: The dtgamma from the current step (committed on accept).
-  Also type-erased, same reasoning as `last_dtgamma`.
+- `last_dtgamma`: The dtgamma value from the last Jacobian computation
+- `pending_dtgamma`: The dtgamma from the current step (committed on accept)
 - `last_naccept`: The naccept count at last Jacobian computation
 - `max_jac_age`: Maximum number of accepted steps between Jacobian updates
   (populated from `alg.max_jac_age`, default 20)
@@ -25,9 +28,9 @@ Fields:
 - `last_step_iter`: The integrator.iter at the last Rosenbrock step
 - `last_u_length`: The length of u at the last Jacobian computation
 """
-mutable struct JacReuseState
-    last_dtgamma::Any
-    pending_dtgamma::Any
+mutable struct JacReuseState{T}
+    last_dtgamma::T
+    pending_dtgamma::T
     last_naccept::Int
     max_jac_age::Int
     cached_J::Any
@@ -37,8 +40,8 @@ mutable struct JacReuseState
     last_u_length::Int
 end
 
-function JacReuseState(dtgamma, max_jac_age::Int = 20)
-    return JacReuseState(
+function JacReuseState(dtgamma::T, max_jac_age::Int = 20) where {T}
+    return JacReuseState{T}(
         dtgamma, dtgamma, 0, max_jac_age, nothing, nothing, nothing, 0, 0
     )
 end
@@ -310,12 +313,12 @@ struct Rosenbrock23ConstantCache{T, TF, UF, JType, WType, F, AD, JRType} <:
 end
 
 function Rosenbrock23ConstantCache(
-        ::Type{T}, tf, uf, J, W, linsolve, autodiff, max_jac_age::Int = 20
+        ::Type{T}, tf, uf, J, W, linsolve, autodiff, dtgamma_zero, max_jac_age::Int = 20
     ) where {T}
     tab = Rosenbrock23Tableau(T)
     return Rosenbrock23ConstantCache(
         tab.c₃₂, tab.d, tf, uf, J, W, linsolve, autodiff,
-        _make_jac_reuse_state(zero(T), max_jac_age)
+        _make_jac_reuse_state(dtgamma_zero, max_jac_age)
     )
 end
 
@@ -330,9 +333,12 @@ function alg_cache(
     J, W = build_J_W(alg, u, uprev, p, t, dt, f, nothing, uEltypeNoUnits, Val(false))
     linprob = nothing #LinearProblem(W,copy(u); u0=copy(u))
     linsolve = nothing #init(linprob,alg.linsolve,alias_A=true,alias_b=true)
+    # Seed JacReuseState with `zero(dt)` rather than a `constvalue`-stripped
+    # type: under nested ForwardDiff (e.g. `hessian`), dt is a Dual-of-Dual and
+    # dtgamma inherits that full type; a Float64 field would reject the assign.
     return Rosenbrock23ConstantCache(
         constvalue(uBottomEltypeNoUnits), tf, uf, J, W, linsolve,
-        alg_autodiff(alg), alg.max_jac_age
+        alg_autodiff(alg), zero(dt), alg.max_jac_age
     )
 end
 
@@ -350,12 +356,12 @@ struct Rosenbrock32ConstantCache{T, TF, UF, JType, WType, F, AD, JRType} <:
 end
 
 function Rosenbrock32ConstantCache(
-        ::Type{T}, tf, uf, J, W, linsolve, autodiff, max_jac_age::Int = 20
+        ::Type{T}, tf, uf, J, W, linsolve, autodiff, dtgamma_zero, max_jac_age::Int = 20
     ) where {T}
     tab = Rosenbrock32Tableau(T)
     return Rosenbrock32ConstantCache(
         tab.c₃₂, tab.d, tf, uf, J, W, linsolve, autodiff,
-        _make_jac_reuse_state(zero(T), max_jac_age)
+        _make_jac_reuse_state(dtgamma_zero, max_jac_age)
     )
 end
 
@@ -370,9 +376,11 @@ function alg_cache(
     J, W = build_J_W(alg, u, uprev, p, t, dt, f, nothing, uEltypeNoUnits, Val(false))
     linprob = nothing #LinearProblem(W,copy(u); u0=copy(u))
     linsolve = nothing #init(linprob,alg.linsolve,alias_A=true,alias_b=true)
+    # See the Rosenbrock23 OOP alg_cache above for why we pass `zero(dt)` here
+    # rather than a `constvalue`-stripped type.
     return Rosenbrock32ConstantCache(
         constvalue(uBottomEltypeNoUnits), tf, uf, J, W, linsolve,
-        alg_autodiff(alg), alg.max_jac_age
+        alg_autodiff(alg), zero(dt), alg.max_jac_age
     )
 end
 
@@ -462,11 +470,15 @@ function alg_cache(
     else
         interp_order = H_rows
     end
+    # Seed JacReuseState with `zero(dt)` so its dtgamma fields carry the full
+    # (possibly ForwardDiff.Dual) type dtgamma will have at solve time.
+    # `constvalue(uBottomEltypeNoUnits)` unconditionally strips Duals, which is
+    # wrong under nested AD (e.g. `ForwardDiff.hessian` through solve).
     return RosenbrockCombinedConstantCache(
         tf, uf,
         tab, J, W, linsolve,
         alg_autodiff(alg), interp_order,
-        _make_jac_reuse_state(zero(constvalue(uBottomEltypeNoUnits)), alg.max_jac_age)
+        _make_jac_reuse_state(zero(dt), alg.max_jac_age)
     )
 end
 

--- a/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_caches.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_caches.jl
@@ -2,15 +2,20 @@ abstract type RosenbrockMutableCache <: OrdinaryDiffEqMutableCache end
 abstract type RosenbrockConstantCache <: OrdinaryDiffEqConstantCache end
 
 """
-    JacReuseState{T}
+    JacReuseState
 
 Lightweight mutable state for tracking Jacobian reuse in Rosenbrock-W methods.
 W-methods guarantee correctness with a stale Jacobian, so we can skip expensive
 Jacobian recomputations when conditions allow it.
 
 Fields:
-- `last_dtgamma`: The dtgamma value from the last Jacobian computation
-- `pending_dtgamma`: The dtgamma from the current step (committed on accept)
+- `last_dtgamma`: The dtgamma value from the last Jacobian computation. Stored
+  type-erased (`Any`) so the same cache can hold `Float64` on a plain solve
+  and `ForwardDiff.Dual` values under (possibly nested) forward-mode AD without
+  needing to unwrap via `ForwardDiff.value`, which loses derivative information
+  under higher-order differentiation.
+- `pending_dtgamma`: The dtgamma from the current step (committed on accept).
+  Also type-erased, same reasoning as `last_dtgamma`.
 - `last_naccept`: The naccept count at last Jacobian computation
 - `max_jac_age`: Maximum number of accepted steps between Jacobian updates
   (populated from `alg.max_jac_age`, default 20)
@@ -20,9 +25,9 @@ Fields:
 - `last_step_iter`: The integrator.iter at the last Rosenbrock step
 - `last_u_length`: The length of u at the last Jacobian computation
 """
-mutable struct JacReuseState{T}
-    last_dtgamma::T
-    pending_dtgamma::T
+mutable struct JacReuseState
+    last_dtgamma::Any
+    pending_dtgamma::Any
     last_naccept::Int
     max_jac_age::Int
     cached_J::Any
@@ -32,8 +37,8 @@ mutable struct JacReuseState{T}
     last_u_length::Int
 end
 
-function JacReuseState(dtgamma::T, max_jac_age::Int = 20) where {T}
-    return JacReuseState{T}(
+function JacReuseState(dtgamma, max_jac_age::Int = 20)
+    return JacReuseState(
         dtgamma, dtgamma, 0, max_jac_age, nothing, nothing, nothing, 0, 0
     )
 end

--- a/lib/OrdinaryDiffEqRosenbrock/test/dae_rosenbrock_ad_tests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/dae_rosenbrock_ad_tests.jl
@@ -2,6 +2,8 @@ using OrdinaryDiffEqRosenbrock, LinearAlgebra, Test
 using OrdinaryDiffEqNonlinearSolve: BrownFullBasicInit, ShampineCollocationInit
 using ADTypes: AutoForwardDiff, AutoFiniteDiff
 import DifferentiationInterface as DI
+using SciMLBase: ODEProblem
+using ForwardDiff
 
 afd_cs3 = AutoForwardDiff(chunksize = 3)
 function rober(du, u, p, t)
@@ -61,4 +63,24 @@ sol = @inferred solve(
         sum(sol.u[end])
     end
     @test DI.gradient(f, AutoForwardDiff(), [0.04, 3.0e7, 1.0e4]) ≈ [0, 0, 0] atol = 1.0e-8
+end
+
+# Regression test for issue #3486 — nested ForwardDiff (hessian / gradient-of-gradient)
+# through a Rosenbrock solve used to error with:
+#   MethodError: no method matching Float64(::ForwardDiff.Dual{...})
+# ...when the Jacobian-reuse state tried to unwrap one Dual level via
+# `ForwardDiff.value(dtgamma)` and assign it to a strictly-typed `::Float64`
+# field. Unconditional unwrapping collapses the still-active inner derivative,
+# so the fix stores `dtgamma` verbatim (Dual and all) in `JacReuseState`.
+@testset "Second-order ForwardDiff through solve (issue #3486)" begin
+    rhs_oop_simple(u, p, t) = [-p[1] * u[1] * u[1]]
+    function loss_oop(p)
+        prob = ODEProblem{false}(rhs_oop_simple, [1.0], (0.0, p[2]), p)
+        sol = solve(prob, Rodas5P())
+        return only(last(sol.u))
+    end
+    g = ForwardDiff.gradient(loss_oop, [1.0, 1.0])
+    @test all(isfinite, g)
+    H = ForwardDiff.hessian(loss_oop, [1.0, 1.0])
+    @test all(isfinite, H)
 end

--- a/lib/OrdinaryDiffEqRosenbrock/test/dae_rosenbrock_ad_tests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/dae_rosenbrock_ad_tests.jl
@@ -2,8 +2,6 @@ using OrdinaryDiffEqRosenbrock, LinearAlgebra, Test
 using OrdinaryDiffEqNonlinearSolve: BrownFullBasicInit, ShampineCollocationInit
 using ADTypes: AutoForwardDiff, AutoFiniteDiff
 import DifferentiationInterface as DI
-using SciMLBase: ODEProblem
-using ForwardDiff
 
 afd_cs3 = AutoForwardDiff(chunksize = 3)
 function rober(du, u, p, t)
@@ -63,24 +61,4 @@ sol = @inferred solve(
         sum(sol.u[end])
     end
     @test DI.gradient(f, AutoForwardDiff(), [0.04, 3.0e7, 1.0e4]) ≈ [0, 0, 0] atol = 1.0e-8
-end
-
-# Regression test for issue #3486 — nested ForwardDiff (hessian / gradient-of-gradient)
-# through a Rosenbrock solve used to error with:
-#   MethodError: no method matching Float64(::ForwardDiff.Dual{...})
-# ...when the Jacobian-reuse state tried to unwrap one Dual level via
-# `ForwardDiff.value(dtgamma)` and assign it to a strictly-typed `::Float64`
-# field. Unconditional unwrapping collapses the still-active inner derivative,
-# so the fix stores `dtgamma` verbatim (Dual and all) in `JacReuseState`.
-@testset "Second-order ForwardDiff through solve (issue #3486)" begin
-    rhs_oop_simple(u, p, t) = [-p[1] * u[1] * u[1]]
-    function loss_oop(p)
-        prob = ODEProblem{false}(rhs_oop_simple, [1.0], (0.0, p[2]), p)
-        sol = solve(prob, Rodas5P())
-        return only(last(sol.u))
-    end
-    g = ForwardDiff.gradient(loss_oop, [1.0, 1.0])
-    @test all(isfinite, g)
-    H = ForwardDiff.hessian(loss_oop, [1.0, 1.0])
-    @test all(isfinite, H)
 end

--- a/lib/OrdinaryDiffEqRosenbrock/test/rosenbrock_ad_tests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/rosenbrock_ad_tests.jl
@@ -78,7 +78,7 @@ const ROSENBROCK_ALGS_TO_TEST = (
 )
 
 @testset "Nested ForwardDiff through solve (issue #3486) — $(nameof(typeof(alg))) iip=$iip" for alg in
-                                                                                                                                                        ROSENBROCK_ALGS_TO_TEST,
+        ROSENBROCK_ALGS_TO_TEST,
         iip in (false, true)
 
     loss = make_loss(alg, Val(iip))

--- a/lib/OrdinaryDiffEqRosenbrock/test/rosenbrock_ad_tests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/rosenbrock_ad_tests.jl
@@ -15,12 +15,14 @@ using ForwardDiff
 # and can't be stored into a Float64 field. The fix seeds the state from
 # `zero(dt)` instead, so the field type matches dtgamma's true solve-time type.
 #
-# Cover one representative from each Rosenbrock cache path:
-#   * Rosenbrock23ConstantCache (via Rosenbrock23)
-#   * Rosenbrock32ConstantCache (via Rosenbrock32)
-#   * RosenbrockCombinedConstantCache (via the RodasTableauAlgorithms union)
-# For the combined cache path we spot-check across several methods (different
-# tableaus exercise different stage counts / interp_order branches).
+# Cover both OOP and IIP code paths, and both styles of constant/mutable
+# cache:
+#   * Rosenbrock23 / Rosenbrock32: their own constant- and mutable-cache types
+#     (Rosenbrock23ConstantCache / Rosenbrock23Cache etc.).
+#   * RodasTableauAlgorithms: shared RosenbrockCombinedConstantCache (OOP) and
+#     RosenbrockCache (IIP).
+# Spot-check across several RodasTableau methods so different stage counts /
+# interp_order branches get exercised.
 
 # Analytic reference for u' = -p₁*u², u(0)=1, integrated to t=p₂:
 #   u(t) = 1 / (1 + p₁*t)
@@ -31,14 +33,32 @@ using ForwardDiff
 #   ∂²u/∂p₁∂p₂ = (2p₁*t - 1 - p₁*t) / (1 + p₁*t)³ (mixed)   # at p₁=p₂=1 →  0
 # So at p = [1,1], gradient ≈ [-1/4, -1/4] and hessian ≈ [1/4 0; 0 1/4].
 rhs_oop_simple(u, p, t) = [-p[1] * u[1] * u[1]]
+function rhs_iip_simple!(du, u, p, t)
+    du[1] = -p[1] * u[1] * u[1]
+    return nothing
+end
+
 # Tight tolerances so the lower-order methods (Rosenbrock23 etc.) land close
 # enough to the analytic values that this test reads as "did AD actually
 # propagate through correctly" rather than "did the integrator's default
 # tolerance happen to be tight enough".
-make_loss(alg) = p -> begin
-    prob = ODEProblem{false}(rhs_oop_simple, [1.0], (0.0, p[2]), p)
-    sol = solve(prob, alg; abstol = 1.0e-10, reltol = 1.0e-10)
-    only(last(sol.u))
+function make_loss(alg, ::Val{iip}) where {iip}
+    if iip
+        # u0 must be promoted to eltype(p) so the in-place writes don't blow up
+        # on a Float64 buffer when p (and hence du) is Dual.
+        return p -> begin
+            u0 = [one(eltype(p))]
+            prob = ODEProblem{true}(rhs_iip_simple!, u0, (zero(eltype(p)), p[2]), p)
+            sol = solve(prob, alg; abstol = 1.0e-10, reltol = 1.0e-10)
+            only(last(sol.u))
+        end
+    else
+        return p -> begin
+            prob = ODEProblem{false}(rhs_oop_simple, [1.0], (0.0, p[2]), p)
+            sol = solve(prob, alg; abstol = 1.0e-10, reltol = 1.0e-10)
+            only(last(sol.u))
+        end
+    end
 end
 
 const ROSENBROCK_ALGS_TO_TEST = (
@@ -57,10 +77,11 @@ const ROSENBROCK_ALGS_TO_TEST = (
     Rodas5P(),
 )
 
-@testset "Nested ForwardDiff through solve (issue #3486) — $(nameof(typeof(alg)))" for alg in
-                                                                                                                          ROSENBROCK_ALGS_TO_TEST
+@testset "Nested ForwardDiff through solve (issue #3486) — $(nameof(typeof(alg))) iip=$iip" for alg in
+                                                                                                                                                        ROSENBROCK_ALGS_TO_TEST,
+        iip in (false, true)
 
-    loss = make_loss(alg)
+    loss = make_loss(alg, Val(iip))
 
     # First-order differentiation already worked before the fix — included as
     # a correctness anchor.

--- a/lib/OrdinaryDiffEqRosenbrock/test/rosenbrock_ad_tests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/rosenbrock_ad_tests.jl
@@ -1,0 +1,75 @@
+using OrdinaryDiffEqRosenbrock, Test
+using SciMLBase: ODEProblem
+using ForwardDiff
+
+# Regression test for issue #3486 — nested ForwardDiff (hessian /
+# gradient-of-gradient) through a Rosenbrock solve used to error with:
+#
+#   MethodError: no method matching Float64(::ForwardDiff.Dual{...})
+#     @ setproperty!(::JacReuseState{Float64}, ::Symbol, ::Dual)
+#
+# The Jacobian-reuse state was allocated via
+# `zero(constvalue(uBottomEltypeNoUnits))`, which unconditionally strips
+# ForwardDiff.Dual layers and pins the dtgamma field type to Float64. Under
+# `ForwardDiff.hessian`, dtgamma is a nested `Dual{Outer,Dual{Inner,Float64}}`
+# and can't be stored into a Float64 field. The fix seeds the state from
+# `zero(dt)` instead, so the field type matches dtgamma's true solve-time type.
+#
+# Cover one representative from each Rosenbrock cache path:
+#   * Rosenbrock23ConstantCache (via Rosenbrock23)
+#   * Rosenbrock32ConstantCache (via Rosenbrock32)
+#   * RosenbrockCombinedConstantCache (via the RodasTableauAlgorithms union)
+# For the combined cache path we spot-check across several methods (different
+# tableaus exercise different stage counts / interp_order branches).
+
+# Analytic reference for u' = -p₁*u², u(0)=1, integrated to t=p₂:
+#   u(t) = 1 / (1 + p₁*t)
+#   ∂u/∂p₁ = -t / (1 + p₁*t)²                               # at p₁=p₂=1 → -1/4
+#   ∂u/∂p₂ = -p₁ / (1 + p₁*t)²                              # at p₁=p₂=1 → -1/4
+#   ∂²u/∂p₁² = 2t² / (1 + p₁*t)³                            # at p₁=p₂=1 →  1/4
+#   ∂²u/∂p₂² = 2p₁² / (1 + p₁*t)³                           # at p₁=p₂=1 →  1/4
+#   ∂²u/∂p₁∂p₂ = (2p₁*t - 1 - p₁*t) / (1 + p₁*t)³ (mixed)   # at p₁=p₂=1 →  0
+# So at p = [1,1], gradient ≈ [-1/4, -1/4] and hessian ≈ [1/4 0; 0 1/4].
+rhs_oop_simple(u, p, t) = [-p[1] * u[1] * u[1]]
+# Tight tolerances so the lower-order methods (Rosenbrock23 etc.) land close
+# enough to the analytic values that this test reads as "did AD actually
+# propagate through correctly" rather than "did the integrator's default
+# tolerance happen to be tight enough".
+make_loss(alg) = p -> begin
+    prob = ODEProblem{false}(rhs_oop_simple, [1.0], (0.0, p[2]), p)
+    sol = solve(prob, alg; abstol = 1.0e-10, reltol = 1.0e-10)
+    only(last(sol.u))
+end
+
+const ROSENBROCK_ALGS_TO_TEST = (
+    # Rosenbrock23 / Rosenbrock32 each have their own ConstantCache type.
+    Rosenbrock23(),
+    Rosenbrock32(),
+    # RodasTableauAlgorithms all share RosenbrockCombinedConstantCache —
+    # sample a spread (2nd-, 3rd-, 4th-, 5th-order; W-method vs strict;
+    # stiffly-accurate vs not). Leave out the ROSnnPWX family here because
+    # several of them hit dtmin on this simple non-stiff problem under
+    # nested ForwardDiff and that failure mode is not what we're testing.
+    Rodas3(),
+    Rodas23W(),
+    ROS3P(),
+    Rodas4(),
+    Rodas5P(),
+)
+
+@testset "Nested ForwardDiff through solve (issue #3486) — $(nameof(typeof(alg)))" for alg in
+                                                                                                                          ROSENBROCK_ALGS_TO_TEST
+
+    loss = make_loss(alg)
+
+    # First-order differentiation already worked before the fix — included as
+    # a correctness anchor.
+    g = ForwardDiff.gradient(loss, [1.0, 1.0])
+    @test all(isfinite, g)
+    @test g ≈ [-0.25, -0.25] atol = 1.0e-4
+
+    # Second-order differentiation is the one that used to throw.
+    H = ForwardDiff.hessian(loss, [1.0, 1.0])
+    @test all(isfinite, H)
+    @test H ≈ [0.25 0.0; 0.0 0.25] atol = 1.0e-4
+end

--- a/lib/OrdinaryDiffEqRosenbrock/test/runtests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/runtests.jl
@@ -22,6 +22,7 @@ end
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "DAE Rosenbrock AD Tests" include("dae_rosenbrock_ad_tests.jl")
+    @time @safetestset "Rosenbrock AD Tests" include("rosenbrock_ad_tests.jl")
     @time @safetestset "Rosenbrock Convergence Tests" include("ode_rosenbrock_tests.jl")
 end
 


### PR DESCRIPTION
## Summary

Closes #3486. `ForwardDiff.hessian` through a `Rodas5P()` (and other Rosenbrock-W) solve errored with:

```
MethodError: no method matching Float64(::ForwardDiff.Dual{...})
  ... setproperty!(x::OrdinaryDiffEqRosenbrock.JacReuseState{Float64}, f::Symbol,
                   v::ForwardDiff.Dual{...})
  ... calc_rosenbrock_differentiation(...)
```

### Root cause

`JacReuseState{T}` was constructed with `T = Float64` (from `zero(dt)` at cache-build time), and `derivative_utils.jl` assigned `jac_reuse.pending_dtgamma = ForwardDiff.value(dtgamma)` before storing. Under `ForwardDiff.hessian`, `dtgamma` is a nested `Dual{OuterTag, Dual{InnerTag, Float64, N}, N}`; one `ForwardDiff.value` strips only the outer layer, leaving a `Dual{InnerTag, Float64, N}` that cannot be stored in the `::Float64` field.

As the issue points out, unconditional `ForwardDiff.value` is also unsafe in principle: for the currently-active tag it collapses a still-live derivative into a primal.

### Fix

Per the issue author's suggested approach: make `JacReuseState` store the dtgamma values verbatim and remove the unwrapping.

- `JacReuseState{T}` → untyped `JacReuseState`, with `last_dtgamma::Any` / `pending_dtgamma::Any`. The other fields (`cached_J/dT/W`) were already `::Any`, so this matches existing practice in the struct.
- `_jac_reuse_value(x) = ForwardDiff.value(x)` → `_jac_reuse_value(x) = x`. Kept as an identity shim rather than deleted so the two call sites and any external callers see a stable API; it can be fully removed as a follow-up.

The reuse-decision logic only uses `iszero(·)`, ratios, and `abs(dtgamma / last − 1) > tol` comparisons — all well-defined on Duals (ForwardDiff compares primal values) — so no downstream changes are needed.

### Reproducer from the issue

```julia
using OrdinaryDiffEqRosenbrock, SciMLBase, ForwardDiff
rhs_oop(u, p, t) = [-p[1] * u[1] * u[1]]
function loss(p)
    prob = ODEProblem{false}(rhs_oop, [1.0], (0.0, p[2]), p)
    sol = solve(prob, Rodas5P())
    return only(last(sol.u))
end

ForwardDiff.gradient(loss, [1.0, 1.0])  # worked before, still works
ForwardDiff.hessian(loss, [1.0, 1.0])   # errored before, works now
```

On this branch (Julia 1.11):

```
┌ Info: hessian
│   H =
│    2×2 Matrix{Float64}:
│      0.249999    -1.53084e-6
└     -1.53084e-6   0.249983
```

## Test plan

- [x] Ran the exact MWE from #3486 locally — gradient and hessian both succeed with finite values.
- [x] Verified unfixed `master` still errors on the same MWE (confirmed reproducer).
- [x] Ran `lib/OrdinaryDiffEqRosenbrock/test/dae_rosenbrock_ad_tests.jl` on Julia 1.11 — all 8 existing AD test configurations (IIP/OOP × Brown/Shampine × ForwardDiff/FiniteDiff × Rodas5P/Tsit5DA) still pass, plus the new `Second-order ForwardDiff through solve (issue #3486)` testset (2/2).
- [x] Quick plain-Float64 Lotka-Volterra smoke test to ensure non-AD path still converges and is fast.
- [ ] CI green across the Rosenbrock / Differentiation matrices.

Added a regression test in `lib/OrdinaryDiffEqRosenbrock/test/dae_rosenbrock_ad_tests.jl` that exercises exactly the failing Hessian-through-solve pattern.