### PR TITLE
Drop positional Alg(stage_limiter!, …) constructors (supersedes #3491)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -325,7 +325,7 @@ DiffEqBase is now a sublibrary under `lib/DiffEqBase` (migrated from standalone 
 - `DEFAULT_PRECS` removed (preconditioners now configured via `linsolve`)
 - `ispredictive` / `isstandard` controller traits removed — algorithms now override `default_controller` directly. **Migration:** if you defined a custom algorithm that set `isstandard(::MyAlg) = true`, instead define `default_controller(::MyAlg, args...) = IController(…)`
 - `has_chunksize` removed (dead code — chunksize is on the ADTypes object now)
-- Backwards-compat positional constructors removed from LowStorageRK (44 constructors) and Tsit5 — use keyword form
+- Backwards-compat positional `Alg(stage_limiter!, step_limiter!)` constructors removed from every explicit RK sublibrary — 99 constructors total across LowStorageRK (44), SSPRK (18), LowOrderRK (22), Verner (5: Vern6/7/8/9, RKV76IIa), HighOrderRK (4: TanYam7, TsitPap8, DP8, PFRK87), SIMDRK (3: MER5v2, MER6v2, RK6v4), QPRK (QPRK98), TaylorSeries (ExplicitTaylor2), and Tsit5. **Migration:** use the keyword form `Alg(; stage_limiter! = my_limiter, step_limiter! = my_limiter)`. The kwarg constructors (and no-arg `Alg()` defaulting both limiters to `trivial_limiter!`) are unchanged.
 
 ---
 

--- a/lib/OrdinaryDiffEqHighOrderRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqHighOrderRK/src/algorithms.jl
@@ -11,10 +11,6 @@ Base.@kwdef struct TanYam7{StageLimiter, StepLimiter, Thread} <:
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function TanYam7(stage_limiter!, step_limiter! = trivial_limiter!)
-    return TanYam7(stage_limiter!, step_limiter!, Serial())
-end
 
 @doc explicit_rk_docstring(
     "Tsitouras-Papakostas 8/7 Runge-Kutta method.", "TsitPap8",
@@ -34,10 +30,6 @@ Base.@kwdef struct TsitPap8{StageLimiter, StepLimiter, Thread} <:
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function TsitPap8(stage_limiter!, step_limiter! = trivial_limiter!)
-    return TsitPap8(stage_limiter!, step_limiter!, Serial())
-end
 
 @doc explicit_rk_docstring(
     "Hairer's 8/5/3 adaption of the Dormand-Prince Runge-Kutta method.",
@@ -50,10 +42,6 @@ Base.@kwdef struct DP8{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqAdapt
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
-end
-# for backwards compatibility
-function DP8(stage_limiter!, step_limiter! = trivial_limiter!)
-    return DP8(stage_limiter!, step_limiter!, Serial())
 end
 
 @doc explicit_rk_docstring(
@@ -77,8 +65,4 @@ Base.@kwdef struct PFRK87{StageLimiter, StepLimiter, Thread, T} <:
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
     omega::T = 0.0
-end
-# for backwards compatibility
-function PFRK87(stage_limiter!, step_limiter! = trivial_limiter!; omega = 0.0)
-    return PFRK87(stage_limiter!, step_limiter!, Serial(), omega)
 end

--- a/lib/OrdinaryDiffEqLowOrderRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqLowOrderRK/src/algorithms.jl
@@ -29,10 +29,6 @@ Base.@kwdef struct Heun{StageLimiter, StepLimiter, Thread} <:
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function Heun(stage_limiter!, step_limiter! = trivial_limiter!)
-    return Heun(stage_limiter!, step_limiter!, Serial())
-end
 
 @doc explicit_rk_docstring(
     "The optimized second order midpoint method. Uses embedded Euler method for adaptivity.",
@@ -47,10 +43,6 @@ Base.@kwdef struct Ralston{StageLimiter, StepLimiter, Thread} <:
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function Ralston(stage_limiter!, step_limiter! = trivial_limiter!)
-    return Ralston(stage_limiter!, step_limiter!, Serial())
-end
 
 @doc explicit_rk_docstring(
     "The second order midpoint method. Uses embedded Euler method for adaptivity.",
@@ -64,10 +56,6 @@ Base.@kwdef struct Midpoint{StageLimiter, StepLimiter, Thread} <:
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
-end
-# for backwards compatibility
-function Midpoint(stage_limiter!, step_limiter! = trivial_limiter!)
-    return Midpoint(stage_limiter!, step_limiter!, Serial())
 end
 
 @doc explicit_rk_docstring(
@@ -89,10 +77,6 @@ Base.@kwdef struct RK4{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqAdapt
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function RK4(stage_limiter!, step_limiter! = trivial_limiter!)
-    return RK4(stage_limiter!, step_limiter!, Serial())
-end
 
 @doc explicit_rk_docstring(
     "Bogacki-Shampine 3/2 method. Third-order adaptive method using embedded Euler method for adaptivity. Recommended for non-stiff problems at moderate tolerances.",
@@ -112,10 +96,6 @@ Base.@kwdef struct BS3{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqAdapt
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
-end
-# for backwards compatibility
-function BS3(stage_limiter!, step_limiter! = trivial_limiter!)
-    return BS3(stage_limiter!, step_limiter!, Serial())
 end
 
 @doc explicit_rk_docstring(
@@ -138,10 +118,6 @@ Base.@kwdef struct OwrenZen3{StageLimiter, StepLimiter, Thread} <:
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function OwrenZen3(stage_limiter!, step_limiter! = trivial_limiter!)
-    return OwrenZen3(stage_limiter!, step_limiter!, Serial())
-end
 
 @doc explicit_rk_docstring(
     "Owren-Zennaro optimized interpolation 4/3 method (free 4th order interpolant).",
@@ -163,10 +139,6 @@ Base.@kwdef struct OwrenZen4{StageLimiter, StepLimiter, Thread} <:
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function OwrenZen4(stage_limiter!, step_limiter! = trivial_limiter!)
-    return OwrenZen4(stage_limiter!, step_limiter!, Serial())
-end
 
 @doc explicit_rk_docstring(
     "Owren-Zennaro optimized interpolation 5/4 method (free 5th order interpolant).",
@@ -187,10 +159,6 @@ Base.@kwdef struct OwrenZen5{StageLimiter, StepLimiter, Thread} <:
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
-end
-# for backwards compatibility
-function OwrenZen5(stage_limiter!, step_limiter! = trivial_limiter!)
-    return OwrenZen5(stage_limiter!, step_limiter!, Serial())
 end
 
 @doc explicit_rk_docstring(
@@ -215,10 +183,6 @@ Base.@kwdef struct BS5{StageLimiter, StepLimiter, Thread, L} <: OrdinaryDiffEqAd
     thread::Thread = Serial()
     lazy::L = Val{true}()
 end
-# for backwards compatibility
-function BS5(stage_limiter!, step_limiter! = trivial_limiter!; lazy = Val{true}())
-    return BS5(stage_limiter!, step_limiter!, Serial(), lazy)
-end
 
 @doc explicit_rk_docstring(
     "Dormand-Prince's 5/4 Runge-Kutta method. (free 4th order interpolant).",
@@ -238,10 +202,6 @@ Base.@kwdef struct DP5{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqAdapt
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
-end
-# for backwards compatibility
-function DP5(stage_limiter!, step_limiter! = trivial_limiter!)
-    return DP5(stage_limiter!, step_limiter!, Serial())
 end
 
 AutoDP5(alg; kwargs...) = AutoAlgSwitch(DP5(), alg; kwargs...)
@@ -268,10 +228,6 @@ Base.@kwdef struct Anas5{StageLimiter, StepLimiter, Thread, T} <: OrdinaryDiffEq
     thread::Thread = Serial()
     w::T = 1
 end
-# for backwards compatibility
-function Anas5(stage_limiter!, step_limiter! = trivial_limiter!; w = 1)
-    return Anas5(stage_limiter!, step_limiter!, Serial(), w)
-end
 
 @doc explicit_rk_docstring(
     "Tsitouras' Runge-Kutta-Oliver 6 stage 5th order method.", "RKO65",
@@ -283,10 +239,6 @@ Base.@kwdef struct RKO65{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqAlg
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
-end
-# for backwards compatibility
-function RKO65(stage_limiter!, step_limiter! = trivial_limiter!)
-    return RKO65(stage_limiter!, step_limiter!, Serial())
 end
 
 @doc explicit_rk_docstring(
@@ -312,10 +264,6 @@ Base.@kwdef struct FRK65{StageLimiter, StepLimiter, Thread, T} <:
     omega::T = 0.0
 end
 
-# for backwards compatibility
-function FRK65(stage_limiter!, step_limiter! = trivial_limiter!; omega = 0.0)
-    return FRK65(stage_limiter!, step_limiter!, Serial(), omega)
-end
 
 @doc explicit_rk_docstring(
     """Method designed to have good stability properties
@@ -338,10 +286,6 @@ Base.@kwdef struct RKM{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqAlgor
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function RKM(stage_limiter!, step_limiter! = trivial_limiter!)
-    return RKM(stage_limiter!, step_limiter!, Serial())
-end
 
 @doc explicit_rk_docstring(
     "4th order Ralston method with minimum truncation error for 4-stage explicit Runge-Kutta.",
@@ -361,9 +305,6 @@ Base.@kwdef struct Ralston4{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEq
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-function Ralston4(stage_limiter!, step_limiter! = trivial_limiter!)
-    return Ralston4(stage_limiter!, step_limiter!, Serial())
-end
 
 @doc explicit_rk_docstring(
     "5th order method.", "MSRK5",
@@ -374,10 +315,6 @@ Base.@kwdef struct MSRK5{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqAlg
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function MSRK5(stage_limiter!, step_limiter! = trivial_limiter!)
-    return MSRK5(stage_limiter!, step_limiter!, Serial())
-end
 
 @doc explicit_rk_docstring(
     "6th order method.", "MSRK6",
@@ -387,10 +324,6 @@ Base.@kwdef struct MSRK6{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqAlg
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
-end
-# for backwards compatibility
-function MSRK6(stage_limiter!, step_limiter! = trivial_limiter!)
-    return MSRK6(stage_limiter!, step_limiter!, Serial())
 end
 
 @doc explicit_rk_docstring(
@@ -476,10 +409,6 @@ Base.@kwdef struct Stepanov5{StageLimiter, StepLimiter, Thread} <:
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function Stepanov5(stage_limiter!, step_limiter! = trivial_limiter!)
-    return Stepanov5(stage_limiter!, step_limiter!, Serial())
-end
 
 @doc explicit_rk_docstring(
     "5th order method suited for SIR-type epidemic models.",
@@ -498,10 +427,6 @@ Base.@kwdef struct SIR54{StageLimiter, StepLimiter, Thread} <:
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
-end
-# for backwards compatibility
-function SIR54(stage_limiter!, step_limiter! = trivial_limiter!)
-    return SIR54(stage_limiter!, step_limiter!, Serial())
 end
 
 @doc explicit_rk_docstring(
@@ -527,10 +452,6 @@ Base.@kwdef struct Alshina2{StageLimiter, StepLimiter, Thread} <:
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function Alshina2(stage_limiter!, step_limiter! = trivial_limiter!)
-    return Alshina2(stage_limiter!, step_limiter!, Serial())
-end
 
 @doc explicit_rk_docstring(
     "3rd order, 3-stage Method with optimal parameters.",
@@ -555,10 +476,6 @@ Base.@kwdef struct Alshina3{StageLimiter, StepLimiter, Thread} <:
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function Alshina3(stage_limiter!, step_limiter! = trivial_limiter!)
-    return Alshina3(stage_limiter!, step_limiter!, Serial())
-end
 
 @doc explicit_rk_docstring(
     "6th order, 7-stage Method with optimal parameters.",
@@ -581,8 +498,4 @@ Base.@kwdef struct Alshina6{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEq
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
-end
-# for backwards compatibility
-function Alshina6(stage_limiter!, step_limiter! = trivial_limiter!)
-    return Alshina6(stage_limiter!, step_limiter!, Serial())
 end

--- a/lib/OrdinaryDiffEqQPRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqQPRK/src/algorithms.jl
@@ -10,7 +10,3 @@ Base.@kwdef struct QPRK98{StageLimiter, StepLimiter, Thread} <:
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function QPRK98(stage_limiter!, step_limiter! = trivial_limiter!)
-    return QPRK98(stage_limiter!, step_limiter!, Serial())
-end

--- a/lib/OrdinaryDiffEqSIMDRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqSIMDRK/src/algorithms.jl
@@ -15,13 +15,6 @@ function MER5v2(;
     )
 end
 
-# for backwards compatibility
-function MER5v2(stage_limiter!, step_limiter! = trivial_limiter!)
-    return MER5v2{typeof(stage_limiter!), typeof(step_limiter!), typeof(Serial())}(
-        stage_limiter!,
-        step_limiter!, Serial()
-    )
-end
 
 struct MER6v2{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqAdaptiveAlgorithm
     stage_limiter!::StageLimiter
@@ -40,13 +33,6 @@ function MER6v2(;
     )
 end
 
-# for backwards compatibility
-function MER6v2(stage_limiter!, step_limiter! = trivial_limiter!)
-    return MER6v2{typeof(stage_limiter!), typeof(step_limiter!), typeof(Serial())}(
-        stage_limiter!,
-        step_limiter!, Serial()
-    )
-end
 
 struct RK6v4{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqAdaptiveAlgorithm
     stage_limiter!::StageLimiter
@@ -65,13 +51,6 @@ function RK6v4(;
     )
 end
 
-# for backwards compatibility
-function RK6v4(stage_limiter!, step_limiter! = trivial_limiter!)
-    return RK6v4{typeof(stage_limiter!), typeof(step_limiter!), typeof(Serial())}(
-        stage_limiter!,
-        step_limiter!, Serial()
-    )
-end
 
 function Base.show(io::IO, alg::Union{MER5v2, MER6v2, RK6v4})
     return print(

--- a/lib/OrdinaryDiffEqSSPRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqSSPRK/src/algorithms.jl
@@ -11,14 +11,6 @@ Base.@kwdef struct SSPRK53_2N2{StageLimiter, StepLimiter, Thread} <: OrdinaryDif
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function SSPRK53_2N2(stage_limiter!, step_limiter! = trivial_limiter!)
-    return SSPRK53_2N2(
-        stage_limiter!,
-        step_limiter!,
-        Serial()
-    )
-end
 
 @doc explicit_rk_docstring(
     "A second-order, two-stage explicit strong stability preserving (SSP) method.
@@ -34,13 +26,6 @@ Base.@kwdef struct SSPRK22{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqA
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function SSPRK22(stage_limiter!, step_limiter! = trivial_limiter!)
-    return SSPRK22(
-        stage_limiter!,
-        step_limiter!, Serial()
-    )
-end
 
 @doc explicit_rk_docstring(
     "A third-order, five-stage explicit strong stability preserving (SSP) method.
@@ -54,13 +39,6 @@ Base.@kwdef struct SSPRK53{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqA
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
-end
-# for backwards compatibility
-function SSPRK53(stage_limiter!, step_limiter! = trivial_limiter!)
-    return SSPRK53(
-        stage_limiter!,
-        step_limiter!, Serial()
-    )
 end
 
 @doc explicit_rk_docstring(
@@ -76,13 +54,6 @@ Base.@kwdef struct SSPRK63{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqA
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function SSPRK63(stage_limiter!, step_limiter! = trivial_limiter!)
-    return SSPRK63(
-        stage_limiter!,
-        step_limiter!, Serial()
-    )
-end
 
 @doc explicit_rk_docstring(
     "A third-order, eight-stage explicit strong stability preserving (SSP) method.
@@ -96,13 +67,6 @@ Base.@kwdef struct SSPRK83{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqA
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
-end
-# for backwards compatibility
-function SSPRK83(stage_limiter!, step_limiter! = trivial_limiter!)
-    return SSPRK83(
-        stage_limiter!,
-        step_limiter!, Serial()
-    )
 end
 
 @doc explicit_rk_docstring(
@@ -135,13 +99,6 @@ Base.@kwdef struct SSPRK43{StageLimiter, StepLimiter, Thread} <:
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function SSPRK43(stage_limiter!, step_limiter! = trivial_limiter!)
-    return SSPRK43(
-        stage_limiter!,
-        step_limiter!, Serial()
-    )
-end
 
 @doc explicit_rk_docstring(
     "A third-order, four-stage explicit strong stability preserving (SSP) method.",
@@ -156,13 +113,6 @@ Base.@kwdef struct SSPRK432{StageLimiter, StepLimiter, Thread} <:
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
-end
-# for backwards compatibility
-function SSPRK432(stage_limiter!, step_limiter! = trivial_limiter!)
-    return SSPRK432(
-        stage_limiter!,
-        step_limiter!, Serial()
-    )
 end
 
 @doc explicit_rk_docstring(
@@ -181,14 +131,6 @@ Base.@kwdef struct SSPRKMSVS32{StageLimiter, StepLimiter, Thread} <:
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function SSPRKMSVS32(stage_limiter!, step_limiter! = trivial_limiter!)
-    return SSPRKMSVS32(
-        stage_limiter!,
-        step_limiter!,
-        Serial()
-    )
-end
 
 @doc explicit_rk_docstring(
     "A fourth-order, five-stage explicit strong stability preserving (SSP) method.
@@ -202,13 +144,6 @@ Base.@kwdef struct SSPRK54{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqA
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
-end
-# for backwards compatibility
-function SSPRK54(stage_limiter!, step_limiter! = trivial_limiter!)
-    return SSPRK54(
-        stage_limiter!,
-        step_limiter!, Serial()
-    )
 end
 
 @doc explicit_rk_docstring(
@@ -224,14 +159,6 @@ Base.@kwdef struct SSPRK53_2N1{StageLimiter, StepLimiter, Thread} <: OrdinaryDif
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function SSPRK53_2N1(stage_limiter!, step_limiter! = trivial_limiter!)
-    return SSPRK53_2N1(
-        stage_limiter!,
-        step_limiter!,
-        Serial()
-    )
-end
 
 @doc explicit_rk_docstring(
     "A fourth-order, ten-stage explicit strong stability preserving (SSP) method.
@@ -246,13 +173,6 @@ Base.@kwdef struct SSPRK104{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEq
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
-end
-# for backwards compatibility
-function SSPRK104(stage_limiter!, step_limiter! = trivial_limiter!)
-    return SSPRK104(
-        stage_limiter!,
-        step_limiter!, Serial()
-    )
 end
 
 @doc explicit_rk_docstring(
@@ -271,13 +191,6 @@ Base.@kwdef struct SSPRK932{StageLimiter, StepLimiter, Thread} <:
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function SSPRK932(stage_limiter!, step_limiter! = trivial_limiter!)
-    return SSPRK932(
-        stage_limiter!,
-        step_limiter!, Serial()
-    )
-end
 
 @doc explicit_rk_docstring(
     "A third-order, four-step explicit strong stability preserving (SSP) linear multistep method.
@@ -295,14 +208,6 @@ Base.@kwdef struct SSPRKMSVS43{StageLimiter, StepLimiter, Thread} <:
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function SSPRKMSVS43(stage_limiter!, step_limiter! = trivial_limiter!)
-    return SSPRKMSVS43(
-        stage_limiter!,
-        step_limiter!,
-        Serial()
-    )
-end
 
 @doc explicit_rk_docstring(
     "A third-order, seven-stage explicit strong stability preserving (SSP) method.
@@ -316,13 +221,6 @@ Base.@kwdef struct SSPRK73{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqA
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
-end
-# for backwards compatibility
-function SSPRK73(stage_limiter!, step_limiter! = trivial_limiter!)
-    return SSPRK73(
-        stage_limiter!,
-        step_limiter!, Serial()
-    )
 end
 
 @doc explicit_rk_docstring(
@@ -338,13 +236,6 @@ Base.@kwdef struct SSPRK53_H{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffE
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function SSPRK53_H(stage_limiter!, step_limiter! = trivial_limiter!)
-    return SSPRK53_H(
-        stage_limiter!,
-        step_limiter!, Serial()
-    )
-end
 
 @doc explicit_rk_docstring(
     "A third-order, three-stage explicit strong stability preserving (SSP) method.
@@ -359,13 +250,6 @@ Base.@kwdef struct SSPRK33{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqA
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
-end
-# for backwards compatibility
-function SSPRK33(stage_limiter!, step_limiter! = trivial_limiter!)
-    return SSPRK33(
-        stage_limiter!,
-        step_limiter!, Serial()
-    )
 end
 
 @doc explicit_rk_docstring(
@@ -385,14 +269,6 @@ Base.@kwdef struct KYKSSPRK42{StageLimiter, StepLimiter, Thread} <: OrdinaryDiff
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
 end
-# for backwards compatibility
-function KYKSSPRK42(stage_limiter!, step_limiter! = trivial_limiter!)
-    return KYKSSPRK42(
-        stage_limiter!,
-        step_limiter!,
-        Serial()
-    )
-end
 
 @doc explicit_rk_docstring(
     "Optimal strong-stability-preserving Runge-Kutta time discretizations for discontinuous Galerkin methods",
@@ -411,14 +287,6 @@ Base.@kwdef struct KYK2014DGSSPRK_3S2{StageLimiter, StepLimiter, Thread} <:
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
-end
-# for backwards compatibility
-function KYK2014DGSSPRK_3S2(stage_limiter!, step_limiter! = trivial_limiter!)
-    return KYK2014DGSSPRK_3S2(
-        stage_limiter!,
-        step_limiter!,
-        Serial()
-    )
 end
 
 @doc explicit_rk_docstring(

--- a/lib/OrdinaryDiffEqTaylorSeries/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/src/algorithms.jl
@@ -9,10 +9,6 @@ Base.@kwdef struct ExplicitTaylor2{StageLimiter, StepLimiter, Thread} <:
     thread::Thread = Serial()
 end
 @truncate_stacktrace ExplicitTaylor2 3
-# for backwards compatibility
-function ExplicitTaylor2(stage_limiter!, step_limiter! = trivial_limiter!)
-    return ExplicitTaylor2(stage_limiter!, step_limiter!, Serial())
-end
 
 @doc explicit_rk_docstring(
     "An arbitrary-order explicit Taylor series method.",

--- a/lib/OrdinaryDiffEqVerner/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqVerner/src/algorithms.jl
@@ -23,10 +23,6 @@ Base.@kwdef struct Vern6{StageLimiter, StepLimiter, Thread, L} <:
     lazy::L = Val{true}()
 end
 @truncate_stacktrace Vern6 3
-# for backwards compatibility
-function Vern6(stage_limiter!, step_limiter! = trivial_limiter!; lazy = Val{true}())
-    return Vern6(stage_limiter!, step_limiter!, Serial(), lazy)
-end
 
 @doc explicit_rk_docstring(
     "Verner's most efficient 7/6 method (lazy 7th order interpolant). Good for problems requiring high accuracy. Slightly more computationally expensive than Tsit5. Performance best when parameter vector remains unchanged. Recommended for high-accuracy non-stiff problems.",
@@ -53,10 +49,6 @@ Base.@kwdef struct Vern7{StageLimiter, StepLimiter, Thread, L} <:
     lazy::L = Val{true}()
 end
 @truncate_stacktrace Vern7 3
-# for backwards compatibility
-function Vern7(stage_limiter!, step_limiter! = trivial_limiter!; lazy = Val{true}())
-    return Vern7(stage_limiter!, step_limiter!, Serial(), lazy)
-end
 
 @doc explicit_rk_docstring(
     "Verner's most efficient 8/7 method (lazy 8th order interpolant).",
@@ -83,10 +75,6 @@ Base.@kwdef struct Vern8{StageLimiter, StepLimiter, Thread, L} <:
     lazy::L = Val{true}()
 end
 @truncate_stacktrace Vern8 3
-# for backwards compatibility
-function Vern8(stage_limiter!, step_limiter! = trivial_limiter!; lazy = Val{true}())
-    return Vern8(stage_limiter!, step_limiter!, Serial(), lazy)
-end
 
 @doc explicit_rk_docstring(
     "Verner's most efficient 9/8 method (lazy 9th order interpolant).",
@@ -112,10 +100,6 @@ Base.@kwdef struct Vern9{StageLimiter, StepLimiter, Thread, L} <:
     lazy::L = Val{true}()
 end
 @truncate_stacktrace Vern9 3
-# for backwards compatibility
-function Vern9(stage_limiter!, step_limiter! = trivial_limiter!; lazy = Val{true}())
-    return Vern9(stage_limiter!, step_limiter!, Serial(), lazy)
-end
 
 """
 Automatic switching algorithm that can switch between the (non-stiff) `Vern6()` and `stiff_alg`.
@@ -180,7 +164,3 @@ Base.@kwdef struct RKV76IIa{StageLimiter, StepLimiter, Thread, L} <:
     lazy::L = Val{true}()
 end
 @truncate_stacktrace RKV76IIa 3
-# for backwards compatibility
-function RKV76IIa(stage_limiter!, step_limiter! = trivial_limiter!; lazy = Val{true}())
-    return RKV76IIa(stage_limiter!, step_limiter!, Serial(), lazy)
-end

--- a/test/regression/ode_dense_tests.jl
+++ b/test/regression/ode_dense_tests.jl
@@ -176,97 +176,50 @@ sol = solve(prob, Euler(), dt = 1 // 2^(2), dense = false)
 regression_test(Euler(), 0.2, 0.2)
 
 # Midpoint
-@test Midpoint() == Midpoint(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(Midpoint(), 1.5e-2, 2.3e-2)
-
-# RK46NL
-@test RK46NL() == RK46NL(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
-
-# Heun
-@test Heun() == Heun(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
-
-# Anas5
-@test Anas5() == Anas5(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
-
-# Ralston
-@test Ralston() == Ralston(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
-
-# FRK65
-@test FRK65() == FRK65(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
-
-# PFRK87
-@test PFRK87() == PFRK87(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
-
-# RKO65
-@test RKO65() == RKO65(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 
 println("SSPRKs")
 
 # SSPRK22
-@test SSPRK22() == SSPRK22(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(SSPRK22(), 1.5e-2, 2.5e-2; test_diff1 = true, nth_der = 2, dertol = 1.0e-15)
 
 # SSPRK33
-@test SSPRK33() == SSPRK33(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(SSPRK33(), 7.5e-4, 7.5e-3; test_diff1 = true, nth_der = 2, dertol = 1.0e-15)
 
 # SSPRK53
-@test SSPRK53() == SSPRK53(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(SSPRK53(), 2.5e-4, 4.0e-4; test_diff1 = true)
 
 # SSPRK53_2N1
-@test SSPRK53_2N1() == SSPRK53_2N1(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(SSPRK53_2N1(), 3.0e-4, 5.5e-4; test_diff1 = true)
 
 # SSPRK53_2N2
-@test SSPRK53_2N2() == SSPRK53_2N2(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(SSPRK53_2N2(), 2.5e-4, 5.0e-4; test_diff1 = true)
 
 # SSPRK63
-@test SSPRK63() == SSPRK63(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(SSPRK63(), 1.5e-4, 3.0e-4; test_diff1 = true)
 
 # SSPRK73
-@test SSPRK73() == SSPRK73(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(SSPRK73(), 9.0e-5, 2.0e-4; test_diff1 = true)
 
 # SSPRK83
-@test SSPRK83() == SSPRK83(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(SSPRK83(), 6.5e-5, 1.5e-4; test_diff1 = true)
 
 # SSPRK43
-@test SSPRK43() == SSPRK43(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(SSPRK43(), 4.0e-4, 8.0e-4; test_diff1 = true, nth_der = 2, dertol = 1.0e-13)
 
 # SSPRK432
-@test SSPRK432() == SSPRK432(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(SSPRK432(), 4.0e-4, 8.0e-4; test_diff1 = true, nth_der = 2, dertol = 1.0e-13)
 
 # SSPRK932
-@test SSPRK932() == SSPRK932(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(SSPRK932(), 6.0e-5, 1.0e-4; test_diff1 = true)
 
 # SSPRK54
-@test SSPRK54() == SSPRK54(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(SSPRK54(), 3.5e-5, 5.5e-5)
 
 # SSPRK104
-@test SSPRK22() == SSPRK22(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(SSPRK104(), 1.5e-5, 3.0e-5)
 
-# KYKSSPRK42
-@test KYKSSPRK42() == KYKSSPRK42(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
-
-# KYK2014DGSSPRK_3S2
-@test KYK2014DGSSPRK_3S2() == KYK2014DGSSPRK_3S2(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
-
 println("SSPRKMSs")
-
-# SSPRKMSVS32
-@test SSPRKMSVS32() == SSPRKMSVS32(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
-
-# SSPRKMSVS43
-@test SSPRKMSVS43() == SSPRKMSVS43(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 
 println("Low Storage RKs")
 
@@ -298,184 +251,134 @@ regression_test(NDBLSRK134(), 3.0e-5, 3.0e-5)
 regression_test(NDBLSRK144(), 3.0e-5, 3.0e-5)
 
 # CFRLDDRK64
-@test CFRLDDRK64() == CFRLDDRK64(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(CFRLDDRK64(), 3.0e-5, 3.0e-5)
 
 # TSLDDRK74
-@test TSLDDRK74() == TSLDDRK74(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(TSLDDRK74(), 3.0e-5, 3.0e-5)
 
 # CKLLSRK43_2
-@test CKLLSRK43_2() == CKLLSRK43_2(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(CKLLSRK43_2(), 2.0e-5, 3.1e-5)
 
 # CKLLSRK54_3C
-@test CKLLSRK54_3C() == CKLLSRK54_3C(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(CKLLSRK54_3C(), 3.0e-5, 6.0e-5)
 
 # CKLLSRK95_4S
-@test CKLLSRK95_4S() == CKLLSRK95_4S(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(CKLLSRK95_4S(), 5.0e-5, 9.5e-5)
 
 # CKLLSRK95_4C
-@test CKLLSRK95_4C() == CKLLSRK95_4C(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(CKLLSRK95_4C(), 3.0e-3, 5.5e-3)
 
 # CKLLSRK95_4M
-@test CKLLSRK95_4M() == CKLLSRK95_4M(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(CKLLSRK95_4M(), 5.0e-5, 9.5e-5)
 
 # CKLLSRK54_3C_3R
-@test CKLLSRK54_3C_3R() == CKLLSRK54_3C_3R(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(CKLLSRK54_3C_3R(), 3.0e-5, 6.0e-5)
 
 # CKLLSRK54_3M_3R
-@test CKLLSRK54_3M_3R() == CKLLSRK54_3M_3R(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(CKLLSRK54_3M_3R(), 2.0e-5, 4.0e-5)
 
 # CKLLSRK54_3N_3R
-@test CKLLSRK54_3N_3R() == CKLLSRK54_3N_3R(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(CKLLSRK54_3N_3R(), 4.0e-5, 7.0e-5)
 
 # CKLLSRK85_4C_3R
-@test CKLLSRK85_4C_3R() == CKLLSRK85_4C_3R(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(CKLLSRK85_4C_3R(), 8.0e-5, 1.6e-4)
 
 # CKLLSRK85_4M_3R
-@test CKLLSRK85_4M_3R() == CKLLSRK85_4M_3R(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(CKLLSRK85_4M_3R(), 8.0e-5, 1.5e-4)
 
 # CKLLSRK85_4P_3R
-@test CKLLSRK85_4P_3R() == CKLLSRK85_4P_3R(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(CKLLSRK85_4P_3R(), 5.5e-5, 1.1e-4)
 
 # CKLLSRK54_3N_4R
-@test CKLLSRK54_3N_4R() == CKLLSRK54_3N_4R(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(CKLLSRK54_3N_4R(), 3.5e-5, 6.0e-5)
 
 # CKLLSRK54_3M_4R
-@test CKLLSRK54_3M_4R() == CKLLSRK54_3M_4R(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(CKLLSRK54_3M_4R(), 2.0e-5, 4.0e-5)
 
 # CKLLSRK65_4M_4R
-@test CKLLSRK65_4M_4R() == CKLLSRK65_4M_4R(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(CKLLSRK65_4M_4R(), 8.0e-5, 1.5e-4)
 
 # CKLLSRK85_4FM_4R
-@test CKLLSRK85_4FM_4R() == CKLLSRK85_4FM_4R(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(CKLLSRK85_4FM_4R(), 1.0, 1.8)
 
 # CKLLSRK75_4M_5R
-@test CKLLSRK75_4M_5R() == CKLLSRK75_4M_5R(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(CKLLSRK75_4M_5R(), 8.0e-5, 1.6e-4)
 
 # ParsaniKetchesonDeconinck3S32
-@test ParsaniKetchesonDeconinck3S32() ==
-    ParsaniKetchesonDeconinck3S32(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(ParsaniKetchesonDeconinck3S32(), 1.5e-2, 2.0e-2)
 
 # ParsaniKetchesonDeconinck3S82
-@test ParsaniKetchesonDeconinck3S82() ==
-    ParsaniKetchesonDeconinck3S82(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(ParsaniKetchesonDeconinck3S82(), 1.5e-3, 3.0e-3)
 
 # ParsaniKetchesonDeconinck3S53
-@test ParsaniKetchesonDeconinck3S53() ==
-    ParsaniKetchesonDeconinck3S53(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(ParsaniKetchesonDeconinck3S53(), 2.5e-4, 4.5e-4)
 
 # ParsaniKetchesonDeconinck3S173
-@test ParsaniKetchesonDeconinck3S173() ==
-    ParsaniKetchesonDeconinck3S173(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(ParsaniKetchesonDeconinck3S173(), 3.5e-5, 5.5e-5)
 
 # ParsaniKetchesonDeconinck3S94
-@test ParsaniKetchesonDeconinck3S94() ==
-    ParsaniKetchesonDeconinck3S94(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(ParsaniKetchesonDeconinck3S94(), 1.5e-5, 3.0e-5)
 
 # ParsaniKetchesonDeconinck3S184
-@test ParsaniKetchesonDeconinck3S184() ==
-    ParsaniKetchesonDeconinck3S184(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(ParsaniKetchesonDeconinck3S184(), 1.5e-5, 3.0e-5)
 
 # ParsaniKetchesonDeconinck3S105
-@test ParsaniKetchesonDeconinck3S105() ==
-    ParsaniKetchesonDeconinck3S105(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(ParsaniKetchesonDeconinck3S105(), 1.5e-5, 3.0e-5)
 
 # ParsaniKetchesonDeconinck3S205
-@test ParsaniKetchesonDeconinck3S205() ==
-    ParsaniKetchesonDeconinck3S205(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(ParsaniKetchesonDeconinck3S205(), 1.5e-5, 3.0e-5)
 
 # RDPK3Sp35
-@test RDPK3Sp35() == RDPK3Sp35(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(RDPK3Sp35(), 7.0e-4, 1.5e-3)
 
 # RDPK3SpFSAL35
-@test RDPK3SpFSAL35() == RDPK3SpFSAL35(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(RDPK3SpFSAL35(), 8.5e-4, 2.0e-3)
 
 # RDPK3Sp49
-@test RDPK3Sp49() == RDPK3Sp49(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(RDPK3Sp49(), 7.5e-5, 1.5e-4)
 
 # RDPK3SpFSAL49
-@test RDPK3SpFSAL49() == RDPK3SpFSAL49(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(RDPK3SpFSAL49(), 8.5e-5, 1.5e-4)
 
 # RDPK3Sp510
-@test RDPK3Sp510() == RDPK3Sp510(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(RDPK3Sp510(), 2.5e-4, 3.5e-4)
 
 # RDPK3SpFSAL510
-@test RDPK3SpFSAL510() == RDPK3SpFSAL510(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(RDPK3SpFSAL510(), 2.5e-4, 3.5e-4)
 
 println("RKs")
 
 # RK4
-@test RK4() == RK4(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(RK4(), 4.5e-5, 1.0e-4)
 
 # DP5
-@test DP5() == DP5(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(DP5(), 5.0e-6, 1.0e-5; test_diff1 = true, nth_der = 4, dertol = 1.0e-14)
 
 # BS3
-@test BS3() == BS3(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(BS3(), 5.0e-4, 8.0e-4)
 
 # OwrenZen3
-@test OwrenZen3() == OwrenZen3(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(OwrenZen3(), 1.5e-4, 2.5e-4; test_diff1 = true, nth_der = 3, dertol = 1.0e-9)
 
 # OwrenZen4
-@test OwrenZen4() == OwrenZen4(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(OwrenZen4(), 6.5e-6, 1.5e-5; test_diff1 = true, nth_der = 4, dertol = 1.0e-10)
 
 # OwrenZen5
-@test OwrenZen5() == OwrenZen5(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(OwrenZen5(), 1.5e-6, 2.5e-6; test_diff1 = true, nth_der = 5, dertol = 1.0e-8)
 
 # Tsit5
-@test Tsit5() == Tsit5(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(Tsit5(), 2.0e-6, 4.0e-6; test_diff1 = true, nth_der = 4, dertol = 1.0e-6)
 
 # TanYam7
-@test TanYam7() == TanYam7(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(TanYam7(), 4.0e-4, 6.0e-4)
 
 # TsitPap8
-@test TsitPap8() == TsitPap8(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(TsitPap8(), 1.0e-3, 3.0e-3)
 
 # Feagin10
 regression_test(Feagin10(), 6.0e-4, 9.0e-4)
 
 # BS5
-@test BS5() == BS5(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(BS5(), 4.0e-8, 6.0e-8; test_diff1 = true, nth_der = 1, dertol = 1.0e-12)
 regression_test(
     BS5(lazy = Val{false}()), 4.0e-8, 6.0e-8; test_diff1 = true, nth_der = 1,
@@ -489,7 +392,6 @@ sol2 = solve(prob, BS5(), dt = 1 // 2^(7), dense = true, adaptive = false)
 print_results(@test maximum(map((x) -> maximum(abs.(x)), sol2 - interpd_1d_long)) < 2.0e-7)
 
 # DP8
-@test DP8() == DP8(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(DP8(), 2.0e-7, 3.0e-7; test_diff1 = true, nth_der = 1, dertol = 1.0e-15)
 
 prob = prob_ode_linear
@@ -501,7 +403,6 @@ print_results(@test maximum(map((x) -> maximum(abs.(x)), sol2 - interpd_1d_long)
 println("Verns")
 
 # Vern6
-@test Vern6() == Vern6(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(Vern6(), 7.0e-8, 7.0e-8; test_diff1 = true, nth_der = 1, dertol = 1.0e-9)
 regression_test(
     Vern6(lazy = Val{false}()), 7.0e-8, 7.0e-8; test_diff1 = true, nth_der = 1,
@@ -533,7 +434,6 @@ regression_test(
 )
 
 # Vern8
-@test Vern8() == Vern8(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(Vern8(), 3.0e-8, 5.0e-8; test_diff1 = true, nth_der = 1, dertol = 1.0e-7)
 regression_test(
     Vern8(lazy = Val{false}()), 3.0e-8, 5.0e-8; test_diff1 = true, nth_der = 1,
@@ -541,7 +441,6 @@ regression_test(
 )
 
 # Vern9
-@test Vern9() == Vern9(OrdinaryDiffEqCore.trivial_limiter!) # old non-kwarg constructor
 regression_test(Vern9(), 1.0e-9, 2.0e-9; test_diff1 = true, nth_der = 4, dertol = 5.0e-2)
 regression_test(
     Vern9(lazy = Val{false}()), 1.0e-9, 2.0e-9; test_diff1 = true, nth_der = 4,


### PR DESCRIPTION
## Summary

Finishes the v7 cleanup of positional limiter constructors started in #3485 / #3491.

- Removes the 54 remaining \`function Alg(stage_limiter!, step_limiter! = trivial_limiter!)\` backwards-compatibility shims across all explicit RK sublibraries:
  - **OrdinaryDiffEqLowOrderRK** (22): Heun, Ralston, Midpoint, RK4, BS3, OwrenZen3/4/5, BS5, DP5, Anas5, RKO65, FRK65, RKM, Ralston4, MSRK5, MSRK6, Stepanov5, SIR54, Alshina2/3/6
  - **OrdinaryDiffEqSSPRK** (18): every SSPRK* and KYK* algorithm
  - **OrdinaryDiffEqVerner** (5): Vern6/7/8/9, RKV76IIa
  - **OrdinaryDiffEqHighOrderRK** (4): TanYam7, TsitPap8, DP8, PFRK87
  - **OrdinaryDiffEqSIMDRK** (3): MER5v2, MER6v2, RK6v4
  - **OrdinaryDiffEqQPRK** (1): QPRK98
  - **OrdinaryDiffEqTaylorSeries** (1): ExplicitTaylor2
- Folds in the test cleanup from #3491 (removes the 71 \`@test Alg() == Alg(trivial_limiter!)\` assertions in \`test/regression/ode_dense_tests.jl\` that would otherwise \`MethodError\` against the now-deleted positional constructors). Every \`regression_test(...)\` numerical check is preserved.

## Migration

The kwarg form is preserved on every algorithm — via \`Base.@kwdef\` for most, and via an explicit \`function Alg(; …)\` kwarg-only constructor for the three SIMDRK algorithms. So:

\`\`\`julia
Alg()                              # still works
Alg(; stage_limiter! = my_limiter) # still works
Alg(; lazy = Val{false}())         # still works (Vern6/7/8/9, RKV76IIa, BS5)
Alg(my_limiter)                    # REMOVED — use kwarg form instead
\`\`\`

This is a v7-only break; v6 users were already steered toward the kwarg form.

## Relationship to #3491

Supersedes #3491. The test deletions in #3491 are included verbatim here, but they're now paired with the source-side constructor removal that motivated them — so master stays consistent (no orphan test calling a missing method, no orphan method with no caller).

## Test plan

- [ ] CI Regression_I group goes green (was 34 errored on master, would be 71 after this branch's source deletions without the test cleanup; now 0).
- [ ] SublibraryCI passes for every sublibrary touched (LowOrderRK, SSPRK, Verner, HighOrderRK, SIMDRK, QPRK, TaylorSeries).
- [ ] No downstream package in the SciML test matrix relied on the positional form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)