### PR TITLE
NEWS: deprecate StochasticDelayDiffEq in favor of DelayDiffEq

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -355,3 +355,9 @@ Same theme as the ODE side — all of the following break identically to the ODE
 - `initial_order` deprecated kwarg removed from DelayDiffEq
 - `ispredictive` / `isstandard` trait definitions removed; algorithms now override `default_controller` directly
 - `@static if isdefined` version guards removed (always true on v7)
+
+### StochasticDelayDiffEq deprecated
+
+`StochasticDelayDiffEq.jl` is deprecated. Use `DelayDiffEq.jl` directly — it has supported SDDE problems for some time, and the separate `StochasticDelayDiffEq` wrapper is no longer being maintained. It will not receive a v7-compatible release.
+
+**Migration:** replace `using StochasticDelayDiffEq` with `using DelayDiffEq` (plus `using StochasticDiffEq` if you were relying on the SDE algorithm re-exports). `MethodOfSteps(alg)` and the `SDDEProblem` constructor continue to work from `DelayDiffEq` / `SciMLBase` respectively.


### PR DESCRIPTION
## Summary

Adds a v7 breaking-changes note that `StochasticDelayDiffEq.jl` is deprecated. `DelayDiffEq.jl` has supported SDDE problems for some time, so the separate wrapper package is not being maintained and will not receive a v7-compatible release.

## Motivation

Came up while surveying the downstream packages that still pin `DiffEqBase = "6.x"` and would need a v7 compat bump. `StochasticDelayDiffEq.jl` v1.13.0 at `DiffEqBase = "6.186"` showed up on that list, but it shouldn't be bumped — the recommended path is to migrate callers off the wrapper. Documenting that alongside the existing DelayDiffEq deprecation items keeps the guidance in one place for v6 → v7 migrators.

Node placement: added as a subsection of the existing `## StochasticDiffEq / DelayDiffEq` section, right after the existing bullet list of shared ODE-side breaking changes.

## Test plan

- [x] `NEWS.md` renders — section heading level matches the surrounding structure (h3 under h2).
- Docs-only change; no CI impact.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>