### PR TITLE
Register SDDE test group in DelayDiffEq test_groups.toml

### DIFF
--- a/lib/DelayDiffEq/test/test_groups.toml
+++ b/lib/DelayDiffEq/test/test_groups.toml
@@ -7,5 +7,8 @@ versions = ["lts", "1.11", "1", "pre"]
 [Regression]
 versions = ["lts", "1.11", "1", "pre"]
 
+[SDDE]
+versions = ["lts", "1.11", "1", "pre"]
+
 [QA]
 versions = ["1"]


### PR DESCRIPTION
## Summary

The `SDDE` test branch in `lib/DelayDiffEq/test/runtests.jl` and the four files under `lib/DelayDiffEq/test/sdde/` were added after the v7 sublibrary migration (ed04f39f73 on 2026-03-25 "Add SDDE tests adapted from StochasticDelayDiffEq.jl", extended in 319f08c8c4 on 2026-04-08), but `lib/DelayDiffEq/test/test_groups.toml` was never updated to register the group.

`SublibraryCI.yml` builds its matrix from that toml via `.github/scripts/compute_affected_sublibraries.jl`, so the `TEST_GROUP == "SDDE"` branch is currently unreachable in CI — the SDDE tests ship in the repo but never run.

Verified this isn't a v7 rebase regression: the standalone `SciML/DelayDiffEq.jl` never had an SDDE group in its `test/runtests.jl` (checked every historical revision of that file), and its `Tests.yml` matrix only ever listed Interface / Integrators / Regression / QA. The SDDE capability is new to DelayDiffEq — adapted from StochasticDelayDiffEq.jl during the v7 timeframe — and the toml entry was simply forgotten.

This registers the group with the same version matrix as Interface / Integrators / Regression. If SDDE is known to be flaky on `pre` (nightly) today, the reviewer may want to trim that similar to how `QA` is scoped to `"1"`.

## Test plan

- [ ] New CI jobs appear: `test (DelayDiffEq_SDDE, lts|1.11|1|pre, ubuntu-latest, 120, 1)`
- [ ] The 4 SDDE safetestsets (`test_prob_sol.jl`, `events.jl`, `nondiagonal_sparse_noise.jl`, `implicit_methods.jl`) actually execute and pass
- [ ] Confirm whether `pre` should be excluded for SDDE (trim if unstable)