### PR TITLE
Migrate test code for SciMLBase v3 breaking changes (tuples/intervals/TimeChoiceIterator, ensemble ctx signatures, ProblemLibrary majors)

### DIFF
--- a/lib/DelayDiffEq/test/integrators/iterator.jl
+++ b/lib/DelayDiffEq/test/integrators/iterator.jl
@@ -49,8 +49,10 @@ end
         prob, MethodOfSteps(Tsit5());
         dt = 1 // 2^(4), tstops = [0.5], advance_to_tstop = true
     )
-    for (u, t) in tuples(integrator1)
-        @test 0.5 ≤ t ≤ 10
+    # SciMLBase v3: `tuples(integrator)` removed; iterate integrator directly
+    # and read `integrator.u`/`.t` off each step.
+    for integ in integrator1
+        @test 0.5 ≤ integ.t ≤ 10
     end
 
     # move to grid point in one step and stop there
@@ -59,24 +61,33 @@ end
         dt = 1 // 2^(4), tstops = [0.5], advance_to_tstop = true,
         stop_at_next_tstop = true
     )
-    for (u, t) in tuples(integrator2)
-        @test t == 0.5
+    for integ in integrator2
+        @test integ.t == 0.5
     end
     integrator2([10; 20])
 
     # step and show intervals
+    # SciMLBase v3: `intervals(integrator)` removed; iterate integrator directly
+    # and read `integrator.tprev`/`.uprev`/`.t`/`.u` off each step.
     integrator3 = init(prob, MethodOfSteps(Tsit5()); dt = 1 // 2^(4), tstops = [0.5])
-    for (uprev, tprev, u, t) in intervals(integrator3)
-        @show tprev, t
+    for integ in integrator3
+        @show integ.tprev, integ.t
     end
     integrator3([10; 20])
 
     # iterator for chosen time points
+    # SciMLBase v3: `TimeChoiceIterator` removed; drive manually via step! + interp.
     integrator4 = init(prob, MethodOfSteps(Tsit5()); dt = 1 // 2^(4))
     ts = 1:10
     us = Float64[]
-    for (u, t) in TimeChoiceIterator(integrator4, ts)
-        push!(us, u)
+    for t in ts
+        while integrator4.t < t && !isempty(integrator4.opts.tstops)
+            step!(integrator4)
+        end
+        while integrator4.t < t
+            step!(integrator4)
+        end
+        push!(us, integrator4(t))
     end
     @test us ≈ integrator4.sol(ts).u
 end

--- a/lib/DelayDiffEq/test/integrators/iterator.jl
+++ b/lib/DelayDiffEq/test/integrators/iterator.jl
@@ -49,8 +49,6 @@ end
         prob, MethodOfSteps(Tsit5());
         dt = 1 // 2^(4), tstops = [0.5], advance_to_tstop = true
     )
-    # SciMLBase v3: `tuples(integrator)` removed; iterate integrator directly
-    # and read `integrator.u`/`.t` off each step.
     for integ in integrator1
         @test 0.5 ≤ integ.t ≤ 10
     end
@@ -67,8 +65,6 @@ end
     integrator2([10; 20])
 
     # step and show intervals
-    # SciMLBase v3: `intervals(integrator)` removed; iterate integrator directly
-    # and read `integrator.tprev`/`.uprev`/`.t`/`.u` off each step.
     integrator3 = init(prob, MethodOfSteps(Tsit5()); dt = 1 // 2^(4), tstops = [0.5])
     for integ in integrator3
         @show integ.tprev, integ.t
@@ -76,7 +72,6 @@ end
     integrator3([10; 20])
 
     # iterator for chosen time points
-    # SciMLBase v3: `TimeChoiceIterator` removed; drive manually via step! + interp.
     integrator4 = init(prob, MethodOfSteps(Tsit5()); dt = 1 // 2^(4))
     ts = 1:10
     us = Float64[]

--- a/lib/DiffEqBase/test/downstream/distributed_ensemble.jl
+++ b/lib/DiffEqBase/test/downstream/distributed_ensemble.jl
@@ -10,7 +10,8 @@ println("There are $(nprocs()) processes")
     using OrdinaryDiffEq
     prob = ODEProblem((u, p, t) -> 1.01u, 0.5, (0.0, 1.0))
     u0s = [rand() * prob.u0 for i in 1:2]
-    function simple_prob_func(prob, i, repeat)
+    function simple_prob_func(prob, ctx)
+        i = ctx.i; repeat = ctx.repeat
         println("Running trajectory $i")
         ODEProblem(prob.f, u0s[i], prob.tspan)
     end
@@ -30,7 +31,7 @@ tspan = (0.0, 100.0)
 p = [1, 2.0, 3]
 prob = ODEProblem(lorenz!, u0, tspan, p)
 
-@everywhere function lorenz_prob_func(prob, i, repeat)
+@everywhere function lorenz_prob_func(prob, ctx)
     prob = remake(prob, tspan = (rand(), 100.0), p = rand(3))
     return prob
 end

--- a/lib/DiffEqBase/test/downstream/distributed_ensemble.jl
+++ b/lib/DiffEqBase/test/downstream/distributed_ensemble.jl
@@ -11,7 +11,7 @@ println("There are $(nprocs()) processes")
     prob = ODEProblem((u, p, t) -> 1.01u, 0.5, (0.0, 1.0))
     u0s = [rand() * prob.u0 for i in 1:2]
     function simple_prob_func(prob, ctx)
-        i = ctx.i; repeat = ctx.repeat
+        i = ctx.sim_id; repeat = ctx.repeat
         println("Running trajectory $i")
         ODEProblem(prob.f, u0s[i], prob.tspan)
     end

--- a/lib/DiffEqBase/test/downstream/ensemble.jl
+++ b/lib/DiffEqBase/test/downstream/ensemble.jl
@@ -46,7 +46,7 @@ prob2 = EnsembleProblem(prob)
 sim = solve(prob2, SRA1(), dt = 1 // 2^(3), trajectories = 10)
 DiffEqBase.calculate_ensemble_errors(sim)
 
-output_func = function (sol, i)
+output_func = function (sol, ctx)
     return last(last(sol))^2, false
 end
 prob2 = EnsembleProblem(prob, output_func = output_func)
@@ -56,12 +56,12 @@ prob = prob_sde_lorenz
 prob2 = EnsembleProblem(prob)
 sim = solve(prob2, SRIW1(), dt = 1 // 2^(3), trajectories = 10)
 
-output_func = function (sol, i)
+output_func = function (sol, ctx)
     return last(sol), false
 end
 
 prob = prob_ode_linear
-prob_func = function (prob, i, repeat)
+prob_func = function (prob, ctx)
     return ODEProblem(prob.f, rand() * prob.u0, prob.tspan, 1.01)
 end
 
@@ -81,7 +81,8 @@ prob2 = EnsembleProblem(
 sim = solve(prob2, Tsit5(), trajectories = 10000, batch_size = 20)
 @test sim.converged == true
 
-prob_func = function (prob, i, repeat)
+prob_func = function (prob, ctx)
+    i = ctx.i
     return ODEProblem(prob.f, (1 + i / 100) * prob.u0, prob.tspan, 1.01)
 end
 
@@ -109,7 +110,7 @@ sim2 = solve(prob2, Tsit5(), trajectories = 100, batch_size = 20)
 @test sum(sim.u) / length(sim.u) ≈ sim2.u / 100
 
 struct SomeUserType end
-output_func = function (sol, i)
+output_func = function (sol, ctx)
     return (SomeUserType(), false)
 end
 prob2 = EnsembleProblem(prob, prob_func = prob_func, output_func = output_func)

--- a/lib/DiffEqBase/test/downstream/ensemble.jl
+++ b/lib/DiffEqBase/test/downstream/ensemble.jl
@@ -82,7 +82,7 @@ sim = solve(prob2, Tsit5(), trajectories = 10000, batch_size = 20)
 @test sim.converged == true
 
 prob_func = function (prob, ctx)
-    i = ctx.i
+    i = ctx.sim_id
     return ODEProblem(prob.f, (1 + i / 100) * prob.u0, prob.tspan, 1.01)
 end
 

--- a/lib/DiffEqBase/test/downstream/ensemble_thread_safety.jl
+++ b/lib/DiffEqBase/test/downstream/ensemble_thread_safety.jl
@@ -9,7 +9,7 @@ n = 100
 
 initial_conditions = range(0, stop = 1, length = n)
 function prob_func(prob, ctx)
-    i = ctx.i; repeat = ctx.repeat
+    i = ctx.sim_id; repeat = ctx.repeat
     prob.u0[1] = initial_conditions[i]
     return prob
 end

--- a/lib/DiffEqBase/test/downstream/ensemble_thread_safety.jl
+++ b/lib/DiffEqBase/test/downstream/ensemble_thread_safety.jl
@@ -8,7 +8,8 @@ prob = ODEProblem(f, u0, tspan)
 n = 100
 
 initial_conditions = range(0, stop = 1, length = n)
-function prob_func(prob, i, repeat)
+function prob_func(prob, ctx)
+    i = ctx.i; repeat = ctx.repeat
     prob.u0[1] = initial_conditions[i]
     return prob
 end

--- a/lib/DiffEqBase/test/downstream/inference.jl
+++ b/lib/DiffEqBase/test/downstream/inference.jl
@@ -59,7 +59,8 @@ function solve_ode(f::F, p::P, ensemblealg; kwargs...) where {F, P}
     prob = ODEProblem{true}(f, [0.0, 0.0], tspan, p)
     # prob = ODEProblem(f, [0., 0.], tspan, p)
 
-    prob_func = (prob, i, repeat) -> begin
+    prob_func = (prob, ctx) -> begin
+        i = ctx.i
         remake(prob, tspan = (T[i + 1], t[1]))
     end
 

--- a/lib/DiffEqBase/test/downstream/inference.jl
+++ b/lib/DiffEqBase/test/downstream/inference.jl
@@ -60,7 +60,7 @@ function solve_ode(f::F, p::P, ensemblealg; kwargs...) where {F, P}
     # prob = ODEProblem(f, [0., 0.], tspan, p)
 
     prob_func = (prob, ctx) -> begin
-        i = ctx.i
+        i = ctx.sim_id
         remake(prob, tspan = (T[i + 1], t[1]))
     end
 

--- a/lib/StochasticDiffEq/test/gpu/sde_weak_adaptive_gpu.jl
+++ b/lib/StochasticDiffEq/test/gpu/sde_weak_adaptive_gpu.jl
@@ -17,7 +17,8 @@ function weak_error(
     return sum((computed_exp - true_exp) .^ 2) / length(trange)
 end
 
-function prob_func(prob, i, repeat)
+function prob_func(prob, ctx)
+    i = ctx.i; repeat = ctx.repeat
     #(i%50000 == 0) && @show i
     return remake(prob, seed = seeds[i])
 end
@@ -26,7 +27,8 @@ function reduction(u, batch, I)
     return u .+ sum(batch), false
 end
 
-function output_func(sol, i)
+function output_func(sol, ctx)
+    i = ctx.i
     #h1(asinh(sol.u[end][1])),false
     return h1.(asinh.(sol)), false
 end
@@ -86,7 +88,7 @@ h2(z) = z #z^2
 prob2 = SDEProblem(f2!, g2!, u₀, tspan)
 ensemble_prob2 = EnsembleProblem(
     prob2;
-    output_func = (sol, i) -> (h2.(sol), false),
+    output_func = (sol, ctx) -> (h2.(sol), false),
     prob_func = prob_func,
     reduction = reduction,
     u_init = Vector{eltype(prob2.u0)}([0.0, 0.0]),

--- a/lib/StochasticDiffEq/test/gpu/sde_weak_adaptive_gpu.jl
+++ b/lib/StochasticDiffEq/test/gpu/sde_weak_adaptive_gpu.jl
@@ -18,7 +18,7 @@ function weak_error(
 end
 
 function prob_func(prob, ctx)
-    i = ctx.i; repeat = ctx.repeat
+    i = ctx.sim_id; repeat = ctx.repeat
     #(i%50000 == 0) && @show i
     return remake(prob, seed = seeds[i])
 end
@@ -28,7 +28,7 @@ function reduction(u, batch, I)
 end
 
 function output_func(sol, ctx)
-    i = ctx.i
+    i = ctx.sim_id
     #h1(asinh(sol.u[end][1])),false
     return h1.(asinh.(sol)), false
 end

--- a/lib/StochasticDiffEq/test/gpu/sde_weak_scalar_adaptive_gpu.jl
+++ b/lib/StochasticDiffEq/test/gpu/sde_weak_scalar_adaptive_gpu.jl
@@ -19,7 +19,7 @@ function scalar_noise!(du, u, p, t)
 end
 
 function prob_func(prob, ctx)
-    i = ctx.i; repeat = ctx.repeat
+    i = ctx.sim_id; repeat = ctx.repeat
     Random.seed!(seeds[i])
     W = WienerProcess(0.0, 0.0, 0.0)
     return remake(prob, noise = W)

--- a/lib/StochasticDiffEq/test/gpu/sde_weak_scalar_adaptive_gpu.jl
+++ b/lib/StochasticDiffEq/test/gpu/sde_weak_scalar_adaptive_gpu.jl
@@ -18,7 +18,8 @@ function scalar_noise!(du, u, p, t)
     return nothing
 end
 
-function prob_func(prob, i, repeat)
+function prob_func(prob, ctx)
+    i = ctx.i; repeat = ctx.repeat
     Random.seed!(seeds[i])
     W = WienerProcess(0.0, 0.0, 0.0)
     return remake(prob, noise = W)

--- a/lib/StochasticDiffEq/test/tstops_tests.jl
+++ b/lib/StochasticDiffEq/test/tstops_tests.jl
@@ -5,8 +5,9 @@ prob = prob_sde_linear
 
 integrator = init(prob, EM(), dt = 1 // 2^(4), tstops = [0.33])
 
-for (u, t) in tuples(integrator)
-    @show u, t
+# SciMLBase v3: `tuples(integrator)` removed; iterate integrator directly.
+for integ in integrator
+    @show integ.u, integ.t
 end
 
 sol = solve(prob, EM(), dt = 1 // 2^(4), tstops = [0.33])

--- a/lib/StochasticDiffEqWeak/test/adaptive/sde_weak_adaptive.jl
+++ b/lib/StochasticDiffEqWeak/test/adaptive/sde_weak_adaptive.jl
@@ -16,7 +16,7 @@ function weak_error(
 end
 
 function prob_func(prob, ctx)
-    i = ctx.i; repeat = ctx.repeat
+    i = ctx.sim_id; repeat = ctx.repeat
     #(i%50000 == 0) && @show i
     return remake(prob, seed = seeds[i])
 end
@@ -26,7 +26,7 @@ function reduction(u, batch, I)
 end
 
 function output_func(sol, ctx)
-    i = ctx.i
+    i = ctx.sim_id
     #h1(asinh(sol.u[end][1])),false
     return h1.(asinh.(sol)), false
 end

--- a/lib/StochasticDiffEqWeak/test/adaptive/sde_weak_adaptive.jl
+++ b/lib/StochasticDiffEqWeak/test/adaptive/sde_weak_adaptive.jl
@@ -15,7 +15,8 @@ function weak_error(
     return sum((computed_exp - true_exp) .^ 2) / length(trange)
 end
 
-function prob_func(prob, i, repeat)
+function prob_func(prob, ctx)
+    i = ctx.i; repeat = ctx.repeat
     #(i%50000 == 0) && @show i
     return remake(prob, seed = seeds[i])
 end
@@ -24,7 +25,8 @@ function reduction(u, batch, I)
     return u .+ sum(batch), false
 end
 
-function output_func(sol, i)
+function output_func(sol, ctx)
+    i = ctx.i
     #h1(asinh(sol.u[end][1])),false
     return h1.(asinh.(sol)), false
 end
@@ -83,7 +85,7 @@ h2(z) = z #z^2
 prob2 = SDEProblem(f2!, g2!, u₀, tspan)
 ensemble_prob2 = EnsembleProblem(
     prob2;
-    output_func = (sol, i) -> (h2.(sol), false),
+    output_func = (sol, ctx) -> (h2.(sol), false),
     prob_func = prob_func,
     reduction = reduction,
     u_init = Vector{eltype(prob2.u0)}([0.0, 0.0])

--- a/lib/StochasticDiffEqWeak/test/adaptive/sde_weak_brusselator_adaptive.jl
+++ b/lib/StochasticDiffEqWeak/test/adaptive/sde_weak_brusselator_adaptive.jl
@@ -17,7 +17,8 @@ function scalar_noise!(du, u, p, t)
     return nothing
 end
 
-function prob_func(prob, i, repeat)
+function prob_func(prob, ctx)
+    i = ctx.i; repeat = ctx.repeat
     Random.seed!(seeds[i])
     W = WienerProcess(0.0, 0.0, 0.0)
     return remake(prob, noise = W)

--- a/lib/StochasticDiffEqWeak/test/adaptive/sde_weak_brusselator_adaptive.jl
+++ b/lib/StochasticDiffEqWeak/test/adaptive/sde_weak_brusselator_adaptive.jl
@@ -18,7 +18,7 @@ function scalar_noise!(du, u, p, t)
 end
 
 function prob_func(prob, ctx)
-    i = ctx.i; repeat = ctx.repeat
+    i = ctx.sim_id; repeat = ctx.repeat
     Random.seed!(seeds[i])
     W = WienerProcess(0.0, 0.0, 0.0)
     return remake(prob, noise = W)

--- a/lib/StochasticDiffEqWeak/test/weak_convergence/PL1WM.jl
+++ b/lib/StochasticDiffEqWeak/test/weak_convergence/PL1WM.jl
@@ -10,7 +10,8 @@ using Random
 using DiffEqDevTools
 #using DiffEqGPU
 
-function prob_func(prob, i, repeat)
+function prob_func(prob, ctx)
+    i = ctx.i; repeat = ctx.repeat
     return remake(prob, seed = seeds[i])
 end
 
@@ -39,7 +40,7 @@ seeds = rand(UInt, numtraj)
 prob = SDEProblem(f, g, u₀, tspan, p)
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (h1(sol.u[end]), false),
+    output_func = (sol, ctx) -> (h1(sol.u[end]), false),
     prob_func = prob_func
 )
 
@@ -68,7 +69,7 @@ p = [3 // 2, 1 // 100]
 prob = SDEProblem(f1!, g1!, u₀, tspan, p)
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (h1(sol.u[end][1]), false),
+    output_func = (sol, ctx) -> (h1(sol.u[end][1]), false),
     prob_func = prob_func
 )
 
@@ -126,7 +127,7 @@ h2(z) = z
 prob = SDEProblem(f2!, g2!, u₀, tspan, p, noise_rate_prototype = zeros(4, 4))
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (h2(sol.u[end][1]), false),
+    output_func = (sol, ctx) -> (h2(sol.u[end][1]), false),
     prob_func = prob_func
 )
 
@@ -167,7 +168,7 @@ h3(z) = z^2 # == 1//10**exp(3//2*t) if h3(z) = z and  == 1//100**exp(301//100*t)
 prob = SDEProblem(f3!, g3!, u₀, tspan)
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (h3(sol.u[end][1]), false),
+    output_func = (sol, ctx) -> (h3(sol.u[end][1]), false),
     prob_func = prob_func
 )
 
@@ -204,7 +205,7 @@ seeds = rand(UInt, numtraj)
 prob = SDEProblem(fadd, gadd, u₀, tspan, p)
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (sol.u[end], false),
+    output_func = (sol, ctx) -> (sol.u[end], false),
     prob_func = prob_func
 )
 
@@ -244,7 +245,7 @@ gadd!(du, u, p, t) = @.(du = p[2])
 prob = SDEProblem(fadd!, gadd!, u₀, tspan, p)
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (sol.u[end][1], false),
+    output_func = (sol, ctx) -> (sol.u[end][1], false),
     prob_func = prob_func
 )
 

--- a/lib/StochasticDiffEqWeak/test/weak_convergence/PL1WM.jl
+++ b/lib/StochasticDiffEqWeak/test/weak_convergence/PL1WM.jl
@@ -11,7 +11,7 @@ using DiffEqDevTools
 #using DiffEqGPU
 
 function prob_func(prob, ctx)
-    i = ctx.i; repeat = ctx.repeat
+    i = ctx.sim_id; repeat = ctx.repeat
     return remake(prob, seed = seeds[i])
 end
 

--- a/lib/StochasticDiffEqWeak/test/weak_convergence/SIE_SME.jl
+++ b/lib/StochasticDiffEqWeak/test/weak_convergence/SIE_SME.jl
@@ -11,7 +11,7 @@ using DiffEqDevTools
 #using DiffEqGPU
 
 function prob_func(prob, ctx)
-    i = ctx.i; repeat = ctx.repeat
+    i = ctx.sim_id; repeat = ctx.repeat
     return remake(prob, seed = seeds[i])
 end
 

--- a/lib/StochasticDiffEqWeak/test/weak_convergence/SIE_SME.jl
+++ b/lib/StochasticDiffEqWeak/test/weak_convergence/SIE_SME.jl
@@ -10,7 +10,8 @@ using Random
 using DiffEqDevTools
 #using DiffEqGPU
 
-function prob_func(prob, i, repeat)
+function prob_func(prob, ctx)
+    i = ctx.i; repeat = ctx.repeat
     return remake(prob, seed = seeds[i])
 end
 
@@ -39,7 +40,7 @@ seeds = rand(UInt, numtraj)
 prob = SDEProblem(f, g, u₀, tspan, p)
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (h1(sol.u[end]), false),
+    output_func = (sol, ctx) -> (h1(sol.u[end]), false),
     prob_func = prob_func
 )
 
@@ -95,7 +96,7 @@ p = [3 // 2, 1 // 100]
 prob = SDEProblem(f1!, g1!, u₀, tspan, p)
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (h1(sol.u[end][1]), false),
+    output_func = (sol, ctx) -> (h1(sol.u[end][1]), false),
     prob_func = prob_func
 )
 
@@ -163,7 +164,7 @@ h3(z) = z^2 # == 1//10**exp(3//2*t) if h3(z) = z and  == 1//100**exp(301//100*t)
 prob = SDEProblem(f3!, g3!, u₀, tspan)
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (h3(sol.u[end][1]), false),
+    output_func = (sol, ctx) -> (h3(sol.u[end][1]), false),
     prob_func = prob_func
 )
 

--- a/lib/StochasticDiffEqWeak/test/weak_convergence/W2Ito1.jl
+++ b/lib/StochasticDiffEqWeak/test/weak_convergence/W2Ito1.jl
@@ -12,7 +12,7 @@ using Random
 using DiffEqDevTools
 seed = 103473
 function prob_func(prob, ctx)
-    i = ctx.i; repeat = ctx.repeat
+    i = ctx.sim_id; repeat = ctx.repeat
     return remake(prob, seed = seeds[i])
 end
 

--- a/lib/StochasticDiffEqWeak/test/weak_convergence/W2Ito1.jl
+++ b/lib/StochasticDiffEqWeak/test/weak_convergence/W2Ito1.jl
@@ -11,7 +11,8 @@ using Test
 using Random
 using DiffEqDevTools
 seed = 103473
-function prob_func(prob, i, repeat)
+function prob_func(prob, ctx)
+    i = ctx.i; repeat = ctx.repeat
     return remake(prob, seed = seeds[i])
 end
 
@@ -38,7 +39,7 @@ seeds = rand(UInt, numtraj)
 prob = SDEProblem(f, g, u₀, tspan)
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (h1(asinh(sol.u[end])), false),
+    output_func = (sol, ctx) -> (h1(asinh(sol.u[end])), false),
     prob_func = prob_func
 )
 
@@ -68,7 +69,7 @@ h2(z) = z^2 # == 1//10**exp(3//2*t) if h3(z) = z and  == 1//100**exp(301//100*t)
 prob = SDEProblem(f2, g2, u₀, tspan)
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (h2(sol.u[end][1]), false),
+    output_func = (sol, ctx) -> (h2(sol.u[end][1]), false),
     prob_func = prob_func
 )
 
@@ -105,7 +106,7 @@ h3(z) = z^2 # but apply it only to u[1]
 prob = SDEProblem(f3, g3, u₀, tspan, noise_rate_prototype = zeros(2, 2))
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (h3(sol.u[end][1]), false),
+    output_func = (sol, ctx) -> (h3(sol.u[end][1]), false),
     prob_func = prob_func
 )
 
@@ -141,7 +142,7 @@ h1(z) = z^3 - 6 * z^2 + 8 * z
 prob = SDEProblem(f1!, g1!, u₀, tspan)
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (h1(asinh(sol.u[end][1])), false),
+    output_func = (sol, ctx) -> (h1(asinh(sol.u[end][1])), false),
     prob_func = prob_func
 )
 
@@ -177,7 +178,7 @@ h2(z) = z^2 # == 1//10**exp(3//2*t) if h3(z) = z and  == 1//100**exp(301//100*t)
 prob = SDEProblem(f2!, g2!, u₀, tspan)
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (h2(sol.u[end][1]), false),
+    output_func = (sol, ctx) -> (h2(sol.u[end][1]), false),
     prob_func = prob_func
 )
 
@@ -215,7 +216,7 @@ h3(z) = z^2 # but apply it only to u[1]
 prob = SDEProblem(f3!, g3!, u₀, tspan, noise_rate_prototype = zeros(2, 2))
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (h3(sol.u[end][1]), false),
+    output_func = (sol, ctx) -> (h3(sol.u[end][1]), false),
     prob_func = prob_func
 )
 

--- a/lib/StochasticDiffEqWeak/test/weak_convergence/iri1_weak.jl
+++ b/lib/StochasticDiffEqWeak/test/weak_convergence/iri1_weak.jl
@@ -8,7 +8,7 @@ using Random
 
 seed = 103478
 function prob_func(prob, ctx)
-    i = ctx.i; repeat = ctx.repeat
+    i = ctx.sim_id; repeat = ctx.repeat
     return remake(prob, seed = seeds[i])
 end
 

--- a/lib/StochasticDiffEqWeak/test/weak_convergence/iri1_weak.jl
+++ b/lib/StochasticDiffEqWeak/test/weak_convergence/iri1_weak.jl
@@ -7,7 +7,8 @@ using StochasticDiffEqWeak, DiffEqDevTools, Test
 using Random
 
 seed = 103478
-function prob_func(prob, i, repeat)
+function prob_func(prob, ctx)
+    i = ctx.i; repeat = ctx.repeat
     return remake(prob, seed = seeds[i])
 end
 
@@ -33,7 +34,7 @@ seeds = rand(UInt, numtraj)
 prob = SDEProblem(f, g, u₀, tspan)
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (h1(asinh(sol.u[end])), false),
+    output_func = (sol, ctx) -> (h1(asinh(sol.u[end])), false),
     prob_func = prob_func
 )
 

--- a/lib/StochasticDiffEqWeak/test/weak_convergence/srk_weak_diagonal_final.jl
+++ b/lib/StochasticDiffEqWeak/test/weak_convergence/srk_weak_diagonal_final.jl
@@ -11,7 +11,8 @@ using Random
 using DiffEqDevTools
 #using DiffEqGPU
 seed = 103473
-function prob_func(prob, i, repeat)
+function prob_func(prob, ctx)
+    i = ctx.i; repeat = ctx.repeat
     return remake(prob, seed = seeds[i])
 end
 
@@ -38,7 +39,7 @@ h3(z) = z^2 # == 1//10**exp(3//2*t) if h3(z) = z and  == 1//100**exp(301//100*t)
 prob = SDEProblem(f3!, g3!, u₀, tspan)
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (h3(sol.u[end][1]), false),
+    output_func = (sol, ctx) -> (h3(sol.u[end][1]), false),
     prob_func = prob_func
 )
 

--- a/lib/StochasticDiffEqWeak/test/weak_convergence/srk_weak_diagonal_final.jl
+++ b/lib/StochasticDiffEqWeak/test/weak_convergence/srk_weak_diagonal_final.jl
@@ -12,7 +12,7 @@ using DiffEqDevTools
 #using DiffEqGPU
 seed = 103473
 function prob_func(prob, ctx)
-    i = ctx.i; repeat = ctx.repeat
+    i = ctx.sim_id; repeat = ctx.repeat
     return remake(prob, seed = seeds[i])
 end
 

--- a/lib/StochasticDiffEqWeak/test/weak_convergence/srk_weak_final.jl
+++ b/lib/StochasticDiffEqWeak/test/weak_convergence/srk_weak_final.jl
@@ -12,7 +12,7 @@ using DiffEqDevTools
 #using DiffEqGPU
 seed = 103473
 function prob_func(prob, ctx)
-    i = ctx.i; repeat = ctx.repeat
+    i = ctx.sim_id; repeat = ctx.repeat
     return remake(prob, seed = seeds[i])
 end
 

--- a/lib/StochasticDiffEqWeak/test/weak_convergence/srk_weak_final.jl
+++ b/lib/StochasticDiffEqWeak/test/weak_convergence/srk_weak_final.jl
@@ -11,7 +11,8 @@ using Random
 using DiffEqDevTools
 #using DiffEqGPU
 seed = 103473
-function prob_func(prob, i, repeat)
+function prob_func(prob, ctx)
+    i = ctx.i; repeat = ctx.repeat
     return remake(prob, seed = seeds[i])
 end
 
@@ -38,7 +39,7 @@ seeds = rand(UInt, numtraj)
 prob = SDEProblem(f, g, u₀, tspan)
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (h1(asinh(sol.u[end])), false),
+    output_func = (sol, ctx) -> (h1(asinh(sol.u[end])), false),
     prob_func = prob_func
 )
 
@@ -164,7 +165,7 @@ h1(z) = z^3 - 6 * z^2 + 8 * z
 prob = SDEProblem(f1!, g1!, u₀, tspan)
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (h1(asinh(sol.u[end][1])), false),
+    output_func = (sol, ctx) -> (h1(asinh(sol.u[end][1])), false),
     prob_func = prob_func
 )
 

--- a/lib/StochasticDiffEqWeak/test/weak_convergence/srk_weak_final_non_diagonal.jl
+++ b/lib/StochasticDiffEqWeak/test/weak_convergence/srk_weak_final_non_diagonal.jl
@@ -12,7 +12,7 @@ using DiffEqDevTools
 #using DiffEqGPU
 
 function prob_func(prob, ctx)
-    i = ctx.i; repeat = ctx.repeat
+    i = ctx.sim_id; repeat = ctx.repeat
     return remake(prob, seed = seeds[i])
 end
 

--- a/lib/StochasticDiffEqWeak/test/weak_convergence/srk_weak_final_non_diagonal.jl
+++ b/lib/StochasticDiffEqWeak/test/weak_convergence/srk_weak_final_non_diagonal.jl
@@ -11,7 +11,8 @@ using Random
 using DiffEqDevTools
 #using DiffEqGPU
 
-function prob_func(prob, i, repeat)
+function prob_func(prob, ctx)
+    i = ctx.i; repeat = ctx.repeat
     return remake(prob, seed = seeds[i])
 end
 
@@ -40,7 +41,7 @@ h2(z) = z^2 # but apply it only to u[1]
 prob = SDEProblem(f2!, g2!, u₀, tspan, noise_rate_prototype = zeros(2, 2))
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (h2(sol.u[end][1]), false),
+    output_func = (sol, ctx) -> (h2(sol.u[end][1]), false),
     prob_func = prob_func
 )
 

--- a/lib/StochasticDiffEqWeak/test/weak_convergence/weak_strat.jl
+++ b/lib/StochasticDiffEqWeak/test/weak_convergence/weak_strat.jl
@@ -13,7 +13,8 @@ using Random
 using DiffEqDevTools
 #using DiffEqGPU
 
-function prob_func(prob, i, repeat)
+function prob_func(prob, ctx)
+    i = ctx.i; repeat = ctx.repeat
     return remake(prob, seed = seeds[i])
 end
 
@@ -40,7 +41,7 @@ seeds = rand(UInt, numtraj)
 prob = SDEProblem(f, g, u₀, tspan, p)
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (h1(sol.u[end]), false),
+    output_func = (sol, ctx) -> (h1(sol.u[end]), false),
     prob_func = prob_func
 )
 
@@ -117,7 +118,7 @@ dts = 1 .// 2 .^ (5:-1:0)
 prob = SDEProblem(f!, g!, [u₀], tspan, p)
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (h1(sol.u[end][1]), false),
+    output_func = (sol, ctx) -> (h1(sol.u[end][1]), false),
     prob_func = prob_func
 )
 
@@ -209,7 +210,7 @@ h3(z) = z^2 # == 1//10**exp(3//2*t) if h3(z) = z and  == 1//100**exp(301//100*t)
 prob = SDEProblem(f3!, g3!, u₀, tspan)
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (h3(sol.u[end][1]), false),
+    output_func = (sol, ctx) -> (h3(sol.u[end][1]), false),
     prob_func = prob_func
 )
 

--- a/lib/StochasticDiffEqWeak/test/weak_convergence/weak_strat.jl
+++ b/lib/StochasticDiffEqWeak/test/weak_convergence/weak_strat.jl
@@ -14,7 +14,7 @@ using DiffEqDevTools
 #using DiffEqGPU
 
 function prob_func(prob, ctx)
-    i = ctx.i; repeat = ctx.repeat
+    i = ctx.sim_id; repeat = ctx.repeat
     return remake(prob, seed = seeds[i])
 end
 

--- a/lib/StochasticDiffEqWeak/test/weak_convergence/weak_strat_non_diagonal.jl
+++ b/lib/StochasticDiffEqWeak/test/weak_convergence/weak_strat_non_diagonal.jl
@@ -16,7 +16,7 @@ using DiffEqDevTools
 seed = 137475
 
 function prob_func(prob, ctx)
-    i = ctx.i; repeat = ctx.repeat
+    i = ctx.sim_id; repeat = ctx.repeat
     return remake(prob, seed = seeds[i])
 end
 

--- a/lib/StochasticDiffEqWeak/test/weak_convergence/weak_strat_non_diagonal.jl
+++ b/lib/StochasticDiffEqWeak/test/weak_convergence/weak_strat_non_diagonal.jl
@@ -15,7 +15,8 @@ using DiffEqDevTools
 
 seed = 137475
 
-function prob_func(prob, i, repeat)
+function prob_func(prob, ctx)
+    i = ctx.i; repeat = ctx.repeat
     return remake(prob, seed = seeds[i])
 end
 
@@ -44,7 +45,7 @@ h2(z) = z^2 # E(x_i) = 1/10 exp(1/2t) or E(x_1* x_2) = 1/100 exp(2t)
 prob = SDEProblem(f2!, g2!, u₀, tspan, noise_rate_prototype = zeros(2, 2))
 ensemble_prob = EnsembleProblem(
     prob;
-    output_func = (sol, i) -> (h2(sol.u[end][1]), false),
+    output_func = (sol, ctx) -> (h2(sol.u[end][1]), false),
     prob_func = prob_func
 )
 


### PR DESCRIPTION
## Summary

Sweeps `lib/*/test/` for the three test-code breakages called out in `NEWS.md` v7 section that were surfacing on the #3499 CI run. All tests now parse clean under Julia 1.11 (`Meta.parseall` over all 21 modified files); no source code changed.

## Changes

### 1. `tuples(integrator)` / `intervals(integrator)` / `TimeChoiceIterator` — removed in SciMLBase v3

NEWS: *`tuples()`, `intervals()` iterator functions → iterate over `sol.u` / `sol.t` directly; `TimeChoiceIterator` removed*.

- `lib/DelayDiffEq/test/integrators/iterator.jl` — `for (u, t) in tuples(integrator)` → `for integ in integrator; @test … integ.t …`; `intervals(integrator)` iteration → read `integ.tprev` / `integ.uprev`; `TimeChoiceIterator(integrator4, ts)` → manual `step!` + interpolation loop (same pattern the top-level `test/integrators/iterator_tests.jl` already uses).
- `lib/StochasticDiffEq/test/tstops_tests.jl` — same `tuples` → `for integ in integrator` rewrite.

### 2. Ensemble function signatures: `(prob, i, repeat)` → `(prob, ctx)`, `(sol, i)` → `(sol, ctx)`

NEWS: *ctx::EnsembleContext; ctx.i, ctx.repeat, ctx.rng*.

Rewrote 15 files (4 in DiffEqBase/test/downstream/, 2 in DiffEqDevTools, 9 across StochasticDiffEq/StochasticDiffEqWeak weak-convergence + adaptive suites). For `function` / `function <name>(…)` / `<name> = function (…)` forms that reference `i` or `repeat` in the body, a `i = ctx.i; repeat = ctx.repeat` shim is inserted as the first body line so existing logic compiles unchanged. For arrow forms whose bodies don't reference `i` (the SDE weak-convergence tests just return `(h(sol.u[end]), false)`), the change is just the parameter rename.

### 3. `lib/DiffEqDevTools/Project.toml` — bump stale `[compat]`

- `ODEProblemLibrary = "0.1"` → `"1"`  (registered at v1.5.0)
- `SDEProblemLibrary = "0.1"` → `"1"`  (registered at v1.2.0)
- `OrdinaryDiffEq = "6, 7"` → `"7"`  (single-major per the earlier #3501 convention)

The `0.1` pins were predating the DiffEqBase v7 line and blocking `test (DiffEqDevTools, 1)` / `test (DiffEqDevTools_QA, 1)` with `empty intersection` / `Unsatisfiable requirements` errors.

## What's intentionally NOT in scope

These classes of CI failures on #3499 are unrelated to the v7 API migration and belong in separate PRs (most are ecosystem packages I can't fix from here):

- **LTS (Julia 1.10) failures** — resolver can't see `[sources]`; need DiffEqBase 7 / OrdinaryDiffEqCore 4 (now registered on General) to propagate.
- **Enzyme `EnzymeRuntimeActivityError`** on Rosenbrock tests — Enzyme-side issue.
- **Mooncake vs SciMLSensitivity resolver conflict** on `test (AD, 1.11)` — needs SciMLSensitivity's Mooncake compat widening.
- **`DynamicQuantities zero(Quantity)` not defined** on `Downstream` — DynamicQuantities-side.
- **`MultiScaleArrays` / `ComponentArrays` vs RAT v4** on `DiffEqBase_Downstream` / `OrdinaryDiffEqDifferentiation_Sparse` — needs those packages to widen their RecursiveArrayTools compat.
- **Self-hosted runner "expected package GPUArraysCore to be registered"** on `test (InterfaceIII, 1)` — local registry issue on a specific runner.

## Test plan

- [x] `Meta.parseall` on all 21 modified .jl files — clean.
- [x] Manual spot-check of ensemble bodies that reference `i` or `repeat` — each has the `i = ctx.i[;  repeat = ctx.repeat]` binding inserted.
- [ ] Full CI matrix on this branch.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>