### PR TITLE
Fix StochasticDiffEq v7 regressions: BoundsError in calculate_solution_errors! under RecursiveArrayTools v4

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.0.0"
+version = "4.0.1"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/lib/OrdinaryDiffEqCore/src/solve.jl
+++ b/lib/OrdinaryDiffEqCore/src/solve.jl
@@ -11,6 +11,74 @@ Base.@constprop :aggressive function SciMLBase.__solve(
     return integrator.sol
 end
 
+# ----------------------------------------------------------------------------
+# _calculate_solution_errors!
+#
+# Thin wrapper around `SciMLBase.calculate_solution_errors!` that works around
+# an upstream bug in SciMLBase v3 on top of RecursiveArrayTools v4.
+#
+# RecursiveArrayTools v4 removed the
+#   `Base.length(VA::AbstractVectorOfArray) = length(VA.u)`
+# specialization. `length(sol)` now falls back to `prod(size(sol))`, i.e. the
+# number of scalar entries across the entire timeseries — not the number of
+# saved time points.
+#
+# SciMLBase's `calculate_solution_errors!(::AbstractRODESolution)` iterates
+# `for i in 1:length(sol)` and indexes `sol.t[i]` / `sol.W[:, i]`, which
+# overruns those arrays for any non-scalar state and throws a `BoundsError`
+# in the final `solve!` postamble on SDE/RODE problems.
+#
+# We special-case RODE solutions here: reimplement the error-fill loop with
+# the correct bound `length(sol.t)` and then delegate the scalar reductions
+# back to SciMLBase by calling the upstream function with
+# `fill_uanalytic = false`.
+#
+# For non-RODE solutions (ODE/DAE), forward to SciMLBase unchanged.
+# ----------------------------------------------------------------------------
+function _calculate_solution_errors!(sol; kwargs...)
+    return SciMLBase.calculate_solution_errors!(sol; kwargs...)
+end
+
+function _calculate_solution_errors!(
+        sol::SciMLBase.AbstractRODESolution; fill_uanalytic = true,
+        timeseries_errors = true, dense_errors = true
+    )
+    f = sol.prob.f isa Tuple ? sol.prob.f[1] : sol.prob.f
+
+    if fill_uanalytic
+        empty!(sol.u_analytic)
+        if f isa SciMLBase.RODEFunction && f.analytic_full == true
+            f.analytic(sol)
+        elseif sol.W isa RecursiveArrayTools.AbstractDiffEqArray{T, N, nothing} where {T, N}
+            for i in 1:length(sol.t)
+                push!(
+                    sol.u_analytic,
+                    f.analytic(
+                        sol.prob.u0, sol.prob.p, sol.t[i], first(sol.W(sol.t[i]))
+                    )
+                )
+            end
+        else
+            for i in 1:length(sol.t)
+                push!(
+                    sol.u_analytic,
+                    f.analytic(sol.prob.u0, sol.prob.p, sol.t[i], sol.W[:, i])
+                )
+            end
+        end
+    end
+
+    # Delegate the norm/L^p reductions to SciMLBase with fill_uanalytic=false
+    # so it doesn't re-enter the buggy loop above.
+    SciMLBase.calculate_solution_errors!(
+        sol;
+        fill_uanalytic = false,
+        timeseries_errors,
+        dense_errors
+    )
+    return nothing
+end
+
 determine_controller_datatype(u::AbstractVector{<:Number}, internalnorm, ts::Tuple{<:Number, <:Number}) = promote_type(typeof(DiffEqBase.value(internalnorm(u, ts[1]))), typeof(DiffEqBase.value(internalnorm(u, ts[2]))), eltype(DiffEqBase.value.(ts)))
 determine_controller_datatype(u, internalnorm, ts::Tuple{<:Number, <:Number}) = promote_type(typeof(DiffEqBase.value(ts[1])), typeof(DiffEqBase.value(ts[2]))) # This seems to be an assumption implicitly taken somewhere
 determine_controller_datatype(u::AbstractVector{<:Number}, internalnorm, ts::Tuple{<:Integer, <:Integer}) = promote_type(typeof(DiffEqBase.value(internalnorm(u, ts[1]))), typeof(DiffEqBase.value(internalnorm(u, ts[2]))), eltype(float.(DiffEqBase.value(ts))))
@@ -788,7 +856,7 @@ function SciMLBase.solve!(integrator::ODEIntegrator)
     f = f isa Tuple ? f[1] : f
 
     if SciMLBase.has_analytic(f)
-        SciMLBase.calculate_solution_errors!(
+        _calculate_solution_errors!(
             integrator.sol;
             timeseries_errors = integrator.opts.timeseries_errors,
             dense_errors = integrator.opts.dense_errors


### PR DESCRIPTION
## Summary

Five StochasticDiffEq CI groups on PR #3502 are failing on Julia 1.x / 1.11 / pre with the same `BoundsError` at `SciMLBase/src/solutions/rode_solutions.jl:221` during the `solve!` postamble:

- `test (StochasticDiffEq_Interface1, 1 / 1.11 / pre)` — `Mass matrix tests` (`mass_matrix_tests.jl`, `ImplicitRKMil`, `101-element Vector{Float64} at index [102]`)
- `test (StochasticDiffEq_Interface2, 1 / 1.11 / pre)` — `Two-dimensional Linear SDE Tests` (`sde_twodimlinear_tests.jl`, `EM`, `9-element Vector at index [10]`)
- `test (StochasticDiffEq_Interface3, 1 / 1.11 / pre)` — `Composite Tests` (`77-element Vector at index [78]`)
- `test (StochasticDiffEq_AlgConvergence2, 1)` — `IIF Convergence Tests` (`11-element Vector at index [12]`)
- `test (StochasticDiffEq_AlgConvergence3, 1)` — `ODE Convergence Regression Tests` (`3-element Vector at index [4]`)
- `test (StochasticDiffEq_NoncommutativeConvergence, 1, self-hosted, high-memory)` — `Noncommutative Noise Tests` (`257-element Vector at index [258]`)

All six hit the same root cause.

## Root cause

SciMLBase v3's `calculate_solution_errors!(::AbstractRODESolution)` still does:
```julia
for i in 1:length(sol)
    push!(sol.u_analytic, f.analytic(sol.prob.u0, sol.prob.p, sol.t[i], sol.W[:, i]))
end
```

RecursiveArrayTools v4 (documented breaking change, see `NEWS.md` RAT migration table) removed the specialization

```julia
Base.length(VA::AbstractVectorOfArray) = length(VA.u)
```

so `length(sol)` now falls back to `prod(size(sol))` — the total number of scalar entries across the whole timeseries, **not** the number of saved time points. For any non-scalar SDE state the loop overruns `sol.t` / `sol.W` and throws a `BoundsError` as soon as a problem with an analytic solution is solved.

Example (three-component mass-matrix SDE, `dt = 0.01`, `tspan = (0, 1)`):
```
length(sol)    = 303   # 3 components × 101 saved timesteps
length(sol.t)  = 101
length(sol.W)  = 101
```
The loop runs to `i = 303`, hits `sol.W[:, 102]`, and aborts.

## Fix

Route the call in `OrdinaryDiffEqCore.solve!` through a local `_calculate_solution_errors!` that special-cases `AbstractRODESolution`:

- reimplement the `sol.u_analytic` fill loop with the correct bound `length(sol.t)`,
- delegate the scalar-reduction tail (`l∞` / `l2` / `L∞` / `L2` and dense errors) back to SciMLBase by calling the upstream function with `fill_uanalytic = false`, so the norms stay in one place,
- fall through unchanged for ODE/DAE solutions.

Bump `OrdinaryDiffEqCore` 4.0.0 → 4.0.1.

Local reproduction before and after the fix:
```julia
using StochasticDiffEq, LinearAlgebra
mm_A = [-2.0 1 4; 4 -2 1; 2 1 3]; mm_b = mm_A * ones(3)
mm_f(du,u,p,t) = (mul!(du, mm_A, u); du .+= t .* mm_b)
mm_analytic(u0,p,t,W) = 2 .* ones(3) .* exp.(t) .- t .- 1
g!(du,u,p,t) = (du .= 0)

prob = SDEProblem(SDEFunction(mm_f, g!; analytic=mm_analytic, mass_matrix=mm_A),
                  ones(3), (0.0, 1.0))
solve(prob, ImplicitRKMil(theta=1), dt=0.01, adaptive=false)
# Before: BoundsError: attempt to access 101-element Vector{Float64} at index [102]
# After:  length(sol.t) = 101, errors = Dict(:l∞ => 0.0274…, :final => 0.0274…, :l2 => 0.0128…)
```

This is also an upstream SciMLBase bug; a separate fix should be submitted there, after which this wrapper becomes a no-op and can be removed. Keeping it here unblocks the v7 release.

## Test plan

- [x] Local reproduction of `mass_matrix_tests.jl` now passes (three-state `ImplicitRKMil`, two variants with/without `symplectic`, two variants with `ImplicitEM`).
- [x] Local reproduction on scalar SDE (`EM`, `dt = 1/10`) — `l∞`, `l2`, `final` errors computed correctly.
- [ ] `StochasticDiffEq_Interface1` (1 / 1.11 / pre) — CI
- [ ] `StochasticDiffEq_Interface2` (1 / 1.11 / pre) — CI
- [ ] `StochasticDiffEq_Interface3` (1 / 1.11 / pre) — CI
- [ ] `StochasticDiffEq_AlgConvergence2` (1) — CI
- [ ] `StochasticDiffEq_AlgConvergence3` (1) — CI
- [ ] `StochasticDiffEq_NoncommutativeConvergence` (1) — CI
- [ ] Confirm no ODE/DAE regressions in CI (`_calculate_solution_errors!` forwards unchanged for non-RODE solutions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)