### PR TITLE
NEWS: before/after code example for StochasticDelayDiffEq → DelayDiffEq migration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -379,3 +379,15 @@ Same theme as the ODE side — all of the following break identically to the ODE
 `StochasticDelayDiffEq.jl` is deprecated. Use `DelayDiffEq.jl` directly — it has supported SDDE problems for some time, and the separate `StochasticDelayDiffEq` wrapper is no longer being maintained. It will not receive a v7-compatible release.
 
 **Migration:** replace `using StochasticDelayDiffEq` with `using DelayDiffEq` (plus `using StochasticDiffEq` if you were relying on the SDE algorithm re-exports). `MethodOfSteps(alg)` and the `SDDEProblem` constructor continue to work from `DelayDiffEq` / `SciMLBase` respectively.
+
+```julia
+# v6
+using StochasticDelayDiffEq
+prob = SDDEProblem(f, g, u0, h, tspan; constant_lags = [1.0])
+sol = solve(prob, RKMil())
+
+# v7
+using DelayDiffEq, StochasticDiffEq
+prob = SDDEProblem(f, g, u0, h, tspan; constant_lags = [1.0])
+sol = solve(prob, MethodOfSteps(RKMil()))
+```

--- a/NEWS.md
+++ b/NEWS.md
@@ -378,7 +378,7 @@ Same theme as the ODE side — all of the following break identically to the ODE
 
 `StochasticDelayDiffEq.jl` is deprecated. Use `DelayDiffEq.jl` directly — it has supported SDDE problems for some time, and the separate `StochasticDelayDiffEq` wrapper is no longer being maintained. It will not receive a v7-compatible release.
 
-**Migration:** replace `using StochasticDelayDiffEq` with `using DelayDiffEq` (plus `using StochasticDiffEq` if you were relying on the SDE algorithm re-exports). `MethodOfSteps(alg)` and the `SDDEProblem` constructor continue to work from `DelayDiffEq` / `SciMLBase` respectively.
+**Migration:** replace `using StochasticDelayDiffEq` with `using DelayDiffEq` (plus `using StochasticDiffEq` if you were relying on the SDE algorithm re-exports). `SDDEProblem` continues to work from `SciMLBase`; bare SDE algorithms are auto-wrapped in `MethodOfSteps` (no explicit wrap required on either the DDE or SDDE path).
 
 ```julia
 # v6
@@ -389,5 +389,5 @@ sol = solve(prob, RKMil())
 # v7
 using DelayDiffEq, StochasticDiffEq
 prob = SDDEProblem(f, g, u0, h, tspan; constant_lags = [1.0])
-sol = solve(prob, MethodOfSteps(RKMil()))
+sol = solve(prob, RKMil())  # auto-wrapped as MethodOfSteps(RKMil()) — DelayDiffEq.jl:99
 ```

--- a/lib/DiffEqBase/src/callbacks.jl
+++ b/lib/DiffEqBase/src/callbacks.jl
@@ -1,7 +1,9 @@
 """
-    initialize!(cb::CallbackSet,u,t,integrator::DEIntegrator)
+    initialize!(cb::CallbackSet, u, t, integrator::DEIntegrator)
 
-Recursively apply `initialize!` and return whether any modified u
+Recursively apply `initialize!` to every callback in `cb` and return
+`true` if any of them signaled a derivative discontinuity (i.e. set
+`integrator.derivative_discontinuity = true`).
 """
 function initialize!(cb::CallbackSet, u, t, integrator::DEIntegrator)
     return initialize!(
@@ -26,9 +28,10 @@ function initialize!(
 end
 
 """
-    finalize!(cb::CallbackSet,u,t,integrator::DEIntegrator)
+    finalize!(cb::CallbackSet, u, t, integrator::DEIntegrator)
 
-Recursively apply `finalize!` and return whether any modified u
+Recursively apply `finalize!` to every callback in `cb` and return
+`true` if any of them signaled a derivative discontinuity.
 """
 function finalize!(cb::CallbackSet, u, t, integrator::DEIntegrator)
     return finalize!(u, t, integrator, false, cb.continuous_callbacks..., cb.discrete_callbacks...)


### PR DESCRIPTION
## Summary

Adds a concrete 2-block before/after code example to the `StochasticDelayDiffEq deprecated` section of `NEWS.md`, showing how to port

```julia
using StochasticDelayDiffEq
sol = solve(prob, RKMil())
```

to

```julia
using DelayDiffEq, StochasticDiffEq
sol = solve(prob, MethodOfSteps(RKMil()))
```

The `SDDEProblem` constructor signature is unchanged; only the solver wrapper is.

## Why also now

This is the right trivial change to kick the full CI matrix since #3502, #3505, and #3507 all landed — test migrations, DelayDiffEq source fixes (jac wrapper, SDDE dispatch restoration, `get_fsalfirstlast` piracy moved to StochasticDiffEqCore), and DiffEqDevTools test env. Want to see the post-fix failure surface on master.

Pure docs; no source or Project.toml changes.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>