### PR TITLE
Fix OrdinaryDiffEqExplicitTableaus test env [sources] path to top-level OrdinaryDiffEq

### DIFF
--- a/lib/OrdinaryDiffEqExplicitTableaus/Project.toml
+++ b/lib/OrdinaryDiffEqExplicitTableaus/Project.toml
@@ -16,12 +16,12 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
 DiffEqDevTools = {path = "../DiffEqDevTools"}
-OrdinaryDiffEq = {path = "../OrdinaryDiffEq"}
+OrdinaryDiffEq = {path = "../.."}
 
 [compat]
 DiffEqBase = "7"
 DiffEqDevTools = "3"
-ODEProblemLibrary = "0.1"
+ODEProblemLibrary = "1"
 OrdinaryDiffEq = "6, 7"
 Test = "<0.0.1, 1"
 julia = "1.10"


### PR DESCRIPTION
## Summary

- The `[sources]` entry for `OrdinaryDiffEq` in `lib/OrdinaryDiffEqExplicitTableaus/Project.toml` pointed at `../OrdinaryDiffEq`, which resolves to `lib/OrdinaryDiffEq` — but `OrdinaryDiffEq` is the **top-level** of the monorepo, not a sibling sublibrary. This made both `test (OrdinaryDiffEqExplicitTableaus, …)` and `test (OrdinaryDiffEqExplicitTableaus_QA, …)` fail on PR #3508 with:
  ```
  ERROR: expected package `OrdinaryDiffEq [1dea7af3]` to exist at path `…/lib/OrdinaryDiffEq`
  ```
- Fix: point the source at `../..` (repo root), matching the working pattern in `lib/DiffEqDevTools/Project.toml` and `lib/StochasticDiffEq/Project.toml`.
- Also bump `[compat] ODEProblemLibrary` from `"0.1"` to `"1"`. Every other sublibrary already pins `ODEProblemLibrary = "1"`; the old `0.1` compat is incompatible with the v7 `OrdinaryDiffEq` / `DiffEqBase 7` chain and would leave the resolver failing even after the path fix.

## Scope

- Strictly scoped to the path + compat issues that cause these two CI cells to fail before any test code runs.
- Real test-code errors surfaced afterward (`UndefVarError: Heun`, `ExplicitRK`, etc.) are separate v7 migration issues and are out of scope.

## Verification

- Grepped every `lib/*/**/Project.toml` for `path = "../OrdinaryDiffEq"` — only this one sublibrary had the bug.
- `julia --project=. -e 'using Pkg; Pkg.activate("lib/OrdinaryDiffEqExplicitTableaus"); Pkg.instantiate()'` — succeeds.
- `Pkg.test("OrdinaryDiffEqExplicitTableaus")` now resolves and proceeds to actual test execution (was previously failing before any test code ran).

## Test plan

- [ ] `test (OrdinaryDiffEqExplicitTableaus, 1, ubuntu-latest, 120, 1)` gets past env setup on CI
- [ ] `test (OrdinaryDiffEqExplicitTableaus_QA, 1, ubuntu-latest, 120, 1)` gets past env setup on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)