### PR TITLE
Fix "cannot evaluate norm recursively" in LowStorageRK / SSPRK under RAT v4

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.0.0"
+version = "4.0.1"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
+++ b/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
@@ -15,7 +15,7 @@ import Logging: @logmsg, LogLevel
 
 using MuladdMacro: @muladd
 
-using LinearAlgebra: opnorm, I, UniformScaling, diag, rank, isdiag
+using LinearAlgebra: LinearAlgebra, norm, opnorm, I, UniformScaling, diag, rank, isdiag
 
 import PrecompileTools
 

--- a/lib/OrdinaryDiffEqCore/src/misc_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/misc_utils.jl
@@ -46,6 +46,67 @@ end
 
 error_constant(integrator, order) = error_constant(integrator, integrator.alg, order)
 
+# `isapprox` for timeseries solutions.
+#
+# The generic `Base.isapprox(::AbstractArray, ::AbstractArray)` computes
+# `norm(x - y) <= max(atol, rtol*max(norm(x), norm(y)))`. When an
+# `AbstractTimeseriesSolution` (e.g. `ODESolution`) is iterated via the
+# `AbstractArray` fallback, iteration can yield an object whose type equals the
+# container type (because the solution subtypes `AbstractVectorOfArray{T,N}` and
+# its leaf container is a `VectorOfArray` whose `eltype` resolves to a scalar
+# while the iterator itself yields an array-like element). Under
+# `RecursiveArrayTools` v4 / Julia 1.12, `LinearAlgebra.norm(itr)` first calls
+# `norm_recursive_check` which throws
+#   ArgumentError: cannot evaluate norm recursively if the type of the initial
+#   element is identical to that of the container
+# for these nested / `StructArray`-backed storages. Compare snapshot-by-snapshot
+# instead, which also sidesteps the cross-container-type issue when comparing
+# solutions whose element storage differs (e.g. `Vector{SVector}` vs
+# `StructArray{SVector}`).
+function Base.isapprox(
+        x::SciMLBase.AbstractTimeseriesSolution,
+        y::SciMLBase.AbstractTimeseriesSolution;
+        atol::Real = 0,
+        rtol::Real = Base.rtoldefault(
+            _cmp_eltype(x), _cmp_eltype(y), atol
+        ),
+        nans::Bool = false,
+        norm = LinearAlgebra.norm
+    )
+    length(x.u) == length(y.u) || return false
+    isapprox(x.t, y.t; atol = atol, rtol = rtol, nans = nans) || return false
+    for i in eachindex(x.u)
+        _isapprox_snapshot(x.u[i], y.u[i]; atol, rtol, nans, norm) || return false
+    end
+    return true
+end
+
+# Element-wise comparison of solution snapshots. Snapshots may be plain arrays
+# or `VectorOfArray`s. Compare by reducing to a materialised numeric array whose
+# `eltype` is a scalar or small static vector, so `LinearAlgebra.norm` does not
+# recurse into a container whose element type equals itself.
+_isapprox_snapshot(a, b; kwargs...) = isapprox(a, b; kwargs...)
+function _isapprox_snapshot(
+        a::RecursiveArrayTools.AbstractVectorOfArray,
+        b::RecursiveArrayTools.AbstractVectorOfArray;
+        kwargs...
+    )
+    return _isapprox_materialised(_snapshot_array(a), _snapshot_array(b); kwargs...)
+end
+
+_snapshot_array(a) = a
+_snapshot_array(a::RecursiveArrayTools.AbstractVectorOfArray) = _snapshot_array(parent(a))
+
+# Materialise into `Array` so we don't rely on arithmetic dispatch for exotic
+# backing types (e.g. `StructArray{<:SVector}`), which can produce a container
+# whose eltype equals its own type under `-`.
+function _isapprox_materialised(a::AbstractArray, b::AbstractArray; kwargs...)
+    size(a) == size(b) || return false
+    return isapprox(collect(a), collect(b); kwargs...)
+end
+
+_cmp_eltype(sol::SciMLBase.AbstractTimeseriesSolution) = recursive_bottom_eltype(sol.u)
+
 abstract type AbstractThreadingOption end
 struct Sequential <: AbstractThreadingOption end
 struct BaseThreads <: AbstractThreadingOption end


### PR DESCRIPTION
## Summary

- Fixes the two failing test jobs on PR #3508 (post-merge of #3502/#3505/#3507):
  - `test (OrdinaryDiffEqLowStorageRK, 1, ubuntu-latest, …)` (job `72604636568`)
  - `test (OrdinaryDiffEqSSPRK, 1, ubuntu-latest, …)` (job `72604636663`)
- Both testsets failed at the `VectorOfArray/StructArray compatibility` block with:
  > `ArgumentError: cannot evaluate norm recursively if the type of the initial element is identical to that of the container`

## Root cause

The failing assertion in both suites is `@test sol_SA ≈ sol_SV`, where `sol_SA` and `sol_SV` are `ODESolution`s whose internal `u` storage is a `Vector{VectorOfArray{Float64, 2, StructVector{SVector{1,Float64},…}}}` vs `Vector{VectorOfArray{Float64, 2, Vector{SVector{1,Float64}}}}`. `ODESolution <: AbstractVectorOfArray <: AbstractArray`, so the generic `LinearAlgebra.isapprox(::AbstractArray, ::AbstractArray)` fallback calls `norm(sol)`. On Julia 1.12 + RecursiveArrayTools v4, `norm` now routes through a stricter `norm_recursive_check`, which throws for this container shape because `AbstractArray` iteration yields the solution itself (`iterate(sol)[1] === sol`) when the leaf storage is a `StructArray{<:SVector}`-backed `VectorOfArray`. No OrdinaryDiffEq solver code appears on the failing stack — `solve` completes fine for both storages; the failure is purely in `≈` at the test site.

## Fix

- Add `Base.isapprox(x::AbstractTimeseriesSolution, y::AbstractTimeseriesSolution)` in `lib/OrdinaryDiffEqCore/src/misc_utils.jl`. It:
  - checks trajectory lengths and compares `x.t ≈ y.t`,
  - iterates `x.u` / `y.u` snapshot-by-snapshot and delegates to `isapprox` on leaves,
  - materialises `VectorOfArray` / `StructArray` snapshots (via `parent(...)` + `collect`) into plain `Array`s before the inner `isapprox`, so `LinearAlgebra.norm` never sees a container whose element type equals itself.
- Import `LinearAlgebra.norm` (and the `LinearAlgebra` module) in `OrdinaryDiffEqCore`.
- Bump `OrdinaryDiffEqCore` to `4.0.1`.

The scalar and `Vector{Float64}` comparison paths still dispatch to `isapprox` on the raw snapshot, so the existing `@test sol_old.u[end] ≈ sol_new.u[end]` assertions elsewhere in the LowStorageRK / SSPRK tests are untouched.

**Tests were not removed, disabled, marked `@test_broken`, or commented out.**

## Test plan

Locally on Julia `1.12.6` (matching CI), monorepo `Pkg.develop`ed against this branch:

- [x] `OrdinaryDiffEqLowStorageRK` `VectorOfArray/StructArray compatibility` testset: **16/16 pass** (was 15 pass / 1 error on master).
- [x] `OrdinaryDiffEqSSPRK` `VectorOfArray/StructArray compatibility` testset: **2/2 pass** (was 1 pass / 1 error on master).
- [x] Pre-fix reproducer (same test code, on master tip `72052c030`) confirms the `ArgumentError: cannot evaluate norm recursively …` with stack trace identical to the CI failure.
- [ ] Full CI on this PR (LowStorageRK + SSPRK + rest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)