### PR TITLE
Fix DelayDiffEq QA + ImplicitDiscreteSolve + FunctionMap post-v7

### DIFF
--- a/lib/DelayDiffEq/src/DelayDiffEq.jl
+++ b/lib/DelayDiffEq/src/DelayDiffEq.jl
@@ -23,8 +23,7 @@ import SymbolicIndexingInterface as SII
 using SciMLBase: AbstractDDEAlgorithm, AbstractDDEIntegrator, AbstractODEIntegrator,
     DEIntegrator
 using SciMLBase: AbstractSDDEProblem, SDDEProblem
-using SciMLBase: ProblemSolverPairingError, DirectAutodiffError, eltypedual,
-    isautodifferentiable
+using SciMLBase: ProblemSolverPairingError
 
 using Base: deleteat!
 import FastBroadcast: @..
@@ -33,8 +32,7 @@ using OrdinaryDiffEqNonlinearSolve: NLAnderson, NLFunctional
 using OrdinaryDiffEqCore: AbstractNLSolverCache, SlowConvergence,
     alg_extrapolates, alg_maximum_order, initialize!
 using OrdinaryDiffEqCore: StochasticDiffEqAlgorithm,
-    StochasticDiffEqRODEAlgorithm,
-    StochasticDiffEqConstantCache, StochasticDiffEqMutableCache
+    StochasticDiffEqRODEAlgorithm
 using OrdinaryDiffEqRosenbrock: RosenbrockMutableCache
 using OrdinaryDiffEqFunctionMap: FunctionMap
 # using OrdinaryDiffEqDifferentiation: resize_grad_config!, resize_jac_config!

--- a/lib/ImplicitDiscreteSolve/src/ImplicitDiscreteSolve.jl
+++ b/lib/ImplicitDiscreteSolve/src/ImplicitDiscreteSolve.jl
@@ -10,6 +10,7 @@ import OrdinaryDiffEqCore: OrdinaryDiffEqAlgorithm, alg_cache, OrdinaryDiffEqMut
     alg_order, beta2_default, beta1_default, dt_required,
     _initialize_dae!, DefaultInit, BrownFullBasicInit, OverrideInit,
     @muladd, @.., _unwrap_val, OrdinaryDiffEqCore, isadaptive,
+    allows_null_u0,
     AbstractController, AbstractControllerCache
 
 using Reexport

--- a/lib/OrdinaryDiffEqFunctionMap/Project.toml
+++ b/lib/OrdinaryDiffEqFunctionMap/Project.toml
@@ -15,6 +15,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 [extras]
 ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+OrdinaryDiffEqLowOrderRK = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -24,6 +25,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
 DiffEqDevTools = {path = "../DiffEqDevTools"}
+OrdinaryDiffEqLowOrderRK = {path = "../OrdinaryDiffEqLowOrderRK"}
 
 [compat]
 Pkg = "1"
@@ -36,6 +38,7 @@ SciMLBase = "3"
 ODEProblemLibrary = "1"
 OrdinaryDiffEq = "7"
 OrdinaryDiffEqCore = "4"
+OrdinaryDiffEqLowOrderRK = "1.5.0"
 julia = "1.10"
 RecursiveArrayTools = "4"
 DiffEqBase = "7"
@@ -43,7 +46,7 @@ SafeTestsets = "0.1.0"
 Reexport = "1.2"
 
 [targets]
-test = ["DiffEqDevTools", "ODEProblemLibrary", "OrdinaryDiffEq", "Random", "SafeTestsets", "Test", "Pkg"]
+test = ["DiffEqDevTools", "ODEProblemLibrary", "OrdinaryDiffEq", "OrdinaryDiffEqLowOrderRK", "Random", "SafeTestsets", "Test", "Pkg"]
 
 [sources.OrdinaryDiffEq]
 path = "../.."

--- a/lib/OrdinaryDiffEqFunctionMap/test/discrete_algorithm_test.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/test/discrete_algorithm_test.jl
@@ -1,4 +1,6 @@
 using OrdinaryDiffEq, Test
+using OrdinaryDiffEqFunctionMap: FunctionMap
+using OrdinaryDiffEqLowOrderRK: Euler
 using SciMLBase: DiscreteProblem, DiscreteFunction
 using ODEProblemLibrary: prob_ode_2Dlinear, prob_ode_linear
 


### PR DESCRIPTION
Three independent sublibrary regressions left over after #3502/#3505/#3507. The `DelayDiffEq_SDDE` Hayes-adaptive-stepping failure that was originally in this PR has been split off to #3515 so its resolution (error-estimator fix vs. `adaptive = false` workaround) can be decided separately without blocking the three clean fixes below.

### 1. DelayDiffEq QA — 5 stale explicit imports

`check_no_stale_explicit_imports` flagged five now-unused symbols in `lib/DelayDiffEq/src/DelayDiffEq.jl`: `DirectAutodiffError`, `eltypedual`, `isautodifferentiable`, `StochasticDiffEqConstantCache`, `StochasticDiffEqMutableCache`.

- The first three were never actually used in source. `alg_utils.jl` defines `SciMLBase.isautodifferentiable(alg::AbstractMethodOfStepsAlgorithm) = SciMLBase.isautodifferentiable(alg.alg)` — that's a fully-qualified access and doesn't need the bare import.
- The two SDE cache types became stale when a871b2e3a moved the `get_fsalfirstlast` overrides out to `StochasticDiffEqCore` — that was the only site in DelayDiffEq's `src/` referencing them. `qa_tests.jl` still imports these SDE cache types directly from `OrdinaryDiffEqCore` for the piracy allowlist, so that test keeps working.

### 2. ImplicitDiscreteSolve — missing import of `allows_null_u0`

`lib/ImplicitDiscreteSolve/src/alg_utils.jl:25` defines `allows_null_u0(alg::IDSolve) = true` without importing the function. That creates a *new* `allows_null_u0` local to `ImplicitDiscreteSolve` rather than adding a method to `OrdinaryDiffEqCore.allows_null_u0`, so the dispatch in `OrdinaryDiffEqCore/src/solve.jl:253` always sees the default `false` and coerces `u0 === nothing` to `Float64[]`. The `alg_cache(::Nothing, ...)` bypass path is never reached, and the test hits `ArgumentError: chunk size cannot be greater than ForwardDiff.structural_length(x) (1 > 0)` from NonlinearSolve trying to build a 0x1 Jacobian. Import `allows_null_u0` from `OrdinaryDiffEqCore` in the main module's `import` list.

### 3. OrdinaryDiffEqFunctionMap — unqualified `FunctionMap` / `Euler`

`test/discrete_algorithm_test.jl` uses `using OrdinaryDiffEq, Test` and expects `FunctionMap` and `Euler` to be in scope. In v7, `OrdinaryDiffEq` stopped re-exporting solver names — `src/OrdinaryDiffEq.jl` exports only a small curated set: `Tsit5`, `Vern*`, `Rosenbrock23`, `Rodas5P`, `FBDF`, `DefaultODEAlgorithm`. Add explicit `using OrdinaryDiffEqFunctionMap: FunctionMap` and `using OrdinaryDiffEqLowOrderRK: Euler`, and add `OrdinaryDiffEqLowOrderRK` to `[extras]` / `[sources]` / `[compat]` / `[targets].test` in the sublibrary's `Project.toml`. `OrdinaryDiffEqFunctionMap` is already the package-under-test so is available without an extras entry. The sibling `discrete_problem_defaults.jl` already uses this explicit-import pattern (line 7: `const FunctionMap = OrdinaryDiffEqFunctionMap.FunctionMap`).

## Validation (local, Julia 1.12.6)

- `ODEDIFFEQ_TEST_GROUP=QA Pkg.test("DelayDiffEq")` — QA Tests **14/14**
- `ODEDIFFEQ_TEST_GROUP=Core Pkg.test("ImplicitDiscreteSolve")` — Implicit Euler 2/2, Solver initializes 16/16, Hard problem 1/1, Handle nothing in u0 2/2, Create NonlinearLeastSquaresProblem 3/3, Null u0 bypasses NonlinearSolve **3/3**, InitialFailure thrown 3/3
- `ODEDIFFEQ_TEST_GROUP=Core Pkg.test("OrdinaryDiffEqFunctionMap")` — DiscreteProblem Defaults 21/21, Discrete Algorithm Tests **14/14**

No test was disabled and no `@test_broken` was added.

## Test plan

- [x] Three failing sublibrary groups pass on 1.12.6 locally
- [ ] CI confirms on `lts`, `1.11`, `1`, `pre`

🤖 Generated with [Claude Code](https://claude.com/claude-code)