### PR TITLE
Drop Threaded group from ALL in ABM test runner

### DIFF
--- a/lib/OrdinaryDiffEqAdamsBashforthMoulton/test/runtests.jl
+++ b/lib/OrdinaryDiffEqAdamsBashforthMoulton/test/runtests.jl
@@ -19,12 +19,15 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "Adams Variable Coefficients Tests" include("adams_tests.jl")
 end
 
-# Threaded tests require Polyester.jl (for FastBroadcast.Threaded() support)
-if TEST_GROUP == "Threaded" || TEST_GROUP == "ALL"
+# Threaded tests require Polyester.jl (for FastBroadcast.Threaded() support).
+# Runs only on explicit `ODEDIFFEQ_TEST_GROUP=Threaded` — the SublibraryCI
+# matrix (lib/OrdinaryDiffEqAdamsBashforthMoulton/test/test_groups.toml)
+# schedules this as its own Julia 1 / 2-thread job. Matches the GPU-group
+# convention in sibling sublibs (LowStorageRK, Rosenbrock, BDF).
+if TEST_GROUP == "Threaded"
     activate_threaded_env()
     @time @safetestset "ABM Threaded Convergence Tests" include("threaded/abm_threaded_convergence_tests.jl")
     @time @safetestset "Regression test for threading versions vs non threading versions" include("threaded/regression_test_threading.jl")
-    Pkg.activate(ORIGINAL_PROJECT)
 end
 
 # Run QA tests (AllocCheck, JET, Aqua) - skip on pre-release Julia


### PR DESCRIPTION
## Summary

`lib/OrdinaryDiffEqAdamsBashforthMoulton/test/runtests.jl:27` called `Pkg.activate(ORIGINAL_PROJECT)` to restore the outer env after `activate_threaded_env()`, but `ORIGINAL_PROJECT` was never defined. Every CI run with `ODEDIFFEQ_TEST_GROUP=Threaded` (which the SublibraryCI matrix schedules explicitly) or `=ALL` errored immediately after the threaded testsets with `UndefVarError: ORIGINAL_PROJECT not defined in Main`.

## Fix

Match the convention used by the other per-group sub-envs in the monorepo (`LowStorageRK` / `Rosenbrock` / `BDF` `GPU` groups; `NonlinearSolve` `ModelingToolkit` group): those groups only fire on explicit `ODEDIFFEQ_TEST_GROUP=<name>` requests from the matrix, and never re-activate the outer project after their sub-env runs.

- Drop `|| TEST_GROUP == "ALL"` from the Threaded conditional. The `Threaded` entry in `lib/OrdinaryDiffEqAdamsBashforthMoulton/test/test_groups.toml` (Julia 1, `num_threads = 2`) already schedules it as its own job.
- Remove the `Pkg.activate(ORIGINAL_PROJECT)` restoration line. No other sublib does this.

## Test plan

- [ ] `test (OrdinaryDiffEqAdamsBashforthMoulton_Threaded, 1, ubuntu-latest, 120, 2)` passes on CI
- [ ] `test (OrdinaryDiffEqAdamsBashforthMoulton, …)` (Core / QA) continues to pass — unaffected by this change