### PR TITLE
Add ImplicitDiscreteSolve [sources] entry to MTK test env for v7 resolve

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
+ImplicitDiscreteSolve = "3263718b-31ed-49cf-8a0f-35a466e8af96"
 IncompleteLU = "40713840-3770-5561-ab4c-a76e7d0d7895"
 LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -12,6 +13,7 @@ OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
+ImplicitDiscreteSolve = {path = "../../../ImplicitDiscreteSolve"}
 OrdinaryDiffEq = {path = "../../../.."}
 OrdinaryDiffEqBDF = {path = "../../../OrdinaryDiffEqBDF"}
 OrdinaryDiffEqNonlinearSolve = {path = "../.."}
@@ -19,6 +21,7 @@ OrdinaryDiffEqSDIRK = {path = "../../../OrdinaryDiffEqSDIRK"}
 
 [compat]
 DiffEqDevTools = "3"
+ImplicitDiscreteSolve = "1.11"
 IncompleteLU = "0.2"
 LinearSolve = "3"
 ModelingToolkit = "10.10, 11"


### PR DESCRIPTION
## Summary

The `OrdinaryDiffEqNonlinearSolve_ModelingToolkit` test group fails to resolve on CI. MTK 11.22.0 (first registered version that admits `SciMLBase v3`) pulls in `ImplicitDiscreteSolve` as a transitive dep, but the **registered** `ImplicitDiscreteSolve 1.11.0` still caps `SciMLBase` at `"2.116.0 - 2"`. Combined with OrdinaryDiffEq's `SciMLBase = "3"` pin, the resolver eliminates every MTK version and errors out:

```
ImplicitDiscreteSolve [3263718b] log:
  ├─possible versions are: 0.1.0 - 1.11.0 or uninstalled
  └─restricted by compatibility requirements with SciMLBase [0bca4576] to versions: uninstalled
```

The monorepo's local `lib/ImplicitDiscreteSolve/Project.toml` already has `SciMLBase = "3"` but hasn't been registered yet.

## Fix

Point the MTK test env at the local copy via `[sources]`. This mirrors the pattern used for `OrdinaryDiffEq` / `OrdinaryDiffEqBDF` / `OrdinaryDiffEqNonlinearSolve` / `OrdinaryDiffEqSDIRK` in the same file. Verified locally: resolver picks MTK 11.22.0 + SciMLBase 3.4.0 + local IDS 1.11.0.

A proper IDS 1.12.0 release with widened `SciMLBase` compat is the permanent fix, but this unblocks the test env in the interim.

## Test plan

- [x] Local `Pkg.resolve()` in `lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/` succeeds (MTK 11.22.0, SciMLBase 3.4.0)
- [ ] CI passes on `test (OrdinaryDiffEqNonlinearSolve_ModelingToolkit, 1)`