### PR TITLE
Restore PIController default for SDE-implicit solvers (fixes Hayes SDDE)

### DIFF
--- a/lib/StochasticDiffEqImplicit/Project.toml
+++ b/lib/StochasticDiffEqImplicit/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqImplicit"
 uuid = "5080b986-4c76-4669-b5dc-373a41579d5b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/StochasticDiffEqImplicit/src/StochasticDiffEqImplicit.jl
+++ b/lib/StochasticDiffEqImplicit/src/StochasticDiffEqImplicit.jl
@@ -4,7 +4,7 @@ using Reexport
 @reexport using StochasticDiffEqCore
 
 import OrdinaryDiffEqCore
-import OrdinaryDiffEqCore: perform_step!, initialize!, issplit, default_controller, PredictiveController
+import OrdinaryDiffEqCore: perform_step!, initialize!, issplit, default_controller, PIController
 
 import StochasticDiffEqCore: alg_cache, alg_order, alg_compatible,
     alg_needs_extra_process, is_split_step, supports_regular_jumps, isadaptive,

--- a/lib/StochasticDiffEqImplicit/src/alg_utils.jl
+++ b/lib/StochasticDiffEqImplicit/src/alg_utils.jl
@@ -5,14 +5,6 @@ alg_order(alg::ISSEM) = 1 // 2
 alg_order(alg::ISSEulerHeun) = 1 // 2
 alg_order(alg::SKenCarp) = 2 // 1
 
-# SDE error estimates are noisy. `PredictiveController.step_reject_controller!`
-# does `dt_new = success_iter == 0 ? 0.1dt : dt / qold` — a monotonic shrink
-# that collapses `dt` under a noisy stochastic error estimate (especially
-# through `MethodOfSteps` where history-interpolation discontinuities
-# compound the signal noise). `PIController` uses the gentler
-# `dt *= max(qmin, min(1, qacc))` on rejection, which is what all six of
-# these solvers were defaulted to pre-#3485 via `ispredictive` being `false`
-# for every `StochasticDiffEqAlgorithm`.
 default_controller(QT, alg::ImplicitEM) = PIController(QT, alg)
 default_controller(QT, alg::ImplicitEulerHeun) = PIController(QT, alg)
 default_controller(QT, alg::ImplicitRKMil) = PIController(QT, alg)

--- a/lib/StochasticDiffEqImplicit/src/alg_utils.jl
+++ b/lib/StochasticDiffEqImplicit/src/alg_utils.jl
@@ -5,12 +5,20 @@ alg_order(alg::ISSEM) = 1 // 2
 alg_order(alg::ISSEulerHeun) = 1 // 2
 alg_order(alg::SKenCarp) = 2 // 1
 
-default_controller(QT, alg::ImplicitEM) = PredictiveController(QT, alg)
-default_controller(QT, alg::ImplicitEulerHeun) = PredictiveController(QT, alg)
-default_controller(QT, alg::ImplicitRKMil) = PredictiveController(QT, alg)
-default_controller(QT, alg::ISSEM) = PredictiveController(QT, alg)
-default_controller(QT, alg::ISSEulerHeun) = PredictiveController(QT, alg)
-default_controller(QT, alg::SKenCarp) = PredictiveController(QT, alg)
+# SDE error estimates are noisy. `PredictiveController.step_reject_controller!`
+# does `dt_new = success_iter == 0 ? 0.1dt : dt / qold` — a monotonic shrink
+# that collapses `dt` under a noisy stochastic error estimate (especially
+# through `MethodOfSteps` where history-interpolation discontinuities
+# compound the signal noise). `PIController` uses the gentler
+# `dt *= max(qmin, min(1, qacc))` on rejection, which is what all six of
+# these solvers were defaulted to pre-#3485 via `ispredictive` being `false`
+# for every `StochasticDiffEqAlgorithm`.
+default_controller(QT, alg::ImplicitEM) = PIController(QT, alg)
+default_controller(QT, alg::ImplicitEulerHeun) = PIController(QT, alg)
+default_controller(QT, alg::ImplicitRKMil) = PIController(QT, alg)
+default_controller(QT, alg::ISSEM) = PIController(QT, alg)
+default_controller(QT, alg::ISSEulerHeun) = PIController(QT, alg)
+default_controller(QT, alg::SKenCarp) = PIController(QT, alg)
 
 supports_regular_jumps(::ImplicitEM) = true
 isadaptive(prob::JumpProblem, alg::ImplicitEM) = false


### PR DESCRIPTION
## Summary

Supersedes the `adaptive = false` workaround in #3515. Fixes the real regression.

#3485 ("Remove legacy controller traits and dead code") flipped six SDE-implicit solvers (`ImplicitEM`, `ImplicitEulerHeun`, `ImplicitRKMil`, `ISSEM`, `ISSEulerHeun`, `SKenCarp`) from the legacy `PIController` default to a hard-coded `PredictiveController` at `lib/StochasticDiffEqImplicit/src/alg_utils.jl:8-13`. Before #3485, every `StochasticDiffEqAlgorithm` had `ispredictive = false`, which `legacy_default_controller` translated into `PIController`.

`PredictiveController.step_reject_controller!` does:

```julia
dt_new = success_iter == 0 ? 0.1 * dt : dt / qold
```

— a monotonic shrink that collapses `dt` under noisy stochastic error estimates. `PIController.step_reject_controller!` is gentler:

```julia
dt *= max(qmin, min(1, qacc))
```

## How we got here

Under `MethodOfSteps(ISSEulerHeun())` on the Hayes SDDE regression test (#3363), the history-interpolation discontinuities compound the stochastic signal noise. The `PredictiveController` rejects every step, `dt` collapses within ~40 inner steps, and the solve aborts with `DtLessThanMin`. ISSEM (Itô, mean-zero `dW²-dt` estimator) also inflated from 34 → 572 steps on SDDE vs. the non-delay SDE — that observation **falsifies** the "Stratonovich estimator bias" hypothesis an earlier investigation landed on: this is a controller-kind issue, not a numerics issue.

## Bisection

First-bad commit `dc50962c6` (merge of #3485). Patching the six `default_controller` entries back to `PIController` restores pre-regression step counts exactly on the Hayes SDDE:

| Method | Pre-#3485 | Master (bad) | With this PR |
|---|---|---|---|
| `ImplicitEM` | 21 | 21 | 21 |
| `ISSEM` | 174 | 572 | 174 |
| `ImplicitEulerHeun` | 2638 | 575 (inflated) | 2638 |
| `ISSEulerHeun` | 2339 | **`DtLessThanMin` @ t≈0.02** | 2339 |

Matches the baseline the Hayes test was originally validated against on `fork/fix-sdde-support`.

## Verified locally

Julia 1.12.6, full DelayDiffEq `SDDE` test group:

- Problem/Solution Tests: 16/16
- Event Tests: 2/2
- Non-diagonal Sparse Noise Tests: 2/2
- **Implicit Method Tests: 12/12**

No test was disabled and no `@test_broken` was added.

## Follow-up

Closes #3515 (the `adaptive = false` workaround is no longer needed). The `MethodOfSteps × implicit-split` history interaction that my earlier investigation pointed at turned out to be downstream of this root cause — with `PIController` back, the interaction is handled correctly.

Bumps `StochasticDiffEqImplicit` to 1.2.1 (patch — behavior-preserving restoration of the pre-#3485 default controller).

## Test plan

- [x] Full `ODEDIFFEQ_TEST_GROUP=SDDE Pkg.test("DelayDiffEq")` passes on Julia 1.12.6
- [ ] CI confirms across Julia versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)