### PR TITLE
Document @max_methods 1 rationale (trigger full SublibraryCI matrix)

### DIFF
--- a/lib/DiffEqBase/src/DiffEqBase.jl
+++ b/lib/DiffEqBase/src/DiffEqBase.jl
@@ -1,4 +1,11 @@
 module DiffEqBase
+
+# `@max_methods 1` constrains method-table resolution to a single matching
+# method per call site. For `DiffEqBase`'s heavily-overloaded interface
+# functions (`solve`, `init`, `step!`, `ODE_DEFAULT_NORM`, etc.) this keeps
+# latency proportional to the number of dispatches actually used rather than
+# the full cross-product of all `AbstractSciMLAlgorithm` × `AbstractSciMLProblem`
+# combinations across the ecosystem.
 if isdefined(Base, :Experimental) &&
         isdefined(Base.Experimental, Symbol("@max_methods"))
     @eval Base.Experimental.@max_methods 1


### PR DESCRIPTION
## Summary

No-op behavior change: just a comment explaining why `DiffEqBase` opts into `Base.Experimental.@max_methods 1`. The real purpose of this PR is to trigger the full SublibraryCI matrix against the newly-registered upstream dependency versions.

## Why

`.github/workflows/SublibraryCI.yml` is dependency-graph-driven (via `.github/scripts/compute_affected_sublibraries.jl`): it only runs sublibs that sit downstream of a changed `lib/*/src/` file. The recent master merges each touched only specific sublibs:

- #3516 / #3520 → `OrdinaryDiffEqAdamsBashforthMoulton` only
- #3519 → `StochasticDiffEqImplicit` (propagated to StochasticDiffEq* sublibs)
- #3512 → `DiffEqDevTools` + some QA test files

So **no single master CI run since the v7 merge has exercised the full 56-sublib matrix** against the latest registered deps:

- `SciMLBase 3.4.2` — RODE scalar-noise `calculate_solution_errors!` fix (#1324)
- `FunctionWrappersWrappers` v1.7.x — Enzyme `set_runtime_activity` propagation fix (#45)
- `ModelingToolkit 11.22.0` — SciMLBase v3 compat
- `BoundaryValueDiffEq 5.22.0` — DiffEqBase v7 compat
- `SciMLBase 3.4.1` — DAEProblem `{iip, specialize}` constructor (#1323)

Touching `lib/DiffEqBase/src/DiffEqBase.jl` triggers DiffEqBase's own Core + QA matrix on 4 Julia versions plus all 52 direct reverse deps on Julia 1 — close to a full v7 sweep.

## Comment added

```julia
# `@max_methods 1` constrains method-table resolution to a single matching
# method per call site. For `DiffEqBase`'s heavily-overloaded interface
# functions (`solve`, `init`, `step!`, `ODE_DEFAULT_NORM`, etc.) this keeps
# latency proportional to the number of dispatches actually used rather than
# the full cross-product of all `AbstractSciMLAlgorithm` × `AbstractSciMLProblem`
# combinations across the ecosystem.
```

The rationale is genuinely useful to document — the `@max_methods 1` line is the kind of thing future contributors might delete without knowing what it guards.

## Test plan

- [ ] CI matrix size > 50 entries (confirms full sublib fan-out)
- [ ] No unexpected failures surface