### PR TITLE
Stabilize sparse algebraic detection complexity test against CI jitter

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/test/sparse_algebraic_detection_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/sparse_algebraic_detection_tests.jl
@@ -50,14 +50,21 @@ using OrdinaryDiffEqNonlinearSolve: find_algebraic_vars_eqs
         find_algebraic_vars_eqs(M_small)
         find_algebraic_vars_eqs(M_large)
 
-        # Measure
-        t_small = @elapsed for _ in 1:10
-            find_algebraic_vars_eqs(M_small)
+        # Measure using best-of-N to reduce scheduler / GC noise on shared runners.
+        # Ratio still reflects algorithmic complexity: O(n^2) would yield a ratio
+        # near 16 even with the minimum, while O(nnz) = O(n) yields ~4.
+        function _best_time(f, M)
+            best = Inf
+            for _ in 1:5
+                t = @elapsed for _ in 1:10
+                    f(M)
+                end
+                best = min(best, t)
+            end
+            return best
         end
-
-        t_large = @elapsed for _ in 1:10
-            find_algebraic_vars_eqs(M_large)
-        end
+        t_small = _best_time(find_algebraic_vars_eqs, M_small)
+        t_large = _best_time(find_algebraic_vars_eqs, M_large)
 
         ratio = t_large / t_small
         size_ratio = n_large / n_small  # 4x size increase
@@ -67,8 +74,10 @@ using OrdinaryDiffEqNonlinearSolve: find_algebraic_vars_eqs
         # Allow some tolerance for measurement noise
         @test ratio < size_ratio * 2  # Should be closer to linear than quadratic
 
-        # Absolute sanity check: processing 40k diagonal shouldn't take > 100ms
-        t_single = @elapsed find_algebraic_vars_eqs(M_large)
+        # Absolute sanity check: processing 40k diagonal shouldn't take > 100ms.
+        # Use minimum of a few runs for the same reason (single @elapsed can be
+        # dominated by a stray GC pause on shared CI runners).
+        t_single = minimum(@elapsed(find_algebraic_vars_eqs(M_large)) for _ in 1:5)
         @test t_single < 0.1  # Should be < 100ms, typically < 1ms
     end
 


### PR DESCRIPTION
## Summary

- The `Complexity O(nnz) not O(n^2)` test in `lib/OrdinaryDiffEqNonlinearSolve/test/sparse_algebraic_detection_tests.jl` flakes on shared / self-hosted runners (observed `ratio = 9.25` against a threshold of `8.0` in the #3521 Sublibrary CI matrix at https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/24835707691/job/72695421388), even though the underlying `find_algebraic_vars_eqs(::SparseMatrixCSC)` is genuinely `O(nnz)`.
- At sub-millisecond wall times, a single `@elapsed` call is easily dominated by GC / scheduler jitter on the small-matrix baseline, which inflates the ratio.
- Switched both the scaling and absolute-time measurements to the minimum of several repeats (standard Julia microbenchmarking practice). The `< size_ratio * 2 == 8` threshold and the `< 100ms` absolute gate are unchanged, so a real `O(n^2)` regression (which would drive the ratio toward 16) would still fail the test.

## Evidence

On master, across 50 back-to-back trials of the original measurement locally, the worst observed ratio was 5.5; median ~5. The CI-reported 9.25 was a noise spike, not an algorithmic regression.

Profile of `find_algebraic_vars_eqs` on a 40k diagonal confirms `O(nnz)` behavior: the hot paths are the CSC inner loop (`M.nzval[idx]`, `M.rowval[idx]`) and the `fill!` for the result Bool arrays — all linear in `n` for a diagonal matrix.

## Test plan

- [x] Run `sparse_algebraic_detection_tests.jl` repeatedly (8 consecutive invocations) on Julia 1.12.6 — all pass.
- [ ] CI (Sublibrary `test (OrdinaryDiffEqNonlinearSolve, 1, ...)`) turns green.

Refs: #3521 (trigger-full-sublib-ci)

Generated with [Claude Code](https://claude.com/claude-code)