### PR TITLE
Add DormandPrince (DP5) tableau to OrdinaryDiffEqExplicitTableaus

### DIFF
--- a/lib/OrdinaryDiffEqExplicitTableaus/src/OrdinaryDiffEqExplicitTableaus.jl
+++ b/lib/OrdinaryDiffEqExplicitTableaus/src/OrdinaryDiffEqExplicitTableaus.jl
@@ -3,7 +3,7 @@ module OrdinaryDiffEqExplicitTableaus
 import DiffEqBase
 
 include("tableaus_low_order.jl")   # Orders 1-4: Euler, Heun, RK4, SSPRK, etc.
-include("tableaus_order5.jl")      # Order 5: RKF5, Tsitouras5, BogakiShampine5, CashKarp, etc.
+include("tableaus_order5.jl")      # Order 5: DormandPrince (DP5), RKF5, Tsitouras5, BogakiShampine5, CashKarp, etc.
 include("tableaus_order6.jl")      # Order 6: Butcher6, Verner6, DormandPrince6, etc.
 include("tableaus_order7.jl")      # Order 7: Verner7, EnrightVerner7, SharpSmart7, etc.
 include("tableaus_order8_9.jl")    # Orders 8-9: CooperVerner8, DormandPrince8, Verner9, etc.

--- a/lib/OrdinaryDiffEqExplicitTableaus/src/tableaus_order5.jl
+++ b/lib/OrdinaryDiffEqExplicitTableaus/src/tableaus_order5.jl
@@ -1,4 +1,42 @@
 """
+    DormandPrince()
+
+Constructs the tableau object for the Dormand-Prince Order 4/5 method (DP5).
+"""
+function DormandPrince(::Type{T} = Float64, ::Type{T_time} = T) where {T, T_time}
+    A = [
+        0 0 0 0 0 0 0
+        1 // 5 0 0 0 0 0 0
+        3 // 40 9 // 40 0 0 0 0 0
+        44 // 45 -56 // 15 32 // 9 0 0 0 0
+        19372 // 6561 -25360 // 2187 64448 // 6561 -212 // 729 0 0 0
+        9017 // 3168 -355 // 33 46732 // 5247 49 // 176 -5103 // 18656 0 0
+        35 // 384 0 500 // 1113 125 // 192 -2187 // 6784 11 // 84 0
+    ]
+    c = [0; 1 // 5; 3 // 10; 4 // 5; 8 // 9; 1; 1]
+    α = [35 // 384; 0; 500 // 1113; 125 // 192; -2187 // 6784; 11 // 84; 0]
+    αEEst = [
+        5179 // 57600,
+        0,
+        7571 // 16695,
+        393 // 640,
+        -92097 // 339200,
+        187 // 2100,
+        1 // 40,
+    ]
+    A = map(T, A)
+    α = map(T, α)
+    αEEst = map(T, αEEst)
+    c = map(T_time, c)
+    return (
+        DiffEqBase.ExplicitRKTableau(
+            A, c, α, 5, αEEst = αEEst, adaptiveorder = 4,
+            fsal = true, stability_size = 3.3066
+        )
+    )
+end
+
+"""
 Runge-Kutta-Fehlberg Order 4/5 method.
 """
 function RKF5(::Type{T} = Float64, ::Type{T_time} = T) where {T, T_time}


### PR DESCRIPTION
## Summary

- Add `DormandPrince()` (the order-5 Dormand-Prince / DP5 tableau) to `OrdinaryDiffEqExplicitTableaus` so the tests resolve.
- Fixes `UndefVarError: DormandPrince not defined in OrdinaryDiffEqExplicitTableaus` in `test (OrdinaryDiffEqExplicitTableaus, 1)` and `test (OrdinaryDiffEqExplicitTableaus_QA, 1)` (observed on #3521).

## Background

`lib/OrdinaryDiffEqExplicitTableaus/test/runtests.jl` (lines 10, 37) and `test/ode_tableau_convergence_tests.jl` (line 92) reference `ET.DormandPrince()` expecting the order-5 tableau, but only `DormandPrince6` and `DormandPrince8` were defined in the sublibrary after the `construct*`-prefix rename (commit 1753f05709).

Historically, `constructDormandPrince` (the bare, order-5 DP5 tableau) was kept in `OrdinaryDiffEqExplicitRK/src/algorithms.jl` because it's the default `ODE_DEFAULT_TABLEAU`. When the rest of the tableaus migrated to the new sublibrary it was not copied across, but the tests assume it's available there.

This PR copies the DP5 tableau verbatim from `OrdinaryDiffEqExplicitRK.constructDormandPrince` into `lib/OrdinaryDiffEqExplicitTableaus/src/tableaus_order5.jl` as `DormandPrince(T, T_time)`. The order-5 test in `ode_tableau_convergence_tests.jl` explicitly compares the result against `DP5()` (which uses the same coefficients), so this is the intended tableau.

## Test plan

- [x] `julia +1.12.6 --project=lib/OrdinaryDiffEqExplicitTableaus -e 'using Pkg; Pkg.test("OrdinaryDiffEqExplicitTableaus")'` — the `UndefVarError: DormandPrince` errors in the "Basic tableau construction", "Two-type construction", and "ODE Tableau Convergence Tests" testsets are gone (15 passes → 32 passes). Remaining errors are unrelated pre-existing scoping issues (`using OrdinaryDiffEq` inside `@testset begin` blocks) and are out of scope here.
- [x] Local smoke: `ET.DormandPrince().order == 5`, `eltype(ET.DormandPrince(BigFloat, Float64).A) == BigFloat`, `eltype(...).c) == Float64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)