### PR TITLE
test(SDE): fix length(sol) overrun in #1121 saveat+ContinuousCallback test

### DIFF
--- a/lib/StochasticDiffEq/test/events_test.jl
+++ b/lib/StochasticDiffEq/test/events_test.jl
@@ -175,8 +175,11 @@ using Random
         maxiters = Int(1.0e10), callback = cb_test
     )
 
-    # Compare saveat values with dense solution sampled at same times
-    phase_saveat = [sol_saveat.u[i][2] for i in 1:length(sol_saveat)]
+    # Compare saveat values with dense solution sampled at same times.
+    # Use `length(sol_saveat.u)` (number of saved timepoints) rather than
+    # `length(sol_saveat)`, since the latter follows the standard
+    # `AbstractArray` convention `prod(size(sol))` in RecursiveArrayTools 4.x.
+    phase_saveat = [sol_saveat.u[i][2] for i in 1:length(sol_saveat.u)]
     phase_dense_sampled = [sol_dense(t)[2] for t in sol_saveat.t]
 
     # The values should match to machine precision

--- a/lib/StochasticDiffEq/test/events_test.jl
+++ b/lib/StochasticDiffEq/test/events_test.jl
@@ -176,9 +176,6 @@ using Random
     )
 
     # Compare saveat values with dense solution sampled at same times.
-    # Use `length(sol_saveat.u)` (number of saved timepoints) rather than
-    # `length(sol_saveat)`, since the latter follows the standard
-    # `AbstractArray` convention `prod(size(sol))` in RecursiveArrayTools 4.x.
     phase_saveat = [sol_saveat.u[i][2] for i in 1:length(sol_saveat.u)]
     phase_dense_sampled = [sol_dense(t)[2] for t in sol_saveat.t]
 


### PR DESCRIPTION
## Summary

Fixes the `BoundsError: attempt to access 1013-element Vector{Vector{Float64}} at index [1014]` failure in `test (StochasticDiffEq_Interface3, 1)`, observed on CI run [24835707691](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/24835707691) for PR #3521.

## Root cause

The `"saveat + ContinuousCallback interpolation (issue #1121)"` testset at `lib/StochasticDiffEq/test/events_test.jl:134` built the `phase_saveat` vector with

```julia
phase_saveat = [sol_saveat.u[i][2] for i in 1:length(sol_saveat)]
```

That works on RecursiveArrayTools 3.x, which overloaded `Base.length(VA::AbstractVectorOfArray) = length(VA.u)`. RecursiveArrayTools 4.x (now resolved under Julia 1.12) dropped that overload, so `length(sol)` falls back to the AbstractArray default `prod(size(sol)) == nstates * ntimepoints == 2 * 1013 == 2026`. The comprehension then walks past the end of `sol.u` (index 1014 on a 1013-element `Vector{Vector{Float64}}`) and throws, matching the stack shown by CI (`collect_to!` → `getindex` on `sol.u`).

`SciMLBase` 3.4.2 does not change this — the regression lives in the `AbstractVectorOfArray` method table in RecursiveArrayTools 4.x, and updating only the registry to pick up SciMLBase 3.4.2 does not recover the old `length`.

## Fix

Use the semantically-correct bound `length(sol_saveat.u)` (the number of saved timepoints). This is version-agnostic: it yields `1013` under both RAT 3.x and RAT 4.x and matches the intent of the original test.

## Test plan

- [x] Reproduced the failure on Julia 1.12.6 with StochasticDiffEq from this branch + SciMLBase 3.4.2 + RecursiveArrayTools 4.2.0.
- [x] Confirmed SciMLBase 3.4.2 alone does not fix it (same `BoundsError`).
- [x] Ran the `saveat + ContinuousCallback interpolation (issue #1121)` testset locally after the fix:
  ```
  Test Summary:                                           | Pass  Total   Time
  saveat + ContinuousCallback interpolation (issue #1121) |    2      2  12.2s
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)