### PR TITLE
Fix Rodas5 UndefVarError in StochasticDiffEq Zeroed Noise safetestset

### DIFF
--- a/lib/StochasticDiffEq/Project.toml
+++ b/lib/StochasticDiffEq/Project.toml
@@ -31,6 +31,7 @@ ImplicitDiscreteSolve = {path = "../ImplicitDiscreteSolve"}
 OrdinaryDiffEq = {path = "../../"}
 OrdinaryDiffEqCore = {path = "../OrdinaryDiffEqCore"}
 OrdinaryDiffEqNonlinearSolve = {path = "../OrdinaryDiffEqNonlinearSolve"}
+OrdinaryDiffEqRosenbrock = {path = "../OrdinaryDiffEqRosenbrock"}
 StochasticDiffEqCore = {path = "../StochasticDiffEqCore"}
 StochasticDiffEqHighOrder = {path = "../StochasticDiffEqHighOrder"}
 StochasticDiffEqIIF = {path = "../StochasticDiffEqIIF"}
@@ -78,6 +79,7 @@ LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 OrdinaryDiffEqDifferentiation = "4302a76b-040a-498a-8c04-15b101fed76b"
+OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
@@ -90,4 +92,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AllocCheck", "DiffEqCallbacks", "DiffEqDevTools", "DiffEqNoiseProcess", "ForwardDiff", "JumpProcesses", "ImplicitDiscreteSolve", "LevyArea", "LinearSolve", "ModelingToolkit", "OrdinaryDiffEq", "OrdinaryDiffEqDifferentiation", "Pkg", "Random", "RecursiveArrayTools", "SciMLOperators", "SDEProblemLibrary", "SafeTestsets", "SparseArrays", "Statistics", "StaticArrays", "Test"]
+test = ["AllocCheck", "DiffEqCallbacks", "DiffEqDevTools", "DiffEqNoiseProcess", "ForwardDiff", "JumpProcesses", "ImplicitDiscreteSolve", "LevyArea", "LinearSolve", "ModelingToolkit", "OrdinaryDiffEq", "OrdinaryDiffEqDifferentiation", "OrdinaryDiffEqRosenbrock", "Pkg", "Random", "RecursiveArrayTools", "SciMLOperators", "SDEProblemLibrary", "SafeTestsets", "SparseArrays", "Statistics", "StaticArrays", "Test"]

--- a/lib/StochasticDiffEq/test/zeroed_noise_test.jl
+++ b/lib/StochasticDiffEq/test/zeroed_noise_test.jl
@@ -1,4 +1,5 @@
 using StochasticDiffEq, OrdinaryDiffEq, Test
+using OrdinaryDiffEqRosenbrock: Rodas5
 import SciMLBase
 
 function f(du, u, p, t)


### PR DESCRIPTION
## Summary

`lib/StochasticDiffEq/test/zeroed_noise_test.jl` references `Rodas5` inside a `@safetestset "Zeroed Noise Tests"` block. `@safetestset` evaluates the file in a fresh anonymous module, so bare `using OrdinaryDiffEq` doesn't help — v7's curated re-export set doesn't include `Rodas5` (only `Tsit5`, `Vern*`, `Rosenbrock23`, `Rodas5P`, `FBDF`, `DefaultODEAlgorithm`). Surfaces on CI as:

```
LoadError: UndefVarError: `Rodas5` not defined in `Main.var"##Zeroed Noise Tests#299"`
Some tests did not pass: 5 passed, 0 failed, 1 errored, 0 broken.
```

Same class of fix as #3522 (DiffEqBase downstream tests) and #3524 (DormandPrince): explicit solver import from the owning sublib.

## Fix

- Add `using OrdinaryDiffEqRosenbrock: Rodas5` to `zeroed_noise_test.jl`.
- Wire `OrdinaryDiffEqRosenbrock` through `[sources]`, `[extras]`, and `[targets].test` in `lib/StochasticDiffEq/Project.toml`.

## Test plan

- [ ] `test (StochasticDiffEq_Interface2, 1, ubuntu-latest, 120, 1)` passes on CI.