### PR TITLE
Respect explicit seed over TaskLocalRNG in SDE _resolve_rng (fixes W2Ito1 + PL1WM weak-convergence)

### DIFF
--- a/lib/StochasticDiffEqCore/Project.toml
+++ b/lib/StochasticDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqCore"
 uuid = "19c5a474-6cd1-4a5f-be79-46dc34e54d7f"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/StochasticDiffEqCore/src/solve.jl
+++ b/lib/StochasticDiffEqCore/src/solve.jl
@@ -60,6 +60,16 @@ function _resolve_rng(rng, seed, prob)
             )
         end
         if rng isa Random.TaskLocalRNG
+            # TaskLocalRNG is the ensemble-layer default, not an explicit
+            # per-trajectory RNG. If the user set an explicit seed (via the
+            # `seed` kwarg or `prob.seed`, typically from `remake(prob, seed=…)`
+            # inside `prob_func`), respect it over the TaskLocalRNG so
+            # `remake(prob, seed=s)` inside an ensemble is actually reproducible.
+            if !iszero(seed)
+                return Random.Xoshiro(seed), seed, false
+            elseif prob isa DiffEqBase.AbstractRODEProblem && !iszero(prob.seed)
+                return Random.Xoshiro(prob.seed), prob.seed, false
+            end
             _seed = rand(rng, UInt64)
             return Random.Xoshiro(_seed), _seed, true
         end


### PR DESCRIPTION
## Summary

Fixes the SciMLBase-v3 ensemble-layer regression where `remake(prob, seed = seeds[i])` inside an `EnsembleProblem.prob_func` was silently ignored for SDE trajectories — surfacing on PR #3521's SublibraryCI matrix as:

- `test (StochasticDiffEqWeak_W2Ito1WeakConvergence, 1)` at `lib/StochasticDiffEqWeak/test/weak_convergence/W2Ito1.jl:159` (IIP scalar case) — order 2.934 vs tolerance `|order - 2| < 0.35`.
- `test (StochasticDiffEqWeak_WeakConvergence1, 1)` at `lib/StochasticDiffEqWeak/test/weak_convergence/PL1WM.jl:232, 269` — same-seed PL1WM vs PL1WMA trajectories fail to match (`sim.solutions[i].u[j] ≈ sim1.solutions[i].u[j]`) and order-2 tolerance misses by 0.02.

The sibling PR agent on `agent-pl1wm` independently arrived at the same one-file fix; this PR consolidates both test failures under a single patch.

## Root cause

SciMLBase v3 renamed the ensemble solver callback to `prob_func(prob, ctx::EnsembleContext)` and introduced a per-trajectory `rng_func` pipeline (`default_rng_func` → `TaskLocalRNG`). For any solver that returns `supports_solve_rng(prob, alg) = true` (all `StochasticDiffEqAlgorithm`s, see `lib/StochasticDiffEqCore/src/alg_utils.jl:6`), the ensemble layer now passes `rng = TaskLocalRNG()` into `solve`.

Inside `_sde_init`, `_resolve_rng(rng::TaskLocalRNG, seed=0, prob)` unconditionally drew a fresh seed from `TaskLocalRNG`:

```julia
if rng isa Random.TaskLocalRNG
    _seed = rand(rng, UInt64)
    return Random.Xoshiro(_seed), _seed, true
end
```

That short-circuited `prob.seed`, even when the user had explicitly set `prob.seed = seeds[i]` via `remake(prob, seed = seeds[i])` inside `prob_func` — which is the canonical pattern used by every StochasticDiffEqWeak weak-convergence test and many downstream reproducibility tests.

Result: the per-trajectory `seeds[i]` array (carefully pre-generated from `Random.seed!(seed); rand(UInt, numtraj)`) was discarded, and every trajectory pulled its Wiener seed from the sequentially-advancing machine-level `TaskLocalRNG`. The weak-order estimate depended on process-level RNG interleaving rather than the stated seed. On `W2Ito1.jl:159` this produced a stable `W2Ito1:2.934…` (outside the `0.35` band). On `PL1WM.jl` it broke the PL1WM-vs-PL1WMA same-seed-same-trajectory reproducibility assertion.

## Fix

`lib/StochasticDiffEqCore/src/solve.jl` — inside the `rng isa Random.TaskLocalRNG` branch of `_resolve_rng`, respect an explicit non-zero `seed` kwarg or `prob.seed` before falling back to drawing from `TaskLocalRNG`:

```julia
if rng isa Random.TaskLocalRNG
    if !iszero(seed)
        return Random.Xoshiro(seed), seed, false
    elseif prob isa DiffEqBase.AbstractRODEProblem && !iszero(prob.seed)
        return Random.Xoshiro(prob.seed), prob.seed, false
    end
    _seed = rand(rng, UInt64)
    return Random.Xoshiro(_seed), _seed, true
end
```

When both the explicit `seed` and `prob.seed` are zero (the user hasn't asked for reproducibility), the existing `rand(rng, UInt64)` path is unchanged — no behavioral change for any code that wasn't already broken.

Also bumps `StochasticDiffEqCore` 1.1.0 → 1.1.1.

## Test plan

- [x] Reproduced `W2Ito1:2.934097195568081` on Julia 1.12.6 locally (matches CI digit-for-digit — confirms determinism of the broken path).
- [ ] CI StochasticDiffEqWeak_W2Ito1WeakConvergence passes.
- [ ] CI StochasticDiffEqWeak_WeakConvergence1 (PL1WM) passes.
- [ ] No new failures in other StochasticDiffEq* weak-convergence or reproducibility suites.