### PR TITLE
Fix Rosenbrock convergence-order test flakiness (Rodas6P dts + Rodas5P+Krylov tol)

### DIFF
--- a/lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl
@@ -207,9 +207,6 @@ end
 
     prob = prob_ode_linear
 
-    # Use larger dts than the default (1/2).^(6:-1:3): the linear test problem
-    # is so small that Rodas6P (order 6) hits Float64 roundoff at dt=1/64,
-    # corrupting the measured convergence slope.
     rodas6p_dts = (1 / 2) .^ (5:-1:2)
     sim = test_convergence(rodas6p_dts, prob, Rodas6P(), dense_errors = true)
     #@test sim.𝒪est[:final]≈5 atol=testTol #-- observed order > 6

--- a/lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl
@@ -207,7 +207,11 @@ end
 
     prob = prob_ode_linear
 
-    sim = test_convergence(dts, prob, Rodas6P(), dense_errors = true)
+    # Use larger dts than the default (1/2).^(6:-1:3): the linear test problem
+    # is so small that Rodas6P (order 6) hits Float64 roundoff at dt=1/64,
+    # corrupting the measured convergence slope.
+    rodas6p_dts = (1 / 2) .^ (5:-1:2)
+    sim = test_convergence(rodas6p_dts, prob, Rodas6P(), dense_errors = true)
     #@test sim.𝒪est[:final]≈5 atol=testTol #-- observed order > 6
     @test sim.𝒪est[:L2] ≈ 6 atol = testTol
 
@@ -217,7 +221,7 @@ end
 
     prob = prob_ode_2Dlinear
 
-    sim = test_convergence(dts, prob, Rodas6P(), dense_errors = true)
+    sim = test_convergence(rodas6p_dts, prob, Rodas6P(), dense_errors = true)
     #@test sim.𝒪est[:final]≈5 atol=testTol #-- observed order > 6
     @test sim.𝒪est[:L2] ≈ 6 atol = testTol
 
@@ -256,6 +260,8 @@ end
         #@test sim.𝒪est[:final]≈5 atol=testTol #-- observed order > 6
         @test sim.𝒪est[:L2] ≈ 5 atol = testTol
 
+        # Krylov linear solvers need tight tolerance for the outer-method
+        # convergence order to surface; LinearSolve now respects reltol/abstol.
         sim = test_convergence(
             dts, prob,
             Rodas5P(
@@ -264,7 +270,8 @@ end
                 ),
                 linsolve = LinearSolve.KrylovJL()
             ),
-            dense_errors = true
+            dense_errors = true,
+            reltol = 1.0e-14, abstol = 1.0e-14
         )
         #@test sim.𝒪est[:final]≈5 atol=testTol #-- observed order > 6
         @test sim.𝒪est[:L2] ≈ 5 atol = testTol
@@ -277,7 +284,8 @@ end
                 ),
                 linsolve = LinearSolve.KrylovJL_GMRES()
             ),
-            dense_errors = true
+            dense_errors = true,
+            reltol = 1.0e-14, abstol = 1.0e-14
         )
         #@test sim.𝒪est[:final]≈5 atol=testTol #-- observed order > 6
         @test sim.𝒪est[:L2] ≈ 5 atol = testTol


### PR DESCRIPTION
## Summary

Four `@test` assertions in `lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl` have been failing on #3521 (and #3520 before it):

- **L212 / L222** — `Rodas6P` on `prob_ode_linear` / `prob_ode_2Dlinear`, measured `L2 ≈ 5.44` / `5.51` vs expected `≈ 6 ± 0.2`.
- **L270 / L283** — `Rodas5P` with `KrylovJL()` / `KrylovJL_GMRES()` linsolve, measured `L2 ≈ 2.83` vs expected `≈ 5 ± 0.2`.

Both are test-setup issues, not solver regressions. Confirmed by reproducing the same 5.44/5.51 slope on the released OrdinaryDiffEqRosenbrock v1.26.0 — so this is *not* a regression from the tableau-sublibrary refactor (#3509/#3511) or the controller-cache refactor (#3422). The Rodas6P test has been flaky ever since Gerd Steinebach flipped the expected order from 5 to 6 in 10be42af7, one day after landing Rodas6P.

### Root causes

1. **Rodas6P (L212/L222).** With `dts = (1/2).^(6:-1:3)`, the smallest step (`1/64`) drives the error on these tiny linear problems to Float64 roundoff (`~1e-15`), corrupting the log-log slope. Widening to `dts = (1/2).^(5:-1:2)` (smallest `1/32`) stays above roundoff and yields `L2 ≈ 6.07` on both problems — comfortably within `atol = 0.2`.
2. **Rodas5P + Krylov (L270/L283).** LinearSolve now respects the requested `reltol`/`abstol`, so the default-tolerance inner Krylov solve clips the outer Rosenbrock order to `~2.83`. Passing `reltol = 1e-14, abstol = 1e-14` — the same fix applied at L319 for `Rodas3` in 6fe734392 — restores `L2 ≈ 5.004`.

### Verified locally on Julia 1.12.6

```
L212: Rodas6P linear    L2 = 6.072619418560989    (expected ≈ 6)
L222: Rodas6P 2Dlinear  L2 = 6.072276736140377    (expected ≈ 6)
L270: Rodas5P+KrylovJL       L2 = 5.004392395316728  (expected ≈ 5)
L283: Rodas5P+KrylovJL_GMRES L2 = 5.004392395316728  (expected ≈ 5)
```

`testTol = 0.2` is unchanged. No solver code modified.

## Test plan

- [ ] CI `test (OrdinaryDiffEqRosenbrock, 1)` passes on Julia 1.12.6 (Core group).
- [ ] All previously failing assertions (`L212`, `L222`, `L270`, `L283`) now report the new measured orders shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)