### PR TITLE
Fix _resolve_rng to honor prob.seed over ensemble's TaskLocalRNG

### DIFF
--- a/lib/StochasticDiffEqCore/src/solve.jl
+++ b/lib/StochasticDiffEqCore/src/solve.jl
@@ -60,6 +60,16 @@ function _resolve_rng(rng, seed, prob)
             )
         end
         if rng isa Random.TaskLocalRNG
+            # TaskLocalRNG is the ensemble-layer default, not an explicit
+            # per-trajectory RNG. If the user set an explicit seed (via the
+            # `seed` kwarg or `prob.seed`, typically from `remake(prob, seed=…)`
+            # inside `prob_func`), respect it over the TaskLocalRNG so
+            # `remake(prob, seed=s)` inside an ensemble is actually reproducible.
+            if !iszero(seed)
+                return Random.Xoshiro(seed), seed, false
+            elseif prob isa DiffEqBase.AbstractRODEProblem && !iszero(prob.seed)
+                return Random.Xoshiro(prob.seed), prob.seed, false
+            end
             _seed = rand(rng, UInt64)
             return Random.Xoshiro(_seed), _seed, true
         end

--- a/lib/StochasticDiffEqCore/test/runtests.jl
+++ b/lib/StochasticDiffEqCore/test/runtests.jl
@@ -29,4 +29,53 @@ if TEST_GROUP == "ALL" || TEST_GROUP == "Core"
             @test IILevyArea() isa IteratedIntegralApprox
         end
     end
+
+    @time @safetestset "_resolve_rng prefers prob.seed over TaskLocalRNG" begin
+        # Regression test for the weak-convergence PL1WM failure:
+        # When the ensemble layer passes `rng=Random.default_rng()` (TaskLocalRNG)
+        # and `prob.seed` is non-zero (typical after `remake(prob, seed=s)` inside
+        # a `prob_func`), the integrator must honor `prob.seed` rather than
+        # consuming a seed from the TaskLocalRNG. Otherwise two algorithms that
+        # differ only in how much randomness they draw per step (e.g. PL1WM vs
+        # PL1WMA for additive noise, where PL1WM needs an extra Z process) will
+        # see unrelated noise streams from the same ensemble seed assignment.
+        using StochasticDiffEqCore
+        using Random
+        using DiffEqBase
+        using Test
+
+        # Fake minimal RODEProblem-like object that just carries a `.seed` field
+        # so we can test _resolve_rng in isolation from the full solve pipeline.
+        struct FakeRODEProblem <: DiffEqBase.AbstractRODEProblem{Nothing, Nothing, Nothing, Nothing}
+            seed::UInt64
+        end
+
+        target_seed = UInt64(0x1234567890abcdef)
+
+        prob = FakeRODEProblem(target_seed)
+        rng = Random.default_rng()
+
+        # TaskLocalRNG path with prob.seed set → prob.seed wins
+        rng_out, _seed, rng_provided = StochasticDiffEqCore._resolve_rng(rng, UInt64(0), prob)
+        @test _seed == target_seed
+        @test !rng_provided
+        @test rng_out isa Random.Xoshiro
+
+        # Explicit seed kwarg takes priority over prob.seed
+        rng_out, _seed, rng_provided = StochasticDiffEqCore._resolve_rng(rng, UInt64(42), prob)
+        @test _seed == UInt64(42)
+        @test !rng_provided
+
+        # prob.seed == 0 → fall back to TaskLocalRNG-derived seed
+        prob0 = FakeRODEProblem(UInt64(0))
+        rng_out, _seed, rng_provided = StochasticDiffEqCore._resolve_rng(rng, UInt64(0), prob0)
+        @test rng_provided
+        @test rng_out isa Random.Xoshiro
+
+        # Non-TaskLocalRNG path is unchanged: explicit user RNG is used as-is
+        user_rng = Random.Xoshiro(99)
+        rng_out, _seed, rng_provided = StochasticDiffEqCore._resolve_rng(user_rng, UInt64(0), prob)
+        @test rng_out === user_rng
+        @test rng_provided
+    end
 end


### PR DESCRIPTION
## Summary

Fixes the `Platen's PL1WM weak second order` testset failures seen on PR #3521's full SublibraryCI run (`test (StochasticDiffEqWeak_WeakConvergence1, 1)`, lines `lib/StochasticDiffEqWeak/test/weak_convergence/PL1WM.jl:232`, `:269`, `:272`).

## Root cause

In SciMLBase v3, `BasicEnsembleSolve` calls `solve(new_prob, alg; rng=Random.default_rng(), kwargs...)` for every algorithm whose `SciMLBase.supports_solve_rng` trait is `true` — which `StochasticDiffEqCore` sets for all SDE/RODE solvers. That `TaskLocalRNG` is the ensemble-layer *default*, not an explicit per-trajectory RNG.

`StochasticDiffEqCore._resolve_rng` treated any non-`nothing` `rng` as authoritative and, when it saw a `TaskLocalRNG`, drew `_seed = rand(rng, UInt64)` — **silently ignoring `prob.seed`**. So the canonical ensemble pattern

```julia
prob_func = (prob, ctx) -> remake(prob, seed = seeds[ctx.sim_id])
```

didn't actually seed anything. Each trajectory pulled its seed from whatever state `TaskLocalRNG` happened to be in, which in turn depends on how much randomness each algorithm drew earlier.

PL1WM needs an auxiliary Z process (`alg_needs_extra_process(PL1WM) = true`) while PL1WMA does not. Same ensemble seed assignment → different TaskLocalRNG consumption → different noise paths → the cross-algorithm equivalence assertions (`sim.solutions[i].u[j] ≈ sim1.solutions[i].u[j]`) failed, and the PL1WMA weak-order estimate on the IIP additive case degraded from ≈ 1.95 to ≈ 1.68.

## Fix

When the passed `rng` is a `TaskLocalRNG`, prefer an explicit `seed` kwarg (> 0), then `prob.seed` (> 0), before falling back to `rand(rng, UInt64)`. Non-TaskLocalRNG callers (e.g. `solve(prob, alg; rng = Xoshiro(42))`) are unchanged. Routes the explicit-seed path through the `!rng_provided` branch so `Random.seed!(W.rng, _seed)` still runs.

## Test plan

- [x] `ODEDIFFEQ_TEST_GROUP=WeakConvergence1 Pkg.test(StochasticDiffEqWeak)` — 10/10 pass on Julia 1.12.6 (measured weak orders 1.77–1.90)
- [x] `StochasticDiffEqCore` regression test added covering `_resolve_rng` for TaskLocalRNG+prob.seed, explicit-seed-wins, zero-prob.seed fallback, and non-TaskLocalRNG preservation (9/9 pass)
- [x] `lib/StochasticDiffEq/test/rng_integrator_tests.jl` — 31/31 pass
- [ ] Full SublibraryCI matrix (will run on PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)