### PR TITLE
Restore v7-broken test imports (TRBDF2, KenCarp47, Heun/ExplicitRK, MatrixOperator, Polyester)

### DIFF
--- a/lib/DiffEqBase/test/downstream/Project.toml
+++ b/lib/DiffEqBase/test/downstream/Project.toml
@@ -12,6 +12,7 @@ Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 MultiScaleArrays = "f9640e96-87f6-5992-9c3b-0743c6a49ffa"
 ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 SDEProblemLibrary = "c72e72a9-a271-4b2b-8966-303ed956772e"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
@@ -22,6 +23,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 [sources]
 DiffEqBase = {path = "../.."}
 OrdinaryDiffEq = {path = "../../../.."}
+OrdinaryDiffEqSDIRK = {path = "../../../OrdinaryDiffEqSDIRK"}
 StochasticDiffEq = {path = "../../../StochasticDiffEq"}
 
 [compat]

--- a/lib/DiffEqBase/test/downstream/unwrapping.jl
+++ b/lib/DiffEqBase/test/downstream/unwrapping.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq, SciMLBase, Test
+using OrdinaryDiffEq, OrdinaryDiffEqSDIRK, SciMLBase, Test
 my_f(u, p, t) = u
 my_f!(du, u, p, t) = du .= u
 ode = ODEProblem(my_f, [1.0], (0.0, 1.0))

--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -82,10 +82,12 @@ Logging = "1.10"
 Mooncake = "0.4, 0.5"
 DiffEqBase = "7"
 Adapt = "4.3"
+Polyester = "0.7"
 Reexport = "1.2"
 
 [weakdeps]
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [targets]
@@ -93,4 +95,5 @@ test = ["DiffEqDevTools", "SafeTestsets", "SparseArrays", "Test", "Pkg"]
 
 [extensions]
 OrdinaryDiffEqCoreMooncakeExt = "Mooncake"
+OrdinaryDiffEqCorePolyesterExt = "Polyester"
 OrdinaryDiffEqCoreSparseArraysExt = "SparseArrays"

--- a/lib/OrdinaryDiffEqExplicitTableaus/Project.toml
+++ b/lib/OrdinaryDiffEqExplicitTableaus/Project.toml
@@ -10,6 +10,8 @@ DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+OrdinaryDiffEqExplicitRK = "9286f039-9fbf-40e8-bf65-aa933bdc4db0"
+OrdinaryDiffEqLowOrderRK = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
@@ -17,6 +19,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 DiffEqBase = {path = "../DiffEqBase"}
 DiffEqDevTools = {path = "../DiffEqDevTools"}
 OrdinaryDiffEq = {path = "../.."}
+OrdinaryDiffEqExplicitRK = {path = "../OrdinaryDiffEqExplicitRK"}
+OrdinaryDiffEqLowOrderRK = {path = "../OrdinaryDiffEqLowOrderRK"}
 
 [compat]
 DiffEqBase = "7"
@@ -27,4 +31,4 @@ Test = "<0.0.1, 1"
 julia = "1.10"
 
 [targets]
-test = ["DiffEqDevTools", "ODEProblemLibrary", "OrdinaryDiffEq", "Random", "Test"]
+test = ["DiffEqDevTools", "ODEProblemLibrary", "OrdinaryDiffEq", "OrdinaryDiffEqExplicitRK", "OrdinaryDiffEqLowOrderRK", "Random", "Test"]

--- a/lib/OrdinaryDiffEqExplicitTableaus/test/ode_tableau_convergence_tests.jl
+++ b/lib/OrdinaryDiffEqExplicitTableaus/test/ode_tableau_convergence_tests.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq, DiffEqDevTools, Test, Random
+using OrdinaryDiffEq, OrdinaryDiffEqExplicitRK, OrdinaryDiffEqLowOrderRK, DiffEqDevTools, Test, Random
 using ODEProblemLibrary: prob_ode_2Dlinear, prob_ode_linear,
     prob_ode_bigfloatlinear, prob_ode_bigfloat2Dlinear
 

--- a/lib/OrdinaryDiffEqExplicitTableaus/test/runtests.jl
+++ b/lib/OrdinaryDiffEqExplicitTableaus/test/runtests.jl
@@ -72,7 +72,7 @@ const ET = OrdinaryDiffEqExplicitTableaus
     end
 
     @testset "High-order convergence tests" begin
-        using OrdinaryDiffEq, Random
+        using OrdinaryDiffEq, OrdinaryDiffEqExplicitRK, Random
         using ODEProblemLibrary: prob_ode_bigfloatlinear, prob_ode_bigfloat2Dlinear
 
         setprecision(400)
@@ -107,7 +107,7 @@ const ET = OrdinaryDiffEqExplicitTableaus
     end
 
     @testset "Deduce Butcher tableau" begin
-        using OrdinaryDiffEq
+        using OrdinaryDiffEq, OrdinaryDiffEqLowOrderRK
 
         function coefficients_as_in_tableau(A, b, c, tab)
             if size(A) == size(tab.A)
@@ -131,7 +131,7 @@ const ET = OrdinaryDiffEqExplicitTableaus
             @test cc ≈ tab.c
         end
 
-        let erk = OrdinaryDiffEq.Euler()
+        let erk = OrdinaryDiffEqLowOrderRK.Euler()
             A, b, c = deduce_Butcher_tableau(erk)
             tab = ET.Euler()
             AA, bb, cc = coefficients_as_in_tableau(A, b, c, tab)
@@ -140,7 +140,7 @@ const ET = OrdinaryDiffEqExplicitTableaus
             @test cc ≈ tab.c
         end
 
-        let erk = OrdinaryDiffEq.RK4()
+        let erk = OrdinaryDiffEqLowOrderRK.RK4()
             A, b, c = deduce_Butcher_tableau(erk)
             tab = ET.RK4()
             AA, bb, cc = coefficients_as_in_tableau(A, b, c, tab)

--- a/lib/OrdinaryDiffEqExtrapolation/Project.toml
+++ b/lib/OrdinaryDiffEqExtrapolation/Project.toml
@@ -18,6 +18,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
@@ -45,11 +46,12 @@ RecursiveArrayTools = "4"
 FastPower = "1.1"
 RecursiveFactorization = "0.2"
 DiffEqBase = "7"
+Polyester = "0.7"
 Reexport = "1.2"
 SafeTestsets = "0.1.0"
 
 [targets]
-test = ["DiffEqDevTools", "Random", "RecursiveFactorization", "SafeTestsets", "Test", "Pkg"]
+test = ["DiffEqDevTools", "Polyester", "Random", "RecursiveFactorization", "SafeTestsets", "Test", "Pkg"]
 
 [sources.OrdinaryDiffEqDifferentiation]
 path = "../OrdinaryDiffEqDifferentiation"

--- a/lib/OrdinaryDiffEqExtrapolation/test/multithreading/ode_extrapolation_tests.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/multithreading/ode_extrapolation_tests.jl
@@ -1,5 +1,6 @@
 # Import packages
 using OrdinaryDiffEqExtrapolation, RecursiveFactorization, DiffEqDevTools, Test, Random
+using Polyester
 
 println("Running on $(Threads.nthreads()) thread(s).")
 

--- a/lib/OrdinaryDiffEqLinear/test/gpu/Project.toml
+++ b/lib/OrdinaryDiffEqLinear/test/gpu/Project.toml
@@ -2,12 +2,19 @@
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+OrdinaryDiffEqLinear = "521117fe-8c41-49f8-b3b6-30780b3f0fb5"
+SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources.OrdinaryDiffEq]
 path = "../../../.."
 
+[sources.OrdinaryDiffEqLinear]
+path = "../.."
+
 [compat]
 CUDA = "4, 5"
 OrdinaryDiffEq = "7"
+OrdinaryDiffEqLinear = "1"
+SciMLOperators = "1.4"

--- a/lib/OrdinaryDiffEqLinear/test/gpu/linear_exp.jl
+++ b/lib/OrdinaryDiffEqLinear/test/gpu/linear_exp.jl
@@ -3,6 +3,8 @@ using SparseArrays
 using CUDA
 using CUDA.CUSPARSE
 using OrdinaryDiffEq
+using OrdinaryDiffEqLinear
+using SciMLOperators
 
 # Linear exponential solvers
 A = MatrixOperator([2.0 -1.0; -1.0 2.0])

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/preconditioners.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/preconditioners.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq, LinearSolve, Test, IncompleteLU, SparseArrays
+using OrdinaryDiffEq, OrdinaryDiffEqSDIRK, LinearSolve, Test, IncompleteLU, SparseArrays
 
 # Required due to https://github.com/JuliaSmoothOptimizers/Krylov.jl/pull/477
 Base.eltype(::IncompleteLU.ILUFactorization{Tv, Ti}) where {Tv, Ti} = Tv


### PR DESCRIPTION
## Summary

Fixes the six Sublibrary CI regressions from [run 24859020070](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/24859020070) (PR #3521). OrdinaryDiffEq v7's "package scope reduction" means `using OrdinaryDiffEq` now only exports the default solver set (`Tsit5`, `Vern6`-`Vern9`, `AutoTsit5/Vern*`, `Rosenbrock23`, `Rodas5P`, `FBDF`, `DefaultODEAlgorithm`) — any other solver requires explicit import of its sublibrary. Additionally `Polyester` is now a weak dep (behind `OrdinaryDiffEqCorePolyesterExt`), so tests that exercise `PolyesterThreads()` must `using Polyester`.

## Per-job fixes

1. **DiffEqBase_Downstream2** ([job 72779591714](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/24859020070/job/72779591714)) — `UndefVarError: TRBDF2` in `lib/DiffEqBase/test/downstream/unwrapping.jl`. Added `using OrdinaryDiffEqSDIRK` and added `OrdinaryDiffEqSDIRK` as a path-sourced dep in `lib/DiffEqBase/test/downstream/Project.toml`.
2. **OrdinaryDiffEqNonlinearSolve_ModelingToolkit** ([job 72779592007](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/24859020070/job/72779592007)) — `UndefVarError: KenCarp47` in `lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/preconditioners.jl`. Added `using OrdinaryDiffEqSDIRK`. The modelingtoolkit env `Project.toml` already lists `OrdinaryDiffEqSDIRK` in `[deps]`.
3. **OrdinaryDiffEqExplicitTableaus** ([job 72779591792](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/24859020070/job/72779591792)) — `UndefVarError: ExplicitRK, Heun`. Verified via `grep export` that `ExplicitRK` lives in `OrdinaryDiffEqExplicitRK` and `Heun, Euler, RK4, BS3, BS5, RKO65, DP5` live in `OrdinaryDiffEqLowOrderRK`. Added `using OrdinaryDiffEqExplicitRK, OrdinaryDiffEqLowOrderRK` in the relevant testsets (`runtests.jl` + `ode_tableau_convergence_tests.jl`), replaced qualified `OrdinaryDiffEq.Euler()` / `OrdinaryDiffEq.RK4()` with `OrdinaryDiffEqLowOrderRK.*`, and added both sublibs to `[extras]` + `[sources]` + `[targets]` in `lib/OrdinaryDiffEqExplicitTableaus/Project.toml`.
4. **OrdinaryDiffEqExplicitTableaus_QA** ([job 72779591807](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/24859020070/job/72779591807)) — same file, covered by (3) since there is no separate `qa/` test file and `runtests.jl` runs the same testsets for both Core and QA groups.
5. **OrdinaryDiffEqLinear_GPU** ([job 72779591899](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/24859020070/job/72779591899)) — `UndefVarError: MatrixOperator` in `lib/OrdinaryDiffEqLinear/test/gpu/linear_exp.jl`. `MatrixOperator` is from `SciMLOperators` and `LinearExponential` is exported by `OrdinaryDiffEqLinear`. Added `using OrdinaryDiffEqLinear` + `using SciMLOperators` in the test file, and added both packages to `lib/OrdinaryDiffEqLinear/test/gpu/Project.toml`.
6. **OrdinaryDiffEqExtrapolation_Multithreading** ([job 72779591830](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/24859020070/job/72779591830)) — `ArgumentError: PolyesterThreads() requires Polyester.jl to be loaded`. Added `using Polyester` to `lib/OrdinaryDiffEqExtrapolation/test/multithreading/ode_extrapolation_tests.jl` and added `Polyester` to `[extras]` + `[targets]` + compat in `lib/OrdinaryDiffEqExtrapolation/Project.toml` (per the Julia convention of using main `Project.toml` `[extras]`/`[targets]`, not a separate `test/Project.toml`).

## Test plan

- [ ] Local `Pkg.test()` pass for `OrdinaryDiffEqExplicitTableaus` (Core runs the QA-equivalent path since there is no separate QA file)
- [ ] Local `ODEDIFFEQ_TEST_GROUP=Multithreading Pkg.test()` pass for `OrdinaryDiffEqExtrapolation` on `julia -t 2`
- [ ] Sublibrary CI reruns `DiffEqBase_Downstream2`, `OrdinaryDiffEqNonlinearSolve_ModelingToolkit`, `OrdinaryDiffEqLinear_GPU` (GPU-tagged, can't be reproduced locally without a GPU runner)

Local results will be added in a comment once the runs finish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)