### PR TITLE
Update ensemble test indexing for RecursiveArrayTools v4

### DIFF
--- a/lib/DiffEqBase/test/downstream/ensemble.jl
+++ b/lib/DiffEqBase/test/downstream/ensemble.jl
@@ -9,10 +9,6 @@ prob2 = EnsembleProblem(prob)
 sim = solve(prob2, SRIW1(), dt = 1 // 2^(3), trajectories = 10)
 
 @test sim.u[1] isa DiffEqBase.RODESolution
-# Under RecursiveArrayTools v4, `sim[i, j]` and `sim[i, j, k]` perform
-# column-major scalar indexing on the flattened ensemble, rather than picking
-# out a whole trajectory/timestep. Use explicit `.u` accessors to preserve the
-# original intent: "the i-th timestep of the j-th trajectory" etc.
 @test sim.u[2].u[1] isa Matrix
 @test sim.u[1].u[2][1] isa Float64
 

--- a/lib/DiffEqBase/test/downstream/ensemble.jl
+++ b/lib/DiffEqBase/test/downstream/ensemble.jl
@@ -9,19 +9,23 @@ prob2 = EnsembleProblem(prob)
 sim = solve(prob2, SRIW1(), dt = 1 // 2^(3), trajectories = 10)
 
 @test sim.u[1] isa DiffEqBase.RODESolution
-@test sim[1, 2] isa Matrix
-@test sim[1, 2, 1] isa Float64
+# Under RecursiveArrayTools v4, `sim[i, j]` and `sim[i, j, k]` perform
+# column-major scalar indexing on the flattened ensemble, rather than picking
+# out a whole trajectory/timestep. Use explicit `.u` accessors to preserve the
+# original intent: "the i-th timestep of the j-th trajectory" etc.
+@test sim.u[2].u[1] isa Matrix
+@test sim.u[1].u[2][1] isa Float64
 
 sim = solve(prob2, SRIW1(), EnsembleThreads(), dt = 1 // 2^(3), trajectories = 10)
 err_sim = DiffEqBase.calculate_ensemble_errors(sim; weak_dense_errors = true)
-@test length(sim) == 10
+@test length(sim.u) == 10
 
 sim = solve(
     prob2, SRIW1(), EnsembleThreads(), dt = 1 // 2^(3), trajectories = 10,
     batch_size = 2
 )
 err_sim = DiffEqBase.calculate_ensemble_errors(sim; weak_dense_errors = true)
-@test length(sim) == 10
+@test length(sim.u) == 10
 
 sim = solve(
     prob2, SRIW1(), EnsembleThreads(), dt = 1 // 2^(3), adaptive = false,
@@ -31,15 +35,15 @@ err_sim = DiffEqBase.calculate_ensemble_errors(sim; weak_timeseries_errors = tru
 
 sim = solve(prob2, SRIW1(), EnsembleThreads(), dt = 1 // 2^(3), trajectories = 10)
 DiffEqBase.calculate_ensemble_errors(sim)
-@test length(sim) == 10
+@test length(sim.u) == 10
 
 sim = solve(prob2, SRIW1(), EnsembleSplitThreads(), dt = 1 // 2^(3), trajectories = 10)
 DiffEqBase.calculate_ensemble_errors(sim)
-@test length(sim) == 10
+@test length(sim.u) == 10
 
 sim = solve(prob2, SRIW1(), EnsembleSerial(), dt = 1 // 2^(3), trajectories = 10)
 DiffEqBase.calculate_ensemble_errors(sim)
-@test length(sim) == 10
+@test length(sim.u) == 10
 
 prob = prob_sde_additivesystem
 prob2 = EnsembleProblem(prob)


### PR DESCRIPTION
## Summary

Fixes the `DiffEqBase_Downstream` CI regression introduced by DiffEqBase v7 / RecursiveArrayTools v4.

Under RAT v4, `AbstractVectorOfArray <: AbstractArray`, so `EnsembleSolution` inherits column-major scalar indexing and `length` semantics:

- `sim[i, j]` returns a scalar element (not a per-trajectory matrix).
- `length(sim)` is `prod(size(sim))` (not the trajectory count).

### Changes in this PR

`lib/DiffEqBase/test/downstream/ensemble.jl`:

- `sim[1, 2] isa Matrix` -> `sim.u[2].u[1] isa Matrix`
- `sim[1, 2, 1] isa Float64` -> `sim.u[1].u[2][1] isa Float64`
- `length(sim) == 10` (five occurrences) -> `length(sim.u) == 10`

These are pure test-file migrations; they preserve the v3 intent under v4 semantics via explicit `.u` accessors.

### Accompanying SciMLBase PR

The CI failure was not just test-side. The stack trace also showed a `BoundsError: attempt to access 9-element Vector{Matrix{Float64}} at index [10]` inside `SciMLBase.calculate_ensemble_errors`, caused by `for i in 1:length(u[1])` under RAT v4 iterating to `prod(size(sol))` rather than `length(sol.u)`. Several `EnsembleAnalysis` helpers had the same class of bug (`get_timestep` / `get_timepoint` iterating `sim`; `timeseries_steps_*` ranges using `length(sim.u[1])`; `EnsembleSummary` using `length(sim)` and an undefined `SciMLSolution` alias).

Those are fixed in [SciML/SciMLBase.jl#1326](https://github.com/SciML/SciMLBase.jl/pull/1326). Both test files in this PR pass locally against that branch.

## Test plan

- [x] `julia --project=lib/DiffEqBase/test/downstream -e 'include(\"lib/DiffEqBase/test/downstream/ensemble.jl\")'` passes with SciMLBase#1326 dev-ed in.
- [x] `julia --project=lib/DiffEqBase/test/downstream -e 'include(\"lib/DiffEqBase/test/downstream/ensemble_analysis.jl\")'` passes with SciMLBase#1326 dev-ed in.
- [ ] `DiffEqBase_Downstream` CI job passes once SciMLBase#1326 is merged and tagged.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>