### PR TITLE
NEWS: document EnsembleSolution indexing migration under RAT v4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -57,6 +57,24 @@ sol_old = RaggedVectorOfArray(sol)   # indexes like v3: sol_old[i] is the i-th t
 
 **Full fallback:** see the "Fallback for RAT v4 indexing" section above — wrapping with `RaggedVectorOfArray` from `RecursiveArrayToolsRaggedArrays.jl` restores v3 indexing.
 
+### EnsembleSolution indexing
+
+The same `AbstractArray` migration applies to `EnsembleSolution` (from `EnsembleProblem` trajectories) and to `EnsembleAnalysis` helpers — an ensemble's `.u` is a `Vector{<:ODESolution}` and the solution itself subtypes `AbstractVectorOfArray`:
+
+| Operation | v3 (old) | v4 (new) | Migration |
+|---|---|---|---|
+| `sim[j]` | j-th trajectory (`ODESolution`) | j-th scalar element of the flattened container | Use `sim.u[j]` |
+| `sim[i, j]` | Trajectory `j`'s i-th timestep (`Matrix` / `Vector`) | Scalar element at column-major position `(i, j)` | Use `sim.u[j].u[i]` |
+| `sim[i, j, k]` | Row `k` of trajectory `j`'s i-th timestep | Scalar at `(i, j, k)` | Use `sim.u[j].u[i][k]` |
+| `length(sim)` | Number of trajectories | `prod(size(sim))` (total scalar count) | Use `length(sim.u)` |
+| `for sol in sim` | Iterate trajectories | Iterate scalar elements (column-major) | Use `for sol in sim.u` |
+
+**Migration shortcut:** as with `ODESolution`, `sim.u[j]` / `sim.u[j].u[i]` / `length(sim.u)` are the forward-compatible forms that work under both v3 and v4.
+
+**EnsembleAnalysis helpers (SciMLBase ≥ 3.4.3):** `get_timestep`, `get_timepoint`, `timeseries_steps_mean/median/quantile/meanvar/meancov/meancor/weighted_meancov`, `EnsembleSummary`, and the weak-error path in `calculate_ensemble_errors` were updated to iterate `sim.u` and use `length(sim.u[1].t)` for the timestep count rather than `length(sim)` / `length(sim.u[1])`. If you pin SciMLBase < 3.4.3 you may hit a `BoundsError` at `calculate_ensemble_errors` on a weak `EnsembleProblem` with `error_estimate`; bump to 3.4.3 or later.
+
+See [SciML/OrdinaryDiffEq.jl#3532](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3532) and [SciML/SciMLBase.jl#1326](https://github.com/SciML/SciMLBase.jl/pull/1326) for the specific v3→v4 ensemble-indexing migrations.
+
 ### Other RAT v4 changes
 
 - `zero(VectorOfArray)` now preserves container type (e.g. `StructVector`) via `rewrap`


### PR DESCRIPTION
## Summary

The existing `RecursiveArrayTools v4` section in `NEWS.md` covers the `sol[i]` / `length(sol)` / `iterate(sol)` migration for `ODESolution`. The same `AbstractVectorOfArray <: AbstractArray` semantics apply to `EnsembleSolution` — `sim[j]`, `sim[i, j]`, `sim[i, j, k]`, `length(sim)`, and `for sol in sim` all shift to column-major scalar indexing over the flattened container. This class of breakage surfaced recently via:

- **#3532** — migrated `lib/DiffEqBase/test/downstream/ensemble.jl` from `sim[i, j]` / `length(sim)` to `sim.u[j].u[i]` / `length(sim.u)`.
- **SciML/SciMLBase.jl#1326** — fixed `calculate_ensemble_errors`, `get_timestep`, `get_timepoint`, the `timeseries_steps_*` helpers, and `EnsembleSummary` to iterate `sim.u` / use `length(sim.u[1].t)` rather than `length(sim)` / `length(sim.u[1])`.

Users hitting `BoundsError: attempt to access N-element Vector{Matrix{Float64}} at index [N+1]` inside `calculate_ensemble_errors`, or surprise scalar-where-Matrix-expected from `sim[i, j]`, need concrete migration guidance. This PR adds that to the existing RAT v4 section.

## Changes

New `### EnsembleSolution indexing` subsection inside `## RecursiveArrayTools v4` with:

- Migration table mirroring the `ODESolution` one, for `sim[j]`, `sim[i, j]`, `sim[i, j, k]`, `length(sim)`, `for sol in sim`.
- Forward-compatible shortcut (`sim.u[j]` / `sim.u[j].u[i]` / `length(sim.u)` work under both v3 and v4).
- Note calling out that the `EnsembleAnalysis` helpers require `SciMLBase >= 3.4.3`, with a link to the concrete `BoundsError` that surfaces on a weak `EnsembleProblem` if someone pins an older SciMLBase.
- Links to #3532 and SciMLBase#1326 for the migration recipe.

## Test plan

- [x] NEWS.md renders cleanly
- [ ] No code change; CI only needs format-check / spell-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)