### PR TITLE
Fix UndefVarError for ExplicitRK/Heun in ExplicitTableaus tests

### DIFF
--- a/lib/OrdinaryDiffEqExplicitTableaus/test/runtests.jl
+++ b/lib/OrdinaryDiffEqExplicitTableaus/test/runtests.jl
@@ -2,6 +2,10 @@ import OrdinaryDiffEqExplicitTableaus
 using DiffEqBase
 using DiffEqDevTools
 using Test
+using OrdinaryDiffEqExplicitRK: ExplicitRK
+using OrdinaryDiffEqLowOrderRK
+using OrdinaryDiffEqLowOrderRK: Heun, BS3, BS5, RKO65
+using OrdinaryDiffEq: OrdinaryDiffEq, Tsit5, Vern7, Vern8
 
 const ET = OrdinaryDiffEqExplicitTableaus
 
@@ -72,7 +76,7 @@ const ET = OrdinaryDiffEqExplicitTableaus
     end
 
     @testset "High-order convergence tests" begin
-        using OrdinaryDiffEq, OrdinaryDiffEqExplicitRK, Random
+        using Random
         using ODEProblemLibrary: prob_ode_bigfloatlinear, prob_ode_bigfloat2Dlinear
 
         setprecision(400)
@@ -107,8 +111,6 @@ const ET = OrdinaryDiffEqExplicitTableaus
     end
 
     @testset "Deduce Butcher tableau" begin
-        using OrdinaryDiffEq, OrdinaryDiffEqLowOrderRK
-
         function coefficients_as_in_tableau(A, b, c, tab)
             if size(A) == size(tab.A)
                 AA = A


### PR DESCRIPTION
## Summary

- CI on #3521 reports `UndefVarError: ExplicitRK not defined in Main` and `UndefVarError: Heun not defined in Main` in `test (OrdinaryDiffEqExplicitTableaus, 1)` and the `_QA` twin.
- Two `@testset begin ... end` blocks in `lib/OrdinaryDiffEqExplicitTableaus/test/runtests.jl` placed `using OrdinaryDiffEq, OrdinaryDiffEqExplicitRK, Random` (line 75) and `using OrdinaryDiffEq, OrdinaryDiffEqLowOrderRK` (line 110) inside the block body. From that position the imports do not reliably install bindings into the enclosing `Main`, so later references to `ExplicitRK` / `Heun` in the same block — and inside `include("ode_tableau_convergence_tests.jl")` which is itself run from another `@testset begin ... end` — resolve against `Main` and fail.
- Move the imports to the top of `runtests.jl` so `ExplicitRK`, `Heun`, `BS3`, `BS5`, `RKO65`, `Tsit5`, `Vern7`, `Vern8` are installed into `Main` before any `@testset` runs. `OrdinaryDiffEqExplicitRK` and `OrdinaryDiffEqLowOrderRK` are already wired through `[sources]`, `[extras]`, `[compat]`, and `[targets].test` in `lib/OrdinaryDiffEqExplicitTableaus/Project.toml`, so no manifest changes are required.
- Follows the same precedent as #3526 (StochasticDiffEq Rodas5 Zeroed Noise safetestset fix).

## Error details (from CI log of PR #3521)

```
High-order convergence tests: Error During Test at .../runtests.jl:74
  UndefVarError: `ExplicitRK` not defined in `Main`
  @ ... runtests.jl:90

Deduce Butcher tableau: Error During Test at .../runtests.jl:109
  UndefVarError: `Heun` not defined in `Main`
  @ ... runtests.jl:125

ODE Tableau Convergence Tests: Error During Test at .../runtests.jl:209
  LoadError: UndefVarError: `ExplicitRK` not defined in `Main`
  @ ode_tableau_convergence_tests.jl:44
```

## Test plan

- [x] Ran `Pkg.test("OrdinaryDiffEqExplicitTableaus")` on Julia 1.12.6 locally — all three `UndefVarError` sites now pass. The remaining 2 errors (`InexactError: Rational` in `High-order convergence tests` and one tableau in `ODE Tableau Convergence Tests`) are pre-existing on master and unrelated to this fix.
- [ ] SublibraryCI on this PR.

---

Generated with Claude Code to unblock #3521's SublibraryCI matrix.