### PR TITLE
Fix KenCarp47/Rodas4/Rodas5 UndefVarError in MTK Preconditioner Tests

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/Project.toml
@@ -3,13 +3,14 @@ DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 ImplicitDiscreteSolve = "3263718b-31ed-49cf-8a0f-35a466e8af96"
 IncompleteLU = "40713840-3770-5561-ab4c-a76e7d0d7895"
 LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 OrdinaryDiffEqBDF = "6ad6398a-0878-4a85-9266-38940aa047c8"
 OrdinaryDiffEqNonlinearSolve = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
+OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
 OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -17,6 +18,7 @@ ImplicitDiscreteSolve = {path = "../../../ImplicitDiscreteSolve"}
 OrdinaryDiffEq = {path = "../../../.."}
 OrdinaryDiffEqBDF = {path = "../../../OrdinaryDiffEqBDF"}
 OrdinaryDiffEqNonlinearSolve = {path = "../.."}
+OrdinaryDiffEqRosenbrock = {path = "../../../OrdinaryDiffEqRosenbrock"}
 OrdinaryDiffEqSDIRK = {path = "../../../OrdinaryDiffEqSDIRK"}
 
 [compat]
@@ -29,4 +31,5 @@ NonlinearSolve = "4.10"
 OrdinaryDiffEq = "7"
 OrdinaryDiffEqBDF = "1"
 OrdinaryDiffEqNonlinearSolve = "1"
+OrdinaryDiffEqRosenbrock = "1"
 OrdinaryDiffEqSDIRK = "1"

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/preconditioners.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/preconditioners.jl
@@ -1,6 +1,3 @@
-# v7 `OrdinaryDiffEq` only re-exports a small solver set; pull in the sublibraries
-# that own the solvers used below (KenCarp47, TRBDF2 live in OrdinaryDiffEqSDIRK;
-# Rodas4/Rodas5 live in OrdinaryDiffEqRosenbrock).
 using OrdinaryDiffEq, LinearSolve, Test, IncompleteLU, SparseArrays
 using OrdinaryDiffEqSDIRK: KenCarp47, TRBDF2
 using OrdinaryDiffEqRosenbrock: Rosenbrock23, Rodas4, Rodas5

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/preconditioners.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/preconditioners.jl
@@ -1,4 +1,9 @@
-using OrdinaryDiffEq, OrdinaryDiffEqSDIRK, LinearSolve, Test, IncompleteLU, SparseArrays
+# v7 `OrdinaryDiffEq` only re-exports a small solver set; pull in the sublibraries
+# that own the solvers used below (KenCarp47, TRBDF2 live in OrdinaryDiffEqSDIRK;
+# Rodas4/Rodas5 live in OrdinaryDiffEqRosenbrock).
+using OrdinaryDiffEq, LinearSolve, Test, IncompleteLU, SparseArrays
+using OrdinaryDiffEqSDIRK: KenCarp47, TRBDF2
+using OrdinaryDiffEqRosenbrock: Rosenbrock23, Rodas4, Rodas5
 
 # Required due to https://github.com/JuliaSmoothOptimizers/Krylov.jl/pull/477
 Base.eltype(::IncompleteLU.ILUFactorization{Tv, Ti}) where {Tv, Ti} = Tv

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
@@ -11,6 +11,7 @@ function activate_modelingtoolkit_env()
             PackageSpec(path = dirname(dirname(dirname(@__DIR__)))),
             PackageSpec(path = dirname(@__DIR__)),
             PackageSpec(path = joinpath(lib_dir, "OrdinaryDiffEqBDF")),
+            PackageSpec(path = joinpath(lib_dir, "OrdinaryDiffEqRosenbrock")),
             PackageSpec(path = joinpath(lib_dir, "OrdinaryDiffEqSDIRK")),
         ]
     )


### PR DESCRIPTION
## Summary

`test (OrdinaryDiffEqNonlinearSolve_ModelingToolkit, 1)` fails with:

```
UndefVarError: `KenCarp47` not defined in Main.var"##Preconditioner Tests#291"
```

v7's `OrdinaryDiffEq` only re-exports a small curated solver set (`Tsit5`, `Vern*`, `Rosenbrock23`, `Rodas5P`, `FBDF`, `DefaultODEAlgorithm`). `KenCarp47`, `TRBDF2`, `Rodas4`, `Rodas5` live in their owning sublibraries. Inside a `@safetestset` (fresh anonymous module), a bare `using OrdinaryDiffEq` doesn't put those names in scope. Same class as #3522 / #3524 / #3526.

## Fix

- **`preconditioners.jl`**: explicit `using OrdinaryDiffEqSDIRK: KenCarp47, TRBDF2` and `using OrdinaryDiffEqRosenbrock: Rosenbrock23, Rodas4, Rodas5`.
- **`modelingtoolkit/Project.toml`**: add `OrdinaryDiffEqRosenbrock` to `[deps]`, `[sources]`, `[compat]`.
- **`runtests.jl`** (`activate_modelingtoolkit_env`): add `OrdinaryDiffEqRosenbrock` to the `Pkg.develop` list so the path `[sources]` entry resolves at test time.

## Test plan

- [ ] `test (OrdinaryDiffEqNonlinearSolve_ModelingToolkit, 1)` passes on CI