### PR TITLE
DiffEqBase: don't leak DEVerbosity default into downstream dispatch

### DIFF
--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.0.0"
+version = "7.0.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/DiffEqBase/src/solve.jl
+++ b/lib/DiffEqBase/src/solve.jl
@@ -90,7 +90,7 @@ end
 
 Base.@constprop :aggressive function init(
         prob::AbstractDEProblem, args...; sensealg = nothing,
-        u0 = nothing, p = nothing, verbose = DEFAULT_VERBOSE, kwargs...
+        u0 = nothing, p = nothing, verbose = nothing, kwargs...
     )
     if sensealg === nothing && has_kwargs(prob) && haskey(prob.kwargs, :sensealg)
         sensealg = prob.kwargs[:sensealg]
@@ -99,7 +99,16 @@ Base.@constprop :aggressive function init(
     u0 = u0 !== nothing ? u0 : prob.u0
     p = p !== nothing ? p : prob.p
 
-    return init_up(prob, sensealg, u0, p, args...; verbose, kwargs...)
+    # Do not forward a verbose default here: downstream solver packages
+    # (e.g. BoundaryValueDiffEqCore with `BVPVerbosity`) own their own
+    # verbosity types and defaults. Forwarding `DiffEqBase.DEVerbosity`
+    # would force their `_process_verbose_param` dispatch tables to
+    # match against a foreign type they do not handle.
+    return if verbose === nothing
+        init_up(prob, sensealg, u0, p, args...; kwargs...)
+    else
+        init_up(prob, sensealg, u0, p, args...; verbose, kwargs...)
+    end
 end
 
 function init(prob::AbstractJumpProblem, args...; kwargs...)
@@ -590,7 +599,7 @@ the extension to other types is straightforward.
 """
 Base.@constprop :aggressive function solve(
         prob::AbstractDEProblem, args...; sensealg = nothing,
-        u0 = nothing, p = nothing, wrap = Val(true), verbose = DEFAULT_VERBOSE, kwargs...
+        u0 = nothing, p = nothing, wrap = Val(true), verbose = nothing, kwargs...
     )
     if sensealg === nothing && haskey(prob.kwargs, :sensealg)
         sensealg = prob.kwargs[:sensealg]
@@ -599,20 +608,41 @@ Base.@constprop :aggressive function solve(
     u0 = u0 !== nothing ? u0 : prob.u0
     p = p !== nothing ? p : prob.p
 
+    # Do not forward a verbose default here: downstream solver packages
+    # (e.g. BoundaryValueDiffEqCore with `BVPVerbosity`) own their own
+    # verbosity types and defaults. Forwarding `DiffEqBase.DEVerbosity`
+    # would force their `_process_verbose_param` dispatch tables to
+    # match against a foreign type they do not handle.
     return if wrap isa Val{true}
         wrap_sol(
+            if verbose === nothing
+                solve_up(
+                    prob, sensealg, u0, p, args...;
+                    originator = SciMLBase.set_mooncakeoriginator_if_mooncake(SciMLBase.ChainRulesOriginator()),
+                    kwargs...
+                )
+            else
+                solve_up(
+                    prob, sensealg, u0, p, args...;
+                    originator = SciMLBase.set_mooncakeoriginator_if_mooncake(SciMLBase.ChainRulesOriginator()),
+                    verbose, kwargs...
+                )
+            end
+        )
+    else
+        if verbose === nothing
+            solve_up(
+                prob, sensealg, u0, p, args...;
+                originator = SciMLBase.set_mooncakeoriginator_if_mooncake(SciMLBase.ChainRulesOriginator()),
+                kwargs...
+            )
+        else
             solve_up(
                 prob, sensealg, u0, p, args...;
                 originator = SciMLBase.set_mooncakeoriginator_if_mooncake(SciMLBase.ChainRulesOriginator()),
                 verbose, kwargs...
             )
-        )
-    else
-        solve_up(
-            prob, sensealg, u0, p, args...;
-            originator = SciMLBase.set_mooncakeoriginator_if_mooncake(SciMLBase.ChainRulesOriginator()),
-            verbose, kwargs...
-        )
+        end
     end
 end
 

--- a/lib/DiffEqBase/test/verbose_inference.jl
+++ b/lib/DiffEqBase/test/verbose_inference.jl
@@ -1,4 +1,5 @@
 using DiffEqBase, Test
+using SciMLBase
 
 # Verify that the DEVerbosity paths of `_process_verbose_param` are type-stable
 # and that passing a Bool throws (v7 breaking change).
@@ -13,4 +14,61 @@ using DiffEqBase, Test
     # Bool is no longer accepted — throws ArgumentError.
     @test_throws ArgumentError DiffEqBase._process_verbose_param(true)
     @test_throws ArgumentError DiffEqBase._process_verbose_param(false)
+end
+
+# Regression test for the BoundaryValueDiffEqCore precompile failure:
+# `DiffEqBase.solve`/`init` must not forward a `DEVerbosity` into kwargs
+# when the caller omits the `verbose` kwarg. Downstream solver packages
+# (e.g. `BoundaryValueDiffEqCore`) have their own verbosity types (e.g.
+# `BVPVerbosity`) and their own default; forwarding `DEVerbosity` would
+# force their `_process_verbose_param` dispatch tables to match against
+# a foreign type and fail with `MethodError`.
+@testset "solve/init does not force DEVerbosity into kwargs" begin
+    # Fake problem + alg + __init/__solve that capture their received kwargs
+    # so we can assert what DiffEqBase.solve/init actually forwards.
+    Base.@kwdef mutable struct _CapturedKwargs
+        solve::Union{Nothing, NamedTuple} = nothing
+        init::Union{Nothing, NamedTuple} = nothing
+    end
+
+    struct _CaptureAlg <: SciMLBase.AbstractDEAlgorithm end
+
+    struct _CaptureProb <: SciMLBase.AbstractDEProblem
+        u0::Vector{Float64}
+        p::SciMLBase.NullParameters
+        tspan::Tuple{Float64, Float64}
+        f::Nothing
+        kwargs::NamedTuple
+    end
+    _CaptureProb() = _CaptureProb([1.0], SciMLBase.NullParameters(), (0.0, 1.0), nothing, NamedTuple())
+
+    captured = _CapturedKwargs()
+
+    SciMLBase.__solve(::_CaptureProb, ::_CaptureAlg; kwargs...) = (captured.solve = NamedTuple(kwargs); nothing)
+    SciMLBase.__init(::_CaptureProb, ::_CaptureAlg; kwargs...) = (captured.init = NamedTuple(kwargs); nothing)
+    DiffEqBase.get_concrete_problem(p::_CaptureProb, isadapt; kwargs...) = p
+    DiffEqBase.isadaptive(::_CaptureAlg) = false
+    DiffEqBase.prepare_alg(alg::_CaptureAlg, u0, p, prob) = alg
+    DiffEqBase.check_prob_alg_pairing(::_CaptureProb, ::_CaptureAlg) = true
+    SciMLBase.has_kwargs(::_CaptureProb) = false
+
+    prob = _CaptureProb()
+    alg = _CaptureAlg()
+
+    # No explicit verbose -> must NOT be in kwargs.
+    solve(prob, alg; wrap = Val(false))
+    @test !haskey(captured.solve, :verbose)
+
+    init(prob, alg)
+    @test !haskey(captured.init, :verbose)
+
+    # Explicit preset -> MUST be forwarded.
+    solve(prob, alg; wrap = Val(false), verbose = DiffEqBase.SciMLLogging.Standard())
+    @test haskey(captured.solve, :verbose)
+    @test captured.solve.verbose isa DiffEqBase.SciMLLogging.AbstractVerbosityPreset
+
+    # Explicit DEVerbosity -> MUST be forwarded.
+    init(prob, alg; verbose = DiffEqBase.DEFAULT_VERBOSE)
+    @test haskey(captured.init, :verbose)
+    @test captured.init.verbose isa DiffEqBase.DEVerbosity
 end

--- a/lib/DiffEqDevTools/test/analyticless_stochastic_wp.jl
+++ b/lib/DiffEqDevTools/test/analyticless_stochastic_wp.jl
@@ -1,5 +1,7 @@
 using Random
 using StochasticDiffEq, DiffEqDevTools, Test
+using DiffEqBase: DEVerbosity
+using DiffEqBase.SciMLLogging: None
 using SDEProblemLibrary: prob_sde_additivesystem
 
 prob = prob_sde_additivesystem
@@ -115,7 +117,8 @@ appxsol_setup = Dict(:alg => EM(), :dt => test_dt)
 wp1 = @time WorkPrecisionSet(
     ensemble_prob, abstols, reltols, setups, test_dt;
     maxiters = 1.0e7,
-    verbose = false, save_everystep = false, save_start = false,
+    verbose = DEVerbosity(None()),
+    save_everystep = false, save_start = false,
     appxsol_setup = appxsol_setup,
     trajectories = numtraj, error_estimate = :weak_final
 )
@@ -124,7 +127,8 @@ wp1 = @time WorkPrecisionSet(
 wp2 = @time WorkPrecisionSet(
     ensemble_prob, abstols, reltols, setups, test_dt;
     maxiters = 1.0e7,
-    verbose = false, save_everystep = false, save_start = false,
+    verbose = DEVerbosity(None()),
+    save_everystep = false, save_start = false,
     appxsol_setup = appxsol_setup, expected_value = exp(-3.0),
     trajectories = numtraj, error_estimate = :weak_final
 )


### PR DESCRIPTION
## Summary

- `DiffEqBase.solve`/`init` were using `verbose = DEFAULT_VERBOSE` (a `DEVerbosity`) as the kwarg default, so the verbose kwarg was **always forwarded** to the downstream `__solve`/`__init` even when the caller omitted it.
- Sibling solver packages with their own verbosity type (e.g. `BoundaryValueDiffEqCore`'s `BVPVerbosity`) then dispatched `_process_verbose_param(::DiffEqBase.DEVerbosity{...})` against their local dispatch table, which only handles `Bool`, `AbstractVerbosityPreset`, and their own `BVPVerbosity` — producing the `MethodError` that was failing `test (DiffEqDevTools, 1)` on PR #3521 (and is the same failure that affects `BoundaryValueDiffEqFIRK`, `BoundaryValueDiffEqMIRK`, `BoundaryValueDiffEqShooting` precompile in any env that loads them).
- Fix: make the default `verbose = nothing` and only forward when a user explicitly passes one. Each downstream solver's own `verbose = …` kwarg default then kicks in as intended.
- Also cleans up `verbose = false`/`true` literals in `lib/DiffEqDevTools/test/analyticless_stochastic_wp.jl` per the v7 `Bool → DEVerbosity`/preset contract.

## Root cause trace

Failing test: `test (DiffEqDevTools, 1)` on 1.12.6:

```
nested task error: MethodError: no method matching _process_verbose_param(
    ::DiffEqBase.DEVerbosity{SciMLLogging.Minimal, SciMLLogging.Minimal, SciMLLogging.WarnLevel, ..., SciMLLogging.Silent}
)

Closest candidates are:
  _process_verbose_param(!Matched::Bool) @ BoundaryValueDiffEqCore
  _process_verbose_param(!Matched::SciMLLogging.AbstractVerbosityPreset) @ BoundaryValueDiffEqCore
  _process_verbose_param(!Matched::BoundaryValueDiffEqCore.BVPVerbosity) @ BoundaryValueDiffEqCore
```

This is triggered by `BoundaryValueDiffEqFIRK`'s `@compile_workload`:

```julia
@compile_workload begin
    @sync for prob in probs, alg in algs
        Threads.@spawn solve(prob, alg; dt = 0.2)   # <-- no verbose
    end
end
```

`DiffEqBase.solve` had `verbose = DEFAULT_VERBOSE` as its default and forwarded it unconditionally, so the `DEVerbosity{Minimal,…}` instance landed in `BoundaryValueDiffEqCore.init_expanded`'s `verbose` kwarg and then into `_process_verbose_param(verbose)`, where it had no matching method.

## What changed

`lib/DiffEqBase/src/solve.jl`:
- `solve(prob, ...; verbose = nothing, ...)` and `init(prob, ...; verbose = nothing, ...)` now use a `nothing` sentinel.
- If `verbose === nothing`, the kwarg is **not** forwarded — so downstream `__solve`/`__init` methods get to use their own default (`BVPVerbosity()`, `Standard()`, etc.).
- If the user explicitly passed `verbose`, it is forwarded exactly as before.

`lib/DiffEqBase/test/verbose_inference.jl`: added regression tests with a stub problem/alg that capture forwarded kwargs, asserting:
- `solve/init` without `verbose` ⇒ `verbose` is not in `__solve`/`__init` kwargs
- `solve` with `verbose = Standard()` ⇒ `verbose` forwarded (preset)
- `init` with `verbose = DEFAULT_VERBOSE` ⇒ `verbose` forwarded (DEVerbosity)

`lib/DiffEqDevTools/test/analyticless_stochastic_wp.jl`: `verbose = false` → `verbose = DEVerbosity(None())` on the two `WorkPrecisionSet(...)` calls. These were flowing through `kwargs...` → `solve(...)` and would trip `_process_verbose_param(::Bool)`'s `ArgumentError` in v7.

`lib/DiffEqBase/Project.toml`: 7.0.0 → 7.0.1 (patch).

## Verification

- `lib/DiffEqBase` test suite (Core group): all green, `Verbose Inference | 8 8` (2 existing + 6 new).
- Without this patch, `Pkg.test("DiffEqDevTools")` on Julia 1.12.6 reproduces the `MethodError` from the failing CI job. With the patch, that precompile failure is gone (a separate `PreparationMismatchError` inside `BoundaryValueDiffEqFIRK 1.14.0`'s own `@compile_workload` is now surfaced as the next blocker — that is unrelated to verbose and lives in the registered package).

## Test plan

- [x] `julia +1.12.6 --project=lib/DiffEqBase -e 'using Pkg; Pkg.test()'` → `Testing DiffEqBase tests passed`
- [x] Reproduced the `MethodError` against master; reproduced absence of the `MethodError` with this patch.
- [ ] `test (DiffEqDevTools, 1)` on CI should stop failing with the verbose `MethodError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)