### PR TITLE
Add more explicit SciMLBase imports to DiffEqBase downstream tests

### DIFF
--- a/lib/DiffEqBase/test/downstream/Project.toml
+++ b/lib/DiffEqBase/test/downstream/Project.toml
@@ -12,6 +12,8 @@ Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 MultiScaleArrays = "f9640e96-87f6-5992-9c3b-0743c6a49ffa"
 ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+OrdinaryDiffEqBDF = "6ad6398a-0878-4a85-9266-38940aa047c8"
+OrdinaryDiffEqLowOrderRK = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
 OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 SDEProblemLibrary = "c72e72a9-a271-4b2b-8966-303ed956772e"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
@@ -23,6 +25,8 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 [sources]
 DiffEqBase = {path = "../.."}
 OrdinaryDiffEq = {path = "../../../.."}
+OrdinaryDiffEqBDF = {path = "../../../OrdinaryDiffEqBDF"}
+OrdinaryDiffEqLowOrderRK = {path = "../../../OrdinaryDiffEqLowOrderRK"}
 OrdinaryDiffEqSDIRK = {path = "../../../OrdinaryDiffEqSDIRK"}
 StochasticDiffEq = {path = "../../../StochasticDiffEq"}
 

--- a/lib/DiffEqBase/test/downstream/bigfloat_events.jl
+++ b/lib/DiffEqBase/test/downstream/bigfloat_events.jl
@@ -1,4 +1,5 @@
 using OrdinaryDiffEq
+using SciMLBase: terminate!
 
 function lorenz!(du, u, p, t)
     du[1] = 10.0 * (u[2] - u[1])

--- a/lib/DiffEqBase/test/downstream/callback_merging.jl
+++ b/lib/DiffEqBase/test/downstream/callback_merging.jl
@@ -1,4 +1,5 @@
 using OrdinaryDiffEq, DiffEqBase, SciMLBase, Test
+using OrdinaryDiffEqLowOrderRK: Euler
 
 # Basic auto callback merging test
 do_nothing = DiscreteCallback(

--- a/lib/DiffEqBase/test/downstream/community_callback_tests.jl
+++ b/lib/DiffEqBase/test/downstream/community_callback_tests.jl
@@ -1,4 +1,5 @@
 using OrdinaryDiffEq, DiffEqCallbacks, LinearAlgebra
+using SciMLBase: terminate!, set_u!
 
 # https://github.com/SciML/DiffEqBase.jl/issues/564 : Fixed
 gravity = 9.8

--- a/lib/DiffEqBase/test/downstream/distributed_ensemble.jl
+++ b/lib/DiffEqBase/test/downstream/distributed_ensemble.jl
@@ -8,6 +8,8 @@ println("There are $(nprocs()) processes")
     Pkg.develop(PackageSpec(path = joinpath(pwd(), "..")))
     Pkg.instantiate()
     using OrdinaryDiffEq
+    using SciMLBase: EnsembleProblem, EnsembleSerial, EnsembleThreads,
+        EnsembleDistributed, EnsembleSplitThreads
     prob = ODEProblem((u, p, t) -> 1.01u, 0.5, (0.0, 1.0))
     u0s = [rand() * prob.u0 for i in 1:2]
     function simple_prob_func(prob, ctx)

--- a/lib/DiffEqBase/test/downstream/ensemble_thread_safety.jl
+++ b/lib/DiffEqBase/test/downstream/ensemble_thread_safety.jl
@@ -1,4 +1,5 @@
 using OrdinaryDiffEq
+using SciMLBase: EnsembleProblem, EnsembleThreads, EnsembleDistributed, EnsembleAnalysis
 function f(du, u, p, t)
     return du[1] = 1.01 * u[1]
 end

--- a/lib/DiffEqBase/test/downstream/labelledarrays.jl
+++ b/lib/DiffEqBase/test/downstream/labelledarrays.jl
@@ -1,4 +1,5 @@
 using OrdinaryDiffEq
+using OrdinaryDiffEqBDF: DImplicitEuler
 using LabelledArrays
 using ADTypes
 

--- a/lib/DiffEqBase/test/downstream/tables.jl
+++ b/lib/DiffEqBase/test/downstream/tables.jl
@@ -1,4 +1,5 @@
 using OrdinaryDiffEq, DataFrames, Test, SymbolicIndexingInterface
+using OrdinaryDiffEqLowOrderRK: Euler
 f_2dlinear = (du, u, p, t) -> du .= 1.01u;
 prob = ODEProblem(f_2dlinear, rand(2, 2), (0.0, 1.0));
 sol1 = solve(prob, Euler(); dt = 1 // 2^(4));


### PR DESCRIPTION
## Summary

Follow-up to #3522 for remaining `UndefVarError`s in `test (DiffEqBase_Downstream, 1)` and `test (DiffEqBase_Downstream2, 1)`:

- `DiffEqBase_Downstream`: `UndefVarError: EnsembleProblem not defined in Main.var"##Ensemble Thread Safety#301"`
- `DiffEqBase_Downstream2`: `UndefVarError: terminate! not defined in Main.var"##Callback BigFloats#314"`

Each `@safetestset` creates a fresh anonymous module, and OrdinaryDiffEq v7 no longer blanket-re-exports SciMLBase, so the specific SciMLBase names used by these tests must be imported explicitly. Kept imports named (not blanket `using SciMLBase`) so test intent stays explicit.

Files touched (all under `lib/DiffEqBase/test/downstream/`):
- `ensemble_thread_safety.jl` — `using SciMLBase: EnsembleProblem, EnsembleThreads, EnsembleDistributed, EnsembleAnalysis`
- `bigfloat_events.jl` — `using SciMLBase: terminate!`
- `community_callback_tests.jl` — `using SciMLBase: terminate!, set_u!` (preemptive: same pattern, uses `terminate!` and `set_u!`)
- `distributed_ensemble.jl` — adds ensemble algorithm type imports inside the `@everywhere` block

## Test plan

- [x] `ODEDIFFEQ_TEST_GROUP=Downstream Pkg.test("DiffEqBase")` on Julia 1.12.6 (locally) — `Ensemble Thread Safety` now runs clean (0 tests, no error); the previously reported UndefVarError is gone. Other Downstream sets (`Kwarg Warnings`, `Solve Error Handling`, `Null Parameters`, `Ensemble Simulations`, `Ensemble Analysis`, `Inference Tests`, etc.) pass.
- [ ] CI confirms `DiffEqBase_Downstream` and `DiffEqBase_Downstream2` groups no longer trip on these SciMLBase names.

Note: An unrelated pre-existing `UndefVarError: Euler` in `Table Inference Tests` remains (it is about `OrdinaryDiffEqLowOrderRK.Euler`, not SciMLBase) and is out of scope here, matching the precedent from #3522.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>