### PR TITLE
Fix InexactError when ExplicitRK cache narrows BigFloat c to Rational dt

### DIFF
--- a/lib/OrdinaryDiffEqExplicitRK/src/explicit_rk_caches.jl
+++ b/lib/OrdinaryDiffEqExplicitRK/src/explicit_rk_caches.jl
@@ -56,7 +56,11 @@ function ExplicitRKConstantCache(tableau, rate_prototype, ::Type{tType} = Float6
     # t + c[i]*dt doesn't promote t beyond what FunctionWrapper signatures
     # expect under AutoSpecialize. `one(tType)` strips units for Unitful
     # quantities while preserving precision for BigFloat/Float32 time types.
-    cType = typeof(one(tType))
+    # Use promote_type so that when `c`'s eltype is already wider than the
+    # dimensionless dt type (e.g. BigFloat `c` with Rational{Int} dt during
+    # convergence testing), we don't attempt a lossy narrowing that could
+    # throw InexactError for non-exactly-representable coefficients.
+    cType = promote_type(eltype(c), typeof(one(tType)))
     c = cType.(c)
     kk = Array{typeof(rate_prototype)}(undef, stages) # Not ks since that's for integrator.opts.dense
     αEEst = isempty(αEEst) ? αEEst : α .- αEEst


### PR DESCRIPTION
## Summary

Fixes the `InexactError: Rational(0.555555...)` failures in
`test (OrdinaryDiffEqExplicitTableaus, 1)` and
`test (OrdinaryDiffEqExplicitTableaus_QA, 1)` on master.

## Root cause

`ExplicitRKConstantCache` (introduced in the AutoSpecialize FunctionWrapper
fix) converts the tableau `c` vector to `typeof(one(dt))` to keep `t + c*dt`
from promoting `t` past a FunctionWrapper signature. When the convergence
tests pass `dts = 1 .// 2 .^ (8:-1:4)` (a `Vector{Rational{Int64}}`) together
with BigFloat tableaux like `ET.EnrightVerner8(BigFloat)` and
`ET.Feagin14(BigFloat)` at `setprecision(400)`, the target becomes
`Rational{Int64}` and the narrowing call `Rational{Int64}.(::Vector{BigFloat})`
throws `InexactError` on coefficients such as `5/9` that are not exactly
representable as `Rational{Int64}` at 400-bit precision.

## Fix

Widen the target with `promote_type(eltype(c), typeof(one(tType)))` so `c`
is only ever upcast toward `dt`'s dimensionless type, never downcast:

- BigFloat `c` with `Rational{Int}` dt — stays BigFloat (no narrowing). `t +
  c*dt` was already promoting to BigFloat, so FunctionWrapper behaviour is
  unchanged in this case.
- Float64 `c` with BigFloat dt — still upcast to BigFloat as before.
- Unitful time types — still dimensionless, because `one(tType)` strips
  units and `c` is dimensionless in practice.

One-line change in `lib/OrdinaryDiffEqExplicitRK/src/explicit_rk_caches.jl`.

## Test plan

- [x] `Pkg.test("OrdinaryDiffEqExplicitTableaus")` on Julia 1.12.6 — 233/233 pass (was 124 pass / 2 error).
- [x] `Pkg.test("OrdinaryDiffEqExplicitRK")` on Julia 1.12.6 — AllocCheck, JET, Aqua all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)