### PR TITLE
Add ImplicitDiscreteSolve [sources] to DiffEqBase MTK test env

### DIFF
--- a/lib/DiffEqBase/test/modelingtoolkit/Project.toml
+++ b/lib/DiffEqBase/test/modelingtoolkit/Project.toml
@@ -2,6 +2,7 @@
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+ImplicitDiscreteSolve = "3263718b-31ed-49cf-8a0f-35a466e8af96"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
@@ -11,12 +12,14 @@ SteadyStateDiffEq = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
+ImplicitDiscreteSolve = {path = "../../../ImplicitDiscreteSolve"}
 OrdinaryDiffEq = {path = "../../../.."}
 
 [compat]
 ADTypes = "1"
 DifferentiationInterface = "0.7"
 ForwardDiff = "0.10, 1"
+ImplicitDiscreteSolve = "1.11"
 ModelingToolkit = "10, 11"
 Mooncake = "0.4, 0.5"
 OrdinaryDiffEq = "7"


### PR DESCRIPTION
## Summary

Same class of fix as #3517 (NLS MTK test env). The `DiffEqBase_ModelingToolkit` test env can't resolve because `ImplicitDiscreteSolve 1.11.0` (registered) caps `SciMLBase` at `"2.116.0 - 2"`, while OrdinaryDiffEq v7 requires `SciMLBase 3`. MTK 11.22+ transitively pulls in IDS, so the resolver eliminates MTK when combined with the v3 pin.

```
Unsatisfiable requirements detected for package ImplicitDiscreteSolve
  └─ restricted by compatibility requirements with SciMLBase to
     versions: uninstalled
```

The monorepo's local `lib/ImplicitDiscreteSolve/Project.toml` already has `SciMLBase = "3"` — path-sourcing it via `[sources]` resolves cleanly.

## Fix

`lib/DiffEqBase/test/modelingtoolkit/Project.toml`:
- Add `ImplicitDiscreteSolve` to `[deps]`
- Add `[sources].ImplicitDiscreteSolve = {path = "../../../ImplicitDiscreteSolve"}`
- Add `[compat].ImplicitDiscreteSolve = "1.11"`

No changes needed in `lib/DiffEqBase/test/runtests.jl`'s `activate_modelingtoolkit_env` — it only does `Pkg.activate + Pkg.instantiate`, and the `[sources]` block handles path resolution directly.

## Test plan

- [ ] `test (DiffEqBase_ModelingToolkit, 1)` resolves cleanly on CI