### PR TITLE
Fix SciMLBase UndefVarError in Linear LSRK GPU test

### DIFF
--- a/lib/OrdinaryDiffEqLowStorageRK/test/gpu/linear_lsrk.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/test/gpu/linear_lsrk.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq, CUDA, Test
+using OrdinaryDiffEq, SciMLBase, CUDA, Test
 CUDA.allowscalar(false)
 N = 256
 # Define the initial condition as normal arrays


### PR DESCRIPTION
## Summary
- Import `FullSpecialize` explicitly in `lib/OrdinaryDiffEqLowStorageRK/test/gpu/linear_lsrk.jl` so the `@safetestset` anonymous module can resolve it.
- The test is run under `@safetestset`, which creates an anonymous module where names must be imported directly; `SciMLBase` was used unqualified (`SciMLBase.FullSpecialize`) without ever being brought into scope, producing `UndefVarError: SciMLBase not defined in Main.var"##Linear LSRK GPU#277"` in the `OrdinaryDiffEqLowStorageRK_GPU` CI job.
- Replaces `SciMLBase.FullSpecialize` with unqualified `FullSpecialize` after `using SciMLBase: FullSpecialize`, matching the style used elsewhere in the repo (e.g. `lib/OrdinaryDiffEqFeagin/test/qa/allocation_tests.jl`).

Failing CI job: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/24888659859/job/72875030018

## Test plan
- [ ] CI `test (OrdinaryDiffEqLowStorageRK_GPU, ...)` loads `Linear LSRK GPU` safetestset without `UndefVarError`.
- [ ] Other test groups remain unaffected.