### PR TITLE
Pass BrownFullBasicInit to Simple DAE GPU test for v7 CheckInit default

### DIFF
--- a/lib/OrdinaryDiffEqRosenbrock/test/gpu/simple_dae.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/gpu/simple_dae.jl
@@ -37,8 +37,6 @@ odef = ODEFunction(dae!, mass_matrix = mass_matrix, jac_prototype = jac_prototyp
 
 tspan = (0.0, 5.0)
 prob = ODEProblem(odef, u0, tspan, p)
-# v7: DefaultInit is CheckInit, so pass BrownFullBasicInit explicitly to let
-# the solver fix the inconsistent initial u0 before integrating.
 sol = solve(prob, Rodas5P(); initializealg = BrownFullBasicInit())
 
 # gpu version

--- a/lib/OrdinaryDiffEqRosenbrock/test/gpu/simple_dae.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/gpu/simple_dae.jl
@@ -1,5 +1,6 @@
 using OrdinaryDiffEqRosenbrock
 using OrdinaryDiffEqNonlinearSolve
+using OrdinaryDiffEqNonlinearSolve: BrownFullBasicInit
 using CUDA
 using LinearAlgebra
 using Adapt
@@ -36,7 +37,9 @@ odef = ODEFunction(dae!, mass_matrix = mass_matrix, jac_prototype = jac_prototyp
 
 tspan = (0.0, 5.0)
 prob = ODEProblem(odef, u0, tspan, p)
-sol = solve(prob, Rodas5P())
+# v7: DefaultInit is CheckInit, so pass BrownFullBasicInit explicitly to let
+# the solver fix the inconsistent initial u0 before integrating.
+sol = solve(prob, Rodas5P(); initializealg = BrownFullBasicInit())
 
 # gpu version
 mass_matrix_d = adapt(CuArray, mass_matrix)
@@ -50,7 +53,7 @@ u0_d = adapt(CuArray, u0)
 p_d = adapt(CuArray, p)
 odef_d = ODEFunction(dae!, mass_matrix = mass_matrix_d, jac_prototype = jac_prototype_d)
 prob_d = ODEProblem(odef_d, u0_d, tspan, p_d)
-sol_d = solve(prob_d, Rodas5P())
+sol_d = solve(prob_d, Rodas5P(); initializealg = BrownFullBasicInit())
 
 @testset "Test constraints in GPU sol" begin
     for t in sol_d.t


### PR DESCRIPTION
## Summary
- Fixes the `Simple DAE GPU` testset failure in the `OrdinaryDiffEqRosenbrock_GPU` CI job ([run](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/24888659859/job/72875030109?pr=3521)).
- OrdinaryDiffEq v7 changed the default `initializealg` from `DefaultInit` (which silently fell through to `BrownFullBasicInit`) to `CheckInit`, which now rejects the inconsistent `u0 = [1.0, 1.0, 0.5, 0.5]` with:
  ```
  DAE initialization failed: your u0 did not satisfy the initialization requirements,
  normresid = 0.7905694150420949 > abstol = 1.0e-6.
  ```
- Pass `initializealg = BrownFullBasicInit()` explicitly to both `solve` calls in `lib/OrdinaryDiffEqRosenbrock/test/gpu/simple_dae.jl` to restore pre-v7 behavior, and import `BrownFullBasicInit` from `OrdinaryDiffEqNonlinearSolve` (it is not re-exported through `OrdinaryDiffEq` into `@safetestset` modules).
- Matches the fix pattern applied in PR #3543 for `lib/DiffEqBase/test/downstream/community_callback_tests.jl`.

## Test plan
- [x] Verified the file parses cleanly (`Base.parse_input_line`).
- [x] Reproduced the exact error message on a CPU-only rig using the same CPU-side `solve(prob, Rodas5P())` call (line 39 of the original file), which fails before any GPU code runs.
- [x] Verified locally that adding `initializealg = BrownFullBasicInit()` makes the CPU `solve` succeed and satisfy the algebraic constraints.
- [ ] CI (GPU): requires CUDA; local rig has no NVIDIA GPU, so the full GPU testset must be validated by Buildkite. The same `initializealg` argument works for the GPU `solve` call because `BrownFullBasicInit` operates on the same abstract array interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)