### PR TITLE
Fix missing solver imports in Reaction-Diffusion Stiff GPU test

### DIFF
--- a/lib/OrdinaryDiffEqStabilizedRK/test/gpu/Project.toml
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/gpu/Project.toml
@@ -2,13 +2,23 @@
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+OrdinaryDiffEqLowOrderRK = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
+OrdinaryDiffEqStabilizedRK = "358294b1-0aab-51c3-aafe-ad5ab194a2ad"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources.OrdinaryDiffEq]
 path = "../../../.."
 
+[sources.OrdinaryDiffEqLowOrderRK]
+path = "../../../OrdinaryDiffEqLowOrderRK"
+
+[sources.OrdinaryDiffEqStabilizedRK]
+path = "../.."
+
 [compat]
 CUDA = "4, 5"
 OrdinaryDiffEq = "7"
+OrdinaryDiffEqLowOrderRK = "1"
+OrdinaryDiffEqStabilizedRK = "1"
 RecursiveArrayTools = "4"

--- a/lib/OrdinaryDiffEqStabilizedRK/test/gpu/reaction_diffusion_stiff.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/gpu/reaction_diffusion_stiff.jl
@@ -1,4 +1,6 @@
 using OrdinaryDiffEq, RecursiveArrayTools, LinearAlgebra, Test
+using OrdinaryDiffEqLowOrderRK: BS3
+using OrdinaryDiffEqStabilizedRK: ROCK2
 
 # Define the constants for the PDE
 const α₂ = 1.0


### PR DESCRIPTION
## Summary
- Fix `UndefVarError: BS3 not defined` in the `Reaction-Diffusion Stiff GPU` safetestset under `lib/OrdinaryDiffEqStabilizedRK/test/gpu/reaction_diffusion_stiff.jl`.
- In v7 the sublibraries are separated and `@safetestset` creates an anonymous module that does not see `OrdinaryDiffEq`'s re-exports, so every solver name must be explicitly imported.
- Add `using OrdinaryDiffEqLowOrderRK: BS3` and `using OrdinaryDiffEqStabilizedRK: ROCK2` at the top of the test file.
- Declare `OrdinaryDiffEqLowOrderRK` and `OrdinaryDiffEqStabilizedRK` as deps (with path sources and compat entries) in the GPU test `Project.toml`, matching the pattern used in `lib/OrdinaryDiffEqDefault/test/gpu/Project.toml`.

CI job being fixed: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/24888659859/job/72875030073

## Test plan
- [x] Verified the updated file parses with `Base.parse_input_line`.
- [x] Instantiated `lib/OrdinaryDiffEqStabilizedRK/test/gpu/Project.toml` locally.
- [x] Ran a scaled-down (N=32, tspan=1.0) CPU version of the test and confirmed `BS3()` and `ROCK2()` both solve successfully.
- [ ] Full GPU run requires the GPU CI runner — watch the `OrdinaryDiffEqStabilizedRK_GPU` buildkite job.

## Notes
Only `BS3` and `ROCK2` are used as unqualified solver names in this file; nothing else needed to be imported. `ODEProblem`, `Tridiagonal`, `mul!`, `@view`, and `@.` continue to come in via `OrdinaryDiffEq`, `LinearAlgebra`, and `Base`.