### PR TITLE
Fix Rodas5 UndefVarError in NLS MTK DAE Initialize Integration test

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/dae_initialize_integration.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/dae_initialize_integration.jl
@@ -1,4 +1,6 @@
 using ModelingToolkit, OrdinaryDiffEq, NonlinearSolve, Test
+using OrdinaryDiffEqRosenbrock: Rodas5, Rodas5P
+using OrdinaryDiffEqNonlinearSolve: BrownFullBasicInit, ShampineCollocationInit
 using ModelingToolkit: D_nounits as D, t_nounits as t
 
 @parameters g e b


### PR DESCRIPTION
## Summary
- Fixes `UndefVarError: Rodas5 not defined` in the `OrdinaryDiffEqNonlinearSolve` test `modelingtoolkit/dae_initialize_integration.jl`, which runs inside a `@safetestset` anonymous module where re-exports from `OrdinaryDiffEq` v7 do not resolve.
- Adds explicit imports: `using OrdinaryDiffEqRosenbrock: Rodas5, Rodas5P` and `using OrdinaryDiffEqNonlinearSolve: BrownFullBasicInit, ShampineCollocationInit` (matching the `using <Pkg>: name` style used elsewhere in the repo, e.g. `nested_ad_nlsolvealg_tests.jl`, `sparse_dae_initialization_tests.jl`).
- CI job this unblocks: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/24888659859/job/72875029983

## Test plan
- [x] Locally instantiate `lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit` and `include` the test file; confirm `Rodas5`, `Rodas5P`, `BrownFullBasicInit`, and `ShampineCollocationInit` resolve and the first `Rodas5()`/`Rodas5P()`/`BrownFullBasicInit()`/`ShampineCollocationInit()` solve calls run without `UndefVarError` (the only remaining failures are in an unrelated `reinit!` testset concerning ModelingToolkit `Initial(x)` behavior).
- [ ] CI `test (OrdinaryDiffEqNonlinearSolve_ModelingToolkit, ...)` passes the load/import phase for `DAE Initialize Integration`.