### PR TITLE
Fix stale prev_simultaneous_events in VCC nudge (DiffEqBase_Downstream CI)

### DIFF
--- a/lib/DiffEqBase/src/callbacks.jl
+++ b/lib/DiffEqBase/src/callbacks.jl
@@ -197,6 +197,21 @@ end
     @. bottom_sign = sign(bottom_condition)
 
     prev_simultaneous_events = integrator.callback_cache.prev_simultaneous_events
+    (; simultaneous_events) = integrator.callback_cache
+    # Snapshot the previous step's triggered events into `prev_simultaneous_events`
+    # BEFORE using them for the nudge logic, then clear `simultaneous_events` so it
+    # can be populated with events detected during this step. Previously this was
+    # done only after the nudge block, which left `prev_simultaneous_events` stale
+    # on the step immediately following an event — causing the repeat-detection
+    # avoidance logic (which relies on `prev_simultaneous_events[idx]`) to be
+    # skipped and the just-fired event to be re-detected.
+    if integrator.event_last_time == callback_idx
+        @. prev_simultaneous_events = !iszero(simultaneous_events)
+    else
+        prev_simultaneous_events .= false
+    end
+    simultaneous_events .= Int8(0)
+
     if integrator.event_last_time == callback_idx
         # If there was a previous event, nudge tprev on the right
         # side of the root (if necessary) to avoid repeat detection
@@ -234,13 +249,6 @@ end
     # Check if an event occurred
     event_occurred, event_idx, top_t, top_sign =
         check_event_occurrence(integrator, callback, bottom_sign)
-
-    # Track simultaneous events
-    (; simultaneous_events) = integrator.callback_cache
-    if event_occurred
-        @. prev_simultaneous_events = !iszero(simultaneous_events)
-        simultaneous_events .= Int8(0)
-    end
 
     # Find callback time if occurrence
     if !event_occurred


### PR DESCRIPTION
## Summary

Fixes the `DiffEqBase_Downstream` CI failure on
`lib/DiffEqBase/test/downstream/callback_detection.jl` — the
`"Successive same event detection"` testset (lines 61-119), specifically
the `affect_integrator: true` branch with `VectorContinuousCallback`,
which was firing every event twice (12 events observed where 6 were
expected).

## Root cause

In the VCC path of `find_callback_time` (`lib/DiffEqBase/src/callbacks.jl`),
the nudge logic used `prev_simultaneous_events[idx]` to:
1. Pick the condition value closest to zero (line ~211).
2. Update `bottom_sign` using `tmp_condition` at the nudged-forward time
   (line ~225), so that a just-fired event is not re-detected.

However, `prev_simultaneous_events` was only populated from the prior
step's `simultaneous_events` *after* the nudge block (at the old lines
240-243, inside `if event_occurred`). On the step immediately following
an event, the nudge block therefore saw a stale (all-`false`) array, so
the `bottom_sign` update was skipped, `bottom_sign` remained
`[-1, -1]` (computed at the raw `tprev` that was rewound by the user's
affect), a sign change was reported, and the rootfinder was called with
`(nudged_t, top_t)` — a same-sign interval. `ModAB` returned
`ReturnCode.InitialFailure` at `x1 = nudged_t ≈ 0.1025`, producing the
spurious `0.10249999999999` entry and a duplicate event at each of
`0.2, 0.4, 0.5, 0.8, 0.9`.

Symptom in the CI log:

```
record = Any[0.1, 0.10249999999999, 0.2, 0.2, 0.4, 0.4, 0.5, 0.5, 0.8, 0.8, 0.9, 0.9]
```

plus repeated `Verbosity toggle: non_enclosing_interval` warnings from
`BracketingNonlinearSolve/modAB.jl`. The `Vector{Any} vs Vector{Float64}`
`promote_shape` error at test line 117 is a consequence of the length
mismatch, not an eltype issue.

## Fix

Snapshot `prev_simultaneous_events = !iszero.(simultaneous_events)` at
the top of `find_callback_time` — *before* the nudge block reads it —
then clear `simultaneous_events` so it can be repopulated for the
current step. When `event_last_time != callback_idx`, clear
`prev_simultaneous_events` so stale state from another callback or a
pre-gap step doesn't leak into the nudge logic.

## Test plan

- [x] The failing testset `Successive same event detection` passes locally
      (`16/16` tests; was `10 pass / 2 fail / 4 error` before).
- [x] `Successive different callbacks in same integration step` still
      passes (`4/4`).
- [x] `lib/DiffEqBase/test/callbacks.jl` unit tests pass (`23/23`).
- [x] `test/integrators/event_repeat_tests.jl` passes (`6/6`).
- [x] `test/integrators/event_detection_tests.jl` passes (`23/23`).
- [x] `test/integrators/ode_event_tests.jl` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)