### PR TITLE
Add missing solver imports to DiffEqBase downstream safetestset tests

### DIFF
--- a/lib/DiffEqBase/test/downstream/Project.toml
+++ b/lib/DiffEqBase/test/downstream/Project.toml
@@ -15,7 +15,9 @@ OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 OrdinaryDiffEqBDF = "6ad6398a-0878-4a85-9266-38940aa047c8"
 OrdinaryDiffEqLowOrderRK = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
 OrdinaryDiffEqNonlinearSolve = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
+OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
 OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
+OrdinaryDiffEqVerner = "79d7bb75-1356-48c1-b8c0-6832512096c2"
 SDEProblemLibrary = "c72e72a9-a271-4b2b-8966-303ed956772e"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
@@ -29,7 +31,9 @@ OrdinaryDiffEq = {path = "../../../.."}
 OrdinaryDiffEqBDF = {path = "../../../OrdinaryDiffEqBDF"}
 OrdinaryDiffEqLowOrderRK = {path = "../../../OrdinaryDiffEqLowOrderRK"}
 OrdinaryDiffEqNonlinearSolve = {path = "../../../OrdinaryDiffEqNonlinearSolve"}
+OrdinaryDiffEqRosenbrock = {path = "../../../OrdinaryDiffEqRosenbrock"}
 OrdinaryDiffEqSDIRK = {path = "../../../OrdinaryDiffEqSDIRK"}
+OrdinaryDiffEqVerner = {path = "../../../OrdinaryDiffEqVerner"}
 StochasticDiffEq = {path = "../../../StochasticDiffEq"}
 
 [compat]

--- a/lib/DiffEqBase/test/downstream/default_linsolve_structure.jl
+++ b/lib/DiffEqBase/test/downstream/default_linsolve_structure.jl
@@ -1,4 +1,5 @@
 using LinearAlgebra, OrdinaryDiffEq, Test, ADTypes
+using OrdinaryDiffEqRosenbrock: Rosenbrock23
 f = (du, u, p, t) -> du .= u ./ t
 jac = (J, u, p, t) -> (J[1, 1] = 1 / t; J[2, 2] = 1 / t; J[1, 2] = 0; J[2, 1] = 0)
 

--- a/lib/DiffEqBase/test/downstream/labelledarrays.jl
+++ b/lib/DiffEqBase/test/downstream/labelledarrays.jl
@@ -1,5 +1,6 @@
 using OrdinaryDiffEq
 using OrdinaryDiffEqBDF: DImplicitEuler
+using OrdinaryDiffEqRosenbrock: Rodas5
 using LabelledArrays
 using ADTypes
 

--- a/lib/DiffEqBase/test/downstream/stats_tests.jl
+++ b/lib/DiffEqBase/test/downstream/stats_tests.jl
@@ -1,5 +1,6 @@
 # ncondition tests
 using OrdinaryDiffEq, Test
+using OrdinaryDiffEqVerner: Vern9
 
 function f(u, p, t)
     return 5 * u


### PR DESCRIPTION
## Summary

Sweeps the `lib/DiffEqBase/test/downstream/` set for unqualified v7-sublib solver references that aren't in scope inside `@safetestset` anonymous modules.

- `labelledarrays.jl`: adds `using OrdinaryDiffEqRosenbrock: Rodas5` — this is the one that surfaced in CI (`UndefVarError: Rodas5 not defined in Main.var\"##LabelledArrays Tests#307\"` at line 29).
- `default_linsolve_structure.jl`: adds `using OrdinaryDiffEqRosenbrock: Rosenbrock23`.
- `stats_tests.jl`: adds `using OrdinaryDiffEqVerner: Vern9`.

Wires `OrdinaryDiffEqRosenbrock` and `OrdinaryDiffEqVerner` into `lib/DiffEqBase/test/downstream/Project.toml` `[deps]` + `[sources]`.

Failing CI job: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/24913182341/job/72962345471

## Test plan
- [ ] CI `test (DiffEqBase_Downstream, ...)` passes the `LabelledArrays Tests`, `default_linsolve_structure`, and `stats_tests` safetestsets.