### PR TITLE
Import LowStorageRK solvers explicitly in Linear LSRK GPU test

### DIFF
--- a/lib/OrdinaryDiffEqLowStorageRK/test/gpu/linear_lsrk.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/test/gpu/linear_lsrk.jl
@@ -1,4 +1,5 @@
 using OrdinaryDiffEq, SciMLBase, CUDA, Test
+using OrdinaryDiffEqLowStorageRK: ORK256, CarpenterKennedy2N54, SHLDDRK64, DGLDDRK73_C
 CUDA.allowscalar(false)
 N = 256
 # Define the initial condition as normal arrays


### PR DESCRIPTION
## Summary
Follow-up to #3545 (which added `using SciMLBase` for `SciMLBase.FullSpecialize`).

`ORK256`, `CarpenterKennedy2N54`, `SHLDDRK64`, and `DGLDDRK73_C` live in `OrdinaryDiffEqLowStorageRK` and aren't re-exported into `@safetestset` anonymous modules by `using OrdinaryDiffEq` under v7, so line 16 (`algs = [ORK256(), CarpenterKennedy2N54(), SHLDDRK64(), DGLDDRK73_C()]`) fails with `UndefVarError: ORK256 not defined`.

Adds `using OrdinaryDiffEqLowStorageRK: ORK256, CarpenterKennedy2N54, SHLDDRK64, DGLDDRK73_C`.

Failing CI job: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/24913182341/job/72962345711

## Test plan
- [ ] CI `test (OrdinaryDiffEqLowStorageRK_GPU, ...)` no longer hits the `ORK256` UndefVarError.