### PR TITLE
Fix GPU FunctionWrapper signature mismatches (analytic jac + initdt)

### DIFF
--- a/lib/DiffEqBase/src/solve.jl
+++ b/lib/DiffEqBase/src/solve.jl
@@ -851,7 +851,14 @@ function promote_f(
                     (Nothing, Nothing)
                 )
             else
-                sig = Tuple{Matrix{uElType}, typeof(u0), typeof(p), typeof(t)}
+                # No `jac_prototype` and no non-dense sparsity pattern. The integrator
+                # builds J via `ArrayInterface.zeromatrix(u)` (see
+                # `OrdinaryDiffEqDifferentiation/src/derivative_utils.jl`), so derive
+                # the wrapper signature from `u0` rather than hardcoding `Matrix`,
+                # which would break GPU arrays (e.g. `CuArray`) and other
+                # non-`Array` storage types.
+                J_T = Base.promote_op(ArrayInterface.zeromatrix, typeof(u0))
+                sig = Tuple{J_T, typeof(u0), typeof(p), typeof(t)}
                 f = @set f.jac = FunctionWrappersWrappers.FunctionWrappersWrapper(
                     Void(f.jac), (sig,), (Nothing,)
                 )

--- a/lib/OrdinaryDiffEqCore/src/initdt.jl
+++ b/lib/OrdinaryDiffEqCore/src/initdt.jl
@@ -56,7 +56,14 @@
         f(f₀, u0, p, t)
     else
         # TODO: use more caches
-        if u0 isa Array && eltype(u0) isa Number
+        # When time is unitless, `f` writes `du` with `eltype(u0)` and the
+        # FunctionWrapper signature emitted by `promote_f` reflects that. Dividing
+        # by `oneunit_tType` is only meaningful for unit-aware time (e.g. Unitful);
+        # for plain numeric `t` it would spuriously promote (e.g. Float32 / Float64
+        # -> Float64) and produce a `du` whose eltype no longer matches the wrapper.
+        if recursive_unitless_eltype(u0) === eltype(u0)
+            f₀ = zero(u0)
+        elseif u0 isa Array && eltype(u0) isa Number
             T = eltype(first(u0) / oneunit_tType)
             f₀ = similar(u0, T)
             fill!(f₀, zero(T))


### PR DESCRIPTION
## Summary

Two related `FunctionWrappersWrapper` signature mismatches surfaced by the v7 monorepo's GPU CI matrix (run [24913182341](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/24913182341)). In each case the wrapper built at solve-setup encodes a CPU `Matrix` / `eltype(u0)` shape, but the integrator then calls it with the GPU / promoted-eltype values it actually computes — `FunctionWrappersWrappers._call` raises `No matching function wrapper was found!`.

## Failures fixed

### 1. `OrdinaryDiffEqCore_GPU` — `Simple GPU` testset (`lib/OrdinaryDiffEqCore/test/gpu/simple_gpu.jl`)

`solve(prob, Rosenbrock23())` on a `CuArray{Float32, 1}` `u0` with a user-supplied `jac` errored:

```
No matching function wrapper was found!
[1] _call(::Tuple{}, arg::Tuple{CuArray{Float32, 2, DeviceMemory}, CuArray{Float32, 1, DeviceMemory}, NullParameters, Float32},
    fww::FunctionWrappersWrapper{Tuple{FunctionWrapper{Nothing,
      Tuple{Matrix{Float32}, CuArray{Float32, 1, DeviceMemory}, NullParameters, Float32}}}, …})
```

Root cause: in `lib/DiffEqBase/src/solve.jl`'s `promote_f`, when `f.jac_prototype === nothing` and there is no non-dense sparsity pattern, the wrapper signature was hardcoded to `Matrix{uElType}` for the Jacobian argument. On GPU, `build_J_W` (`OrdinaryDiffEqDifferentiation/src/derivative_utils.jl`) constructs J via `ArrayInterface.zeromatrix(u)` — `CuArray{Float32, 2}` for a `CuArray{Float32, 1}` `u0` — so the wrapper had no matching variant.

Fix: derive the J type from `u0` to match whatever the integrator actually allocates:

```julia
J_T = Base.promote_op(ArrayInterface.zeromatrix, typeof(u0))
sig = Tuple{J_T, typeof(u0), typeof(p), typeof(t)}
```

### 2. `OrdinaryDiffEqDefault_GPU` — `Autoswitch GPU` testset (`lib/OrdinaryDiffEqDefault/test/gpu/autoswitch.jl`)

`solve(ODEProblem(f, CUDA.ones(1), (0.0, 1.0)), AutoTsit5(Rosenbrock23()), …)` errored from `OrdinaryDiffEqCore/src/initdt.jl:66`:

```
No matching function wrapper was found!
[1] _call(::Tuple{}, arg::Tuple{CuArray{Float64, 1, DeviceMemory}, CuArray{Float32, 1, DeviceMemory}, NullParameters, Float64}, fww::…)
```

Root cause: the non-FSAL `initdt` path built `f₀` as `zero.(u0 ./ oneunit_tType)`. For unitless time, the `./ oneunit_tType` is semantically a no-op but spuriously promotes eltype (`Float32 / Float64 -> Float64`), so `u0::CuArray{Float32, 1}` with `tspan::Tuple{Float64, Float64}` produced `f₀::CuArray{Float64, 1}`. Every wrapper variant from `promote_f` is keyed on `eltype(u0)`, so the call to `f(f₀, u0, p, t)` had no matching signature.

Fix: when `recursive_unitless_eltype(u0) === eltype(u0)` (no Unitful time), use `zero(u0)` directly so `f₀` matches the wrapper. Fall back to the original division for unit-aware types where the quotient eltype is the dimensionally-correct one.

## Verification

Both fixes verified on a Tesla V100 against `OrdinaryDiffEq.jl` master:

- `OrdinaryDiffEqCore/test/gpu/simple_gpu.jl` — passes (was: `Simple GPU` testset 7 passed / 1 errored)
- `OrdinaryDiffEqDefault/test/gpu/autoswitch.jl` — passes (was: `Got exception outside of a @test`)
- `OrdinaryDiffEqCore/test/gpu/hermite_test.jl` — still passes
- CPU `Vector{Float64}` Rosenbrock23 with analytic jac — still passes

(The unrelated `LowStorageRK_GPU` failure in the same CI run is an `UndefVarError: ORK256` import issue, not a wrapper-signature mismatch, and is out of scope here.)

## Test plan

- [ ] `OrdinaryDiffEqCore_GPU` job goes green
- [ ] `OrdinaryDiffEqDefault_GPU` job goes green
- [ ] No regressions in non-GPU `OrdinaryDiffEqCore` / `DiffEqBase` matrix