### PR TITLE
Add local_only flag to skip expensive test groups on transitive CI triggers

### DIFF
--- a/.github/scripts/compute_affected_sublibraries.jl
+++ b/.github/scripts/compute_affected_sublibraries.jl
@@ -24,6 +24,14 @@
 #   runner      — string or array of labels (default: "ubuntu-latest")
 #   timeout     — integer, job timeout in minutes (default: 120)
 #   num_threads — integer, JULIA_NUM_THREADS (default: 1)
+#   local_only  — boolean (default: false). When true, the group is skipped
+#                 whenever this sublibrary is only being tested because an
+#                 upstream dependency changed (i.e. it landed in the matrix
+#                 transitively, not because its own files were touched). Use
+#                 this for groups so expensive that running them on every
+#                 dependency-graph rebuild is wasteful — e.g. weak-convergence
+#                 tests in the StochasticDiffEq sublibraries. The group still
+#                 runs whenever any file under lib/<this-pkg>/ is edited.
 #
 # If no test/test_groups.toml exists, the default is:
 #   Core on ["lts", "1.11", "1", "pre"]
@@ -118,6 +126,7 @@ struct TestGroupConfig
     runner::Any  # String or Vector{String}
     timeout::Int
     num_threads::Int
+    local_only::Bool
 end
 
 function load_test_groups(lib_dir::String, pkg::String)
@@ -131,12 +140,13 @@ function load_test_groups(lib_dir::String, pkg::String)
             runner = runner_raw isa Vector ? convert(Vector{String}, runner_raw) : runner_raw::String
             timeout = Int(get(config, "timeout", 120))
             num_threads = Int(get(config, "num_threads", 1))
-            groups[name] = TestGroupConfig(versions, runner, timeout, num_threads)
+            local_only = Bool(get(config, "local_only", false))
+            groups[name] = TestGroupConfig(versions, runner, timeout, num_threads, local_only)
         end
         return groups
     end
     return Dict{String, TestGroupConfig}(
-        k => TestGroupConfig(v, "ubuntu-latest", 120, 1) for (k, v) in DEFAULT_TEST_GROUPS
+        k => TestGroupConfig(v, "ubuntu-latest", 120, 1, false) for (k, v) in DEFAULT_TEST_GROUPS
     )
 end
 
@@ -194,6 +204,9 @@ function build_matrix(
         is_downstream = pkg in transitive
         for group_name in sort!(collect(keys(groups)))
             config = groups[group_name]
+            # local_only groups don't run when this package was only pulled
+            # in via the reverse-dependency graph.
+            is_downstream && config.local_only && continue
             ci_group = group_name == "Core" ? pkg : "$(pkg)_$(group_name)"
             # Downstream (transitive) deps only run on latest stable.
             versions = is_downstream ? [DOWNSTREAM_VERSION] : config.versions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,29 @@ Each sublibrary declares its CI jobs through `test/test_groups.toml`. Groups lis
 `.github/scripts/compute_affected_sublibraries.jl`. The group name is passed to the
 sublibrary's `test/runtests.jl` via `ENV["ODEDIFFEQ_TEST_GROUP"]`.
 
+### Skipping a group on dependency-graph triggers (`local_only`)
+
+By default, when an upstream sublibrary's source changes, every reverse-dependent
+sublibrary is added to the matrix and its full set of test groups runs (on Julia 1
+only). For groups that are too expensive to justify running on every upstream change —
+for example the weak-convergence Monte-Carlo tests in `StochasticDiffEqWeak`,
+`StochasticDiffEq`, and `StochasticDiffEqROCK` — set `local_only = true` in the
+group's entry:
+
+```toml
+[WeakConvergence2]
+versions = ["1"]
+runner = ["self-hosted", "Linux", "X64", "high-memory"]
+timeout = 300
+local_only = true
+```
+
+`local_only` groups still run whenever any file under this sublibrary's own
+`lib/<pkg>/` directory is edited (a "direct" trigger). They are skipped only when
+the sublibrary lands in the matrix transitively because an upstream dependency
+changed. Use this for groups whose value scales with this sublibrary's solvers,
+not with upstream behavior.
+
 ### Per-group test environments
 
 A group that needs dependencies beyond the sublibrary's main `[targets].test` list should

--- a/lib/StochasticDiffEq/test/test_groups.toml
+++ b/lib/StochasticDiffEq/test/test_groups.toml
@@ -21,18 +21,27 @@ versions = ["1"]
 [AlgConvergence3]
 versions = ["1"]
 
+# Weak-convergence groups are extremely expensive (Monte-Carlo trajectory
+# studies) and only exercise StochasticDiffEq's own weak solvers, so they are
+# marked local_only: they run when this package's source/tests are edited but
+# are skipped when this package is only pulled into the matrix because an
+# upstream dependency changed. See compute_affected_sublibraries.jl.
+
 [WeakConvergence1]
 versions = ["1"]
+local_only = true
 
 [OOPWeakConvergence]
 versions = ["1"]
 runner = ["self-hosted", "Linux", "X64", "high-memory"]
 timeout = 300
+local_only = true
 
 [IIPWeakConvergence]
 versions = ["1"]
 runner = ["self-hosted", "Linux", "X64", "high-memory"]
 timeout = 300
+local_only = true
 
 [Multithreaded]
 versions = ["1"]
@@ -44,6 +53,7 @@ timeout = 240
 versions = ["1"]
 runner = ["self-hosted", "Linux", "X64", "gpu"]
 timeout = 240
+local_only = true
 
 [Allocations]
 versions = ["1"]

--- a/lib/StochasticDiffEqROCK/test/test_groups.toml
+++ b/lib/StochasticDiffEqROCK/test/test_groups.toml
@@ -1,10 +1,14 @@
 [Core]
 versions = ["1.11", "1", "pre"]
 
+# Weak-convergence Monte-Carlo studies — too expensive to run on every
+# upstream-dependency change, so marked local_only. See
+# compute_affected_sublibraries.jl.
 [SROCKC2WeakConvergence]
 versions = ["1"]
 runner = ["self-hosted", "Linux", "X64", "high-memory"]
 timeout = 240
+local_only = true
 
 [QA]
 versions = ["1"]

--- a/lib/StochasticDiffEqWeak/test/test_groups.toml
+++ b/lib/StochasticDiffEqWeak/test/test_groups.toml
@@ -1,45 +1,61 @@
 [Core]
 versions = ["1.11", "1", "pre"]
 
+# Weak-convergence groups are extremely expensive (Monte-Carlo trajectory
+# studies) and only exercise StochasticDiffEqWeak's own solvers, so they are
+# marked local_only: they run when this package's source/tests are edited but
+# are skipped when this package is only pulled into the matrix because an
+# upstream dependency changed.
+
 [WeakConvergence1]
 versions = ["1"]
+local_only = true
 
 [WeakConvergence2]
 versions = ["1"]
 runner = ["self-hosted", "Linux", "X64", "high-memory"]
 timeout = 300
+local_only = true
 
 [W2Ito1WeakConvergence]
 versions = ["1"]
+local_only = true
 
 [WeakConvergence3]
 versions = ["1"]
 runner = ["self-hosted", "Linux", "X64", "high-memory"]
 timeout = 300
+local_only = true
 
 [SIESMEWeakConvergence]
 versions = ["1"]
+local_only = true
 
 [WeakConvergence4]
 versions = ["1"]
 runner = ["self-hosted", "Linux", "X64", "high-memory"]
 timeout = 420
+local_only = true
 
 [WeakConvergence5]
 versions = ["1"]
 runner = ["self-hosted", "Linux", "X64", "high-memory"]
 timeout = 300
+local_only = true
 
 [WeakConvergence6]
 versions = ["1"]
 runner = ["self-hosted", "Linux", "X64", "high-memory"]
 timeout = 300
+local_only = true
 
 [IRI1WeakConvergence]
 versions = ["1"]
+local_only = true
 
 [WeakAdaptiveCPU]
 versions = ["1"]
+local_only = true
 
 [QA]
 versions = ["1"]


### PR DESCRIPTION
## Summary

- Add an opt-in `local_only = true` field to entries in `lib/<pkg>/test/test_groups.toml`. When set, `compute_affected_sublibraries.jl` drops the group from the matrix if the sublibrary was pulled into the matrix only because an upstream dependency changed. The group still runs on any direct edit under `lib/<pkg>/`.
- Mark every weak-convergence group in `StochasticDiffEqWeak`, `StochasticDiffEq`, and `StochasticDiffEqROCK` as `local_only`. The cheap `Core` / `QA` / `Interface*` groups stay as they are and continue to fire on transitive triggers.
- Document the field under "Test Group Structure" in `CONTRIBUTING.md`.

## Why

Sublibrary CI fans out to every reverse dependency on an upstream `src/` change. That is the right default for ordinary regression coverage, but the SDE weak-convergence groups are dominated by Monte-Carlo trajectory studies (some run on `high-memory` self-hosted runners with 5–7 minute timeouts) and only exercise solvers in their own sublibrary. Running them on every dependency-graph rebuild burns CI minutes without exercising anything new.

## Behavior

| Trigger | Non-`local_only` group | `local_only` group |
|---|---|---|
| Edit under `lib/<this-pkg>/` (direct) | runs on configured versions | runs on configured versions |
| Edit under an upstream dep's `src/` (transitive) | runs on `1` only | **skipped** |
| Edit only under `lib/<this-pkg>/test/` | runs (no transitive propagation) | runs |

## Test plan

- [x] Local validation script driving `compute_affected_sublibraries.jl` through its real CLI (stdin → JSON) — 35 assertions covering direct and transitive triggers across `StochasticDiffEqWeak`, `StochasticDiffEq`, `StochasticDiffEqROCK`. All pass.
- [x] Confirmed that editing `lib/StochasticDiffEqCore/src/solve.jl` produces a matrix with **no** weak-convergence entries for any of the three sublibraries, while `Core` / `QA` / `Interface*` still propagate.
- [x] Confirmed that editing `lib/StochasticDiffEqWeak/src/algorithms.jl` keeps every weak-convergence group present (and still fans `Core` across `["1.11", "1", "pre"]`).
- [ ] CI on this PR exercises the path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)