### PR TITLE
Add OrdinaryDiffEqLowStorageRK + SciMLBase deps to LSRK GPU test env

### DIFF
--- a/lib/OrdinaryDiffEqLowStorageRK/test/gpu/Project.toml
+++ b/lib/OrdinaryDiffEqLowStorageRK/test/gpu/Project.toml
@@ -1,11 +1,18 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+OrdinaryDiffEqLowStorageRK = "b0944070-b475-4768-8dec-fb6eb410534d"
+SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources.OrdinaryDiffEq]
 path = "../../../.."
 
+[sources.OrdinaryDiffEqLowStorageRK]
+path = "../.."
+
 [compat]
 CUDA = "4, 5"
 OrdinaryDiffEq = "7"
+OrdinaryDiffEqLowStorageRK = "1"
+SciMLBase = "3"


### PR DESCRIPTION
## Summary

`OrdinaryDiffEqLowStorageRK_GPU` job in [run 24913182341](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/24913182341) failed with:

```
LoadError: UndefVarError: `ORK256` not defined in `Main.var"##Linear LSRK GPU#277"`
```

The test file already does:

```julia
using OrdinaryDiffEq, SciMLBase, CUDA, Test
using OrdinaryDiffEqLowStorageRK: ORK256, CarpenterKennedy2N54, SHLDDRK64, DGLDDRK73_C
```

In v6, `OrdinaryDiffEq` re-exported these symbols, so `using OrdinaryDiffEq` was enough. In v7 the umbrella exports a smaller surface, so the explicit `using OrdinaryDiffEqLowStorageRK: …` (and `using SciMLBase`) need their packages listed as direct deps in the test environment — they aren't anymore, since v7 dropped them from the umbrella's transitive set.

This PR adds `OrdinaryDiffEqLowStorageRK` and `SciMLBase` as path-`[sources]` deps in `lib/OrdinaryDiffEqLowStorageRK/test/gpu/Project.toml` so the safetestset can actually load the sublibrary and resolve `ORK256` et al.

## Verification

Tesla V100 (demeter3): all four algorithms (`ORK256`, `CarpenterKennedy2N54`, `SHLDDRK64`, `DGLDDRK73_C`) now run their CPU-vs-GPU `≈` checks and pass.

## Test plan

- [ ] `OrdinaryDiffEqLowStorageRK_GPU` job goes green