### PR TITLE
Fix benchmark CI for the monorepo's [sources] sublibraries

### DIFF
--- a/.github/scripts/compare_benchmarks.jl
+++ b/.github/scripts/compare_benchmarks.jl
@@ -1,0 +1,87 @@
+#!/usr/bin/env julia
+# Compare two BenchmarkTools JSON result files (as written by
+# `BenchmarkTools.save`) and emit a Markdown summary on stdout.
+#
+# Usage:
+#   julia --startup-file=no compare_benchmarks.jl <base.json> <head.json> [<title>]
+#
+# Output: a Markdown section with one row per benchmark leaf. The "ratio"
+# column is `head_time / base_time` — under 1.0 means the PR is faster.
+
+using Pkg
+Pkg.activate(; temp = true)
+Pkg.add(Pkg.PackageSpec(; name = "BenchmarkTools"))
+
+using BenchmarkTools
+using BenchmarkTools: leaves
+using Printf
+
+length(ARGS) >= 2 || error("usage: compare_benchmarks.jl <base.json> <head.json> [<title>]")
+
+const BASE_PATH = ARGS[1]
+const HEAD_PATH = ARGS[2]
+const TITLE     = length(ARGS) >= 3 ? ARGS[3] : "Benchmark results"
+
+isfile(BASE_PATH) || error("base results not found: $BASE_PATH")
+isfile(HEAD_PATH) || error("head results not found: $HEAD_PATH")
+
+base = BenchmarkTools.load(BASE_PATH)[1]::BenchmarkGroup
+head = BenchmarkTools.load(HEAD_PATH)[1]::BenchmarkGroup
+
+# Format a duration in human-friendly units.
+function fmt_time(ns::Real)
+    ns < 1e3   && return @sprintf("%.2f ns", ns)
+    ns < 1e6   && return @sprintf("%.2f μs", ns / 1e3)
+    ns < 1e9   && return @sprintf("%.2f ms", ns / 1e6)
+    return @sprintf("%.2f s", ns / 1e9)
+end
+fmt_mem(b::Real) = b < 1024 ? @sprintf("%d B", b) :
+    b < 1024^2 ? @sprintf("%.1f KiB", b / 1024) :
+    b < 1024^3 ? @sprintf("%.2f MiB", b / 1024^2) :
+                  @sprintf("%.2f GiB", b / 1024^3)
+
+# `leaves` returns Vector{Tuple{Vector{Any}, Trial-or-Estimate}}. Build a
+# {key_path => estimate} dict for each side so we can join.
+to_map(g) = Dict(join(string.(k), " / ") => v for (k, v) in leaves(g))
+base_map = to_map(base)
+head_map = to_map(head)
+all_keys = sort!(collect(union(keys(base_map), keys(head_map))))
+
+println("## ", TITLE)
+println()
+println("| Benchmark | base time | PR time | ratio | base mem | PR mem |")
+println("|---|---:|---:|---:|---:|---:|")
+
+regressed = String[]
+for k in all_keys
+    b = get(base_map, k, nothing)
+    h = get(head_map, k, nothing)
+    bt = b === nothing ? NaN : time(b)
+    ht = h === nothing ? NaN : time(h)
+    bm = b === nothing ? 0   : memory(b)
+    hm = h === nothing ? 0   : memory(h)
+    ratio = (isnan(bt) || isnan(ht) || bt == 0) ? NaN : ht / bt
+    ratio_cell = isnan(ratio) ? "—" : @sprintf("%.2fx", ratio)
+    if !isnan(ratio) && ratio > 1.10
+        ratio_cell *= " ⚠️"
+        push!(regressed, k)
+    elseif !isnan(ratio) && ratio < 0.90
+        ratio_cell *= " 🚀"
+    end
+    println("| `", k, "` | ",
+        isnan(bt) ? "—" : fmt_time(bt), " | ",
+        isnan(ht) ? "—" : fmt_time(ht), " | ",
+        ratio_cell, " | ",
+        b === nothing ? "—" : fmt_mem(bm), " | ",
+        h === nothing ? "—" : fmt_mem(hm), " |")
+end
+
+println()
+if isempty(regressed)
+    println("_No benchmarks regressed by more than 10%._")
+else
+    println("**", length(regressed), " benchmark(s) regressed by more than 10%:**")
+    for k in regressed
+        println("- `", k, "`")
+    end
+end

--- a/.github/scripts/run_benchmarks.jl
+++ b/.github/scripts/run_benchmarks.jl
@@ -1,0 +1,82 @@
+#!/usr/bin/env julia
+# Run benchmark/benchmarks.jl against a checkout of this monorepo, producing
+# a JSON file with `BenchmarkTools.minimum` results.
+#
+# OrdinaryDiffEq.jl's top-level Project.toml depends on a number of sublibraries
+# (OrdinaryDiffEqRosenbrockTableaus, OrdinaryDiffEqExplicitTableaus, …) that
+# only live in this repo's `lib/` tree and are not in the General registry.
+# They are wired up via `[sources]` in Project.toml. On Julia 1.10 (LTS) Pkg
+# does not natively understand `[sources]`, so a plain `Pkg.develop(path=…)`
+# of the umbrella package fails to resolve those deps. We therefore parse
+# `[sources]` ourselves and `Pkg.develop` each path-source first, then add
+# the umbrella package on top.
+#
+# Usage:
+#   julia --startup-file=no run_benchmarks.jl <repo_path> <output_json> [<extra_pkg>…]
+#
+# Arguments:
+#   repo_path     — path to the OrdinaryDiffEq.jl checkout to benchmark.
+#   output_json   — file to write JSON results to.
+#   extra_pkg…    — additional registered packages to add to the env (e.g.
+#                   StableRNGs, StaticArrays, BenchmarkTools is always added).
+
+using Pkg
+using TOML
+
+length(ARGS) >= 2 || error("usage: run_benchmarks.jl <repo_path> <output_json> [extra_pkg…]")
+
+const REPO        = abspath(ARGS[1])
+const OUTPUT_JSON = abspath(ARGS[2])
+const EXTRA_PKGS  = String[ARGS[3:end]...]
+
+isdir(REPO) || error("repo_path is not a directory: $REPO")
+isfile(joinpath(REPO, "Project.toml")) ||
+    error("no Project.toml at $REPO")
+const SCRIPT = joinpath(REPO, "benchmark", "benchmarks.jl")
+isfile(SCRIPT) || error("no benchmark script at $SCRIPT")
+
+# Fresh, isolated env so we don't leak state between revs.
+Pkg.activate(; temp = true)
+
+# Pre-develop every path-based [sources] entry from the umbrella Project.toml.
+# Mirrors AirspeedVelocity's `dev_source_pkgs` so we work on Julia 1.10 too.
+project = TOML.parsefile(joinpath(REPO, "Project.toml"))
+sources = get(project, "sources", Dict{String, Any}())
+path_specs = Pkg.PackageSpec[]
+for (name, meta) in sources
+    haskey(meta, "path") || continue
+    raw = meta["path"]
+    p   = isabspath(raw) ? raw : joinpath(REPO, raw)
+    push!(path_specs, Pkg.PackageSpec(; name = name, path = p))
+end
+isempty(path_specs) || Pkg.develop(path_specs)
+
+# The umbrella package itself.
+Pkg.develop(Pkg.PackageSpec(; path = REPO))
+
+# Benchmark tooling + script-specific deps.
+extras = vcat(["BenchmarkTools"], EXTRA_PKGS)
+Pkg.add([Pkg.PackageSpec(; name = p) for p in unique(extras)])
+
+Pkg.instantiate()
+Pkg.precompile()
+
+@info "Running benchmark script: $SCRIPT"
+include(SCRIPT)  # defines `SUITE::BenchmarkGroup`
+
+@assert @isdefined(SUITE) "benchmark script did not define `SUITE`"
+
+using BenchmarkTools
+
+@info "Tuning benchmarks"
+BenchmarkTools.tune!(SUITE; verbose = false)
+
+@info "Running benchmarks"
+results = BenchmarkTools.run(SUITE; verbose = true)
+
+# `minimum` collapses each leaf BenchmarkTrial to a single estimate so PR-vs-base
+# diffs are stable. `BenchmarkTools.save` writes BenchmarkTools' standard JSON
+# wire format, which `BenchmarkTools.load` (and therefore judge/regressions) reads.
+mkpath(dirname(OUTPUT_JSON))
+BenchmarkTools.save(OUTPUT_JSON, BenchmarkTools.minimum(results))
+@info "Wrote results to $OUTPUT_JSON"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,21 +9,73 @@ permissions:
   pull-requests: write
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
         version: ["1", "lts"]
-    env:
-      # Force consistent Julia depot path for self-hosted runners
-      JULIA_DEPOT_PATH: ~/.julia
     steps:
-      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+      - name: Check out PR head
+        uses: actions/checkout@v6
         with:
-          julia-version: ${{ matrix.version }}
-          script: "benchmark/benchmarks.jl"
-          extra-pkgs: "StableRNGs,StaticArrays"
-          job-summary: true
+          path: head
+
+      - name: Check out PR base
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+
+      - name: Cache Julia depot
+        uses: julia-actions/cache@v3
+        continue-on-error: true
+
+      # The umbrella OrdinaryDiffEq Project.toml depends on a number of
+      # in-tree-only sublibraries (e.g. OrdinaryDiffEqRosenbrockTableaus) that
+      # are wired up via [sources]. AirspeedVelocity's `benchpkg` adds the
+      # umbrella from a git URL, which on Julia 1.10 doesn't honour [sources]
+      # and therefore can't resolve those deps. The helper script handles this
+      # by walking [sources] and `Pkg.develop`-ing each path entry first.
+
+      - name: Benchmark PR base
+        run: |
+          julia --startup-file=no head/.github/scripts/run_benchmarks.jl \
+            base \
+            "$GITHUB_WORKSPACE/results/base.json" \
+            StableRNGs StaticArrays
+
+      - name: Benchmark PR head
+        run: |
+          julia --startup-file=no head/.github/scripts/run_benchmarks.jl \
+            head \
+            "$GITHUB_WORKSPACE/results/head.json" \
+            StableRNGs StaticArrays
+
+      - name: Render comparison
+        if: success()
+        run: |
+          julia --startup-file=no head/.github/scripts/compare_benchmarks.jl \
+            "$GITHUB_WORKSPACE/results/base.json" \
+            "$GITHUB_WORKSPACE/results/head.json" \
+            "Benchmark results (Julia ${{ matrix.version }})" \
+            > "$GITHUB_WORKSPACE/results/summary.md"
+          cat "$GITHUB_WORKSPACE/results/summary.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: benchmark-${{ matrix.version }}
+          path: results/
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

The benchmark CI has been failing on every PR with `Unsatisfiable requirements detected for package OrdinaryDiffEqRosenbrockTableaus`.

**Root cause.** `benchmark.yml` ran `MilesCranmer/AirspeedVelocity.jl@action-v1`, which calls `benchpkg` with `--url=<repo clone URL>`. Internally that becomes `Pkg.add(PackageSpec(name="OrdinaryDiffEq", rev=...))` inside a fresh temp env. The umbrella Project.toml depends on a number of in-tree-only sublibraries (`OrdinaryDiffEqRosenbrockTableaus`, `OrdinaryDiffEqExplicitTableaus`, `OrdinaryDiffEqRosenbrockTableaus`, `OrdinaryDiffEqImplicitTableaus`, …) wired up via `[sources]`. Julia 1.10's `Pkg` does **not** honour `[sources]` for path-based deps, and AirspeedVelocity's `dev_source_pkgs` helper only fires when `--path` is set (not `--url`). So `benchpkg` couldn't resolve those packages from any registry and exited with a `Pkg.Resolve` error before any benchmark ran.

**Fix.** Drop the AirspeedVelocity action and use a self-contained workflow that explicitly handles `[sources]`:

- `.github/scripts/run_benchmarks.jl` — opens a fresh temp env, walks `Project.toml`'s `[sources]` table and `Pkg.develop`s each path entry first, then `Pkg.develop`s the umbrella package on top. Runs `benchmark/benchmarks.jl` and writes `BenchmarkTools.minimum(results)` via `BenchmarkTools.save`. Works on Julia 1.10 and 1.11.
- `.github/scripts/compare_benchmarks.jl` — loads two `BenchmarkTools.save` JSONs, joins them by benchmark key path, and emits a Markdown table with time / memory / ratio columns. Flags >10% regressions with ⚠️ and >10% improvements with 🚀.
- `.github/workflows/benchmark.yml` — checks out PR head and PR base into separate working directories, runs the helper against each, renders the comparison into `$GITHUB_STEP_SUMMARY`, and uploads the JSON artifacts for offline diffing.

## Test plan

- [x] Smoke-tested `run_benchmarks.jl` against the upstream master tree on Julia 1.11.9 — all five benchmarks complete successfully (`scaling/linear/N50`, `nonstiff/lotka_volterra/{Tsit5,Vern7}`, `stiff/rober/{FBDF,Rodas5P}`).
- [x] Smoke-tested `run_benchmarks.jl` on Julia 1.10.11 (the LTS path that was breaking in CI) — same five benchmarks complete; `[sources]` deps resolved correctly.
- [x] Smoke-tested `compare_benchmarks.jl` against two real result files — produced a clean Markdown table with no formatting issues.
- [ ] CI on this PR exercises the full workflow end-to-end against `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)