### PR TITLE
Allow new major versions of ODEInterfaceDiffEq and Sundials in tests

### DIFF
--- a/lib/DiffEqBase/test/sundials/Project.toml
+++ b/lib/DiffEqBase/test/sundials/Project.toml
@@ -11,4 +11,4 @@ OrdinaryDiffEqBDF = {path = "../../../OrdinaryDiffEqBDF"}
 [compat]
 OrdinaryDiffEq = "7"
 OrdinaryDiffEqBDF = "1"
-Sundials = "4, 5"
+Sundials = "4, 5, 6"

--- a/test/odeinterface/Project.toml
+++ b/test/odeinterface/Project.toml
@@ -9,7 +9,7 @@ OrdinaryDiffEqLowOrderRK = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
 
 [compat]
 ODEInterface = "0.5"
-ODEInterfaceDiffEq = "3.13"
+ODEInterfaceDiffEq = "3.13, 4"
 OrdinaryDiffEq = "7"
 OrdinaryDiffEqCore = "4"
 OrdinaryDiffEqExplicitRK = "1"


### PR DESCRIPTION
## Summary

The SciMLBase v3 / DiffEqBase v7 ecosystem upgrade is being shipped on each wrapper as a **major** version bump:

- DASKR → 3.0 (SciML/DASKR.jl#90)
- DASSL → 3.0 (SciML/DASSL.jl#89)
- IRKGaussLegendre → 0.3 (SciML/IRKGaussLegendre.jl#113)
- ODEInterfaceDiffEq → 4.0 (SciML/ODEInterfaceDiffEq.jl#96)
- LSODA → 0.8 (rveltz/LSODA.jl#80)
- Sundials → 6.0 (SciML/Sundials.jl#527)

…with the prior v3-allowing minor/patch releases yanked in JuliaRegistries/General#153846.

Of those packages, only `ODEInterfaceDiffEq` and `Sundials` appear in this repo's test deps. Widen their compat so the tests can resolve against the new majors once registered.

## Changes

- `test/odeinterface/Project.toml` — `ODEInterfaceDiffEq = "3.13"` → `"3.13, 4"`
- `lib/DiffEqBase/test/sundials/Project.toml` — `Sundials = "4, 5"` → `"4, 5, 6"`

## Test plan
- [ ] CI green on the relevant test groups (ODEInterface integration, DiffEqBase Sundials regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)