### PR TITLE
Add FW15Stage10 adaptive algorithm struct

### DIFF
--- a/lib/OrdinaryDiffEqHighOrderRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqHighOrderRK/src/algorithms.jl
@@ -82,3 +82,22 @@ end
 function PFRK87(stage_limiter!, step_limiter! = trivial_limiter!; omega = 0.0)
     return PFRK87(stage_limiter!, step_limiter!, False(), omega)
 end
+
+
+
+
+@doc explicit_rk_docstring(
+    "Explicit 15-stage Runge-Kutta method of order 10 by Stepanov (2025).",
+    "FW15Stage10",
+    references = """@article{stepanov2025rk10,
+    title={On Runge-Kutta methods of order 10},
+    author={Stepanov, Misha},
+    year={2025},
+    journal={arXiv preprint arXiv:2504.17329}
+    }"""
+)
+Base.@kwdef struct FW15Stage10{StageLimiter, StepLimiter, Thread} <: OrdinaryDiffEqAdaptiveAlgorithm
+    stage_limiter!::StageLimiter = trivial_limiter!
+    step_limiter!::StepLimiter = trivial_limiter!
+    thread::Thread = False()
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [x ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context
Work in progress FW15Stage10 adaptive implementation
This PR adds the FW15Stage10 struct as an adaptive algorithm (inheriting from OrdinaryDiffEqAdaptiveAlgorithm), addressing issue #2694.
The embedded lower-order method coefficients b̂ are still being worked on  see discussion in #2694.
Fixes #2694