### PR TITLE
Drop unused OrdinaryDiffEqRosenbrockTableaus from top-level deps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,6 @@ OrdinaryDiffEqBDF = "6ad6398a-0878-4a85-9266-38940aa047c8"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 OrdinaryDiffEqDefault = "50262376-6c5a-4cf5-baba-aaf4f84d72d7"
 OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
-OrdinaryDiffEqRosenbrockTableaus = "b4bd8bb3-f80f-41d2-9b21-73a655b304b9"
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 OrdinaryDiffEqVerner = "79d7bb75-1356-48c1-b8c0-6832512096c2"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
@@ -22,7 +21,6 @@ OrdinaryDiffEqBDF = {path = "lib/OrdinaryDiffEqBDF"}
 OrdinaryDiffEqCore = {path = "lib/OrdinaryDiffEqCore"}
 OrdinaryDiffEqDefault = {path = "lib/OrdinaryDiffEqDefault"}
 OrdinaryDiffEqRosenbrock = {path = "lib/OrdinaryDiffEqRosenbrock"}
-OrdinaryDiffEqRosenbrockTableaus = {path = "lib/OrdinaryDiffEqRosenbrockTableaus"}
 OrdinaryDiffEqTsit5 = {path = "lib/OrdinaryDiffEqTsit5"}
 OrdinaryDiffEqVerner = {path = "lib/OrdinaryDiffEqVerner"}
 OrdinaryDiffEqDifferentiation = {path = "lib/OrdinaryDiffEqDifferentiation"}


### PR DESCRIPTION
## Problem

The top-level `OrdinaryDiffEq` package lists `OrdinaryDiffEqRosenbrockTableaus` in `[deps]` and `[sources]`, but `src/OrdinaryDiffEq.jl` never `using` or `import`-s it directly. The only real consumer is `OrdinaryDiffEqRosenbrock`, which has it as a hard runtime dep — so the top-level gets it transitively without a direct dep.

Because there's no matching `[compat]` entry for `OrdinaryDiffEqRosenbrockTableaus`, the v7.0.0 registration ([JuliaRegistries/General#154004](https://github.com/JuliaRegistries/General/pull/154004)) stalled with:

> The following dependencies do not have a `[compat]` entry that is upper-bounded and only includes a finite number of breaking releases: OrdinaryDiffEqRosenbrockTableaus

## Fix

Drop the dead `[deps]` and `[sources]` entries. Tableaus still installs transitively via `OrdinaryDiffEqRosenbrock`. No public API change.

## Test plan

- [ ] CI green on master after merge
- [ ] Re-fire `@JuliaRegistrator register()` on the merge commit; AutoMerge clears for `OrdinaryDiffEq v7.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)