### PR TITLE
Fix BoundsError in InterpolationData for SDE/SDDE solutions with empty ks

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.0.1"
+version = "4.0.2"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/lib/OrdinaryDiffEqCore/src/dense/generic_dense.jl
+++ b/lib/OrdinaryDiffEqCore/src/dense/generic_dense.jl
@@ -647,6 +647,15 @@ function _evaluate_interpolant(
         cache, idxs,
         deriv, ks, ts, p, differential_vars
     ) where {F}
+    # Linear fallback when the per-step k storage is empty (e.g. SDE/SDDE
+    # solutions that reuse OrdinaryDiffEqCore.InterpolationData but never
+    # populate ks). Without this, ks[i₊] throws a BoundsError before we
+    # ever reach the linear-fallback inside _ode_interpolant.
+    if isempty(ks)
+        return linear_interpolant(
+            Θ, dt, timeseries[i₋], timeseries[i₊], idxs, deriv
+        )
+    end
     _ode_addsteps!(
         ks[i₊], ts[i₋], timeseries[i₋], timeseries[i₊], dt, f, p,
         cache
@@ -732,7 +741,10 @@ function evaluate_interpolant(
             Θ, dt, timeseries[i₋], timeseries[i₊], 0, cache, idxs,
             deriv, differential_vars
         )
-    elseif !id.dense
+    elseif !id.dense || isempty(ks)
+        # SDE/SDDE solutions reuse OrdinaryDiffEqCore.InterpolationData but
+        # never populate ks; fall back to linear interpolation in that case
+        # to avoid a BoundsError when accessing ks[i₊] below.
         return linear_interpolant(Θ, dt, timeseries[i₋], timeseries[i₊], idxs, deriv)
     elseif cache isa CompositeCache
         return evaluate_composite_cache(
@@ -856,7 +868,7 @@ function ode_interpolation!(
                     )
                 )
             end
-        elseif !id.dense
+        elseif !id.dense || isempty(ks)
             if _vals_eltype(vals) <: AbstractArray
                 linear_interpolant!(
                     _get_val(vals, j), Θ, dt, timeseries[i₋], timeseries[i₊], idxs,
@@ -1048,7 +1060,7 @@ function ode_interpolation(
                 Θ, dt, timeseries[i₋], timeseries[i₊], 0, cache, idxs,
                 deriv, differential_vars
             )
-        elseif !id.dense
+        elseif !id.dense || isempty(ks)
             val = linear_interpolant(Θ, dt, timeseries[i₋], timeseries[i₊], idxs, deriv)
         elseif cache isa CompositeCache
             _ode_addsteps!(
@@ -1168,7 +1180,7 @@ function ode_interpolation!(
                 out, Θ, dt, timeseries[i₋], timeseries[i₊], 0, cache, idxs,
                 deriv, differential_vars
             )
-        elseif !id.dense
+        elseif !id.dense || isempty(ks)
             linear_interpolant!(out, Θ, dt, timeseries[i₋], timeseries[i₊], idxs, deriv)
         elseif cache isa CompositeCache
             _ode_addsteps!(


### PR DESCRIPTION
## Summary
- The `DiffEqDevTools` `Analyticless Convergence Tests` group has been failing on master with a `BoundsError: attempt to access 0-element Vector{Vector{Vector{Float64}}} at index [2]` whenever `appxtrue` calls the interpolant of an SDDE solution that uses `OrdinaryDiffEqCore.InterpolationData` but never populates `ks` (e.g. `MethodOfSteps(RKMil)` over an `SDDEProblem`).
- Commit 11f7280a6f added an `isempty(k)` linear fallback inside `_ode_interpolant`, but the call sites in `generic_dense.jl` access `ks[i₊]` (and call `_ode_addsteps!`) **before** that fallback ever runs.
- This PR adds the analogous `isempty(ks)` short-circuit at every call site in `generic_dense.jl`: `_evaluate_interpolant`, `evaluate_interpolant`, the scalar `ode_interpolation` / `ode_interpolation!`, and the vector `ode_interpolation!`. Each falls through to `linear_interpolant` / `linear_interpolant!`, matching the existing `!id.dense` branch.

## Diagnosis
Failing CI run (pre-existing master failure across unrelated PRs): https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/25053979241/job/73389128438

Stack trace in the log shows `appxtrue` -> `RODESolution(...)(t)` -> `ode_interpolation` -> `evaluate_interpolant` -> `_evaluate_interpolant` -> `ks[i₊]` BoundsError, with `ks::Vector{Vector{Vector{Float64}}}` of length 0.

## Test plan
- [x] Reproduced the original `BoundsError` locally with the exact failing problem (SDDE Hayes model + `MethodOfSteps(RKMil())`).
- [x] After the fix, the previously-erroring `analyticless_test_convergence(... MethodOfSteps(RKMil()), ...)` runs cleanly and reports a sensible order-1 convergence estimate (~0.9–1.5 across runs).
- [x] Ran the full `lib/DiffEqDevTools/test/analyticless_convergence_tests.jl` locally on this branch (Julia 1.12.6); test summary went from `Pass=5, Fail=1, Error=1` (CI master) to `Pass=6, Fail=1, Error=0`. The remaining `Fail` is a pre-existing weak-final accuracy issue on the SDE EnsembleProblem at `analyticless_convergence_tests.jl:92` (was previously `@test_broken`; out of scope for this PR).