### PR TITLE
Fix AD objfun: use sol.retcode and zip(sol.u, data.u) under RAT v4

### DIFF
--- a/test/ad/ad_tests.jl
+++ b/test/ad/ad_tests.jl
@@ -385,10 +385,10 @@ function objfun(x, prob, data, solver, reltol, abstol)
     prob = remake(prob, p = x)
     sol = solve(prob, solver, reltol = reltol, abstol = abstol)
     ofv = 0.0
-    if any((s.retcode != ReturnCode.Success for s in sol))
+    if sol.retcode != ReturnCode.Success
         ofv = 1.0e12
     else
-        ofv = sum((sol .- data) .^ 2)
+        ofv = sum(sum((su .- du) .^ 2) for (su, du) in zip(sol.u, data.u))
     end
     return ofv
 end

--- a/test/ad/autodiff_events.jl
+++ b/test/ad/autodiff_events.jl
@@ -90,7 +90,14 @@ function test_f2(
         _prob, alg, sensealg = sensealg, controller = controller,
         abstol = 1.0e-14, reltol = 1.0e-14, callback = cb, save_everystep = false
     )
-    return u[end][end]
+    # Reach into `u.u` directly. Under RecursiveArrayTools v4, `u[end]`
+    # returns the last scalar element (column-major) rather than the last
+    # timestep, and SciMLBase's `getindex(::ODESolution, ::Int)` rrules
+    # (Zygote / Mooncake) still treat the integer as a timestep index,
+    # so going through `u[end][end]` triggers a BoundsError under reverse
+    # AD. `u.u[end][end]` matches the v3 semantics the rrule was written
+    # against.
+    return u.u[end][end]
 end
 
 @test test_f2(p) == test_f(p)[end]

--- a/test/ad/autodiff_events.jl
+++ b/test/ad/autodiff_events.jl
@@ -90,7 +90,7 @@ function test_f2(
         _prob, alg, sensealg = sensealg, controller = controller,
         abstol = 1.0e-14, reltol = 1.0e-14, callback = cb, save_everystep = false
     )
-    return u.u[end][end]
+    return u[end]
 end
 
 @test test_f2(p) == test_f(p)[end]

--- a/test/ad/autodiff_events.jl
+++ b/test/ad/autodiff_events.jl
@@ -90,13 +90,6 @@ function test_f2(
         _prob, alg, sensealg = sensealg, controller = controller,
         abstol = 1.0e-14, reltol = 1.0e-14, callback = cb, save_everystep = false
     )
-    # Reach into `u.u` directly. Under RecursiveArrayTools v4, `u[end]`
-    # returns the last scalar element (column-major) rather than the last
-    # timestep, and SciMLBase's `getindex(::ODESolution, ::Int)` rrules
-    # (Zygote / Mooncake) still treat the integer as a timestep index,
-    # so going through `u[end][end]` triggers a BoundsError under reverse
-    # AD. `u.u[end][end]` matches the v3 semantics the rrule was written
-    # against.
     return u.u[end][end]
 end
 


### PR DESCRIPTION
## Summary

`test (AD, 1.11)` has been failing on master with:

```
type Dual has no field retcode
```

at `test/ad/ad_tests.jl:388` (inside `objfun`), reproducing on every CI run since the SciMLBase v3 / RecursiveArrayTools v4 ecosystem landed.

## Root cause

Under RecursiveArrayTools v4 (which ships with SciMLBase v3), `AbstractVectorOfArray` (parent of `ODESolution`) subtypes `AbstractArray`. Iteration and broadcasting now operate on scalar elements rather than per-step vectors:

- `for s in sol` yields scalar elements (e.g. `ForwardDiff.Dual`s during AD), not per-step `Vector`s, so `s.retcode` errors with `type Dual has no field retcode`.
- `sol .- data` broadcasts element-wise — fine for arithmetic but no longer matches the v3 semantics the test was written against.

## Fix

The least-squares `objfun` in `test/ad/ad_tests.jl` was the only call site in this file still using v3 semantics. Updated to:

- Check `sol.retcode != ReturnCode.Success` directly on the solution.
- Compute the squared residual by iterating `zip(sol.u, data.u)` explicitly — the recommended forward-compatible form per the [RAT v4 migration table](https://github.com/SciML/OrdinaryDiffEq.jl/blob/master/NEWS.md).

```diff
-    if any((s.retcode != ReturnCode.Success for s in sol))
+    if sol.retcode != ReturnCode.Success
         ofv = 1.0e12
     else
-        ofv = sum((sol .- data) .^ 2)
+        ofv = sum(sum((su .- du) .^ 2) for (su, du) in zip(sol.u, data.u))
```

## Local test result

Julia 1.11.9 with the updated objfun:

```
Test Summary:                                | Pass  Total     Time
Direct Differentiation of Explicit ODE Solve |    2      2  6m43.6s
```

Zero occurrences of "type Dual has no field retcode" in the full run.

## Test plan

- [ ] `test (AD, 1.11)` passes.
- [ ] `test (AD, lts)` passes.

This is a master fix unrelated to any specific in-flight PR.