### PR TITLE
Fix reinit! to propagate Initial(...) params with SciMLBase 3.6

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
@@ -472,14 +472,6 @@ function SciMLBase.reinit!(
         # want to avoid. So we pass an empty array of pairs to make it think this is
         # a symbolic `remake` and it can modify `newp` inplace. The array of pairs is a
         # const global to avoid allocating every time this function is called.
-        #
-        # SciMLBase 3.6.0 added a `LateBindingUpdateU0PContext` argument to
-        # `late_binding_update_u0_p` (see SciMLBase remake.jl). Its 6-arg wrapper now
-        # forwards through the 7-arg `(prob, root_indp, ..., ctx)` overload, so the
-        # MTK overload that takes `(prob, sys::AbstractSystem, ...)` without `ctx` is
-        # never reached and `Initial(...)` parameters are not propagated. We sidestep
-        # the new context-aware dispatch by computing `root_indp` ourselves and calling
-        # the 7-arg form (without `ctx`), which still hits MTK's overload.
         root_indp = SciMLBase.get_root_indp(integrator.sol.prob)
         u0,
             newp = SciMLBase.late_binding_update_u0_p(

--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
@@ -472,9 +472,18 @@ function SciMLBase.reinit!(
         # want to avoid. So we pass an empty array of pairs to make it think this is
         # a symbolic `remake` and it can modify `newp` inplace. The array of pairs is a
         # const global to avoid allocating every time this function is called.
+        #
+        # SciMLBase 3.6.0 added a `LateBindingUpdateU0PContext` argument to
+        # `late_binding_update_u0_p` (see SciMLBase remake.jl). Its 6-arg wrapper now
+        # forwards through the 7-arg `(prob, root_indp, ..., ctx)` overload, so the
+        # MTK overload that takes `(prob, sys::AbstractSystem, ...)` without `ctx` is
+        # never reached and `Initial(...)` parameters are not propagated. We sidestep
+        # the new context-aware dispatch by computing `root_indp` ourselves and calling
+        # the 7-arg form (without `ctx`), which still hits MTK's overload.
+        root_indp = SciMLBase.get_root_indp(integrator.sol.prob)
         u0,
             newp = SciMLBase.late_binding_update_u0_p(
-            integrator.sol.prob, u0,
+            integrator.sol.prob, root_indp, u0,
             EMPTY_ARRAY_OF_PAIRS, t0, u0, integrator.p
         )
         if newp !== integrator.p


### PR DESCRIPTION
## Summary

Fixes 4 pre-existing master failures in `OrdinaryDiffEqNonlinearSolve_ModelingToolkit` CI (e.g. https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/25053979241/job/73389128637) — the `\`reinit!\` updates initial parameters` testset in `lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/dae_initialize_integration.jl` (lines 98-101).

## Root cause

SciMLBase 3.6.0 added a `LateBindingUpdateU0PContext` parameter to `late_binding_update_u0_p`. Its 6-arg wrapper now forwards through a new 8-arg `(prob, root_indp, u0, p, t0, newu0, newp, ctx)` overload, which dispatches to the SciMLBase identity stub. MTK's existing 7-arg overload `late_binding_update_u0_p(prob, sys::AbstractSystem, u0, p, t0, newu0, newp)` (without `ctx`) is no longer reached from `reinit!`. As a result, `reinit!(integrator, new_u0)` stops propagating the new state into `Initial(x)` / `Initial(y)` parameters: both `integ.ps[Initial(x)]` / `integ.ps[Initial(y)]` and `integ[x]` / `integ[y]` stay at their pre-`reinit!` values.

This is dispatch-driven and does not show up at all under SciMLBase < 3.6.

## Fix

In `OrdinaryDiffEqCore`'s `reinit!`, sidestep the new context-aware dispatch by computing `root_indp = SciMLBase.get_root_indp(integrator.sol.prob)` ourselves and calling the 7-arg form `late_binding_update_u0_p(prob, root_indp, u0, ..., newp)` (no `ctx`). That form still dispatches to MTK's 7-arg overload, which is the path that actually updates the `Initial(...)` parameters in `MTKParameters.initials`.

This keeps the change scoped to ODE Core (one-line plus comment) and works whether MTK upgrades to overload the new 8-arg form or not.

## Test plan

- [x] Reproduce the failure locally with `~/.juliaup/bin/julia +1.11 --project=lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/dae_initialize_integration.jl` against master — 4 fails on `reinit!` testset
- [x] Apply fix — DAE Initialize Integration: 21/21 passes locally; `reinit!` updates initial parameters: 8/8
- [x] Re-ran NLStep Tests (19 pass / 6 broken — unchanged), Preconditioner Tests (18/18) locally to confirm no regression in adjacent groups
- [x] Runic check passes on `lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl`
- [ ] Wait for SublibraryCI `OrdinaryDiffEqNonlinearSolve_ModelingToolkit` to confirm green