### PR TITLE
CI: fix Julia 1.10 lts dev step (registry refresh + active project skip)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -98,6 +98,21 @@ jobs:
           key: julia-cache;workflow=${{ github.workflow }};job=${{ github.job }};os=${{ runner.os }};group=${{ matrix.group }};version=${{ matrix.version }};run_id=${{ github.run_id }};run_attempt=${{ github.run_attempt }}
           restore-keys: |
             julia-cache;workflow=${{ github.workflow }};job=${{ github.job }};os=${{ runner.os }};group=${{ matrix.group }};version=${{ matrix.version }};
+      - name: Refresh General registry directly from git
+        shell: julia --color=yes --project=. {0}
+        run: |
+          using Pkg
+          # Force a fresh git clone of General to dodge pkg server lag.
+          # Must run BEFORE the Pkg.develop step below: that step's resolve
+          # needs current versions of registered deps (e.g. SciMLBase v3,
+          # CoverageTools), and the cached pkg-server registry is often
+          # several days stale, so develop's resolve fails with "expected
+          # package <X> to be registered".
+          try
+              Pkg.Registry.rm("General")
+          catch
+          end
+          Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/JuliaRegistries/General.git"))
       - name: Develop local path deps (Julia < 1.11)
         shell: julia --color=yes --project=. {0}
         run: |
@@ -119,16 +134,6 @@ jobs:
               isempty(specs) || Pkg.develop(specs)
             end
           end
-      - name: Refresh General registry directly from git
-        shell: julia --color=yes --project=. {0}
-        run: |
-          using Pkg
-          # Force a fresh git clone of General to dodge pkg server lag.
-          try
-              Pkg.Registry.rm("General")
-          catch
-          end
-          Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/JuliaRegistries/General.git"))
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:

--- a/.github/workflows/SublibraryCI.yml
+++ b/.github/workflows/SublibraryCI.yml
@@ -82,6 +82,21 @@ jobs:
         continue-on-error: true
         with:
           cache-compiled: 'false'
+      - name: Refresh General registry directly from git
+        shell: julia --color=yes --project=. {0}
+        run: |
+          using Pkg
+          # Force a fresh git clone of General to dodge pkg server lag.
+          # Must run BEFORE the Pkg.develop step below: that step's resolve
+          # needs current versions of registered deps (e.g. SciMLBase v3),
+          # and the cached pkg-server registry is often several days stale,
+          # so develop's resolve fails with "expected package <X> to be
+          # registered".
+          try
+              Pkg.Registry.rm("General")
+          catch
+          end
+          Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/JuliaRegistries/General.git"))
       - name: Develop local path deps (Julia < 1.11)
         shell: julia --color=yes --project=. {0}
         run: |

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,6 +61,13 @@ end
         # a higher-level sublibrary like OrdinaryDiffEqDefault.
         if VERSION < v"1.11.0-DEV.0"
             developed = Set{String}()
+            # Never develop the active project: when sublibraries cyclically
+            # reference each other via [sources] (e.g. DiffEqDevTools points
+            # back at OrdinaryDiffEqCore), the transitive walk below would
+            # otherwise try to `Pkg.develop` the active project itself, which
+            # Pkg refuses with "package <X> has the same name or UUID as the
+            # active project".
+            push!(developed, normpath(joinpath(lib_dir, base_group)))
             specs = Pkg.PackageSpec[]
             queue = [joinpath(lib_dir, base_group)]
             while !isempty(queue)


### PR DESCRIPTION
## Summary

Two pre-existing master CI infrastructure bugs that together fail every `(<group>, lts)` job at the develop step before tests even run.

### 1. Develop step runs before registry refresh

`CI.yml` already had a "Refresh General registry directly from git" step that reclones General to dodge pkg-server lag, but it ran *after* the `Pkg.develop` step. The develop's resolver therefore hit the stale cached registry and aborted with `expected package <X> to be registered`. Examples on PR #3576 / PR #3577 CI:
- `test (Integrators_I, lts)` — `expected package SciMLBase [0bca4576] to be registered`
- `test (InterfaceIII, lts)` — `expected package CoverageTools [c36e975a] to be registered`

Reorder so registry refresh runs first.

`SublibraryCI.yml` had no registry refresh step at all and hit the same class of failure. Added one before its develop step.

Julia 1.11+ matrix cells are unaffected: `[sources]` is supported natively there and the develop scripts are no-ops under their `VERSION < v"1.11.0-DEV.0"` guard.

### 2. Transitive `[sources]` walk develops the active project

`test/runtests.jl` walks `[sources]` recursively when activating a sublibrary, so nested deps like `OrdinaryDiffEqRosenbrockTableaus` get developed when running a higher-level sublib. Several sublibrary `Project.toml`s have cycles back to the active project — e.g. `lib/DiffEqDevTools/Project.toml` lists `OrdinaryDiffEqCore = {path = \"../OrdinaryDiffEqCore\"}`. Testing `lib/OrdinaryDiffEqCore` therefore queues itself, and `Pkg.develop` refuses:

```
package \`OrdinaryDiffEqCore [bbf590c4]\` has the same name or UUID as the active project
```

Pre-seed the `developed` set with the active project's path so the walk skips it.

## Files

- `.github/workflows/CI.yml` — registry refresh moved before develop.
- `.github/workflows/SublibraryCI.yml` — registry refresh added before develop.
- `test/runtests.jl` — active project added to `developed` set up front.

## Test plan

- [ ] All `(<group>, lts)` matrix cells in CI.yml resolve successfully through the develop step (was failing on `expected package <X> to be registered`).
- [ ] `test (OrdinaryDiffEqCore, lts, ...)` and similar SublibraryCI cells with cyclic [sources] resolve successfully (was failing on `same name or UUID as the active project`).
- [ ] No regression on Julia 1.11 / 1 / pre cells (their develop steps are no-ops under the `VERSION` guard).