### PR TITLE
Fix AD retcode check under ForwardDiff

### DIFF
--- a/test/ad/ad_tests.jl
+++ b/test/ad/ad_tests.jl
@@ -385,7 +385,7 @@ function objfun(x, prob, data, solver, reltol, abstol)
     prob = remake(prob, p = x)
     sol = solve(prob, solver, reltol = reltol, abstol = abstol)
     ofv = 0.0
-    if sol.retcode != ReturnCode.Success
+    if !SciMLBase.successful_retcode(sol)
         ofv = 1.0e12
     else
         ofv = sum(sum((su .- du) .^ 2) for (su, du) in zip(sol.u, data.u))


### PR DESCRIPTION
## Summary

- Use `SciMLBase.successful_retcode(sol)` in the AD objective helper instead of reading `sol.retcode` directly.
- Avoids `type Dual has no field retcode` when ForwardDiff traces the objective and SciMLBase's solution retcode property fallback iterates the solution values.

## Tests

- `JULIA_DEPOT_PATH=/tmp/julia_depot_direct JULIA_PKG_SERVER= GROUP=AD julia --project=. -e 'using Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/JuliaRegistries/General.git")); Pkg.test()'`
  - `AD Tests | 28299 28299`
  - `OrdinaryDiffEq tests passed`
