### PR TITLE
refactor: specialize tableau/cache constructors on Type{T} arguments

### DIFF
--- a/lib/DiffEqDevTools/src/ode_tableaus.jl
+++ b/lib/DiffEqDevTools/src/ode_tableaus.jl
@@ -6,7 +6,7 @@ specific ordinary differential equations using the explicit Runge-Kutta
 method `erk`. The type `T` will be used for computations and is the
 `eltype` of `A`, `b`, and `c`.
 """
-function deduce_Butcher_tableau(erk, T = Float64)
+function deduce_Butcher_tableau(erk, ::Type{T} = Float64) where {T}
     # get the number of stages s
     step_counter_s = 0
     function f_for_s(du, u, p, t)

--- a/lib/OrdinaryDiffEqExtrapolation/src/extrapolation_caches.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/extrapolation_caches.jl
@@ -344,14 +344,14 @@ struct extrapolation_coefficients{T1, T2, T3}
 end
 
 function create_extrapolation_coefficients(
-        T,
+        ::Type{T},
         alg::Union{
             ExtrapolationMidpointDeuflhard,
             ExtrapolationMidpointHairerWanner,
             ImplicitDeuflhardExtrapolation,
             ImplicitHairerWannerExtrapolation,
         }
-    )
+    ) where {T}
     # Compute and return extrapolation_coefficients
 
     (; min_order, init_order, max_order, sequence) = alg
@@ -429,7 +429,9 @@ function create_extrapolation_coefficients(
     )
 end
 
-function create_extrapolation_coefficients(T, alg::ImplicitEulerBarycentricExtrapolation)
+function create_extrapolation_coefficients(
+        ::Type{T}, alg::ImplicitEulerBarycentricExtrapolation
+    ) where {T}
     # Compute and return extrapolation_coefficients
 
     (; min_order, init_order, max_order, sequence) = alg
@@ -959,7 +961,7 @@ function create_extrapolation_coefficients(
     )
 end
 
-function generate_sequence(T, alg::ImplicitEulerExtrapolation)
+function generate_sequence(::Type{T}, alg::ImplicitEulerExtrapolation) where {T}
     # Compute and return extrapolation_coefficients
 
     (; min_order, init_order, max_order, sequence) = alg

--- a/lib/OrdinaryDiffEqFIRK/src/firk_tableaus.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_tableaus.jl
@@ -15,7 +15,7 @@ struct RadauIIA3Tableau{T, T2}
     e2::T
 end
 
-function RadauIIA3Tableau(T, T2)
+function RadauIIA3Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     T11 = T(0.10540925533894596)
     T12 = T(-0.29814239699997197)
     T21 = T(0.9486832980505138)
@@ -70,7 +70,7 @@ end
 # inv(T) * inv(A) * T = [γ  0  0
 #                        0  α -β
 #                        0  β  α]
-function RadauIIA5Tableau(T, T2)
+function RadauIIA5Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     T11 = convert(T, 9.1232394870892942792e-2)
     T12 = convert(T, -0.14125529502095420843e0)
     T13 = convert(T, -3.0029194105147424492e-2)
@@ -184,7 +184,7 @@ struct RadauIIA9Tableau{T, T2}
     e5::T
 end
 
-function RadauIIA9Tableau(T, T2)
+function RadauIIA9Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     T11 = convert(T, -1.251758622050104589014e-2)
     T12 = convert(T, -1.024204781790882707009e-2)
     T13 = convert(T, 4.767387729029572386318e-2)
@@ -285,7 +285,7 @@ function RadauIIATableau{T1, T2}(tab::RadauIIATableau{T1, T2}) where {T1, T2}
     return RadauIIATableau{T1, T2}(tab.T, tab.TI, tab.c, tab.γ, tab.α, tab.β, tab.e)
 end
 
-function RadauIIATableau(T1, T2, num_stages::Int)
+function RadauIIATableau(::Type{T1}, ::Type{T2}, num_stages::Int) where {T1, T2}
     tab = get(RadauIIATableauCache, (T1, T2, num_stages)) do
         tab = generateRadauTableau(T1, T2, num_stages)
         RadauIIATableauCache[T1, T2, num_stages] = tab
@@ -294,7 +294,7 @@ function RadauIIATableau(T1, T2, num_stages::Int)
     return RadauIIATableau{T1, T2}(tab)
 end
 
-function generateRadauTableau(T1, T2, num_stages::Int)
+function generateRadauTableau(::Type{T1}, ::Type{T2}, num_stages::Int) where {T1, T2}
     c = reverse!(1 .- gaussradau(num_stages, T1)[1]) ./ 2
     if T1 == T2
         c2 = c
@@ -360,7 +360,7 @@ end
 
 import FastGaussQuadrature: gausslegendre
 
-function GaussLegendreTableau(T1, T2, num_stages::Int)
+function GaussLegendreTableau(::Type{T1}, ::Type{T2}, num_stages::Int) where {T1, T2}
     tab = get(GaussLegendreTableauCache, (T1, T2, num_stages)) do
         tab = generateGaussLegendreTableau(T1, T2, num_stages)
         GaussLegendreTableauCache[(T1, T2, num_stages)] = tab
@@ -374,7 +374,7 @@ end
 
 # TODO: add the symplectic integrator stage decoupling from Antonan et al to increase efficiency
 
-function generateGaussLegendreTableau(T1, T2, num_stages::Int)
+function generateGaussLegendreTableau(::Type{T1}, ::Type{T2}, num_stages::Int) where {T1, T2}
     x, w = gausslegendre(num_stages)
     c = T2.((x .+ 1) ./ 2)
     b = T1.(w ./ 2)

--- a/lib/OrdinaryDiffEqLowOrderRK/src/low_order_rk_caches.jl
+++ b/lib/OrdinaryDiffEqLowOrderRK/src/low_order_rk_caches.jl
@@ -699,7 +699,7 @@ struct RKO65ConstantCache{T1, T2} <: OrdinaryDiffEqConstantCache
     c5::T2
     c6::T2
 
-    function RKO65ConstantCache(T1, T2)
+    function RKO65ConstantCache(::Type{T1}, ::Type{T2}) where {T1, T2}
         # elements of Butcher Table
         α21 = T1(1 // 6)
         α31 = T1(-15 // 8)
@@ -898,7 +898,7 @@ struct FRK65ConstantCache{T1, T2} <: OrdinaryDiffEqConstantCache
     f10::T1
     f11::T1
 
-    function FRK65ConstantCache(T1, T2)
+    function FRK65ConstantCache(::Type{T1}, ::Type{T2}) where {T1, T2}
 
         # elements of Butcher Table
         α21 = T1(1 // 89)

--- a/lib/OrdinaryDiffEqLowOrderRK/src/low_order_rk_tableaus.jl
+++ b/lib/OrdinaryDiffEqLowOrderRK/src/low_order_rk_tableaus.jl
@@ -106,7 +106,7 @@ function OwrenZen3ConstantCache(T::Type{<:CompiledFloats}, T2::Type{<:CompiledFl
     )
 end
 
-function OwrenZen3ConstantCache(T, T2)
+function OwrenZen3ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     a21 = convert(T, 12 // 23)
     a31 = convert(T, -68 // 375)
     a32 = convert(T, 368 // 375)
@@ -222,7 +222,7 @@ function OwrenZen4ConstantCache(T::Type{<:CompiledFloats}, T2::Type{<:CompiledFl
     )
 end
 
-function OwrenZen4ConstantCache(T, T2)
+function OwrenZen4ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     a21 = convert(T, 1 // 6)
     a31 = convert(T, 44 // 1369)
     a32 = convert(T, 363 // 1369)
@@ -425,7 +425,7 @@ function OwrenZen5ConstantCache(T::Type{<:CompiledFloats}, T2::Type{<:CompiledFl
     )
 end
 
-function OwrenZen5ConstantCache(T, T2)
+function OwrenZen5ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     a21 = convert(T, 1 // 6)
     a31 = convert(T, 1 // 16)
     a32 = convert(T, 3 // 16)
@@ -1202,7 +1202,7 @@ end
 end
 
 #=
-function DP5_dense_bs(T)
+function DP5_dense_bs(::Type{T}) where {T}
   b1  = convert(T,5179//57600)
   b3  = convert(T,7571//16695)
   b4  = convert(T,393//640)
@@ -1278,7 +1278,7 @@ function Anas5ConstantCache(T::Type{<:CompiledFloats}, T2::Type{<:CompiledFloats
     )
 end
 
-function Anas5ConstantCache(T, T2)
+function Anas5ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     a21 = convert(T, 1 // 10)
     a31 = convert(T, -2 // 9)
     a32 = convert(T, 5 // 9)
@@ -1839,7 +1839,7 @@ struct Alshina2ConstantCache{T, T2} <: OrdinaryDiffEqConstantCache
     c2::T2
 end
 
-function Alshina2ConstantCache(T, T2)
+function Alshina2ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     a21 = convert(T, 0.6666666666666666)
 
     b1 = convert(T, 0.25)
@@ -1865,7 +1865,7 @@ struct Alshina3ConstantCache{T, T2} <: OrdinaryDiffEqConstantCache
     c3::T2
 end
 
-function Alshina3ConstantCache(T, T2)
+function Alshina3ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     a21 = convert(T, 0.5)
     # a31 = convert(T, 0.0)
     a32 = convert(T, 0.75)
@@ -1920,7 +1920,7 @@ struct Alshina6ConstantCache{T, T2} <: OrdinaryDiffEqConstantCache
     c7::T2
 end
 
-function Alshina6ConstantCache(T, T2)
+function Alshina6ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     a21 = convert(T, 0.5714285714285714)
     a31 = convert(T, 1.0267857142857142)
     a32 = convert(T, -0.3125)
@@ -1980,7 +1980,7 @@ struct Ralston4ConstantCache{T, T2} <: OrdinaryDiffEqConstantCache
     b4::T
 end
 
-function Ralston4ConstantCache(T, T2)
+function Ralston4ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     s5 = sqrt(convert(T, 5))
     b1 = (263 + 24 * s5) / 1812
     b4 = (30 - 4 * s5) / 123

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_caches.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_caches.jl
@@ -24,7 +24,7 @@ struct LowStorageRK2NConstantCache{N, T, T2} <: OrdinaryDiffEqConstantCache
     c2end::NTuple{N, T2} # c1 is always zero
 end
 
-function ORK256ConstantCache(T, T2)
+function ORK256ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A2 = convert(T, -1.0)
     A3 = convert(T, -1.55798)
     A4 = convert(T, -1.0)
@@ -108,7 +108,7 @@ struct RK46NLConstantCache{T, T2} <: OrdinaryDiffEqConstantCache
     c5::T2
     c6::T2
 
-    function RK46NLConstantCache(T, T2)
+    function RK46NLConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
         α2 = T(-0.737101392796)
         α3 = T(-1.634740794343)
         α4 = T(-0.74473900378)
@@ -158,7 +158,7 @@ end
     thread::Thread
 end
 
-function CarpenterKennedy2N54ConstantCache(T, T2)
+function CarpenterKennedy2N54ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A2 = convert(T, -567301805773 // 1357537059087)
     A3 = convert(T, -2404267990393 // 2016746695238)
     A4 = convert(T, -3550918686646 // 2091501179385)
@@ -232,7 +232,7 @@ mutable struct SHLDDRK_2NConstantCache{T1, T2} <: OrdinaryDiffEqConstantCache
     step::Int
 end
 
-function SHLDDRK_2NConstantCache(T1, T2)
+function SHLDDRK_2NConstantCache(::Type{T1}, ::Type{T2}) where {T1, T2}
     α21 = T1(-0.6051226)
     α31 = T1(-2.0437564)
     α41 = T1(-0.7406999)
@@ -327,7 +327,7 @@ struct SHLDDRK52ConstantCache{T1, T2} <: OrdinaryDiffEqConstantCache
     c5::T2
 end
 
-function SHLDDRK52ConstantCache(T1, T2)
+function SHLDDRK52ConstantCache(::Type{T1}, ::Type{T2}) where {T1, T2}
     α2 = T1(-0.6913065)
     α3 = T1(-2.655155)
     α4 = T1(-0.8147688)
@@ -409,7 +409,7 @@ function alg_cache(
     )
 end
 
-function SHLDDRK64ConstantCache(T, T2)
+function SHLDDRK64ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     #TODO: Solve the order conditions with more accuracy
     A2 = convert(T, -0.4919575)
     A3 = convert(T, -0.8946264)
@@ -470,7 +470,7 @@ function alg_cache(
     return SHLDDRK64ConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function DGLDDRK73_CConstantCache(T, T2)
+function DGLDDRK73_CConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A2 = convert(T, -0.808316387498383)
     A3 = convert(T, -1.503407858773331)
     A4 = convert(T, -1.053064525050744)
@@ -536,7 +536,7 @@ function alg_cache(
     return DGLDDRK73_CConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function DGLDDRK84_CConstantCache(T, T2)
+function DGLDDRK84_CConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A2 = convert(T, -0.721296248227924)
     A3 = convert(T, -0.0107733657161298)
     A4 = convert(T, -0.516258469893097)
@@ -605,7 +605,7 @@ function alg_cache(
     return DGLDDRK84_CConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function DGLDDRK84_FConstantCache(T, T2)
+function DGLDDRK84_FConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A2 = convert(T, -0.5534431294501569)
     A3 = convert(T, 0.0106598757020349)
     A4 = convert(T, -0.5515812888932)
@@ -674,7 +674,7 @@ function alg_cache(
     return DGLDDRK84_FConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function NDBLSRK124ConstantCache(T, T2)
+function NDBLSRK124ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A2 = convert(T, -0.0923311242368072)
     A3 = convert(T, -0.9441056581158819)
     A4 = convert(T, -4.3271273247576394)
@@ -755,7 +755,7 @@ function alg_cache(
     return NDBLSRK124ConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function NDBLSRK134ConstantCache(T, T2)
+function NDBLSRK134ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A2 = convert(T, -0.6160178650170565)
     A3 = convert(T, -0.4449487060774118)
     A4 = convert(T, -1.0952033345276178)
@@ -839,7 +839,7 @@ function alg_cache(
     return NDBLSRK134ConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function NDBLSRK144ConstantCache(T, T2)
+function NDBLSRK144ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A2 = convert(T, -0.718801210867241)
     A3 = convert(T, -0.778533117342157)
     A4 = convert(T, -0.0053282796654044)
@@ -949,7 +949,7 @@ struct LowStorageRK2CConstantCache{N, T, T2} <: OrdinaryDiffEqConstantCache
     c2end::NTuple{N, T2} # c1 is always zero
 end
 
-function CFRLDDRK64ConstantCache(T, T2)
+function CFRLDDRK64ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A2 = convert(T, 0.17985400977138)
     A3 = convert(T, 0.14081893152111)
     A4 = convert(T, 0.08255631629428)
@@ -1007,7 +1007,7 @@ function alg_cache(
     return CFRLDDRK64ConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function TSLDDRK74ConstantCache(T, T2)
+function TSLDDRK74ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A2 = convert(T, 0.241566650129646868)
     A3 = convert(T, 0.0423866513027719953)
     A4 = convert(T, 0.215602732678803776)
@@ -1092,7 +1092,7 @@ struct LowStorageRK3SConstantCache{N, T, T2} <: OrdinaryDiffEqConstantCache
     c2end::NTuple{N, T2} # c1 is always zero
 end
 
-function ParsaniKetchesonDeconinck3S32ConstantCache(T, T2)
+function ParsaniKetchesonDeconinck3S32ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     γ102 = convert(T, -1.2664395576322218e-1)
     γ103 = convert(T, 1.1426980685848858e+0)
     γ12end = (γ102, γ103)
@@ -1156,7 +1156,7 @@ function alg_cache(
     )
 end
 
-function ParsaniKetchesonDeconinck3S82ConstantCache(T, T2)
+function ParsaniKetchesonDeconinck3S82ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     γ102 = convert(T, 4.2397552118208004e-1)
     γ103 = convert(T, -2.3528852074619033e-1)
     γ104 = convert(T, 7.9598685017877846e-1)
@@ -1250,7 +1250,7 @@ function alg_cache(
     )
 end
 
-function ParsaniKetchesonDeconinck3S53ConstantCache(T, T2)
+function ParsaniKetchesonDeconinck3S53ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     γ102 = convert(T, 2.5876919610938998e-1)
     γ103 = convert(T, -1.3243708384977859e-1)
     γ104 = convert(T, 5.0556648948362981e-2)
@@ -1326,7 +1326,7 @@ function alg_cache(
     )
 end
 
-function ParsaniKetchesonDeconinck3S173ConstantCache(T, T2)
+function ParsaniKetchesonDeconinck3S173ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     γ102 = convert(T, 7.9377023961829174e-1)
     γ103 = convert(T, -8.3475116244241754e-2)
     γ104 = convert(T, -1.6706337980062214e-2)
@@ -1492,7 +1492,7 @@ function alg_cache(
     )
 end
 
-function ParsaniKetchesonDeconinck3S94ConstantCache(T, T2)
+function ParsaniKetchesonDeconinck3S94ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     γ102 = convert(T, -4.6556413837561301e+0)
     γ103 = convert(T, -7.7202649689034453e-1)
     γ104 = convert(T, -4.0244202720632174e+0)
@@ -1592,7 +1592,7 @@ function alg_cache(
     )
 end
 
-function ParsaniKetchesonDeconinck3S184ConstantCache(T, T2)
+function ParsaniKetchesonDeconinck3S184ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     γ102 = convert(T, 1.1750819811951678e+0)
     γ103 = convert(T, 3.0909017892654811e-1)
     γ104 = convert(T, 1.4409117788115862e+0)
@@ -1764,7 +1764,7 @@ function alg_cache(
     )
 end
 
-function ParsaniKetchesonDeconinck3S105ConstantCache(T, T2)
+function ParsaniKetchesonDeconinck3S105ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     γ102 = convert(T, 4.0436600785287713e-1)
     γ103 = convert(T, -8.5034274641295027e-1)
     γ104 = convert(T, -6.9508941671218478e+0)
@@ -1870,7 +1870,7 @@ function alg_cache(
     )
 end
 
-function ParsaniKetchesonDeconinck3S205ConstantCache(T, T2)
+function ParsaniKetchesonDeconinck3S205ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     γ102 = convert(T, -1.168247970322938e+0)
     γ103 = convert(T, -2.5112155037089772e+0)
     γ104 = convert(T, -5.5259960154735988e-1)
@@ -2090,7 +2090,7 @@ struct LowStorageRK3SpConstantCache{N, T, T2} <: OrdinaryDiffEqConstantCache
     bhat2end::NTuple{N, T}
 end
 
-function RDPK3Sp35ConstantCache(T, T2)
+function RDPK3Sp35ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     γ12end = (
         convert(T, big"2.587669070352079020144955303389306026e-01"),
         convert(T, big"-1.324366873994502973977035353758550057e-01"),
@@ -2210,7 +2210,7 @@ function alg_cache(
     return RDPK3Sp35ConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function RDPK3Sp49ConstantCache(T, T2)
+function RDPK3Sp49ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     γ12end = (
         convert(T, big"-4.655641301259180308677051498071354582e+00"),
         convert(T, big"-7.720264924836063859141482018013692338e-01"),
@@ -2378,7 +2378,7 @@ function alg_cache(
     return RDPK3Sp49ConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function RDPK3Sp510ConstantCache(T, T2)
+function RDPK3Sp510ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     γ12end = (
         convert(T, big"4.043660078504695837542588769963326988e-01"),
         convert(T, big"-8.503427464263185087039788184485627962e-01"),
@@ -2598,7 +2598,7 @@ struct LowStorageRK3SpFSALConstantCache{N, T, T2} <: OrdinaryDiffEqConstantCache
     bhatfsal::T
 end
 
-function RDPK3SpFSAL35ConstantCache(T, T2)
+function RDPK3SpFSAL35ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     γ12end = (
         convert(T, big"2.587771979725733308135192812685323706e-01"),
         convert(T, big"-1.324380360140723382965420909764953437e-01"),
@@ -2722,7 +2722,7 @@ function alg_cache(
     return RDPK3SpFSAL35ConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function RDPK3SpFSAL49ConstantCache(T, T2)
+function RDPK3SpFSAL49ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     γ12end = (
         convert(T, big"-4.655641447335068552684422206224169103e+00"),
         convert(T, big"-7.720265099645871829248487209517314217e-01"),
@@ -2894,7 +2894,7 @@ function alg_cache(
     return RDPK3SpFSAL49ConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function RDPK3SpFSAL510ConstantCache(T, T2)
+function RDPK3SpFSAL510ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     γ12end = (
         convert(T, big"4.043660121685749695640462197806189975e-01"),
         convert(T, big"-8.503427289575839690883191973980814832e-01"),
@@ -3106,7 +3106,7 @@ struct LowStorageRK2RPConstantCache{N, T, T2} <: OrdinaryDiffEqConstantCache
     Cᵢ::NTuple{N, T2}
 end
 
-function CKLLSRK43_2ConstantCache(T, T2)
+function CKLLSRK43_2ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A1 = convert(T, Int128(11847461282814) // Int128(36547543011857))
     A2 = convert(T, Int128(3943225443063) // Int128(7078155732230))
     A3 = convert(T, Int128(-346793006927) // Int128(4029903576067))
@@ -3172,7 +3172,7 @@ function alg_cache(
     return CKLLSRK43_2ConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function CKLLSRK54_3CConstantCache(T, T2)
+function CKLLSRK54_3CConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A1 = convert(T, BigInt(970286171893) // BigInt(4311952581923))
     A2 = convert(T, BigInt(6584761158862) // BigInt(12103376702013))
     A3 = convert(T, BigInt(2251764453980) // BigInt(15575788980749))
@@ -3249,7 +3249,7 @@ function alg_cache(
     return CKLLSRK54_3CConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function CKLLSRK95_4SConstantCache(T, T2)
+function CKLLSRK95_4SConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A1 = convert(T, BigInt(1107026461565) // BigInt(5417078080134))
     A2 = convert(T, BigInt(38141181049399) // BigInt(41724347789894))
     A3 = convert(T, BigInt(493273079041) // BigInt(11940823631197))
@@ -3358,7 +3358,7 @@ function alg_cache(
     return CKLLSRK95_4SConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function CKLLSRK95_4CConstantCache(T, T2)
+function CKLLSRK95_4CConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A1 = convert(T, BigInt(2756167973529) // BigInt(16886029417639))
     A2 = convert(T, BigInt(11436141375279) // BigInt(13592993952163))
     A3 = convert(T, BigInt(88551658327) // BigInt(2352971381260))
@@ -3467,7 +3467,7 @@ function alg_cache(
     return CKLLSRK95_4CConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function CKLLSRK95_4MConstantCache(T, T2)
+function CKLLSRK95_4MConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A1 = convert(T, BigInt(5573095071601) // BigInt(11304125995793))
     A2 = convert(T, BigInt(315581365608) // BigInt(4729744040249))
     A3 = convert(T, BigInt(8734064225157) // BigInt(30508564569118))
@@ -3608,7 +3608,7 @@ struct LowStorageRK3RPConstantCache{N, T, T2} <: OrdinaryDiffEqConstantCache
     Cᵢ::NTuple{N, T2}
 end
 
-function CKLLSRK54_3C_3RConstantCache(T, T2)
+function CKLLSRK54_3C_3RConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A₁1 = convert(T, BigInt(2365592473904) // BigInt(8146167614645))
     A₁2 = convert(T, BigInt(4278267785271) // BigInt(6823155464066))
     A₁3 = convert(T, BigInt(2789585899612) // BigInt(8986505720531))
@@ -3694,7 +3694,7 @@ function alg_cache(
     return CKLLSRK54_3C_3RConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function CKLLSRK54_3M_3RConstantCache(T, T2)
+function CKLLSRK54_3M_3RConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A₁1 = convert(T, BigInt(17396840518954) // BigInt(49788467287365))
     A₁2 = convert(T, BigInt(21253110367599) // BigInt(14558944785238))
     A₁3 = convert(T, BigInt(4293647616769) // BigInt(14519312872408))
@@ -3777,7 +3777,7 @@ function alg_cache(
     return CKLLSRK54_3M_3RConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function CKLLSRK54_3N_3RConstantCache(T, T2)
+function CKLLSRK54_3N_3RConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A₁1 = convert(T, BigInt(4745337637855) // BigInt(22386579876409))
     A₁2 = convert(T, BigInt(6808157035527) // BigInt(13197844641179))
     A₁3 = convert(T, BigInt(4367509502613) // BigInt(10454198590847))
@@ -3863,7 +3863,7 @@ function alg_cache(
     return CKLLSRK54_3N_3RConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function CKLLSRK85_4C_3RConstantCache(T, T2)
+function CKLLSRK85_4C_3RConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A₁1 = convert(T, BigInt(141236061735) // BigInt(3636543850841))
     A₁2 = convert(T, BigInt(7367658691349) // BigInt(25881828075080))
     A₁3 = convert(T, BigInt(6185269491390) // BigInt(13597512850793))
@@ -3976,7 +3976,7 @@ function alg_cache(
     return CKLLSRK85_4C_3RConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function CKLLSRK85_4M_3RConstantCache(T, T2)
+function CKLLSRK85_4M_3RConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A₁1 = convert(T, BigInt(967290102210) // BigInt(6283494269639))
     A₁2 = convert(T, BigInt(852959821520) // BigInt(5603806251467))
     A₁3 = convert(T, BigInt(8043261511347) // BigInt(8583649637008))
@@ -4089,7 +4089,7 @@ function alg_cache(
     return CKLLSRK85_4M_3RConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function CKLLSRK85_4P_3RConstantCache(T, T2)
+function CKLLSRK85_4P_3RConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A₁1 = convert(T, BigInt(1298271176151) // BigInt(60748409385661))
     A₁2 = convert(T, BigInt(14078610000243) // BigInt(41877490110127))
     A₁3 = convert(T, BigInt(553998884433) // BigInt(1150223130613))
@@ -4237,7 +4237,7 @@ struct LowStorageRK4RPConstantCache{N, T, T2} <: OrdinaryDiffEqConstantCache
     Cᵢ::NTuple{N, T2}
 end
 
-function CKLLSRK54_3N_4RConstantCache(T, T2)
+function CKLLSRK54_3N_4RConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A₁1 = convert(T, BigInt(9435338793489) // BigInt(32856462503258))
     A₁2 = convert(T, BigInt(6195609865473) // BigInt(14441396468602))
     A₁3 = convert(T, BigInt(7502925572378) // BigInt(28098850972003))
@@ -4331,7 +4331,7 @@ function alg_cache(
     return CKLLSRK54_3N_4RConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function CKLLSRK54_3M_4RConstantCache(T, T2)
+function CKLLSRK54_3M_4RConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A₁1 = convert(T, BigInt(7142524119) // BigInt(20567653057))
     A₁2 = convert(T, BigInt(20567653057) // BigInt(89550000000))
     A₁3 = convert(T, BigInt(7407775) // BigInt(2008982))
@@ -4414,7 +4414,7 @@ function alg_cache(
     return CKLLSRK54_3M_4RConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function CKLLSRK65_4M_4RConstantCache(T, T2)
+function CKLLSRK65_4M_4RConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A₁1 = convert(T, BigInt(1811061732419) // BigInt(6538712036350))
     A₁2 = convert(T, BigInt(936386506953) // BigInt(6510757757683))
     A₁3 = convert(T, BigInt(8253430823511) // BigInt(9903985211908))
@@ -4518,7 +4518,7 @@ function alg_cache(
     return CKLLSRK65_4M_4RConstantCache(constvalue(uBottomEltypeNoUnits), constvalue(tTypeNoUnits))
 end
 
-function CKLLSRK85_4FM_4RConstantCache(T, T2)
+function CKLLSRK85_4FM_4RConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A₁1 = convert(T, BigInt(319960152914) // BigInt(39034091721739))
     A₁2 = convert(T, BigInt(16440040368765) // BigInt(7252463661539))
     A₁3 = convert(T, BigInt(1381950791880) // BigInt(6599155371617))
@@ -4683,7 +4683,7 @@ struct LowStorageRK5RPConstantCache{N, T, T2} <: OrdinaryDiffEqConstantCache
     Cᵢ::NTuple{N, T2}
 end
 
-function CKLLSRK75_4M_5RConstantCache(T, T2)
+function CKLLSRK75_4M_5RConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A₁1 = convert(T, BigInt(984894634849) // BigInt(6216792334776))
     A₁2 = convert(T, BigInt(984894634849) // BigInt(5526037630912))
     A₁3 = convert(T, BigInt(13256335809797) // BigInt(10977774807827))

--- a/lib/OrdinaryDiffEqPDIRK/src/pdirk_caches.jl
+++ b/lib/OrdinaryDiffEqPDIRK/src/pdirk_caches.jl
@@ -26,7 +26,7 @@ struct PDIRK44Tableau{T, T2}
     b4::T
 end
 
-function PDIRK44Tableau(T, T2)
+function PDIRK44Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ1 = convert(T2, 1 // 2)
     γ2 = convert(T2, 2 // 3)
     γs = (γ1, γ2)

--- a/lib/OrdinaryDiffEqPRK/src/prk_caches.jl
+++ b/lib/OrdinaryDiffEqPRK/src/prk_caches.jl
@@ -30,7 +30,7 @@ struct KuttaPRK2p5ConstantCache{T, T2} <: OrdinaryDiffEqConstantCache
     c4::T2
     c5_6::Array{T2, 1}
 
-    function KuttaPRK2p5ConstantCache(T, T2)
+    function KuttaPRK2p5ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
         α21 = T(1 // 3)
         α31 = T(4 // 25)
         α32 = T(6 // 25)

--- a/lib/OrdinaryDiffEqSDIRK/src/sdirk_tableaus.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/sdirk_tableaus.jl
@@ -32,7 +32,7 @@ z = (1.5+√2)*zprev + (2.5+2√2)*zᵧ - (6+4.5√2)*(uᵧ-uprev) = (by def. of
   = (1.5+√2)*zprev + (2.5+2√2)*zᵧ - (6+4.5√2)*(d*zᵧ + d*zprev) =
   = (-√2)/2*zprev + (1+(√2)/2)*zᵧ
 =#
-function TRBDF2Tableau(T, T2)
+function TRBDF2Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T2, 2 - sqrt(2))
     d = convert(T, 1 - sqrt(2) / 2)
     ω = convert(T, sqrt(2) / 4)
@@ -114,7 +114,7 @@ z₄ = yhat - uprev = a31*z1 + a32*z2 + γ*z3
 # Note Hermite is too small of an interval for this one!!!
 =#
 
-function Kvaerno3Tableau(T, T2)
+function Kvaerno3Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T2, 0.4358665215)
     a31 = convert(T, 0.490563388419108)
     a32 = convert(T, 0.073570090080892)
@@ -232,7 +232,7 @@ function KenCarp3Tableau(T::Type{<:CompiledFloats}, T2::Type{<:CompiledFloats})
     )
 end
 
-function KenCarp3Tableau(T, T2)
+function KenCarp3Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T2, 1767732205903 // 4055673282236)
     a31 = convert(T, 2746238789719 // 10658868560708)
     a32 = -convert(T, 640167445237 // 6845629431997)
@@ -381,7 +381,7 @@ Hairer's extrapolation is no better.
 Using constant extrapolations
 =#
 
-function Cash4Tableau(T, T2)
+function Cash4Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T2, 0.435866521508)
     a21 = convert(T, -1.1358665215)
     a31 = convert(T, 1.08543330679)
@@ -427,7 +427,7 @@ struct SFSDIRK4Tableau{T, T2}
     c4::T2
 end
 
-function SFSDIRK4Tableau(T, T2)
+function SFSDIRK4Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T2, 0.097961082941)
     a21 = convert(T, 0.262318069183)
     a31 = convert(T, 0.230169419019)
@@ -468,7 +468,7 @@ struct SFSDIRK5Tableau{T, T2}
     c5::T2
 end
 
-function SFSDIRK5Tableau(T, T2)
+function SFSDIRK5Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T2, 0.078752939968)
     a21 = convert(T, 0.222465723027)
     a31 = convert(T, 0.2031923617)
@@ -525,7 +525,7 @@ struct SFSDIRK6Tableau{T, T2}
     c6::T2
 end
 
-function SFSDIRK6Tableau(T, T2)
+function SFSDIRK6Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T2, 0.067410767219)
     a21 = convert(T, 0.194216850802)
     a31 = convert(T, 0.194216850802)
@@ -597,7 +597,7 @@ struct SFSDIRK7Tableau{T, T2}
     c7::T2
 end
 
-function SFSDIRK7Tableau(T, T2)
+function SFSDIRK7Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T2, 0.056879041592)
     a21 = convert(T, 0.172205581756)
     a31 = convert(T, 0.135485903539)
@@ -687,7 +687,7 @@ struct SFSDIRK8Tableau{T, T2}
     c8::T2
 end
 
-function SFSDIRK8Tableau(T, T2)
+function SFSDIRK8Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T2, 0.050353353407)
     a21 = convert(T, 0.147724666662)
     a31 = convert(T, 0.114455029802)
@@ -790,7 +790,7 @@ struct Hairer4Tableau{T, T2}
     α43::T2
 end
 
-function Hairer4Tableau(T, T2)
+function Hairer4Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T2, 1 // 4)
     c2 = convert(T2, 3 // 4)
     c3 = convert(T2, 11 // 20)
@@ -953,7 +953,7 @@ function Hairer4Tableau(T, T2)
     )
 end
 
-function Hairer42Tableau(T, T2)
+function Hairer42Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T, 4 // 15)
     c2 = convert(T2, 23 // 30)
     c3 = convert(T2, 17 // 30)
@@ -1121,7 +1121,7 @@ dt = c2
 ((-2θ + 3θ^2) + (6θ*(1-θ)/c2)*γ)
 =#
 
-function Kvaerno4Tableau(T, T2)
+function Kvaerno4Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T2, 0.4358665215)
     a31 = convert(T, 0.140737774731968)
     a32 = convert(T, -0.108365551378832)
@@ -1236,7 +1236,7 @@ struct CFNLIRK3Tableau{T, T2}
     eb4::T
 end
 
-function CFNLIRK3Tableau(T, T2)
+function CFNLIRK3Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     #Implicit Tableau
     γ = convert(T2, 0.43586652150846)
     a31 = convert(T, 0.0)
@@ -1324,7 +1324,7 @@ y₁-y₀ = a51*z₁ + a52*z₂ + a53*z₃ + a54*z₄ + γ*z₅
 (-2θ + 3θ^2 + γ*(6θ*(1-θ)/dt))
 
 =#
-function KenCarp4Tableau(T, T2)
+function KenCarp4Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T2, 1 // 4)
     a31 = convert(T, 8611 // 62500)
     a32 = -convert(T, 1743 // 31250)
@@ -1501,7 +1501,7 @@ dt = c3
 (-2θ + 3θ^2 + γ*(6θ*(1-θ)/dt))
 =#
 
-function Kvaerno5Tableau(T, T2)
+function Kvaerno5Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T2, 0.26)
     a31 = convert(T, 0.13)
     a32 = convert(T, 0.84033320996790809)
@@ -1694,7 +1694,7 @@ dt = c5
 
 =#
 
-function KenCarp5Tableau(T, T2)
+function KenCarp5Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T2, 41 // 200)
     a31 = convert(T, 41 // 400)
     a32 = -convert(T, 567603406766 // 11931857230679)
@@ -1857,7 +1857,7 @@ struct ESDIRK54I8L2SATableau{T, T2}
     btilde8::T
 end
 
-function ESDIRK54I8L2SATableau(T, T2)
+function ESDIRK54I8L2SATableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T2, 1 // 4)
     a31 = convert(T, 1748874742213 // 5795261096931)
     a32 = convert(T, 1748874742213 // 5795261096931)
@@ -1941,7 +1941,7 @@ struct ESDIRK436L2SA2Tableau{T, T2}
     btilde6::T
 end
 
-function ESDIRK436L2SA2Tableau(T, T2)
+function ESDIRK436L2SA2Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T, 31 // 125)
     a31 = convert(T, -360286518617 // 7014585480527)
     a32 = convert(T, -360286518617 // 7014585480527)
@@ -2014,7 +2014,7 @@ struct ESDIRK437L2SATableau{T, T2}
     btilde7::T
 end
 
-function ESDIRK437L2SATableau(T, T2)
+function ESDIRK437L2SATableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T, 1 // 8)
     a31 = convert(T, -39188347878 // 1513744654945)
     a32 = convert(T, -39188347878 // 1513744654945)
@@ -2096,7 +2096,7 @@ struct ESDIRK547L2SA2Tableau{T, T2}
     btilde7::T
 end
 
-function ESDIRK547L2SA2Tableau(T, T2)
+function ESDIRK547L2SA2Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T, 23 // 125)
     a31 = convert(T, 791020047304 // 3561426431547)
     a32 = convert(T, 791020047304 // 3561426431547)
@@ -2194,7 +2194,7 @@ struct ESDIRK659L2SATableau{T, T2}
     btilde9::T
 end
 
-function ESDIRK659L2SATableau(T, T2)
+function ESDIRK659L2SATableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T, 2 // 9)
     a31 = convert(T, 1 // 9)
     a32 = convert(T, -52295652026801 // 1014133226193379)
@@ -2265,7 +2265,7 @@ struct SDIRK22Tableau{T}
     β::T
 end
 
-function SDIRK22Tableau(T)
+function SDIRK22Tableau(::Type{T}) where {T}
     a = convert(T, 1 - 1 / sqrt(2))
     α = convert(T, -sqrt(2))
     β = convert(T, 1 + sqrt(2))
@@ -2421,7 +2421,7 @@ y₁-y₀ = a61*z₁ + a62*z₂ + a63*z₃ + a64*z₄ + a65*z₅ + γ*z₆
 (-2θ + 3θ^2 + γ*(6θ*(1-θ)/dt))
 
 =#
-function KenCarp47Tableau(T, T2)
+function KenCarp47Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T2, 1235 // 10000)
     a31 = convert(T, 624185399699 // 4186980696204)
     a32 = a31
@@ -2703,7 +2703,7 @@ y₁-y₀ = a71*z₁ + a72*z₂ + a73*z₃ + a74*z₄ + a75*z₅ + a76*z₆ + γ
 
 =#
 
-function KenCarp58Tableau(T, T2)
+function KenCarp58Tableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T2, 2 // 9)
     a31 = convert(T, 2366667076620 // 8822750406821)
     a32 = a31

--- a/lib/OrdinaryDiffEqSSPRK/src/ssprk_caches.jl
+++ b/lib/OrdinaryDiffEqSSPRK/src/ssprk_caches.jl
@@ -113,7 +113,7 @@ struct KYKSSPRK42ConstantCache{T, T2} <: SSPRKConstantCache
     c3::T2
 end
 
-function KYKSSPRK42ConstantCache(T, T2)
+function KYKSSPRK42ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     α20 = T(0.394806441339829)
     α21 = T(0.605193558660171)
     α30 = T(0.00279730708739)
@@ -193,7 +193,7 @@ struct SSPRK53ConstantCache{T, T2} <: SSPRKConstantCache
     c3::T2
     c4::T2
 
-    function SSPRK53ConstantCache(T, T2)
+    function SSPRK53ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
         α30 = T(0.355909775063327)
         α32 = T(0.644090224936674)
         α40 = T(0.367933791638137)
@@ -274,7 +274,7 @@ struct SSPRK53_2N1ConstantCache{T, T2} <: SSPRKConstantCache
     c3::T2
     c4::T2
 
-    function SSPRK53_2N1ConstantCache(T, T2)
+    function SSPRK53_2N1ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
         α40 = T(0.571403511494104)
         α43 = T(0.428596488505896)
         β10 = T(0.443568244942995)
@@ -355,7 +355,7 @@ struct SSPRK53_2N2ConstantCache{T, T2} <: SSPRKConstantCache
     c3::T2
     c4::T2
 
-    function SSPRK53_2N2ConstantCache(T, T2)
+    function SSPRK53_2N2ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
         α30 = T(0.682342861037239)
         α32 = T(0.317657138962761)
         α50 = T(0.0452309744824)
@@ -434,7 +434,7 @@ struct SSPRK53_HConstantCache{T, T2} <: SSPRKConstantCache
     c3::T2
     c4::T2
 
-    function SSPRK53_HConstantCache(T, T2)
+    function SSPRK53_HConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
         α30 = T(0.308684154602513)
         α32 = T(0.691315845397487)
         α40 = T(0.280514990468574)
@@ -515,7 +515,7 @@ struct SSPRK63ConstantCache{T, T2} <: SSPRKConstantCache
     c4::T2
     c5::T2
 
-    function SSPRK63ConstantCache(T, T2)
+    function SSPRK63ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
         α40 = T(0.476769811285196)
         α41 = T(0.098511733286064)
         α43 = T(0.42471845542874)
@@ -606,7 +606,7 @@ struct SSPRK73ConstantCache{T, T2} <: SSPRKConstantCache
     c5::T2
     c6::T2
 
-    function SSPRK73ConstantCache(T, T2)
+    function SSPRK73ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
         α40 = T(0.184962588071072)
         α43 = T(0.815037411928928)
         α50 = T(0.18071865657038)
@@ -705,7 +705,7 @@ struct SSPRK83ConstantCache{T, T2} <: SSPRKConstantCache
     c6::T2
     c7::T2
 
-    function SSPRK83ConstantCache(T, T2)
+    function SSPRK83ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
         α50 = T(0.421366967085359)
         α51 = T(0.005949401107575)
         α54 = T(0.572683631807067)
@@ -790,7 +790,7 @@ struct SSPRK43ConstantCache{T, T2} <: SSPRKConstantCache
     half_u::T
     half_t::T2
 
-    function SSPRK43ConstantCache(T, T2)
+    function SSPRK43ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
         one_third_u = inv(T(3))
         two_thirds_u = 2 * one_third_u
         half_u = T(0.5)
@@ -1107,7 +1107,7 @@ struct SSPRK54ConstantCache{T, T2} <: SSPRKConstantCache
     c3::T2
     c4::T2
 
-    function SSPRK54ConstantCache(T, T2)
+    function SSPRK54ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
         β10 = T(0.39175222657189)
         α20 = T(0.444370493651235)
         α21 = T(0.555629506348765)
@@ -1250,7 +1250,7 @@ struct KYK2014DGSSPRK_3S2_ConstantCache{T, T2} <: OrdinaryDiffEqConstantCache
     c_1::T
     c_2::T
 
-    function KYK2014DGSSPRK_3S2_ConstantCache(T, T2)
+    function KYK2014DGSSPRK_3S2_ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
         α_10 = T(1.0)
         α_20 = T(0.087353119859156)
         α_21 = T(0.912646880140844)
@@ -1319,7 +1319,7 @@ struct pRRK22ConstantCache{T, T2} <: SSPRKConstantCache
     α21::T
     β21::T
 
-    function pRRK22ConstantCache(T, T2, κ)
+    function pRRK22ConstantCache(::Type{T}, ::Type{T2}, κ) where {T, T2}
         α10 = T(1)
         β10 = T(1)
         α20 = T(1 // 2)
@@ -1383,7 +1383,7 @@ struct pRRK33ConstantCache{T, T2} <: SSPRKConstantCache
     α32::T
     β32::T
 
-    function pRRK33ConstantCache(T, T2, κ)
+    function pRRK33ConstantCache(::Type{T}, ::Type{T2}, κ) where {T, T2}
         α10 = T(1)
         β10 = T(1)
         α20 = T(3 // 4)
@@ -1457,7 +1457,7 @@ struct pRRK54ConstantCache{T, T2} <: SSPRKConstantCache
     c3::T2
     c4::T2
 
-    function pRRK54ConstantCache(T, T2, κ)
+    function pRRK54ConstantCache(::Type{T}, ::Type{T2}, κ) where {T, T2}
         β10 = T(0.39175222657189)
         α20 = T(0.444370493651235)
         α21 = T(0.555629506348765)

--- a/lib/OrdinaryDiffEqStabilizedRK/src/rkc_tableaus_rock2.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/rkc_tableaus_rock2.jl
@@ -1,4 +1,4 @@
-function ROCK2ConstantCache(T, T2, zprev)
+function ROCK2ConstantCache(::Type{T}, ::Type{T2}, zprev) where {T, T2}
     ms = (
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
         20,

--- a/lib/OrdinaryDiffEqStabilizedRK/src/rkc_tableaus_rock4.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/rkc_tableaus_rock4.jl
@@ -1,4 +1,4 @@
-function ROCK4ConstantCache(T, T2, zprev)
+function ROCK4ConstantCache(::Type{T}, ::Type{T2}, zprev) where {T, T2}
     ms = (
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
         20,

--- a/lib/OrdinaryDiffEqSymplecticRK/src/symplectic_tableaus.jl
+++ b/lib/OrdinaryDiffEqSymplecticRK/src/symplectic_tableaus.jl
@@ -3,7 +3,7 @@ struct SymplecticTableau{aType, bType} <: HamiltonConstantCache
     b::bType
 end
 
-function PseudoVerletLeapfrogConstantCache(T, T2)
+function PseudoVerletLeapfrogConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     a1 = convert(T, 1)
     a2 = convert(T, 0)
     b1 = convert(T, 1 // 2)
@@ -11,7 +11,7 @@ function PseudoVerletLeapfrogConstantCache(T, T2)
     return SymplecticTableau((a1, a2), (b1, b2))
 end
 
-function McAte2ConstantCache(T, T2)
+function McAte2ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     a2 = convert(T, 1 - (1 / 2) * sqrt(convert(T, 2)))
     a1 = convert(T, 1 - a2)
     b2 = convert(T, 1 / (2 * (1 - a2)))
@@ -19,7 +19,7 @@ function McAte2ConstantCache(T, T2)
     return SymplecticTableau((a1, a2), (b1, b2))
 end
 
-function Ruth3ConstantCache(T, T2)
+function Ruth3ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     a1 = convert(T, 2 // 3)
     a2 = convert(T, -2 // 3)
     a3 = convert(T, 1)
@@ -29,7 +29,7 @@ function Ruth3ConstantCache(T, T2)
     return SymplecticTableau((a1, a2, a3), (b1, b2, b3))
 end
 
-function McAte3ConstantCache(T, T2)
+function McAte3ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     a1 = convert(T, 0.9196615230173999)
     a2 = convert(T, 0.25 / a1 - a1 / 2)
     a3 = convert(T, 1 - a1 - a2)
@@ -39,7 +39,7 @@ function McAte3ConstantCache(T, T2)
     return SymplecticTableau((a1, a2, a3), (b1, b2, b3))
 end
 
-function CandyRoz4ConstantCache(T, T2)
+function CandyRoz4ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     a1 = convert(T, (2 + T(2)^(1 // 3) + convert(T, 2)^(-1 // 3)) / 6)
     a2 = convert(T, (1 - T(2)^(1 // 3) - convert(T, 2)^(-1 // 3)) / 6)
     a3 = convert(T, a2)
@@ -75,7 +75,7 @@ function McAte4ConstantCache(T::Type, T2::Type)
     return SymplecticTableau((a1, a2, a3, a4), (b1, b2, b3, b4))
 end
 
-function CalvoSanz4ConstantCache(T, T2)
+function CalvoSanz4ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     a1 = convert(T, 0.20517766154229)
     a2 = convert(T, 0.40302128160421)
     a3 = -convert(T, 0.12092087633891)
@@ -152,7 +152,7 @@ function McAte5ConstantCache(T::Type, T2::Type)
     return SymplecticTableau((a1, a2, a3, a4, a5, a6), (b1, b2, b3, b4, b5, b6))
 end
 
-function Yoshida6ConstantCache(T, T2)
+function Yoshida6ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     a1 = convert(T, 0.78451361047756)
     a2 = convert(T, 0.23557321335936)
     a3 = convert(T, -1.1776799841789)

--- a/lib/StochasticDiffEqHighOrder/src/tableaus.jl
+++ b/lib/StochasticDiffEqHighOrder/src/tableaus.jl
@@ -39,7 +39,7 @@ end
 
 Constructs the tableau type for the SRIW1 method.
 """
-function constructSRIW1(T = Float64, T2 = Float64)
+function constructSRIW1(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 3 // 4; 0; 0]
     c₁ = [0; 1 // 4; 1; 1 // 4]
     A₀ = [
@@ -87,7 +87,7 @@ end
 
 Constructs the tableau type for the SRIW1 method.
 """
-function constructSRIW2(T = Float64, T2 = Float64)
+function constructSRIW2(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 1; 1 // 2; 0]
     c₁ = [0; 1 // 4; 1; 1 // 4]
     A₀ = [
@@ -135,7 +135,7 @@ end
 
 Opti6-12-11-10-01-47
 """
-function constructSRIOpt1(T = Float64, T2 = Float64)
+function constructSRIOpt1(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     A₀ = [
         0.0 0.0 0.0 0.0; -0.04199224421316468 0.0 0.0 0.0;
         2.842612915017106 -2.0527723684000727 0.0 0.0;
@@ -178,7 +178,7 @@ end
 
 Opti6-12-11-10-01-47
 """
-function constructSRIOpt2(T = Float64, T2 = Float64)
+function constructSRIOpt2(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c0 = [0.0, 0.13804532298278663, 0.9999999999999992, 0.9999999999999994]
     c1 = [0.0, 0.45605532163856893, 0.999999999999996, 0.9999999999999962]
     A0 = [
@@ -228,7 +228,7 @@ end
 
 Constructs the taleau type for the SRA1 method.
 """
-function constructSRA1(T = Float64, T2 = Float64)
+function constructSRA1(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     α = [1 // 3; 2 // 3]
     β₁ = [1; 0]
     β₂ = [-1; 1]
@@ -254,7 +254,7 @@ end
 
 Constructs the taleau type for the SRA2 method.
 """
-function constructSRA2(T = Float64, T2 = Float64)
+function constructSRA2(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     α = [1 // 3; 2 // 3]
     β₁ = [0; 1]
     β₂ = [3 // 2; -3 // 2]
@@ -280,7 +280,7 @@ end
 
 Constructs the taleau type for the SRA3 method.
 """
-function constructSRA3(T = Float64, T2 = Float64)
+function constructSRA3(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     α = [1 // 6; 1 // 6; 2 // 3]
     β₁ = [1; 0; 0]
     β₂ = [-1; 1; 0]
@@ -308,7 +308,7 @@ end
 
 Constructs the taleau type for the SOSRA method.
 """
-function constructSOSRA(T = Float64, T2 = Float64)
+function constructSOSRA(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     a1 = 0.2889874966892885
     a2 = 0.6859880440839937
     a3 = 0.025024459226717772
@@ -357,7 +357,7 @@ end
 
 Constructs the taleau type for the SOSRA method.
 """
-function constructSOSRA2(T = Float64, T2 = Float64)
+function constructSOSRA2(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     a1 = 0.4999999999999998
     a2 = -0.9683897375354181
     a3 = 1.4683897375354185
@@ -463,7 +463,7 @@ end
 
 Constructs the tableau type for the implicit SKenCarp method as a RosslerSRA tableau.
 """
-function constructSKenCarp(T = Float64, T2 = Float64)
+function constructSKenCarp(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     γ = convert(T, 0.435866521508459)
     a31 = convert(T, 0.2576482460664272)
     a32 = -convert(T, 0.09351476757488625)
@@ -518,7 +518,7 @@ end
 
 Constructs the tableau type for the explicit part of SKenCarp as a RosslerSRA tableau.
 """
-function constructExplicitSKenCarp(T = Float64, T2 = Float64)
+function constructExplicitSKenCarp(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     γ = convert(T, 0.435866521508459)
     a31 = convert(T, 0.2576482460664272)
     a32 = -convert(T, 0.09351476757488625)

--- a/lib/StochasticDiffEqImplicit/src/tableaus.jl
+++ b/lib/StochasticDiffEqImplicit/src/tableaus.jl
@@ -93,7 +93,7 @@ function SKenCarpTableau(::Type{T}, ::Type{T2}) where {
     )
 end
 
-function SKenCarpTableau(T, T2)
+function SKenCarpTableau(::Type{T}, ::Type{T2}) where {T, T2}
     γ = convert(T, 1767732205903 // 4055673282236)
     a31 = convert(T, 2746238789719 // 10658868560708)
     a32 = -convert(T, 640167445237 // 6845629431997)

--- a/lib/StochasticDiffEqWeak/src/tableaus.jl
+++ b/lib/StochasticDiffEqWeak/src/tableaus.jl
@@ -22,7 +22,7 @@ struct RoesslerRI{T, T2} <: Tableau
     quantile::T
 end
 
-function constructDRI1(T = Float64, T2 = Float64)
+function constructDRI1(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 1 // 2; 1]
     c₁ = [0; 342 // 491; 342 // 491]
     c₂ = [0; 0; 0]
@@ -72,7 +72,7 @@ function constructDRI1(T = Float64, T2 = Float64)
     )
 end
 
-function constructRI1(T = Float64, T2 = Float64)
+function constructRI1(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 2 // 3; 2 // 3]
     c₁ = [0; 1; 1]
     c₂ = [0; 0; 0]
@@ -122,7 +122,7 @@ function constructRI1(T = Float64, T2 = Float64)
     )
 end
 
-function constructRI3(T = Float64, T2 = Float64)
+function constructRI3(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 1; 1 // 2]
     c₁ = [0; 1; 1]
     c₂ = [0; 0; 0]
@@ -172,7 +172,7 @@ function constructRI3(T = Float64, T2 = Float64)
     )
 end
 
-function constructRI5(T = Float64, T2 = Float64)
+function constructRI5(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 1; 5 // 12]
     c₁ = [0; 1 // 4; 1 // 4]
     c₂ = [0; 0; 0]
@@ -222,7 +222,7 @@ function constructRI5(T = Float64, T2 = Float64)
     )
 end
 
-function constructRI6(T = Float64, T2 = Float64)
+function constructRI6(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 1; 0]
     c₁ = [0; 1; 1]
     c₂ = [0; 0; 0]
@@ -272,7 +272,7 @@ function constructRI6(T = Float64, T2 = Float64)
     )
 end
 
-function constructRDI1WM(T = Float64, T2 = Float64)
+function constructRDI1WM(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 2 // 3]
     c₁ = [0; 0]
     c₂ = [0; 0]
@@ -316,7 +316,7 @@ function constructRDI1WM(T = Float64, T2 = Float64)
     )
 end
 
-function constructRDI2WM(T = Float64, T2 = Float64)
+function constructRDI2WM(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 1; 0]
     c₁ = [0; 2 // 3; 2 // 3]
     c₂ = [0; 0; 0]
@@ -366,7 +366,7 @@ function constructRDI2WM(T = Float64, T2 = Float64)
     )
 end
 
-function constructRDI3WM(T = Float64, T2 = Float64)
+function constructRDI3WM(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 1 // 2; 3 // 4]
     c₁ = [0; 2 // 3; 2 // 3]
     c₂ = [0; 0; 0]
@@ -416,7 +416,7 @@ function constructRDI3WM(T = Float64, T2 = Float64)
     )
 end
 
-function constructRDI4WM(T = Float64, T2 = Float64)
+function constructRDI4WM(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 1 // 2; 1]
     c₁ = [0; 2 // 3; 2 // 3]
     c₂ = [0; 0; 0]
@@ -566,7 +566,7 @@ struct RoesslerRS{T, T2} <: Tableau
     quantile::T
 end
 
-function constructRS1(T = Float64, T2 = Float64)
+function constructRS1(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 0; 1; 0]
     c₁ = [0; 0; 1; 1]
     c₂ = [0; 0; 0; 0]
@@ -626,7 +626,7 @@ function constructRS1(T = Float64, T2 = Float64)
     )
 end
 
-function constructRS2(T = Float64, T2 = Float64)
+function constructRS2(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 2 // 3; 2 // 3; 0]
     c₁ = [0; 0; 1; 1]
     c₂ = [0; 0; 0; 0]
@@ -783,7 +783,7 @@ struct KomoriNON{T} <: Tableau
     quantile::T
 end
 
-function constructNON(T = Float64)
+function constructNON(::Type{T} = Float64) where {T}
     c0 = [1 // 6; 1 // 3; 1 // 3; 1 // 6]
     cj = [1 // 8; 3 // 8; 3 // 8; 1 // 8]
     cjl = [0; 1 // 2; -1 // 2; 0]
@@ -934,7 +934,7 @@ struct KomoriNON2{T} <: Tableau
     quantile::T
 end
 
-function constructNON2(T = Float64)
+function constructNON2(::Type{T} = Float64) where {T}
     # gamma is a free parameter
     γ = 1
     c0 = [1 // 6; 1 // 3; 1 // 3; 1 // 6]


### PR DESCRIPTION
## Summary

Extends the pattern from #3591 (Verner) to **all remaining tableau and ConstantCache constructors** across the monorepo. Replaces signatures of the form `f(T, T2)` (where `T`, `T2` are passed as untyped values, blocking specialization on element type) with `f(::Type{T}, ::Type{T2}) where {T, T2}` so dispatch specializes per element type.

For functions with positional defaults (StochasticDiffEq tableaus), preserves the default with `::Type{T} = Float64`.

## Touched (135 sites across 16 files)

- **OrdinaryDiffEqLowStorageRK** (44): all `*ConstantCache` ctors
- **OrdinaryDiffEqSDIRK** (24): all `*Tableau` ctors + `SDIRK22Tableau(T)`
- **OrdinaryDiffEqSSPRK** (14): inner ctors inside parametric structs; preserves `new{T,T2}(...)` since `where {T, T2}` keeps both names in scope
- **StochasticDiffEqWeak** (13) + **StochasticDiffEqHighOrder** (11): `construct*` fns with `T = Float64, T2 = Float64` defaults
- **OrdinaryDiffEqLowOrderRK** (11): 8 generic fallbacks under `CompiledFloats` fast-paths, plus `DP5_dense_bs`, `RKO65`, `FRK65`
- **OrdinaryDiffEqSymplecticRK** (7): single-method ctors that lacked a `CompiledFloats` fast-path and so weren't covered by the prior symplectic refactor (`PseudoVerletLeapfrog`, `McAte2`, `Ruth3`, `McAte3`, `CandyRoz4`, `CalvoSanz4`, `Yoshida6`)
- **OrdinaryDiffEqFIRK** (7): `RadauIIA{3,5,9}Tableau`, `RadauIIATableau`, `generateRadauTableau`, `GaussLegendreTableau`, `generateGaussLegendreTableau`
- **OrdinaryDiffEqExtrapolation** (3): two `create_extrapolation_coefficients` methods + `generate_sequence`
- **OrdinaryDiffEqStabilizedRK** (2): `ROCK2`/`ROCK4 ConstantCache(T, T2, zprev)`
- **OrdinaryDiffEqPDIRK** (1) + **OrdinaryDiffEqPRK** (1) + **StochasticDiffEqImplicit** (1) + **DiffEqDevTools** (1): one ctor each

## Why this is safe

- `f(::Type{T}, ::Type{T2}) where {T, T2}` is a strict generalization of `f(T, T2)` for `Type`-typed arguments and yields identical values for any concrete invocation — only specialization behavior changes.
- No method ambiguity with existing `T::Type{<:CompiledFloats}` fast-paths because the latter remains strictly more specific.
- The SSPRK inner-constructor edits preserve the trailing `new{T, T2}(...)` since the method-level `where {T, T2}` keeps both names in scope.

## Test plan

- [x] All 16 modified files parse cleanly under Julia 1.10
- [x] All 13 affected sub-packages precompile cleanly:
      OrdinaryDiffEq{LowOrderRK, SDIRK, FIRK, LowStorageRK, SSPRK, StabilizedRK, PDIRK, PRK, Extrapolation, SymplecticRK} + StochasticDiffEq{Weak, HighOrder, Implicit} + DiffEqDevTools
- [ ] Full CI matrix
- [ ] Allocation/JET checks unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)