### PR TITLE
fix(DiffEqDevTools): add Pkg to test deps

### DIFF
--- a/lib/DiffEqDevTools/Project.toml
+++ b/lib/DiffEqDevTools/Project.toml
@@ -106,6 +106,7 @@ OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 OrdinaryDiffEqVerner = "79d7bb75-1356-48c1-b8c0-6832512096c2"
 ParameterizedFunctions = "65888b18-ceab-5e60-b2b9-181511a3b968"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SDEProblemLibrary = "c72e72a9-a271-4b2b-8966-303ed956772e"
@@ -124,4 +125,4 @@ StochasticDiffEqWeak = "af2a2fcd-1c36-4cbe-a6d0-5afda784a085"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["BoundaryValueDiffEq", "BVProblemLibrary", "DelayDiffEq", "DDEProblemLibrary", "ImplicitDiscreteSolve", "NonlinearSolve", "ODEProblemLibrary", "OrdinaryDiffEq", "OrdinaryDiffEqBDF", "OrdinaryDiffEqCore", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqNonlinearSolve", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqTsit5", "OrdinaryDiffEqVerner", "ParameterizedFunctions", "Plots", "Random", "SDEProblemLibrary", "StochasticDiffEq", "StochasticDiffEqCore", "StochasticDiffEqHighOrder", "StochasticDiffEqIIF", "StochasticDiffEqImplicit", "StochasticDiffEqLeaping", "StochasticDiffEqLevyArea", "StochasticDiffEqLowOrder", "StochasticDiffEqMilstein", "StochasticDiffEqROCK", "StochasticDiffEqRODE", "StochasticDiffEqWeak", "Test"]
+test = ["BoundaryValueDiffEq", "BVProblemLibrary", "DelayDiffEq", "DDEProblemLibrary", "ImplicitDiscreteSolve", "NonlinearSolve", "ODEProblemLibrary", "OrdinaryDiffEq", "OrdinaryDiffEqBDF", "OrdinaryDiffEqCore", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqNonlinearSolve", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqTsit5", "OrdinaryDiffEqVerner", "ParameterizedFunctions", "Pkg", "Plots", "Random", "SDEProblemLibrary", "StochasticDiffEq", "StochasticDiffEqCore", "StochasticDiffEqHighOrder", "StochasticDiffEqIIF", "StochasticDiffEqImplicit", "StochasticDiffEqLeaping", "StochasticDiffEqLevyArea", "StochasticDiffEqLowOrder", "StochasticDiffEqMilstein", "StochasticDiffEqROCK", "StochasticDiffEqRODE", "StochasticDiffEqWeak", "Test"]


### PR DESCRIPTION
## Summary
- `lib/DiffEqDevTools/test/runtests.jl` does `using Pkg` (added in 806fb77 when QA was split into a separate Aqua testset that calls `Pkg.activate(joinpath(@__DIR__, "qa"))`).
- On Julia 1.11+, `Pkg` is no longer auto-loaded, so the DiffEqDevTools test job fails immediately on every Julia version with `ArgumentError: Package Pkg not found in current path` before any testset runs.
- Adds `Pkg` to `[extras]` and to `targets.test` in `lib/DiffEqDevTools/Project.toml`.

This was hidden on master because the path-filtered CI hasn't run the DiffEqDevTools matrix since 806fb77 landed. It surfaced on PR #3592 (which touches `lib/DiffEqDevTools/src/ode_tableaus.jl` and triggers the matrix), failing on `1`, `1.11`, `lts`, and `pre`.

Failing job for reference: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/25303733750/job/74175400870?pr=3592

## Test plan
- [ ] DiffEqDevTools sublibrary CI passes on `1`, `1.11`, `lts`, and `pre`

🤖 Generated with [Claude Code](https://claude.com/claude-code)