### PR TITLE
Fix #3595: tighten Kvaerno3+NLFunctional convergence test

### DIFF
--- a/lib/OrdinaryDiffEqSDIRK/test/sdirk_convergence_tests.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/sdirk_convergence_tests.jl
@@ -81,7 +81,14 @@ testTol = 0.2
     sim16 = test_convergence(dts, prob, Kvaerno3())
     @test sim16.𝒪est[:final] ≈ 3 atol = testTol
 
-    sim162 = test_convergence(dts, prob, Kvaerno3(nlsolve = NLFunctional()))
+    # NLFunctional default κ=1//100 is too loose for order-3 measurement at the
+    # tested dt range; tighten κ + raise max_iter so the nonlinear residual is
+    # below truncation error. See SciML/OrdinaryDiffEq.jl#3595.
+    sim162 = test_convergence(
+        dts, prob,
+        Kvaerno3(nlsolve = NLFunctional(κ = 1 // 1000, max_iter = 100));
+        abstol = 1.0e-12, reltol = 1.0e-12
+    )
     @test sim162.𝒪est[:final] ≈ 3 atol = testTol
 
     sim17 = test_convergence(dts, prob, KenCarp3())


### PR DESCRIPTION
## Fix #3595: Stabilize Kvaerno3 + NLFunctional convergence test across platforms

### Description

This PR fixes inconsistent convergence order results in the `Kvaerno3 + NLFunctional` test across different platforms.

The root cause is the default `NLFunctional` parameter `κ = 1//100`, which introduces a fast-path convergence condition (`ndz < 1e-5` at iteration 1) that does **not scale with user tolerances**. At the tested `dt` range, this condition becomes borderline:

* On local Apple Silicon, the fast-path is triggered → test passes (~3rd order)
* On CI (Linux x86_64), it is not triggered → falls back to κ-based convergence → residual too loose → degraded order (~2nd order)

---

### Changes

* Tightened convergence criteria:

  * `κ = 1//1000`
  * `max_iter = 100`
  * `abstol = reltol = 1e-12`
* Ensures nonlinear residual stays below truncation error
* Makes the convergence test deterministic and platform-independent

---

### Results

* Out-of-place: **3.0044**
* In-place: **3.0038**
* Matches expected 3rd-order accuracy and aligns with Newton reference

---

### Notes

The underlying issue lies in the hardcoded fast-path threshold (`ndz < 1e-5`) in `nlsolve.jl`, which should ideally scale with tolerance. However, modifying that would affect all implicit solvers and is intentionally left out of scope for this PR.

