### PR TITLE
Fix flipped sign in VectorContinuousCallback simultaneous_events (closes #3594)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -447,6 +447,8 @@ Each entry of `simultaneous_events` encodes both whether condition `i` triggered
 | `+1` | upcrossing (condition went from negative to positive) |
 | `-1` | downcrossing (condition went from positive to negative) |
 
+(Note: the first releases of the v7 incorrectly flipped this sign and it was immediately corrected)
+
 The vector's length is the callback's `len`; the entries are stable across steps. `affect_neg!` is no longer called for `VectorContinuousCallback` — your single `affect!` handles both crossing directions by inspecting the sign of each nonzero entry.
 
 **Migration:**

--- a/NEWS.md
+++ b/NEWS.md
@@ -444,8 +444,8 @@ Each entry of `simultaneous_events` encodes both whether condition `i` triggered
 | value | meaning |
 |---|---|
 | `0`  | condition did not trigger this step |
-| `-1` | upcrossing (condition went from negative to positive) |
-| `+1` | downcrossing (condition went from positive to negative) |
+| `+1` | upcrossing (condition went from negative to positive) |
+| `-1` | downcrossing (condition went from positive to negative) |
 
 The vector's length is the callback's `len`; the entries are stable across steps. `affect_neg!` is no longer called for `VectorContinuousCallback` — your single `affect!` handles both crossing directions by inspecting the sign of each nonzero entry.
 
@@ -468,7 +468,7 @@ function affect!(integrator, simultaneous_events)
         s = simultaneous_events[i]
         s == 0 && continue
         if i == 1
-            # ball 1 hit the ground; s == -1 upcrossing, s == +1 downcrossing
+            # ball 1 hit the ground; s == +1 upcrossing, s == -1 downcrossing
         elseif i == 2
             # ball 2 hit the ground
         end

--- a/lib/DiffEqBase/src/callbacks.jl
+++ b/lib/DiffEqBase/src/callbacks.jl
@@ -263,7 +263,7 @@ end
                 if min_event_idx < 0
                     min_event_idx = i
                 end
-                simultaneous_events[i] = Int8(sign(ArrayInterface.allowed_getindex(bottom_sign, i)))
+                simultaneous_events[i] = Int8(-sign(ArrayInterface.allowed_getindex(bottom_sign, i)))
             end
         end
         residual = zero(eltype(bottom_condition))
@@ -297,7 +297,7 @@ end
                     min_event_idx = idx
                     callback_t = cbi_t
                     residual = zero_func(cbi_t)
-                    simultaneous_events[idx] = Int8(sign(ArrayInterface.allowed_getindex(bottom_sign, idx)))
+                    simultaneous_events[idx] = Int8(-sign(ArrayInterface.allowed_getindex(bottom_sign, idx)))
                 end
             end
         end
@@ -500,8 +500,8 @@ For `VectorContinuousCallback`, `callback.affect!` is called once with the full
 Each element of `simultaneous_events` encodes both whether the event triggered and
 its crossing direction:
   - `0`: event did not trigger
-  - `-1`: event triggered via upcrossing (condition went from negative to positive)
-  - `+1`: event triggered via downcrossing (condition went from positive to negative)
+  - `+1`: event triggered via upcrossing (condition went from negative to positive)
+  - `-1`: event triggered via downcrossing (condition went from positive to negative)
 
 Multiple events may be nonzero simultaneously when they occur at the same time.
 The `affect_neg!` field is not called for `VectorContinuousCallback`; the user's

--- a/test/integrators/event_detection_tests.jl
+++ b/test/integrators/event_detection_tests.jl
@@ -130,11 +130,11 @@ end
 
 function affect_combined!(integrator, events)
     for (idx, dir) in enumerate(events)
-        if dir == -1 # upcrossing — old affect! path
+        if dir == 1 # upcrossing — old affect! path
             z[] += 1
             @show integrator.u[1]
             @show integrator.u[3]
-        elseif dir == 1 # downcrossing — old affect_neg! path
+        elseif dir == -1 # downcrossing — old affect_neg! path
             if idx == 1
                 x[] += 1
                 integrator.u[2] = -0.9integrator.u[2]

--- a/test/integrators/ode_event_tests.jl
+++ b/test/integrators/ode_event_tests.jl
@@ -121,7 +121,7 @@ end
 
 affect! = function (integrator, events)
     for (idx, dir) in enumerate(events)
-        if dir == 1 && idx == 1 # downcrossing
+        if dir == -1 && idx == 1 # downcrossing
             integrator.u[2] = -integrator.u[2]
         end
     end
@@ -172,7 +172,7 @@ end
 
 affect! = function (integrator, events)
     for (idx, dir) in enumerate(events)
-        if dir == 1 && idx == 1 # downcrossing
+        if dir == -1 && idx == 1 # downcrossing
             integrator.u[2] = -integrator.u[2]
         end
     end
@@ -324,7 +324,7 @@ end
 
 vaffect2! = function (integrator, events)
     for (idx, dir) in enumerate(events)
-        if dir == 1 && idx == 1 # downcrossing
+        if dir == -1 && idx == 1 # downcrossing
             if integrator.t >= 3.5
                 terminate!(integrator)
             else
@@ -658,4 +658,56 @@ end
     # region (t=0.00128 to t=0.00135) instead of going negative without a callback.
     @test abs(sol(0.00128)[1]) < 0.01
     @test abs(sol(0.00135)[1]) < 0.01
+end
+
+# Regression test for https://github.com/SciML/OrdinaryDiffEq.jl/issues/3594
+# `simultaneous_events[i]` must report +1 for upcrossings (negative→positive)
+# and -1 for downcrossings (positive→negative).
+@testset "VectorContinuousCallback crossing-direction sign (#3594)" begin
+    function rhs_3594!(du, u, p, t)
+        du[1] = -sin(t)
+        du[2] = -3sin(3t)
+        return
+    end
+    function cond_3594(out, u, t, integ)
+        out[1] = u[1]
+        out[2] = u[2]
+        return
+    end
+
+    # Roots of u[1] = cos(t) and u[2] = cos(3t) on (0, π):
+    #   u[1]: t = π/2  (1 → -1, downcrossing)
+    #   u[2]: t = π/6  (1 → -1, downcrossing)
+    #         t = π/2  (-1 → 1, upcrossing)
+    #         t = 5π/6 (1 → -1, downcrossing)
+    crossings = Tuple{Int, Int, Float64}[]  # (idx, dir, t)
+    function aff_3594!(integ, evts)
+        for (idx, dir) in enumerate(evts)
+            iszero(dir) && continue
+            push!(crossings, (idx, Int(dir), integ.t))
+        end
+        return
+    end
+
+    prob = ODEProblem(rhs_3594!, ones(2), (0.0, Float64(π)))
+    cb = VectorContinuousCallback(cond_3594, aff_3594!, 2)
+    solve(prob, Tsit5(); callback = cb)
+
+    # Find each expected crossing and check its reported direction.
+    # u[2] downcrossing near t = π/6
+    e1 = findfirst(((idx, _, t),) -> idx == 2 && abs(t - π / 6) < 1.0e-2, crossings)
+    @test e1 !== nothing
+    @test crossings[e1][2] == -1
+    # u[2] upcrossing near t = π/2
+    e2 = findfirst(((idx, _, t),) -> idx == 2 && abs(t - π / 2) < 1.0e-2, crossings)
+    @test e2 !== nothing
+    @test crossings[e2][2] == +1
+    # u[1] downcrossing near t = π/2
+    e3 = findfirst(((idx, _, t),) -> idx == 1 && abs(t - π / 2) < 1.0e-2, crossings)
+    @test e3 !== nothing
+    @test crossings[e3][2] == -1
+    # u[2] downcrossing near t = 5π/6
+    e4 = findfirst(((idx, _, t),) -> idx == 2 && abs(t - 5π / 6) < 1.0e-2, crossings)
+    @test e4 !== nothing
+    @test crossings[e4][2] == -1
 end


### PR DESCRIPTION
## Summary

- Fixes #3594: `VectorContinuousCallback` reported `+1` for downcrossings and `-1` for upcrossings — the opposite of the intuitive "+1 = up, −1 = down" convention.
- The internal `simultaneous_events[i]` was assigned `sign(bottom_sign[i])` (i.e. the *previous* sign of the condition). Negate it so the public encoding reflects crossing direction.
- New encoding (matching the docstring, the v7 NEWS migration table, and Aayush's MRE):
  - `0`  — condition did not trigger
  - `+1` — upcrossing (negative → positive)
  - `−1` — downcrossing (positive → negative)
- Internal `prev_sign` semantics in `apply_callback!` for plain `ContinuousCallback` are unchanged.
- Updates the two direction-aware tests in `ode_event_tests.jl` and `event_detection_tests.jl` to the new convention. Adds a regression test reproducing the issue's MRE (`du[1] = -sin(t)`, `du[2] = -3sin(3t)`, conditions on `u[1]`, `u[2]`) and asserting the sign reported at each of the four crossings of `cos(t)`/`cos(3t)` on `(0, π)`.

## Test plan

- [x] Manual MRE from the issue now reports `u[2] down` at `t = π/6`, `u[2] up` at `t = π/2`, `u[1] down` at `t = π/2`, `u[2] down` at `t = 5π/6`.
- [x] `GROUP=Integrators_I` test group passes locally (Events Tests, Event Detection Tests 23/23, Event Repetition Detection Tests 6/6, Step Limiter Tests 129/129).
- [x] `GROUP=DiffEqBase` test group passes locally.
- [x] New regression testset `VectorContinuousCallback crossing-direction sign (#3594)` passes (8/8).
- [x] Runic format check is clean for changed files.
- [ ] CI green on full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)