### PR TITLE
Fix #3596: seed JacReuseState with tTypeNoUnits, not zero(dt)

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -891,10 +891,6 @@ system matrix. Supports Jacobian reuse for W-methods via `jac_reuse` in the cach
 function calc_rosenbrock_differentiation(integrator, cache, dtgamma, repeat_step)
     jac_reuse = get_jac_reuse(cache)
 
-    # Skip reuse if jac_reuse can't hold dtgamma: e.g. JacReuseState{Float64} when
-    # dtgamma is a ForwardDiff.Dual (AD differentiation w.r.t. t0). This mismatch
-    # arises when the cache was built with zero(dt) instead of zero(tTypeNoUnits)
-    # (older registered versions of rosenbrock_caches.jl, see #3596).
     if repeat_step || jac_reuse === nothing ||
             !(typeof(dtgamma) <: typeof(jac_reuse.pending_dtgamma))
         dT = calc_tderivative(integrator, cache)

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -891,8 +891,12 @@ system matrix. Supports Jacobian reuse for W-methods via `jac_reuse` in the cach
 function calc_rosenbrock_differentiation(integrator, cache, dtgamma, repeat_step)
     jac_reuse = get_jac_reuse(cache)
 
-    # If no reuse support or repeat step, use standard path
-    if repeat_step || jac_reuse === nothing
+    # Skip reuse if jac_reuse can't hold dtgamma: e.g. JacReuseState{Float64} when
+    # dtgamma is a ForwardDiff.Dual (AD differentiation w.r.t. t0). This mismatch
+    # arises when the cache was built with zero(dt) instead of zero(tTypeNoUnits)
+    # (older registered versions of rosenbrock_caches.jl, see #3596).
+    if repeat_step || jac_reuse === nothing ||
+            !(typeof(dtgamma) <: typeof(jac_reuse.pending_dtgamma))
         dT = calc_tderivative(integrator, cache)
         W = calc_W(integrator, cache, dtgamma, repeat_step)
         return dT, W

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -891,8 +891,7 @@ system matrix. Supports Jacobian reuse for W-methods via `jac_reuse` in the cach
 function calc_rosenbrock_differentiation(integrator, cache, dtgamma, repeat_step)
     jac_reuse = get_jac_reuse(cache)
 
-    if repeat_step || jac_reuse === nothing ||
-            !(typeof(dtgamma) <: typeof(jac_reuse.pending_dtgamma))
+    if repeat_step || jac_reuse === nothing
         dT = calc_tderivative(integrator, cache)
         W = calc_W(integrator, cache, dtgamma, repeat_step)
         return dT, W

--- a/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_caches.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_caches.jl
@@ -324,12 +324,6 @@ function alg_cache(
     linprob = nothing #LinearProblem(W,copy(u); u0=copy(u))
     linsolve = nothing #init(linprob,alg.linsolve,alias_A=true,alias_b=true)
     tab = Rosenbrock23Tableau(constvalue(uBottomEltypeNoUnits))
-    # Seed JacReuseState with `zero(tTypeNoUnits)` rather than `zero(dt)`:
-    # tTypeNoUnits comes from `oneunit(first(tspan))` so it always reflects the
-    # full integration time type (e.g. `Dual` under AD, `Dual{Dual}` under
-    # nested AD). `dt` may be passed as a `Float64` placeholder when the user
-    # didn't supply one (#3596). Using tTypeNoUnits guarantees the dtgamma
-    # field can hold whatever dtgamma = dt * gamma evaluates to at perform_step.
     return Rosenbrock23ConstantCache(
         tab.c₃₂, tab.d, tf, uf, J, W, linsolve, alg_autodiff(alg),
         _make_jac_reuse_state(zero(tTypeNoUnits), alg.max_jac_age)
@@ -361,8 +355,6 @@ function alg_cache(
     linprob = nothing #LinearProblem(W,copy(u); u0=copy(u))
     linsolve = nothing #init(linprob,alg.linsolve,alias_A=true,alias_b=true)
     tab = Rosenbrock32Tableau(constvalue(uBottomEltypeNoUnits))
-    # See the Rosenbrock23 OOP alg_cache above for why we pass `zero(dt)` here
-    # rather than a `constvalue`-stripped type.
     return Rosenbrock32ConstantCache(
         tab.c₃₂, tab.d, tf, uf, J, W, linsolve, alg_autodiff(alg),
         _make_jac_reuse_state(zero(tTypeNoUnits), alg.max_jac_age)
@@ -455,8 +447,6 @@ function alg_cache(
     else
         interp_order = H_rows
     end
-    # Seed JacReuseState with `zero(tTypeNoUnits)` so its dtgamma fields carry
-    # the full integration time type at solve time (Dual under AD). See #3596.
     return RosenbrockCombinedConstantCache(
         tf, uf,
         tab, J, W, linsolve,

--- a/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_caches.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_caches.jl
@@ -243,7 +243,7 @@ function alg_cache(
         fsalfirst, fsallast, dT, J, W, tmp, atmp, weight, tab, tf, uf,
         linsolve_tmp,
         linsolve, jac_config, grad_config, reltol, alg, algebraic_vars, alg.step_limiter!,
-        alg.stage_limiter!, _make_jac_reuse_state(zero(dt), alg.max_jac_age)
+        alg.stage_limiter!, _make_jac_reuse_state(zero(tTypeNoUnits), alg.max_jac_age)
     )
 end
 
@@ -295,7 +295,7 @@ function alg_cache(
         u, uprev, k₁, k₂, k₃, du1, du2, f₁, fsalfirst, fsallast, dT, J, W,
         tmp, atmp, weight, tab, tf, uf, linsolve_tmp, linsolve, jac_config,
         grad_config, reltol, alg, algebraic_vars, alg.step_limiter!, alg.stage_limiter!,
-        _make_jac_reuse_state(zero(dt), alg.max_jac_age)
+        _make_jac_reuse_state(zero(tTypeNoUnits), alg.max_jac_age)
     )
 end
 
@@ -324,12 +324,15 @@ function alg_cache(
     linprob = nothing #LinearProblem(W,copy(u); u0=copy(u))
     linsolve = nothing #init(linprob,alg.linsolve,alias_A=true,alias_b=true)
     tab = Rosenbrock23Tableau(constvalue(uBottomEltypeNoUnits))
-    # Seed JacReuseState with `zero(dt)` rather than a `constvalue`-stripped
-    # type: under nested ForwardDiff (e.g. `hessian`), dt is a Dual-of-Dual and
-    # dtgamma inherits that full type; a Float64 field would reject the assign.
+    # Seed JacReuseState with `zero(tTypeNoUnits)` rather than `zero(dt)`:
+    # tTypeNoUnits comes from `oneunit(first(tspan))` so it always reflects the
+    # full integration time type (e.g. `Dual` under AD, `Dual{Dual}` under
+    # nested AD). `dt` may be passed as a `Float64` placeholder when the user
+    # didn't supply one (#3596). Using tTypeNoUnits guarantees the dtgamma
+    # field can hold whatever dtgamma = dt * gamma evaluates to at perform_step.
     return Rosenbrock23ConstantCache(
         tab.c₃₂, tab.d, tf, uf, J, W, linsolve, alg_autodiff(alg),
-        _make_jac_reuse_state(zero(dt), alg.max_jac_age)
+        _make_jac_reuse_state(zero(tTypeNoUnits), alg.max_jac_age)
     )
 end
 
@@ -362,7 +365,7 @@ function alg_cache(
     # rather than a `constvalue`-stripped type.
     return Rosenbrock32ConstantCache(
         tab.c₃₂, tab.d, tf, uf, J, W, linsolve, alg_autodiff(alg),
-        _make_jac_reuse_state(zero(dt), alg.max_jac_age)
+        _make_jac_reuse_state(zero(tTypeNoUnits), alg.max_jac_age)
     )
 end
 
@@ -452,13 +455,13 @@ function alg_cache(
     else
         interp_order = H_rows
     end
-    # Seed JacReuseState with `zero(dt)` so its dtgamma fields carry the full
-    # (possibly ForwardDiff.Dual) type dtgamma will have at solve time.
+    # Seed JacReuseState with `zero(tTypeNoUnits)` so its dtgamma fields carry
+    # the full integration time type at solve time (Dual under AD). See #3596.
     return RosenbrockCombinedConstantCache(
         tf, uf,
         tab, J, W, linsolve,
         alg_autodiff(alg), interp_order,
-        _make_jac_reuse_state(zero(dt), alg.max_jac_age)
+        _make_jac_reuse_state(zero(tTypeNoUnits), alg.max_jac_age)
     )
 end
 
@@ -531,7 +534,7 @@ function alg_cache(
         dT, J, W, tmp, atmp, weight, tab, tf, uf, linsolve_tmp,
         linsolve, jac_config, grad_config, reltol, alg,
         _get_step_limiter(alg), _get_stage_limiter(alg), interp_order,
-        _make_jac_reuse_state(zero(dt), alg.max_jac_age)
+        _make_jac_reuse_state(zero(tTypeNoUnits), alg.max_jac_age)
     )
 end
 


### PR DESCRIPTION
## Fix #3596: Seed `JacReuseState` with `tTypeNoUnits` for AD compatibility

### Description

This PR fixes a type instability issue encountered when differentiating ODE solves with respect to the initial time `t0` using `ForwardDiff`.

On Julia LTS (1.10) Linux x86_64, all four out-of-place Rosenbrock methods:

* `Rosenbrock23`
* `Rosenbrock32`
* `Rodas4`
* `Rodas5`

fail with:

```
MethodError: no method matching Float64(::ForwardDiff.Dual{...})
setproperty!(::JacReuseState{Float64}, ..., ::Dual)
```

(Not reproducible on macOS aarch64 with the same versions.)

---

### Root Cause

`JacReuseState{T}` was initialized using `zero(dt)` inside `alg_cache`.

When `solve()` is called without an explicit `dt`, the internal `_dt` may be derived from:

```
eltype(prob.tspan)(0)
```

There exists an execution path where this results in a `Float64`, even when `tspan[1]` is a `ForwardDiff.Dual`. This causes:

* Cache initialized as `JacReuseState{Float64}`
* Runtime `dt` becomes `Dual`
* Assignment failure when storing `dt * gamma` (Dual → Float64)

---

### Fix

Initialize `JacReuseState` using:

```
zero(tTypeNoUnits)
```

* `tTypeNoUnits` is derived from:

  ```
  oneunit(first(tspan))
  ```
* It reliably reflects the actual time type at solve time:

  * `Dual` under AD
  * `Dual{Dual}` under nested AD

This ensures all internal fields (e.g., `dtgamma`) correctly accept `dt * gamma`.

---

### Changes

* Updated all 6 `alg_cache` call sites:

  * Rosenbrock23 (OOP + IIP)
  * Rosenbrock32 (OOP + IIP)
  * Rodas methods (combined OOP + IIP)

---

### Results

* Fixes ForwardDiff differentiation w.r.t. `t0` on Julia LTS Linux
* Works for:

  * Single AD
  * Nested AD (Hessian)
* Type inference preserved:

  * `@inferred solve` passes for both OOP and IIP

---

### Notes

This change ensures consistency between cache initialization and runtime types, preventing AD-related type conflicts without impacting performance or existing solver behavior.
