### PR TITLE
Bump DRI1 weak-convergence test to 1e6 trajectories

### DIFF
--- a/lib/DiffEqDevTools/Project.toml
+++ b/lib/DiffEqDevTools/Project.toml
@@ -28,6 +28,8 @@ OrdinaryDiffEqFIRK = {path = "../OrdinaryDiffEqFIRK"}
 OrdinaryDiffEqLowOrderRK = {path = "../OrdinaryDiffEqLowOrderRK"}
 OrdinaryDiffEqNonlinearSolve = {path = "../OrdinaryDiffEqNonlinearSolve"}
 OrdinaryDiffEqRosenbrock = {path = "../OrdinaryDiffEqRosenbrock"}
+OrdinaryDiffEqSDIRK = {path = "../OrdinaryDiffEqSDIRK"}
+OrdinaryDiffEqSSPRK = {path = "../OrdinaryDiffEqSSPRK"}
 OrdinaryDiffEqTsit5 = {path = "../OrdinaryDiffEqTsit5"}
 OrdinaryDiffEqVerner = {path = "../OrdinaryDiffEqVerner"}
 StochasticDiffEq = {path = "../StochasticDiffEq"}
@@ -64,6 +66,8 @@ OrdinaryDiffEqFIRK = "2"
 OrdinaryDiffEqLowOrderRK = "2"
 OrdinaryDiffEqNonlinearSolve = "2"
 OrdinaryDiffEqRosenbrock = "2"
+OrdinaryDiffEqSDIRK = "2"
+OrdinaryDiffEqSSPRK = "2"
 OrdinaryDiffEqTsit5 = "2"
 OrdinaryDiffEqVerner = "2"
 ParameterizedFunctions = "5.24"
@@ -104,6 +108,8 @@ OrdinaryDiffEqFIRK = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 OrdinaryDiffEqLowOrderRK = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
 OrdinaryDiffEqNonlinearSolve = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
+OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
+OrdinaryDiffEqSSPRK = "669c94d9-1f4b-4b64-b377-1aa079aa2388"
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 OrdinaryDiffEqVerner = "79d7bb75-1356-48c1-b8c0-6832512096c2"
 ParameterizedFunctions = "65888b18-ceab-5e60-b2b9-181511a3b968"
@@ -127,4 +133,4 @@ StochasticDiffEqWeak = "af2a2fcd-1c36-4cbe-a6d0-5afda784a085"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["BoundaryValueDiffEq", "BVProblemLibrary", "DelayDiffEq", "DDEProblemLibrary", "ImplicitDiscreteSolve", "NonlinearSolve", "ODEProblemLibrary", "OrdinaryDiffEq", "OrdinaryDiffEqBDF", "OrdinaryDiffEqCore", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqNonlinearSolve", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqTsit5", "OrdinaryDiffEqVerner", "ParameterizedFunctions", "Pkg", "Plots", "Random", "SDEProblemLibrary", "SciMLLogging", "StochasticDiffEq", "StochasticDiffEqCore", "StochasticDiffEqHighOrder", "StochasticDiffEqIIF", "StochasticDiffEqImplicit", "StochasticDiffEqLeaping", "StochasticDiffEqLevyArea", "StochasticDiffEqLowOrder", "StochasticDiffEqMilstein", "StochasticDiffEqROCK", "StochasticDiffEqRODE", "StochasticDiffEqWeak", "Test"]
+test = ["BoundaryValueDiffEq", "BVProblemLibrary", "DelayDiffEq", "DDEProblemLibrary", "ImplicitDiscreteSolve", "NonlinearSolve", "ODEProblemLibrary", "OrdinaryDiffEq", "OrdinaryDiffEqBDF", "OrdinaryDiffEqCore", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqNonlinearSolve", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqSSPRK", "OrdinaryDiffEqTsit5", "OrdinaryDiffEqVerner", "ParameterizedFunctions", "Pkg", "Plots", "Random", "SDEProblemLibrary", "SciMLLogging", "StochasticDiffEq", "StochasticDiffEqCore", "StochasticDiffEqHighOrder", "StochasticDiffEqIIF", "StochasticDiffEqImplicit", "StochasticDiffEqLeaping", "StochasticDiffEqLevyArea", "StochasticDiffEqLowOrder", "StochasticDiffEqMilstein", "StochasticDiffEqROCK", "StochasticDiffEqRODE", "StochasticDiffEqWeak", "Test"]

--- a/lib/DiffEqDevTools/test/analyticless_convergence_tests.jl
+++ b/lib/DiffEqDevTools/test/analyticless_convergence_tests.jl
@@ -73,7 +73,12 @@ h2(z) = z^2 # but apply it only to u[1]
 
 prob = SDEProblem(f2!, g2!, u₀, tspan, noise_rate_prototype = zeros(2, 2))
 
-numtraj = Int(1.0e5)
+# 1e6 trajectories, not 1e5: at 1e5 the MC standard error σ/√N on the smallest
+# dt's mean is comparable to the order-2 bias C·dt² at dt=1/8, so the order
+# regression sits in the noise floor and the slope wobbles between roughly
+# 1.3 and 2.3 across master seeds. Bumping by 10× brings the order estimate
+# reliably to ≈2.0 ± 0.3.
+numtraj = Int(1.0e6)
 seed = 100
 Random.seed!(seed)
 seeds = rand(UInt, numtraj)

--- a/lib/DiffEqDevTools/test/analyticless_convergence_tests.jl
+++ b/lib/DiffEqDevTools/test/analyticless_convergence_tests.jl
@@ -73,11 +73,6 @@ h2(z) = z^2 # but apply it only to u[1]
 
 prob = SDEProblem(f2!, g2!, u₀, tspan, noise_rate_prototype = zeros(2, 2))
 
-# 1e6 trajectories, not 1e5: at 1e5 the MC standard error σ/√N on the smallest
-# dt's mean is comparable to the order-2 bias C·dt² at dt=1/8, so the order
-# regression sits in the noise floor and the slope wobbles between roughly
-# 1.3 and 2.3 across master seeds. Bumping by 10× brings the order estimate
-# reliably to ≈2.0 ± 0.3.
 numtraj = Int(1.0e6)
 seed = 100
 Random.seed!(seed)

--- a/lib/DiffEqDevTools/test/stability_region_test.jl
+++ b/lib/DiffEqDevTools/test/stability_region_test.jl
@@ -1,5 +1,10 @@
 using DiffEqDevTools, Test
 using OrdinaryDiffEq
+# v7 OrdinaryDiffEq does not blanket-reexport every algorithm; pull in the
+# specific solvers this file uses from their sublibraries.
+using OrdinaryDiffEqLowOrderRK: RK4
+using OrdinaryDiffEqSDIRK: ImplicitEuler
+using OrdinaryDiffEqSSPRK: SSPRK33, SSPRK104
 
 # Test stability_region with algorithm-based interface
 @test @inferred(stability_region(Tsit5())) ≈ stability_region(Tsit5()) rtol = 1.0e-3

--- a/lib/DiffEqDevTools/test/stability_region_test.jl
+++ b/lib/DiffEqDevTools/test/stability_region_test.jl
@@ -1,7 +1,5 @@
 using DiffEqDevTools, Test
 using OrdinaryDiffEq
-# v7 OrdinaryDiffEq does not blanket-reexport every algorithm; pull in the
-# specific solvers this file uses from their sublibraries.
 using OrdinaryDiffEqLowOrderRK: RK4
 using OrdinaryDiffEqSDIRK: ImplicitEuler
 using OrdinaryDiffEqSSPRK: SSPRK33, SSPRK104


### PR DESCRIPTION
## Summary

Fixes the recent CI failure of `lib/DiffEqDevTools/test/analyticless_convergence_tests.jl` (`abs(sim.𝒪est[:weak_final] - 2.0) < 0.3` on the DRI1 / 2×2-noise SDE) by raising `numtraj` from `1e5` to `1e6`. The previous `@test_broken` TODO blamed *SciMLBase v3 seed handling* — that lead doesn't hold up. The actual cause is Monte Carlo noise: at 1e5 trajectories the MC standard error σ/√N on the smallest-dt mean is comparable to the order-2 bias `C·dt²` at dt=1/8, so the order regression sits in the noise floor and the slope wobbles between ≈1.3 and ≈2.3 depending on the master seed.

## Diagnosis

Verified locally that `prob.seed` plumbing is fine:

- `remake(prob, seed = k)` correctly stores the seed (`prob.seed == k`).
- Same seed → bit-identical trajectory.
- Distinct seeds → distinct trajectories.
- `ctx.sim_id` ranges over `1:numtraj` with no collisions, even under `EnsembleThreads`.
- `EnsembleSerial` and `EnsembleThreads` produce bit-identical convergence estimates.

Empirical scan on this branch (locally):

| numtraj | order @ seed=100 | mean across 8 master seeds | range |
|---|---|---|---|
| 1e4 | 0.80 | — | — |
| 1e5 | 1.35 | 1.68 | 1.32–2.26 |
| 1e6 | 1.80 | 2.07 (4 seeds) | 1.76–2.29 |

DRI1's true weak order is ≈2.0, visible once MC noise is suppressed enough. The previous "Was ≈2.0 previously" reflected a favorable position in the RNG stream — any change in random-number consumption (e.g. a tableau tweak in StochasticDiffEq) shifts where seed=100 lands in the noise distribution.

## Test plan

- [x] Locally with `seed=100`, `numtraj=1e6`: `sim.𝒪est[:weak_final] = 1.797`, `|order - 2.0| = 0.203 < 0.3` ✓
- [x] Across 4 master seeds at `numtraj=1e6`: orders `[2.29, 2.27, 1.95, 1.76]`, mean 2.07, all within ±0.3 of 2.0 (worst case 0.29).
- [x] Runic format check is clean for the changed file.
- [ ] CI green on the `DiffEqDevTools` test job.

## Cost

CI runtime for this block: ~30s → ~125s on a 14-thread machine. ~95s of CI time bought back a meaningful weak-convergence test where the previous one was telling us about RNG-stream position more than DRI1's order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)