### PR TITLE
Migrate analyticless_stochastic_wp test to SciMLLogging verbose API

### DIFF
--- a/lib/DiffEqDevTools/Project.toml
+++ b/lib/DiffEqDevTools/Project.toml
@@ -72,6 +72,7 @@ RecursiveArrayTools = "4"
 RootedTrees = "2"
 SDEProblemLibrary = "1"
 SciMLBase = "3"
+SciMLLogging = "1.9"
 Statistics = "1"
 StochasticDiffEq = "7"
 StochasticDiffEqCore = "2"
@@ -110,6 +111,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SDEProblemLibrary = "c72e72a9-a271-4b2b-8966-303ed956772e"
+SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 StochasticDiffEqCore = "19c5a474-6cd1-4a5f-be79-46dc34e54d7f"
 StochasticDiffEqHighOrder = "0520c28c-50fd-4d16-9c96-902fc80b3bab"
@@ -125,4 +127,4 @@ StochasticDiffEqWeak = "af2a2fcd-1c36-4cbe-a6d0-5afda784a085"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["BoundaryValueDiffEq", "BVProblemLibrary", "DelayDiffEq", "DDEProblemLibrary", "ImplicitDiscreteSolve", "NonlinearSolve", "ODEProblemLibrary", "OrdinaryDiffEq", "OrdinaryDiffEqBDF", "OrdinaryDiffEqCore", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqNonlinearSolve", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqTsit5", "OrdinaryDiffEqVerner", "ParameterizedFunctions", "Pkg", "Plots", "Random", "SDEProblemLibrary", "StochasticDiffEq", "StochasticDiffEqCore", "StochasticDiffEqHighOrder", "StochasticDiffEqIIF", "StochasticDiffEqImplicit", "StochasticDiffEqLeaping", "StochasticDiffEqLevyArea", "StochasticDiffEqLowOrder", "StochasticDiffEqMilstein", "StochasticDiffEqROCK", "StochasticDiffEqRODE", "StochasticDiffEqWeak", "Test"]
+test = ["BoundaryValueDiffEq", "BVProblemLibrary", "DelayDiffEq", "DDEProblemLibrary", "ImplicitDiscreteSolve", "NonlinearSolve", "ODEProblemLibrary", "OrdinaryDiffEq", "OrdinaryDiffEqBDF", "OrdinaryDiffEqCore", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqNonlinearSolve", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqTsit5", "OrdinaryDiffEqVerner", "ParameterizedFunctions", "Pkg", "Plots", "Random", "SDEProblemLibrary", "SciMLLogging", "StochasticDiffEq", "StochasticDiffEqCore", "StochasticDiffEqHighOrder", "StochasticDiffEqIIF", "StochasticDiffEqImplicit", "StochasticDiffEqLeaping", "StochasticDiffEqLevyArea", "StochasticDiffEqLowOrder", "StochasticDiffEqMilstein", "StochasticDiffEqROCK", "StochasticDiffEqRODE", "StochasticDiffEqWeak", "Test"]

--- a/lib/DiffEqDevTools/test/analyticless_stochastic_wp.jl
+++ b/lib/DiffEqDevTools/test/analyticless_stochastic_wp.jl
@@ -1,6 +1,7 @@
 using Random
 using StochasticDiffEq, DiffEqDevTools, Test
 using SDEProblemLibrary: prob_sde_additivesystem
+using SciMLLogging: None
 
 prob = prob_sde_additivesystem
 prob = SDEProblem(prob.f, prob.g, prob.u0, (0.0, 0.1), prob.p)
@@ -115,7 +116,7 @@ appxsol_setup = Dict(:alg => EM(), :dt => test_dt)
 wp1 = @time WorkPrecisionSet(
     ensemble_prob, abstols, reltols, setups, test_dt;
     maxiters = 1.0e7,
-    verbose = false, save_everystep = false, save_start = false,
+    verbose = None(), save_everystep = false, save_start = false,
     appxsol_setup = appxsol_setup,
     trajectories = numtraj, error_estimate = :weak_final
 )
@@ -124,7 +125,7 @@ wp1 = @time WorkPrecisionSet(
 wp2 = @time WorkPrecisionSet(
     ensemble_prob, abstols, reltols, setups, test_dt;
     maxiters = 1.0e7,
-    verbose = false, save_everystep = false, save_start = false,
+    verbose = None(), save_everystep = false, save_start = false,
     appxsol_setup = appxsol_setup, expected_value = exp(-3.0),
     trajectories = numtraj, error_estimate = :weak_final
 )


### PR DESCRIPTION
> **Draft:** please ignore until reviewed by @ChrisRackauckas.

## Summary

`lib/DiffEqDevTools/test/analyticless_stochastic_wp.jl` was failing across all four julia versions in the `DiffEqDevTools` CI job after the v7 verbose-parameter migration. Two `WorkPrecisionSet` calls passed `verbose = false`, which is forwarded to `solve` and now throws:

```
ArgumentError: Passing a `Bool` for `verbose` is no longer supported in
OrdinaryDiffEq v7. Use `DEVerbosity()` or a preset like `Standard()`,
`None()`, etc. from SciMLLogging.
```

Switch both call sites to `verbose = None()` (imported via `using SciMLLogging: None`) to preserve the original "be quiet during this benchmark" intent under the new API. `SciMLLogging` is added to `lib/DiffEqDevTools/Project.toml`'s `[extras]` + `[targets].test` (with `[compat] = "1.9"` floor matching what DiffEqBase already pins).

## Test plan

- [x] Locally instantiated a sandbox env developing `DiffEqBase`, `DiffEqDevTools`, `StochasticDiffEq` from this branch and adding `SDEProblemLibrary`/`SciMLLogging`.
- [x] Ran `julia --project=. test/analyticless_stochastic_wp.jl` end-to-end: 28m wall, exit code 0, no `Test Failed` output, both `@test all(...)` and `@test isapprox(...)` assertions pass.
- [x] Runic format check is clean for the changed test file.
- [ ] CI green on the `DiffEqDevTools` matrix (1 / 1.11 / lts / pre).

## Context

After PR #3600 fixed the `analyticless_convergence_tests.jl` weak-final order regression, the `Analyticless Convergence Tests` testset stopped erroring and execution moved on to the next file in the include list — `analyticless_stochastic_wp.jl` — which surfaced this pre-existing v7 verbose-API breakage. This PR is the natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)