### PR TITLE
Strip ForwardDiff.Duals before Int8 in VCC simultaneous_events

### DIFF
--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.2.0"
+version = "7.2.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/DiffEqBase/src/callbacks.jl
+++ b/lib/DiffEqBase/src/callbacks.jl
@@ -263,7 +263,11 @@ end
                 if min_event_idx < 0
                     min_event_idx = i
                 end
-                simultaneous_events[i] = Int8(-sign(ArrayInterface.allowed_getindex(bottom_sign, i)))
+                # `bottom_sign` may carry ForwardDiff.Duals when AD is
+                # tracing through the callback path. The `Int8` slot is for
+                # bookkeeping only — the derivative information is irrelevant
+                # — so strip the Dual via `value` before converting.
+                simultaneous_events[i] = Int8(-sign(value(ArrayInterface.allowed_getindex(bottom_sign, i))))
             end
         end
         residual = zero(eltype(bottom_condition))
@@ -297,7 +301,7 @@ end
                     min_event_idx = idx
                     callback_t = cbi_t
                     residual = zero_func(cbi_t)
-                    simultaneous_events[idx] = Int8(-sign(ArrayInterface.allowed_getindex(bottom_sign, idx)))
+                    simultaneous_events[idx] = Int8(-sign(value(ArrayInterface.allowed_getindex(bottom_sign, idx))))
                 end
             end
         end

--- a/lib/DiffEqBase/src/callbacks.jl
+++ b/lib/DiffEqBase/src/callbacks.jl
@@ -263,10 +263,6 @@ end
                 if min_event_idx < 0
                     min_event_idx = i
                 end
-                # `bottom_sign` may carry ForwardDiff.Duals when AD is
-                # tracing through the callback path. The `Int8` slot is for
-                # bookkeeping only — the derivative information is irrelevant
-                # — so strip the Dual via `value` before converting.
                 simultaneous_events[i] = Int8(-sign(value(ArrayInterface.allowed_getindex(bottom_sign, i))))
             end
         end


### PR DESCRIPTION
## Summary

Fixes `MethodError: no method matching Int8(::ForwardDiff.Dual{...})` when
AD (Zygote/ForwardDiff/etc.) traces through a problem containing a
`VectorContinuousCallback`.

In `find_callback_time` we encode each component's crossing direction
into `simultaneous_events::Vector{Int8}`:

```julia
simultaneous_events[i] = Int8(-sign(allowed_getindex(bottom_sign, i)))
```

When AD is active, `bottom_sign` may carry `ForwardDiff.Dual` values
(the condition function was differentiated). `Int8(::Dual)` has no
method, so we crash. The Dual's derivative is irrelevant here —
`simultaneous_events` is bookkeeping used only by the user's `affect!`
to know which components fired and in which direction. Strip the Dual
via `SciMLBase.value` (already imported into `DiffEqBase`) before the
`sign`/`Int8` chain.

Bumps DiffEqBase to v7.2.1.

## Test plan

- [ ] Hit the affected path locally — run the SciML/SciMLSensitivity.jl#1432
      Callbacks2 group (`vector_continuous_callbacks.jl`) with
      ForwardDiff/Zygote AD and confirm it no longer crashes at
      `callbacks.jl:266` / `callbacks.jl:300`.
- [ ] OrdinaryDiffEq's own callback / event tests stay green.

This PR is a draft — please ignore until reviewed by @ChrisRackauckas.