### PR TITLE
Fix DDE preset callbacks at propagated tstops

### DIFF
--- a/lib/DelayDiffEq/src/integrators/interface.jl
+++ b/lib/DelayDiffEq/src/integrators/interface.jl
@@ -584,6 +584,18 @@ function DiffEqBase.get_tstops_max(integrator::DDEIntegrator)
     return isempty(tstops_array) ? integrator.sol.prob.tspan[end] : maximum(tstops_array)
 end
 
+OrdinaryDiffEqCore._get_next_step_tstop(integrator::DDEIntegrator) = integrator.next_step_tstop
+function OrdinaryDiffEqCore._set_tstop_flag!(
+        integrator::DDEIntegrator, is_tstop::Bool, target = nothing
+    )
+    integrator.next_step_tstop = is_tstop
+    if is_tstop && target !== nothing
+        integrator.tstop_target = target
+    end
+    return nothing
+end
+OrdinaryDiffEqCore._get_tstop_target(integrator::DDEIntegrator) = integrator.tstop_target
+
 # update integrator when u is modified by callbacks
 function OrdinaryDiffEqCore.handle_callback_modifiers!(integrator::DDEIntegrator)
     integrator.reeval_fsal = true # recalculate fsalfirst after applying step

--- a/lib/DelayDiffEq/src/integrators/type.jl
+++ b/lib/DelayDiffEq/src/integrators/type.jl
@@ -85,6 +85,8 @@ mutable struct DDEIntegrator{
     force_stepfail::Bool
     last_stepfail::Bool
     just_hit_tstop::Bool
+    next_step_tstop::Bool
+    tstop_target::tType
     do_error_check::Bool
     event_last_time::Int
     vector_event_last_time::Int

--- a/lib/DelayDiffEq/src/integrators/utils.jl
+++ b/lib/DelayDiffEq/src/integrators/utils.jl
@@ -286,7 +286,10 @@ function add_next_discontinuities!(integrator, order, t = integrator.t)
         for lag in constant_lags
             if integrator.tdir * lag < maxlag
                 # calculate discontinuity and add it to heap of discontinuities and time stops
-                d = Discontinuity(integrator.tdir * (t + lag), next_order)
+                tstop = snap_to_user_tstop(
+                    integrator.tdir * (t + lag), integrator.opts.tstops
+                )
+                d = Discontinuity(tstop, next_order)
                 push!(integrator.d_discontinuities_propagated, d)
                 push!(integrator.tstops_propagated, d.t)
             end
@@ -351,4 +354,25 @@ function _pop!(x, y)
             pop!(y)
         end
     end
+end
+
+function snap_to_user_tstop(t, tstops)
+    isempty(tstops) && return t
+
+    for tstop in tstops.valtree
+        if is_close_tstop(t, tstop)
+            return tstop
+        end
+    end
+
+    return t
+end
+
+function is_close_tstop(t, tstop)
+    if t isa AbstractFloat && tstop isa AbstractFloat && isfinite(t) && isfinite(tstop)
+        scale = max(abs(t), abs(tstop))
+        return abs(t - tstop) <= 100 * eps(scale)
+    end
+
+    return t == tstop
 end

--- a/lib/DelayDiffEq/src/solve.jl
+++ b/lib/DelayDiffEq/src/solve.jl
@@ -486,6 +486,8 @@ function SciMLBase.__init(
     u_modified = false
     EEst = QT(1)
     just_hit_tstop = false
+    next_step_tstop = false
+    tstop_target = zero(t0)
     do_error_check = true
     isout = false
     accept_step = false
@@ -555,6 +557,8 @@ function SciMLBase.__init(
         force_stepfail,
         last_stepfail,
         just_hit_tstop,
+        next_step_tstop,
+        tstop_target,
         do_error_check,
         event_last_time,
         vector_event_last_time,

--- a/lib/DelayDiffEq/test/integrators/events.jl
+++ b/lib/DelayDiffEq/test/integrators/events.jl
@@ -1,5 +1,6 @@
 using DelayDiffEq, DDEProblemLibrary, DiffEqDevTools, DiffEqCallbacks
 using OrdinaryDiffEqTsit5
+using Statistics
 using Test
 
 const prob = prob_dde_constant_1delay_scalar
@@ -53,6 +54,50 @@ end
     cb = DiscreteCallback((u, t, integrator) -> t == 4, terminate!)
     sol = @test_logs solve(prob, alg; callback = cb, tstops = [4.0])
     @test sol.t[end] == 4
+end
+
+@testset "preset callback at constant-lag propagated tstop" begin
+    function lif2_Ndelay!(du, u, h, p, t)
+        u1, u2 = u
+        gL1, EL1, C1, _, I1, gL2, EL2, C2, _, I2, λ, T... = p
+
+        H = Float64[h(p, t - τ)[2] for τ in T]
+        append!(H, u2)
+
+        du[1] = (-gL1 * (u1 - EL1) + I1 - λ * (u1 - mean(H))) / C1
+        du[2] = (-gL2 * (u2 - EL2) + I2) / C2
+    end
+
+    fired = Float64[]
+    up_Iex2!(integrator) = (push!(fired, integrator.t); integrator.p[10] = 210.0)
+    down_Iex2!(integrator) = integrator.p[10] = 0.0
+
+    cb = CallbackSet(
+        ContinuousCallback(
+            (u, t, integrator) -> u[1] - integrator.p[4],
+            integrator -> (integrator.u[1] = integrator.p[2])
+        ),
+        ContinuousCallback(
+            (u, t, integrator) -> u[2] - integrator.p[9],
+            integrator -> (integrator.u[2] = integrator.p[7])
+        ),
+        PresetTimeCallback([2.0, 9.0], up_Iex2!),
+        PresetTimeCallback([3.0, 10.0], down_Iex2!)
+    )
+
+    u0 = [-75.0, -75.0]
+    tspan = (0.0, 12.0)
+    p1 = [10.0, -75.0, 5.0, -55.0, 100.0]
+    p2 = [10.0, -75.0, 5.0, -55.0, 0.0]
+    delays = [0.2, 4.0]
+    p = [p1; p2; [2.0]; delays]
+    h(p, t) = u0
+
+    prob = DDEProblem(lif2_Ndelay!, u0, h, tspan, p; callback = cb, constant_lags = delays)
+    sol = solve(prob, MethodOfSteps(Tsit5()))
+
+    @test sol.retcode == ReturnCode.Success
+    @test any(==(9.0), fired)
 end
 
 @testset "save discontinuity" begin


### PR DESCRIPTION
## Summary

- Fixes DDE `PresetTimeCallback` hits when a constant-lag propagated discontinuity lands at the same time up to floating-point roundoff.
- Adds DDE tstop snap state mirroring the ODE integrator path so accepted tstop steps can use the exact target time.
- Adds a regression test for `SciML/DifferentialEquations.jl#1124`, where `constant_lags = [0.2, 4.0]` caused the preset callback at `t = 9.0` to be skipped.

## Explanation

For DDEs with constant lags, propagated discontinuity tstops can accumulate small floating-point drift. In the reported case, the propagated discontinuity reached `8.999999999999996`, which sorted before the user callback tstop at `9.0`. The solver therefore stepped to the drifted propagated tstop, and `PresetTimeCallback` did not fire because it checks the preset time list exactly.

This change snaps newly propagated constant-lag discontinuity tstops to an existing user tstop when they differ only by roundoff. It also gives `DDEIntegrator` the same tstop target bookkeeping used by ODE integrators, so tstop-driven accepted steps can report the exact target time to callback handling.

Fixes SciML/DifferentialEquations.jl#1124.

## Tests

- `julia -e 'using Pkg; Pkg.activate(; temp=true); Pkg.develop(path="/private/tmp/ode-v6-backport/lib/DelayDiffEq"); Pkg.add(["DDEProblemLibrary", "DiffEqCallbacks", "DiffEqDevTools", "OrdinaryDiffEqTsit5"]); include("/private/tmp/ode-v6-backport/lib/DelayDiffEq/test/integrators/events.jl")'`
  - `continuous`: 8/8 passed
  - `discrete`: 4/4 passed
  - `preset callback at constant-lag propagated tstop`: 2/2 passed
  - `save discontinuity`: 3/3 passed
  - `periodic callback`: 2/2 passed
- `julia --project=@runic -e 'using Runic; exit(Runic.main(["--check", "lib/DelayDiffEq/src/integrators/interface.jl", "lib/DelayDiffEq/src/integrators/type.jl", "lib/DelayDiffEq/src/integrators/utils.jl", "lib/DelayDiffEq/src/solve.jl", "lib/DelayDiffEq/test/integrators/events.jl"]))'`
- `git diff --check`
