### PR TITLE
DDE: don't pop user tstops in discontinuity-merge cleanup (fixes DiffEq.jl#1124)

### DIFF
--- a/lib/DelayDiffEq/src/integrators/utils.jl
+++ b/lib/DelayDiffEq/src/integrators/utils.jl
@@ -220,10 +220,13 @@ function OrdinaryDiffEqCore.handle_discontinuities!(integrator::DDEIntegrator)
             order = min(order, d2.order)
         end
 
-        # also remove all corresponding time stops
-        while OrdinaryDiffEqCore.has_tstop(integrator) &&
-                abs(OrdinaryDiffEqCore.first_tstop(integrator) - tdir_t) < maxΔt
-            OrdinaryDiffEqCore.pop_tstop!(integrator)
+        # also remove all corresponding propagated time stops, but never user
+        # tstops: a user-supplied tstop (e.g. from PresetTimeCallback) at exactly
+        # this time must still fire even if a propagated discontinuity drifted
+        # to within `maxΔt` of it (issue #1124).
+        while !isempty(integrator.tstops_propagated) &&
+                abs(first(integrator.tstops_propagated) - tdir_t) < maxΔt
+            pop!(integrator.tstops_propagated)
         end
     end
 

--- a/lib/DelayDiffEq/test/integrators/events.jl
+++ b/lib/DelayDiffEq/test/integrators/events.jl
@@ -1,5 +1,6 @@
 using DelayDiffEq, DDEProblemLibrary, DiffEqDevTools, DiffEqCallbacks
 using OrdinaryDiffEqTsit5
+using OrdinaryDiffEqVerner
 using Test
 
 const prob = prob_dde_constant_1delay_scalar
@@ -92,4 +93,29 @@ end
     @test sol.retcode == ReturnCode.Success
     # Should be triggered approximately 10 times (at t=1,2,3,...,10)
     @test counter[] >= 9
+end
+
+# Issue SciML/DifferentialEquations.jl#1124: PresetTimeCallback was skipped when
+# a propagated-discontinuity tstop drifted (by float roundoff from compounded
+# constant lags) to within 10*eps of the user tstop. The discontinuity-handling
+# cleanup eagerly popped *any* nearby tstop, swallowing the user's preset tstop
+# along with the propagated one. Vern9 is used because the order-7 path
+# `5*0.2 + 2*4 = 9.0` is below Vern9's order-tracking limit but above Tsit5's,
+# so propagation reaches the collision time on this trivial problem.
+@testset "preset time callback near propagated discontinuity (#1124)" begin
+    f(du, u, h, p, t) = (du .= 0)
+    h(p, t) = [0.0]
+
+    fired = Ref(0)
+    preset = PresetTimeCallback([9.0], integ -> (fired[] += 1))
+
+    prob = DDEProblem(
+        f, [0.0], h, (0.0, 12.0);
+        constant_lags = [0.2, 4.0], callback = preset
+    )
+
+    sol = solve(prob, MethodOfSteps(Vern9()))
+    @test sol.retcode == ReturnCode.Success
+    @test fired[] == 1
+    @test 9.0 in sol.t
 end


### PR DESCRIPTION
## Summary

Fixes [SciML/DifferentialEquations.jl#1124](https://github.com/SciML/DifferentialEquations.jl/issues/1124). `PresetTimeCallback` (and any user-supplied `tstops`) was silently swallowed in DDEs whenever a propagated-discontinuity tstop drifted to within `10 * eps(t)` of the user tstop.

This is the "fix the callback" approach — restrict the discontinuity-merge cleanup to internal tstops only — that was discussed on #3603 (the alternative "snap propagated tstops to user tstops" approach was rejected as having too many caveats).

## Root cause

In `handle_discontinuities!` (`lib/DelayDiffEq/src/integrators/utils.jl`), after a propagated discontinuity is processed the routine clears nearby tstops:

```julia
while OrdinaryDiffEqCore.has_tstop(integrator) &&
        abs(OrdinaryDiffEqCore.first_tstop(integrator) - tdir_t) < maxΔt
    OrdinaryDiffEqCore.pop_tstop!(integrator)
end
```

`has_tstop` / `pop_tstop!` walk the merged view of `integrator.opts.tstops` (user) and `integrator.tstops_propagated` (internal). The intent of the loop is only to consume the internal tstop paired with the discontinuity being processed; but it eagerly pops user tstops too whenever they fall in the window.

The window collapses onto user tstops because of float roundoff in propagation. With `constant_lags = [0.2, 4.0]`, the propagation tree contains paths to `t = 9.0` such as `5*0.2 + 2*4`, evaluated iteratively as `t + lag`. Iterative addition produces tstops at `9.0`, `8.999999999999998` (-1 ulp), and `8.999999999999996` (-2 ulps) — all within `10 * eps(9.0) ≈ 1.78e-14`, so the loop chains through them and eats the user tstop too.

This is why `[0.2, 4]` triggers the bug at `t = 9` while `[0.1, 4]` and `[0.3, 4]` do not — those lag combinations don't produce propagated tstops adjacent to the user tstops `[2, 9]`.

## Fix

Restrict the cleanup loop to `tstops_propagated`. User tstops (from `PresetTimeCallback`, explicit `tstops=`, etc.) are never popped by the discontinuity-merge logic. The user tstop survives the merge and `PresetTimeCallback` fires.

## Reproducer

```julia
using DelayDiffEq, DiffEqCallbacks

f(du, u, h, p, t) = (du .= 0)
h(p, t) = [0.0]

fired = Ref(0)
preset = PresetTimeCallback([9.0], integ -> (fired[] += 1))

prob = DDEProblem(
    f, [0.0], h, (0.0, 12.0);
    constant_lags = [0.2, 4.0], callback = preset
)
solve(prob, MethodOfSteps(Vern9()))

@assert fired[] == 1   # fails on master, passes with this PR
```

(Vern9 is needed in the trivial-DDE reproducer because Tsit5's discontinuity-order limit prevents tracking the order-7 path `5*0.2 + 2*4 = 9.0`. The original issue uses Tsit5 but reaches the same configuration via in-flight `ContinuousCallback` firings that inject fresh order-0 discontinuities mid-integration.)

A regression test mirroring the reproducer has been added in `lib/DelayDiffEq/test/integrators/events.jl`.

## Test plan

- [x] Bug reproduces on master (PresetTimeCallback at t=9 not called)
- [x] Fix resolves the reproducer
- [x] Existing event tests still pass
- [x] Runic format check passes
- [ ] CI green

> **Please ignore this PR until reviewed by @ChrisRackauckas.**