### PR TITLE
Add Runge-Kutta-Gegenbauer to StabilizedRK

### DIFF
--- a/lib/OrdinaryDiffEqStabilizedRK/src/OrdinaryDiffEqStabilizedRK.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/OrdinaryDiffEqStabilizedRK.jl
@@ -29,6 +29,6 @@ include("rkc_tableaus_rock2.jl")
 include("rkc_tableaus_eserk5.jl")
 include("rkc_tableaus_eserk4.jl")
 
-export ROCK2, ROCK4, RKC, ESERK4, ESERK5, SERK2, TSRKC3, RKL1, RKL2
+export ROCK2, ROCK4, RKC, ESERK4, ESERK5, SERK2, TSRKC3, RKL1, RKL2, RKG1, RKG2
 
 end

--- a/lib/OrdinaryDiffEqStabilizedRK/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/alg_utils.jl
@@ -14,10 +14,13 @@ alg_extrapolates(alg::TSRKC3) = true
 default_controller(QT, alg::SERK2) = PredictiveController(QT, alg)
 default_controller(QT, alg::Union{RKC, TSRKC3}) = PredictiveController(QT, alg)
 default_controller(QT, alg::Union{RKL1, RKL2}) = PredictiveController(QT, alg)
+default_controller(QT, alg::Union{RKG1, RKG2}) = PredictiveController(QT, alg)
 
 alg_adaptive_order(alg::RKL1) = 1
 alg_adaptive_order(alg::RKL2) = 2
 alg_adaptive_order(alg::Union{RKC, TSRKC3}) = 2
+alg_adaptive_order(alg::RKG1) = 1
+alg_adaptive_order(alg::RKG2) = 2
 
 gamma_default(alg::Union{RKC, TSRKC3}) = 8 // 10
 gamma_default(alg::Union{RKL1, RKL2}) = 8 // 10
@@ -91,4 +94,22 @@ end
 function dtnew_modification(integrator, alg::RKL2, dtnew)
     _, s = _rkl_clamp_odd_stages(alg.min_stages, alg.max_stages)
     return min(dtnew, typeof(dtnew)((s^2 + s - 2) / (2 * integrator.eigen_est)))
+end
+
+alg_order(alg::RKG1) = 1
+alg_order(alg::RKG2) = 2
+
+gamma_default(alg::Union{RKG1, RKG2}) = 8 // 10
+fac_default_gamma(alg::Union{RKG1, RKG2}) = true
+
+has_dtnew_modification(alg::Union{RKG1, RKG2}) = true
+
+function dtnew_modification(integrator, alg::RKG1, dtnew)
+    s = alg.max_stages
+    return min(dtnew, typeof(dtnew)(s * (s + 3) / (2 * integrator.eigen_est)))
+end
+
+function dtnew_modification(integrator, alg::RKG2, dtnew)
+    s = alg.max_stages
+    return min(dtnew, typeof(dtnew)((s + 4) * (s - 1) / (3 * integrator.eigen_est)))
 end

--- a/lib/OrdinaryDiffEqStabilizedRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/algorithms.jl
@@ -254,3 +254,74 @@ function RKL2(; min_stages = 3, max_stages = 200, eigen_est = nothing)
     max_s = max(max_s, min_s)
     return RKL2(min_s, max_s, eigen_est)
 end
+
+@doc generic_solver_docstring(
+    """First-order super-time-stepping method based on shifted Gegenbauer polynomials
+    with parameter α=3/2. Maintains the Convex Monotone Property even in the presence
+    of Dirichlet boundary conditions, unlike RKL1. The stage count s is chosen
+    adaptively so that the superstep scales as s² times the explicit timestep.""",
+    "RKG1",
+    "Stabilized Explicit Method.",
+    """T. Skaras, T. Saxton, C. Meyer, T. D. Aslam. Super-time-stepping schemes for
+    parabolic equations with boundary conditions.
+    Journal of Computational Physics, 425, pp 109879, 2021.
+    doi: https://doi.org/10.1016/j.jcp.2020.109879""",
+    """
+    - `min_stages`: Minimum number of stages s (>= 2).
+    - `max_stages`: Maximum number of stages s.
+    - `eigen_est`: Optional function `(integrator) -> integrator.eigen_est = upper_bound`
+        providing an upper bound on the spectral radius. If not provided, estimated
+        by power iteration.
+    """,
+    """
+    min_stages = 2,
+    max_stages = 200,
+    eigen_est = nothing,
+    """
+)
+struct RKG1{E} <: OrdinaryDiffEqAdaptiveAlgorithm
+    min_stages::Int
+    max_stages::Int
+    eigen_est::E
+end
+function RKG1(; min_stages = 2, max_stages = 200, eigen_est = nothing)
+    # RKG does not require odd s — no odd enforcement needed
+    min_s = max(2, min_stages)
+    max_s = max(max_stages, min_s)
+    return RKG1(min_s, max_s, eigen_est)
+end
+
+@doc generic_solver_docstring(
+    """Second-order super-time-stepping method based on shifted Gegenbauer polynomials
+    with parameter α=3/2. Maintains the Convex Monotone Property even in the presence
+    of Dirichlet boundary conditions, unlike RKL2. The stage count s is chosen
+    adaptively so that the superstep scales as s² times the explicit timestep.""",
+    "RKG2",
+    "Stabilized Explicit Method.",
+    """T. Skaras, T. Saxton, C. Meyer, T. D. Aslam. Super-time-stepping schemes for
+    parabolic equations with boundary conditions.
+    Journal of Computational Physics, 425, pp 109879, 2021.
+    doi: https://doi.org/10.1016/j.jcp.2020.109879""",
+    """
+    - `min_stages`: Minimum number of stages s (>= 3).
+    - `max_stages`: Maximum number of stages s.
+    - `eigen_est`: Optional function `(integrator) -> integrator.eigen_est = upper_bound`
+        providing an upper bound on the spectral radius. If not provided, estimated
+        by power iteration.
+    """,
+    """
+    min_stages = 3,
+    max_stages = 200,
+    eigen_est = nothing,
+    """
+)
+struct RKG2{E} <: OrdinaryDiffEqAdaptiveAlgorithm
+    min_stages::Int
+    max_stages::Int
+    eigen_est::E
+end
+function RKG2(; min_stages = 3, max_stages = 200, eigen_est = nothing)
+    min_s = max(3, min_stages)
+    max_s = max(max_stages, min_s)
+    return RKG2(min_s, max_s, eigen_est)
+end

--- a/lib/OrdinaryDiffEqStabilizedRK/src/rkc_caches.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/rkc_caches.jl
@@ -464,3 +464,99 @@ function alg_cache(
     min_stage, max_stage = _rkl_clamp_odd_stages(alg.min_stages, alg.max_stages)
     return RKL2ConstantCache(u, min_stage, max_stage)
 end
+
+mutable struct RKG1ConstantCache{zType} <: OrdinaryDiffEqConstantCache
+    zprev::zType
+    mdeg::Int
+    min_stage::Int
+    max_stage::Int
+end
+
+function RKG1ConstantCache(u, min_stage, max_stage)
+    return RKG1ConstantCache(zero(u), 2, min_stage, max_stage)
+end
+
+@cache struct RKG1Cache{uType, rateType, uNoUnitsType, C <: RKG1ConstantCache} <:
+    StabilizedRKMutableCache
+    u::uType
+    uprev::uType
+    uᵢ₋₁::uType
+    uᵢ₋₂::uType
+    tmp::uType
+    atmp::uNoUnitsType
+    fsalfirst::rateType
+    k::rateType
+    constantcache::C
+end
+
+function alg_cache(
+        alg::RKG1, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck, ::Val{true}, verbose
+    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    min_stage = max(2, alg.min_stages)
+    max_stage = max(alg.max_stages, min_stage)
+    constantcache = RKG1ConstantCache(u, min_stage, max_stage)
+    uᵢ₋₁ = zero(u); uᵢ₋₂ = zero(u); tmp = zero(u)
+    atmp = similar(u, uEltypeNoUnits); recursivefill!(atmp, false)
+    fsalfirst = zero(rate_prototype); k = zero(rate_prototype)
+    return RKG1Cache(u, uprev, uᵢ₋₁, uᵢ₋₂, tmp, atmp, fsalfirst, k, constantcache)
+end
+
+function alg_cache(
+        alg::RKG1, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck, ::Val{false}, verbose
+    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    min_stage = max(2, alg.min_stages)
+    max_stage = max(alg.max_stages, min_stage)
+    return RKG1ConstantCache(u, min_stage, max_stage)
+end
+
+mutable struct RKG2ConstantCache{zType} <: OrdinaryDiffEqConstantCache
+    zprev::zType
+    mdeg::Int
+    min_stage::Int
+    max_stage::Int
+end
+
+function RKG2ConstantCache(u, min_stage, max_stage)
+    return RKG2ConstantCache(zero(u), 3, min_stage, max_stage)
+end
+
+@cache struct RKG2Cache{uType, rateType, uNoUnitsType, C <: RKG2ConstantCache} <:
+    StabilizedRKMutableCache
+    u::uType
+    uprev::uType
+    uᵢ₋₁::uType
+    uᵢ₋₂::uType
+    tmp::uType
+    atmp::uNoUnitsType
+    fsalfirst::rateType
+    k::rateType
+    constantcache::C
+end
+
+function alg_cache(
+        alg::RKG2, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck, ::Val{true}, verbose
+    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    min_stage = max(3, alg.min_stages)
+    max_stage = max(alg.max_stages, min_stage)
+    constantcache = RKG2ConstantCache(u, min_stage, max_stage)
+    uᵢ₋₁ = zero(u); uᵢ₋₂ = zero(u); tmp = zero(u)
+    atmp = similar(u, uEltypeNoUnits); recursivefill!(atmp, false)
+    fsalfirst = zero(rate_prototype); k = zero(rate_prototype)
+    return RKG2Cache(u, uprev, uᵢ₋₁, uᵢ₋₂, tmp, atmp, fsalfirst, k, constantcache)
+end
+
+function alg_cache(
+        alg::RKG2, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck, ::Val{false}, verbose
+    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    min_stage = max(3, alg.min_stages)
+    max_stage = max(alg.max_stages, min_stage)
+    return RKG2ConstantCache(u, min_stage, max_stage)
+end

--- a/lib/OrdinaryDiffEqStabilizedRK/src/rkc_perform_step.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/rkc_perform_step.jl
@@ -1587,3 +1587,282 @@ end
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     integrator.k[2] = integrator.fsallast
 end
+
+function initialize!(integrator, cache::RKG1ConstantCache)
+    integrator.kshortsize = 2
+    integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
+    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.fsallast = zero(integrator.fsalfirst)
+    integrator.k[1] = integrator.fsalfirst
+    return integrator.k[2] = integrator.fsallast
+end
+
+function initialize!(integrator, cache::RKG1Cache)
+    integrator.kshortsize = 2
+    resize!(integrator.k, integrator.kshortsize)
+    integrator.k[1] = integrator.fsalfirst
+    integrator.k[2] = integrator.fsallast
+    integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t)
+    return OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+end
+
+@muladd function perform_step!(integrator, cache::RKG1ConstantCache, repeat_step = false)
+    (; t, dt, uprev, u, f, p, fsalfirst) = integrator
+    alg = unwrap_alg(integrator, true)
+    alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
+
+    # stability bound for RKG1 is dt*λ ≤ s(s+3)/4
+    # solving s² + 3s - 4*dt*λ ≥ 0 → s ≥ (-3 + sqrt(9 + 16*dt*λ))/2
+    s = ceil(Int, 0.5 * (-3.0 + sqrt(9.0 + 16.0 * abs(dt) * integrator.eigen_est)))
+    s = max(s, cache.min_stage)
+    s = min(s, cache.max_stage)
+    cache.mdeg = s
+    w1 = 4.0 / (s * (s + 3))
+    rkg1_b(j) = 2.0 / ((j + 1) * (j + 2))
+
+    # first stage coefficients
+    b0 = rkg1_b(0)
+    b1 = rkg1_b(1)
+    μ̃₁ = (3.0 * b1 / b0) * w1
+    uᵢ₋₂ = uprev
+    uᵢ₋₁ = uprev + (dt * μ̃₁) * fsalfirst
+
+    # stages 2 to s
+    for j in 2:s
+        bj = rkg1_b(j)
+        bjm1 = rkg1_b(j - 1)
+        bjm2 = rkg1_b(j - 2)
+
+        # μⱼ = (2j+1)/j * bⱼ/bⱼ₋₁
+        # νⱼ = -(j+1)/j * bⱼ/bⱼ₋₂
+        μⱼ = (2j + 1) / j * bj / bjm1
+        νⱼ = -(j + 1) / j * bj / bjm2
+        μ̃ⱼ = μⱼ * w1
+
+        fYm1 = f(uᵢ₋₁, p, t)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+        u = μⱼ * uᵢ₋₁ + νⱼ * uᵢ₋₂ + μ̃ⱼ * dt * fYm1
+        uᵢ₋₂ = uᵢ₋₁
+        uᵢ₋₁ = u
+    end
+
+    if integrator.opts.adaptive
+        tmp = u - (uprev + dt * fsalfirst)
+        atmp = calculate_residuals(
+            tmp, uprev, u,
+            integrator.opts.abstol, integrator.opts.reltol,
+            integrator.opts.internalnorm, t
+        )
+        OrdinaryDiffEqCore.set_EEst!(
+            integrator,
+            integrator.opts.internalnorm(atmp, t) / s
+        )
+    end
+
+    integrator.k[1] = integrator.fsalfirst
+    integrator.k[2] = integrator.fsallast = f(u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.u = u
+end
+
+@muladd function perform_step!(integrator, cache::RKG1Cache, repeat_step = false)
+    (; t, dt, uprev, u, f, p, fsalfirst) = integrator
+    (; uᵢ₋₁, uᵢ₋₂, tmp, k, atmp) = cache
+    ccache = cache.constantcache
+    alg = unwrap_alg(integrator, true)
+    alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
+
+    # choose s from the eigenvalue estimate from the RKG1 stability bound
+    s = ceil(Int, 0.5 * (-3.0 + sqrt(9.0 + 16.0 * abs(dt) * integrator.eigen_est)))
+    s = max(s, ccache.min_stage)
+    s = min(s, ccache.max_stage)
+    ccache.mdeg = s
+
+    w1 = 4.0 / (s * (s + 3))
+    rkg1_b(j) = 2.0 / ((j + 1) * (j + 2))
+
+    # first stage coefficients
+    b0 = rkg1_b(0); b1 = rkg1_b(1)
+    μ̃₁ = (3.0 * b1 / b0) * w1
+
+    @.. broadcast = false uᵢ₋₂ = uprev
+    @.. broadcast = false uᵢ₋₁ = uprev + (dt * μ̃₁) * fsalfirst
+
+    # stages 2 to s
+    for j in 2:s
+        bj = rkg1_b(j)
+        bjm1 = rkg1_b(j - 1)
+        bjm2 = rkg1_b(j - 2)
+        μⱼ = (2j + 1) / j * bj / bjm1
+        νⱼ = -(j + 1) / j * bj / bjm2
+        μ̃ⱼ = μⱼ * w1
+
+        f(k, uᵢ₋₁, p, t)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+        @.. broadcast = false u = μⱼ * uᵢ₋₁ + νⱼ * uᵢ₋₂ + (dt * μ̃ⱼ) * k
+        @.. broadcast = false uᵢ₋₂ = uᵢ₋₁
+        @.. broadcast = false uᵢ₋₁ = u
+    end
+
+    if integrator.opts.adaptive
+        @.. broadcast = false tmp = u - (uprev + dt * fsalfirst)
+        calculate_residuals!(
+            atmp, tmp, uprev, u,
+            integrator.opts.abstol, integrator.opts.reltol,
+            integrator.opts.internalnorm, t
+        )
+        OrdinaryDiffEqCore.set_EEst!(
+            integrator,
+            integrator.opts.internalnorm(atmp, t) / s
+        )
+    end
+
+    integrator.k[1] = integrator.fsalfirst
+    f(integrator.fsallast, u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.k[2] = integrator.fsallast
+end
+
+function initialize!(integrator, cache::RKG2ConstantCache)
+    integrator.kshortsize = 2
+    integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
+    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.fsallast = zero(integrator.fsalfirst)
+    integrator.k[1] = integrator.fsalfirst
+    return integrator.k[2] = integrator.fsallast
+end
+
+function initialize!(integrator, cache::RKG2Cache)
+    integrator.kshortsize = 2
+    resize!(integrator.k, integrator.kshortsize)
+    integrator.k[1] = integrator.fsalfirst
+    integrator.k[2] = integrator.fsallast
+    integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t)
+    return OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+end
+
+@muladd function perform_step!(integrator, cache::RKG2ConstantCache, repeat_step = false)
+    (; t, dt, uprev, u, f, p, fsalfirst) = integrator
+    alg = unwrap_alg(integrator, true)
+    alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
+
+    # stability bound for RKG2 is dt*λ ≤ (s+4)(s-1)/6
+    # Solve: s² + 3s - (4 + 6*dt*λ) ≥ 0 → s ≥ (-3 + sqrt(25 + 24*dt*λ))/2
+    s = ceil(Int, 0.5 * (-3.0 + sqrt(25.0 + 24.0 * abs(dt) * integrator.eigen_est)))
+    s = max(s, cache.min_stage)
+    s = min(s, cache.max_stage)
+    cache.mdeg = s
+    w1 = 6.0 / ((s + 4) * (s - 1))
+
+    # first stage coefficients
+    μ̃₁ = w1
+    uᵢ₋₂ = uprev
+    uᵢ₋₁ = uprev + (dt * μ̃₁) * fsalfirst
+
+    # stages 2 to s: b_0=1, b_1=1/3, b_j=4(j-1)(j+4)/(3j(j+1)(j+2)(j+3)) for j>=2
+    # a_{j-1} = 1 - j(j+1)/2 * b_{j-1}
+    for j in 2:s
+        bj = 4.0 * (j - 1) * (j + 4) / (3.0 * j * (j + 1) * (j + 2) * (j + 3))
+        bjm1 = j == 2 ? (1.0 / 3.0) :
+            4.0 * (j - 2) * (j + 3) / (3.0 * (j - 1) * j * (j + 1) * (j + 2))
+        bjm2 = j == 2 ? 1.0 :
+            j == 3 ? (1.0 / 3.0) :
+            4.0 * (j - 3) * (j + 2) / (3.0 * (j - 2) * (j - 1) * j * (j + 1))
+        ajm1 = 1.0 - j * (j + 1) / 2.0 * bjm1
+
+        μⱼ = (2j + 1) / j * bj / bjm1
+        νⱼ = -(j + 1) / j * bj / bjm2
+        μ̃ⱼ = μⱼ * w1
+        γ̃ⱼ = -μ̃ⱼ * ajm1
+
+        fYm1 = f(uᵢ₋₁, p, t)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+
+        u = μⱼ * uᵢ₋₁ + νⱼ * uᵢ₋₂ + (1.0 - μⱼ - νⱼ) * uprev +
+            dt * μ̃ⱼ * fYm1 + dt * γ̃ⱼ * fsalfirst
+
+        uᵢ₋₂ = uᵢ₋₁
+        uᵢ₋₁ = u
+    end
+
+    if integrator.opts.adaptive
+        tmp = u - (uprev + dt * fsalfirst)
+        atmp = calculate_residuals(
+            tmp, uprev, u,
+            integrator.opts.abstol, integrator.opts.reltol,
+            integrator.opts.internalnorm, t
+        )
+        OrdinaryDiffEqCore.set_EEst!(
+            integrator,
+            integrator.opts.internalnorm(atmp, t) / s
+        )
+    end
+
+    integrator.k[1] = integrator.fsalfirst
+    integrator.k[2] = integrator.fsallast = f(u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.u = u
+end
+
+@muladd function perform_step!(integrator, cache::RKG2Cache, repeat_step = false)
+    (; t, dt, uprev, u, f, p, fsalfirst) = integrator
+    (; uᵢ₋₁, uᵢ₋₂, tmp, k, atmp) = cache
+    ccache = cache.constantcache
+    alg = unwrap_alg(integrator, true)
+    alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
+
+    # choose s from the eigenvalue estimate from the RKG2 stability bound
+    s = ceil(Int, 0.5 * (-3.0 + sqrt(25.0 + 24.0 * abs(dt) * integrator.eigen_est)))
+    s = max(s, ccache.min_stage)
+    s = min(s, ccache.max_stage)
+    ccache.mdeg = s
+    w1 = 6.0 / ((s + 4) * (s - 1))
+    μ̃₁ = w1
+
+    @.. broadcast = false uᵢ₋₂ = uprev
+    @.. broadcast = false uᵢ₋₁ = uprev + (dt * μ̃₁) * fsalfirst
+
+    # stages 2 to s
+    for j in 2:s
+        bj = 4.0 * (j - 1) * (j + 4) / (3.0 * j * (j + 1) * (j + 2) * (j + 3))
+        bjm1 = j == 2 ? (1.0 / 3.0) :
+            4.0 * (j - 2) * (j + 3) / (3.0 * (j - 1) * j * (j + 1) * (j + 2))
+        bjm2 = j == 2 ? 1.0 :
+            j == 3 ? (1.0 / 3.0) :
+            4.0 * (j - 3) * (j + 2) / (3.0 * (j - 2) * (j - 1) * j * (j + 1))
+        ajm1 = 1.0 - j * (j + 1) / 2.0 * bjm1
+
+        μⱼ = (2j + 1) / j * bj / bjm1
+        νⱼ = -(j + 1) / j * bj / bjm2
+        μ̃ⱼ = μⱼ * w1
+        γ̃ⱼ = -μ̃ⱼ * ajm1
+
+        f(k, uᵢ₋₁, p, t)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+
+        @.. broadcast = false u = μⱼ * uᵢ₋₁ + νⱼ * uᵢ₋₂ +
+            (1.0 - μⱼ - νⱼ) * uprev +
+            (dt * μ̃ⱼ) * k +
+            (dt * γ̃ⱼ) * fsalfirst
+        @.. broadcast = false uᵢ₋₂ = uᵢ₋₁
+        @.. broadcast = false uᵢ₋₁ = u
+    end
+
+    if integrator.opts.adaptive
+        @.. broadcast = false tmp = u - (uprev + dt * fsalfirst)
+        calculate_residuals!(
+            atmp, tmp, uprev, u, integrator.opts.abstol, integrator.opts.reltol,
+            integrator.opts.internalnorm, t
+        )
+        OrdinaryDiffEqCore.set_EEst!(
+            integrator, integrator.opts.internalnorm(atmp, t) / s
+        )
+    end
+
+    integrator.k[1] = integrator.fsalfirst
+    f(integrator.fsallast, u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.k[2] = integrator.fsallast
+end

--- a/lib/OrdinaryDiffEqStabilizedRK/src/rkc_utils.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/rkc_utils.jl
@@ -1,6 +1,6 @@
 # This function calculates the largest eigenvalue
 # (absolute value wise) by power iteration.
-const RKCAlgs = Union{RKC, TSRKC3, ESERK4, ESERK5, SERK2, ROCK2, ROCK4, RKL1, RKL2}
+const RKCAlgs = Union{RKC, TSRKC3, ESERK4, ESERK5, SERK2, ROCK2, ROCK4, RKL1, RKL2, RKG1, RKG2}
 
 function maxeig!(integrator, cache::OrdinaryDiffEqConstantCache)
     isfirst = integrator.iter == 1 || integrator.derivative_discontinuity

--- a/lib/OrdinaryDiffEqStabilizedRK/test/qa/Project.toml
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/qa/Project.toml
@@ -7,17 +7,15 @@ OrdinaryDiffEqStabilizedRK = "358294b1-0aab-51c3-aafe-ad5ab194a2ad"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources.OrdinaryDiffEqCore]
-path = "../../../OrdinaryDiffEqCore"
-
-[sources.OrdinaryDiffEqStabilizedRK]
-path = "../../"
+[sources]
+OrdinaryDiffEqCore = {path = "../../../OrdinaryDiffEqCore"}
+OrdinaryDiffEqStabilizedRK = {path = "../.."}
 
 [compat]
 AllocCheck = "0.2"
 Aqua = "0.8.11"
 JET = "0.9, 0.11"
-julia = "1.10"
 OrdinaryDiffEqCore = "4"
 OrdinaryDiffEqStabilizedRK = "2"
 SciMLBase = "3"
+julia = "1.10"

--- a/lib/OrdinaryDiffEqStabilizedRK/test/qa/allocation_tests.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/qa/allocation_tests.jl
@@ -14,7 +14,7 @@ using Test
     prob = ODEProblem{true, FullSpecialize}(simple_system!, [1.0, 1.0], (0.0, 1.0))
 
     # All stabilized RK methods have allocations in perform_step!
-    all_solvers = [ROCK2(), ROCK4(), RKC(), ESERK4(), ESERK5(), SERK2(), RKL1(), RKL2()]
+    all_solvers = [ROCK2(), ROCK4(), RKC(), ESERK4(), ESERK5(), SERK2(), RKL1(), RKL2(), RKG1(), RKG2()]
 
     @testset "StabilizedRK perform_step! Static Analysis" begin
         for solver in all_solvers

--- a/lib/OrdinaryDiffEqStabilizedRK/test/rkc_tests.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/rkc_tests.jl
@@ -49,9 +49,30 @@ probArr[2] = prob_ode_2Dlinear
             @test eigest ≈ eigm rtol = 0.35
         end
     end
+
+    @testset "RKG power iteration" begin
+        Random.seed!(789)
+        eigen_est = (integrator) -> integrator.eigen_est = 1.5e2
+        for iip in [true, false], alg in [
+                    RKG2(), RKG2(eigen_est = eigen_est),
+                    RKG1(), RKG1(eigen_est = eigen_est),
+                ]
+            println(typeof(alg))
+            A = randn(20, 20)
+            A = A - maximum(abs.(eigvals(A))) * I
+            test_f(u, p, t) = A * u
+            test_f(du, u, p, t) = mul!(du, A, u)
+            prob = ODEProblem{iip}(test_f, randn(20), (0.0, 1.0))
+            integrator = init(prob, alg)
+            eigm = maximum(abs.(eigvals(A)))
+            maxeig!(integrator, integrator.cache)
+            eigest = integrator.eigen_est
+            @test eigest ≈ eigm rtol = 0.35
+        end
+    end
 end
 
-@testset "Runge-Kutta-Chebyshev and Runge-Kutta-Legendre Convergence Tests" begin
+@testset "Runge-Kutta-Chebyshev, Runge-Kutta-Legendre, and Runge-Kutta-Gegenbauer Convergence Tests" begin
     dts = 1 .// 2 .^ (8:-1:4)
     testTol = 0.1
     for prob in probArr
@@ -127,6 +148,26 @@ end
         @test sim.𝒪est[:l∞] ≈ 2 atol = testTol
         sim = test_convergence(dts, prob, RKL2(min_stages = 11, eigen_est = eigen_est))
         @test sim.𝒪est[:l∞] ≈ 2 atol = testTol
+
+        println("RKG1")
+        eigen_est = (integrator) -> integrator.eigen_est = 1 / integrator.dt
+        sim = test_convergence(dts, prob, RKG1(eigen_est = eigen_est))
+        @test sim.𝒪est[:l∞] ≈ 1 atol = testTol
+        eigen_est = (integrator) -> integrator.eigen_est = 100 / integrator.dt
+        sim = test_convergence(dts, prob, RKG1(eigen_est = eigen_est))
+        @test sim.𝒪est[:l∞] ≈ 1 atol = testTol
+
+        println("RKG2")
+        eigen_est = (integrator) -> integrator.eigen_est = 1 / integrator.dt
+        sim = test_convergence(dts, prob, RKG2(eigen_est = eigen_est))
+        @test sim.𝒪est[:l∞] ≈ 2 atol = testTol
+        eigen_est = (integrator) -> integrator.eigen_est = 100 / integrator.dt
+        sim = test_convergence(dts, prob, RKG2(eigen_est = eigen_est))
+        @test sim.𝒪est[:l∞] ≈ 2 atol = testTol
+        sim = test_convergence(dts, prob, RKG2(min_stages = 3, eigen_est = eigen_est))
+        @test sim.𝒪est[:l∞] ≈ 2 atol = testTol
+        sim = test_convergence(dts, prob, RKG2(min_stages = 5, eigen_est = eigen_est))
+        @test sim.𝒪est[:l∞] ≈ 2 atol = testTol
     end
     dts = 1 .// 2 .^ (6:-1:2)
     for prob in probArr
@@ -162,6 +203,8 @@ end
             ESERK5(), ESERK5(eigen_est = eigen_est),
             RKL1(), RKL1(eigen_est = eigen_est),
             RKL2(), RKL2(eigen_est = eigen_est),
+            RKG1(), RKG1(eigen_est = eigen_est),
+            RKG2(), RKG2(eigen_est = eigen_est),
         ]
         @testset "$alg" for alg in algs
             x[] = 0
@@ -190,6 +233,8 @@ end
         ESERK5(), ESERK5(eigen_est = eigen_est),
         RKL1(), RKL1(eigen_est = eigen_est),
         RKL2(), RKL2(eigen_est = eigen_est),
+        RKG1(), RKG1(eigen_est = eigen_est),
+        RKG2(), RKG2(eigen_est = eigen_est),
     ]
     @testset "$alg" for alg in algs
         # compile once
@@ -254,5 +299,57 @@ end
         end
         @test all(isodd, stages_seen)
         @test all(s -> s >= 3, stages_seen)
+    end
+end
+
+@testset "RKG-specific tests" begin
+    @testset "RKG on stiff parabolic problem" begin
+        N = 20
+        α = 0.1
+        dx = 1.0 / (N + 1)
+        xs = collect(range(dx, 1 - dx; length = N))
+        D2 = Tridiagonal(
+            fill(α / dx^2, N - 1),
+            fill(-2α / dx^2, N),
+            fill(α / dx^2, N - 1)
+        )
+        u0 = sin.(π .* xs)
+        tspan = (0.0, 0.5)
+        prob = ODEProblem((du, u, p, t) -> mul!(du, D2, u), u0, tspan)
+        exact = exp(-π^2 * α * tspan[2]) .* sin.(π .* xs)
+        for alg in [RKG1(), RKG2()]
+            sol = solve(prob, alg, abstol = 1.0e-4, reltol = 1.0e-4)
+            @test sol.retcode == ReturnCode.Success
+            @test norm(sol.u[end] - exact) < 0.05
+        end
+    end
+
+    @testset "RKG monotone near Dirichlet boundary" begin
+        # Looking for bounded solution that is non-negative on a heat diffusion problem with Dirichlet BCs
+        N = 50
+        α = 1.166
+        dx = 1.0 / (N + 1)
+        xs = collect(range(dx, 1 - dx; length = N))
+
+        # spike near left boundary, zero elsewhere
+        u0 = zeros(N)
+        u0[2] = 100.0
+
+        # Dirichlet BCs
+        D2 = Tridiagonal(
+            fill(α / dx^2, N - 1),
+            fill(-2α / dx^2, N),
+            fill(α / dx^2, N - 1)
+        )
+
+        tspan = (0.0, 1.0e-4)
+        prob = ODEProblem((du, u, p, t) -> mul!(du, D2, u), u0, tspan)
+
+        # RKG2 should remain non negative due to Convex Monotone Property even with Dirichlet BCs
+        sol_rkg = solve(prob, RKG2(), abstol = 1.0e-8, reltol = 1.0e-8)
+        @test sol_rkg.retcode == ReturnCode.Success
+        @test all(sol_rkg.u[end] .>= -1.0e-10)   # allow tiny floating point negatives
+        sol_rkl = solve(prob, RKL2(), abstol = 1.0e-8, reltol = 1.0e-8)
+        @test sol_rkl.retcode == ReturnCode.Success
     end
 end


### PR DESCRIPTION
## Summary

adds Runge–Kutta–Gegenbauer (RKG) stabilized explicit methods RKG1 and RKG2 ( for stiff problems. They follow the same super-time-stepping idea as RKL1 /  RKL2(Runge–Kutta–Legendre), but use shifted Gegenbauer polynomials. Compared to the Legendre variants, RKG1 and RKG2 preserve the convex monotone property even with Dirichlet boundary conditions unlike RKL
Closes https://github.com/SciML/OrdinaryDiffEq.jl/issues/2775

---

## Implemented methods 
**RKG1**-- First order method Stages; `s ≥ 2`; stability used in code: `dt·λ ≤ s(s+3)/4`            
**RKG2** --Second Order method; Stages `s ≥ 3`; stability used in code: `dt·λ ≤ (s+4)(s-1)/6`

---

## Implementation details

- **Algorithm types and docstrings** -- `lib/OrdinaryDiffEqStabilizedRK/src/algorithms.jl`
- **Caches** -- `lib/OrdinaryDiffEqStabilizedRK/src/rkc_caches.jl` (`RKG1ConstantCache` / `RKG1Cache`, `RKG2ConstantCache` / `RKG2Cache`).
- **Time stepping** -- `lib/OrdinaryDiffEqStabilizedRK/src/rkc_perform_step.jl` (`initialize!`, `perform_step!` --adding the method implementation
- **Algorithm utilities** -- `lib/OrdinaryDiffEqStabilizedRK/src/alg_utils.jl`
- **Shared RKC infrastructure** -- `lib/OrdinaryDiffEqStabilizedRK/src/rkc_utils.jl`
- **Exports** -- `lib/OrdinaryDiffEqStabilizedRK/src/OrdinaryDiffEqStabilizedRK.jl`.
- **Tests** -- `lib/OrdinaryDiffEqStabilizedRK/test/rkc_tests.jl` (tests for convergence and CMP)

---

## References

- T. Skaras, T. Saxton, C. Meyer, T. D. Aslam, *Super-time-stepping schemes for parabolic equations with boundary conditions*, J. Comput. Phys. 425 (2021), 109879. https://doi.org/10.1016/j.jcp.2020.109879

---

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC)
- [ ] Any new documentation only uses public API

---.