### PR TITLE
Update FIRK docs to add Gauss-Legendre

### DIFF
--- a/docs/src/implicit/FIRK.md
+++ b/docs/src/implicit/FIRK.md
@@ -35,7 +35,7 @@ These methods are recommended for:
 
 RadauIIA methods are based on Gaussian collocation and achieve order 2s-1 for s stages, making them among the highest-order implicit methods available. They represent the ODE analog of Gaussian quadrature with a fixed right node (Gauss-Radau). They are L-stable, meaning they are stiffly accurate and handle large negative eigenvalues/stiffness ratios. For more details on recent advances in FIRK methods, see our paper: [High-Order Adaptive Time Stepping for the Incompressible Navier-Stokes Equations](https://arxiv.org/abs/2412.14362).
 
-Gauss–Legendre methods use the roots of the Legendre polynomial directly as collocation points and achieve an order of 2s, the highest order IRK available. They are also A-stable, symetric, and can be symplectic in certain usages. They conserve energy within the system, and do not have the same damping properties as RadauIIA meaning they preserve oscilations. 
+Gauss–Legendre methods use the roots of the Legendre polynomial directly as collocation points and achieve an order of 2s, the highest order IRK available. They are also A-stable, symmetric, and can be symplectic in certain usages. They conserve energy within the system, and do not have the same damping properties as RadauIIA meaning they preserve oscilations. 
 
 ## Computational Considerations
 

--- a/docs/src/implicit/FIRK.md
+++ b/docs/src/implicit/FIRK.md
@@ -17,8 +17,8 @@ FIRK methods provide:
   - **Highest-order implicit methods** (excluding extrapolation)
   - **Superior accuracy** for very low tolerance requirements (≤ 1e-9)
   - **A-stable and L-stable** behavior for stiff problems
-  - **Higher order per stage** than SDIRK methods (order 2s+1 for s stages)
-  - **Special geometric properties** (some methods are symplectic)
+  - **Higher order per stage** than SDIRK methods (order 2s or 2s-1 for s stages)
+  - **Geometric properties** can be displayed by some methods in certain cases
   - **Excellent for small to medium systems** with high accuracy requirements
 
 ## When to Use FIRK Methods
@@ -33,7 +33,9 @@ These methods are recommended for:
 
 ## Mathematical Background
 
-RadauIIA methods are based on Gaussian collocation and achieve order 2s+1 for s stages, making them among the highest-order implicit methods available. They represent the ODE analog of Gaussian quadrature. For more details on recent advances in FIRK methods, see our paper: [High-Order Adaptive Time Stepping for the Incompressible Navier-Stokes Equations](https://arxiv.org/abs/2412.14362).
+RadauIIA methods are based on Gaussian collocation and achieve order 2s-1 for s stages, making them among the highest-order implicit methods available. They represent the ODE analog of Gaussian quadrature with a fixed right node (Gauss-Radau). They are L-stable, meaning they are stiffly accurate and handle large negative eigenvalues/stiffness ratios. For more details on recent advances in FIRK methods, see our paper: [High-Order Adaptive Time Stepping for the Incompressible Navier-Stokes Equations](https://arxiv.org/abs/2412.14362).
+
+Gauss–Legendre methods use the roots of the Legendre polynomial directly as collocation points and achieve an order of 2s, the highest order IRK available. They are also A-stable, symetric, and can be symplectic in certain usages. They conserve energy within the system, and do not have the same damping properties as RadauIIA meaning they preserve oscilations. 
 
 ## Computational Considerations
 
@@ -56,6 +58,7 @@ RadauIIA methods are based on Gaussian collocation and achieve order 2s+1 for s 
   - **`RadauIIA5`**: 5th-order method, good balance of accuracy and efficiency
   - **`RadauIIA9`**: 9th-order method for extremely high accuracy requirements
   - **`RadauIIA3`**: 3rd-order method for moderate accuracy needs
+  - **`GaussLegendre`**: 2s order method for high accuracy in nonstiff or conservative problems
 
 ### System size considerations
 
@@ -81,4 +84,5 @@ RadauIIA3
 RadauIIA5
 RadauIIA9
 AdaptiveRadau
+GaussLegendre
 ```

--- a/docs/src/implicit/FIRK.md
+++ b/docs/src/implicit/FIRK.md
@@ -35,7 +35,7 @@ These methods are recommended for:
 
 RadauIIA methods are based on Gaussian collocation and achieve order 2s-1 for s stages, making them among the highest-order implicit methods available. They represent the ODE analog of Gaussian quadrature with a fixed right node (Gauss-Radau). They are L-stable, meaning they are stiffly accurate and handle large negative eigenvalues/stiffness ratios. For more details on recent advances in FIRK methods, see our paper: [High-Order Adaptive Time Stepping for the Incompressible Navier-Stokes Equations](https://arxiv.org/abs/2412.14362).
 
-Gauss–Legendre methods use the roots of the Legendre polynomial directly as collocation points and achieve an order of 2s, the highest order IRK available. They are also A-stable, symmetric, and can be symplectic in certain usages. They conserve energy within the system, and do not have the same damping properties as RadauIIA meaning they preserve oscilations. 
+Gauss–Legendre methods use the roots of the Legendre polynomial directly as collocation points and achieve an order of 2s, the highest order IRK available. They are also A-stable, symmetric, and can be symplectic in certain usages. They conserve energy within the system but are not L-Stable like Radau, which means they preserve oscilations instead of damping. 
 
 ## Computational Considerations
 

--- a/lib/OrdinaryDiffEqFIRK/README.md
+++ b/lib/OrdinaryDiffEqFIRK/README.md
@@ -6,7 +6,7 @@
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor%27s%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 [![SciML Code Style](https://img.shields.io/static/v1?label=code%20style&message=SciML&color=9558b2&labelColor=389826)](https://github.com/SciML/SciMLStyle)
 
-OrdinaryDiffEqFIRK.jl is a component of the [OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl) monorepo. Fully Implicit Runge-Kutta methods (Radau IIA family) for stiff problems.
+OrdinaryDiffEqFIRK.jl is a component of the [OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl) monorepo. It provides fully implicit Runge-Kutta (FIRK) methods, including the Radau IIA family for stiff problems and Gauss–Legendre methods for conservative problems
 While completely independent and usable on its own, users wanting the full ODE solver suite should use [OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl).
 
 ## Solvers
@@ -15,5 +15,6 @@ While completely independent and usable on its own, users wanting the full ODE s
 - `RadauIIA5`
 - `RadauIIA9`
 - `AdaptiveRadau`
+- `GaussLegendre`
 
 For a full description of the solvers and their options, see the [ODE solver documentation](https://docs.sciml.ai/DiffEqDocs/stable/).


### PR DESCRIPTION
added to FIRK docs: GaussLegendre FIRK

- README: mention Gauss–Legendre FIRK
- FIRK.md: GaussLegendre in narrative + @docs; Radau IIA order 2s-1 (Gauss–Radau); Gauss-Legendre 2s;
- Previously RadauIIA showed order 2s+1, changed to 2s-1 and also added some more descriptions on properties

Files: lib/OrdinaryDiffEqFIRK/README.md, docs/src/implicit/FIRK.md 
Related to #3470.