### PR TITLE
Fix non-Boolean @test_broken in AutoZygote PIDController gradient test

### DIFF
--- a/test/ad/autodiff_events.jl
+++ b/test/ad/autodiff_events.jl
@@ -105,25 +105,14 @@ end
         backend,
         p
     )
-    if VERSION >= v"1.11"
-        g5 = DI.gradient(
-            θ -> test_f2(
-                θ, ReverseDiffAdjoint(),
-                PIDController(1 / 18.0, 1 / 9.0, 1 / 18.0)
-            ),
-            backend,
-            p
-        )
-    else
-        @test_broken g5 = DI.gradient(
-            θ -> test_f2(
-                θ, ReverseDiffAdjoint(),
-                PIDController(1 / 18.0, 1 / 9.0, 1 / 18.0)
-            ),
-            backend,
-            p
-        )
-    end
+    g5 = DI.gradient(
+        θ -> test_f2(
+            θ, ReverseDiffAdjoint(),
+            PIDController(1 / 18.0, 1 / 9.0, 1 / 18.0)
+        ),
+        backend,
+        p
+    )
     g6 = DI.gradient(
         θ -> test_f2(
             θ, ForwardDiffSensitivity(),
@@ -146,9 +135,7 @@ end
     @test g2 ≈ findiff[2, 1:2]
     @test g3 ≈ findiff[2, 1:2]
     @test g4 ≈ findiff[2, 1:2]
-    if VERSION >= v"1.11"
-        @test g5 ≈ findiff[2, 1:2]
-    end
+    @test g5 ≈ findiff[2, 1:2]
     @test g6 ≈ findiff[2, 1:2]
     @test_broken g7 ≈ findiff[2, 1:2]
 end


### PR DESCRIPTION
> Please ignore until reviewed by @ChrisRackauckas.

## Summary

- Fixes the `Gradient tests with AutoZygote()` error on master CI (`AD/lts` job — Julia 1.10).
- Root cause: `@test_broken g5 = DI.gradient(...)` passes an *assignment expression* to `@test_broken`. The macro evaluates the expression and requires a `Bool`. While the underlying gradient call errored, the macro silently recorded a `Broken` test. Once dependencies improved enough for `DI.gradient` to actually return a `Vector{Float64}`, the macro hit `Expression evaluated to non-Boolean` and the testset errored.
- Fix: drop the `if VERSION >= v"1.11"` split entirely. The PIDController + ReverseDiffAdjoint + AutoZygote gradient now matches the FiniteDiff reference on Julia 1.10 LTS as well as 1.11+, so it should be a regular passing `@test`, not `@test_broken`.

## Verification

Ran `test/ad/autodiff_events.jl` locally on Julia 1.10:
```
Test Summary:                    | Pass  Broken  Total     Time
Gradient tests with AutoZygote() |    6       2      8  2m19.5s
```
Pre-fix that testset reported `Pass: 5, Error: 1, Broken: 2` and the file errored. Verified on Julia 1.11 too: `g5 ≈ findiff[2, 1:2]` is `true` with the same numeric values. `runic --check` is clean.

The two remaining `Broken` entries in that testset are the `g7` Enzyme/PredictiveController + ReverseDiffAdjoint pair, which are intentionally `@test_broken`.

## Test plan

- [ ] CI `test (AD, lts)` job passes
- [ ] CI `test (AD, 1.11)` job still passes (no regression)
- [ ] No format-check regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)