### PR TITLE
add docs for RKL and RKG supertimestepping methods

### DIFF
--- a/docs/src/semiimplicit/StabilizedRK.md
+++ b/docs/src/semiimplicit/StabilizedRK.md
@@ -6,6 +6,8 @@ CollapsedDocStrings = true
 
 Stabilized Runge-Kutta methods are explicit schemes designed to handle moderately stiff problems by extending the stability region through careful tableau construction. These methods use an upper bound on the spectral radius of the Jacobian to achieve much larger stable timesteps than conventional explicit methods. **These methods are good for large real eigenvalue problems, but not for problems where the complex eigenvalues are large.**
 
+Two families are included: polynomial-based methods (ROCK2, ROCK4, RKC, etc.) using precomputed tableaus, and super-time-stepping methods (RKL1, RKL2, RKG1, RKG2) which use analytic recurrence relations from orthogonal polynomials to adaptively select stage counts, achieving timesteps scaling as s² times the explicit limit.
+
 ## Key Properties
 
 Stabilized RK methods provide:
@@ -16,6 +18,7 @@ Stabilized RK methods provide:
   - **Automatic spectral radius estimation** or user-supplied bounds
   - **Efficient for parabolic PDEs** with moderate stiffness
   - **Good performance** on problems with well-separated timescales
+  - **Super-time-stepping variants** (RKL, RKG) with s²-scaling timesteps and monotonicity-preserving properties for parabolic operators
 
 ## When to Use Stabilized RK Methods
 
@@ -31,6 +34,8 @@ These methods are recommended for:
 ## Mathematical Background
 
 Stabilized methods achieve extended stability by constructing tableaus with enlarged stability regions, often using Chebyshev polynomials or orthogonal polynomial techniques. The stable timestep is determined by the spectral radius bound rather than the CFL condition. **Important**: These methods extend stability primarily along the negative real axis, making them effective for large real eigenvalues but ineffective when complex eigenvalues dominate the stiffness.
+
+The super-time-stepping methods (RKL, RKG) compute coefficients analytically at runtime using three-term recurrences of Legendre and Gegenbauer polynomials, rather than precomputed tableaus. An s-stage scheme advances the solution by up to s² times the explicit Forward Euler limit, with s chosen adaptively each step from the spectral radius estimate.
 
 ## Spectral Radius Estimation
 
@@ -48,6 +53,7 @@ If not provided, the methods include automatic estimation procedures.
 
   - **`RKC`**: Second-order one-step stabilized method for low accuracy requirements
   - **`TSRKC3`**: Third-order two-step stabilized method for moderate accuracy requirements
+  - **`RKL2`**: Second-order, monotone stable, super-time-stepping method for parabolic PDEs
 
 ## Performance Guidelines
 
@@ -59,6 +65,13 @@ If not provided, the methods include automatic estimation procedures.
   - **Very large systems** where stabilized RK methods are more efficient than BDF methods due to no linear algebra requirements
   - **Parabolic PDEs** with diffusion-dominated (real eigenvalue) stiffness
   - **Problems where spectral radius** can be estimated reliably
+
+### When super-time-stepping methods excel
+
+  - **Parabolic PDEs** where the explicit timestep is constrained by dx²
+  - **High stiffness ratios** (> 100), giving an s-fold speedup over explicit sub-cycling
+  - **Non-linear diffusion** with spatially varying coefficients, where RKL/RKG monotonicity prevents spurious oscillations
+  - **Mixed hyperbolic-parabolic systems** via Strang splitting
 
 ### When to use alternatives
 
@@ -87,4 +100,8 @@ TSRKC3
 SERK2
 ESERK4
 ESERK5
+RKL1
+RKL2
+RKG1
+RKG2
 ```


### PR DESCRIPTION
Added documentation for RKL1, RKL2, RKG1, and RKG2 super-time-stepping methods, including mathematical background and advantages
