### PR TITLE
Fix ARS343 BoundsError: set split_guess to [0,1,2,3] instead of zeros

### DIFF
--- a/lib/OrdinaryDiffEqSDIRK/src/generic_imex_perform_step.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/generic_imex_perform_step.jl
@@ -138,9 +138,7 @@ end
             end
         end
 
-        if integrator.f isa SplitFunction
-            z_guess = z[1]
-        elseif !isempty(α) && !iszero(α[i][1])
+        if !isempty(α) && !iszero(α[i])
             z_guess = zero(u)
             for j in 1:(i - 1)
                 z_guess = z_guess + α[i][j] * z[j]
@@ -213,7 +211,7 @@ end
     (; zs, ks, atmp, nlsolver, step_limiter!) = cache
     (; tmp) = nlsolver
     tab = cache.tab
-    (; Ai, bi, Ae, be, c, btilde, ebtilde, α, s, reuse_W_at_stage2, split_guess) = tab
+    (; Ai, bi, Ae, be, c, btilde, ebtilde, α, s, reuse_W_at_stage2) = tab
     alg = unwrap_alg(integrator, true)
     γ = Ai[2, 2]
 
@@ -250,9 +248,7 @@ end
             end
         end
 
-        if integrator.f isa SplitFunction
-            copyto!(zs[i], zs[split_guess[i]])
-        elseif !isempty(α) && !iszero(α[i][1])
+        if !isempty(α) && !iszero(α[i])
             fill!(zs[i], zero(eltype(u)))
             for j in 1:(i - 1)
                 @..zs[i] = zs[i] + α[i][j] * zs[j]

--- a/lib/OrdinaryDiffEqSDIRK/src/imex_tableaus.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/imex_tableaus.jl
@@ -10,7 +10,6 @@ struct ESDIRKIMEXTableau{T, T2}
     order::Int
     s::Int
     reuse_W_at_stage2::Bool
-    split_guess::Vector{Int}  # for SplitFunction: split_guess[i] = which previous stage to copy for stage i
     nlsolver_init_c::T2       # initial c for build_nlsolver (matches master per-alg cache)
 end
 
@@ -131,7 +130,7 @@ function KenCarp3ESDIRKIMEXTableau(T::Type{<:CompiledFloats}, T2::Type{<:Compile
 
     return ESDIRKIMEXTableau(
         Ai, bi_vec, Ae, be_vec, c_vec,
-        btilde_vec, ebtilde_vec, α_vecs, 3, s, true, [0, 1, 2, 2], c3
+        btilde_vec, ebtilde_vec, α_vecs, 3, s, true, c3
     )
 end
 
@@ -264,7 +263,7 @@ function KenCarp3ESDIRKIMEXTableau(T, T2)
 
     return ESDIRKIMEXTableau(
         Ai, bi_vec, Ae, be_vec, c_vec,
-        btilde_vec, ebtilde_vec, α_vecs, 3, s, true, [0, 1, 2, 2], c3
+        btilde_vec, ebtilde_vec, α_vecs, 3, s, true, c3
     )
 end
 
@@ -315,9 +314,14 @@ function ARS343Tableau(T::Type{<:CompiledFloats}, T2::Type{<:CompiledFloats})
 
     c_vec = T2[zero(T2), c2, c3, c4]
 
+    α_vecs = [zeros(T2, s) for _ in 1:s]
+    α_vecs[2][1] = one(T2)
+    α_vecs[3][2] = one(T2)
+    α_vecs[4][3] = one(T2)
+
     return ESDIRKIMEXTableau(
         Ai, bi_vec, Ae, be_vec, c_vec,
-        T[], T[], Vector{T2}[], 3, s, false, zeros(Int, s), c3
+        T[], T[], α_vecs, 3, s, false, c3
     )
 end
 
@@ -488,7 +492,7 @@ function KenCarp4ESDIRKIMEXTableau(T, T2)
 
     return ESDIRKIMEXTableau(
         Ai, bi_vec, Ae, be_vec, c_vec,
-        btilde_vec, ebtilde_vec, α_vecs, 4, s, true, [0, 1, 2, 2, 4, 5], c3
+        btilde_vec, ebtilde_vec, α_vecs, 4, s, true, c3
     )
 end
 
@@ -713,7 +717,7 @@ function KenCarp5ESDIRKIMEXTableau(T, T2)
 
     return ESDIRKIMEXTableau(
         Ai, bi_vec, Ae, be_vec, c_vec,
-        btilde_vec, ebtilde_vec, α_vecs, 5, s, true, [0, 1, 2, 3, 2, 3, 2, 5], c3
+        btilde_vec, ebtilde_vec, α_vecs, 5, s, true, c3
     )
 end
 
@@ -760,9 +764,14 @@ function ARS343Tableau(T, T2)
 
     c_vec = T2[zero(T2), convert(T2, c2), convert(T2, c3), convert(T2, c4)]
 
+    α_vecs = [zeros(T2, s) for _ in 1:s]
+    α_vecs[2][1] = one(T2)
+    α_vecs[3][2] = one(T2)
+    α_vecs[4][3] = one(T2)
+
     return ESDIRKIMEXTableau(
         Ai, bi_vec, Ae, be_vec, c_vec,
-        T[], T[], Vector{T2}[], 3, s, false, zeros(Int, s), convert(T2, c3)
+        T[], T[], α_vecs, 3, s, false, convert(T2, c3)
     )
 end
 
@@ -833,7 +842,7 @@ function Kvaerno3ESDIRKIMEXTableau(T, T2)
 
     return ESDIRKIMEXTableau(
         Ai, bi_vec, Ae, be_vec, c_vec,
-        btilde_vec, T[], α_vecs, 3, s, true, zeros(Int, s),
+        btilde_vec, T[], α_vecs, 3, s, true,
         convert(T2, 2) * convert(T2, 0.4358665215)
     )
 end
@@ -922,7 +931,7 @@ function Kvaerno4ESDIRKIMEXTableau(T, T2)
 
     return ESDIRKIMEXTableau(
         Ai, bi_vec, Ae, be_vec, c_vec,
-        btilde_vec, T[], α_vecs, 4, s, true, zeros(Int, s), c3
+        btilde_vec, T[], α_vecs, 4, s, true, c3
     )
 end
 
@@ -1054,7 +1063,7 @@ function Kvaerno5ESDIRKIMEXTableau(T, T2)
 
     return ESDIRKIMEXTableau(
         Ai, bi_vec, Ae, be_vec, c_vec,
-        btilde_vec, T[], α_vecs, 5, s, true, zeros(Int, s), c3
+        btilde_vec, T[], α_vecs, 5, s, true, c3
     )
 end
 
@@ -1256,7 +1265,7 @@ function KenCarp47ESDIRKIMEXTableau(T, T2)
 
     return ESDIRKIMEXTableau(
         Ai, bi_vec, Ae, be_vec, c_vec,
-        btilde_vec, ebtilde_vec, α_vecs, 4, s, true, [0, 1, 2, 3, 1, 3, 6], c3
+        btilde_vec, ebtilde_vec, α_vecs, 4, s, true, c3
     )
 end
 
@@ -1501,7 +1510,7 @@ function KenCarp58ESDIRKIMEXTableau(T, T2)
 
     return ESDIRKIMEXTableau(
         Ai, bi_vec, Ae, be_vec, c_vec,
-        btilde_vec, ebtilde_vec, α_vecs, 5, s, true, [0, 1, 2, 1, 2, 3, 3, 7], c3
+        btilde_vec, ebtilde_vec, α_vecs, 5, s, true, c3
     )
 end
 
@@ -1519,7 +1528,7 @@ function _pure_esdirk_to_imex_tableau(
     be_vec = zeros(T, s)
     return ESDIRKIMEXTableau(
         Ai_mat, bi_vec, Ae, be_vec, c_vec,
-        btilde_vec, T[], Vector{T2}[], order, s, false, zeros(Int, s), c_vec[3]
+        btilde_vec, T[], Vector{T2}[], order, s, false, c_vec[3]
     )
 end
 

--- a/lib/OrdinaryDiffEqSDIRK/test/sdirk_convergence_tests.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/sdirk_convergence_tests.jl
@@ -163,3 +163,23 @@ testTol = 0.2
     sim122 = test_convergence(dts, prob, ESDIRK659L2SA())
     @test sim122.𝒪est[:final] ≈ 6 atol = testTol
 end
+
+@testset "ARS343 SplitODEProblem" begin
+    dts = 1 .// 2 .^ (8:-1:4)
+
+    # OOP: regression test for #3623 (BoundsError at index [0]) + order check
+    f1_oop = (u, p, t) -> -u
+    f2_oop = (u, p, t) -> 2u
+    ff_oop = SplitFunction(f1_oop, f2_oop; analytic = (u0, p, t) -> exp(t) * u0)
+    prob_oop = SplitODEProblem(ff_oop, 1.0, (0.0, 1.0))
+    sim_oop = test_convergence(dts, prob_oop, ARS343())
+    @test sim_oop.𝒪est[:l∞] ≈ 3 atol = testTol
+
+    # IIP: same problem, in-place
+    f1_iip! = (du, u, p, t) -> (du .= -u)
+    f2_iip! = (du, u, p, t) -> (du .= 2u)
+    ff_iip = SplitFunction(f1_iip!, f2_iip!; analytic = (u0, p, t) -> exp(t) .* u0)
+    prob_iip = SplitODEProblem(ff_iip, [1.0, 0.5], (0.0, 1.0))
+    sim_iip = test_convergence(dts, prob_iip, ARS343())
+    @test sim_iip.𝒪est[:l∞] ≈ 3 atol = testTol
+end


### PR DESCRIPTION
split_guess[i] tells the FSAL IMEX perform_step! which zs slot to copy as initial guess for stage i. zeros(Int, s) caused zs[0] to be accessed, triggering a BoundsError when solving SplitODEProblems with ARS343. Fixes #3623

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
