### PR TITLE
Default solve(prob::DAEProblem) to DFBDF

### DIFF
--- a/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
+++ b/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
@@ -7,7 +7,7 @@ using OrdinaryDiffEqCore: alg_stability_size, beta2_default, beta1_default, Auto
 using OrdinaryDiffEqVerner: Vern7, Vern8, Vern9, Vern6
 using OrdinaryDiffEqTsit5: Tsit5
 using OrdinaryDiffEqRosenbrock: Rosenbrock23, Rodas5P
-using OrdinaryDiffEqBDF: FBDF
+using OrdinaryDiffEqBDF: FBDF, DFBDF
 import OrdinaryDiffEqCore
 
 import OrdinaryDiffEqCore: is_mass_matrix_alg, default_autoswitch, isdefaultalg

--- a/lib/OrdinaryDiffEqDefault/src/default_alg.jl
+++ b/lib/OrdinaryDiffEqDefault/src/default_alg.jl
@@ -48,6 +48,7 @@ function isdefaultalg(
 end
 
 SciMLBase.supports_solve_rng(::SciMLBase.AbstractODEProblem, ::Nothing) = true
+SciMLBase.supports_solve_rng(::SciMLBase.AbstractDAEProblem, ::Nothing) = true
 
 function SciMLBase.__init(prob::ODEProblem, ::Nothing, args...; kwargs...)
     return SciMLBase.__init(
@@ -58,6 +59,19 @@ end
 function SciMLBase.__solve(prob::ODEProblem, ::Nothing, args...; kwargs...)
     return SciMLBase.__solve(
         prob, DefaultODEAlgorithm(autodiff = AutoFiniteDiff()),
+        args...; wrap = Val(false), kwargs...
+    )
+end
+
+function SciMLBase.__init(prob::DAEProblem, ::Nothing, args...; kwargs...)
+    return SciMLBase.__init(
+        prob, DFBDF(autodiff = AutoFiniteDiff()),
+        args...; wrap = Val(false), kwargs...
+    )
+end
+function SciMLBase.__solve(prob::DAEProblem, ::Nothing, args...; kwargs...)
+    return SciMLBase.__solve(
+        prob, DFBDF(autodiff = AutoFiniteDiff()),
         args...; wrap = Val(false), kwargs...
     )
 end

--- a/lib/OrdinaryDiffEqDefault/test/default_solver_tests.jl
+++ b/lib/OrdinaryDiffEqDefault/test/default_solver_tests.jl
@@ -181,3 +181,21 @@ cb = DiscreteCallback(
 prob = ODEProblem((u, p, t) -> [0.0], [0.0], (0.0, 1.0))
 sol = solve(prob, callback = cb)
 @test counter[] == 1
+
+# DAEProblem default solver should be DFBDF (residual-form fully implicit DAE)
+function dae_rober!(out, du, u, p, t)
+    out[1] = -0.04u[1] + 1.0e4 * u[2] * u[3] - du[1]
+    out[2] = 0.04u[1] - 3.0e7 * u[2]^2 - 1.0e4 * u[2] * u[3] - du[2]
+    out[3] = u[1] + u[2] + u[3] - 1.0
+    return nothing
+end
+u0_dae = [1.0, 0.0, 0.0]
+du0_dae = [-0.04, 0.04, 0.0]
+prob_dae = DAEProblem(
+    dae_rober!, du0_dae, u0_dae, (0.0, 1.0e3); differential_vars = [true, true, false]
+)
+sol_dae_default = solve(prob_dae)
+sol_dae_dfbdf = solve(prob_dae, DFBDF(autodiff = AutoFiniteDiff()))
+@test sol_dae_default.retcode == ReturnCode.Success
+@test sol_dae_default.t == sol_dae_dfbdf.t
+@test sol_dae_default.u == sol_dae_dfbdf.u


### PR DESCRIPTION
## Summary
- Adds `SciMLBase.__init` / `__solve` dispatches in `OrdinaryDiffEqDefault` for `DAEProblem` with `::Nothing` algorithm, routing residual-form DAEs to `DFBDF(autodiff = AutoFiniteDiff())` by default. Mirrors the existing `ODEProblem` defaults.
- Also adds `SciMLBase.supports_solve_rng(::AbstractDAEProblem, ::Nothing) = true`.
- Adds a Robertson residual-form DAE test verifying `solve(prob_dae)` succeeds and matches `solve(prob_dae, DFBDF(autodiff = AutoFiniteDiff()))` step-for-step.

Without this, `solve(prob_dae)` with no explicit algorithm errors with `NoDefaultAlgorithmError`. After: it transparently uses DFBDF, which is the natural default for fully implicit BDF on residual-form DAEs.

> **Note:** Please ignore this PR until reviewed by @ChrisRackauckas.

## Test plan
- [x] `Pkg.test()` on `OrdinaryDiffEqDefault` locally on Julia 1.10 — `Default Solver Tests | 46 46 2m37.6s`, JET 1/1, Aqua 10/10 all green.
- [ ] CI green on the standard matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)