### PR TITLE
Regression test for #3627 VCC stuck-at-zero

### DIFF
--- a/test/integrators/ode_event_tests.jl
+++ b/test/integrators/ode_event_tests.jl
@@ -711,3 +711,49 @@ end
     @test e4 !== nothing
     @test crossings[e4][2] == -1
 end
+
+# Regression test for https://github.com/SciML/OrdinaryDiffEq.jl/issues/3627
+# After triggering a VCC condition and pinning the state so the condition
+# value sits at exactly 0 for the rest of the integration, the rootfinder
+# must not keep re-firing the same callback. `findall_events!` had lost the
+# `prev_sign != 0` guard, so `0 * (next_sign) ≤ 0` resolved true on every
+# subsequent step and the solve MaxIters'd. Equivalent of the user's
+# "sticking surface" MWE.
+@testset "VectorContinuousCallback stuck-at-zero (#3627)" begin
+    f_stick(u, p, t) = [0.5, p[1]]
+
+    function stick_condition!(out, u, t, integrator)
+        out[1] = u[1] - 5.0
+        out[2] = u[2] - 1.0
+        return
+    end
+
+    fired = Tuple{Float64, Int}[]
+    function stick_affect!(integrator, events)
+        for i in eachindex(events)
+            if events[i] != 0
+                push!(fired, (integrator.t, i))
+                # Stick u[2] at 1 by zeroing its derivative — out[2] then
+                # sits at exactly 0 for the rest of the integration.
+                i == 2 && (integrator.p[1] = 0.0)
+            end
+        end
+        return
+    end
+
+    cb = VectorContinuousCallback(
+        stick_condition!, stick_affect!, 2;
+        save_positions = (false, false)
+    )
+    prob = ODEProblem(f_stick, [0.0, 0.0], (0.0, 20.0), [1.0])
+    sol = solve(prob, Tsit5(), callback = cb, maxiters = 100_000)
+
+    @test sol.retcode == ReturnCode.Success
+    # out[2] crosses zero at t = 1; out[1] crosses zero at t = 10.
+    # Nothing else should fire — without the prev_sign != 0 guard, idx = 2
+    # would be reported on every step from t = 1 onward.
+    @test length(fired) == 2
+    @test fired[1] == (1.0, 2)
+    @test fired[2][2] == 1
+    @test isapprox(fired[2][1], 10.0; atol = 1.0e-10)
+end


### PR DESCRIPTION
## Summary

Captures DaniGlez's "sticking surface" MWE from #3627 as a regression test against #3626's `findall_events!` fix.

Without the `prev_sign != 0` guard restored in 2acc488, `out[2]` sitting at exactly `0` after the first VCC fire makes `prev_sign * next_sign <= 0` resolve true on every subsequent step and the solve `MaxIters` out. With the fix, the second condition fires once at `t = 10` and the solve completes cleanly.

Closes #3627.

## Test plan
- [x] Smoke-test of MWE locally: `retcode = Success`, `fired = [(1.0, 2), (9.999999999999996, 1)]`.
- [ ] CI green on Integrators_I across all Julia versions.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>