### PR TITLE
Fix Hermite dense output for Rosenbrock DAEs with empty H matrix

### DIFF
--- a/lib/OrdinaryDiffEqRosenbrock/src/OrdinaryDiffEqRosenbrock.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/OrdinaryDiffEqRosenbrock.jl
@@ -13,7 +13,7 @@ import OrdinaryDiffEqCore: alg_order, alg_adaptive_order, isWmethod, isfsal, _un
     calculate_residuals, has_stiff_interpolation, ODEIntegrator,
     resize_non_user_cache!, _ode_addsteps!, full_cache,
     DerivativeOrderNotPossibleError, _ad_chunksize_int, _ad_fdtype, _fixup_ad,
-    LinearAliasSpecifier, copyat_or_push!
+    LinearAliasSpecifier, copyat_or_push!, DifferentialVarsUndefined
 using MuladdMacro, FastBroadcast, RecursiveArrayTools
 import MacroTools: namify
 using MacroTools: @capture

--- a/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_interpolants.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_interpolants.jl
@@ -7,6 +7,16 @@ ROSENBROCKS_WITH_INTERPOLATIONS = Union{
     HybridExplicitImplicitConstantCache, HybridExplicitImplicitCache,
 }
 
+# Mask used by the `interp_order == -1` Hermite fallback (methods with no
+# H matrix store k[1]=f₀, k[2]=f₁). For DAE algebraic variables, f₀/f₁ are
+# residuals, not derivatives, so the Hermite correction is invalid there —
+# the mask is zero on algebraic vars to fall back to linear interpolation.
+@inline _dae_hermite_mask(::Nothing, ::Any) = true
+@inline _dae_hermite_mask(::DifferentialVarsUndefined, ::Any) = false
+@inline _dae_hermite_mask(dv::AbstractArray, ::Nothing) = dv
+@inline _dae_hermite_mask(dv::AbstractArray, idxs::Number) = dv[idxs]
+@inline _dae_hermite_mask(dv::AbstractArray, idxs) = @view dv[idxs]
+
 function _ode_interpolant(
         Θ, dt, y₀, y₁, k,
         cache::ROSENBROCKS_WITH_INTERPOLATIONS,
@@ -173,9 +183,19 @@ From MATLAB ODE Suite by Shampine
     )
     Θ1 = 1 - Θ
     if hasproperty(cache, :interp_order) && cache.interp_order == -1
-        # Generic Hermite: k[1]=f₀, k[2]=f₁ (methods with no H matrix)
-        @.. Θ1 * y₀ + Θ * y₁ +
-            Θ * (Θ - 1) * ((1 - 2Θ) * (y₁ - y₀) + (Θ - 1) * dt * k[1] + Θ * dt * k[2])
+        # Generic Hermite: k[1]=f₀, k[2]=f₁ (methods with no H matrix).
+        # Mask the Hermite correction by `differential_vars` so DAE algebraic
+        # variables fall back to linear interpolation (f₀/f₁ are residuals there).
+        m = _dae_hermite_mask(differential_vars, nothing)
+        if m === true
+            @.. Θ1 * y₀ + Θ * y₁ +
+                Θ * (Θ - 1) * ((1 - 2Θ) * (y₁ - y₀) + (Θ - 1) * dt * k[1] + Θ * dt * k[2])
+        elseif m === false
+            @.. Θ1 * y₀ + Θ * y₁
+        else
+            @.. Θ1 * y₀ + Θ * y₁ +
+                m * Θ * (Θ - 1) * ((1 - 2Θ) * (y₁ - y₀) + (Θ - 1) * dt * k[1] + Θ * dt * k[2])
+        end
     elseif !hasproperty(cache, :interp_order) || cache.interp_order == 2
         @.. Θ1 * y₀ + Θ * (y₁ + Θ1 * (k[1] + Θ * k[2]))
     elseif cache.interp_order == 4
@@ -196,8 +216,16 @@ end
     )
     Θ1 = 1 - Θ
     if hasproperty(cache, :interp_order) && cache.interp_order == -1
-        @views @.. Θ1 * y₀[idxs] + Θ * y₁[idxs] +
-            Θ * (Θ - 1) * ((1 - 2Θ) * (y₁[idxs] - y₀[idxs]) + (Θ - 1) * dt * k[1][idxs] + Θ * dt * k[2][idxs])
+        m = _dae_hermite_mask(differential_vars, idxs)
+        if m === true
+            @views @.. Θ1 * y₀[idxs] + Θ * y₁[idxs] +
+                Θ * (Θ - 1) * ((1 - 2Θ) * (y₁[idxs] - y₀[idxs]) + (Θ - 1) * dt * k[1][idxs] + Θ * dt * k[2][idxs])
+        elseif m === false
+            @views @.. Θ1 * y₀[idxs] + Θ * y₁[idxs]
+        else
+            @views @.. Θ1 * y₀[idxs] + Θ * y₁[idxs] +
+                m * Θ * (Θ - 1) * ((1 - 2Θ) * (y₁[idxs] - y₀[idxs]) + (Θ - 1) * dt * k[1][idxs] + Θ * dt * k[2][idxs])
+        end
     elseif !hasproperty(cache, :interp_order) || cache.interp_order == 2
         @views @.. Θ1 * y₀[idxs] + Θ * (y₁[idxs] + Θ1 * (k[1][idxs] + Θ * k[2][idxs]))
     elseif cache.interp_order == 4
@@ -224,8 +252,16 @@ end
     )
     Θ1 = 1 - Θ
     if hasproperty(cache, :interp_order) && cache.interp_order == -1
-        @.. out = Θ1 * y₀ + Θ * y₁ +
-            Θ * (Θ - 1) * ((1 - 2Θ) * (y₁ - y₀) + (Θ - 1) * dt * k[1] + Θ * dt * k[2])
+        m = _dae_hermite_mask(differential_vars, nothing)
+        if m === true
+            @.. out = Θ1 * y₀ + Θ * y₁ +
+                Θ * (Θ - 1) * ((1 - 2Θ) * (y₁ - y₀) + (Θ - 1) * dt * k[1] + Θ * dt * k[2])
+        elseif m === false
+            @.. out = Θ1 * y₀ + Θ * y₁
+        else
+            @.. out = Θ1 * y₀ + Θ * y₁ +
+                m * Θ * (Θ - 1) * ((1 - 2Θ) * (y₁ - y₀) + (Θ - 1) * dt * k[1] + Θ * dt * k[2])
+        end
     elseif !hasproperty(cache, :interp_order) || cache.interp_order == 2
         @.. out = Θ1 * y₀ + Θ * (y₁ + Θ1 * (k[1] + Θ * k[2]))
     elseif cache.interp_order == 4
@@ -247,8 +283,16 @@ end
     )
     Θ1 = 1 - Θ
     if hasproperty(cache, :interp_order) && cache.interp_order == -1
-        @views @.. out = Θ1 * y₀[idxs] + Θ * y₁[idxs] +
-            Θ * (Θ - 1) * ((1 - 2Θ) * (y₁[idxs] - y₀[idxs]) + (Θ - 1) * dt * k[1][idxs] + Θ * dt * k[2][idxs])
+        m = _dae_hermite_mask(differential_vars, idxs)
+        if m === true
+            @views @.. out = Θ1 * y₀[idxs] + Θ * y₁[idxs] +
+                Θ * (Θ - 1) * ((1 - 2Θ) * (y₁[idxs] - y₀[idxs]) + (Θ - 1) * dt * k[1][idxs] + Θ * dt * k[2][idxs])
+        elseif m === false
+            @views @.. out = Θ1 * y₀[idxs] + Θ * y₁[idxs]
+        else
+            @views @.. out = Θ1 * y₀[idxs] + Θ * y₁[idxs] +
+                m * Θ * (Θ - 1) * ((1 - 2Θ) * (y₁[idxs] - y₀[idxs]) + (Θ - 1) * dt * k[1][idxs] + Θ * dt * k[2][idxs])
+        end
     elseif !hasproperty(cache, :interp_order) || cache.interp_order == 2
         @views @.. out = Θ1 * y₀[idxs] + Θ * (y₁[idxs] + Θ1 * (k[1][idxs] + Θ * k[2][idxs]))
     elseif cache.interp_order == 4
@@ -281,7 +325,23 @@ end
         },
         idxs::Nothing, T::Type{Val{1}}, differential_vars
     )
-    if !hasproperty(cache, :interp_order) || cache.interp_order == 2
+    if hasproperty(cache, :interp_order) && cache.interp_order == -1
+        m = _dae_hermite_mask(differential_vars, nothing)
+        hermite_deriv = @.. (
+            k[1] + Θ * (
+                -4 * dt * k[1] - 2 * dt * k[2] - 6 * y₀ +
+                    Θ * (3 * dt * k[1] + 3 * dt * k[2] + 6 * y₀ - 6 * y₁) +
+                    6 * y₁
+            )
+        ) / dt
+        if m === true
+            hermite_deriv
+        elseif m === false
+            @.. (y₁ - y₀) / dt
+        else
+            @.. m * hermite_deriv + (true - m) * (y₁ - y₀) / dt
+        end
+    elseif !hasproperty(cache, :interp_order) || cache.interp_order == 2
         @.. (k[1] + Θ * (-2 * k[1] + 2 * k[2] - 3 * k[2] * Θ) - y₀ + y₁) / dt
     elseif cache.interp_order == 4
         @.. (
@@ -313,7 +373,23 @@ end
         },
         idxs, T::Type{Val{1}}, differential_vars
     )
-    if !hasproperty(cache, :interp_order) || cache.interp_order == 2
+    if hasproperty(cache, :interp_order) && cache.interp_order == -1
+        m = _dae_hermite_mask(differential_vars, idxs)
+        hermite_deriv = @views @.. (
+            k[1][idxs] + Θ * (
+                -4 * dt * k[1][idxs] - 2 * dt * k[2][idxs] - 6 * y₀[idxs] +
+                    Θ * (3 * dt * k[1][idxs] + 3 * dt * k[2][idxs] + 6 * y₀[idxs] - 6 * y₁[idxs]) +
+                    6 * y₁[idxs]
+            )
+        ) / dt
+        if m === true
+            hermite_deriv
+        elseif m === false
+            @views @.. (y₁[idxs] - y₀[idxs]) / dt
+        else
+            @views @.. m * hermite_deriv + (true - m) * (y₁[idxs] - y₀[idxs]) / dt
+        end
+    elseif !hasproperty(cache, :interp_order) || cache.interp_order == 2
         @views @.. (
             k[1][idxs] +
                 Θ * (-2 * k[1][idxs] + 2 * k[2][idxs] - 3 * k[2][idxs] * Θ) -
@@ -351,7 +427,28 @@ end
         },
         idxs::Nothing, T::Type{Val{1}}, differential_vars
     )
-    if !hasproperty(cache, :interp_order) || cache.interp_order == 2
+    if hasproperty(cache, :interp_order) && cache.interp_order == -1
+        m = _dae_hermite_mask(differential_vars, nothing)
+        if m === true
+            @.. out = (
+                k[1] + Θ * (
+                    -4 * dt * k[1] - 2 * dt * k[2] - 6 * y₀ +
+                        Θ * (3 * dt * k[1] + 3 * dt * k[2] + 6 * y₀ - 6 * y₁) +
+                        6 * y₁
+                )
+            ) / dt
+        elseif m === false
+            @.. out = (y₁ - y₀) / dt
+        else
+            @.. out = m * (
+                k[1] + Θ * (
+                    -4 * dt * k[1] - 2 * dt * k[2] - 6 * y₀ +
+                        Θ * (3 * dt * k[1] + 3 * dt * k[2] + 6 * y₀ - 6 * y₁) +
+                        6 * y₁
+                )
+            ) / dt + (true - m) * (y₁ - y₀) / dt
+        end
+    elseif !hasproperty(cache, :interp_order) || cache.interp_order == 2
         @.. out = (k[1] + Θ * (-2 * k[1] + 2 * k[2] - 3 * k[2] * Θ) - y₀ + y₁) / dt
     elseif cache.interp_order == 4
         @.. out = (
@@ -385,7 +482,28 @@ end
         },
         idxs, T::Type{Val{1}}, differential_vars
     )
-    if !hasproperty(cache, :interp_order) || cache.interp_order == 2
+    if hasproperty(cache, :interp_order) && cache.interp_order == -1
+        m = _dae_hermite_mask(differential_vars, idxs)
+        if m === true
+            @views @.. out = (
+                k[1][idxs] + Θ * (
+                    -4 * dt * k[1][idxs] - 2 * dt * k[2][idxs] - 6 * y₀[idxs] +
+                        Θ * (3 * dt * k[1][idxs] + 3 * dt * k[2][idxs] + 6 * y₀[idxs] - 6 * y₁[idxs]) +
+                        6 * y₁[idxs]
+                )
+            ) / dt
+        elseif m === false
+            @views @.. out = (y₁[idxs] - y₀[idxs]) / dt
+        else
+            @views @.. out = m * (
+                k[1][idxs] + Θ * (
+                    -4 * dt * k[1][idxs] - 2 * dt * k[2][idxs] - 6 * y₀[idxs] +
+                        Θ * (3 * dt * k[1][idxs] + 3 * dt * k[2][idxs] + 6 * y₀[idxs] - 6 * y₁[idxs]) +
+                        6 * y₁[idxs]
+                )
+            ) / dt + (true - m) * (y₁[idxs] - y₀[idxs]) / dt
+        end
+    elseif !hasproperty(cache, :interp_order) || cache.interp_order == 2
         @views @.. out = (
             k[1][idxs] +
                 Θ *

--- a/lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl
@@ -388,3 +388,44 @@ end
         end
     end
 end
+
+@testset "Issue #3631: DAE dense output for Rosenbrock methods with empty H" begin
+    # Methods without a stiff-aware dense output (empty H matrix, e.g. ROS34PW2,
+    # ROS34PW3, Rodas3) stored f(uprev) and f(u) and reused the standard Hermite
+    # cubic. For DAE problems those values are residuals on algebraic variables,
+    # not derivatives, so Hermite was producing wildly wrong off-knot values.
+    # See https://github.com/SciML/OrdinaryDiffEq.jl/issues/3631.
+    function f!(du, u, p, t)
+        du[1] = 20 * ((t - 1)^(p - 1) + t * (p - 1) * (t - 1)^(p - 2))
+        du[2] = u[1] - u[2]
+        return nothing
+    end
+    anasol(t, p) = 10 .* t .* (t .- 1) .^ (p - 1)
+
+    p = 3
+    u0 = [0.0, 0.0]
+    tspan = (0.0, 1.5)
+    M = zeros(2, 2)
+    M[1, 1] = 1
+    M[1, 2] = 1
+    prob = ODEProblem(ODEFunction(f!, mass_matrix = M), u0, tspan, p)
+
+    tt = collect(0:0.01:tspan[2])
+
+    # Methods with their own dense output should match the analytical solution
+    # almost exactly; methods that fall back to the generic Hermite path must
+    # at least be bounded by O(dt) — Hermite-on-residuals previously produced
+    # interpolation errors orders of magnitude larger than the knot errors.
+    for (method, expected_interp) in (
+            (Rodas4P, 1.0e-10), (ROS34PW2, 5.0e-2),
+            (ROS34PW3, 5.0e-2), (Rodas3, 5.0e-2),
+        )
+        sol = solve(prob, method(); dense = true, reltol = 1.0e-4, abstol = 1.0e-4)
+        err_knot = maximum(abs.(sol[1, :] .- anasol(sol.t, p)))
+        err_interp = maximum(abs.(sol(tt; idxs = 1) .- anasol(tt, p)))
+        @test err_knot < 1.0e-6
+        @test err_interp < expected_interp
+        # interp error should not be wildly larger than knot error
+        @test err_interp < 100 * max(err_knot, 1.0e-4)
+    end
+end


### PR DESCRIPTION
Closes #3631.

> Please ignore until reviewed by @ChrisRackauckas.

## Problem

Rosenbrock methods without their own stiff-aware dense output (Rodas3, ROS34PW2, ROS34PW3, ROK4a, …) fall back to a generic cubic Hermite that reuses `k[1] = f(uprev, p, t)` and `k[2] = f(u, p, t+dt)`. On a DAE problem (singular or non-`I` mass matrix), `f` on algebraic variables is the residual rather than a derivative, so the Hermite correction is invalid there and produces large oscillations between knots while the knot values themselves are accurate.

Reproducer from the issue:
```julia
M = zeros(2,2); M[1,1] = 1; M[1,2] = 1
prob = ODEProblem(ODEFunction(f!, mass_matrix=M), u0, tspan, p)
sol = solve(prob, ROS34PW2(), dense=true, reltol=1e-4, abstol=1e-4)
maximum(abs.(sol[1, :] .- anasol(sol.t, p)))         # 2.7e-15  (knot)
maximum(abs.(sol(tt; idxs=1) .- anasol(tt, p)))      # 0.0894    (dense — wrong)
```

`Rodas4P` (has a proper `H` matrix) gives ~1e-14 in both columns.

## Fix

In `rosenbrock_interpolants.jl`, the `interp_order == -1` branch now masks the Hermite correction by `differential_vars` so algebraic components reduce to linear interpolation:

| `differential_vars`                  | Behavior                              |
|--------------------------------------|---------------------------------------|
| `nothing` (pure ODE)                 | full Hermite — unchanged              |
| `DifferentialVarsUndefined` (non-diag M) | pure linear interpolation         |
| `BitVector` (diagonal singular M)    | Hermite on differential, linear on algebraic |

Also adds the missing `interp_order == -1` branch for the `Val{1}` derivative interpolant — previously it fell through to a cubic formula that referenced `k[3]`, which doesn't exist for the Hermite-fallback case.

After the fix the reproducer's interpolation error drops to ~0.0082 at `reltol=1e-4` and to ~0.00044 at `reltol=1e-6` (linear convergence is `O(dt)`, matching expectations for a method with no stiff-aware dense output).

## Test plan

- [x] New regression test `test/ode_rosenbrock_tests.jl` reproduces the issue across `Rodas4P`, `ROS34PW2`, `ROS34PW3`, `Rodas3`.
- [x] Full `OrdinaryDiffEqRosenbrock` test suite passes locally (Core + QA, Julia 1.11).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)