### PR TITLE
Bump version of OrdinaryDiffEqSDIRK from 2.1.0 to 2.2.0

### DIFF
--- a/lib/OrdinaryDiffEqSDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqSDIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSDIRK"
 uuid = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.0"
+version = "2.2.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
It would be nice to get a new release including https://github.com/SciML/OrdinaryDiffEq.jl/pull/3196 (after fixing it in https://github.com/SciML/OrdinaryDiffEq.jl/pull/3624).