### PR TITLE
Bump versions of sublibs with unreleased source changes

### DIFF
--- a/lib/DelayDiffEq/Project.toml
+++ b/lib/DelayDiffEq/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.0.0"
+version = "6.0.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "3.1.0"
+version = "3.1.1"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 

--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFIRK"
 uuid = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.0"
+version = "2.2.0"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqNewmark/Project.toml
+++ b/lib/OrdinaryDiffEqNewmark/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqNewmark"
 uuid = "d204908a-63b9-11ef-18f5-cfec7123a93b"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Dennis Ogiermann <termi-official@users.noreply.github.com>"]
 
 [deps]

--- a/lib/OrdinaryDiffEqRosenbrock/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrock/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqRosenbrock"
 uuid = "43230ef6-c299-4910-a778-202eb28ce4ce"
-version = "2.1.0"
+version = "2.2.0"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 
 [deps]

--- a/lib/OrdinaryDiffEqStabilizedRK/Project.toml
+++ b/lib/OrdinaryDiffEqStabilizedRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqStabilizedRK"
 uuid = "358294b1-0aab-51c3-aafe-ad5ab194a2ad"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.0"
+version = "2.2.0"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"


### PR DESCRIPTION
Coordinates version bumps for every sublib that has source changes since its last registered release. Companion to PR #3634 (which bumped `OrdinaryDiffEqSDIRK` to 2.2.0 but did not get registered).

## Bumps

| Sublib | From | To | Reason |
|---|---|---|---|
| DelayDiffEq | 6.0.0 | 6.0.1 | bug fix: don't pop user tstops in discontinuity-merge cleanup (#1124) |
| OrdinaryDiffEqDifferentiation | 3.1.0 | 3.1.1 | internal: drop `Union{Nothing, ...}` from `JacReuseState` cache slots |
| OrdinaryDiffEqFIRK | 2.1.0 | 2.2.0 | feature: BigFloat gauss-legendre support |
| OrdinaryDiffEqNewmark | 2.0.0 | 2.1.0 | feature: Generalized Alpha method |
| OrdinaryDiffEqRosenbrock | 2.1.0 | 2.2.0 | fix: Hermite dense output for Rosenbrock DAEs with empty H matrix; parameterize `JacReuseState` by cached J/D/W types |
| OrdinaryDiffEqStabilizedRK | 2.1.0 | 2.2.0 | feature: Runge-Kutta-Gegenbauer methods |

## Registrations to follow

After this merges, the following will be registered via `@JuliaRegistrator register subdir=...` comments on the merge commit:

- `lib/DelayDiffEq` (6.0.1)
- `lib/OrdinaryDiffEqDifferentiation` (3.1.1)
- `lib/OrdinaryDiffEqFIRK` (2.2.0)
- `lib/OrdinaryDiffEqNewmark` (2.1.0)
- `lib/OrdinaryDiffEqRosenbrock` (2.2.0)
- `lib/OrdinaryDiffEqStabilizedRK` (2.2.0)

And separately re-trigger registration for sublibs already at a newer version on master that never got their last release through:

- `lib/OrdinaryDiffEqSDIRK` (2.2.0, from #3634 — never registered)
- `lib/StochasticDiffEqImplicit` (2.1.0 — registered version is 2.0.0)
- `lib/StochasticDiffEqWeak` (2.1.0 — registered version is 2.0.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)