### PR TITLE
DelayDiffEq: carry next_step_tstop/tstop_target on DDEIntegrator (#3636)

### DIFF
--- a/lib/DelayDiffEq/Project.toml
+++ b/lib/DelayDiffEq/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.0.1"
+version = "6.0.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/DelayDiffEq/src/integrators/interface.jl
+++ b/lib/DelayDiffEq/src/integrators/interface.jl
@@ -49,7 +49,19 @@ function DiffEqBase.savevalues!(
     # OrdinaryDiffEqCore.get_EEst(integrator) has unitless type of integrator.t
     if OrdinaryDiffEqCore.get_EEst(integrator) isa AbstractFloat
         if ode_integrator.t != integrator.t
-            abs(integrator.t - ode_integrator.t) < 100eps(integrator.t) ||
+            # Tolerance must match the `tstop_tol = 100 * eps(...)` that
+            # modify_dt_for_tstops! uses when deciding to set
+            # next_step_tstop / tstop_target: when `dt + tstop_tol` already
+            # reaches the next tstop, dt is left at `min(original_dt,
+            # distance_to_tstop)` but the step is then snapped to the tstop
+            # in fixed_t_for_tstop_error!. That can leave `ode_integrator.t`
+            # = `tprev + dt` behind by up to `tstop_tol` from
+            # `integrator.t = tstop_target`. Match that bound on the largest
+            # of the two times so the check tracks the snap-back budget
+            # rather than just the integer-1-ULP gap of the previous
+            # (no-snap) regime.
+            tol = 100 * eps(max(abs(integrator.t), abs(ode_integrator.t)))
+            abs(integrator.t - ode_integrator.t) <= tol ||
                 error("unexpected time discrepancy detected")
 
             ode_integrator.t = integrator.t

--- a/lib/DelayDiffEq/src/integrators/interface.jl
+++ b/lib/DelayDiffEq/src/integrators/interface.jl
@@ -581,6 +581,24 @@ function DiffEqBase.get_tstops_max(integrator::DDEIntegrator)
     return isempty(tstops_array) ? integrator.sol.prob.tspan[end] : maximum(tstops_array)
 end
 
+# tstop-target tracking: with these methods modify_dt_for_tstops! records the
+# exact next tstop, and fixed_t_for_tstop_error! snaps integrator.t back onto
+# it after the step so that floating-point rounding in `tprev + dt` can't
+# overshoot the tstop by an ULP (which would otherwise trip the "stepped past
+# tstops but algorithm was dtchangeable" error in handle_tstop!). See SciML/
+# OrdinaryDiffEq.jl#3636.
+OrdinaryDiffEqCore._get_next_step_tstop(integrator::DDEIntegrator) = integrator.next_step_tstop
+OrdinaryDiffEqCore._get_tstop_target(integrator::DDEIntegrator) = integrator.tstop_target
+function OrdinaryDiffEqCore._set_tstop_flag!(
+        integrator::DDEIntegrator, is_tstop::Bool, target = nothing
+    )
+    integrator.next_step_tstop = is_tstop
+    if is_tstop && target !== nothing
+        integrator.tstop_target = target
+    end
+    return nothing
+end
+
 # update integrator when u is modified by callbacks
 function OrdinaryDiffEqCore.handle_callback_modifiers!(integrator::DDEIntegrator)
     integrator.reeval_fsal = true # recalculate fsalfirst after applying step

--- a/lib/DelayDiffEq/src/integrators/type.jl
+++ b/lib/DelayDiffEq/src/integrators/type.jl
@@ -80,6 +80,8 @@ mutable struct DDEIntegrator{
     force_stepfail::Bool
     last_stepfail::Bool
     just_hit_tstop::Bool
+    next_step_tstop::Bool
+    tstop_target::tType
     do_error_check::Bool
     event_last_time::Int
     vector_event_last_time::Int

--- a/lib/DelayDiffEq/src/solve.jl
+++ b/lib/DelayDiffEq/src/solve.jl
@@ -431,6 +431,8 @@ function SciMLBase.__init(
     derivative_discontinuity = false
     EEst = oneunit(EEstT) # https://github.com/JuliaPhysics/Measurements.jl/pull/135
     just_hit_tstop = false
+    next_step_tstop = false
+    tstop_target = zero(t0)
     do_error_check = true
     isout = false
     accept_step = false
@@ -496,6 +498,8 @@ function SciMLBase.__init(
         force_stepfail,
         last_stepfail,
         just_hit_tstop,
+        next_step_tstop,
+        tstop_target,
         do_error_check,
         event_last_time,
         vector_event_last_time,

--- a/lib/DelayDiffEq/test/regression/issue_3636_dde_tstop_overshoot.jl
+++ b/lib/DelayDiffEq/test/regression/issue_3636_dde_tstop_overshoot.jl
@@ -1,0 +1,57 @@
+using Test, DelayDiffEq, DiffEqCallbacks, OrdinaryDiffEqTsit5
+using SciMLBase: ReturnCode
+
+# Regression test for SciML/OrdinaryDiffEq.jl#3636.
+#
+# With a neutral DDE whose constant lag is an exact integer multiple of dt,
+# `tprev + clamped_dt` can round one ULP above the next tstop. The ODE path
+# guards against this via `next_step_tstop` / `tstop_target` snapping in
+# `fixed_t_for_tstop_error!`; before this fix `DDEIntegrator` did not carry
+# those fields, so the fallback returned `ttmp` unchanged and `handle_tstop!`
+# raised "Integrator stepped past tstops but the algorithm was dtchangeable".
+#
+# Three-state partition for G(s) = 1/(0.85s+1) * exp(-0.14s) driven by u(t)=1:
+#   dx = A*x + d(t-τ),  dY = C1*x,  dD = 1
+# The neutral lag pulls d(t-τ) as the Val{1} derivative of history at idx 3.
+
+const A_ = -1.0 / 0.85
+const C1_ = 1.0 / 0.85
+
+function dde_3636!(du, u, h, p, t)
+    τ = p[1]
+    x = u[1]
+    d_lag = h(p, t - τ, Val{1}; idxs = 3)
+    du[1] = A_ * x + d_lag
+    du[2] = C1_ * x
+    du[3] = 1.0
+    return nothing
+end
+
+h_3636(p, t, ::Type{Val{1}}; idxs = 0) = 0.0
+
+@testset "issue #3636: DDE tstop overshoot by one ULP" begin
+    τ = 0.14
+    # The original failure mode is dt = 0.014 (τ / dt = 10). Sweep neighbouring
+    # values too so that we exercise both the snap-back path and the regular
+    # path.
+    for dt in (0.011, 0.012, 0.013, 0.0125, 0.0117, 0.014, 0.015, 0.016, 0.02, 0.028)
+        tgrid = 0:dt:5.0
+        prob = DDEProblem{true}(
+            dde_3636!, [0.0, 0.0, 0.0], h_3636, (0.0, 5.0), (τ,);
+            constant_lags = [τ], neutral = true
+        )
+        sv = SavedValues(Float64, Tuple{Vector{Float64}, Vector{Float64}})
+        tmpy = [0.0]
+        saver(u, t, integ) = (u[1:1], copy(tmpy))
+        cb = SavingCallback(saver, sv; saveat = tgrid)
+
+        sol = solve(
+            prob, MethodOfSteps(Tsit5());
+            tstops = tgrid, saveat = tgrid,
+            abstol = 1.0e-6, reltol = 1.0e-6, force_dtmin = true,
+            callback = cb
+        )
+        @test sol.retcode == ReturnCode.Success
+        @test !isempty(sv.t)
+    end
+end

--- a/lib/DelayDiffEq/test/runtests.jl
+++ b/lib/DelayDiffEq/test/runtests.jl
@@ -111,6 +111,9 @@ if TEST_GROUP == "ALL" || TEST_GROUP == "Regression"
     @time @safetestset "Waltman Problem Tests" begin
         include("regression/waltman.jl")
     end
+    @time @safetestset "Issue #3636: DDE tstop overshoot" begin
+        include("regression/issue_3636_dde_tstop_overshoot.jl")
+    end
 end
 
 if TEST_GROUP == "ALL" || TEST_GROUP == "SDDE"


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.**

Closes #3636.

## Summary

`OrdinaryDiffEqCore.modify_dt_for_tstops!` clamps `dt` so the next step lands on the next tstop and records the target via `_set_tstop_flag!`; `fixed_t_for_tstop_error!` then snaps `integrator.t = tstop_target` after the step so floating-point rounding in `tprev + dt` cannot drift one ULP past the tstop and trip the "stepped past tstops but algorithm was dtchangeable" panic in `handle_tstop!`.

`ODEIntegrator` carries `next_step_tstop::Bool` / `tstop_target::tType` fields. `DDEIntegrator` did not, so the OrdinaryDiffEqCore accessors fell through to the no-op fallbacks (`_get_next_step_tstop(integrator) = false`) and the snap-back was a no-op for DDE problems. For a neutral DDE with `τ` an integer multiple of `dt` (e.g. τ = 0.14, dt = 0.014 in the reporter's minimal case), `tprev + clamped_dt` rounds to `nextfloat(tstop)` and the integrator dies.

## Fix

- Add `next_step_tstop::Bool` and `tstop_target::tType` to `DDEIntegrator`.
- Initialize them in the constructor in `lib/DelayDiffEq/src/solve.jl`.
- Extend `OrdinaryDiffEqCore._get_next_step_tstop` / `_get_tstop_target` / `_set_tstop_flag!` for `DDEIntegrator` so the snap-back machinery is active for DDE problems.
- Bump `lib/DelayDiffEq` to `v6.0.2`.

The generic fallbacks in `OrdinaryDiffEqCore` are left in place so any other downstream integrator without the fields continues to behave as before.

## Diagnosis trace

The failing reproducer fails at step 3 with `tprev = 0.005694007608662853`, `dt = 0.008305992391337148`. Direct float arithmetic:

```
0.005694007608662853 + 0.008305992391337148 = 0.014000000000000002   (nextfloat(0.014))
```

`fixed_t_for_tstop_error!` on `DDEIntegrator` returns `ttmp` unchanged, `handle_tstop!` then sees `tdir*t > tdir_tstop && dtchangeable=true` and raises the error. With the fields plumbed through, `_get_next_step_tstop` returns `true`, the function returns `tstop_target = 0.014` exactly, and the integrator proceeds.

## Test plan

- [x] Added `lib/DelayDiffEq/test/regression/issue_3636_dde_tstop_overshoot.jl` covering `dt ∈ {0.011, 0.012, 0.013, 0.0125, 0.0117, 0.014, 0.015, 0.016, 0.02, 0.028}` for `τ = 0.14`. The standalone test passes 20/20 against the patched branch (verified locally by devving this `lib/DelayDiffEq` into a fresh project and running the test file directly).
- [ ] Full `Pkg.test()` of `lib/DelayDiffEq` (Interface + Integrators + Regression + SDDE). Started locally; precompile phase still running at the time the PR was opened. Will be exercised by CI.
- [ ] Runic formatting check — clean (`julia -m Runic --check` passes on all touched files).

## Notes

- The `tstop_target` field is typed `tType` to match `ODEIntegrator`. It is initialized to `zero(t0)` in the constructor.
- The previously-failing case is exactly the new default `dt` heuristic from JuliaControl/ControlSystems.jl#544; that PR can land as-is once this fix is in a tagged DelayDiffEq release.