### PR TITLE
Fix QNDF StackOverflowError on Newton failure (#3645)

### DIFF
--- a/lib/OrdinaryDiffEqBDF/Project.toml
+++ b/lib/OrdinaryDiffEqBDF/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqBDF"
 uuid = "6ad6398a-0878-4a85-9266-38940aa047c8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqBDF/src/controllers.jl
+++ b/lib/OrdinaryDiffEqBDF/src/controllers.jl
@@ -207,6 +207,18 @@ function step_reject_controller!(integrator, cache::Union{QNDFCache, QNDFConstan
     return bdf_step_reject_controller!(integrator, cache, cache.EEst1)
 end
 
+# Without this method, falling through to the generic 2-arg
+# `post_newton_controller!(integrator, alg)` in OrdinaryDiffEqCore recurses
+# back into the `BDFControllerCache` 3-arg dispatch above, which calls the
+# 2-arg again — a StackOverflowError on the first Newton failure.
+function post_newton_controller!(integrator, alg::QNDF)
+    return post_newton_controller!(integrator, integrator.cache, alg)
+end
+function post_newton_controller!(integrator, cache::Union{QNDFCache, QNDFConstantCache}, ::QNDF)
+    integrator.dt = integrator.dt / get_failfactor(integrator)
+    return nothing
+end
+
 function step_reject_controller!(integrator, alg::FBDF)
     return step_reject_controller!(integrator, integrator.cache, alg)
 end

--- a/lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl
@@ -1,7 +1,7 @@
 using OrdinaryDiffEqBDF, OrdinaryDiffEqCore, ForwardDiff, Test
 using OrdinaryDiffEqCore: DEVerbosity
 import OrdinaryDiffEqCore.SciMLLogging as SciMLLogging
-using OrdinaryDiffEqNonlinearSolve: BrownFullBasicInit
+using OrdinaryDiffEqNonlinearSolve: BrownFullBasicInit, NLNewton
 
 foop = (u, p, t) -> u * p
 proboop = ODEProblem(foop, ones(2), (0.0, 1000.0), 1.0)
@@ -176,4 +176,23 @@ if VERSION >= v"1.12"
         allocs = @allocated step!(integrator)
         @test allocs == 0
     end
+end
+
+# Regression test for issue #3645: Newton failure with QNDF used to recurse
+# through `post_newton_controller!(integrator, alg::QNDF)` →
+# generic 2-arg in core → `BDFControllerCache` 3-arg → 2-arg again …,
+# producing a `StackOverflowError` on the first failed Newton step.
+@testset "QNDF Newton failure does not StackOverflow (#3645)" begin
+    f_qndf!(du, u, p, t) = (du[1] = -1.0e6 * (u[1] - cos(t)); nothing)
+    prob_qndf = ODEProblem(f_qndf!, [0.0], (0.0, 1.0))
+    # Cripple the Newton solver so it can never converge.
+    alg = QNDF(; nlsolve = NLNewton(; max_iter = 1, κ = 1.0e-30))
+    sol = solve(
+        prob_qndf, alg; dt = 0.5, reltol = 1.0e-12, abstol = 1.0e-12,
+        verbose = DEVerbosity(SciMLLogging.None())
+    )
+    # With the fix, repeated Newton failures shrink dt until dtmin and
+    # the solver gives up cleanly (Unstable) instead of overflowing the stack.
+    @test sol.retcode != ReturnCode.Success
+    @test sol.retcode != ReturnCode.Default
 end


### PR DESCRIPTION
## Summary

Closes #3645.

The 2-arg `post_newton_controller!(integrator, alg::QNDF)` had no QNDF-specific method, so it fell through to the generic 2-arg in `OrdinaryDiffEqCore`, which redirects to the 3-arg dispatch with `integrator.controller_cache`. For QNDF that cache is `BDFControllerCache`, whose 3-arg dispatch (in `lib/OrdinaryDiffEqBDF/src/controllers.jl:46-47`) calls the 2-arg version back — producing infinite recursion and a `StackOverflowError` on the first failed Newton step.

`FBDF` and `DFBDF` already have their own 2-arg methods that route to algorithm-cache dispatch, so they were unaffected. The same recursion was technically possible all the way back to PR #3422 (introduction of `DummyControllerCache`), but the recursion edge in `DummyControllerCache` did not produce visible failures until #3570 added `BDFControllerCache` and someone actually triggered a Newton-failure on QNDF.

## Fix

Add `post_newton_controller!(integrator, alg::QNDF)` and a 3-arg companion for `Union{QNDFCache, QNDFConstantCache}` that performs the historical default behavior (`dt /= get_failfactor(integrator)`), mirroring how `FBDF`/`DFBDF` break the same cycle. No behavioral change beyond eliminating the recursion — the new method does exactly what the pre-#3422 generic 3-arg path did.

## Reproducer

```julia
using OrdinaryDiffEqBDF
using OrdinaryDiffEqNonlinearSolve: NLNewton

f!(du, u, p, t) = (du[1] = -1.0e6 * (u[1] - cos(t)); nothing)
prob = ODEProblem(f!, [0.0], (0.0, 1.0))
# Cripple Newton so it never converges → force_stepfail = true → handle_force_stepfail! → infinite recursion.
solve(prob, QNDF(; nlsolve = NLNewton(; max_iter = 1, κ = 1e-30)); dt = 0.5)
```

- **Before:** `StackOverflowError` on the first failed Newton step.
- **After:** `retcode = Unstable` (the solver gives up cleanly when dt shrinks below `dtmin`, which is the correct behavior with a deliberately-broken Newton solver).

## Verification

- New regression test added to `lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl` (`@testset "QNDF Newton failure does not StackOverflow (#3645)"`).
- Full `OrdinaryDiffEqBDF` Core test suite: **32/32 BDF Regression Tests pass**, all DAE + Convergence + Inference tests green on Julia 1.12.6.
- Runic format check clean.

## Note

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)