### PR TITLE
docs: fix unresolved @refs in controllers.md (master docs build)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,10 @@
 using Documenter, OrdinaryDiffEq, DiffEqDevTools
 using OrdinaryDiffEqCore
+# Bring controller API symbols into Main so unqualified @ref links in
+# docs/src/api/controllers.md resolve. These are not exported by
+# OrdinaryDiffEqCore but are documented public API.
+using OrdinaryDiffEqCore: default_controller, resolve_basic,
+                          get_EEst, set_EEst!, CompositeController
 using ImplicitDiscreteSolve
 using OrdinaryDiffEqAMF
 using OrdinaryDiffEqAdamsBashforthMoulton


### PR DESCRIPTION
## Summary

The Documentation workflow has been failing on master with five
`Cannot resolve @ref ... No docstring found in doc for binding Main.X`
errors, followed by `makedocs encountered an error [:cross_references]`,
since #3638 added \`docs/src/api/controllers.md\`.

Failing references:

- \`default_controller\`
- \`resolve_basic\`
- \`get_EEst\`
- \`set_EEst!\`
- \`CompositeController\`

These are documented public API on OrdinaryDiffEqCore but are not
exported, so \`using OrdinaryDiffEqCore\` does not put them in \`Main\`,
and Documenter's unqualified \`[X](@ref)\` resolution against \`Main.X\`
fails. (\`CommonControllerOptions\`, \`PIController\`, etc. happen to
resolve because of how Documenter matches by docstring binding for
types that are reachable via the documented module list — the
functions in the failing set don't get the same treatment.)

The fix is a one-line \`using OrdinaryDiffEqCore: ...\` in
\`docs/make.jl\` for the five symbols. The @docs blocks in
\`controllers.md\` are unchanged — they already use the qualified
\`OrdinaryDiffEqCore.X\` form.

## Investigation

- Run that observed the failure on master:
  https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/25988549916
  (and on every Documentation run since #3638).
- The bisected commit that introduced the failure is 9f28b38d16
  (\"Docs: Controller API reference page\", #3638).
- I did not rebuild docs locally end-to-end (the docs environment is
  expensive to instantiate); the fix is verified by matching
  Documenter's @ref resolution rules against the docstring locations.

## Test plan

- [ ] CI Documentation workflow goes green.

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)