### PR TITLE
Bump sublib versions for release

### DIFF
--- a/lib/OrdinaryDiffEqExplicitTableaus/Project.toml
+++ b/lib/OrdinaryDiffEqExplicitTableaus/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExplicitTableaus"
 uuid = "3278f1b1-0f5c-4cde-98e0-ba5eb00db955"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.0"
+version = "2.0.1"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/OrdinaryDiffEqImplicitTableaus/Project.toml
+++ b/lib/OrdinaryDiffEqImplicitTableaus/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqImplicitTableaus"
 uuid = "75f66a49-58fc-43e3-9173-2340726368f7"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.0"
+version = "2.0.1"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/OrdinaryDiffEqSDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqSDIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSDIRK"
 uuid = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.3.0"
+version = "2.4.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqSIMDRK/Project.toml
+++ b/lib/OrdinaryDiffEqSIMDRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSIMDRK"
 uuid = "dc97f408-7a72-40e4-9b0d-228a53b292f8"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Elrod <elrodc@gmail.com>"]
-version = "2.0.0"
+version = "2.0.1"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqTsit5/Project.toml
+++ b/lib/OrdinaryDiffEqTsit5/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqTsit5"
 uuid = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.0.0"
+version = "2.0.1"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"


### PR DESCRIPTION
## Summary
Bump versions on sublibs with unreleased code in master so they can be registered.

- `OrdinaryDiffEqExplicitTableaus`: 2.0.0 → 2.0.1 (patch) — only change since registration is the compat revert in cfb94cd95.
- `OrdinaryDiffEqImplicitTableaus`: 2.0.0 → 2.0.1 (patch) — same revert.
- `OrdinaryDiffEqSDIRK`: 2.3.0 → **2.4.0** (minor) — CFNLIRK3 migrated to ESDIRKIMEX tableau form (#3651), unified `calculate_error_estimate!` (#3650), `@generated perform_step!` regression fix (#3643).
- `OrdinaryDiffEqSIMDRK`: 2.0.0 → 2.0.1 (patch) — single test-file update in b3c6a83fa.
- `OrdinaryDiffEqTsit5`: 2.0.0 → 2.0.1 (patch) — compat reverts only.

`OrdinaryDiffEqBDF` is already at 2.1.1 on master (registered: 2.1.0) — will be registered after this merges.

## Release plan
After merge, comment one Registrator trigger per sublib on the merge commit:
- @JuliaRegistrator register subdir="lib/OrdinaryDiffEqBDF"
- @JuliaRegistrator register subdir="lib/OrdinaryDiffEqExplicitTableaus"
- @JuliaRegistrator register subdir="lib/OrdinaryDiffEqImplicitTableaus"
- @JuliaRegistrator register subdir="lib/OrdinaryDiffEqSDIRK"
- @JuliaRegistrator register subdir="lib/OrdinaryDiffEqSIMDRK"
- @JuliaRegistrator register subdir="lib/OrdinaryDiffEqTsit5"

## Test plan
- [ ] CI green on this PR
- [ ] Verify TagBot creates the 6 corresponding GitHub releases after registry merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)