### PR TITLE
Tag lib/ subpackages via TagBot matrix

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,15 +1,106 @@
 name: TagBot
+
 on:
   issue_comment:
     types:
       - created
   workflow_dispatch:
+    inputs:
+      lookback:
+        default: "3"
+
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
+
 jobs:
-  TagBot:
+  TagBot-OrdinaryDiffEq:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
-      - uses: JuliaRegistries/TagBot@v1
+      - name: Tag OrdinaryDiffEq
+        uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}
+
+  TagBot-Subpackages:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - DelayDiffEq
+          - DiffEqBase
+          - DiffEqDevTools
+          - ImplicitDiscreteSolve
+          - OrdinaryDiffEqAMF
+          - OrdinaryDiffEqAdamsBashforthMoulton
+          - OrdinaryDiffEqBDF
+          - OrdinaryDiffEqCore
+          - OrdinaryDiffEqDefault
+          - OrdinaryDiffEqDifferentiation
+          - OrdinaryDiffEqExplicitRK
+          - OrdinaryDiffEqExplicitTableaus
+          - OrdinaryDiffEqExponentialRK
+          - OrdinaryDiffEqExtrapolation
+          - OrdinaryDiffEqFIRK
+          - OrdinaryDiffEqFeagin
+          - OrdinaryDiffEqFunctionMap
+          - OrdinaryDiffEqHighOrderRK
+          - OrdinaryDiffEqIMEXMultistep
+          - OrdinaryDiffEqImplicitTableaus
+          - OrdinaryDiffEqLinear
+          - OrdinaryDiffEqLowOrderRK
+          - OrdinaryDiffEqLowStorageRK
+          - OrdinaryDiffEqMultirate
+          - OrdinaryDiffEqNewmark
+          - OrdinaryDiffEqNonlinearSolve
+          - OrdinaryDiffEqNordsieck
+          - OrdinaryDiffEqPDIRK
+          - OrdinaryDiffEqPRK
+          - OrdinaryDiffEqQPRK
+          - OrdinaryDiffEqRKIP
+          - OrdinaryDiffEqRKN
+          - OrdinaryDiffEqRosenbrock
+          - OrdinaryDiffEqRosenbrockTableaus
+          - OrdinaryDiffEqSDIRK
+          - OrdinaryDiffEqSIMDRK
+          - OrdinaryDiffEqSSPRK
+          - OrdinaryDiffEqStabilizedIRK
+          - OrdinaryDiffEqStabilizedRK
+          - OrdinaryDiffEqSymplecticRK
+          - OrdinaryDiffEqTaylorSeries
+          - OrdinaryDiffEqTsit5
+          - OrdinaryDiffEqVerner
+          - SimpleImplicitDiscreteSolve
+          - StochasticDiffEq
+          - StochasticDiffEqCore
+          - StochasticDiffEqHighOrder
+          - StochasticDiffEqIIF
+          - StochasticDiffEqImplicit
+          - StochasticDiffEqLeaping
+          - StochasticDiffEqLevyArea
+          - StochasticDiffEqLowOrder
+          - StochasticDiffEqMilstein
+          - StochasticDiffEqROCK
+          - StochasticDiffEqRODE
+          - StochasticDiffEqWeak
+    steps:
+      - name: Tag ${{ matrix.package }}
+        uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}
+          subdir: "lib/${{ matrix.package }}"


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

## Summary

Mirrors the NonlinearSolve.jl TagBot setup so each registered subpackage under `lib/` gets its own git tag/release when it's registered. Today the monorepo only carries the top-level `OrdinaryDiffEq` tag (`v7.0.0`, etc.), and there are no tags for any of the 56 subpackages in `lib/` — which makes diffing between versions of, say, `OrdinaryDiffEqCore` or `StochasticDiffEq` tedious (currently requires `git blame` on each `Project.toml` version bump, then scrolling through non-squashed commits).

## Background

From [Slack discussion](https://julialang.slack.com/) with Joshua Lampert and Hendrik Ranocha:

> Joshua: I maintain several packages [which] heavily depend on subpackages of OrdinaryDiffEq.jl and I often see myself trying to debug failing CI in the packages I maintain, which come from changes in OrdinaryDiffEq.jl. For this I often want to check diffs between versions of subpackages [...] However, due to OrdinaryDiffEq.jl being a monorepo, [...] there are no Git tags or releases of the subpackages I can use [...] Therefore, I usually navigate on GitHub into the subpackage I'm interesting in and check the commit history.

NonlinearSolve.jl already does this (see `.github/workflows/TagBot.yml` there); Chris confirmed it should be easy to copy the pattern here and chose to keep merge commits (not squash) so bisecting performance regressions to individual commits still works.

## What this PR does

- Splits `TagBot.yml` into two jobs:
  - `TagBot-OrdinaryDiffEq` — tags the top-level package (existing behavior, just renamed).
  - `TagBot-Subpackages` — a matrix job that calls `JuliaRegistries/TagBot@v1` once per subpackage with `subdir: lib/<package>`, the same mechanism NonlinearSolve.jl uses.
- Adds the standard explicit `permissions:` block and `workflow_dispatch.inputs.lookback` knob copied from the NonlinearSolve.jl workflow.
- The matrix lists all 56 directories under `lib/`. Verified each has a `name`/`uuid`/`version` in its `Project.toml`. The matrix is exactly `ls lib/` (verified via `comm`).

## Notes

- `fail-fast: false` so one subpackage failing to tag doesn't cancel the others.
- This only affects *future* registrations — TagBot will start emitting `<Subpackage>-vX.Y.Z` tags from the next registration of each subpackage. It will not retroactively tag previously-registered versions.
- Three historical standalone repos (`SciML/DiffEqBase.jl`, `SciML/StochasticDiffEq.jl`, `SciML/DelayDiffEq.jl`) are already archived, so tagging them here from `lib/` is safe — there's no other home to conflict with.

## Test plan

- [ ] Workflow YAML parses (verified locally with `yaml.safe_load`).
- [ ] Manually trigger `workflow_dispatch` after merge and confirm no errors when there's nothing to tag.
- [ ] Confirm the next subpackage registration produces a `<Subpackage>-vX.Y.Z` tag on the monorepo.