### PR TITLE
Add tableau embedded-pair consistency test for adaptive SDIRK/ESDIRK

### DIFF
--- a/lib/OrdinaryDiffEqSDIRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/runtests.jl
@@ -15,5 +15,6 @@ if (TEST_GROUP == "QA" || TEST_GROUP == "ALL") && isempty(VERSION.prerelease)
     activate_qa_env()
 end
 
+@time @safetestset "Tableau consistency" include("tableau_consistency_tests.jl")
 @time @safetestset "Convergence" include("sdirk_convergence_tests.jl")
 @time @safetestset "DAE tests" include("dae_esdirk_test.jl")

--- a/lib/OrdinaryDiffEqSDIRK/test/tableau_consistency_tests.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/tableau_consistency_tests.jl
@@ -3,20 +3,21 @@ using Test
 
 const SDIRK = OrdinaryDiffEqSDIRK
 
-# A valid embedded pair has sum(bi) = sum(b̂i) = 1, hence sum(btilde) = 0.
-adaptive_algs = [
-    KenCarp3(), KenCarp4(), KenCarp5(), KenCarp47(), KenCarp58(),
-    Kvaerno3(), Kvaerno4(), Kvaerno5(),
-    ESDIRK54I8L2SA(), ESDIRK436L2SA2(), ESDIRK437L2SA(), ESDIRK547L2SA2(),
-    ESDIRK659L2SA(),
-    Hairer4(), Hairer42(), SDIRK2(), Cash4(), TRBDF2(),
+all_algs = [
+    ImplicitEuler(), ImplicitMidpoint(), Trapezoid(), TRBDF2(), SDIRK2(),
+    Kvaerno3(), KenCarp3(), Cash4(), Hairer4(), Hairer42(), SSPSDIRK2(),
+    Kvaerno4(), Kvaerno5(), KenCarp4(), KenCarp47(), KenCarp5(), KenCarp58(),
+    ESDIRK54I8L2SA(), SFSDIRK4(), SFSDIRK5(), SFSDIRK6(), SFSDIRK7(), SFSDIRK8(),
+    ESDIRK436L2SA2(), ESDIRK437L2SA(), ESDIRK547L2SA2(), ESDIRK659L2SA(),
+    CFNLIRK3(), ARS343(),
 ]
 
 @testset "Tableau embedded-pair consistency" begin
-    for alg in adaptive_algs
+    for alg in all_algs
         tab = SDIRK.ESDIRKIMEXTableau(alg, Float64, Float64)
         @testset "$(nameof(typeof(alg)))" begin
             @test isapprox(sum(tab.bi), 1; atol = 1e-9)
+            isempty(tab.btilde) && continue
             if alg isa ESDIRK659L2SA
                 @test_broken isapprox(sum(tab.btilde), 0; atol = 1e-9)  # #3659
             else

--- a/lib/OrdinaryDiffEqSDIRK/test/tableau_consistency_tests.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/tableau_consistency_tests.jl
@@ -1,0 +1,27 @@
+using OrdinaryDiffEqSDIRK
+using Test
+
+const SDIRK = OrdinaryDiffEqSDIRK
+
+# A valid embedded pair has sum(bi) = sum(b̂i) = 1, hence sum(btilde) = 0.
+adaptive_algs = [
+    KenCarp3(), KenCarp4(), KenCarp5(), KenCarp47(), KenCarp58(),
+    Kvaerno3(), Kvaerno4(), Kvaerno5(),
+    ESDIRK54I8L2SA(), ESDIRK436L2SA2(), ESDIRK437L2SA(), ESDIRK547L2SA2(),
+    ESDIRK659L2SA(),
+    Hairer4(), Hairer42(), SDIRK2(), Cash4(), TRBDF2(),
+]
+
+@testset "Tableau embedded-pair consistency" begin
+    for alg in adaptive_algs
+        tab = SDIRK.ESDIRKIMEXTableau(alg, Float64, Float64)
+        @testset "$(nameof(typeof(alg)))" begin
+            @test isapprox(sum(tab.bi), 1; atol = 1e-9)
+            if alg isa ESDIRK659L2SA
+                @test_broken isapprox(sum(tab.btilde), 0; atol = 1e-9)  # #3659
+            else
+                @test isapprox(sum(tab.btilde), 0; atol = 1e-9)
+            end
+        end
+    end
+end


### PR DESCRIPTION
## Summary
- Adds `tableau_consistency_tests.jl`: asserts `sum(bi) ≈ 1` and `sum(btilde) ≈ 0` for every adaptive SDIRK/ESDIRK method (the embedded-pair invariant `sum(b) = sum(b̂) = 1`).
- Catches the class of transcription error that silently breaks adaptive step-size control.
- `ESDIRK659L2SA` is `@test_broken` pending the coefficient fix tracked in #3659.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
