### PR TITLE
Fix ESDIRK659L2SA embedded coefficients so adaptive solves work (#3659)

### DIFF
--- a/lib/OrdinaryDiffEqSDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqSDIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSDIRK"
 uuid = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.5.0"
+version = "2.5.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqSDIRK/src/sdirk_tableaus.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/sdirk_tableaus.jl
@@ -2187,15 +2187,15 @@ function ESDIRK659L2SATableau(::Type{T}, ::Type{T2}) where {T, T2}
     c7 = convert(T2, 81796628710131 // 911762868125288)
     c8 = convert(T2, 97 // 100)
     c9 = convert(T2, 1)
-    btilde1 = convert(T, 0.036418002807163403)
+    btilde1 = convert(T, 204006714482445 // 253120897457864)
     btilde2 = convert(T, 0)
-    btilde3 = convert(T, 0.049747916989695301)
-    btilde4 = convert(T, -0.039556130113697963)
-    btilde5 = convert(T, 0.043307354544533494)
-    btilde6 = convert(T, 0.027945068216436289)
-    btilde7 = convert(T, -0.084785557158034153)
-    btilde8 = convert(T, -0.043850564548362114)
-    btilde9 = convert(T, 0.01077390926225627)
+    btilde3 = convert(T, 818062434310719 // 743038324242217)
+    btilde4 = a94 - convert(T, 1376520686137389 // 1064235527052079)
+    btilde5 = a95 - convert(T, -574817982095666 // 1374329821545869)
+    btilde6 = a96 - convert(T, -507643245828272 // 1001056758847831)
+    btilde7 = a97 - convert(T, 2013538191006793 // 972919262949000)
+    btilde8 = a98 - convert(T, 352681731710820 // 726444701718347)
+    btilde9 = convert(T, 1602386750057009 // 6720377925948840)
     return ESDIRK659L2SATableau(
         γ,
         a31, a32,

--- a/lib/OrdinaryDiffEqSDIRK/src/sdirk_tableaus.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/sdirk_tableaus.jl
@@ -2187,15 +2187,15 @@ function ESDIRK659L2SATableau(::Type{T}, ::Type{T2}) where {T, T2}
     c7 = convert(T2, 81796628710131 // 911762868125288)
     c8 = convert(T2, 97 // 100)
     c9 = convert(T2, 1)
-    btilde1 = convert(T, 204006714482445 // 253120897457864)
+    btilde1 = convert(T, 0.036418002807163403)
     btilde2 = convert(T, 0)
-    btilde3 = convert(T, 818062434310719 // 743038324242217)
-    btilde4 = convert(T, -4352947315360352 // 1695885076290837)
-    btilde5 = convert(T, 4343240072384756 // 4531602892210441)
-    btilde6 = convert(T, 3512964806614449 // 5680260981303268)
-    btilde7 = convert(T, -8547437843719087 // 4555265955453704)
-    btilde8 = convert(T, -6600542869175559 // 6801491069014681)
-    btilde9 = convert(T, 1602386750057009 // 6720377925948840)
+    btilde3 = convert(T, 0.049747916989695301)
+    btilde4 = convert(T, -0.039556130113697963)
+    btilde5 = convert(T, 0.043307354544533494)
+    btilde6 = convert(T, 0.027945068216436289)
+    btilde7 = convert(T, -0.084785557158034153)
+    btilde8 = convert(T, -0.043850564548362114)
+    btilde9 = convert(T, 0.01077390926225627)
     return ESDIRK659L2SATableau(
         γ,
         a31, a32,

--- a/lib/OrdinaryDiffEqSDIRK/test/tableau_consistency_tests.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/tableau_consistency_tests.jl
@@ -18,11 +18,7 @@ all_algs = [
         @testset "$(nameof(typeof(alg)))" begin
             @test isapprox(sum(tab.bi), 1; atol = 1e-9)
             isempty(tab.btilde) && continue
-            if alg isa ESDIRK659L2SA
-                @test_broken isapprox(sum(tab.btilde), 0; atol = 1e-9)  # #3659
-            else
-                @test isapprox(sum(tab.btilde), 0; atol = 1e-9)
-            end
+            @test isapprox(sum(tab.btilde), 0; atol = 1e-9)
         end
     end
 end


### PR DESCRIPTION
## Summary

Fixes #3659. `ESDIRK659L2SA` adaptive solves were running to `MaxIters` because the embedded `btilde` coefficients were inconsistent (`sum(btilde) ≠ 0`), breaking the error estimator while leaving the main order-6 method itself correct.

This PR replaces the embedded pair with a derived minimum-norm order-5 embedded solution satisfying the full order conditions for the fixed `(A,c)` tableau. The primary method (`A`, `b`) is unchanged; only the adaptive error estimate is corrected.

## Verification

* Issue repro now returns `retcode=Success` with sane adaptive step counts
* Fixed-step convergence unchanged (order ≈ 6)
* Error scales monotonically with tolerance
* Stiff van der Pol (`μ=1000`) adaptive solves behave normally again
* `tableau_consistency_tests.jl`: `47/47` pass (`ESDIRK659L2SA` moved from `@test_broken` to `@test`)

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
