### PR TITLE
Fix Tracker gradient through solve on RecursiveArrayTools v4

### DIFF
--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.5.0"
+version = "7.5.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/DiffEqBase/ext/DiffEqBaseTrackerExt.jl
+++ b/lib/DiffEqBase/ext/DiffEqBaseTrackerExt.jl
@@ -3,6 +3,7 @@ module DiffEqBaseTrackerExt
 using DiffEqBase
 import DiffEqBase: value
 import Tracker
+import RecursiveArrayTools
 
 # Support adaptive with non-tracked time
 @inline function DiffEqBase.ODE_DEFAULT_NORM(u::Tracker.TrackedArray, t)
@@ -107,6 +108,18 @@ Tracker.@grad function DiffEqBase.solve_up(
         SciMLBase.TrackerOriginator(), args...; kwargs...
     )
 
+    # `AbstractVectorOfArray` (parent of `ODESolution`) became
+    # `<: AbstractArray` in RecursiveArrayTools v4. The generic
+    # `sol isa AbstractArray` branch below then returns the nested
+    # `Vector{Vector{Float64}}` in `sol.u` directly, which Tracker tracks
+    # as a `TrackedVector{Vector{Float64}, …}`. `sum` on that reduces the
+    # outer vector element-wise and yields a `Vector{Float64}` instead of
+    # a scalar, breaking `Tracker.gradient(loss, p)` callers with
+    # "Function output is not scalar". Stack into a real matrix so
+    # downstream Tracker reductions behave the same as on RAT v3.
+    if sol isa RecursiveArrayTools.AbstractVectorOfArray
+        return Array(sol), pb_f
+    end
     if sol isa AbstractArray
         !hasfield(typeof(sol), :u) && return sol, pb_f # being safe here
         return sol.u, pb_f # AbstractNoTimeSolution isa AbstractArray


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## Summary

Fixes the Tracker outer-AD gradient failures tracked in
[SciMLSensitivity.jl#1331](https://github.com/SciML/SciMLSensitivity.jl/issues/1331). The issue was filed as "Tracker tests fail on Julia 1.12+", but bisecting the actual failure shows the trigger is the `RecursiveArrayTools` major version bump, not Julia.

In RAT v4, `AbstractVectorOfArray <: AbstractArray`, so the generic `sol isa AbstractArray` branch in the Tracker `@grad function DiffEqBase.solve_up` now matches `ODESolution` and returns the nested `sol.u` — a `Vector{Vector{Float64}}`. Tracker tracks that vector-of-vectors directly, and downstream `sum(solve(...))` reduces the outer vector element-wise into a `Vector{Float64}`, so `Tracker.gradient(loss, p)` trips its `losscheck` with `"Function output is not scalar"`.

On RAT v3, `AbstractVectorOfArray` was not an `AbstractArray`, so the same code path fell through to `convert(AbstractArray, sol)`, which RAT v3 implemented as `stack(VA.u)` — a flat `Matrix{Float64}`. That matrix tracked correctly and `sum` reduced to a scalar.

## Fix

Detect `AbstractVectorOfArray` first in the Tracker `@grad` and `Array(sol)` (i.e. `stack(sol.u)`) it before handing the value to Tracker. This restores the pre-RAT-v4 behavior with no changes to the API.

```julia
if sol isa RecursiveArrayTools.AbstractVectorOfArray
    return Array(sol), pb_f
end
```

`RecursiveArrayTools` is already a direct `[deps]` of `DiffEqBase` (compat `"4"`), so no compat changes are needed.

## Repro

On the current package set (Julia 1.12.6, Tracker 0.2.38, RAT 4.3.0, SciMLSensitivity master):

```julia
using SciMLSensitivity, OrdinaryDiffEq
import Tracker

function fiip(du, u, p, t)
    du[1] = p[1]*u[1] - p[2]*u[1]*u[2]
    du[2] = -p[3]*u[2] + p[4]*u[1]*u[2]
end
prob = ODEProblem(fiip, [1.0, 1.0], (0.0, 10.0), [1.5, 1.0, 3.0, 1.0])

loss = p -> sum(solve(prob, Tsit5(); p, saveat=0.1,
                      abstol=1e-10, reltol=1e-10,
                      sensealg=InterpolatingAdjoint()))

Tracker.gradient(loss, [1.5, 1.0, 3.0, 1.0])
# ERROR: Function output is not scalar
```

With this PR all five originally-failing tests in SciMLSensitivity's `test/concrete_solve_derivatives.jl` (`save_idxs`, `save_everystep=false`, non-integer `saveat=2.3`, `VecOfArray`, `BouncingBall`) pass with `@test_broken false; continue` guards removed.

## Test plan
- [ ] Existing DiffEqBase tests pass.
- [ ] Follow-up PR in SciMLSensitivity.jl removes the `@test_broken false` Tracker guards in `test/concrete_solve_derivatives.jl` and the originally-failing tests pass.