### PR TITLE
Fix Tracker gradient on RAT v4 by preserving the ODESolution wrapper

### DIFF
--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.5.0"
+version = "7.5.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/DiffEqBase/ext/DiffEqBaseTrackerExt.jl
+++ b/lib/DiffEqBase/ext/DiffEqBaseTrackerExt.jl
@@ -108,21 +108,11 @@ Tracker.@grad function DiffEqBase.solve_up(
         SciMLBase.TrackerOriginator(), args...; kwargs...
     )
 
-    # In RecursiveArrayTools v4 `AbstractVectorOfArray <: AbstractArray`,
-    # so the `sol isa AbstractArray` branch below now matches ODESolution and
-    # returns the nested `Vector{Vector{Float64}}` in `sol.u`. Downstream
-    # `sum(solve(...))` then reduces the outer vector element-wise and Tracker
-    # errors with "Function output is not scalar". Return the wrapper itself
-    # so the caller's reduction goes through the RAT v4 AbstractArray
-    # interface and produces a scalar as before.
-    if sol isa RecursiveArrayTools.AbstractVectorOfArray
-        return sol, pb_f
-    end
     if sol isa AbstractArray
         !hasfield(typeof(sol), :u) && return sol, pb_f # being safe here
         return sol.u, pb_f # AbstractNoTimeSolution isa AbstractArray
     end
-    return convert(AbstractArray, sol), pb_f
+    return sol, pb_f
 end
 
 end

--- a/lib/DiffEqBase/ext/DiffEqBaseTrackerExt.jl
+++ b/lib/DiffEqBase/ext/DiffEqBaseTrackerExt.jl
@@ -3,6 +3,7 @@ module DiffEqBaseTrackerExt
 using DiffEqBase
 import DiffEqBase: value
 import Tracker
+import RecursiveArrayTools
 
 # Support adaptive with non-tracked time
 @inline function DiffEqBase.ODE_DEFAULT_NORM(u::Tracker.TrackedArray, t)
@@ -107,6 +108,16 @@ Tracker.@grad function DiffEqBase.solve_up(
         SciMLBase.TrackerOriginator(), args...; kwargs...
     )
 
+    # In RecursiveArrayTools v4 `AbstractVectorOfArray <: AbstractArray`,
+    # so the `sol isa AbstractArray` branch below now matches ODESolution and
+    # returns the nested `Vector{Vector{Float64}}` in `sol.u`. Downstream
+    # `sum(solve(...))` then reduces the outer vector element-wise and Tracker
+    # errors with "Function output is not scalar". Return the wrapper itself
+    # so the caller's reduction goes through the RAT v4 AbstractArray
+    # interface and produces a scalar as before.
+    if sol isa RecursiveArrayTools.AbstractVectorOfArray
+        return sol, pb_f
+    end
     if sol isa AbstractArray
         !hasfield(typeof(sol), :u) && return sol, pb_f # being safe here
         return sol.u, pb_f # AbstractNoTimeSolution isa AbstractArray


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Summary

Re-take on the Tracker + RAT v4 fix after the original #3663 was reverted in #3664. Same root cause, different correct shape.

In RecursiveArrayTools v4, `AbstractVectorOfArray <: AbstractArray`, so the `sol isa AbstractArray` branch in `Tracker.@grad function DiffEqBase.solve_up` now matches ODESolution and returns the nested `sol.u :: Vector{Vector{Float64}}` directly. Tracker tracks the vector-of-vectors, and downstream `sum(solve(...))` reduces the outer vector element-wise into a `Vector{Float64}`, breaking `Tracker.gradient(loss, p)` callers with `"Function output is not scalar"`.

The previous fix (#3663) stacked the data into a fresh `Matrix{Float64}` via `Array(sol)`. That changed the return type of `solve(...)` from a wrapper to a matrix and broke downstream consumers — hence the revert in #3664. This PR returns the ODESolution wrapper itself for `AbstractVectorOfArray` inputs, so callers reduce through the RAT v4 AbstractArray interface and produce a scalar without losing the solution type.

## Verification

Local on Julia 1.12.6 + RAT 4.3.0 + Tracker 0.2.38 + SciMLSensitivity master, with DiffEqBase 7.5.1 from this branch:

| Pattern | Result |
|---|---|
| `sum(solve(remake(prob; p), Tsit5()))` | scalar gradient ✓ |
| `sum(solve(...; save_idxs = [1]))` | scalar gradient ✓ |
| `sum(solve(...; save_everystep = false))` | scalar gradient ✓ |
| `sum(solve(...; saveat = 2.3))` | scalar gradient ✓ |

The five `@test_broken false` guards in `test/concrete_solve_derivatives.jl` (lines 518, 548, 579, 611, 735) on SciMLSensitivity are slated for removal in SciML/SciMLSensitivity.jl#1452, gated on this PR landing.

## Refs

- SciML/SciMLSensitivity.jl#1331 — original Tracker-on-1.12 issue (misattributed; the real cause is RAT v4 not 1.12)
- #3663 — first attempt (Array(sol) — wrong shape)
- #3664 — revert
- SciML/SciMLSensitivity.jl#1452 — companion that removes the `@test_broken` guards

## Test plan
- [x] All 4 Tracker patterns produce scalar gradients locally
- [x] Comment on `solve_up @grad` updated to explain RAT v4 semantics
- [ ] CI green