### PR TITLE
Restore AbstractVectorOfArray branch in Tracker @grad (RAT v4)

### DIFF
--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.5.4"
+version = "7.5.5"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/DiffEqBase/ext/DiffEqBaseTrackerExt.jl
+++ b/lib/DiffEqBase/ext/DiffEqBaseTrackerExt.jl
@@ -108,6 +108,16 @@ Tracker.@grad function DiffEqBase.solve_up(
         SciMLBase.TrackerOriginator(), args...; kwargs...
     )
 
+    # In RecursiveArrayTools v4 `AbstractVectorOfArray <: AbstractArray`, so
+    # the `sol isa AbstractArray` branch below now matches ODESolution and
+    # returns the nested `Vector{Vector{Float64}}` in `sol.u`. Downstream
+    # `sum(solve(...))` then reduces the outer vector element-wise and Tracker
+    # errors with "Function output is not scalar". Return the wrapper itself
+    # for AbstractVectorOfArray so the caller's reduction goes through the
+    # RAT v4 AbstractArray interface and produces a scalar as before.
+    if sol isa RecursiveArrayTools.AbstractVectorOfArray
+        return sol, pb_f
+    end
     if sol isa AbstractArray
         !hasfield(typeof(sol), :u) && return sol, pb_f # being safe here
         return sol.u, pb_f # AbstractNoTimeSolution isa AbstractArray


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Follow-up to #3665, which was merged with the critical fix line accidentally dropped during review. With DiffEqBase 7.5.1 (released from #3665 at 2026-05-21T14:08Z), `Tracker.gradient(p -> sum(solve(prob; p)), p0)` still errors with `"Function output is not scalar"` on Julia 1.12+ — i.e. the original bug from SciML/SciMLSensitivity.jl#1331 is *not* actually fixed.

## What happened

PR #3665 ended up making only one effective change to `DiffEqBaseTrackerExt.jl`:

```diff
- return convert(AbstractArray, sol), pb_f
+ return sol, pb_f
```

That line is the *fallback* — it's unreachable for an `ODESolution` because the earlier branch:

```julia
if sol isa AbstractArray
    !hasfield(typeof(sol), :u) && return sol, pb_f
    return sol.u, pb_f
end
```

fires first. Under RecursiveArrayTools v4 `AbstractVectorOfArray <: AbstractArray`, so this branch matches `ODESolution`, sees the `u` field, and returns `sol.u :: Vector{Vector{Float64}}`. Tracker tracks the nested vector and downstream `sum(solve(...))` reduces the outer vector element-wise into a `Vector{Float64}`, triggering Tracker's "Function output is not scalar" check.

The original commit on #3665 (`61b0c61`) included the actual fix — a new `if sol isa RecursiveArrayTools.AbstractVectorOfArray; return sol, pb_f; end` branch *before* the `if sol isa AbstractArray` check. The follow-up commit on the same PR (`139911b`, titled "Update DiffEqBaseTrackerExt.jl") then deleted that new branch, leaving only the (unreachable) fallback change.

## Summary
- Restores the `if sol isa AbstractVectorOfArray; return sol, pb_f; end` branch *before* the `if sol isa AbstractArray` check, so `ODESolution` (and any other VoA) goes back unchanged through Tracker.
- Bumps `lib/DiffEqBase/Project.toml` to `7.5.2`.
- The dropped fallback change from #3665 is kept as-is (`return sol, pb_f` instead of `convert(AbstractArray, sol)`).

## Verification
On Julia 1.12.6 / DiffEqBase 7.5.1 + this patch (dev'd locally):

**Smoke MWE** (4/4 pass, all produce scalar tracked gradients):
```
PASS  NamedTuple()                => ([9.02, 1.33] (tracked),)
PASS  (save_idxs = [1],)          => ([9.02, 0.0]  (tracked),)
PASS  (save_everystep = false,)   => ([4.48, 0.37] (tracked),)
PASS  (saveat = 2.3,)             => ([0.0,  0.0]  (tracked),)
```

**SciMLSensitivity `concrete_solve_derivatives.jl` (with `@test_broken false` guards removed per #1452)** — 5/5 previously-broken testsets pass:
```
Test Summary:              | Pass  Total     Time
save_idxs Tests            |    2      2  1m24.3s
save_everystep=false Tests |    2      2  16.4s
Non-integer saveat Tests   |    2      2  28.2s
VecOfArray Derivatives     |    2      2  16.2s
BouncingBall ODE           |    3      3  45.7s
```

Without this patch (released DiffEqBase 7.5.1): all 4 MWE cases fail with `"Function output is not scalar"`; the SciMLSensitivity testsets would fail identically once #1452 unfreezes them.

## Test plan
- [ ] CI green on this PR
- [ ] Tag DiffEqBase 7.5.2
- [ ] Re-run CI on SciML/SciMLSensitivity.jl#1452 against the 7.5.2 release

Refs SciML/SciMLSensitivity.jl#1331, SciML/SciMLSensitivity.jl#1452.