### PR TITLE
Fix/nlsolvealg linsolve propagation

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -52,8 +52,7 @@ function initialize!(
         nlp_params = (tmp, γ, α, tstep, invγdt, method, p, dt, f)
     end
 
-    new_prob = remake(cache.prob, p = nlp_params, u0 = z)
-    cache.cache = init(new_prob, alg.alg; verbose = nlsolver.cache.cache.verbose)
+    SciMLBase.reinit!(cache.cache, z, p = nlp_params)
     return nothing
 end
 


### PR DESCRIPTION
Fix #3564: NonlinearSolveAlg now respects the ODE solver's linsolve choice


## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
