### PR TITLE
DiffEqBaseEnzymeExt: port NS#936/937 fixes (caches walk + alias preserve)

### DIFF
--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.5.1"
+version = "7.5.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -155,4 +155,4 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["DiffEqCallbacks", "Distributed", "Measurements", "Unitful", "FlexUnits", "LabelledArrays", "ForwardDiff", "SparseArrays", "InteractiveUtils", "Pkg", "Random", "RecursiveArrayToolsRaggedArrays","ReverseDiff", "StaticArrays", "SafeTestsets", "Test", "Distributions", "DynamicQuantities", "Aqua"]
+test = ["ChainRulesCore", "DiffEqCallbacks", "Distributed", "Enzyme", "Measurements", "Unitful", "FlexUnits", "LabelledArrays", "ForwardDiff", "SparseArrays", "InteractiveUtils", "Pkg", "Random", "RecursiveArrayToolsRaggedArrays","ReverseDiff", "StaticArrays", "SafeTestsets", "Test", "Distributions", "DynamicQuantities", "Aqua"]

--- a/lib/DiffEqBase/ext/DiffEqBaseEnzymeExt.jl
+++ b/lib/DiffEqBase/ext/DiffEqBaseEnzymeExt.jl
@@ -6,6 +6,7 @@ module DiffEqBaseEnzymeExt
     using Enzyme
     import Enzyme: Const, MixedDuplicated
     using ChainRulesCore
+    import SciMLStructures
 
 
     @inline function copy_or_reuse(config, val, idx)
@@ -19,6 +20,116 @@ module DiffEqBaseEnzymeExt
     @inline function arg_copy(data, i)
         config, args = data
         copy_or_reuse(config, args[i].val, i + 5)
+    end
+
+    # Accumulate a tangent `darg` into a shadow `dval`.
+    # When `dval` is a SciMLStructure (e.g. MTKParameters), `darg` may be:
+    #   - A tunable gradient vector (from SciMLSensitivity's EnzymeOriginator path)
+    #   - Another SciMLStructure
+    #   - A broadcastable array
+    # In all cases, accumulation goes through the SciMLStructures interface.
+    #
+    # `diff_tunables` mirrors the sensealg field of the same name and means
+    # "differentiate only the Tunable portion." When `true` (the default and
+    # the value carried by `QuadratureAdjoint`/`GaussAdjoint`/`InterpolatingAdjoint`
+    # adjoints unless the user opted out) only the Tunable slice of a structured
+    # `darg` is accumulated. When `false`, `SciMLSensitivity.adjointbackpass`
+    # returns a structured cotangent whose gradient contribution may live in
+    # non-Tunable fields such as `caches` (e.g. SCC sub-problem buffers feeding
+    # `explicitfuns!`), so those fields are walked in as well.
+    function _accum_tangent!(dval, darg; diff_tunables::Bool = true)
+        if SciMLStructures.isscimlstructure(dval) && !(dval isa AbstractArray)
+            if SciMLStructures.isscimlstructure(darg)
+                shadow_tunables, _, _ = SciMLStructures.canonicalize(
+                    SciMLStructures.Tunable(), dval,
+                )
+                darg_tunables, _, _ = SciMLStructures.canonicalize(
+                    SciMLStructures.Tunable(), darg,
+                )
+                shadow_tunables .+= darg_tunables
+                SciMLStructures.replace!(SciMLStructures.Tunable(), dval, shadow_tunables)
+                if !diff_tunables
+                    for field in fieldnames(typeof(darg))
+                        field === :tunable && continue
+                        hasfield(typeof(dval), field) || continue
+                        _accum_nested!(getfield(dval, field), getfield(darg, field))
+                    end
+                end
+            elseif darg isa AbstractVector
+                shadow_tunables, _, _ = SciMLStructures.canonicalize(
+                    SciMLStructures.Tunable(), dval,
+                )
+                if length(darg) == length(shadow_tunables)
+                    shadow_tunables .+= darg
+                    SciMLStructures.replace!(
+                        SciMLStructures.Tunable(), dval, shadow_tunables,
+                    )
+                else
+                    dval .+= darg
+                end
+            elseif darg isa NamedTuple
+                # Full parameter gradient from a structured adjoint backpass
+                # (includes caches and other non-tunable components).
+                # Accumulate each matching field into the shadow.
+                for field in fieldnames(typeof(darg))
+                    src = getfield(darg, field)
+                    src === nothing && continue
+                    if hasfield(typeof(dval), field)
+                        dst = getfield(dval, field)
+                        _accum_nested!(dst, src)
+                    end
+                end
+            else
+                dval .+= darg
+            end
+        else
+            dval .+= darg
+        end
+        return nothing
+    end
+
+    # Recursively accumulate nested containers (tuples of arrays, etc.)
+    function _accum_nested!(dst::AbstractArray, src::AbstractArray)
+        dst .+= src
+        return nothing
+    end
+    function _accum_nested!(dst::Tuple, src::Tuple)
+        for (d, s) in zip(dst, src)
+            _accum_nested!(d, s)
+        end
+        return nothing
+    end
+    _accum_nested!(::Any, ::Nothing) = nothing
+    _accum_nested!(::Nothing, ::Any) = nothing
+    _accum_nested!(::Nothing, ::Nothing) = nothing
+
+    # Build the shadow `ODESolution` for the augmented primal. A plain
+    # `Enzyme.make_zero(sol)` recursively allocates fresh zero buffers for every
+    # mutable field of `sol`, including `sol.prob.p` and `sol.prob.u0`, which are
+    # aliased to the active `p` / `u0` shadows the outer caller is differentiating
+    # against. Severing that aliasing means a cotangent written into the returned
+    # `sol.prob.p` field by a downstream consumer (e.g. anything reading the
+    # solution's parameters) goes into a dangling buffer instead of the buffer
+    # the outer Enzyme tape is tracking, silently dropping that gradient
+    # contribution.
+    #
+    # Pre-seed the `make_zero` seen-set so `prob.p` and `prob.u0` map to
+    # themselves: recursion into those fields short-circuits via `haskey(seen, …)`,
+    # preserving aliasing with the outer shadow. The actual derivative-carrying
+    # field (`sol.u`) still gets a fresh zero buffer.
+    @inline function _make_solution_zero(sol)
+        seen = IdDict()
+        _preseed_alias!(seen, sol.prob.p)
+        _preseed_alias!(seen, sol.prob.u0)
+        return Enzyme.make_zero(Core.Typeof(sol), seen, sol, Val(false))
+    end
+
+    @inline _preseed_alias!(::IdDict, ::Nothing) = nothing
+    @inline function _preseed_alias!(seen::IdDict, v)
+        if ismutable(v)
+            seen[v] = v
+        end
+        return nothing
     end
 
     # Note these following functions are generally not considered user facing from within Enzyme.
@@ -52,7 +163,7 @@ module DiffEqBaseEnzymeExt
         end
 
         shadow = if Enzyme.EnzymeRules.needs_shadow(config)
-            Enzyme.make_zero(res[1])::RT
+            _make_solution_zero(res[1])::RT
         else
             nothing
         end
@@ -77,6 +188,28 @@ module DiffEqBaseEnzymeExt
             dres, clos = tape
             dres = dres::RT
             dargs = clos(dres)
+            # Mirror the `diff_tunables` choice the inner adjoint will make. When
+            # the user passes a concrete sensealg, honor its `diff_tunables` field.
+            # When the outer sensealg is `nothing` (default), `_concrete_solve_adjoint`
+            # delegates to `automatic_sensealg_choice`, which picks
+            # `diff_tunables = Val(false)` whenever `prob.p` is a SciMLStructure
+            # with a non-empty `caches` field (e.g. an MTKParameters tied to an
+            # SCCNonlinearProblem's `explicitfuns!` coupling). Reproducing that
+            # predicate here lets the accumulator walk every non-Tunable field of
+            # a structured `darg` so the meaningful cotangent isn't dropped.
+            diff_tunables = let s = sensealg.val, pv = p.val
+                if s isa DiffEqBase.AbstractSensitivityAlgorithm &&
+                        hasproperty(s, :diff_tunables)
+                    !(getproperty(s, :diff_tunables) isa Val{false})
+                else
+                    !(
+                        SciMLStructures.isscimlstructure(pv) &&
+                            !(pv isa AbstractArray) &&
+                            hasfield(typeof(pv), :caches) &&
+                            !isempty(pv.caches)
+                    )
+                end
+            end
             for (darg, ptr) in zip(dargs, (func, prob, sensealg, u0, p, args...))
                 if ptr isa Enzyme.Const
                     continue
@@ -85,9 +218,9 @@ module DiffEqBaseEnzymeExt
                     continue
                 end
                 if ptr isa MixedDuplicated
-                    ptr.dval[] .+= darg
+                    _accum_tangent!(ptr.dval[], darg; diff_tunables)
                 else
-                    ptr.dval .+= darg
+                    _accum_tangent!(ptr.dval, darg; diff_tunables)
                 end
             end
             Enzyme.make_zero!(dres.u)

--- a/lib/DiffEqBase/test/enzyme_accum_tangent.jl
+++ b/lib/DiffEqBase/test/enzyme_accum_tangent.jl
@@ -1,0 +1,60 @@
+module EnzymeAccumTangentTests
+
+using Test
+using DiffEqBase
+import ChainRulesCore, Enzyme  # triggers DiffEqBaseEnzymeExt
+import SciMLStructures
+import SciMLStructures: Tunable
+
+mutable struct MockMTKParams
+    tunable::Vector{Float64}
+    caches::Tuple{Vector{Float64}}
+end
+
+SciMLStructures.isscimlstructure(::MockMTKParams) = true
+SciMLStructures.ismutablescimlstructure(::MockMTKParams) = true
+function SciMLStructures.canonicalize(::Tunable, p::MockMTKParams)
+    return p.tunable, (val) -> MockMTKParams(collect(val), p.caches), true
+end
+function SciMLStructures.replace!(::Tunable, p::MockMTKParams, val)
+    p.tunable .= val
+    return nothing
+end
+
+const EXT = Base.get_extension(DiffEqBase, :DiffEqBaseEnzymeExt)
+
+@testset "EnzymeExt._accum_tangent! gates non-Tunable walk on diff_tunables (NS#936)" begin
+    # Regression for SciML/NonlinearSolve.jl#936 (ported to DiffEqBase). The
+    # reverse rule mirrors `sensealg.diff_tunables` into this kwarg:
+    #
+    #   * `diff_tunables = true`  (default) — backpass returned a
+    #     Tunable-only cotangent; leave non-Tunable fields of any
+    #     structured `darg` alone.
+    #   * `diff_tunables = false` — backpass returned a *structured*
+    #     cotangent (e.g. caches from SCC `explicitfuns!` coupling, or any
+    #     MTKParameters-bound ODE with non-empty caches). Walk every
+    #     non-Tunable field of `darg` into `dval` so the meaningful
+    #     contribution lands.
+
+    # diff_tunables = false: caches must accumulate.
+    dval = MockMTKParams([0.0, 0.0], (zeros(3),))
+    darg = MockMTKParams([1.0, 2.0], ([10.0, 20.0, 30.0],))
+    EXT._accum_tangent!(dval, darg; diff_tunables = false)
+    @test dval.tunable == [1.0, 2.0]
+    @test dval.caches[1] == [10.0, 20.0, 30.0]
+
+    # And `+=` semantics on repeated calls.
+    darg2 = MockMTKParams([0.5, 0.5], ([1.0, 2.0, 3.0],))
+    EXT._accum_tangent!(dval, darg2; diff_tunables = false)
+    @test dval.tunable == [1.5, 2.5]
+    @test dval.caches[1] == [11.0, 22.0, 33.0]
+
+    # diff_tunables = true (default): only Tunable touched.
+    dval2 = MockMTKParams([0.0, 0.0], (zeros(3),))
+    darg3 = MockMTKParams([1.0, 2.0], ([10.0, 20.0, 30.0],))
+    EXT._accum_tangent!(dval2, darg3)
+    @test dval2.tunable == [1.0, 2.0]
+    @test dval2.caches[1] == zeros(3)
+end
+
+end

--- a/lib/DiffEqBase/test/enzyme_make_solution_zero.jl
+++ b/lib/DiffEqBase/test/enzyme_make_solution_zero.jl
@@ -1,0 +1,61 @@
+module EnzymeMakeSolutionZeroTests
+
+using Test
+using DiffEqBase
+import ChainRulesCore, Enzyme  # triggers DiffEqBaseEnzymeExt
+using SciMLBase
+
+const EXT = Base.get_extension(DiffEqBase, :DiffEqBaseEnzymeExt)
+
+@testset "EnzymeExt._make_solution_zero preserves prob.p / prob.u0 aliasing (NS#937)" begin
+    # Regression for SciML/NonlinearSolve.jl#937 (ported to DiffEqBase). The
+    # reverse rule builds the return-value shadow via `make_zero(sol)`.
+    # A plain `Enzyme.make_zero` recursively zeros every mutable field of
+    # `sol`, including `sol.prob.p` and `sol.prob.u0`, which the outer caller
+    # has already registered as active shadows for the `p` / `u0` arguments.
+    # Severing that aliasing means any cotangent written into the returned
+    # `sol.prob.p` (or `.u0`) by a downstream consumer lands in a dangling
+    # buffer instead of the one the outer Enzyme tape is tracking, silently
+    # dropping that gradient contribution.
+    #
+    # `_make_solution_zero` pre-seeds the `make_zero` seen-set with identity
+    # entries for `prob.p` and `prob.u0` so the recursion short-circuits and
+    # the original buffers are reused verbatim in the shadow.
+
+    f(du, u, p, t) = (du .= p .* u; nothing)
+    u0 = [1.0, 1.0]
+    p = [0.5, 0.25]
+    tspan = (0.0, 1.0)
+    prob = ODEProblem(f, u0, tspan, p)
+    sol = SciMLBase.build_solution(
+        prob, nothing, [0.0, 1.0], [copy(u0), copy(u0)];
+        calculate_error = false,
+    )
+
+    # Naive `Enzyme.make_zero` allocates fresh buffers for prob.p / prob.u0.
+    dsol_naive = Enzyme.make_zero(sol)
+    @test objectid(dsol_naive.prob.p) != objectid(sol.prob.p)
+    @test objectid(dsol_naive.prob.u0) != objectid(sol.prob.u0)
+
+    # The extension helper keeps them aliased to the primal.
+    dsol = EXT._make_solution_zero(sol)
+    @test objectid(dsol.prob.p) == objectid(sol.prob.p)
+    @test objectid(dsol.prob.u0) == objectid(sol.prob.u0)
+    @test dsol.prob.p === sol.prob.p
+    @test dsol.prob.u0 === sol.prob.u0
+    # The actual derivative-carrying field (u) is still a fresh zero buffer.
+    @test objectid(dsol.u) != objectid(sol.u)
+    @test all(uu -> all(iszero, uu), dsol.u)
+
+    # Guard the `nothing`/non-mutable path: a problem with `nothing` p
+    # must not crash the pre-seed helper.
+    prob_nop = ODEProblem(f, u0, tspan, SciMLBase.NullParameters())
+    sol_nop = SciMLBase.build_solution(
+        prob_nop, nothing, [0.0, 1.0], [copy(u0), copy(u0)];
+        calculate_error = false,
+    )
+    dsol_nop = EXT._make_solution_zero(sol_nop)
+    @test dsol_nop.prob.u0 === sol_nop.prob.u0
+end
+
+end

--- a/lib/DiffEqBase/test/runtests.jl
+++ b/lib/DiffEqBase/test/runtests.jl
@@ -47,6 +47,10 @@ end
         @time @safetestset "ODE default unstable check" include("ode_default_unstable_check.jl")
         @time @safetestset "Problem Kwargs Merging" include("problem_kwargs_merging.jl")
         @time @safetestset "Verbose Inference" include("verbose_inference.jl")
+        if isempty(VERSION.prerelease)
+            @time @safetestset "EnzymeExt _accum_tangent! caches accumulation (NS#936)" include("enzyme_accum_tangent.jl")
+            @time @safetestset "EnzymeExt _make_solution_zero preserves prob.p/u0 aliasing (NS#937)" include("enzyme_make_solution_zero.jl")
+        end
     end
 
     # QA tests — Aqua quality checks


### PR DESCRIPTION
Please ignore this PR until reviewed by @ChrisRackauckas.

## Summary

The Enzyme reverse rule for `DiffEqBase.solve_up` in `lib/DiffEqBase/ext/DiffEqBaseEnzymeExt.jl` had the same two latent bugs that `NonlinearSolveBaseEnzymeExt` accumulated over the past year on the steady-state / NLLS adjoint path. Both are silent gradient drops, and both fire on the ODE / DDE adjoint as soon as `prob.p` is an MTKParameters carrying non-empty `caches` (anything wired to MTK's `explicitfuns!` SCC coupling or `paraminit`-driven init).

This PR is a direct port of the two NonlinearSolveBase fixes:

* **NS#936** (caches walk): replace the bare `ptr.dval .+= darg` accumulation in the reverse rule with `_accum_tangent!(ptr.dval, darg; diff_tunables)`. The new helper:
  * Goes through `SciMLStructures.canonicalize(Tunable(), …)` / `replace!` when the shadow is a SciMLStructure, so the Tunable slice is accumulated correctly instead of falling back to an undefined element-wise iteration.
  * When `diff_tunables = false`, also walks each non-Tunable field (`caches`, `initials`, `discrete`, `constant`, `nonnumeric`, …) of a structured `darg`. This is exactly what `SciMLSensitivity.adjointbackpass` returns whenever `automatic_sensealg_choice` picks `diff_tunables = Val(false)` (i.e. whenever `prob.p` is a SciMLStructure with non-empty `caches`).
  * The `diff_tunables` value is derived inside the reverse rule the same way NS#936 derives it: honor `sensealg.diff_tunables` when the user passed an explicit sensealg, else mirror `automatic_sensealg_choice`'s predicate on `prob.p`.

* **NS#937** (alias preserve): replace `Enzyme.make_zero(res[1])::RT` in the augmented primal with `_make_solution_zero(res[1])::RT`. The new helper pre-seeds the `make_zero` `IdDict` so `sol.prob.p` and `sol.prob.u0` keep aliasing the outer Enzyme shadows. Without this, recursive `make_zero` allocates fresh buffers for those fields and any cotangent written into the returned `sol.prob.p` by a downstream consumer goes into a dangling buffer instead of the buffer the outer tape is tracking.

The helpers are lifted verbatim from `NonlinearSolveBaseEnzymeExt` (same kwarg name `diff_tunables`, same predicate, same `_accum_nested!` dispatch tree, same `_preseed_alias!` guard). Future fixes to one extension should transplant cleanly to the other.

Reference fixes:
* `NonlinearSolve.jl/lib/NonlinearSolveBase/ext/NonlinearSolveBaseEnzymeExt.jl:25-89` (`_accum_tangent!`)
* `NonlinearSolve.jl/lib/NonlinearSolveBase/ext/NonlinearSolveBaseEnzymeExt.jl:140-153` (`_make_solution_zero`)

`automatic_sensealg_choice` predicate the kwarg derivation mirrors lives in `SciMLSensitivity/src/concrete_solve.jl:136-336`.

## Test plan

New regression tests in `lib/DiffEqBase/test/`:

- [x] `enzyme_accum_tangent.jl` — `MockMTKParams` regression. With the old `.+=` path the caches stay zero; with the new accumulator under `diff_tunables = false` the caches accumulate and `+=` repeated-call semantics hold. With `diff_tunables = true` (default), only Tunable is touched. **6/6 pass.**
- [x] `enzyme_make_solution_zero.jl` — builds an `ODESolution` and verifies `dsol.prob.p === sol.prob.p`, `dsol.prob.u0 === sol.prob.u0`, while `dsol.u` is still a fresh zero buffer. Naive `Enzyme.make_zero` fails the aliasing check (regression guard). Also covers the `NullParameters` / `nothing` path of the pre-seed helper. **9/9 pass.**
- [x] Both testsets are wired into the `Core` group of `lib/DiffEqBase/test/runtests.jl` (gated on `isempty(VERSION.prerelease)`, matching the extension's own gate).
- [x] Full `Pkg.test("DiffEqBase")` on Julia 1.10 — all pre-existing tests still pass alongside the new ones.

## Notes

- End-to-end Enzyme.gradient on a real ODE with MTKParameters + non-empty caches is best verified against the desauty-equivalent reproducer post-merge — that requires a much heavier MTK / SciMLSensitivity setup than is appropriate for this PR's unit-test surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)