### PR TITLE
CI: drop Pkg.Registry.rm/add step and JULIA_PKG_SERVER override

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,11 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     continue-on-error: ${{ matrix.group == 'Downstream' }}
-    env:
-      # Bypass Julia's Pkg server for registry; it lags behind JuliaRegistries/General
-      # by up to hours and caches on a TTL. Resolve against git directly so newly
-      # registered package versions are seen immediately by CI.
-      JULIA_PKG_SERVER: ""
     strategy:
       fail-fast: false
       matrix:
@@ -98,21 +93,6 @@ jobs:
           key: julia-cache;workflow=${{ github.workflow }};job=${{ github.job }};os=${{ runner.os }};group=${{ matrix.group }};version=${{ matrix.version }};run_id=${{ github.run_id }};run_attempt=${{ github.run_attempt }}
           restore-keys: |
             julia-cache;workflow=${{ github.workflow }};job=${{ github.job }};os=${{ runner.os }};group=${{ matrix.group }};version=${{ matrix.version }};
-      - name: Refresh General registry directly from git
-        shell: julia --color=yes --project=. {0}
-        run: |
-          using Pkg
-          # Force a fresh git clone of General to dodge pkg server lag.
-          # Must run BEFORE the Pkg.develop step below: that step's resolve
-          # needs current versions of registered deps (e.g. SciMLBase v3,
-          # CoverageTools), and the cached pkg-server registry is often
-          # several days stale, so develop's resolve fails with "expected
-          # package <X> to be registered".
-          try
-              Pkg.Registry.rm("General")
-          catch
-          end
-          Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/JuliaRegistries/General.git"))
       - name: Develop local path deps (Julia < 1.11)
         shell: julia --color=yes --project=. {0}
         run: |


### PR DESCRIPTION
## Summary

Reverts the two pieces PR #3419 added to `.github/workflows/CI.yml`:
- The job-scope `env: JULIA_PKG_SERVER: \"\"` override (lines 24–28)
- The `Refresh General registry directly from git` step that does `Pkg.Registry.rm(\"General\")` + `Pkg.Registry.add(...git URL...)` (lines 101–115)

#3419 added both as a one-time workaround for SciMLBase v3 having just been registered and not yet propagated to `pkg.julialang.org`. That window has long since closed (SciMLBase v3 has been on the mirror for over a month), so the workaround is now dead weight — and the rm+add step in particular is actively breaking CI.

## Why this fires as CI failures today

Every PR's ~68-cell matrix fans out across the SciML self-hosted runners (multiple instances per physical host: 24 on demeter3, 24 on demeter4, 16 on arctic4, etc). On hosts where Julia's `depots1()` resolves to `/home/chrisrackauckas/.julia` (verified on demeter3 from the pidlock path in failing logs), all N runner instances on that host share **one** `~/.julia/registries/.pid` for Pkg's registry serialization.

68 jobs simultaneously executing `Pkg.Registry.rm(\"General\") ; Pkg.Registry.add(...git clone...)` produces a seconds-to-minutes-long window where the registry tree is missing or partially written. Concurrent jobs that hit the resolve path during that window fail with:

\`\`\`
registry \`General\` not found
expected package CoverageTools [c36e975a] to be registered
SystemError: opening file \".../General/A/ARFFFiles/Package.toml\":
  No such file or directory
\`\`\`

That's exactly the pattern that's been hitting nearly every multi-cell PR (#3672 had 15+ such failures across demeter3/demeter4/deepsea4/arctic4).

## Why this is safe to remove

This brings `CI.yml` in line with the standard SciML test workflow pattern (`setup-julia` → `Pkg.develop` → `julia-buildpkg` → `julia-runtest`, with the default pkg server). Identical structure to `SciML/ModelingToolkit.jl/.github/workflows/Tests.yml` and `SciML/SciMLBase.jl/.github/workflows/Tests.yml`.

If pkg-server lag becomes a problem again for a specific freshly-registered version, the right fix is a single `Pkg.Registry.update(\"General\")` (idempotent, atomic, short pidlock window) rather than rm-and-reclone — *not* what this PR is restoring.

## Test plan

- [ ] CI on this PR is green across the matrix (the change is to CI itself, so the PR's own run is the regression test)
- [ ] Spot-check that demeter3-hosted jobs (lts row tends to land there) no longer show \`registry General not found\` or \`Package.toml: No such file\` errors