### PR TITLE
Bump sublib versions for release

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "3.1.1"
+version = "3.2.0"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 

--- a/lib/OrdinaryDiffEqRosenbrock/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrock/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqRosenbrock"
 uuid = "43230ef6-c299-4910-a778-202eb28ce4ce"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 
 [deps]
@@ -48,7 +48,7 @@ ODEProblemLibrary = "1"
 OrdinaryDiffEqCore = "4"
 OrdinaryDiffEqDifferentiation = "3"
 OrdinaryDiffEqNonlinearSolve = "2"
-OrdinaryDiffEqRosenbrockTableaus = "2"
+OrdinaryDiffEqRosenbrockTableaus = "2.1"
 Pkg = "1"
 PrecompileTools = "1.2, 1.3"
 Preferences = "1.4"

--- a/lib/OrdinaryDiffEqRosenbrockTableaus/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrockTableaus/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqRosenbrockTableaus"
 uuid = "b4bd8bb3-f80f-41d2-9b21-73a655b304b9"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.0"
+version = "2.1.0"
 
 [extras]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqSDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqSDIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSDIRK"
 uuid = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.6.0"
+version = "2.7.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
## Summary

Minor version bumps for sublibs with unreleased source changes since the previous release bump (#3655):

- **OrdinaryDiffEqSDIRK** 2.6.0 → 2.7.0 — inline ESDIRK/IMEX `perform_step` stages, drop `@generated` and `S` type-param (#3676)
- **OrdinaryDiffEqRosenbrock** 2.2.0 → 2.3.0 — new `Rodas4PW` W-method + `derivative_utils` changes for issue #3633 (#3672); pins `OrdinaryDiffEqRosenbrockTableaus` compat to `"2.1"` since `Rodas4PW` depends on the new tableau
- **OrdinaryDiffEqRosenbrockTableaus** 2.0.0 → 2.1.0 — `Rodas4PWTableau` (#3672)
- **OrdinaryDiffEqDifferentiation** 3.1.1 → 3.2.0 — `derivative_utils` changes per issue #3633 (#3672)

No dependent compat bumps needed: existing dependent compats (`"2"`, `"2.5"`, `"3"`) all permit the new minor versions.

## Test plan

- [ ] CI passes on all affected sublibs

🤖 Generated with [Claude Code](https://claude.com/claude-code)