### PR TITLE
DiffEqBaseEnzymeExt: accept any sensealg Annotation (unblocks SciMLSensitivity #1456)

### DIFF
--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.5.1"
+version = "7.5.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/DiffEqBase/ext/DiffEqBaseEnzymeExt.jl
+++ b/lib/DiffEqBase/ext/DiffEqBaseEnzymeExt.jl
@@ -29,14 +29,24 @@ module DiffEqBaseEnzymeExt
 
     Enzyme.EnzymeRules.has_easy_rule(::typeof(DiffEqBase.solve_up), prob, sensalg::Union{Nothing, DiffEqBase.AbstractSensitivityAlgorithm}, u0, p, args...; kwargs...) = nothing
 
+    # `sensealg` is semantically inactive (a configuration token, not a value
+    # whose tangent has meaning), but Enzyme's `set_runtime_activity(Reverse)`
+    # can still promote module-level `const _MTK_SENSEALG = GaussAdjoint(...)`
+    # references — or any sensealg captured in an `ODEProblem` field — to
+    # `Duplicated{<:AbstractSensitivityAlgorithm}` before this rule is matched.
+    # Accept any `Enzyme.Annotation` (Const / Duplicated / MixedDuplicated /
+    # Active) here and read only `sensealg.val`; the shadow has no meaning.
     function Enzyme.EnzymeRules.augmented_primal(
             config::Enzyme.EnzymeRules.RevConfigWidth{1},
             func::Const{typeof(DiffEqBase.solve_up)}, RTA::Union{Type{Duplicated{RT}}, Type{MixedDuplicated{RT}}}, prob,
-            sensealg::Union{
-                Const{Nothing}, Const{<:DiffEqBase.AbstractSensitivityAlgorithm},
-            },
+            sensealg::Enzyme.Annotation,
             u0, p, args...; kwargs...
         ) where {RT}
+        sensealg.val isa Union{Nothing, DiffEqBase.AbstractSensitivityAlgorithm} ||
+            throw(ArgumentError(
+            "DiffEqBaseEnzymeExt: `sensealg` must be `nothing` or " *
+                "`<:AbstractSensitivityAlgorithm`, got $(typeof(sensealg.val))",
+        ))
 
         res = DiffEqBase._solve_adjoint(
             copy_or_reuse(config, prob.val, 2), copy_or_reuse(config, sensealg.val, 3),
@@ -67,9 +77,7 @@ module DiffEqBaseEnzymeExt
     function Enzyme.EnzymeRules.reverse(
             config::Enzyme.EnzymeRules.RevConfigWidth{1},
             func::Const{typeof(DiffEqBase.solve_up)}, ::Union{Type{Duplicated{RT}}, Type{MixedDuplicated{RT}}}, tape, prob,
-            sensealg::Union{
-                Const{Nothing}, Const{<:DiffEqBase.AbstractSensitivityAlgorithm},
-            },
+            sensealg::Enzyme.Annotation,
             u0, p, args...; kwargs...
         ) where {RT}
 
@@ -77,8 +85,14 @@ module DiffEqBaseEnzymeExt
             dres, clos = tape
             dres = dres::RT
             dargs = clos(dres)
+            # `sensealg` is inactive (see augmented_primal note); skip its slot
+            # whether it arrived as Const or as a runtime-activity-promoted
+            # Duplicated/MixedDuplicated/Active.
             for (darg, ptr) in zip(dargs, (func, prob, sensealg, u0, p, args...))
                 if ptr isa Enzyme.Const
+                    continue
+                end
+                if ptr === sensealg
                     continue
                 end
                 if darg == ChainRulesCore.NoTangent()


### PR DESCRIPTION
> [DRAFT — please ignore until reviewed by @ChrisRackauckas]

## Summary

`DiffEqBaseEnzymeExt.augmented_primal` / `reverse` rules on `DiffEqBase.solve_up` were signed for `sensealg::Union{Const{Nothing}, Const{<:AbstractSensitivityAlgorithm}}`. That signature was too narrow: under `Enzyme.set_runtime_activity(Reverse)`, Enzyme can promote a module-level `const _MTK_SENSEALG = GaussAdjoint(...)` reference — or any sensealg captured in an `ODEProblem` field — to `Duplicated{<:AbstractSensitivityAlgorithm}` before the rule is matched. The rule then failed to dispatch and Enzyme fell back to native reverse, producing a `MethodError`.

This loosens both rules to accept any `Enzyme.Annotation` on `sensealg` (Const / Duplicated / MixedDuplicated / Active) and reads only `sensealg.val` inside; the shadow on `sensealg` has no semantic meaning because an `AbstractSensitivityAlgorithm` is a configuration token, not a derivative-carrying value.

## Why this is safe

`SciMLBase` already declares `EnzymeRules.inactive_type(::Type{<:AbstractSensitivityAlgorithm}) = true`, expressing the same semantic. The narrow `Const`-only signature was an unnecessary additional restriction. The body of both rules now skips `sensealg`'s slot when accumulating cotangents, regardless of which annotation it arrived under.

## Reproducer

The `@test_broken` Enzyme block in `SciML/SciMLSensitivity.jl` `test/mtk.jl` calls `solve(prob, Rodas5P(); sensealg = _MTK_SENSEALG, ...)` under `Enzyme.autodiff(set_runtime_activity(Reverse), ..., Duplicated(prob, diprob))`. Before this PR, it failed with `MethodError` on the `solve_up` rule's `sensealg` signature.

After this PR, the rule dispatches and execution proceeds into `_solve_adjoint`. It then hits a separate downstream `MethodError` inside Enzyme's `runtime_generic_augfwd` trying to construct `MixedDuplicated(::ODESolution, ...)` without the required `Base.RefValue{T1}` second argument — the MTK runtime-activity wrapping issue tracked in SciMLSensitivity.jl#1359 / EnzymeAD/Enzyme.jl#3117. That is out of scope here, so the `@test_broken` in #1456 stays broken pending the upstream Enzyme fix.

## Bumps

`DiffEqBase` 7.5.1 → 7.5.2.

## Test plan

- [ ] CI green
- [ ] Confirms `solve_up` Enzyme rule still dispatches under plain `Reverse` (sanity, all existing tests)
- [ ] Manual: focused MWE shows `MethodError` moves from rule dispatch to downstream MTK wrapping (documented above)

Linked: SciML/SciMLSensitivity.jl#1456