### PR TITLE
Bump stale ESDIRK lorenz step-count bounds (fixes #3669)

### DIFF
--- a/test/regression/ode_adaptive_tests.jl
+++ b/test/regression/ode_adaptive_tests.jl
@@ -148,7 +148,7 @@ sol_linear = solve(prob_linear, ESDIRK547L2SA2())
 @test SciMLBase.successful_retcode(sol_linear)
 
 sol_lorenz = solve(prob_lorenz, ESDIRK547L2SA2())
-@test length(sol_lorenz.u) < 1000
+@test length(sol_lorenz.u) < 1100
 @test SciMLBase.successful_retcode(sol_lorenz)
 
 # ESDIRK659L2SA
@@ -158,7 +158,7 @@ sol_linear = solve(prob_linear, ESDIRK659L2SA())
 @test SciMLBase.successful_retcode(sol_linear)
 
 sol_lorenz = solve(prob_lorenz, ESDIRK659L2SA())
-@test length(sol_lorenz.u) < 1000
+@test length(sol_lorenz.u) < 1200
 @test SciMLBase.successful_retcode(sol_lorenz)
 
 # Adaptivity tests for Alshina2, 3


### PR DESCRIPTION
Fixes #3669.

## Summary

`test/regression/ode_adaptive_tests.jl` had stale step-count guards for `ESDIRK547L2SA2()` and `ESDIRK659L2SA()` on `prob_lorenz`. Both bumped to leave comfortable headroom:

- `ESDIRK547L2SA2`: `< 1000` → `< 1100` (current: 1010 steps)
- `ESDIRK659L2SA`: `< 1000` → `< 1200` (current: 1146 steps)

The third failure listed in #3669 — `@test_broken length(sol_linear.u) < 10` on `ESDIRK659L2SA` — was already flipped to plain `@test` in #3676.

**Please ignore this PR until reviewed by @ChrisRackauckas.**

## Root cause investigation

The three failures in #3669 have two distinct causes, not one. Verified by bisecting:

| Failure | Pre-#3662 | Post-#3662 (current master) | Cause |
|---|---|---|---|
| ESDIRK659L2SA `prob_ode_linear` `@test_broken < 10` | 3554 steps, Success | **5 steps**, Success | #3662 |
| ESDIRK659L2SA `prob_lorenz` `< 1000` | MaxIters at 999386 | **1146 steps**, Success | #3662 |
| ESDIRK547L2SA2 `prob_lorenz` `< 1000` | **1010 steps**, Success | **1010 steps**, Success | NOT #3662 |

#3662 fixed `ESDIRK659L2SA`'s embedded `btilde` coefficients so its adaptive estimator works. That improved both its `prob_ode_linear` (3554 → 5 steps) and `prob_lorenz` behavior (MaxIters → 1146) — both ESDIRK659L2SA failures stem from this.

The `ESDIRK547L2SA2` failure is older and unrelated. The `< 1000` bound was set when the method was added in Feb 2023 (`4b56c4ef3`); the algorithm has drifted to ~1010 across the 2026 SDIRK/nlsolver refactors. It went unnoticed because `Regression_I` only runs on PRs, not master pushes.

## Test plan

- [x] Local verification: both `solve(prob_lorenz, ESDIRK547L2SA2())` and `solve(prob_lorenz, ESDIRK659L2SA())` return `Success` with the new bounds.
- [x] Runic clean.
- [ ] CI `Regression_I` group passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)