### PR TITLE
DiffEqBaseEnzymeExt: restore SensitivityADPassThrough fallback

### DIFF
--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.5.2"
+version = "7.5.3"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/DiffEqBase/ext/DiffEqBaseEnzymeExt.jl
+++ b/lib/DiffEqBase/ext/DiffEqBaseEnzymeExt.jl
@@ -34,19 +34,18 @@ module DiffEqBaseEnzymeExt
     # can still promote module-level `const _MTK_SENSEALG = GaussAdjoint(...)`
     # references — or any sensealg captured in an `ODEProblem` field — to
     # `Duplicated{<:AbstractSensitivityAlgorithm}` before this rule is matched.
-    # Accept any `Enzyme.Annotation` (Const / Duplicated / MixedDuplicated /
-    # Active) here and read only `sensealg.val`; the shadow has no meaning.
+    # Accept any `Enzyme.Annotation` wrapping a sensealg value (Const /
+    # Duplicated / MixedDuplicated / Active) and read only `sensealg.val`;
+    # the shadow has no meaning. The inner-type constraint keeps
+    # `SensitivityADPassThrough` (which is `<:AbstractDEAlgorithm`, not
+    # `<:AbstractSensitivityAlgorithm`) off this rule so that case still
+    # falls through to direct AD of `solve_up`.
     function Enzyme.EnzymeRules.augmented_primal(
             config::Enzyme.EnzymeRules.RevConfigWidth{1},
             func::Const{typeof(DiffEqBase.solve_up)}, RTA::Union{Type{Duplicated{RT}}, Type{MixedDuplicated{RT}}}, prob,
-            sensealg::Enzyme.Annotation,
+            sensealg::Enzyme.Annotation{<:Union{Nothing, DiffEqBase.AbstractSensitivityAlgorithm}},
             u0, p, args...; kwargs...
         ) where {RT}
-        sensealg.val isa Union{Nothing, DiffEqBase.AbstractSensitivityAlgorithm} ||
-            throw(ArgumentError(
-            "DiffEqBaseEnzymeExt: `sensealg` must be `nothing` or " *
-                "`<:AbstractSensitivityAlgorithm`, got $(typeof(sensealg.val))",
-        ))
 
         res = DiffEqBase._solve_adjoint(
             copy_or_reuse(config, prob.val, 2), copy_or_reuse(config, sensealg.val, 3),
@@ -77,7 +76,7 @@ module DiffEqBaseEnzymeExt
     function Enzyme.EnzymeRules.reverse(
             config::Enzyme.EnzymeRules.RevConfigWidth{1},
             func::Const{typeof(DiffEqBase.solve_up)}, ::Union{Type{Duplicated{RT}}, Type{MixedDuplicated{RT}}}, tape, prob,
-            sensealg::Enzyme.Annotation,
+            sensealg::Enzyme.Annotation{<:Union{Nothing, DiffEqBase.AbstractSensitivityAlgorithm}},
             u0, p, args...; kwargs...
         ) where {RT}
 


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

### Summary

PR #3678 loosened the `solve_up` augmented_primal/reverse Enzyme rules from `Const{Nothing}|Const{<:AbstractSensitivityAlgorithm}` to a plain `Enzyme.Annotation`, plus a runtime check that throws on anything other than `nothing`/`AbstractSensitivityAlgorithm`. That regressed the existing `test/ad/ad_tests.jl:583` "Direct Differentiation of Explicit ODE Solve" test, which deliberately uses `sensealg = SensitivityADPassThrough()` to skip adjoint machinery and AD directly through `solve_up`:

```
ArgumentError: DiffEqBaseEnzymeExt: `sensealg` must be `nothing` or `<:AbstractSensitivityAlgorithm`, got DiffEqBase.SensitivityADPassThrough
```

(Failing run: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/26435108036/job/77816028999.)

`SensitivityADPassThrough <: AbstractDEAlgorithm`, not `<: AbstractSensitivityAlgorithm`. Pre-#3678 the tight `Const{<:AbstractSensitivityAlgorithm}` bound simply did not dispatch on `Const{SensitivityADPassThrough}`, so Enzyme fell through to direct AD of `solve_up`. Post-#3678 the rule swallowed it and immediately raised the new ArgumentError.

### Fix

Restore the original dispatch behavior for `SensitivityADPassThrough` while keeping #3678's wider outer-annotation acceptance:

- Constrain the **inner** sensealg value type to `<:Union{Nothing, AbstractSensitivityAlgorithm}`.
- Drop the now-redundant runtime ArgumentError check (type system handles it).

The outer `Enzyme.Annotation` (Const, Duplicated, MixedDuplicated, Active) is still freely accepted, which preserves the original motivation of #3678 — tolerate `set_runtime_activity(Reverse)` promoting a sensealg const to `Duplicated{GaussAdjoint{...}}` before the rule matches.

### Files

- `lib/DiffEqBase/ext/DiffEqBaseEnzymeExt.jl` — narrower inner type, remove runtime check
- `lib/DiffEqBase/Project.toml` — bump to 7.5.3

### Verification

The forward-mode Enzyme failure mode in this specific test ("Not yet implemented, mixed activity for jl_new_struct" on `ODEProblem{true, FullSpecialize}` construction) reproduces on my local Julia 1.11.9 environment for both pre-#3678 and post-fix code — it's an Enzyme-internal forward-mode issue unrelated to the EnzymeExt rule. Pre-#3678 master CI was green on this exact test on the GitHub runner, so the dispatch-level fix should restore CI to green there. The actual CI failure path was REVERSE-mode (`augmented_primal#3`), which is what this PR targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)