### PR TITLE
Lowstorage 2c

### DIFF
--- a/lib/OrdinaryDiffEqLowStorageRK/src/OrdinaryDiffEqLowStorageRK.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/OrdinaryDiffEqLowStorageRK.jl
@@ -25,8 +25,10 @@ using Reexport
 include("arrayfuse.jl")
 include("algorithms.jl")
 include("alg_utils.jl")
+include("low_storage_tableaus.jl")
 include("low_storage_rk_caches.jl")
 include("low_storage_rk_perform_step.jl")
+include("generic_low_storage_perform_step.jl")
 
 import PrecompileTools
 import Preferences

--- a/lib/OrdinaryDiffEqLowStorageRK/src/generic_low_storage_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/generic_low_storage_perform_step.jl
@@ -1,5 +1,5 @@
 @muladd function _perform_step_iip!(
-        integrator, cache, tab::LowStorageRKTableau{:two_n}
+        integrator, cache, tab::LowStorageRKTableau{TwoN}
     )
     (; t, dt, u, f, p) = integrator
     (; k, tmp, williamson_condition, stage_limiter!, step_limiter!, thread) = cache
@@ -28,7 +28,7 @@
 end
 
 @muladd function _perform_step_oop!(
-        integrator, tab::LowStorageRKTableau{:two_n}
+        integrator, tab::LowStorageRKTableau{TwoN}
     )
     (; t, dt, u, f, p) = integrator
     (; A2end, B1, B2end, c2end) = tab

--- a/lib/OrdinaryDiffEqLowStorageRK/src/generic_low_storage_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/generic_low_storage_perform_step.jl
@@ -1,0 +1,51 @@
+@muladd function _perform_step_iip!(
+        integrator, cache, tab::LowStorageRKTableau{:two_n}
+    )
+    (; t, dt, u, f, p) = integrator
+    (; k, tmp, williamson_condition, stage_limiter!, step_limiter!, thread) = cache
+    (; A2end, B1, B2end, c2end) = tab
+
+    f(k, u, p, t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    @.. broadcast = false thread = thread tmp = dt * k
+    @.. broadcast = false thread = thread u = u + B1 * tmp
+
+    for i in eachindex(A2end)
+        if williamson_condition
+            f(ArrayFuse(tmp, u, (A2end[i], dt, B2end[i])), u, p, t + c2end[i] * dt)
+        else
+            @.. broadcast = false thread = thread tmp = A2end[i] * tmp
+            stage_limiter!(u, integrator, p, t + c2end[i] * dt)
+            f(k, u, p, t + c2end[i] * dt)
+            @.. broadcast = false thread = thread tmp = tmp + dt * k
+            @.. broadcast = false thread = thread u = u + B2end[i] * tmp
+        end
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    end
+    stage_limiter!(u, integrator, p, t + dt)
+    step_limiter!(u, integrator, p, t + dt)
+    return nothing
+end
+
+@muladd function _perform_step_oop!(
+        integrator, tab::LowStorageRKTableau{:two_n}
+    )
+    (; t, dt, u, f, p) = integrator
+    (; A2end, B1, B2end, c2end) = tab
+
+    tmp = dt * integrator.fsalfirst
+    u = u + B1 * tmp
+
+    for i in eachindex(A2end)
+        k = f(u, p, t + c2end[i] * dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+        tmp = A2end[i] * tmp + dt * k
+        u = u + B2end[i] * tmp
+    end
+
+    integrator.k[1] = integrator.fsalfirst
+    integrator.fsalfirst = f(u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.u = u
+    return nothing
+end

--- a/lib/OrdinaryDiffEqLowStorageRK/src/generic_low_storage_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/generic_low_storage_perform_step.jl
@@ -49,3 +49,47 @@ end
     integrator.u = u
     return nothing
 end
+
+@muladd function _perform_step_iip!(
+        integrator, cache, tab::LowStorageRKTableau{:two_c}
+    )
+    (; t, dt, u, f, p) = integrator
+    (; k, fsalfirst, tmp, stage_limiter!, step_limiter!, thread) = cache
+    (; A2end, B1, B2end, c2end) = tab
+
+    @.. broadcast = false thread = thread k = integrator.fsalfirst
+    @.. broadcast = false thread = thread u = u + B1 * dt * k
+
+    for i in eachindex(A2end)
+        @.. broadcast = false thread = thread tmp = u + A2end[i] * dt * k
+        f(k, tmp, p, t + c2end[i] * dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+        @.. broadcast = false thread = thread u = u + B2end[i] * dt * k
+    end
+    step_limiter!(u, integrator, p, t + dt)
+    f(k, u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    return nothing
+end
+
+@muladd function _perform_step_oop!(
+        integrator, tab::LowStorageRKTableau{:two_c}
+    )
+    (; t, dt, u, f, p) = integrator
+    (; A2end, B1, B2end, c2end) = tab
+
+    k = integrator.fsalfirst = integrator.f(u, p, t)
+    integrator.k[1] = integrator.fsalfirst
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    u = u + B1 * dt * k
+
+    for i in eachindex(A2end)
+        tmp = u + A2end[i] * dt * k
+        k = integrator.f(tmp, p, t + c2end[i] * dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+        u = u + B2end[i] * dt * k
+    end
+
+    integrator.u = u
+    return nothing
+end

--- a/lib/OrdinaryDiffEqLowStorageRK/src/generic_low_storage_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/generic_low_storage_perform_step.jl
@@ -51,7 +51,7 @@ end
 end
 
 @muladd function _perform_step_iip!(
-        integrator, cache, tab::LowStorageRKTableau{:two_c}
+        integrator, cache, tab::LowStorageRKTableau{TwoC}
     )
     (; t, dt, u, f, p) = integrator
     (; k, fsalfirst, tmp, stage_limiter!, step_limiter!, thread) = cache
@@ -73,7 +73,7 @@ end
 end
 
 @muladd function _perform_step_oop!(
-        integrator, tab::LowStorageRKTableau{:two_c}
+        integrator, tab::LowStorageRKTableau{TwoC}
     )
     (; t, dt, u, f, p) = integrator
     (; A2end, B1, B2end, c2end) = tab

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_caches.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_caches.jl
@@ -605,13 +605,6 @@ end
     thread::Thread
 end
 
-struct LowStorageRK2CConstantCache{N, T, T2} <: OrdinaryDiffEqConstantCache
-    A2end::NTuple{N, T} # A1 is always zero
-    B1::T
-    B2end::NTuple{N, T}
-    c2end::NTuple{N, T2} # c1 is always zero
-end
-
 function CFRLDDRK64ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A2 = convert(T, 0.17985400977138)
     A3 = convert(T, 0.14081893152111)
@@ -635,7 +628,7 @@ function CFRLDDRK64ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c6 = convert(T2, 0.83050587987157)
     c2end = (c2, c3, c4, c5, c6)
 
-    return LowStorageRK2CConstantCache(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{:two_c}(A2end, B1, B2end, c2end)
 end
 
 function TSLDDRK74ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -664,7 +657,7 @@ function TSLDDRK74ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c7 = convert(T2, 0.91124223849547205)
     c2end = (c2, c3, c4, c5, c6, c7)
 
-    return LowStorageRK2CConstantCache(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{:two_c}(A2end, B1, B2end, c2end)
 end
 
 # 3S low storage methods introduced by Ketcheson

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_caches.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_caches.jl
@@ -628,7 +628,7 @@ function CFRLDDRK64ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c6 = convert(T2, 0.83050587987157)
     c2end = (c2, c3, c4, c5, c6)
 
-    return LowStorageRKTableau{:two_c}(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{TwoC}(A2end, B1, B2end, c2end)
 end
 
 function TSLDDRK74ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -657,7 +657,7 @@ function TSLDDRK74ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c7 = convert(T2, 0.91124223849547205)
     c2end = (c2, c3, c4, c5, c6, c7)
 
-    return LowStorageRKTableau{:two_c}(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{TwoC}(A2end, B1, B2end, c2end)
 end
 
 # 3S low storage methods introduced by Ketcheson

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_caches.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_caches.jl
@@ -37,7 +37,7 @@ function ORK256ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c5 = convert(T2, 0.8)
     c2end = (c2, c3, c4, c5)
 
-    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{TwoN}(A2end, B1, B2end, c2end)
 end
 
 function alg_cache(
@@ -137,7 +137,7 @@ function CarpenterKennedy2N54ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c5 = convert(T2, 2802321613138 // 2924317926251)
     c2end = (c2, c3, c4, c5)
 
-    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{TwoN}(A2end, B1, B2end, c2end)
 end
 
 @cache mutable struct SHLDDRK_2NCache{
@@ -352,7 +352,7 @@ function SHLDDRK64ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c6 = convert(T2, 0.9271047)
     c2end = (c2, c3, c4, c5, c6)
 
-    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{TwoN}(A2end, B1, B2end, c2end)
 end
 
 function DGLDDRK73_CConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -381,7 +381,7 @@ function DGLDDRK73_CConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c7 = convert(T2, 0.998046608462379)
     c2end = (c2, c3, c4, c5, c6, c7)
 
-    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{TwoN}(A2end, B1, B2end, c2end)
 end
 
 function DGLDDRK84_CConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -413,7 +413,7 @@ function DGLDDRK84_CConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c8 = convert(T2, 0.919902896453866)
     c2end = (c2, c3, c4, c5, c6, c7, c8)
 
-    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{TwoN}(A2end, B1, B2end, c2end)
 end
 
 function DGLDDRK84_FConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -445,7 +445,7 @@ function DGLDDRK84_FConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c8 = convert(T2, 0.9484087623348481)
     c2end = (c2, c3, c4, c5, c6, c7, c8)
 
-    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{TwoN}(A2end, B1, B2end, c2end)
 end
 
 function NDBLSRK124ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -489,7 +489,7 @@ function NDBLSRK124ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c12 = convert(T2, 0.9032588871651854)
     c2end = (c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12)
 
-    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{TwoN}(A2end, B1, B2end, c2end)
 end
 
 function NDBLSRK134ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -536,7 +536,7 @@ function NDBLSRK134ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c13 = convert(T2, 0.9126827615920843)
     c2end = (c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13)
 
-    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{TwoN}(A2end, B1, B2end, c2end)
 end
 
 function NDBLSRK144ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -586,7 +586,7 @@ function NDBLSRK144ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c14 = convert(T2, 0.8734213127600976)
     c2end = (c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14)
 
-    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{TwoN}(A2end, B1, B2end, c2end)
 end
 
 # 2C low storage methods introduced by Calvo, Franco, Rández (2004)

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_caches.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_caches.jl
@@ -17,13 +17,6 @@ get_fsalfirstlast(cache::LowStorageRKMutableCache, u) = (cache.fsalfirst, cache.
     thread::Thread
 end
 
-struct LowStorageRK2NConstantCache{N, T, T2} <: OrdinaryDiffEqConstantCache
-    A2end::NTuple{N, T} # A1 is always zero
-    B1::T
-    B2end::NTuple{N, T}
-    c2end::NTuple{N, T2} # c1 is always zero
-end
-
 function ORK256ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A2 = convert(T, -1.0)
     A3 = convert(T, -1.55798)
@@ -44,7 +37,7 @@ function ORK256ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c5 = convert(T2, 0.8)
     c2end = (c2, c3, c4, c5)
 
-    return LowStorageRK2NConstantCache(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
 end
 
 function alg_cache(
@@ -144,7 +137,7 @@ function CarpenterKennedy2N54ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c5 = convert(T2, 2802321613138 // 2924317926251)
     c2end = (c2, c3, c4, c5)
 
-    return LowStorageRK2NConstantCache(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
 end
 
 @cache mutable struct SHLDDRK_2NCache{
@@ -359,7 +352,7 @@ function SHLDDRK64ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c6 = convert(T2, 0.9271047)
     c2end = (c2, c3, c4, c5, c6)
 
-    return LowStorageRK2NConstantCache(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
 end
 
 function DGLDDRK73_CConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -388,7 +381,7 @@ function DGLDDRK73_CConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c7 = convert(T2, 0.998046608462379)
     c2end = (c2, c3, c4, c5, c6, c7)
 
-    return LowStorageRK2NConstantCache(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
 end
 
 function DGLDDRK84_CConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -420,7 +413,7 @@ function DGLDDRK84_CConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c8 = convert(T2, 0.919902896453866)
     c2end = (c2, c3, c4, c5, c6, c7, c8)
 
-    return LowStorageRK2NConstantCache(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
 end
 
 function DGLDDRK84_FConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -452,7 +445,7 @@ function DGLDDRK84_FConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c8 = convert(T2, 0.9484087623348481)
     c2end = (c2, c3, c4, c5, c6, c7, c8)
 
-    return LowStorageRK2NConstantCache(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
 end
 
 function NDBLSRK124ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -496,7 +489,7 @@ function NDBLSRK124ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c12 = convert(T2, 0.9032588871651854)
     c2end = (c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12)
 
-    return LowStorageRK2NConstantCache(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
 end
 
 function NDBLSRK134ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -543,7 +536,7 @@ function NDBLSRK134ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c13 = convert(T2, 0.9126827615920843)
     c2end = (c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13)
 
-    return LowStorageRK2NConstantCache(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
 end
 
 function NDBLSRK144ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -593,7 +586,7 @@ function NDBLSRK144ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c14 = convert(T2, 0.8734213127600976)
     c2end = (c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14)
 
-    return LowStorageRK2NConstantCache(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
 end
 
 # 2C low storage methods introduced by Calvo, Franco, Rández (2004)

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_perform_step.jl
@@ -1,38 +1,14 @@
-# 2N low storage methods
-function initialize!(integrator, cache::LowStorageRK2NConstantCache)
-    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+function initialize!(integrator, cache::LowStorageRKTableau{:two_n})
+    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     integrator.kshortsize = 1
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-
-    # Avoid undefined entries if k is an array of arrays
     integrator.fsallast = zero(integrator.fsalfirst)
     return integrator.k[1] = integrator.fsalfirst
 end
 
-@muladd function perform_step!(
-        integrator, cache::LowStorageRK2NConstantCache,
-        repeat_step = false
-    )
-    (; t, dt, u, f, p) = integrator
-    (; A2end, B1, B2end, c2end) = cache
-
-    # u1
-    tmp = dt * integrator.fsalfirst
-    u = u + B1 * tmp
-
-    # other stages
-    for i in eachindex(A2end)
-        k = f(u, p, t + c2end[i] * dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-        tmp = A2end[i] * tmp + dt * k
-        u = u + B2end[i] * tmp
-    end
-
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    integrator.k[1] = integrator.fsalfirst
-    integrator.fsalfirst = f(u, p, t + dt) # For interpolation, then FSAL'd
-    integrator.u = u
+function perform_step!(integrator, cache::LowStorageRKTableau{:two_n}, repeat_step = false)
+    return _perform_step_oop!(integrator, cache)
 end
 
 get_fsalfirstlast(cache::LowStorageRK2NCache, u) = (nothing, nothing)
@@ -42,35 +18,12 @@ function initialize!(integrator, cache::LowStorageRK2NCache)
     integrator.kshortsize = 1
     resize!(integrator.k, integrator.kshortsize)
     integrator.k[1] = k
-    integrator.f(k, integrator.uprev, integrator.p, integrator.t) # FSAL for interpolation
+    integrator.f(k, integrator.uprev, integrator.p, integrator.t)
     return OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 end
 
-@muladd function perform_step!(integrator, cache::LowStorageRK2NCache, repeat_step = false)
-    (; t, dt, u, f, p) = integrator
-    (; k, tmp, williamson_condition, stage_limiter!, step_limiter!, thread) = cache
-    (; A2end, B1, B2end, c2end) = cache.tab
-
-    # u1
-    f(k, u, p, t)
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    @.. broadcast = false thread = thread tmp = dt * k
-    @.. broadcast = false thread = thread u = u + B1 * tmp
-    # other stages
-    for i in eachindex(A2end)
-        if williamson_condition
-            f(ArrayFuse(tmp, u, (A2end[i], dt, B2end[i])), u, p, t + c2end[i] * dt)
-        else
-            @.. broadcast = false thread = thread tmp = A2end[i] * tmp
-            stage_limiter!(u, integrator, p, t + c2end[i] * dt)
-            f(k, u, p, t + c2end[i] * dt)
-            @.. broadcast = false thread = thread tmp = tmp + dt * k
-            @.. broadcast = false thread = thread u = u + B2end[i] * tmp
-        end
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    end
-    stage_limiter!(u, integrator, p, t + dt)
-    step_limiter!(u, integrator, p, t + dt)
+function perform_step!(integrator, cache::LowStorageRK2NCache, repeat_step = false)
+    return _perform_step_iip!(integrator, cache, cache.tab)
 end
 
 # 2C low storage methods

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_perform_step.jl
@@ -26,71 +26,29 @@ function perform_step!(integrator, cache::LowStorageRK2NCache, repeat_step = fal
     return _perform_step_iip!(integrator, cache, cache.tab)
 end
 
-# 2C low storage methods
-function initialize!(integrator, cache::LowStorageRK2CConstantCache)
-    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+function initialize!(integrator, cache::LowStorageRKTableau{:two_c})
+    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     integrator.kshortsize = 1
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-
-    # Avoid undefined entries if k is an array of arrays
     integrator.fsallast = zero(integrator.fsalfirst)
     return integrator.k[1] = integrator.fsalfirst
 end
 
-@muladd function perform_step!(
-        integrator, cache::LowStorageRK2CConstantCache,
-        repeat_step = false
-    )
-    (; t, dt, u, f, p) = integrator
-    (; A2end, B1, B2end, c2end) = cache
-
-    # u1
-    k = integrator.fsalfirst = f(u, p, t)
-    integrator.k[1] = integrator.fsalfirst
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    u = u + B1 * dt * k
-
-    # other stages
-    for i in eachindex(A2end)
-        tmp = u + A2end[i] * dt * k
-        k = f(tmp, p, t + c2end[i] * dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-        u = u + B2end[i] * dt * k
-    end
-
-    integrator.u = u
+function perform_step!(integrator, cache::LowStorageRKTableau{:two_c}, repeat_step = false)
+    return _perform_step_oop!(integrator, cache)
 end
 
 function initialize!(integrator, cache::LowStorageRK2CCache)
-    (; k, fsalfirst) = cache
-
     integrator.kshortsize = 1
     resize!(integrator.k, integrator.kshortsize)
     integrator.k[1] = integrator.fsalfirst
-    integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # FSAL for interpolation
+    integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t)
     return OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 end
 
-@muladd function perform_step!(integrator, cache::LowStorageRK2CCache, repeat_step = false)
-    (; t, dt, u, f, p) = integrator
-    (; k, fsalfirst, tmp, stage_limiter!, step_limiter!, thread) = cache
-    (; A2end, B1, B2end, c2end) = cache.tab
-
-    # u1
-    @.. broadcast = false thread = thread k = integrator.fsalfirst
-    @.. broadcast = false thread = thread u = u + B1 * dt * k
-
-    # other stages
-    for i in eachindex(A2end)
-        @.. broadcast = false thread = thread tmp = u + A2end[i] * dt * k
-        f(k, tmp, p, t + c2end[i] * dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-        @.. broadcast = false thread = thread u = u + B2end[i] * dt * k
-    end
-    step_limiter!(u, integrator, p, t + dt)
-    f(k, u, p, t + dt)
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+function perform_step!(integrator, cache::LowStorageRK2CCache, repeat_step = false)
+    return _perform_step_iip!(integrator, cache, cache.tab)
 end
 
 # 3S low storage methods

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_perform_step.jl
@@ -1,4 +1,4 @@
-function initialize!(integrator, cache::LowStorageRKTableau{:two_n})
+function initialize!(integrator, cache::LowStorageRKTableau{TwoN})
     integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     integrator.kshortsize = 1
@@ -7,7 +7,7 @@ function initialize!(integrator, cache::LowStorageRKTableau{:two_n})
     return integrator.k[1] = integrator.fsalfirst
 end
 
-function perform_step!(integrator, cache::LowStorageRKTableau{:two_n}, repeat_step = false)
+function perform_step!(integrator, cache::LowStorageRKTableau{TwoN}, repeat_step = false)
     return _perform_step_oop!(integrator, cache)
 end
 

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_perform_step.jl
@@ -26,7 +26,7 @@ function perform_step!(integrator, cache::LowStorageRK2NCache, repeat_step = fal
     return _perform_step_iip!(integrator, cache, cache.tab)
 end
 
-function initialize!(integrator, cache::LowStorageRKTableau{:two_c})
+function initialize!(integrator, cache::LowStorageRKTableau{TwoC})
     integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     integrator.kshortsize = 1
@@ -35,7 +35,7 @@ function initialize!(integrator, cache::LowStorageRKTableau{:two_c})
     return integrator.k[1] = integrator.fsalfirst
 end
 
-function perform_step!(integrator, cache::LowStorageRKTableau{:two_c}, repeat_step = false)
+function perform_step!(integrator, cache::LowStorageRKTableau{TwoC}, repeat_step = false)
     return _perform_step_oop!(integrator, cache)
 end
 

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_tableaus.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_tableaus.jl
@@ -1,3 +1,5 @@
+@enum LowStorageRKForm TwoN TwoC
+
 struct LowStorageRKTableau{form, N, T, T2} <: OrdinaryDiffEqConstantCache
     A2end::NTuple{N, T}
     B1::T

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_tableaus.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_tableaus.jl
@@ -1,0 +1,12 @@
+struct LowStorageRKTableau{form, N, T, T2} <: OrdinaryDiffEqConstantCache
+    A2end::NTuple{N, T}
+    B1::T
+    B2end::NTuple{N, T}
+    c2end::NTuple{N, T2}
+end
+
+function LowStorageRKTableau{form}(
+        A2end::NTuple{N, T}, B1::T, B2end::NTuple{N, T}, c2end::NTuple{N, T2}
+    ) where {form, N, T, T2}
+    return LowStorageRKTableau{form, N, T, T2}(A2end, B1, B2end, c2end)
+end


### PR DESCRIPTION
## Summary

Converts the **2C family** (CFRLDDRK64, TSLDDRK74) to use `LowStorageRKTableau{:two_c}` in place of the deleted `LowStorageRK2CConstantCache`.

Adds `_perform_step_oop!` / `_perform_step_iip!` dispatch for `:two_c` in `generic_low_storage_perform_step.jl`. Thin wrappers in `low_storage_rk_perform_step.jl` delegate to the generic implementations.

Part of the stacked series: #3683 (2N) → **#3684 (2C)** → #3685 → #3686 → #3687 → #3688.

## Test plan

- [x] OOP and IIP paths validated against master — step counts and solution values identical.
- [ ] CI passes.
