### PR TITLE
Lowstorage rp

### DIFF
--- a/lib/OrdinaryDiffEqLowStorageRK/src/OrdinaryDiffEqLowStorageRK.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/OrdinaryDiffEqLowStorageRK.jl
@@ -25,8 +25,10 @@ using Reexport
 include("arrayfuse.jl")
 include("algorithms.jl")
 include("alg_utils.jl")
+include("low_storage_tableaus.jl")
 include("low_storage_rk_caches.jl")
 include("low_storage_rk_perform_step.jl")
+include("generic_low_storage_perform_step.jl")
 
 import PrecompileTools
 import Preferences

--- a/lib/OrdinaryDiffEqLowStorageRK/src/generic_low_storage_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/generic_low_storage_perform_step.jl
@@ -1,5 +1,5 @@
 @muladd function _perform_step_iip!(
-        integrator, cache, tab::LowStorageRKTableau{:two_n}
+        integrator, cache, tab::LowStorageRKTableau{TwoN}
     )
     (; t, dt, u, f, p) = integrator
     (; k, tmp, williamson_condition, stage_limiter!, step_limiter!, thread) = cache
@@ -28,7 +28,7 @@
 end
 
 @muladd function _perform_step_oop!(
-        integrator, tab::LowStorageRKTableau{:two_n}
+        integrator, tab::LowStorageRKTableau{TwoN}
     )
     (; t, dt, u, f, p) = integrator
     (; A2end, B1, B2end, c2end) = tab

--- a/lib/OrdinaryDiffEqLowStorageRK/src/generic_low_storage_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/generic_low_storage_perform_step.jl
@@ -93,3 +93,47 @@ end
     integrator.u = u
     return nothing
 end
+
+@muladd function _perform_step_oop!(integrator, tab::LowStorageRK3SConstantCache)
+    (; t, dt, uprev, u, f, p) = integrator
+    (; γ12end, γ22end, γ32end, δ2end, β1, β2end, c2end) = tab
+
+    tmp = u
+    u = tmp + β1 * dt * integrator.fsalfirst
+
+    for i in eachindex(γ12end)
+        k = f(u, p, t + c2end[i] * dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+        tmp = tmp + δ2end[i] * u
+        u = γ12end[i] * u + γ22end[i] * tmp + γ32end[i] * uprev + β2end[i] * dt * k
+    end
+
+    integrator.fsallast = f(u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.k[1] = integrator.fsalfirst
+    integrator.u = u
+    return nothing
+end
+
+@muladd function _perform_step_iip!(integrator, cache, tab::LowStorageRK3SConstantCache)
+    (; t, dt, uprev, u, f, p) = integrator
+    (; k, fsalfirst, tmp, stage_limiter!, step_limiter!, thread) = cache
+    (; γ12end, γ22end, γ32end, δ2end, β1, β2end, c2end) = tab
+
+    @.. broadcast = false thread = thread tmp = u
+    @.. broadcast = false thread = thread u = tmp + β1 * dt * integrator.fsalfirst
+
+    for i in eachindex(γ12end)
+        f(k, u, p, t + c2end[i] * dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+        @.. broadcast = false thread = thread tmp = tmp + δ2end[i] * u
+        @.. broadcast = false thread = thread u = γ12end[i] * u + γ22end[i] * tmp +
+            γ32end[i] * uprev +
+            β2end[i] * dt * k
+    end
+
+    step_limiter!(u, integrator, p, t + dt)
+    f(k, u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    return nothing
+end

--- a/lib/OrdinaryDiffEqLowStorageRK/src/generic_low_storage_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/generic_low_storage_perform_step.jl
@@ -1,0 +1,51 @@
+@muladd function _perform_step_iip!(
+        integrator, cache, tab::LowStorageRKTableau{:two_n}
+    )
+    (; t, dt, u, f, p) = integrator
+    (; k, tmp, williamson_condition, stage_limiter!, step_limiter!, thread) = cache
+    (; A2end, B1, B2end, c2end) = tab
+
+    f(k, u, p, t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    @.. broadcast = false thread = thread tmp = dt * k
+    @.. broadcast = false thread = thread u = u + B1 * tmp
+
+    for i in eachindex(A2end)
+        if williamson_condition
+            f(ArrayFuse(tmp, u, (A2end[i], dt, B2end[i])), u, p, t + c2end[i] * dt)
+        else
+            @.. broadcast = false thread = thread tmp = A2end[i] * tmp
+            stage_limiter!(u, integrator, p, t + c2end[i] * dt)
+            f(k, u, p, t + c2end[i] * dt)
+            @.. broadcast = false thread = thread tmp = tmp + dt * k
+            @.. broadcast = false thread = thread u = u + B2end[i] * tmp
+        end
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    end
+    stage_limiter!(u, integrator, p, t + dt)
+    step_limiter!(u, integrator, p, t + dt)
+    return nothing
+end
+
+@muladd function _perform_step_oop!(
+        integrator, tab::LowStorageRKTableau{:two_n}
+    )
+    (; t, dt, u, f, p) = integrator
+    (; A2end, B1, B2end, c2end) = tab
+
+    tmp = dt * integrator.fsalfirst
+    u = u + B1 * tmp
+
+    for i in eachindex(A2end)
+        k = f(u, p, t + c2end[i] * dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+        tmp = A2end[i] * tmp + dt * k
+        u = u + B2end[i] * tmp
+    end
+
+    integrator.k[1] = integrator.fsalfirst
+    integrator.fsalfirst = f(u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.u = u
+    return nothing
+end

--- a/lib/OrdinaryDiffEqLowStorageRK/src/generic_low_storage_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/generic_low_storage_perform_step.jl
@@ -49,3 +49,47 @@ end
     integrator.u = u
     return nothing
 end
+
+@muladd function _perform_step_iip!(
+        integrator, cache, tab::LowStorageRKTableau{:two_c}
+    )
+    (; t, dt, u, f, p) = integrator
+    (; k, fsalfirst, tmp, stage_limiter!, step_limiter!, thread) = cache
+    (; A2end, B1, B2end, c2end) = tab
+
+    @.. broadcast = false thread = thread k = integrator.fsalfirst
+    @.. broadcast = false thread = thread u = u + B1 * dt * k
+
+    for i in eachindex(A2end)
+        @.. broadcast = false thread = thread tmp = u + A2end[i] * dt * k
+        f(k, tmp, p, t + c2end[i] * dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+        @.. broadcast = false thread = thread u = u + B2end[i] * dt * k
+    end
+    step_limiter!(u, integrator, p, t + dt)
+    f(k, u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    return nothing
+end
+
+@muladd function _perform_step_oop!(
+        integrator, tab::LowStorageRKTableau{:two_c}
+    )
+    (; t, dt, u, f, p) = integrator
+    (; A2end, B1, B2end, c2end) = tab
+
+    k = integrator.fsalfirst = integrator.f(u, p, t)
+    integrator.k[1] = integrator.fsalfirst
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    u = u + B1 * dt * k
+
+    for i in eachindex(A2end)
+        tmp = u + A2end[i] * dt * k
+        k = integrator.f(tmp, p, t + c2end[i] * dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+        u = u + B2end[i] * dt * k
+    end
+
+    integrator.u = u
+    return nothing
+end

--- a/lib/OrdinaryDiffEqLowStorageRK/src/generic_low_storage_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/generic_low_storage_perform_step.jl
@@ -51,7 +51,7 @@ end
 end
 
 @muladd function _perform_step_iip!(
-        integrator, cache, tab::LowStorageRKTableau{:two_c}
+        integrator, cache, tab::LowStorageRKTableau{TwoC}
     )
     (; t, dt, u, f, p) = integrator
     (; k, fsalfirst, tmp, stage_limiter!, step_limiter!, thread) = cache
@@ -73,7 +73,7 @@ end
 end
 
 @muladd function _perform_step_oop!(
-        integrator, tab::LowStorageRKTableau{:two_c}
+        integrator, tab::LowStorageRKTableau{TwoC}
     )
     (; t, dt, u, f, p) = integrator
     (; A2end, B1, B2end, c2end) = tab

--- a/lib/OrdinaryDiffEqLowStorageRK/src/generic_low_storage_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/generic_low_storage_perform_step.jl
@@ -292,3 +292,354 @@ end
     end
     return nothing
 end
+
+@muladd function _perform_step_oop!(integrator, tab::LowStorageRK2RPConstantCache)
+    (; t, dt, u, uprev, f, fsalfirst, p) = integrator
+    (; Aᵢ, Bₗ, B̂ₗ, Bᵢ, B̂ᵢ, Cᵢ) = tab
+
+    k = fsalfirst
+    tmp = uprev
+    integrator.opts.adaptive && (tmp = zero(uprev))
+
+    for i in eachindex(Aᵢ)
+        integrator.opts.adaptive && (tmp = tmp + (Bᵢ[i] - B̂ᵢ[i]) * dt * k)
+        gprev = u + Aᵢ[i] * dt * k
+        u = u + Bᵢ[i] * dt * k
+        k = f(gprev, p, t + Cᵢ[i] * dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    end
+
+    integrator.opts.adaptive && (tmp = tmp + (Bₗ - B̂ₗ) * dt * k)
+    u = u + Bₗ * dt * k
+
+    if integrator.opts.adaptive
+        atmp = calculate_residuals(
+            tmp, uprev, u, integrator.opts.abstol,
+            integrator.opts.reltol, integrator.opts.internalnorm, t
+        )
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+
+    integrator.k[1] = integrator.fsalfirst
+    integrator.fsallast = f(u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.u = u
+    return nothing
+end
+
+@muladd function _perform_step_iip!(integrator, cache, tab::LowStorageRK2RPConstantCache)
+    (; t, dt, u, uprev, f, fsalfirst, p) = integrator
+    (; k, gprev, tmp, atmp, stage_limiter!, step_limiter!, thread) = cache
+    (; Aᵢ, Bₗ, B̂ₗ, Bᵢ, B̂ᵢ, Cᵢ) = tab
+
+    @.. broadcast = false thread = thread k = fsalfirst
+    integrator.opts.adaptive && (@.. broadcast = false tmp = zero(uprev))
+
+    for i in eachindex(Aᵢ)
+        integrator.opts.adaptive &&
+            (@.. broadcast = false thread = thread tmp = tmp + (Bᵢ[i] - B̂ᵢ[i]) * dt * k)
+        @.. broadcast = false thread = thread gprev = u + Aᵢ[i] * dt * k
+        @.. broadcast = false thread = thread u = u + Bᵢ[i] * dt * k
+        f(k, gprev, p, t + Cᵢ[i] * dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    end
+
+    integrator.opts.adaptive &&
+        (@.. broadcast = false thread = thread tmp = tmp + (Bₗ - B̂ₗ) * dt * k)
+    @.. broadcast = false thread = thread u = u + Bₗ * dt * k
+
+    if integrator.opts.adaptive
+        calculate_residuals!(
+            atmp, tmp, uprev, u, integrator.opts.abstol,
+            integrator.opts.reltol, integrator.opts.internalnorm, t,
+            thread
+        )
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+
+    step_limiter!(u, integrator, p, t + dt)
+    f(k, u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    return nothing
+end
+
+@muladd function _perform_step_oop!(integrator, tab::LowStorageRK3RPConstantCache)
+    (; t, dt, u, uprev, f, fsalfirst, p) = integrator
+    (; Aᵢ₁, Aᵢ₂, Bₗ, B̂ₗ, Bᵢ, B̂ᵢ, Cᵢ) = tab
+
+    fᵢ₋₂ = zero(fsalfirst)
+    k = fsalfirst
+    uᵢ₋₁ = uprev
+    uᵢ₋₂ = uprev
+    tmp = uprev
+    integrator.opts.adaptive && (tmp = zero(uprev))
+
+    for i in eachindex(Aᵢ₁)
+        integrator.opts.adaptive && (tmp = tmp + (Bᵢ[i] - B̂ᵢ[i]) * dt * k)
+        gprev = uᵢ₋₂ + (Aᵢ₁[i] * k + Aᵢ₂[i] * fᵢ₋₂) * dt
+        u = u + Bᵢ[i] * dt * k
+        fᵢ₋₂ = k
+        uᵢ₋₂ = uᵢ₋₁
+        uᵢ₋₁ = u
+        k = f(gprev, p, t + Cᵢ[i] * dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    end
+
+    integrator.opts.adaptive && (tmp = tmp + (Bₗ - B̂ₗ) * dt * k)
+    u = u + Bₗ * dt * k
+
+    if integrator.opts.adaptive
+        atmp = calculate_residuals(
+            tmp, uprev, u, integrator.opts.abstol,
+            integrator.opts.reltol, integrator.opts.internalnorm, t
+        )
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+
+    integrator.k[1] = integrator.fsalfirst
+    integrator.fsallast = f(u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.u = u
+    return nothing
+end
+
+@muladd function _perform_step_iip!(integrator, cache, tab::LowStorageRK3RPConstantCache)
+    (; t, dt, u, uprev, f, fsalfirst, p) = integrator
+    (; k, uᵢ₋₁, uᵢ₋₂, gprev, fᵢ₋₂, tmp, atmp, stage_limiter!, step_limiter!, thread) = cache
+    (; Aᵢ₁, Aᵢ₂, Bₗ, B̂ₗ, Bᵢ, B̂ᵢ, Cᵢ) = tab
+
+    @.. broadcast = false thread = thread fᵢ₋₂ = zero(fsalfirst)
+    @.. broadcast = false thread = thread k = fsalfirst
+    integrator.opts.adaptive && (@.. broadcast = false thread = thread tmp = zero(uprev))
+    @.. broadcast = false thread = thread uᵢ₋₁ = uprev
+    @.. broadcast = false thread = thread uᵢ₋₂ = uprev
+
+    for i in eachindex(Aᵢ₁)
+        integrator.opts.adaptive &&
+            (@.. broadcast = false thread = thread tmp = tmp + (Bᵢ[i] - B̂ᵢ[i]) * dt * k)
+        @.. broadcast = false thread = thread gprev = uᵢ₋₂ + (Aᵢ₁[i] * k + Aᵢ₂[i] * fᵢ₋₂) * dt
+        @.. broadcast = false thread = thread u = u + Bᵢ[i] * dt * k
+        @.. broadcast = false thread = thread fᵢ₋₂ = k
+        @.. broadcast = false thread = thread uᵢ₋₂ = uᵢ₋₁
+        @.. broadcast = false thread = thread uᵢ₋₁ = u
+        f(k, gprev, p, t + Cᵢ[i] * dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    end
+
+    integrator.opts.adaptive &&
+        (@.. broadcast = false thread = thread tmp = tmp + (Bₗ - B̂ₗ) * dt * k)
+    @.. broadcast = false thread = thread u = u + Bₗ * dt * k
+
+    step_limiter!(u, integrator, p, t + dt)
+
+    if integrator.opts.adaptive
+        calculate_residuals!(
+            atmp, tmp, uprev, u, integrator.opts.abstol,
+            integrator.opts.reltol, integrator.opts.internalnorm, t,
+            thread
+        )
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+
+    f(k, u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    return nothing
+end
+
+@muladd function _perform_step_oop!(integrator, tab::LowStorageRK4RPConstantCache)
+    (; t, dt, u, uprev, f, fsalfirst, p) = integrator
+    (; Aᵢ₁, Aᵢ₂, Aᵢ₃, Bₗ, B̂ₗ, Bᵢ, B̂ᵢ, Cᵢ) = tab
+
+    fᵢ₋₂ = zero(fsalfirst)
+    fᵢ₋₃ = zero(fsalfirst)
+    k = fsalfirst
+    uᵢ₋₁ = uprev
+    uᵢ₋₂ = uprev
+    uᵢ₋₃ = uprev
+    tmp = uprev
+    integrator.opts.adaptive && (tmp = zero(uprev))
+
+    for i in eachindex(Aᵢ₁)
+        integrator.opts.adaptive && (tmp = tmp + (Bᵢ[i] - B̂ᵢ[i]) * dt * k)
+        gprev = uᵢ₋₃ + (Aᵢ₁[i] * k + Aᵢ₂[i] * fᵢ₋₂ + Aᵢ₃[i] * fᵢ₋₃) * dt
+        u = u + Bᵢ[i] * dt * k
+        fᵢ₋₃ = fᵢ₋₂
+        fᵢ₋₂ = k
+        uᵢ₋₃ = uᵢ₋₂
+        uᵢ₋₂ = uᵢ₋₁
+        uᵢ₋₁ = u
+        k = f(gprev, p, t + Cᵢ[i] * dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    end
+
+    integrator.opts.adaptive && (tmp = tmp + (Bₗ - B̂ₗ) * dt * k)
+    u = u + Bₗ * dt * k
+
+    if integrator.opts.adaptive
+        atmp = calculate_residuals(
+            tmp, uprev, u, integrator.opts.abstol,
+            integrator.opts.reltol, integrator.opts.internalnorm, t
+        )
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+
+    integrator.k[1] = integrator.fsalfirst
+    integrator.fsallast = f(u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.u = u
+    return nothing
+end
+
+@muladd function _perform_step_iip!(integrator, cache, tab::LowStorageRK4RPConstantCache)
+    (; t, dt, u, uprev, f, fsalfirst, p) = integrator
+    (;
+        k, uᵢ₋₁, uᵢ₋₂, uᵢ₋₃, gprev, fᵢ₋₂, fᵢ₋₃, tmp, atmp,
+        stage_limiter!, step_limiter!, thread,
+    ) = cache
+    (; Aᵢ₁, Aᵢ₂, Aᵢ₃, Bₗ, B̂ₗ, Bᵢ, B̂ᵢ, Cᵢ) = tab
+
+    @.. broadcast = false thread = thread fᵢ₋₂ = zero(fsalfirst)
+    @.. broadcast = false thread = thread fᵢ₋₃ = zero(fsalfirst)
+    @.. broadcast = false thread = thread k = fsalfirst
+    integrator.opts.adaptive && (@.. broadcast = false thread = thread tmp = zero(uprev))
+    @.. broadcast = false thread = thread uᵢ₋₁ = uprev
+    @.. broadcast = false thread = thread uᵢ₋₂ = uprev
+    @.. broadcast = false thread = thread uᵢ₋₃ = uprev
+
+    for i in eachindex(Aᵢ₁)
+        integrator.opts.adaptive &&
+            (@.. broadcast = false thread = thread tmp = tmp + (Bᵢ[i] - B̂ᵢ[i]) * dt * k)
+        @.. broadcast = false thread = thread gprev = uᵢ₋₃ +
+            (Aᵢ₁[i] * k + Aᵢ₂[i] * fᵢ₋₂ + Aᵢ₃[i] * fᵢ₋₃) * dt
+        @.. broadcast = false thread = thread u = u + Bᵢ[i] * dt * k
+        @.. broadcast = false thread = thread fᵢ₋₃ = fᵢ₋₂
+        @.. broadcast = false thread = thread fᵢ₋₂ = k
+        @.. broadcast = false thread = thread uᵢ₋₃ = uᵢ₋₂
+        @.. broadcast = false thread = thread uᵢ₋₂ = uᵢ₋₁
+        @.. broadcast = false thread = thread uᵢ₋₁ = u
+        f(k, gprev, p, t + Cᵢ[i] * dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    end
+
+    integrator.opts.adaptive &&
+        (@.. broadcast = false thread = thread tmp = tmp + (Bₗ - B̂ₗ) * dt * k)
+    @.. broadcast = false thread = thread u = u + Bₗ * dt * k
+
+    step_limiter!(u, integrator, p, t + dt)
+
+    if integrator.opts.adaptive
+        calculate_residuals!(
+            atmp, tmp, uprev, u, integrator.opts.abstol,
+            integrator.opts.reltol, integrator.opts.internalnorm, t,
+            thread
+        )
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+
+    f(k, u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    return nothing
+end
+
+@muladd function _perform_step_oop!(integrator, tab::LowStorageRK5RPConstantCache)
+    (; t, dt, u, uprev, f, fsalfirst, p) = integrator
+    (; Aᵢ₁, Aᵢ₂, Aᵢ₃, Aᵢ₄, Bₗ, B̂ₗ, Bᵢ, B̂ᵢ, Cᵢ) = tab
+
+    fᵢ₋₂ = zero(fsalfirst)
+    fᵢ₋₃ = zero(fsalfirst)
+    fᵢ₋₄ = zero(fsalfirst)
+    k = fsalfirst
+    uᵢ₋₁ = uprev
+    uᵢ₋₂ = uprev
+    uᵢ₋₃ = uprev
+    uᵢ₋₄ = uprev
+    tmp = uprev
+    integrator.opts.adaptive && (tmp = zero(uprev))
+
+    for i in eachindex(Aᵢ₁)
+        integrator.opts.adaptive && (tmp = tmp + (Bᵢ[i] - B̂ᵢ[i]) * dt * k)
+        gprev = uᵢ₋₄ + (Aᵢ₁[i] * k + Aᵢ₂[i] * fᵢ₋₂ + Aᵢ₃[i] * fᵢ₋₃ + Aᵢ₄[i] * fᵢ₋₄) * dt
+        u = u + Bᵢ[i] * dt * k
+        fᵢ₋₄ = fᵢ₋₃
+        fᵢ₋₃ = fᵢ₋₂
+        fᵢ₋₂ = k
+        uᵢ₋₄ = uᵢ₋₃
+        uᵢ₋₃ = uᵢ₋₂
+        uᵢ₋₂ = uᵢ₋₁
+        uᵢ₋₁ = u
+        k = f(gprev, p, t + Cᵢ[i] * dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    end
+
+    integrator.opts.adaptive && (tmp = tmp + (Bₗ - B̂ₗ) * dt * k)
+    u = u + Bₗ * dt * k
+
+    if integrator.opts.adaptive
+        atmp = calculate_residuals(
+            tmp, uprev, u, integrator.opts.abstol,
+            integrator.opts.reltol, integrator.opts.internalnorm, t
+        )
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+
+    integrator.k[1] = integrator.fsalfirst
+    integrator.fsallast = f(u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.u = u
+    return nothing
+end
+
+@muladd function _perform_step_iip!(integrator, cache, tab::LowStorageRK5RPConstantCache)
+    (; t, dt, u, uprev, f, fsalfirst, p) = integrator
+    (;
+        k, uᵢ₋₁, uᵢ₋₂, uᵢ₋₃, uᵢ₋₄, gprev, fᵢ₋₂, fᵢ₋₃, fᵢ₋₄, tmp,
+        atmp, stage_limiter!, step_limiter!, thread,
+    ) = cache
+    (; Aᵢ₁, Aᵢ₂, Aᵢ₃, Aᵢ₄, Bₗ, B̂ₗ, Bᵢ, B̂ᵢ, Cᵢ) = tab
+
+    @.. broadcast = false thread = thread fᵢ₋₂ = zero(fsalfirst)
+    @.. broadcast = false thread = thread fᵢ₋₃ = zero(fsalfirst)
+    @.. broadcast = false thread = thread fᵢ₋₄ = zero(fsalfirst)
+    @.. broadcast = false thread = thread k = fsalfirst
+    integrator.opts.adaptive && (@.. broadcast = false thread = thread tmp = zero(uprev))
+    @.. broadcast = false thread = thread uᵢ₋₁ = uprev
+    @.. broadcast = false thread = thread uᵢ₋₂ = uprev
+    @.. broadcast = false thread = thread uᵢ₋₃ = uprev
+    @.. broadcast = false thread = thread uᵢ₋₄ = uprev
+
+    for i in eachindex(Aᵢ₁)
+        integrator.opts.adaptive &&
+            (@.. broadcast = false thread = thread tmp = tmp + (Bᵢ[i] - B̂ᵢ[i]) * dt * k)
+        @.. broadcast = false thread = thread gprev = uᵢ₋₄ +
+            (Aᵢ₁[i] * k + Aᵢ₂[i] * fᵢ₋₂ + Aᵢ₃[i] * fᵢ₋₃ + Aᵢ₄[i] * fᵢ₋₄) * dt
+        @.. broadcast = false thread = thread u = u + Bᵢ[i] * dt * k
+        @.. broadcast = false thread = thread fᵢ₋₄ = fᵢ₋₃
+        @.. broadcast = false thread = thread fᵢ₋₃ = fᵢ₋₂
+        @.. broadcast = false thread = thread fᵢ₋₂ = k
+        @.. broadcast = false thread = thread uᵢ₋₄ = uᵢ₋₃
+        @.. broadcast = false thread = thread uᵢ₋₃ = uᵢ₋₂
+        @.. broadcast = false thread = thread uᵢ₋₂ = uᵢ₋₁
+        @.. broadcast = false thread = thread uᵢ₋₁ = u
+        f(k, gprev, p, t + Cᵢ[i] * dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    end
+
+    integrator.opts.adaptive &&
+        (@.. broadcast = false thread = thread tmp = tmp + (Bₗ - B̂ₗ) * dt * k)
+    @.. broadcast = false thread = thread u = u + Bₗ * dt * k
+
+    step_limiter!(u, integrator, p, t + dt)
+
+    if integrator.opts.adaptive
+        calculate_residuals!(
+            atmp, tmp, uprev, u, integrator.opts.abstol,
+            integrator.opts.reltol, integrator.opts.internalnorm, t,
+            thread
+        )
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+
+    f(k, u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    return nothing
+end

--- a/lib/OrdinaryDiffEqLowStorageRK/src/generic_low_storage_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/generic_low_storage_perform_step.jl
@@ -137,3 +137,158 @@ end
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     return nothing
 end
+
+@muladd function _perform_step_oop!(integrator, tab::LowStorageRK3SpConstantCache)
+    (; t, dt, uprev, u, f, p) = integrator
+    (; γ12end, γ22end, γ32end, δ2end, β1, β2end, c2end, bhat1, bhat2end) = tab
+
+    integrator.fsalfirst = f(uprev, p, t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.k[1] = integrator.fsalfirst
+    tmp = uprev
+    u = tmp + β1 * dt * integrator.fsalfirst
+    utilde = u
+    if integrator.opts.adaptive
+        utilde = bhat1 * dt * integrator.fsalfirst
+    end
+
+    for i in eachindex(γ12end)
+        k = f(u, p, t + c2end[i] * dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+        tmp = tmp + δ2end[i] * u
+        u = γ12end[i] * u + γ22end[i] * tmp + γ32end[i] * uprev + β2end[i] * dt * k
+        if integrator.opts.adaptive
+            utilde = utilde + bhat2end[i] * dt * k
+        end
+    end
+
+    if integrator.opts.adaptive
+        atmp = calculate_residuals(
+            utilde, uprev, u, integrator.opts.abstol,
+            integrator.opts.reltol, integrator.opts.internalnorm, t
+        )
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+
+    integrator.u = u
+    return nothing
+end
+
+@muladd function _perform_step_iip!(integrator, cache, tab::LowStorageRK3SpConstantCache)
+    (; t, dt, uprev, u, f, p) = integrator
+    (; k, tmp, utilde, atmp, stage_limiter!, step_limiter!, thread) = cache
+    (; γ12end, γ22end, γ32end, δ2end, β1, β2end, c2end, bhat1, bhat2end) = tab
+
+    f(integrator.fsalfirst, uprev, p, t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    @.. broadcast = false thread = thread tmp = uprev
+    @.. broadcast = false thread = thread u = tmp + β1 * dt * integrator.fsalfirst
+    if integrator.opts.adaptive
+        @.. broadcast = false thread = thread utilde = bhat1 * dt * integrator.fsalfirst
+    end
+
+    for i in eachindex(γ12end)
+        stage_limiter!(u, integrator, p, t + c2end[i] * dt)
+        f(k, u, p, t + c2end[i] * dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+        @.. broadcast = false thread = thread tmp = tmp + δ2end[i] * u
+        @.. broadcast = false thread = thread u = γ12end[i] * u + γ22end[i] * tmp +
+            γ32end[i] * uprev + β2end[i] * dt * k
+        if integrator.opts.adaptive
+            @.. broadcast = false thread = thread utilde = utilde + bhat2end[i] * dt * k
+        end
+    end
+
+    stage_limiter!(u, integrator, p, t + dt)
+    step_limiter!(u, integrator, p, t + dt)
+
+    if integrator.opts.adaptive
+        calculate_residuals!(
+            atmp, utilde, uprev, u, integrator.opts.abstol,
+            integrator.opts.reltol, integrator.opts.internalnorm, t,
+            thread
+        )
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+    return nothing
+end
+
+@muladd function _perform_step_oop!(integrator, tab::LowStorageRK3SpFSALConstantCache)
+    (; t, dt, uprev, u, f, p) = integrator
+    (; γ12end, γ22end, γ32end, δ2end, β1, β2end, c2end, bhat1, bhat2end, bhatfsal) = tab
+
+    tmp = uprev
+    u = tmp + β1 * dt * integrator.fsalfirst
+    utilde = u
+    if integrator.opts.adaptive
+        utilde = bhat1 * dt * integrator.fsalfirst
+    end
+
+    for i in eachindex(γ12end)
+        k = f(u, p, t + c2end[i] * dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+        tmp = tmp + δ2end[i] * u
+        u = γ12end[i] * u + γ22end[i] * tmp + γ32end[i] * uprev + β2end[i] * dt * k
+        if integrator.opts.adaptive
+            utilde = utilde + bhat2end[i] * dt * k
+        end
+    end
+
+    integrator.fsallast = f(u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+
+    if integrator.opts.adaptive
+        utilde = utilde + bhatfsal * dt * integrator.fsallast
+        atmp = calculate_residuals(
+            utilde, uprev, u, integrator.opts.abstol,
+            integrator.opts.reltol, integrator.opts.internalnorm, t
+        )
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+
+    integrator.k[1] = integrator.fsalfirst
+    integrator.k[2] = integrator.fsallast
+    integrator.u = u
+    return nothing
+end
+
+@muladd function _perform_step_iip!(integrator, cache, tab::LowStorageRK3SpFSALConstantCache)
+    (; t, dt, uprev, u, f, p) = integrator
+    (; k, tmp, utilde, atmp, stage_limiter!, step_limiter!, thread) = cache
+    (; γ12end, γ22end, γ32end, δ2end, β1, β2end, c2end, bhat1, bhat2end, bhatfsal) = tab
+
+    @.. broadcast = false thread = thread tmp = uprev
+    @.. broadcast = false thread = thread u = tmp + β1 * dt * integrator.fsalfirst
+    if integrator.opts.adaptive
+        @.. broadcast = false thread = thread utilde = bhat1 * dt * integrator.fsalfirst
+    end
+
+    for i in eachindex(γ12end)
+        stage_limiter!(u, integrator, p, t + c2end[i] * dt)
+        f(k, u, p, t + c2end[i] * dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+        @.. broadcast = false thread = thread tmp = tmp + δ2end[i] * u
+        @.. broadcast = false thread = thread u = γ12end[i] * u + γ22end[i] * tmp +
+            γ32end[i] * uprev + β2end[i] * dt * k
+        if integrator.opts.adaptive
+            @.. broadcast = false thread = thread utilde = utilde + bhat2end[i] * dt * k
+        end
+    end
+
+    stage_limiter!(u, integrator, p, t + dt)
+    step_limiter!(u, integrator, p, t + dt)
+
+    f(k, u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+
+    if integrator.opts.adaptive
+        @.. broadcast = false thread = thread utilde = utilde + bhatfsal * dt * k
+        calculate_residuals!(
+            atmp, utilde, uprev, u, integrator.opts.abstol,
+            integrator.opts.reltol, integrator.opts.internalnorm, t,
+            thread
+        )
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+    return nothing
+end

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_caches.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_caches.jl
@@ -605,13 +605,6 @@ end
     thread::Thread
 end
 
-struct LowStorageRK2CConstantCache{N, T, T2} <: OrdinaryDiffEqConstantCache
-    A2end::NTuple{N, T} # A1 is always zero
-    B1::T
-    B2end::NTuple{N, T}
-    c2end::NTuple{N, T2} # c1 is always zero
-end
-
 function CFRLDDRK64ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A2 = convert(T, 0.17985400977138)
     A3 = convert(T, 0.14081893152111)
@@ -635,7 +628,7 @@ function CFRLDDRK64ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c6 = convert(T2, 0.83050587987157)
     c2end = (c2, c3, c4, c5, c6)
 
-    return LowStorageRK2CConstantCache(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{:two_c}(A2end, B1, B2end, c2end)
 end
 
 function TSLDDRK74ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -664,7 +657,7 @@ function TSLDDRK74ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c7 = convert(T2, 0.91124223849547205)
     c2end = (c2, c3, c4, c5, c6, c7)
 
-    return LowStorageRK2CConstantCache(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{:two_c}(A2end, B1, B2end, c2end)
 end
 
 # 3S low storage methods introduced by Ketcheson

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_caches.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_caches.jl
@@ -628,7 +628,7 @@ function CFRLDDRK64ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c6 = convert(T2, 0.83050587987157)
     c2end = (c2, c3, c4, c5, c6)
 
-    return LowStorageRKTableau{:two_c}(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{TwoC}(A2end, B1, B2end, c2end)
 end
 
 function TSLDDRK74ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -657,7 +657,7 @@ function TSLDDRK74ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c7 = convert(T2, 0.91124223849547205)
     c2end = (c2, c3, c4, c5, c6, c7)
 
-    return LowStorageRKTableau{:two_c}(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{TwoC}(A2end, B1, B2end, c2end)
 end
 
 # 3S low storage methods introduced by Ketcheson

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_caches.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_caches.jl
@@ -37,7 +37,7 @@ function ORK256ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c5 = convert(T2, 0.8)
     c2end = (c2, c3, c4, c5)
 
-    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{TwoN}(A2end, B1, B2end, c2end)
 end
 
 function alg_cache(
@@ -137,7 +137,7 @@ function CarpenterKennedy2N54ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c5 = convert(T2, 2802321613138 // 2924317926251)
     c2end = (c2, c3, c4, c5)
 
-    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{TwoN}(A2end, B1, B2end, c2end)
 end
 
 @cache mutable struct SHLDDRK_2NCache{
@@ -352,7 +352,7 @@ function SHLDDRK64ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c6 = convert(T2, 0.9271047)
     c2end = (c2, c3, c4, c5, c6)
 
-    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{TwoN}(A2end, B1, B2end, c2end)
 end
 
 function DGLDDRK73_CConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -381,7 +381,7 @@ function DGLDDRK73_CConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c7 = convert(T2, 0.998046608462379)
     c2end = (c2, c3, c4, c5, c6, c7)
 
-    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{TwoN}(A2end, B1, B2end, c2end)
 end
 
 function DGLDDRK84_CConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -413,7 +413,7 @@ function DGLDDRK84_CConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c8 = convert(T2, 0.919902896453866)
     c2end = (c2, c3, c4, c5, c6, c7, c8)
 
-    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{TwoN}(A2end, B1, B2end, c2end)
 end
 
 function DGLDDRK84_FConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -445,7 +445,7 @@ function DGLDDRK84_FConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c8 = convert(T2, 0.9484087623348481)
     c2end = (c2, c3, c4, c5, c6, c7, c8)
 
-    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{TwoN}(A2end, B1, B2end, c2end)
 end
 
 function NDBLSRK124ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -489,7 +489,7 @@ function NDBLSRK124ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c12 = convert(T2, 0.9032588871651854)
     c2end = (c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12)
 
-    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{TwoN}(A2end, B1, B2end, c2end)
 end
 
 function NDBLSRK134ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -536,7 +536,7 @@ function NDBLSRK134ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c13 = convert(T2, 0.9126827615920843)
     c2end = (c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13)
 
-    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{TwoN}(A2end, B1, B2end, c2end)
 end
 
 function NDBLSRK144ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -586,7 +586,7 @@ function NDBLSRK144ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c14 = convert(T2, 0.8734213127600976)
     c2end = (c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14)
 
-    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{TwoN}(A2end, B1, B2end, c2end)
 end
 
 # 2C low storage methods introduced by Calvo, Franco, Rández (2004)

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_caches.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_caches.jl
@@ -17,13 +17,6 @@ get_fsalfirstlast(cache::LowStorageRKMutableCache, u) = (cache.fsalfirst, cache.
     thread::Thread
 end
 
-struct LowStorageRK2NConstantCache{N, T, T2} <: OrdinaryDiffEqConstantCache
-    A2end::NTuple{N, T} # A1 is always zero
-    B1::T
-    B2end::NTuple{N, T}
-    c2end::NTuple{N, T2} # c1 is always zero
-end
-
 function ORK256ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     A2 = convert(T, -1.0)
     A3 = convert(T, -1.55798)
@@ -44,7 +37,7 @@ function ORK256ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c5 = convert(T2, 0.8)
     c2end = (c2, c3, c4, c5)
 
-    return LowStorageRK2NConstantCache(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
 end
 
 function alg_cache(
@@ -144,7 +137,7 @@ function CarpenterKennedy2N54ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c5 = convert(T2, 2802321613138 // 2924317926251)
     c2end = (c2, c3, c4, c5)
 
-    return LowStorageRK2NConstantCache(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
 end
 
 @cache mutable struct SHLDDRK_2NCache{
@@ -359,7 +352,7 @@ function SHLDDRK64ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c6 = convert(T2, 0.9271047)
     c2end = (c2, c3, c4, c5, c6)
 
-    return LowStorageRK2NConstantCache(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
 end
 
 function DGLDDRK73_CConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -388,7 +381,7 @@ function DGLDDRK73_CConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c7 = convert(T2, 0.998046608462379)
     c2end = (c2, c3, c4, c5, c6, c7)
 
-    return LowStorageRK2NConstantCache(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
 end
 
 function DGLDDRK84_CConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -420,7 +413,7 @@ function DGLDDRK84_CConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c8 = convert(T2, 0.919902896453866)
     c2end = (c2, c3, c4, c5, c6, c7, c8)
 
-    return LowStorageRK2NConstantCache(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
 end
 
 function DGLDDRK84_FConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -452,7 +445,7 @@ function DGLDDRK84_FConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c8 = convert(T2, 0.9484087623348481)
     c2end = (c2, c3, c4, c5, c6, c7, c8)
 
-    return LowStorageRK2NConstantCache(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
 end
 
 function NDBLSRK124ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -496,7 +489,7 @@ function NDBLSRK124ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c12 = convert(T2, 0.9032588871651854)
     c2end = (c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12)
 
-    return LowStorageRK2NConstantCache(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
 end
 
 function NDBLSRK134ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -543,7 +536,7 @@ function NDBLSRK134ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c13 = convert(T2, 0.9126827615920843)
     c2end = (c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13)
 
-    return LowStorageRK2NConstantCache(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
 end
 
 function NDBLSRK144ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
@@ -593,7 +586,7 @@ function NDBLSRK144ConstantCache(::Type{T}, ::Type{T2}) where {T, T2}
     c14 = convert(T2, 0.8734213127600976)
     c2end = (c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14)
 
-    return LowStorageRK2NConstantCache(A2end, B1, B2end, c2end)
+    return LowStorageRKTableau{:two_n}(A2end, B1, B2end, c2end)
 end
 
 # 2C low storage methods introduced by Calvo, Franco, Rández (2004)

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_perform_step.jl
@@ -1,38 +1,14 @@
-# 2N low storage methods
-function initialize!(integrator, cache::LowStorageRK2NConstantCache)
-    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+function initialize!(integrator, cache::LowStorageRKTableau{:two_n})
+    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     integrator.kshortsize = 1
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-
-    # Avoid undefined entries if k is an array of arrays
     integrator.fsallast = zero(integrator.fsalfirst)
     return integrator.k[1] = integrator.fsalfirst
 end
 
-@muladd function perform_step!(
-        integrator, cache::LowStorageRK2NConstantCache,
-        repeat_step = false
-    )
-    (; t, dt, u, f, p) = integrator
-    (; A2end, B1, B2end, c2end) = cache
-
-    # u1
-    tmp = dt * integrator.fsalfirst
-    u = u + B1 * tmp
-
-    # other stages
-    for i in eachindex(A2end)
-        k = f(u, p, t + c2end[i] * dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-        tmp = A2end[i] * tmp + dt * k
-        u = u + B2end[i] * tmp
-    end
-
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    integrator.k[1] = integrator.fsalfirst
-    integrator.fsalfirst = f(u, p, t + dt) # For interpolation, then FSAL'd
-    integrator.u = u
+function perform_step!(integrator, cache::LowStorageRKTableau{:two_n}, repeat_step = false)
+    return _perform_step_oop!(integrator, cache)
 end
 
 get_fsalfirstlast(cache::LowStorageRK2NCache, u) = (nothing, nothing)
@@ -42,35 +18,12 @@ function initialize!(integrator, cache::LowStorageRK2NCache)
     integrator.kshortsize = 1
     resize!(integrator.k, integrator.kshortsize)
     integrator.k[1] = k
-    integrator.f(k, integrator.uprev, integrator.p, integrator.t) # FSAL for interpolation
+    integrator.f(k, integrator.uprev, integrator.p, integrator.t)
     return OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 end
 
-@muladd function perform_step!(integrator, cache::LowStorageRK2NCache, repeat_step = false)
-    (; t, dt, u, f, p) = integrator
-    (; k, tmp, williamson_condition, stage_limiter!, step_limiter!, thread) = cache
-    (; A2end, B1, B2end, c2end) = cache.tab
-
-    # u1
-    f(k, u, p, t)
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    @.. broadcast = false thread = thread tmp = dt * k
-    @.. broadcast = false thread = thread u = u + B1 * tmp
-    # other stages
-    for i in eachindex(A2end)
-        if williamson_condition
-            f(ArrayFuse(tmp, u, (A2end[i], dt, B2end[i])), u, p, t + c2end[i] * dt)
-        else
-            @.. broadcast = false thread = thread tmp = A2end[i] * tmp
-            stage_limiter!(u, integrator, p, t + c2end[i] * dt)
-            f(k, u, p, t + c2end[i] * dt)
-            @.. broadcast = false thread = thread tmp = tmp + dt * k
-            @.. broadcast = false thread = thread u = u + B2end[i] * tmp
-        end
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    end
-    stage_limiter!(u, integrator, p, t + dt)
-    step_limiter!(u, integrator, p, t + dt)
+function perform_step!(integrator, cache::LowStorageRK2NCache, repeat_step = false)
+    return _perform_step_iip!(integrator, cache, cache.tab)
 end
 
 # 2C low storage methods

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_perform_step.jl
@@ -26,71 +26,29 @@ function perform_step!(integrator, cache::LowStorageRK2NCache, repeat_step = fal
     return _perform_step_iip!(integrator, cache, cache.tab)
 end
 
-# 2C low storage methods
-function initialize!(integrator, cache::LowStorageRK2CConstantCache)
-    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+function initialize!(integrator, cache::LowStorageRKTableau{:two_c})
+    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     integrator.kshortsize = 1
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-
-    # Avoid undefined entries if k is an array of arrays
     integrator.fsallast = zero(integrator.fsalfirst)
     return integrator.k[1] = integrator.fsalfirst
 end
 
-@muladd function perform_step!(
-        integrator, cache::LowStorageRK2CConstantCache,
-        repeat_step = false
-    )
-    (; t, dt, u, f, p) = integrator
-    (; A2end, B1, B2end, c2end) = cache
-
-    # u1
-    k = integrator.fsalfirst = f(u, p, t)
-    integrator.k[1] = integrator.fsalfirst
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    u = u + B1 * dt * k
-
-    # other stages
-    for i in eachindex(A2end)
-        tmp = u + A2end[i] * dt * k
-        k = f(tmp, p, t + c2end[i] * dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-        u = u + B2end[i] * dt * k
-    end
-
-    integrator.u = u
+function perform_step!(integrator, cache::LowStorageRKTableau{:two_c}, repeat_step = false)
+    return _perform_step_oop!(integrator, cache)
 end
 
 function initialize!(integrator, cache::LowStorageRK2CCache)
-    (; k, fsalfirst) = cache
-
     integrator.kshortsize = 1
     resize!(integrator.k, integrator.kshortsize)
     integrator.k[1] = integrator.fsalfirst
-    integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # FSAL for interpolation
+    integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t)
     return OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 end
 
-@muladd function perform_step!(integrator, cache::LowStorageRK2CCache, repeat_step = false)
-    (; t, dt, u, f, p) = integrator
-    (; k, fsalfirst, tmp, stage_limiter!, step_limiter!, thread) = cache
-    (; A2end, B1, B2end, c2end) = cache.tab
-
-    # u1
-    @.. broadcast = false thread = thread k = integrator.fsalfirst
-    @.. broadcast = false thread = thread u = u + B1 * dt * k
-
-    # other stages
-    for i in eachindex(A2end)
-        @.. broadcast = false thread = thread tmp = u + A2end[i] * dt * k
-        f(k, tmp, p, t + c2end[i] * dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-        @.. broadcast = false thread = thread u = u + B2end[i] * dt * k
-    end
-    step_limiter!(u, integrator, p, t + dt)
-    f(k, u, p, t + dt)
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+function perform_step!(integrator, cache::LowStorageRK2CCache, repeat_step = false)
+    return _perform_step_iip!(integrator, cache, cache.tab)
 end
 
 # 3S low storage methods

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_perform_step.jl
@@ -1,4 +1,4 @@
-function initialize!(integrator, cache::LowStorageRKTableau{:two_n})
+function initialize!(integrator, cache::LowStorageRKTableau{TwoN})
     integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     integrator.kshortsize = 1
@@ -7,7 +7,7 @@ function initialize!(integrator, cache::LowStorageRKTableau{:two_n})
     return integrator.k[1] = integrator.fsalfirst
 end
 
-function perform_step!(integrator, cache::LowStorageRKTableau{:two_n}, repeat_step = false)
+function perform_step!(integrator, cache::LowStorageRKTableau{TwoN}, repeat_step = false)
     return _perform_step_oop!(integrator, cache)
 end
 

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_perform_step.jl
@@ -129,61 +129,20 @@ function perform_step!(integrator, cache::LowStorageRK3SpFSALCache, repeat_step 
     return _perform_step_iip!(integrator, cache, cache.tab)
 end
 
-# 2R+ low storage methods
 function initialize!(integrator, cache::LowStorageRK2RPConstantCache)
-    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     integrator.kshortsize = 1
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-
-    # Avoid undefined entries if k is an array of arrays
     integrator.fsallast = zero(integrator.fsalfirst)
     return integrator.k[1] = integrator.fsalfirst
 end
 
-@muladd function perform_step!(
-        integrator, cache::LowStorageRK2RPConstantCache,
-        repeat_step = false
-    )
-    (; t, dt, u, uprev, f, fsalfirst, p) = integrator
-    (; Aᵢ, Bₗ, B̂ₗ, Bᵢ, B̂ᵢ, Cᵢ) = cache
-
-    k = fsalfirst
-    # Initialize tmp for JET
-    tmp = uprev
-    integrator.opts.adaptive && (tmp = zero(uprev))
-
-    #stages 1 to s-1
-    for i in eachindex(Aᵢ)
-        integrator.opts.adaptive && (tmp = tmp + (Bᵢ[i] - B̂ᵢ[i]) * dt * k)
-        gprev = u + Aᵢ[i] * dt * k
-        u = u + Bᵢ[i] * dt * k
-        k = f(gprev, p, t + Cᵢ[i] * dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    end
-
-    #last stage
-    integrator.opts.adaptive && (tmp = tmp + (Bₗ - B̂ₗ) * dt * k)
-    u = u + Bₗ * dt * k
-
-    #Error estimate
-    if integrator.opts.adaptive
-        atmp = calculate_residuals(
-            tmp, uprev, u, integrator.opts.abstol,
-            integrator.opts.reltol, integrator.opts.internalnorm, t
-        )
-        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
-    end
-
-    integrator.k[1] = integrator.fsalfirst
-    integrator.fsallast = f(u, p, t + dt) # For interpolation, then FSAL'd
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    integrator.u = u
+function perform_step!(integrator, cache::LowStorageRK2RPConstantCache, repeat_step = false)
+    return _perform_step_oop!(integrator, cache)
 end
 
 function initialize!(integrator, cache::LowStorageRK2RPCache)
-    (; k, fsalfirst) = cache
-
     integrator.kshortsize = 1
     resize!(integrator.k, integrator.kshortsize)
     integrator.k[1] = integrator.fsalfirst
@@ -191,105 +150,24 @@ function initialize!(integrator, cache::LowStorageRK2RPCache)
     return OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 end
 
-@muladd function perform_step!(integrator, cache::LowStorageRK2RPCache, repeat_step = false)
-    (; t, dt, u, uprev, f, fsalfirst, p) = integrator
-    (; k, gprev, tmp, atmp, stage_limiter!, step_limiter!, thread) = cache
-    (; Aᵢ, Bₗ, B̂ₗ, Bᵢ, B̂ᵢ, Cᵢ) = cache.tab
-
-    @.. broadcast = false thread = thread k = fsalfirst
-    integrator.opts.adaptive && (@.. broadcast = false tmp = zero(uprev))
-
-    #stages 1 to s-1
-    for i in eachindex(Aᵢ)
-        integrator.opts.adaptive &&
-            (@.. broadcast = false thread = thread tmp = tmp + (Bᵢ[i] - B̂ᵢ[i]) * dt * k)
-        @.. broadcast = false thread = thread gprev = u + Aᵢ[i] * dt * k
-        @.. broadcast = false thread = thread u = u + Bᵢ[i] * dt * k
-        f(k, gprev, p, t + Cᵢ[i] * dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    end
-
-    #last stage
-    integrator.opts.adaptive &&
-        (@.. broadcast = false thread = thread tmp = tmp + (Bₗ - B̂ₗ) * dt * k)
-    @.. broadcast = false thread = thread u = u + Bₗ * dt * k
-
-    #Error estimate
-    if integrator.opts.adaptive
-        calculate_residuals!(
-            atmp, tmp, uprev, u, integrator.opts.abstol,
-            integrator.opts.reltol, integrator.opts.internalnorm, t,
-            thread
-        )
-        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
-    end
-
-    step_limiter!(u, integrator, p, t + dt)
-    f(k, u, p, t + dt)
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+function perform_step!(integrator, cache::LowStorageRK2RPCache, repeat_step = false)
+    return _perform_step_iip!(integrator, cache, cache.tab)
 end
 
-# 3R+ low storage methods
 function initialize!(integrator, cache::LowStorageRK3RPConstantCache)
-    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     integrator.kshortsize = 1
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-
-    # Avoid undefined entries if k is an array of arrays
     integrator.fsallast = zero(integrator.fsalfirst)
     return integrator.k[1] = integrator.fsalfirst
 end
 
-@muladd function perform_step!(
-        integrator, cache::LowStorageRK3RPConstantCache,
-        repeat_step = false
-    )
-    (; t, dt, u, uprev, f, fsalfirst, p) = integrator
-    (; Aᵢ₁, Aᵢ₂, Bₗ, B̂ₗ, Bᵢ, B̂ᵢ, Cᵢ) = cache
-
-    fᵢ₋₂ = zero(fsalfirst)
-    k = fsalfirst
-    uᵢ₋₁ = uprev
-    uᵢ₋₂ = uprev
-    # Initialize tmp for JET
-    tmp = uprev
-    integrator.opts.adaptive && (tmp = zero(uprev))
-
-    #stages 1 to s-1
-    for i in eachindex(Aᵢ₁)
-        integrator.opts.adaptive && (tmp = tmp + (Bᵢ[i] - B̂ᵢ[i]) * dt * k)
-        gprev = uᵢ₋₂ + (Aᵢ₁[i] * k + Aᵢ₂[i] * fᵢ₋₂) * dt
-        u = u + Bᵢ[i] * dt * k
-        fᵢ₋₂ = k
-        uᵢ₋₂ = uᵢ₋₁
-        uᵢ₋₁ = u
-        k = f(gprev, p, t + Cᵢ[i] * dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    end
-
-    #last stage
-    integrator.opts.adaptive && (tmp = tmp + (Bₗ - B̂ₗ) * dt * k)
-    u = u + Bₗ * dt * k
-
-    #Error estimate
-    if integrator.opts.adaptive
-        atmp = calculate_residuals(
-            tmp, uprev, u, integrator.opts.abstol,
-            integrator.opts.reltol, integrator.opts.internalnorm, t
-        )
-        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
-    end
-
-    integrator.k[1] = integrator.fsalfirst
-    integrator.fsallast = f(u, p, t + dt) # For interpolation, then FSAL'd
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    integrator.u = u
+function perform_step!(integrator, cache::LowStorageRK3RPConstantCache, repeat_step = false)
+    return _perform_step_oop!(integrator, cache)
 end
 
 function initialize!(integrator, cache::LowStorageRK3RPCache)
-    (; k, fsalfirst) = cache
-
     integrator.kshortsize = 1
     resize!(integrator.k, integrator.kshortsize)
     integrator.k[1] = integrator.fsalfirst
@@ -297,116 +175,25 @@ function initialize!(integrator, cache::LowStorageRK3RPCache)
     return OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 end
 
-@muladd function perform_step!(integrator, cache::LowStorageRK3RPCache, repeat_step = false)
-    (; t, dt, u, uprev, f, fsalfirst, p) = integrator
-    (; k, uᵢ₋₁, uᵢ₋₂, gprev, fᵢ₋₂, tmp, atmp, stage_limiter!, step_limiter!, thread) = cache
-    (; Aᵢ₁, Aᵢ₂, Bₗ, B̂ₗ, Bᵢ, B̂ᵢ, Cᵢ) = cache.tab
-
-    @.. broadcast = false thread = thread fᵢ₋₂ = zero(fsalfirst)
-    @.. broadcast = false thread = thread k = fsalfirst
-    integrator.opts.adaptive && (@.. broadcast = false thread = thread tmp = zero(uprev))
-    @.. broadcast = false thread = thread uᵢ₋₁ = uprev
-    @.. broadcast = false thread = thread uᵢ₋₂ = uprev
-
-    #stages 1 to s-1
-    for i in eachindex(Aᵢ₁)
-        integrator.opts.adaptive &&
-            (@.. broadcast = false thread = thread tmp = tmp + (Bᵢ[i] - B̂ᵢ[i]) * dt * k)
-        @.. broadcast = false thread = thread gprev = uᵢ₋₂ + (Aᵢ₁[i] * k + Aᵢ₂[i] * fᵢ₋₂) * dt
-        @.. broadcast = false thread = thread u = u + Bᵢ[i] * dt * k
-        @.. broadcast = false thread = thread fᵢ₋₂ = k
-        @.. broadcast = false thread = thread uᵢ₋₂ = uᵢ₋₁
-        @.. broadcast = false thread = thread uᵢ₋₁ = u
-        f(k, gprev, p, t + Cᵢ[i] * dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    end
-
-    #last stage
-    integrator.opts.adaptive &&
-        (@.. broadcast = false thread = thread tmp = tmp + (Bₗ - B̂ₗ) * dt * k)
-    @.. broadcast = false thread = thread u = u + Bₗ * dt * k
-
-    step_limiter!(u, integrator, p, t + dt)
-
-    #Error estimate
-    if integrator.opts.adaptive
-        calculate_residuals!(
-            atmp, tmp, uprev, u, integrator.opts.abstol,
-            integrator.opts.reltol, integrator.opts.internalnorm, t,
-            thread
-        )
-        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
-    end
-
-    f(k, u, p, t + dt)
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+function perform_step!(integrator, cache::LowStorageRK3RPCache, repeat_step = false)
+    return _perform_step_iip!(integrator, cache, cache.tab)
 end
 
-# 4R+ low storage methods
+
 function initialize!(integrator, cache::LowStorageRK4RPConstantCache)
-    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     integrator.kshortsize = 1
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-
-    # Avoid undefined entries if k is an array of arrays
     integrator.fsallast = zero(integrator.fsalfirst)
     return integrator.k[1] = integrator.fsalfirst
 end
 
-@muladd function perform_step!(
-        integrator, cache::LowStorageRK4RPConstantCache,
-        repeat_step = false
-    )
-    (; t, dt, u, uprev, f, fsalfirst, p) = integrator
-    (; Aᵢ₁, Aᵢ₂, Aᵢ₃, Bₗ, B̂ₗ, Bᵢ, B̂ᵢ, Cᵢ) = cache
-
-    fᵢ₋₂ = zero(fsalfirst)
-    fᵢ₋₃ = zero(fsalfirst)
-    k = fsalfirst
-    uᵢ₋₁ = uprev
-    uᵢ₋₂ = uprev
-    uᵢ₋₃ = uprev
-    # Initialize tmp for JET
-    tmp = uprev
-    integrator.opts.adaptive && (tmp = zero(uprev))
-
-    #stages 1 to s-1
-    for i in eachindex(Aᵢ₁)
-        integrator.opts.adaptive && (tmp = tmp + (Bᵢ[i] - B̂ᵢ[i]) * dt * k)
-        gprev = uᵢ₋₃ + (Aᵢ₁[i] * k + Aᵢ₂[i] * fᵢ₋₂ + Aᵢ₃[i] * fᵢ₋₃) * dt
-        u = u + Bᵢ[i] * dt * k
-        fᵢ₋₃ = fᵢ₋₂
-        fᵢ₋₂ = k
-        uᵢ₋₃ = uᵢ₋₂
-        uᵢ₋₂ = uᵢ₋₁
-        uᵢ₋₁ = u
-        k = f(gprev, p, t + Cᵢ[i] * dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    end
-
-    #last stage
-    integrator.opts.adaptive && (tmp = tmp + (Bₗ - B̂ₗ) * dt * k)
-    u = u + Bₗ * dt * k
-
-    #Error estimate
-    if integrator.opts.adaptive
-        atmp = calculate_residuals(
-            tmp, uprev, u, integrator.opts.abstol,
-            integrator.opts.reltol, integrator.opts.internalnorm, t
-        )
-        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
-    end
-
-    integrator.k[1] = integrator.fsalfirst
-    integrator.fsallast = f(u, p, t + dt) # For interpolation, then FSAL'd
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    integrator.u = u
+function perform_step!(integrator, cache::LowStorageRK4RPConstantCache, repeat_step = false)
+    return _perform_step_oop!(integrator, cache)
 end
 
 function initialize!(integrator, cache::LowStorageRK4RPCache)
-    (; k, fsalfirst) = cache
-
     integrator.kshortsize = 1
     resize!(integrator.k, integrator.kshortsize)
     integrator.k[1] = integrator.fsalfirst
@@ -414,132 +201,25 @@ function initialize!(integrator, cache::LowStorageRK4RPCache)
     return OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 end
 
-@muladd function perform_step!(integrator, cache::LowStorageRK4RPCache, repeat_step = false)
-    (; t, dt, u, uprev, f, fsalfirst, p) = integrator
-    (;
-        k, uᵢ₋₁, uᵢ₋₂, uᵢ₋₃, gprev, fᵢ₋₂, fᵢ₋₃, tmp, atmp,
-        stage_limiter!, step_limiter!, thread,
-    ) = cache
-    (; Aᵢ₁, Aᵢ₂, Aᵢ₃, Bₗ, B̂ₗ, Bᵢ, B̂ᵢ, Cᵢ) = cache.tab
-
-    @.. broadcast = false thread = thread fᵢ₋₂ = zero(fsalfirst)
-    @.. broadcast = false thread = thread fᵢ₋₃ = zero(fsalfirst)
-    @.. broadcast = false thread = thread k = fsalfirst
-    integrator.opts.adaptive && (@.. broadcast = false thread = thread tmp = zero(uprev))
-    @.. broadcast = false thread = thread uᵢ₋₁ = uprev
-    @.. broadcast = false thread = thread uᵢ₋₂ = uprev
-    @.. broadcast = false thread = thread uᵢ₋₃ = uprev
-
-    #stages 1 to s-1
-    for i in eachindex(Aᵢ₁)
-        integrator.opts.adaptive &&
-            (@.. broadcast = false thread = thread tmp = tmp + (Bᵢ[i] - B̂ᵢ[i]) * dt * k)
-        @.. broadcast = false thread = thread gprev = uᵢ₋₃ +
-            (
-            Aᵢ₁[i] * k + Aᵢ₂[i] * fᵢ₋₂ +
-                Aᵢ₃[i] * fᵢ₋₃
-        ) *
-            dt
-        @.. broadcast = false thread = thread u = u + Bᵢ[i] * dt * k
-        @.. broadcast = false thread = thread fᵢ₋₃ = fᵢ₋₂
-        @.. broadcast = false thread = thread fᵢ₋₂ = k
-        @.. broadcast = false thread = thread uᵢ₋₃ = uᵢ₋₂
-        @.. broadcast = false thread = thread uᵢ₋₂ = uᵢ₋₁
-        @.. broadcast = false thread = thread uᵢ₋₁ = u
-        f(k, gprev, p, t + Cᵢ[i] * dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    end
-
-    #last stage
-    integrator.opts.adaptive &&
-        (@.. broadcast = false thread = thread tmp = tmp + (Bₗ - B̂ₗ) * dt * k)
-    @.. broadcast = false thread = thread u = u + Bₗ * dt * k
-
-    step_limiter!(u, integrator, p, t + dt)
-
-    #Error estimate
-    if integrator.opts.adaptive
-        calculate_residuals!(
-            atmp, tmp, uprev, u, integrator.opts.abstol,
-            integrator.opts.reltol, integrator.opts.internalnorm, t,
-            thread
-        )
-        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
-    end
-
-    f(k, u, p, t + dt)
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+function perform_step!(integrator, cache::LowStorageRK4RPCache, repeat_step = false)
+    return _perform_step_iip!(integrator, cache, cache.tab)
 end
 
-# 5R+ low storage methods
+
 function initialize!(integrator, cache::LowStorageRK5RPConstantCache)
-    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     integrator.kshortsize = 1
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-
-    # Avoid undefined entries if k is an array of arrays
     integrator.fsallast = zero(integrator.fsalfirst)
     return integrator.k[1] = integrator.fsalfirst
 end
 
-@muladd function perform_step!(
-        integrator, cache::LowStorageRK5RPConstantCache,
-        repeat_step = false
-    )
-    (; t, dt, u, uprev, f, fsalfirst, p) = integrator
-    (; Aᵢ₁, Aᵢ₂, Aᵢ₃, Aᵢ₄, Bₗ, B̂ₗ, Bᵢ, B̂ᵢ, Cᵢ) = cache
-
-    fᵢ₋₂ = zero(fsalfirst)
-    fᵢ₋₃ = zero(fsalfirst)
-    fᵢ₋₄ = zero(fsalfirst)
-    k = fsalfirst
-    uᵢ₋₁ = uprev
-    uᵢ₋₂ = uprev
-    uᵢ₋₃ = uprev
-    uᵢ₋₄ = uprev
-    # Initialize tmp for JET
-    tmp = uprev
-    integrator.opts.adaptive && (tmp = zero(uprev))
-
-    #stages 1 to s-1
-    for i in eachindex(Aᵢ₁)
-        integrator.opts.adaptive && (tmp = tmp + (Bᵢ[i] - B̂ᵢ[i]) * dt * k)
-        gprev = uᵢ₋₄ + (Aᵢ₁[i] * k + Aᵢ₂[i] * fᵢ₋₂ + Aᵢ₃[i] * fᵢ₋₃ + Aᵢ₄[i] * fᵢ₋₄) * dt
-        u = u + Bᵢ[i] * dt * k
-        fᵢ₋₄ = fᵢ₋₃
-        fᵢ₋₃ = fᵢ₋₂
-        fᵢ₋₂ = k
-        uᵢ₋₄ = uᵢ₋₃
-        uᵢ₋₃ = uᵢ₋₂
-        uᵢ₋₂ = uᵢ₋₁
-        uᵢ₋₁ = u
-        k = f(gprev, p, t + Cᵢ[i] * dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    end
-
-    #last stage
-    integrator.opts.adaptive && (tmp = tmp + (Bₗ - B̂ₗ) * dt * k)
-    u = u + Bₗ * dt * k
-
-    #Error estimate
-    if integrator.opts.adaptive
-        atmp = calculate_residuals(
-            tmp, uprev, u, integrator.opts.abstol,
-            integrator.opts.reltol, integrator.opts.internalnorm, t
-        )
-        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
-    end
-
-    integrator.k[1] = integrator.fsalfirst
-    integrator.fsallast = f(u, p, t + dt) # For interpolation, then FSAL'd
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    integrator.u = u
+function perform_step!(integrator, cache::LowStorageRK5RPConstantCache, repeat_step = false)
+    return _perform_step_oop!(integrator, cache)
 end
 
 function initialize!(integrator, cache::LowStorageRK5RPCache)
-    (; k, fsalfirst) = cache
-
     integrator.kshortsize = 1
     resize!(integrator.k, integrator.kshortsize)
     integrator.k[1] = integrator.fsalfirst
@@ -547,404 +227,6 @@ function initialize!(integrator, cache::LowStorageRK5RPCache)
     return OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 end
 
-@muladd function perform_step!(integrator, cache::LowStorageRK5RPCache, repeat_step = false)
-    (; t, dt, u, uprev, f, fsalfirst, p) = integrator
-    (;
-        k, uᵢ₋₁, uᵢ₋₂, uᵢ₋₃, uᵢ₋₄, gprev, fᵢ₋₂, fᵢ₋₃, fᵢ₋₄, tmp,
-        atmp, stage_limiter!, step_limiter!, thread,
-    ) = cache
-    (; Aᵢ₁, Aᵢ₂, Aᵢ₃, Aᵢ₄, Bₗ, B̂ₗ, Bᵢ, B̂ᵢ, Cᵢ) = cache.tab
-
-    @.. broadcast = false thread = thread fᵢ₋₂ = zero(fsalfirst)
-    @.. broadcast = false thread = thread fᵢ₋₃ = zero(fsalfirst)
-    @.. broadcast = false thread = thread fᵢ₋₄ = zero(fsalfirst)
-    @.. broadcast = false thread = thread k = fsalfirst
-    integrator.opts.adaptive && (@.. broadcast = false thread = thread tmp = zero(uprev))
-    @.. broadcast = false thread = thread uᵢ₋₁ = uprev
-    @.. broadcast = false thread = thread uᵢ₋₂ = uprev
-    @.. broadcast = false thread = thread uᵢ₋₃ = uprev
-    @.. broadcast = false thread = thread uᵢ₋₄ = uprev
-
-    #stages 1 to s-1
-    for i in eachindex(Aᵢ₁)
-        integrator.opts.adaptive &&
-            (@.. broadcast = false thread = thread tmp = tmp + (Bᵢ[i] - B̂ᵢ[i]) * dt * k)
-        @.. broadcast = false thread = thread gprev = uᵢ₋₄ +
-            (
-            Aᵢ₁[i] * k + Aᵢ₂[i] * fᵢ₋₂ +
-                Aᵢ₃[i] * fᵢ₋₃ +
-                Aᵢ₄[i] * fᵢ₋₄
-        ) * dt
-        @.. broadcast = false thread = thread u = u + Bᵢ[i] * dt * k
-        @.. broadcast = false thread = thread fᵢ₋₄ = fᵢ₋₃
-        @.. broadcast = false thread = thread fᵢ₋₃ = fᵢ₋₂
-        @.. broadcast = false thread = thread fᵢ₋₂ = k
-        @.. broadcast = false thread = thread uᵢ₋₄ = uᵢ₋₃
-        @.. broadcast = false thread = thread uᵢ₋₃ = uᵢ₋₂
-        @.. broadcast = false thread = thread uᵢ₋₂ = uᵢ₋₁
-        @.. broadcast = false thread = thread uᵢ₋₁ = u
-        f(k, gprev, p, t + Cᵢ[i] * dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    end
-
-    #last stage
-    integrator.opts.adaptive &&
-        (@.. broadcast = false thread = thread tmp = tmp + (Bₗ - B̂ₗ) * dt * k)
-    @.. broadcast = false thread = thread u = u + Bₗ * dt * k
-
-    step_limiter!(u, integrator, p, t + dt)
-
-    #Error estimate
-    if integrator.opts.adaptive
-        calculate_residuals!(
-            atmp, tmp, uprev, u, integrator.opts.abstol,
-            integrator.opts.reltol, integrator.opts.internalnorm, t,
-            thread
-        )
-        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
-    end
-
-    f(k, u, p, t + dt)
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-end
-
-function initialize!(integrator, cache::RK46NLCache)
-    (; k, fsalfirst) = cache
-
-    integrator.kshortsize = 1
-    resize!(integrator.k, integrator.kshortsize)
-    integrator.k[1] = integrator.fsalfirst
-    integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # FSAL for interpolation
-    return OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-end
-
-@muladd function perform_step!(integrator, cache::RK46NLCache, repeat_step = false)
-    (; t, dt, uprev, u, f, p) = integrator
-    (; k, fsalfirst, tmp, stage_limiter!, step_limiter!, thread) = cache
-    (; α2, α3, α4, α5, α6, β1, β2, β3, β4, β5, β6, c2, c3, c4, c5, c6) = cache.tab
-
-    # u1
-    @.. broadcast = false thread = thread tmp = dt * fsalfirst
-    @.. broadcast = false thread = thread u = uprev + β1 * tmp
-    stage_limiter!(u, integrator, p, t + c2 * dt)
-    # u2
-    f(k, u, p, t + c2 * dt)
-    @.. broadcast = false thread = thread tmp = α2 * tmp + dt * k
-    @.. broadcast = false thread = thread u = u + β2 * tmp
-    stage_limiter!(u, integrator, p, t + c3 * dt)
-    # u3
-    f(k, u, p, t + c3 * dt)
-    @.. broadcast = false thread = thread tmp = α3 * tmp + dt * k
-    @.. broadcast = false thread = thread u = u + β3 * tmp
-    stage_limiter!(u, integrator, p, t + c4 * dt)
-    # u4
-    f(k, u, p, t + c4 * dt)
-    @.. broadcast = false thread = thread tmp = α4 * tmp + dt * k
-    @.. broadcast = false thread = thread u = u + β4 * tmp
-    stage_limiter!(u, integrator, p, t + c5 * dt)
-    # u5 = u
-    f(k, u, p, t + c5 * dt)
-    @.. broadcast = false thread = thread tmp = α5 * tmp + dt * k
-    @.. broadcast = false thread = thread u = u + β5 * tmp
-    stage_limiter!(u, integrator, p, t + c6 * dt)
-
-    f(k, u, p, t + c6 * dt)
-    @.. broadcast = false thread = thread tmp = α6 * tmp + dt * k
-    @.. broadcast = false thread = thread u = u + β6 * tmp
-    stage_limiter!(u, integrator, p, t + dt)
-    step_limiter!(u, integrator, p, t + dt)
-
-    f(k, u, p, t + dt)
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 6)
-end
-
-function initialize!(integrator, cache::RK46NLConstantCache)
-    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    integrator.kshortsize = 1
-    integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-
-    # Avoid undefined entries if k is an array of arrays
-    integrator.fsallast = zero(integrator.fsalfirst)
-    return integrator.k[1] = integrator.fsalfirst
-end
-
-@muladd function perform_step!(integrator, cache::RK46NLConstantCache, repeat_step = false)
-    (; t, dt, uprev, u, f, p) = integrator
-    (; α2, α3, α4, α5, α6, β1, β2, β3, β4, β5, β6, c2, c3, c4, c5, c6) = cache
-
-    # u1
-    tmp = dt * integrator.fsalfirst
-    u = uprev + β1 * tmp
-    # u2
-    tmp = α2 * tmp + dt * f(u, p, t + c2 * dt)
-    u = u + β2 * tmp
-    # u3
-    tmp = α3 * tmp + dt * f(u, p, t + c3 * dt)
-    u = u + β3 * tmp
-    # u4
-    tmp = α4 * tmp + dt * f(u, p, t + c4 * dt)
-    u = u + β4 * tmp
-    # u5 = u
-    tmp = α5 * tmp + dt * f(u, p, t + c5 * dt)
-    u = u + β5 * tmp
-    # u6
-    tmp = α6 * tmp + dt * f(u, p, t + c6 * dt)
-    u = u + β6 * tmp
-
-    integrator.fsallast = f(u, p, t + dt) # For interpolation, then FSAL'd
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 6)
-    integrator.k[1] = integrator.fsalfirst
-    integrator.u = u
-end
-
-function initialize!(integrator, cache::SHLDDRK52ConstantCache)
-    integrator.kshortsize = 2
-    integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-
-    # Avoid undefined entries if k is an array of arrays
-    integrator.fsallast = zero(integrator.fsalfirst)
-    integrator.k[1] = integrator.fsalfirst
-    return integrator.k[2] = integrator.fsallast
-end
-
-@muladd function perform_step!(
-        integrator, cache::SHLDDRK52ConstantCache,
-        repeat_step = false
-    )
-    (; t, dt, uprev, u, f, p) = integrator
-    (; α2, α3, α4, α5, β1, β2, β3, β4, β5, c2, c3, c4, c5) = cache
-
-    # u1
-    tmp = dt * integrator.fsalfirst
-    u = uprev + β1 * tmp
-    # u2
-    tmp = α2 * tmp + dt * f(u, p, t + c2 * dt)
-    u = u + β2 * tmp
-    # u3
-    tmp = α3 * tmp + dt * f(u, p, t + c3 * dt)
-    u = u + β3 * tmp
-    # u4
-    tmp = α4 * tmp + dt * f(u, p, t + c4 * dt)
-    u = u + β4 * tmp
-    # u5 = u
-    tmp = α5 * tmp + dt * f(u, p, t + c5 * dt)
-    u = u + β5 * tmp
-
-    integrator.fsallast = f(u, p, t + dt) # For interpolation, then FSAL'd
-    integrator.k[1] = integrator.fsalfirst
-    integrator.k[2] = integrator.fsallast
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 5)
-    integrator.u = u
-end
-
-function initialize!(integrator, cache::SHLDDRK52Cache)
-    (; k, fsalfirst) = cache
-
-    integrator.kshortsize = 2
-    resize!(integrator.k, integrator.kshortsize)
-    integrator.k[1] = integrator.fsalfirst
-    integrator.k[2] = integrator.fsallast
-    integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # FSAL for interpolation
-    return OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-end
-
-@muladd function perform_step!(integrator, cache::SHLDDRK52Cache, repeat_step = false)
-    (; t, dt, uprev, u, f, p) = integrator
-    (; k, fsalfirst, tmp, stage_limiter!, step_limiter!, thread) = cache
-    (; α2, α3, α4, α5, β1, β2, β3, β4, β5, c2, c3, c4, c5) = cache.tab
-
-    # u1
-    @.. thread = thread tmp = dt * fsalfirst
-    @.. thread = thread u = uprev + β1 * tmp
-    stage_limiter!(u, integrator, p, t + c2 * dt)
-    # u2
-    f(k, u, p, t + c2 * dt)
-    @.. thread = thread tmp = α2 * tmp + dt * k
-    @.. thread = thread u = u + β2 * tmp
-    stage_limiter!(u, integrator, p, t + c3 * dt)
-    # u3
-    f(k, u, p, t + c3 * dt)
-    @.. thread = thread tmp = α3 * tmp + dt * k
-    @.. thread = thread u = u + β3 * tmp
-    stage_limiter!(u, integrator, p, t + c4 * dt)
-    # u4
-    f(k, u, p, t + c4 * dt)
-    @.. thread = thread tmp = α4 * tmp + dt * k
-    @.. thread = thread u = u + β4 * tmp
-    stage_limiter!(u, integrator, p, t + c5 * dt)
-    # u5 = u
-    f(k, u, p, t + c5 * dt)
-    @.. thread = thread tmp = α5 * tmp + dt * k
-    @.. thread = thread u = u + β5 * tmp
-    stage_limiter!(u, integrator, p, t + dt)
-    step_limiter!(u, integrator, p, t + dt)
-
-    f(k, u, p, t + dt)
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 5)
-end
-
-function initialize!(integrator, cache::SHLDDRK_2NConstantCache)
-    integrator.kshortsize = 2
-    integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-
-    # Avoid undefined entries if k is an array of arrays
-    integrator.fsallast = zero(integrator.fsalfirst)
-    integrator.k[1] = integrator.fsalfirst
-    return integrator.k[2] = integrator.fsallast
-end
-
-@muladd function perform_step!(
-        integrator, cache::SHLDDRK_2NConstantCache,
-        repeat_step = false
-    )
-    (; t, dt, uprev, u, f, p) = integrator
-    (;
-        α21, α31, α41, α51, β11, β21, β31, β41, β51, c21, c31, c41, c51, α22, α32,
-        α42, α52, α62, β12, β22, β32, β42, β52, β62, c22, c32, c42, c52, c62,
-    ) = cache
-
-    if integrator.derivative_discontinuity
-        cache.step = 1
-    end
-    # cnt = cache.step
-
-    if cache.step % 2 == 1
-        cache.step += 1
-        # u1
-        tmp = dt * integrator.fsalfirst
-        u = uprev + β11 * tmp
-        # u2
-        tmp = α21 * tmp + dt * f(u, p, t + c21 * dt)
-        u = u + β21 * tmp
-        # u3
-        tmp = α31 * tmp + dt * f(u, p, t + c31 * dt)
-        u = u + β31 * tmp
-        # u4
-        tmp = α41 * tmp + dt * f(u, p, t + c41 * dt)
-        u = u + β41 * tmp
-        # u5 = u
-        tmp = α51 * tmp + dt * f(u, p, t + c51 * dt)
-        u = u + β51 * tmp
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 4)
-    else
-        cache.step += 1
-        # u1
-        tmp = dt * integrator.fsalfirst
-        u = uprev + β12 * tmp
-        # u2
-        tmp = α22 * tmp + dt * f(u, p, t + c22 * dt)
-        u = u + β22 * tmp
-        # u3
-        tmp = α32 * tmp + dt * f(u, p, t + c32 * dt)
-        u = u + β32 * tmp
-        # u4
-        tmp = α42 * tmp + dt * f(u, p, t + c42 * dt)
-        u = u + β42 * tmp
-        # u5 = u
-        tmp = α52 * tmp + dt * f(u, p, t + c52 * dt)
-        u = u + β52 * tmp
-        tmp = α62 * tmp + dt * f(u, p, t + c62 * dt)
-        u = u + β62 * tmp
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 5)
-    end
-
-    integrator.fsallast = f(u, p, t + dt) # For interpolation, then FSAL'd
-    integrator.k[1] = integrator.fsalfirst
-    integrator.k[2] = integrator.fsallast
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    integrator.u = u
-end
-
-function initialize!(integrator, cache::SHLDDRK_2NCache)
-    (; k, fsalfirst) = cache
-
-    integrator.kshortsize = 2
-    resize!(integrator.k, integrator.kshortsize)
-    integrator.k[1] = integrator.fsalfirst
-    integrator.k[2] = integrator.fsallast
-    integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # FSAL for interpolation
-    return OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-end
-
-@muladd function perform_step!(integrator, cache::SHLDDRK_2NCache, repeat_step = false)
-    (; t, dt, uprev, u, f, p) = integrator
-    (; k, fsalfirst, tmp, stage_limiter!, step_limiter!, thread) = cache
-    (;
-        α21, α31, α41, α51, β11, β21, β31, β41, β51, c21, c31, c41, c51, α22, α32, α42,
-        α52, α62, β12, β22, β32, β42, β52, β62, c22, c32, c42, c52, c62,
-    ) = cache.tab
-
-    if integrator.derivative_discontinuity
-        cache.step = 1
-    end
-
-    if cache.step % 2 == 1
-        # u1
-        @.. thread = thread tmp = dt * fsalfirst
-        @.. thread = thread u = uprev + β11 * tmp
-        stage_limiter!(u, integrator, p, t + c21 * dt)
-        # u2
-        f(k, u, p, t + c21 * dt)
-        @.. thread = thread tmp = α21 * tmp + dt * k
-        @.. thread = thread u = u + β21 * tmp
-        stage_limiter!(u, integrator, p, t + c31 * dt)
-        # u3
-        f(k, u, p, t + c31 * dt)
-        @.. thread = thread tmp = α31 * tmp + dt * k
-        @.. thread = thread u = u + β31 * tmp
-        stage_limiter!(u, integrator, p, t + c41 * dt)
-        # u4
-        f(k, u, p, t + c41 * dt)
-        @.. thread = thread tmp = α41 * tmp + dt * k
-        @.. thread = thread u = u + β41 * tmp
-        stage_limiter!(u, integrator, p, t + c51 * dt)
-        # u5 = u
-        f(k, u, p, t + c51 * dt)
-        @.. thread = thread tmp = α51 * tmp + dt * k
-        @.. thread = thread u = u + β51 * tmp
-        stage_limiter!(u, integrator, p, t + dt)
-        step_limiter!(u, integrator, p, t + dt)
-
-        f(k, u, p, t + dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 5)
-    else
-        # u1
-        @.. thread = thread tmp = dt * fsalfirst
-        @.. thread = thread u = uprev + β12 * tmp
-        stage_limiter!(u, integrator, p, t + c22 * dt)
-        # u2
-        f(k, u, p, t + c22 * dt)
-        @.. thread = thread tmp = α22 * tmp + dt * k
-        @.. thread = thread u = u + β22 * tmp
-        stage_limiter!(u, integrator, p, t + c32 * dt)
-        # u3
-        f(k, u, p, t + c32 * dt)
-        @.. thread = thread tmp = α32 * tmp + dt * k
-        @.. thread = thread u = u + β32 * tmp
-        stage_limiter!(u, integrator, p, t + c42 * dt)
-        # u4
-        f(k, u, p, t + c42 * dt)
-        @.. thread = thread tmp = α42 * tmp + dt * k
-        @.. thread = thread u = u + β42 * tmp
-        stage_limiter!(u, integrator, p, t + c52 * dt)
-        # u5 = u
-        f(k, u, p, t + c52 * dt)
-        @.. thread = thread tmp = α52 * tmp + dt * k
-        @.. thread = thread u = u + β52 * tmp
-        stage_limiter!(u, integrator, p, t + c62 * dt)
-        # u6 = u
-        f(k, u, p, t + c62 * dt)
-        @.. thread = thread tmp = α62 * tmp + dt * k
-        @.. thread = thread u = u + β62 * tmp
-        stage_limiter!(u, integrator, p, t + dt)
-        step_limiter!(u, integrator, p, t + dt)
-
-        f(k, u, p, t + dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 6)
-    end
+function perform_step!(integrator, cache::LowStorageRK5RPCache, repeat_step = false)
+    return _perform_step_iip!(integrator, cache, cache.tab)
 end

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_perform_step.jl
@@ -77,223 +77,56 @@ function perform_step!(integrator, cache::LowStorageRK3SCache, repeat_step = fal
     return _perform_step_iip!(integrator, cache, cache.tab)
 end
 
-# 3S+ low storage methods: 3S methods adding another memory location for the embedded method (non-FSAL version)
 function initialize!(integrator, cache::LowStorageRK3SpConstantCache)
-    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     integrator.kshortsize = 1
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-
-    # Avoid undefined entries if k is an array of arrays
     integrator.fsallast = zero(integrator.fsalfirst)
     return integrator.k[1] = integrator.fsalfirst
 end
 
-@muladd function perform_step!(
-        integrator, cache::LowStorageRK3SpConstantCache,
-        repeat_step = false
-    )
-    (; t, dt, uprev, u, f, p) = integrator
-    (; γ12end, γ22end, γ32end, δ2end, β1, β2end, c2end, bhat1, bhat2end) = cache
-
-    # u1
-    integrator.fsalfirst = f(uprev, p, t)
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    integrator.k[1] = integrator.fsalfirst
-    tmp = uprev
-    u = tmp + β1 * dt * integrator.fsalfirst
-    # Initialize utilde for JET
-    utilde = u
-    if integrator.opts.adaptive
-        utilde = bhat1 * dt * integrator.fsalfirst
-    end
-
-    # other stages
-    for i in eachindex(γ12end)
-        k = f(u, p, t + c2end[i] * dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-        tmp = tmp + δ2end[i] * u
-        u = γ12end[i] * u + γ22end[i] * tmp + γ32end[i] * uprev + β2end[i] * dt * k
-        if integrator.opts.adaptive
-            utilde = utilde + bhat2end[i] * dt * k
-        end
-    end
-
-    if integrator.opts.adaptive
-        atmp = calculate_residuals(
-            utilde, uprev, u, integrator.opts.abstol,
-            integrator.opts.reltol, integrator.opts.internalnorm, t
-        )
-        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
-    end
-
-    integrator.u = u
+function perform_step!(integrator, cache::LowStorageRK3SpConstantCache, repeat_step = false)
+    return _perform_step_oop!(integrator, cache)
 end
 
 function initialize!(integrator, cache::LowStorageRK3SpCache)
-    (; k, fsalfirst) = cache
-
     integrator.kshortsize = 1
     resize!(integrator.k, integrator.kshortsize)
     return integrator.k[1] = integrator.fsalfirst
 end
 
-@muladd function perform_step!(integrator, cache::LowStorageRK3SpCache, repeat_step = false)
-    (; t, dt, uprev, u, f, p) = integrator
-    (; k, tmp, utilde, atmp, stage_limiter!, step_limiter!, thread) = cache
-    (; γ12end, γ22end, γ32end, δ2end, β1, β2end, c2end, bhat1, bhat2end) = cache.tab
-
-    # u1
-    f(integrator.fsalfirst, uprev, p, t)
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    @.. broadcast = false thread = thread tmp = uprev
-    @.. broadcast = false thread = thread u = tmp + β1 * dt * integrator.fsalfirst
-    if integrator.opts.adaptive
-        @.. broadcast = false thread = thread utilde = bhat1 * dt * integrator.fsalfirst
-    end
-
-    # other stages
-    for i in eachindex(γ12end)
-        stage_limiter!(u, integrator, p, t + c2end[i] * dt)
-        f(k, u, p, t + c2end[i] * dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-        @.. broadcast = false thread = thread tmp = tmp + δ2end[i] * u
-        @.. broadcast = false thread = thread u = γ12end[i] * u + γ22end[i] * tmp +
-            γ32end[i] * uprev + β2end[i] * dt * k
-        if integrator.opts.adaptive
-            @.. broadcast = false thread = thread utilde = utilde + bhat2end[i] * dt * k
-        end
-    end
-
-    stage_limiter!(u, integrator, p, t + dt)
-    step_limiter!(u, integrator, p, t + dt)
-
-    if integrator.opts.adaptive
-        calculate_residuals!(
-            atmp, utilde, uprev, u, integrator.opts.abstol,
-            integrator.opts.reltol, integrator.opts.internalnorm, t,
-            thread
-        )
-        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
-    end
+function perform_step!(integrator, cache::LowStorageRK3SpCache, repeat_step = false)
+    return _perform_step_iip!(integrator, cache, cache.tab)
 end
 
-# 3S+ FSAL low storage methods: 3S methods adding another memory location for the embedded method (FSAL version)
 function initialize!(integrator, cache::LowStorageRK3SpFSALConstantCache)
-    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     integrator.kshortsize = 2
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-
-    # Avoid undefined entries if k is an array of arrays
     integrator.fsallast = zero(integrator.fsalfirst)
     integrator.k[1] = integrator.fsalfirst
     return integrator.k[2] = integrator.fsallast
 end
 
-@muladd function perform_step!(
-        integrator, cache::LowStorageRK3SpFSALConstantCache,
-        repeat_step = false
+function perform_step!(
+        integrator, cache::LowStorageRK3SpFSALConstantCache, repeat_step = false
     )
-    (; t, dt, uprev, u, f, p) = integrator
-    (; γ12end, γ22end, γ32end, δ2end, β1, β2end, c2end, bhat1, bhat2end, bhatfsal) = cache
-
-    # u1
-    tmp = uprev
-    u = tmp + β1 * dt * integrator.fsalfirst
-    # Initialize utilde for JET
-    utilde = u
-    if integrator.opts.adaptive
-        utilde = bhat1 * dt * integrator.fsalfirst
-    end
-
-    # other stages
-    for i in eachindex(γ12end)
-        k = f(u, p, t + c2end[i] * dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-        tmp = tmp + δ2end[i] * u
-        u = γ12end[i] * u + γ22end[i] * tmp + γ32end[i] * uprev + β2end[i] * dt * k
-        if integrator.opts.adaptive
-            utilde = utilde + bhat2end[i] * dt * k
-        end
-    end
-
-    # FSAL
-    integrator.fsallast = f(u, p, t + dt)
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-
-    if integrator.opts.adaptive
-        utilde = utilde + bhatfsal * dt * integrator.fsallast
-        atmp = calculate_residuals(
-            utilde, uprev, u, integrator.opts.abstol,
-            integrator.opts.reltol, integrator.opts.internalnorm, t
-        )
-        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
-    end
-
-    integrator.k[1] = integrator.fsalfirst
-    integrator.k[2] = integrator.fsallast
-    integrator.u = u
+    return _perform_step_oop!(integrator, cache)
 end
 
 function initialize!(integrator, cache::LowStorageRK3SpFSALCache)
-    (; k, fsalfirst) = cache
-
     integrator.kshortsize = 2
     resize!(integrator.k, integrator.kshortsize)
     integrator.k[1] = integrator.fsalfirst
     integrator.k[2] = integrator.fsallast
-    integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # FSAL for interpolation
+    integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t)
     return OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 end
 
-@muladd function perform_step!(
-        integrator, cache::LowStorageRK3SpFSALCache,
-        repeat_step = false
-    )
-    (; t, dt, uprev, u, f, p) = integrator
-    (; k, tmp, utilde, atmp, stage_limiter!, step_limiter!, thread) = cache
-    (;
-        γ12end, γ22end, γ32end, δ2end, β1, β2end,
-        c2end, bhat1, bhat2end, bhatfsal,
-    ) = cache.tab
-
-    # u1
-    @.. broadcast = false thread = thread tmp = uprev
-    @.. broadcast = false thread = thread u = tmp + β1 * dt * integrator.fsalfirst
-    if integrator.opts.adaptive
-        @.. broadcast = false thread = thread utilde = bhat1 * dt * integrator.fsalfirst
-    end
-
-    # other stages
-    for i in eachindex(γ12end)
-        stage_limiter!(u, integrator, p, t + c2end[i] * dt)
-        f(k, u, p, t + c2end[i] * dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-        @.. broadcast = false thread = thread tmp = tmp + δ2end[i] * u
-        @.. broadcast = false thread = thread u = γ12end[i] * u + γ22end[i] * tmp +
-            γ32end[i] * uprev + β2end[i] * dt * k
-        if integrator.opts.adaptive
-            @.. broadcast = false thread = thread utilde = utilde + bhat2end[i] * dt * k
-        end
-    end
-
-    stage_limiter!(u, integrator, p, t + dt)
-    step_limiter!(u, integrator, p, t + dt)
-
-    # FSAL
-    f(k, u, p, t + dt)
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-
-    if integrator.opts.adaptive
-        @.. broadcast = false thread = thread utilde = utilde + bhatfsal * dt * k
-        calculate_residuals!(
-            atmp, utilde, uprev, u, integrator.opts.abstol,
-            integrator.opts.reltol, integrator.opts.internalnorm, t,
-            thread
-        )
-        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
-    end
+function perform_step!(integrator, cache::LowStorageRK3SpFSALCache, repeat_step = false)
+    return _perform_step_iip!(integrator, cache, cache.tab)
 end
 
 # 2R+ low storage methods

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_perform_step.jl
@@ -26,7 +26,7 @@ function perform_step!(integrator, cache::LowStorageRK2NCache, repeat_step = fal
     return _perform_step_iip!(integrator, cache, cache.tab)
 end
 
-function initialize!(integrator, cache::LowStorageRKTableau{:two_c})
+function initialize!(integrator, cache::LowStorageRKTableau{TwoC})
     integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     integrator.kshortsize = 1
@@ -35,7 +35,7 @@ function initialize!(integrator, cache::LowStorageRKTableau{:two_c})
     return integrator.k[1] = integrator.fsalfirst
 end
 
-function perform_step!(integrator, cache::LowStorageRKTableau{:two_c}, repeat_step = false)
+function perform_step!(integrator, cache::LowStorageRKTableau{TwoC}, repeat_step = false)
     return _perform_step_oop!(integrator, cache)
 end
 

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_rk_perform_step.jl
@@ -53,73 +53,28 @@ end
 
 # 3S low storage methods
 function initialize!(integrator, cache::LowStorageRK3SConstantCache)
-    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
+    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     integrator.kshortsize = 1
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-
-    # Avoid undefined entries if k is an array of arrays
     integrator.fsallast = zero(integrator.fsalfirst)
     return integrator.k[1] = integrator.fsalfirst
 end
 
-@muladd function perform_step!(
-        integrator, cache::LowStorageRK3SConstantCache,
-        repeat_step = false
-    )
-    (; t, dt, uprev, u, f, p) = integrator
-    (; γ12end, γ22end, γ32end, δ2end, β1, β2end, c2end) = cache
-
-    # u1
-    tmp = u
-    u = tmp + β1 * dt * integrator.fsalfirst
-
-    # other stages
-    for i in eachindex(γ12end)
-        k = f(u, p, t + c2end[i] * dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-        tmp = tmp + δ2end[i] * u
-        u = γ12end[i] * u + γ22end[i] * tmp + γ32end[i] * uprev + β2end[i] * dt * k
-    end
-
-    integrator.fsallast = f(u, p, t + dt) # For interpolation, then FSAL'd
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    integrator.k[1] = integrator.fsalfirst
-    integrator.u = u
+function perform_step!(integrator, cache::LowStorageRK3SConstantCache, repeat_step = false)
+    return _perform_step_oop!(integrator, cache)
 end
 
 function initialize!(integrator, cache::LowStorageRK3SCache)
-    (; k, fsalfirst) = cache
-
     integrator.kshortsize = 1
     resize!(integrator.k, integrator.kshortsize)
     integrator.k[1] = integrator.fsalfirst
-    integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # FSAL for interpolation
+    integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t)
     return OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 end
 
-@muladd function perform_step!(integrator, cache::LowStorageRK3SCache, repeat_step = false)
-    (; t, dt, uprev, u, f, p) = integrator
-    (; k, fsalfirst, tmp, stage_limiter!, step_limiter!, thread) = cache
-    (; γ12end, γ22end, γ32end, δ2end, β1, β2end, c2end) = cache.tab
-
-    # u1
-    @.. broadcast = false thread = thread tmp = u
-    @.. broadcast = false thread = thread u = tmp + β1 * dt * integrator.fsalfirst
-
-    # other stages
-    for i in eachindex(γ12end)
-        f(k, u, p, t + c2end[i] * dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-        @.. broadcast = false thread = thread tmp = tmp + δ2end[i] * u
-        @.. broadcast = false thread = thread u = γ12end[i] * u + γ22end[i] * tmp +
-            γ32end[i] * uprev +
-            β2end[i] * dt * k
-    end
-
-    step_limiter!(u, integrator, p, t + dt)
-    f(k, u, p, t + dt)
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+function perform_step!(integrator, cache::LowStorageRK3SCache, repeat_step = false)
+    return _perform_step_iip!(integrator, cache, cache.tab)
 end
 
 # 3S+ low storage methods: 3S methods adding another memory location for the embedded method (non-FSAL version)

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_tableaus.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_tableaus.jl
@@ -1,3 +1,5 @@
+@enum LowStorageRKForm TwoN TwoC
+
 struct LowStorageRKTableau{form, N, T, T2} <: OrdinaryDiffEqConstantCache
     A2end::NTuple{N, T}
     B1::T

--- a/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_tableaus.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/low_storage_tableaus.jl
@@ -1,0 +1,12 @@
+struct LowStorageRKTableau{form, N, T, T2} <: OrdinaryDiffEqConstantCache
+    A2end::NTuple{N, T}
+    B1::T
+    B2end::NTuple{N, T}
+    c2end::NTuple{N, T2}
+end
+
+function LowStorageRKTableau{form}(
+        A2end::NTuple{N, T}, B1::T, B2end::NTuple{N, T}, c2end::NTuple{N, T2}
+    ) where {form, N, T, T2}
+    return LowStorageRKTableau{form, N, T, T2}(A2end, B1, B2end, c2end)
+end


### PR DESCRIPTION
## Summary

Converts the **RP families** (2RP: CKLLSRK54_3C_3R/54_3M_3R/54_3N_3R/85_4C_3R/85_4M_3R/85_4P_3R; 3RP: CKLLSRK54_3N_4R/54_3M_4R/65_4M_4R/85_4FM_4R/75_4M_5R; 4RP; 5RP) to plain-dispatch step implementations in `generic_low_storage_perform_step.jl`, dispatched on `LowStorageRK2RPConstantCache`, `LowStorageRK3RPConstantCache`, `LowStorageRK4RPConstantCache`, and `LowStorageRK5RPConstantCache`.

Thin wrappers in `low_storage_rk_perform_step.jl` delegate to the generic implementations.

Part of the stacked series: #3683 (2N) → #3684 (2C) → #3685 (3S) → #3686 (3Sp + 3SpFSAL) → **#3687 (2RP/3RP/4RP/5RP)** → #3688.

## Test plan

- [x] OOP and IIP paths validated against master — step counts and solution values identical.
- [ ] CI passes.
