### PR TITLE
Fix DDE+SDIRK2 iip/scalar divergence: restore nlsolver.c=c[1] in IIP stage 1

### DIFF
--- a/lib/OrdinaryDiffEqSDIRK/src/generic_imex_perform_step.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/generic_imex_perform_step.jl
@@ -116,6 +116,7 @@ end
         end
         nlsolver.z = zs[1]
         nlsolver.tmp = uprev
+        nlsolver.c = c[1]
         zs[1] = nlsolve!(nlsolver, integrator, cache, repeat_step)
         nlsolvefail(nlsolver) && return
         # All implicit stages share γ on the diagonal; reuse the W from stage 1.


### PR DESCRIPTION
## Summary

One-line fix in `lib/OrdinaryDiffEqSDIRK/src/generic_imex_perform_step.jl` to restore an `nlsolver.c = c[1]` assignment that the OOP path has but the IIP path was missing. **Please ignore until reviewed by @ChrisRackauckas.**

## Bug

`lib/DelayDiffEq/test/interface/multi_algorithm.jl`'s `Constant delays` testset throws `DimensionMismatch` on SDIRK2:

```
sol_ip = solve(prob_dde_constant_2delays_ip,     MethodOfSteps(SDIRK2(nlsolve=...)))
sol_scalar = solve(prob_dde_constant_2delays_scalar, MethodOfSteps(SDIRK2(nlsolve=...)))
length(sol_ip.t), length(sol_scalar.t)   # (11, 36) — iip is wildly wrong
```

iip takes giant steps that snap exactly to discontinuity tstops (0.2, 0.333, 0.4, 0.533, ...) with `u` changing linearly between them — visibly not the actual DDE solution. Both return `ReturnCode.Success`, so the controller blew dt up without ever rejecting.

## Root cause

In `generic_imex_perform_step.jl`, the OOP `_perform_step` (line 1404) correctly sets `nlsolver.c = c[1]` before the stage-1 `nlsolve!`. The IIP `_perform_step_iip!` (line 117–119) was missing this assignment:

```julia
 nlsolver.z = zs[1]
 nlsolver.tmp = uprev
+nlsolver.c = c[1]      # <-- this line
 zs[1] = nlsolve!(nlsolver, integrator, cache, repeat_step)
```

`nlsolver.c` controls `cache.tstep = integrator.t + nlsolver.c * dt` inside the Newton solver, which is the time argument passed to `f` during the implicit solve. Without the assignment, IIP stage 1 carried over the stale `c` left behind by the previous outer step's stage 2 (= `c[2]`).

For SDIRK2 (`c = [1, 0]`, `Ai = [[1,0],[-1,1]]`), once stage 1 mistakenly uses `c=0` instead of `c=1`, the SDIRK2 stage-2 algebra reduces both stages to the same fixed point `zs[1] == zs[2] == dt*f(t, uprev)`. The embedded error estimate `btilde[1]*zs[1] + btilde[2]*zs[2] = (zs[1] - zs[2]) / 2` then collapses to exactly 0, so the PI controller is free to grow dt unboundedly.

## Why only SDIRK2

- Algorithms with `explicit_first_stage = true` (most of them) skip the `nlsolve!` at stage 1 entirely, so the missing assignment never matters.
- Algorithms with `s = 1` (ImplicitEuler) have no stage 2 to leave a stale `c` behind.
- For `SSPSDIRK2` / `Trapezoid` the cancellation algebra works out differently and the error estimate doesn't collapse to exactly 0.
- SDIRK2's `c = [1, 0]` + 2-stage tableau is the unique configuration where the missing assignment produces `zs[1] == zs[2]` exactly.

## Bisect

Regression introduced in #3641 (commit `99187d02e`, 2026-05-17, *Fix behavioral regressions in generic SDIRK/IMEX perform_step*). That commit dropped `nlsolver.c = c[1]` and `nlsolver.γ = γ` from both IIP and OOP stage-1 sites. A follow-up restored them in OOP; #3643's `@generated` rewrite and #3676's inline both preserved the IIP gap.

## Verification

Ran the `Constant delays` testset locally on Julia 1.11 with this patch:

- **Before**: `DimensionMismatch: a has size (11,), b has size (36,)` on SDIRK2.
- **After**: 27/27 tests pass across all nine algorithms (BS3, Tsit5, RK4, Vern6, SDIRK2, TRBDF2, KenCarp4, Rosenbrock23, Rodas4). SDIRK2 `sol.errors[:l∞] = 0.0035`, well under the 3.8e-1 threshold.
- No regression on ImplicitEuler, TRBDF2, Trapezoid, KenCarp4, Kvaerno3, SSPSDIRK2, SDIRK22 — iip-vs-scalar step counts unchanged before vs. after.

## Test plan

- [x] `Constant delays` testset passes locally for all 9 algorithms
- [x] No iip-vs-scalar step-count regressions for the other implicit algs
- [ ] CI `test (DelayDiffEq_Integrators, *)` and `test (DelayDiffEq_Interface, *)` go green
- [ ] CI SDIRK sublib tests stay green

🤖 Generated with [Claude Code](https://claude.com/claude-code)