### PR TITLE
Pin JULIA_DEPOT_PATH=~/.julia in CI.yml + SublibraryCI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,6 +21,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     continue-on-error: ${{ matrix.group == 'Downstream' }}
+    env:
+      # Pin the depot path so the "Refresh General registry" step and the
+      # subsequent julia-actions/julia-{buildpkg,runtest} steps all read
+      # and write the same depot on self-hosted runners (where the runner
+      # may otherwise inject ~/github-runners/<name>/.julia for some steps
+      # but not others, causing "expected package X to be registered"
+      # failures when General is refreshed into ~/.julia but resolve
+      # happens against the per-runner depot). Matches benchmark.yml.
+      JULIA_DEPOT_PATH: ~/.julia
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/SublibraryCI.yml
+++ b/.github/workflows/SublibraryCI.yml
@@ -65,6 +65,15 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
+    env:
+      # Pin the depot path so the "Refresh General registry" step below and
+      # the subsequent julia-actions/julia-{buildpkg,runtest} steps all read
+      # and write the same depot on self-hosted runners (where the runner
+      # may otherwise inject ~/github-runners/<name>/.julia for some steps
+      # but not others, leaving the freshly-added General registry invisible
+      # to later resolve calls and producing "expected package X to be
+      # registered" failures). Matches benchmark.yml.
+      JULIA_DEPOT_PATH: ~/.julia
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3


### PR DESCRIPTION
## Summary

Mirror `benchmark.yml`'s already-deployed depot-path pin into `CI.yml` and `SublibraryCI.yml`. Two-line patch per file (a job-level `env:` block setting `JULIA_DEPOT_PATH: ~/.julia`). **Please ignore until reviewed by @ChrisRackauckas.**

This addresses the intermittent `expected package X to be registered` failures on self-hosted runners labeled `ubuntu-latest` (`demeter3-*`, `deepsea4-*`).

## Mechanism

Reconstructed from the `OrdinaryDiffEqTsit5` SublibraryCI log on #3407 where this exact failure fired:

1. The "Refresh General registry directly from git" step runs `julia --project=. {0}`. With no job-level `JULIA_DEPOT_PATH`, Julia defaults to `~/.julia` ⇒ `/home/chrisrackauckas/.julia`. `Pkg.Registry.add(General.git)` writes the fresh registry there. (Log: pidfile at `/home/chrisrackauckas/.julia/registries/.pid`.)
2. `julia-actions/julia-runtest@v1` invokes Julia through the action wrapper, which on the self-hosted runner picks up the runner-injected `JULIA_DEPOT_PATH=~/github-runners/<name>/.julia` instead. (Log: \`Updating registry at \`~/github-runners/demeter3-12/.julia/registries/HolyLabRegistry\`\`.)
3. That per-runner depot is missing the General registry refreshed in step 1, so `Pkg.develop` fails with `expected package FastBroadcast [7034ab61] to be registered`.

Pinning `JULIA_DEPOT_PATH: ~/.julia` at the job level forces every step (refresh, buildpkg, runtest) to read and write the same depot, so the freshly-added General registry is visible to subsequent resolve calls.

## Precedent

`benchmark.yml` lines 20–22 already do this with the comment *\"Force consistent Julia depot path for self-hosted runners\"*. `benchmark.yml` doesn't see these failures; `CI.yml` and `SublibraryCI.yml` do. This PR just propagates the workaround.

## Affected jobs (observed failures with this fingerprint)

On #3407 (and similarly on #3681, #3676):
- `test (OrdinaryDiffEqTsit5, 1)` — `FastBroadcast not registered`
- `test (OrdinaryDiffEqStabilizedIRK_QA, 1)` — `FastBroadcast not registered`
- `test (OrdinaryDiffEqFunctionMap_QA, 1)` — `FunctionWrappers not registered`
- `test (StochasticDiffEqCore_QA, 1)` — `CoverageTools not registered`
- `test (StochasticDiffEq_QA, 1)` — `ADTypes not registered`
- `test (InterfaceIV, pre)` — `SciMLBase not registered`
- `test (ODEInterfaceRegression, lts)` — `ODEInterface not registered`
- `test (Regression_I, pre)` — `Registry.toml: No such file or directory`

All of these landed on self-hosted runners (`demeter3-*` / `deepsea4-*`) per \`gh api jobs/<id>.runner_name\`.

## Diff

Job-level `env: { JULIA_DEPOT_PATH: ~/.julia }` block added to:
- `.github/workflows/CI.yml` (the matrix \`test:\` job)
- `.github/workflows/SublibraryCI.yml` (the dynamic-matrix \`test:\` job)

Each addition is the same 9-line block (8 lines of comment + 1 line of \`JULIA_DEPOT_PATH\`).

## Test plan

- [ ] CI on this PR uses `~/.julia` consistently (verify by inspecting any \"Refresh General registry\" log: both depot paths should match)
- [ ] None of the \`expected package X to be registered\` failures fire on this PR
- [ ] Other workflows (\`Documentation\`, \`Spell Check\`, \`Downstream\`, \`Downgrade\`, \`FormatCheck\`, \`benchmark\`) are unaffected

Caveat: this fix only addresses the symptoms reachable from a workflow-level env var. If the underlying issue is that self-hosted runners ship with a stale \`~/.julia\` registry that doesn't get refreshed, the runners themselves still need periodic cleanup. This PR ensures that the explicit *refresh step* in each workflow actually persists into the depot Julia subsequently uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)