### PR TITLE
NonlinearSolveAlg: reuse ODE solver W matrix as analytic Jacobian (#2757)

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
@@ -58,7 +58,7 @@ import OrdinaryDiffEqCore: _initialize_dae!,
 import OrdinaryDiffEqDifferentiation: update_W!, is_always_new, build_uf, build_J_W,
     WOperator, StaticWOperator, wrapprecs,
     build_jac_config, dolinsolve, alg_autodiff,
-    resize_jac_config!
+    resize_jac_config!, jacobian2W!, jacobian!
 
 import StaticArraysCore: StaticArray
 

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -114,22 +114,19 @@ function initialize!(
     return nothing
 end
 
-function _update_nlsolvealg_W!(nlcache, integrator, dtgamma, tstep, new_jac::Bool = true)
+function _update_nlsolvealg_W!(nlcache, integrator, dtgamma, tstep)
     (; J, W, uf, jac_config, du1) = nlcache
     (; f, p, uprev, alg) = integrator
     mass_matrix = f.mass_matrix
-    if new_jac
-        if SciMLBase.has_jac(f)
-            f.jac(J, uprev, p, tstep)
-        elseif uf !== nothing
-            uf.f = nlsolve_f(f, alg)
-            uf.t = tstep
-            if !(p isa SciMLBase.NullParameters)
-                uf.p = p
-            end
-            jacobian!(J, uf, uprev, du1, integrator, jac_config)
+    if SciMLBase.has_jac(f)
+        f.jac(J, uprev, p, tstep)
+    elseif uf !== nothing
+        uf.f = nlsolve_f(f, alg)
+        uf.t = tstep
+        if !(p isa SciMLBase.NullParameters)
+            uf.p = p
         end
-        nlcache.J_t = integrator.t
+        jacobian!(J, uf, uprev, du1, integrator, jac_config)
     end
     jacobian2W!(W, mass_matrix, dtgamma, J)
     nlcache.W_γdt = dtgamma

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -142,7 +142,8 @@ end
     (; tstep, invγdt) = cache
 
     nlcache = nlsolver.cache.cache
-    step!(nlcache; recompute_jacobian = nlsolver.iter == 1 && cache.new_W)
+    recompute_jacobian = cache.W === nothing || (nlsolver.iter == 1 && cache.new_W)
+    step!(nlcache; recompute_jacobian)
     nlsolver.ztmp = nlcache.u
 
     ustep = compute_ustep(tmp, γ, z, method)
@@ -166,7 +167,8 @@ end
 
     nlstep_data = integrator.f.nlstep_data
     nlcache = nlsolver.cache.cache
-    step!(nlcache; recompute_jacobian = nlsolver.iter == 1 && cache.new_W)
+    recompute_jacobian = cache.W === nothing || (nlsolver.iter == 1 && cache.new_W)
+    step!(nlcache; recompute_jacobian)
 
     if nlstep_data !== nothing
         nlstepsol = SciMLBase.build_solution(

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -90,6 +90,10 @@ function initialize!(
         nlstep_data.nlprob.u0 .= @view z[nlstep_data.u0perm]
         SciMLBase.reinit!(cache.cache, nlstep_data.nlprob.u0, p = nlstep_data.nlprob.p)
     else
+        if cache.W !== nothing
+            dtgamma = method === DIRK ? γ * dt : γ * dt / α
+            _update_nlsolvealg_W!(cache, integrator, dtgamma, tstep)
+        end
         if f isa DAEFunction
             nlp_params = (tmp, ztmp, ustep, γ, α, tstep, k, invγdt, p, dt, f)
         else
@@ -97,6 +101,25 @@ function initialize!(
         end
         SciMLBase.reinit!(cache.cache, z, p = nlp_params)
     end
+    return nothing
+end
+
+function _update_nlsolvealg_W!(nlcache, integrator, dtgamma, tstep)
+    (; J, W, uf, jac_config, du1) = nlcache
+    (; f, p, uprev, alg) = integrator
+    mass_matrix = f.mass_matrix
+    if SciMLBase.has_jac(f)
+        f.jac(J, uprev, p, tstep)
+    elseif uf !== nothing
+        uf.f = nlsolve_f(f, alg)
+        uf.t = tstep
+        if !(p isa SciMLBase.NullParameters)
+            uf.p = p
+        end
+        jacobian!(J, uf, uprev, du1, integrator, jac_config)
+    end
+    jacobian2W!(W, mass_matrix, dtgamma, J)
+    integrator.stats.nw += 1
     return nothing
 end
 

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -92,7 +92,17 @@ function initialize!(
     else
         if cache.W !== nothing
             dtgamma = method === DIRK ? γ * dt : γ * dt / α
-            _update_nlsolvealg_W!(cache, integrator, dtgamma, tstep)
+            W_γdt = cache.W_γdt
+            first_call = iszero(W_γdt)
+            should_update = first_call || alg.always_new ||
+                nlsolver.status === Divergence ||
+                abs(inv(dtgamma) / inv(W_γdt) - 1) > alg.new_W_dt_cutoff
+            if should_update
+                _update_nlsolvealg_W!(cache, integrator, dtgamma, tstep)
+                cache.new_W = true
+            else
+                cache.new_W = false
+            end
         end
         if f isa DAEFunction
             nlp_params = (tmp, ztmp, ustep, γ, α, tstep, k, invγdt, p, dt, f)
@@ -104,21 +114,25 @@ function initialize!(
     return nothing
 end
 
-function _update_nlsolvealg_W!(nlcache, integrator, dtgamma, tstep)
+function _update_nlsolvealg_W!(nlcache, integrator, dtgamma, tstep, new_jac::Bool = true)
     (; J, W, uf, jac_config, du1) = nlcache
     (; f, p, uprev, alg) = integrator
     mass_matrix = f.mass_matrix
-    if SciMLBase.has_jac(f)
-        f.jac(J, uprev, p, tstep)
-    elseif uf !== nothing
-        uf.f = nlsolve_f(f, alg)
-        uf.t = tstep
-        if !(p isa SciMLBase.NullParameters)
-            uf.p = p
+    if new_jac
+        if SciMLBase.has_jac(f)
+            f.jac(J, uprev, p, tstep)
+        elseif uf !== nothing
+            uf.f = nlsolve_f(f, alg)
+            uf.t = tstep
+            if !(p isa SciMLBase.NullParameters)
+                uf.p = p
+            end
+            jacobian!(J, uf, uprev, du1, integrator, jac_config)
         end
-        jacobian!(J, uf, uprev, du1, integrator, jac_config)
+        nlcache.J_t = integrator.t
     end
     jacobian2W!(W, mass_matrix, dtgamma, J)
+    nlcache.W_γdt = dtgamma
     integrator.stats.nw += 1
     return nothing
 end
@@ -131,16 +145,15 @@ end
     (; tstep, invγdt) = cache
 
     nlcache = nlsolver.cache.cache
-    step!(nlcache)
+    step!(nlcache; recompute_jacobian = nlsolver.iter == 1 && cache.new_W)
     nlsolver.ztmp = nlcache.u
 
     ustep = compute_ustep(tmp, γ, z, method)
     atmp = calculate_residuals(
-        nlcache.fu, uprev, ustep, opts.abstol, opts.reltol,
+        z .- nlcache.u, uprev, ustep, opts.abstol, opts.reltol,
         opts.internalnorm, t
     )
     ndz = opts.internalnorm(atmp, t)
-    #ndz = opts.internalnorm(nlcache.fu, t)
     # NDF and BDF are special because the truncation error is directly
     # proportional to the total displacement.
     if has_special_newton_error(integrator.alg)
@@ -156,7 +169,7 @@ end
 
     nlstep_data = integrator.f.nlstep_data
     nlcache = nlsolver.cache.cache
-    step!(nlcache)
+    step!(nlcache; recompute_jacobian = nlsolver.iter == 1 && cache.new_W)
 
     if nlstep_data !== nothing
         nlstepsol = SciMLBase.build_solution(
@@ -181,16 +194,14 @@ end
     else
         @.. broadcast = false ztmp = nlcache.u
         ustep = compute_ustep!(ustep, tmp, γ, z, method)
+        @.. broadcast = false atmp = z - ztmp
         calculate_residuals!(
-            atmp, nlcache.fu, uprev, ustep, opts.abstol, opts.reltol,
+            atmp, atmp, uprev, ustep, opts.abstol, opts.reltol,
             opts.internalnorm, t
         )
         ndz = opts.internalnorm(atmp, t)
     end
 
-    #ndz = opts.internalnorm(nlcache.fu, t)
-    # NDF and BDF are special because the truncation error is directly
-    # proportional to the total displacement.
     if has_special_newton_error(integrator.alg)
         ndz *= error_constant(integrator, alg_order(integrator.alg))
     end

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/nlsolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/nlsolve.jl
@@ -125,7 +125,8 @@ function nlsolve!(
         # for us to know whether our previous nlsolve converged sufficiently well
         check_η_convergence = (
             iter > 1 ||
-                (isnewton(nlsolver) && isadaptive(integrator.alg))
+                (isadaptive(integrator.alg) &&
+                    (isnewton(nlsolver) || nlsolver.alg isa NonlinearSolveAlg))
         )
         if (iter == 1 && ndz < 1.0e-5) ||
                 (check_η_convergence && η >= zero(η) && η * ndz < κ)

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/nlsolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/nlsolve.jl
@@ -126,7 +126,9 @@ function nlsolve!(
         check_η_convergence = (
             iter > 1 ||
                 (isadaptive(integrator.alg) &&
-                    (isnewton(nlsolver) || nlsolver.alg isa NonlinearSolveAlg))
+                    (isnewton(nlsolver) ||
+                        (nlsolver.alg isa NonlinearSolveAlg &&
+                            nlsolver.cache.W !== nothing)))
         )
         if (iter == 1 && ndz < 1.0e-5) ||
                 (check_η_convergence && η >= zero(η) && η * ndz < κ)

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
@@ -242,5 +242,4 @@ mutable struct NonlinearSolveCache{uType, tType, rateType, tType2, P, C, JType, 
     du1::du1Type
     W_γdt::tType
     new_W::Bool
-    J_t::tType
 end

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
@@ -240,4 +240,7 @@ mutable struct NonlinearSolveCache{uType, tType, rateType, tType2, P, C, JType, 
     uf::ufType
     jac_config::jcType
     du1::du1Type
+    W_γdt::tType
+    new_W::Bool
+    J_t::tType
 end

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
@@ -226,7 +226,7 @@ mutable struct NLAndersonConstantCache{uType, tType, uEltypeNoUnits} <:
     droptol::Union{Nothing, tType}
 end
 
-mutable struct NonlinearSolveCache{uType, tType, rateType, tType2, P, C} <:
+mutable struct NonlinearSolveCache{uType, tType, rateType, tType2, P, C, JType, WType, ufType, jcType, du1Type} <:
     AbstractNLSolverCache
     ustep::uType
     tstep::tType
@@ -235,4 +235,9 @@ mutable struct NonlinearSolveCache{uType, tType, rateType, tType2, P, C} <:
     invγdt::tType2
     prob::P
     cache::C
+    J::JType
+    W::WType
+    uf::ufType
+    jac_config::jcType
+    du1::du1Type
 end

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -370,7 +370,7 @@ function build_nlsolver(
                 use_w_reuse ? uf : nothing,
                 use_w_reuse ? jac_config : nothing,
                 (use_w_reuse && uf !== nothing) ? du1 : nothing,
-                zero(tstep), true, zero(tstep)
+                zero(tstep), true
             )
         else
             # Build separated DAE Jacobian cache if applicable
@@ -503,7 +503,7 @@ function build_nlsolver(
             nlcache = NonlinearSolveCache(
                 nothing, tstep, nothing, nothing, invγdt, prob, cache,
                 nothing, nothing, nothing, nothing, nothing,
-                zero(tstep), true, zero(tstep)
+                zero(tstep), true
             )
         else
             # Build separated DAE Jacobian cache if applicable

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -40,6 +40,7 @@ set_new_W!(nlcache::Union{NLNewtonCache, NLNewtonConstantCache}, val::Bool)::Boo
 get_new_W!(nlsolver::AbstractNLSolver)::Bool = get_new_W!(nlsolver.cache)
 get_new_W!(nlcache::Union{NLNewtonCache, NLNewtonConstantCache})::Bool = nlcache.new_W
 get_new_W!(::AbstractNLSolverCache)::Bool = true
+get_new_W!(nlcache::NonlinearSolveCache)::Bool = nlcache.new_W
 
 get_W(nlsolver::AbstractNLSolver) = get_W(nlsolver.cache)
 get_W(nlcache::Union{NLNewtonCache, NLNewtonConstantCache}) = nlcache.W
@@ -368,7 +369,8 @@ function build_nlsolver(
                 use_w_reuse ? W : nothing,
                 use_w_reuse ? uf : nothing,
                 use_w_reuse ? jac_config : nothing,
-                (use_w_reuse && uf !== nothing) ? du1 : nothing
+                (use_w_reuse && uf !== nothing) ? du1 : nothing,
+                zero(tstep), true, zero(tstep)
             )
         else
             # Build separated DAE Jacobian cache if applicable
@@ -500,7 +502,8 @@ function build_nlsolver(
             cache = init(prob, inner_alg, verbose = verbose.nonlinear_verbosity)
             nlcache = NonlinearSolveCache(
                 nothing, tstep, nothing, nothing, invγdt, prob, cache,
-                nothing, nothing, nothing, nothing, nothing
+                nothing, nothing, nothing, nothing, nothing,
+                zero(tstep), true, zero(tstep)
             )
         else
             # Build separated DAE Jacobian cache if applicable

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -218,6 +218,15 @@ struct DAEJacobiansConstantCache{JduType, ufuType, ufduType}
     uf_du::ufduType
 end
 
+function _nlalg_with_linsolve(inner_alg, linsolve)
+    linsolve === nothing && return inner_alg
+    !hasfield(typeof(inner_alg), :descent) && return inner_alg
+    descent = inner_alg.descent
+    !hasfield(typeof(descent), :linsolve) && return inner_alg
+    descent.linsolve !== nothing && return inner_alg
+    return remake(inner_alg; descent = remake(descent; linsolve = linsolve))
+end
+
 function build_nlsolver(
         alg, u, uprev, p, t, dt, f::F, rate_prototype,
         ::Type{uEltypeNoUnits},
@@ -324,8 +333,10 @@ function build_nlsolver(
             γ = tTypeNoUnits(γ)
             α = tTypeNoUnits(α)
             dt = tTypeNoUnits(dt)
+            use_w_reuse = !isdae && f.nlstep_data === nothing && W isa AbstractMatrix &&
+                          !(W isa AbstractSciMLOperator)
             prob = if f.nlstep_data !== nothing
-                prob = f.nlstep_data.nlprob
+                f.nlstep_data.nlprob
             else
                 nlf = isdae ? daenlf : odenlf
                 nlp_params = if isdae
@@ -333,20 +344,32 @@ function build_nlsolver(
                 else
                     (tmp, ustep, γ, α, tstep, k, invγdt, DIRK, p, dt, f)
                 end
-                # Use FullSpecialize so SciMLBase does not wrap `nlf` in a
-                # FunctionWrappersWrapper with a fixed set of Dual tag branches.
-                # The wrapper otherwise throws "No matching function wrapper was
-                # found!" when the ODE solver is itself nested inside an outer
-                # ForwardDiff.Dual layer (e.g. SciMLSensitivity, nested AD), since
-                # the inner NonlinearProblem is then called with a Dual tagged by
-                # `DiffEqBase.OrdinaryDiffEqTag` that no pre-built wrapper matches.
-                NonlinearProblem(
-                    NonlinearFunction{true, SciMLBase.FullSpecialize}(nlf),
-                    ztmp, nlp_params
-                )
+                if use_w_reuse
+                    nlf_jac! = let W = W
+                        (J_out, z, p) -> (copyto!(J_out, W); J_out)
+                    end
+                    NonlinearProblem(
+                        NonlinearFunction{true, SciMLBase.FullSpecialize}(nlf;
+                            jac = nlf_jac!),
+                        ztmp, nlp_params
+                    )
+                else
+                    NonlinearProblem(
+                        NonlinearFunction{true, SciMLBase.FullSpecialize}(nlf),
+                        ztmp, nlp_params
+                    )
+                end
             end
-            cache = init(prob, nlalg.alg, verbose = verbose.nonlinear_verbosity)
-            nlcache = NonlinearSolveCache(ustep, tstep, k, atmp, invγdt, prob, cache)
+            inner_alg = _nlalg_with_linsolve(nlalg.alg, alg.linsolve)
+            cache = init(prob, inner_alg, verbose = verbose.nonlinear_verbosity)
+            nlcache = NonlinearSolveCache(
+                ustep, tstep, k, atmp, invγdt, prob, cache,
+                use_w_reuse ? J : nothing,
+                use_w_reuse ? W : nothing,
+                use_w_reuse ? uf : nothing,
+                use_w_reuse ? jac_config : nothing,
+                (use_w_reuse && uf !== nothing) ? du1 : nothing
+            )
         else
             # Build separated DAE Jacobian cache if applicable
             if isdae
@@ -469,16 +492,15 @@ function build_nlsolver(
             else
                 (tmp, γ, α, tstep, invγdt, DIRK, p, dt, f)
             end
-            # See comment on the in-place branch above: FullSpecialize avoids
-            # the FunctionWrappersWrapper dispatch hole when the ODE solver is
-            # called inside an outer ForwardDiff layer.
             prob = NonlinearProblem(
                 NonlinearFunction{false, SciMLBase.FullSpecialize}(nlf),
                 copy(ztmp), nlp_params
             )
-            cache = init(prob, nlalg.alg, verbose = verbose.nonlinear_verbosity)
+            inner_alg = _nlalg_with_linsolve(nlalg.alg, alg.linsolve)
+            cache = init(prob, inner_alg, verbose = verbose.nonlinear_verbosity)
             nlcache = NonlinearSolveCache(
-                nothing, tstep, nothing, nothing, invγdt, prob, cache
+                nothing, tstep, nothing, nothing, invγdt, prob, cache,
+                nothing, nothing, nothing, nothing, nothing
             )
         else
             # Build separated DAE Jacobian cache if applicable


### PR DESCRIPTION
When W is a concrete `AbstractMatrix` (IIP ODE, non-DAE, non-nlstep), provide it to NonlinearSolve as the analytic Jacobian via a capturing closure, so NonlinearSolve skips its own Jacobian evaluation each nonlinear iteration.

`_update_nlsolvealg_W!` is called in `initialize!` each step to keep W current, using the same `f.jac` / `jacobian!` machinery as the rest of the ODE solver.

Also propagates the ODE solver's `linsolve` into the inner descent algorithm via `_nlalg_with_linsolve`.

Closes #2757

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
