### PR TITLE
Add RKMC2 method to StabilizedRK library

### DIFF
--- a/docs/src/semiimplicit/StabilizedRK.md
+++ b/docs/src/semiimplicit/StabilizedRK.md
@@ -96,6 +96,7 @@ first_steps("OrdinaryDiffEqStabilizedRK", "ROCK4")
 ROCK2 
 ROCK4 
 RKC
+RKMC2
 TSRKC3
 SERK2
 ESERK4

--- a/lib/OrdinaryDiffEqStabilizedRK/README.md
+++ b/lib/OrdinaryDiffEqStabilizedRK/README.md
@@ -14,8 +14,14 @@ While completely independent and usable on its own, users wanting the full ODE s
 - `ROCK2`
 - `ROCK4`
 - `RKC`
+- `RKMC2`
+- `TSRKC3`
 - `ESERK4`
 - `ESERK5`
 - `SERK2`
+- `RKL1`
+- `RKL2`
+- `RKG1`
+- `RKG2`
 
 For a full description of the solvers and their options, see the [ODE solver documentation](https://docs.sciml.ai/DiffEqDocs/stable/).

--- a/lib/OrdinaryDiffEqStabilizedRK/src/OrdinaryDiffEqStabilizedRK.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/OrdinaryDiffEqStabilizedRK.jl
@@ -29,6 +29,6 @@ include("rkc_tableaus_rock2.jl")
 include("rkc_tableaus_eserk5.jl")
 include("rkc_tableaus_eserk4.jl")
 
-export ROCK2, ROCK4, RKC, ESERK4, ESERK5, SERK2, TSRKC3, RKL1, RKL2, RKG1, RKG2
+export ROCK2, ROCK4, RKC, RKMC2, ESERK4, ESERK5, SERK2, TSRKC3, RKL1, RKL2, RKG1, RKG2
 
 end

--- a/lib/OrdinaryDiffEqStabilizedRK/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/alg_utils.jl
@@ -6,29 +6,30 @@ alg_order(alg::ESERK5) = 5
 alg_order(alg::SERK2) = 2
 
 alg_order(alg::RKC) = 2
+alg_order(alg::RKMC2) = 2
 
 alg_order(alg::TSRKC3) = 3
 
 alg_extrapolates(alg::TSRKC3) = true
 
 default_controller(QT, alg::SERK2) = PredictiveController(QT, alg)
-default_controller(QT, alg::Union{RKC, TSRKC3}) = PredictiveController(QT, alg)
+default_controller(QT, alg::Union{RKC, TSRKC3, RKMC2}) = PredictiveController(QT, alg)
 default_controller(QT, alg::Union{RKL1, RKL2}) = PredictiveController(QT, alg)
 default_controller(QT, alg::Union{RKG1, RKG2}) = PredictiveController(QT, alg)
 
 alg_adaptive_order(alg::RKL1) = 1
 alg_adaptive_order(alg::RKL2) = 2
-alg_adaptive_order(alg::Union{RKC, TSRKC3}) = 2
+alg_adaptive_order(alg::Union{RKC, TSRKC3, RKMC2}) = 2
 alg_adaptive_order(alg::RKG1) = 1
 alg_adaptive_order(alg::RKG2) = 2
 
-gamma_default(alg::Union{RKC, TSRKC3}) = 8 // 10
+gamma_default(alg::Union{RKC, TSRKC3, RKMC2}) = 8 // 10
 gamma_default(alg::Union{RKL1, RKL2}) = 8 // 10
 qmax_default(alg::TSRKC3) = 2
 
-fac_default_gamma(alg::Union{RKC, SERK2, TSRKC3}) = true
+fac_default_gamma(alg::Union{RKC, SERK2, TSRKC3, RKMC2}) = true
 fac_default_gamma(alg::Union{RKL1, RKL2}) = true
-has_dtnew_modification(alg::Union{ROCK2, ROCK4, SERK2, ESERK4, ESERK5}) = true
+has_dtnew_modification(alg::Union{ROCK2, ROCK4, SERK2, ESERK4, ESERK5, RKMC2}) = true
 
 function dtnew_modification(integrator, alg::ROCK2, dtnew)
     return min(
@@ -65,6 +66,11 @@ function dtnew_modification(integrator, alg::ESERK4, dtnew)
 end
 function dtnew_modification(integrator, alg::ESERK5, dtnew)
     return min(dtnew, typeof(dtnew)((0.98 * 2000 * 2000 / integrator.eigen_est)))
+end
+function dtnew_modification(integrator, alg::RKMC2, dtnew)
+    s = min(alg.max_stages, 1000)
+    rho_max = 0.31 * (s + 0.83)^1.87
+    return min(dtnew, typeof(dtnew)(rho_max / integrator.eigen_est))
 end
 
 

--- a/lib/OrdinaryDiffEqStabilizedRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/algorithms.jl
@@ -178,6 +178,37 @@ SERK2(; eigen_est = nothing) = SERK2(eigen_est)
 function TSRKC3 end
 
 @doc generic_solver_docstring(
+    """Second order method. Exhibits high stability for real eigenvalues with a monotonically
+    increasing and positive stability function, giving smaller error constants than RKC.""",
+    "RKMC2",
+    "Stabilized Explicit Method.",
+    """Boris Faleichik, Andrew Moisa. Explicit Runge-Kutta-Chebyshev methods of second order
+    with monotonic stability polynomial. Journal of Computational and Applied Mathematics,
+    476, pp 117061, 2026. doi: https://doi.org/10.1016/j.cam.2025.117061""",
+    """
+    - `min_stages`: The minimum degree of the Chebyshev polynomial (>= 3).
+    - `max_stages`: The maximum degree of the Chebyshev polynomial.
+    - `eigen_est`: function of the form
+        `(integrator) -> integrator.eigen_est = upper_bound`,
+        where `upper_bound` is an estimated upper bound on the spectral radius of the Jacobian matrix.
+        If `eigen_est` is not provided, `upper_bound` will be estimated using the power iteration.
+    """,
+    """
+    min_stages = 3,
+    max_stages = 1000,
+    eigen_est = nothing,
+    """
+)
+struct RKMC2{E} <: OrdinaryDiffEqAdaptiveAlgorithm
+    min_stages::Int
+    max_stages::Int
+    eigen_est::E
+end
+function RKMC2(; min_stages = 3, max_stages = 1000, eigen_est = nothing)
+    return RKMC2(max(3, min_stages), max_stages, eigen_est)
+end
+
+@doc generic_solver_docstring(
     """First-order super-time-stepping method based on shifted Legendre polynomials.
     Monotone and convex-monotone stable for parabolic operators. The stage count s
     is chosen adaptively from the spectral radius so that the superstep scales as s²

--- a/lib/OrdinaryDiffEqStabilizedRK/src/rkc_caches.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/rkc_caches.jl
@@ -158,6 +158,54 @@ function alg_cache(
     return RKCConstantCache(u)
 end
 
+mutable struct RKMC2ConstantCache{zType} <: OrdinaryDiffEqConstantCache
+    zprev::zType
+    mdeg::Int
+    min_stage::Int
+    max_stage::Int
+    w0::Float64
+    w1::Float64
+end
+
+@cache struct RKMC2Cache{uType, rateType, uNoUnitsType, C <: RKMC2ConstantCache} <:
+    StabilizedRKMutableCache
+    u::uType
+    uprev::uType
+    gprev::uType
+    gprev2::uType
+    tmp::uType
+    atmp::uNoUnitsType
+    fsalfirst::rateType
+    k::rateType
+    constantcache::C
+end
+
+function alg_cache(
+        alg::RKMC2, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{true}, verbose
+    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    constantcache = RKMC2ConstantCache(zero(u), 0, alg.min_stages, alg.max_stages, 0.0, 0.0)
+    gprev = zero(u)
+    gprev2 = zero(u)
+    tmp = zero(u)
+    atmp = similar(u, uEltypeNoUnits)
+    recursivefill!(atmp, false)
+    fsalfirst = zero(rate_prototype)
+    k = zero(rate_prototype)
+    return RKMC2Cache(u, uprev, gprev, gprev2, tmp, atmp, fsalfirst, k, constantcache)
+end
+
+function alg_cache(
+        alg::RKMC2, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{false}, verbose
+    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    return RKMC2ConstantCache(zero(u), 0, alg.min_stages, alg.max_stages, 0.0, 0.0)
+end
+
 mutable struct ESERK4ConstantCache{T, zType} <: OrdinaryDiffEqConstantCache
     ms::NTuple{46, Int}
     Cᵤ::NTuple{4, Int}

--- a/lib/OrdinaryDiffEqStabilizedRK/src/rkc_perform_step.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/rkc_perform_step.jl
@@ -1866,3 +1866,198 @@ end
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     integrator.k[2] = integrator.fsallast
 end
+
+function initialize!(integrator, cache::RKMC2ConstantCache)
+    integrator.kshortsize = 2
+    integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
+    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.fsallast = zero(integrator.fsalfirst)
+    integrator.k[1] = integrator.fsalfirst
+    return integrator.k[2] = integrator.fsallast
+end
+
+function initialize!(integrator, cache::RKMC2Cache)
+    integrator.kshortsize = 2
+    resize!(integrator.k, integrator.kshortsize)
+    integrator.k[1] = integrator.fsalfirst
+    integrator.k[2] = integrator.fsallast
+    integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t)
+    return OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+end
+
+@muladd function perform_step!(integrator, cache::RKMC2ConstantCache, repeat_step = false)
+    (; t, dt, uprev, u, f, p, fsalfirst) = integrator
+    alg = unwrap_alg(integrator, true)
+    alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
+
+    # selects stage count from eigenvalue estimate 
+    mdeg = max(3, ceil(Int, -0.8306782178712795 + 1.8547887825836553 * (abs(dt) * integrator.eigen_est)^0.533871357807877))
+    mdeg = min(max(mdeg, cache.min_stage), cache.max_stage)
+
+    # solves the equaton for w0, the parameter used to shift the Chebyshev polynomial to be monotone, using bisection on α = acosh(w0)
+    if mdeg != cache.mdeg
+        cache.mdeg = mdeg
+        s = mdeg
+        sign_s = iseven(s) ? 1 : -1
+        αlo, αhi = 1e-10, 2.0
+        for _ in 1:50
+            α = (αlo + αhi) / 2
+            Ts    = cosh(s * α)
+            Tsm1  = cosh((s - 1) * α)
+            Tsm2  = cosh((s - 2) * α)
+            dTsm1 = (s - 1) * sinh((s - 1) * α) / sinh(α)
+            fval  = 1 + sign_s / (s * (s - 2)) + cosh(α) + Ts / (2s) -
+                Tsm2 / (2 * (s - 2)) - (1 + Tsm1)^2 / dTsm1
+            fval > 0 ? (αlo = α) : (αhi = α)
+        end
+        α     = (αlo + αhi) / 2
+        Tsm1  = cosh((s - 1) * α)
+        dTsm1 = (s - 1) * sinh((s - 1) * α) / sinh(α)
+        cache.w0 = cosh(α)
+        cache.w1 = (1 + Tsm1) / dTsm1
+    end
+    w0, w1 = cache.w0, cache.w1
+
+    # initializes the b value tracking: bⱼ = 1/(1+Tⱼ(w0)) via Chebyshev recurrence on Tⱼ(w0)
+    Tj₋₂ = one(w0)        
+    Tj₋₁ = w0              
+    bj₋₂ = 1 / (1 + Tj₋₂) 
+    bj₋₁ = 1 / (1 + Tj₋₁) 
+
+    # stage 1: Y₁ = y₀ + h·b₁·w₁·F₀
+    gprev2 = copy(uprev)
+    μs = bj₋₁ * w1
+    gprev = uprev + dt * μs * fsalfirst
+    th2 = zero(eltype(u))
+    th1 = μs
+    bs = bj₋₁
+
+    # stages 2 to s using the shifted Chebyshev reccurance
+    for j in 2:mdeg
+        Tj = 2 * w0 * Tj₋₁ - Tj₋₂
+        bj = 1 / (1 + Tj)
+        bs = bj
+        μ  = 2 * w0 * bj / bj₋₁
+        ν  = -bj / bj₋₂
+        μ̃  = 2 * w1 * bj / bj₋₁
+        u  = f(gprev, p, t + dt * th1)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+        u  = (1 - μ - ν) * uprev + μ * gprev + ν * gprev2 + dt * μ̃ * (u - bj₋₁ * fsalfirst)
+        th = μ * th1 + ν * th2 + μ̃ * (1 - bj₋₁)
+        if j < mdeg
+            gprev2 = gprev
+            gprev  = u
+            th2    = th1
+            th1    = th
+            Tj₋₂   = Tj₋₁
+            Tj₋₁   = Tj
+            bj₋₂   = bj₋₁
+            bj₋₁   = bj
+        end
+    end
+
+    # final solution combination of the stages 
+    γs = bj₋₁ / (2 * mdeg * w1)
+    δs = -bj₋₁ / (2 * (mdeg - 2) * w1)
+    u = (1 - γs / bs - δs / bj₋₂) * uprev + (γs / bs) * u + (δs / bj₋₂) * gprev2 + dt * bj₋₁ * fsalfirst
+    integrator.fsallast = f(u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+
+    # error estimate according to the paper is (1/10)*(y₀ - y₁ + dt*f(t+h,y₁))
+    if integrator.opts.adaptive
+        tmp = (uprev - u + dt * integrator.fsallast) / 10
+        atmp = calculate_residuals(tmp, uprev, u, integrator.opts.abstol,
+            integrator.opts.reltol, integrator.opts.internalnorm, t)
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+    integrator.k[1] = integrator.fsalfirst
+    integrator.k[2] = integrator.fsallast
+    integrator.u = u
+end
+
+@muladd function perform_step!(integrator, cache::RKMC2Cache, repeat_step = false)
+    (; t, dt, uprev, u, f, p, fsalfirst) = integrator
+    (; k, tmp, gprev, gprev2, atmp) = cache
+    ccache = cache.constantcache
+    alg = unwrap_alg(integrator, true)
+    alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
+
+    mdeg = max(3, ceil(Int, -0.8306782178712795 + 1.8547887825836553 * (abs(dt) * integrator.eigen_est)^0.533871357807877))
+    mdeg = min(max(mdeg, ccache.min_stage), ccache.max_stage)
+
+    if mdeg != ccache.mdeg
+        ccache.mdeg = mdeg
+        s = mdeg
+        sign_s = iseven(s) ? 1 : -1
+        αlo, αhi = 1e-10, 2.0
+        for _ in 1:50
+            α = (αlo + αhi) / 2
+            Ts    = cosh(s * α)
+            Tsm1  = cosh((s - 1) * α)
+            Tsm2  = cosh((s - 2) * α)
+            dTsm1 = (s - 1) * sinh((s - 1) * α) / sinh(α)
+            fval  = 1 + sign_s / (s * (s - 2)) + cosh(α) + Ts / (2s) - Tsm2 / (2 * (s - 2)) - (1 + Tsm1)^2 / dTsm1
+            fval > 0 ? (αlo = α) : (αhi = α)
+        end
+        α     = (αlo + αhi) / 2
+        Tsm1  = cosh((s - 1) * α)
+        dTsm1 = (s - 1) * sinh((s - 1) * α) / sinh(α)
+        ccache.w0 = cosh(α)
+        ccache.w1 = (1 + Tsm1) / dTsm1
+    end
+    w0, w1 = ccache.w0, ccache.w1
+
+    Tj₋₂ = one(w0)
+    Tj₋₁ = w0
+    bj₋₂ = 1 / (1 + Tj₋₂)
+    bj₋₁ = 1 / (1 + Tj₋₁)
+
+    @.. broadcast = false gprev2 = uprev
+    μs = bj₋₁ * w1
+    @.. broadcast = false gprev = uprev + dt * μs * fsalfirst
+    th2 = zero(eltype(u))
+    th1 = μs
+    bs = bj₋₁
+
+    for j in 2:mdeg
+        Tj = 2 * w0 * Tj₋₁ - Tj₋₂
+        bj = 1 / (1 + Tj)
+        bs = bj
+        μ  = 2 * w0 * bj / bj₋₁
+        ν  = -bj / bj₋₂
+        μ̃  = 2 * w1 * bj / bj₋₁
+        f(k, gprev, p, t + dt * th1)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+        @.. broadcast = false u = (1 - μ - ν) * uprev + μ * gprev + ν * gprev2 + dt * μ̃ * (k - bj₋₁ * fsalfirst)
+        th = μ * th1 + ν * th2 + μ̃ * (1 - bj₋₁)
+        if j < mdeg
+            @.. broadcast = false gprev2 = gprev
+            @.. broadcast = false gprev  = u
+            th2  = th1
+            th1  = th
+            Tj₋₂ = Tj₋₁
+            Tj₋₁ = Tj
+            bj₋₂ = bj₋₁
+            bj₋₁ = bj
+        end
+    end
+
+    # final solution combination of the stages
+    γs = bj₋₁ / (2 * mdeg * w1)
+    δs = -bj₋₁ / (2 * (mdeg - 2) * w1)
+    @.. broadcast = false u = (1 - γs / bs - δs / bj₋₂) * uprev + (γs / bs) * u + (δs / bj₋₂) * gprev2 + dt * bj₋₁ * fsalfirst
+
+    f(integrator.fsallast, u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+
+    if integrator.opts.adaptive
+        @.. broadcast = false tmp = (uprev - u + dt * integrator.fsallast) / 10
+        calculate_residuals!(atmp, tmp, uprev, u, integrator.opts.abstol,
+            integrator.opts.reltol, integrator.opts.internalnorm, t)
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+    integrator.k[1] = integrator.fsalfirst
+    integrator.k[2] = integrator.fsallast
+    integrator.u = u
+end

--- a/lib/OrdinaryDiffEqStabilizedRK/test/qa/allocation_tests.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/qa/allocation_tests.jl
@@ -14,7 +14,7 @@ using Test
     prob = ODEProblem{true, FullSpecialize}(simple_system!, [1.0, 1.0], (0.0, 1.0))
 
     # All stabilized RK methods have allocations in perform_step!
-    all_solvers = [ROCK2(), ROCK4(), RKC(), ESERK4(), ESERK5(), SERK2(), RKL1(), RKL2(), RKG1(), RKG2()]
+    all_solvers = [ROCK2(), ROCK4(), RKC(), ESERK4(), ESERK5(), SERK2(), RKL1(), RKL2(), RKG1(), RKG2(), RKMC2()]
 
     @testset "StabilizedRK perform_step! Static Analysis" begin
         for solver in all_solvers

--- a/lib/OrdinaryDiffEqStabilizedRK/test/rkc_tests.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/rkc_tests.jl
@@ -109,6 +109,16 @@ end
         eigen_est = (integrator) -> integrator.eigen_est = 10000 / integrator.dt
         sim = test_convergence(dts, prob, RKC(eigen_est = eigen_est))
         @test sim.𝒪est[:l∞] ≈ 2 atol = testTol
+        println("RKMC2")
+        eigen_est = (integrator) -> integrator.eigen_est = 1 / integrator.dt
+        sim = test_convergence(dts, prob, RKMC2(eigen_est = eigen_est))
+        @test sim.𝒪est[:l∞] ≈ 2 atol = testTol
+        eigen_est = (integrator) -> integrator.eigen_est = 100 / integrator.dt
+        sim = test_convergence(dts, prob, RKMC2(eigen_est = eigen_est))
+        @test sim.𝒪est[:l∞] ≈ 2 atol = testTol
+        eigen_est = (integrator) -> integrator.eigen_est = 10000 / integrator.dt
+        sim = test_convergence(dts, prob, RKMC2(eigen_est = eigen_est))
+        @test sim.𝒪est[:l∞] ≈ 2 atol = testTol
         println("TSRKC3")
         eigen_est = (integrator) -> integrator.eigen_est = 1 / integrator.dt
         sim = test_convergence(dts, prob, TSRKC3(eigen_est = eigen_est))
@@ -197,6 +207,7 @@ end
             ROCK2(), ROCK2(eigen_est = eigen_est),
             ROCK4(), ROCK4(eigen_est = eigen_est),
             RKC(), RKC(eigen_est = eigen_est),
+            RKMC2(), RKMC2(eigen_est = eigen_est),
             TSRKC3(), TSRKC3(eigen_est = eigen_est),
             SERK2(), SERK2(eigen_est = eigen_est),
             ESERK4(), ESERK4(eigen_est = eigen_est),
@@ -227,6 +238,7 @@ end
         ROCK2(), ROCK2(eigen_est = eigen_est),
         ROCK4(), ROCK4(eigen_est = eigen_est),
         RKC(), RKC(eigen_est = eigen_est),
+        RKMC2(), RKMC2(eigen_est = eigen_est),
         TSRKC3(), TSRKC3(eigen_est = eigen_est),
         SERK2(), SERK2(eigen_est = eigen_est),
         ESERK4(), ESERK4(eigen_est = eigen_est),


### PR DESCRIPTION
## Monotone Runge-Kutta-Chebyshev (RKMC)

Closes #2908

Adds RKMC2 to OrdinaryDiffEqStabilizedRK, which is a 2nd order explicit Runge-Kutta-Chebyshev method from Faleichik and Moisa (2026) with a monotonic, positive stability polynomial on the negative real axis. It targets the same mildly stiff problems but shifts the Chebyshev polynomial so the stability function stays monotone. The other parts of the algorithm are similar to the standard RKC. Includes implementation (caches, perform_step!, adaptive controller), tests in rkc_tests.jl, and README/docs updates.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
 
