### PR TITLE
SDIRK: add IMEX-SSP family + ESDIRKIMEXTableau non-ESDIRK support

### DIFF
--- a/lib/OrdinaryDiffEqSDIRK/test/sdirk_convergence_tests.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/sdirk_convergence_tests.jl
@@ -185,7 +185,7 @@ end
 end
 
 @testset "IMEX-SSP family SplitODEProblem" begin
-    dts = 1 .// 2 .^ (8:-1:4)
+    dts = 1 .// 2 .^ (10:-1:6)
     f1_oop = (u, p, t) -> -u
     f2_oop = (u, p, t) -> 2u
     ff_oop = SplitFunction(f1_oop, f2_oop; analytic = (u0, p, t) -> exp(t) * u0)
@@ -194,17 +194,14 @@ end
     f2_iip! = (du, u, p, t) -> (du .= 2u)
     ff_iip = SplitFunction(f1_iip!, f2_iip!; analytic = (u0, p, t) -> exp(t) .* u0)
     prob_iip = SplitODEProblem(ff_iip, [1.0, 0.5], (0.0, 1.0))
-    # IMEX-SSP methods have noisy pre-asymptotic convergence on the standard dt
-    # range — loosen atol slightly. IMEXSSP3332 sits at ~2.2 here; at finer dt it
-    # cleans up to ~2.02.
     for (alg, expected) in (
             (IMEXSSP222(), 2), (IMEXSSP2322(), 2),
             (IMEXSSP3332(), 2), (IMEXSSP3433(), 3),
         )
         sim_oop = test_convergence(dts, prob_oop, alg)
-        @test sim_oop.𝒪est[:l∞] ≈ expected atol = 0.3
+        @test sim_oop.𝒪est[:l∞] ≈ expected atol = testTol
         sim_iip = test_convergence(dts, prob_iip, alg)
-        @test sim_iip.𝒪est[:l∞] ≈ expected atol = 0.3
+        @test sim_iip.𝒪est[:l∞] ≈ expected atol = testTol
     end
 end
 


### PR DESCRIPTION
## Summary

Adds four IMEX-SSP schemes from Pareschi & Russo (2005): `IMEXSSP222`, `IMEXSSP2322`, `IMEXSSP3332`, and `IMEXSSP3433`, partially addressing #2065.

Supporting these methods required a small extension to the `ESDIRKIMEXTableau` framework. A new `ce` field was added to store explicit abscissae separately from the implicit `c` values, with the constructor defaulting to `ce = copy(c)` so all existing ESDIRK methods remain unchanged. The generic IMEX stepping code was updated to use `ce` for explicit evaluations and to handle methods with an implicit first stage (`explicit_first_stage = false`).

## Verification

Convergence was verified on a `SplitODEProblem(f₁=-u, f₂=2u)` with analytic solution `u(t)=exp(t)u₀`. Measured orders match expectations: approximately second order for `IMEXSSP222`, `IMEXSSP2322`, and `IMEXSSP3332`, and third order for `IMEXSSP3433`. Existing methods (`ARS343`, `ARS222`, `KenCarp3`) were rechecked and remain unchanged.

Tableau consistency tests pass (`54/54`).

## Tests

* Added convergence tests for all four IMEX-SSP methods in both OOP and IIP modes.
* Added all four methods to the tableau consistency test suite.

All tests pass locally.

## Scope

This PR covers only the IMEX-SSP family. `BHR553` will follow in a separate PR after its coefficient/order issue is resolved.

## Reference

Pareschi, L. & Russo, G. (2005). *Implicit-explicit Runge-Kutta schemes and applications to hyperbolic systems with relaxation*. Journal of Scientific Computing, 25, 129–155.

