### PR TITLE
Multirate: add MRAB (Adams-Bashforth k-step) explicit solver

### DIFF
--- a/lib/OrdinaryDiffEqMultirate/Project.toml
+++ b/lib/OrdinaryDiffEqMultirate/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqMultirate"
 uuid = "d4b830b4-ac80-426b-8507-16693d424963"
 authors = ["singhharsh1708 <hs1663531@gmail.com>"]
-version = "2.0.0"
+version = "2.1.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/OrdinaryDiffEqMultirate/src/OrdinaryDiffEqMultirate.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/OrdinaryDiffEqMultirate.jl
@@ -20,7 +20,9 @@ include("algorithms.jl")
 include("alg_utils.jl")
 include("mreef_caches.jl")
 include("mreef_perform_step.jl")
+include("mrab_caches.jl")
+include("mrab_perform_step.jl")
 
-export MREEF
+export MREEF, MRAB
 
 end

--- a/lib/OrdinaryDiffEqMultirate/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/alg_utils.jl
@@ -4,3 +4,12 @@ isfsal(::MREEF) = false
 function prepare_alg(alg::MREEF, u0::AbstractArray, p, prob)
     return alg
 end
+
+alg_order(alg::MRAB) = alg.k
+isfsal(::MRAB) = false
+
+function prepare_alg(alg::MRAB, u0::AbstractArray, p, prob)
+    1 <= alg.k <= 5 || throw(ArgumentError("MRAB: `k` must satisfy 1 ≤ k ≤ 5"))
+    alg.m >= 1 || throw(ArgumentError("MRAB: `m` must be ≥ 1"))
+    return alg
+end

--- a/lib/OrdinaryDiffEqMultirate/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/algorithms.jl
@@ -28,3 +28,38 @@ Base.@kwdef struct MREEF <: OrdinaryDiffEqAdaptiveAlgorithm
     order::Int = 4
     seq::Symbol = :harmonic
 end
+
+@doc generic_solver_docstring(
+    "Multirate Adams–Bashforth (MRAB).
+
+Solves a split ODE of the form `du/dt = f1(u,t) + f2(u,t)` where `f1` is the
+fast component and `f2` is the slow component (SciML convention). The slow rate
+`f2` is evaluated once per macro interval and held constant across the `m` fast
+substeps; the fast rate `f1` is advanced with a `k`-step explicit Adams–Bashforth
+formula on each fast substep, using the combined rate `f1 + f2_frozen` for the
+linear-multistep update. The first `k - 1` fast substeps of the first macro
+interval bootstrap the history with explicit Euler.
+
+Order `k` for the fast component; globally first-order limited by the frozen
+slow rate (same starting order as MREEF before Richardson extrapolation).",
+    "MRAB",
+    "Multirate explicit linear-multistep method.",
+    """@techreport{sandu2007multirate,
+    title={Multirate explicit Adams methods for time integration of conservation laws},
+    author={Sandu, Adrian and Constantinescu, Emil M},
+    year={2007},
+    institution={Virginia Polytechnic Institute and State University},
+    number={CS-TR-07-30}}""",
+    """
+    - `k`: Adams–Bashforth order, `1 ≤ k ≤ 5`. Default is `2`.
+    - `m`: number of fast substeps per macro interval. Default is `4`.
+    """,
+    """
+    k::Int = 2,
+    m::Int = 4,
+    """
+)
+Base.@kwdef struct MRAB <: OrdinaryDiffEqAdaptiveAlgorithm
+    k::Int = 2
+    m::Int = 4
+end

--- a/lib/OrdinaryDiffEqMultirate/src/mrab_caches.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/mrab_caches.jl
@@ -1,0 +1,41 @@
+struct MRABConstantCache <: OrdinaryDiffEqConstantCache end
+
+@cache mutable struct MRABCache{uType, rateType, uNoUnitsType} <: OrdinaryDiffEqMutableCache
+    u::uType
+    uprev::uType
+    tmp::uType
+    atmp::uNoUnitsType
+    k_slow::rateType
+    k_fast::rateType
+    F_history::Vector{rateType}
+    fsalfirst::rateType
+    k::rateType
+end
+
+get_fsalfirstlast(cache::MRABCache, u) = (cache.fsalfirst, cache.k)
+
+function alg_cache(
+        alg::MRAB, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{true}, verbose
+    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    tmp = zero(u)
+    atmp = similar(u, uEltypeNoUnits)
+    recursivefill!(atmp, false)
+    k_slow = zero(rate_prototype)
+    k_fast = zero(rate_prototype)
+    F_history = [zero(rate_prototype) for _ in 1:(alg.k)]
+    fsalfirst = zero(rate_prototype)
+    k = zero(rate_prototype)
+    return MRABCache(u, uprev, tmp, atmp, k_slow, k_fast, F_history, fsalfirst, k)
+end
+
+function alg_cache(
+        alg::MRAB, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{false}, verbose
+    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    return MRABConstantCache()
+end

--- a/lib/OrdinaryDiffEqMultirate/src/mrab_perform_step.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/mrab_perform_step.jl
@@ -1,0 +1,185 @@
+# ── MRAB: Adams–Bashforth coefficients ────────────────────────────────────────
+#
+# Standard explicit AB-k weights `β` ordered so that
+#   u_{n+1} = u_n + h * Σ_{i=1}^k β[i] * F_{n+1-i}
+# (β[1] applies to the most recent rate sample).
+
+@inline function _ab_betas(k::Int)
+    if k == 1
+        return (1.0,)
+    elseif k == 2
+        return (3 / 2, -1 / 2)
+    elseif k == 3
+        return (23 / 12, -16 / 12, 5 / 12)
+    elseif k == 4
+        return (55 / 24, -59 / 24, 37 / 24, -9 / 24)
+    elseif k == 5
+        return (1901 / 720, -2774 / 720, 2616 / 720, -1274 / 720, 251 / 720)
+    else
+        throw(ArgumentError("MRAB: unsupported Adams order k=$k (supported: 1..5)"))
+    end
+end
+
+# ── MRAB initialize! ──────────────────────────────────────────────────────────
+
+function initialize!(integrator, cache::MRABCache)
+    integrator.kshortsize = 2
+    (; fsalfirst, k) = cache
+    integrator.fsalfirst = fsalfirst
+    integrator.fsallast = k
+    resize!(integrator.k, integrator.kshortsize)
+    integrator.k[1] = integrator.fsalfirst
+    integrator.k[2] = integrator.fsallast
+    integrator.f.f1(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t)
+    integrator.f.f2(cache.tmp, integrator.uprev, integrator.p, integrator.t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)  # f1
+    integrator.stats.nf2 += 1  # f2
+    return integrator.fsalfirst .+= cache.tmp
+end
+
+function initialize!(integrator, cache::MRABConstantCache)
+    integrator.kshortsize = 2
+    integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
+    integrator.fsalfirst = integrator.f.f1(integrator.uprev, integrator.p, integrator.t) +
+        integrator.f.f2(integrator.uprev, integrator.p, integrator.t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.stats.nf2 += 1
+    integrator.fsallast = zero(integrator.fsalfirst)
+    integrator.k[1] = integrator.fsalfirst
+    return integrator.k[2] = integrator.fsallast
+end
+
+# ── MRAB perform_step! (in-place, MutableCache) ───────────────────────────────
+#
+# One macro step from t to t+dt with m fast substeps of length h = dt/m.
+# Slow rate f2 is evaluated once per macro step and held frozen across the m
+# fast substeps. The combined effective rate F = f1(u, t_fast) + f2_frozen is
+# advanced with explicit AB-k. Within-step history bootstrap: substep ℓ uses
+# AB-min(ℓ, k) (i.e., Euler on substep 1, AB2 on substep 2, …).
+
+function perform_step!(integrator, cache::MRABCache, repeat_step = false)
+    (; t, dt, uprev, u, f, p) = integrator
+    (; tmp, atmp, k_slow, k_fast, F_history) = cache
+    alg = unwrap_alg(integrator, false)
+    k = alg.k
+    m = alg.m
+    h = dt / m
+    βs = _ab_betas(k)
+
+    @.. broadcast = false u = uprev
+    f.f2(k_slow, u, p, t)
+    integrator.stats.nf2 += 1
+
+    n_hist = 0
+    for ℓ in 1:m
+        t_fast = t + (ℓ - 1) * h
+        f.f1(k_fast, u, p, t_fast)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+
+        # Push F = f1 + f2_frozen onto history ring (newest at index 1).
+        @.. broadcast = false F_history[min(n_hist + 1, k)] = k_fast + k_slow
+        # Rotate older entries down (so index 1 stays newest after we grow).
+        for j in min(n_hist + 1, k):-1:2
+            F_history[j], F_history[j - 1] = F_history[j - 1], F_history[j]
+        end
+        n_hist = min(n_hist + 1, k)
+
+        ks = min(ℓ, k)
+        βs_use = _ab_betas(ks)
+        # u <- u + h * Σ_{i=1}^ks βs_use[i] * F_history[i]
+        for i in 1:ks
+            β = βs_use[i]
+            Fi = F_history[i]
+            @.. broadcast = false u = u + h * β * Fi
+        end
+    end
+
+    # Embedded error estimate: last-substep AB-k vs AB-(k-1).
+    return if integrator.opts.adaptive && k >= 2
+        # Reconstruct the AB-(k-1) update for the last substep using current history.
+        βs_low = _ab_betas(k - 1)
+        @.. broadcast = false tmp = zero(tmp)
+        for i in 1:(k - 1)
+            β = βs_low[i]
+            Fi = F_history[i]
+            @.. broadcast = false tmp = tmp + h * β * Fi
+        end
+        # Difference: (AB-k contribution) - (AB-(k-1) contribution) on last substep.
+        @.. broadcast = false k_fast = zero(k_fast)
+        for i in 1:k
+            β = βs[i]
+            Fi = F_history[i]
+            @.. broadcast = false k_fast = k_fast + h * β * Fi
+        end
+        @.. broadcast = false tmp = k_fast - tmp
+        calculate_residuals!(
+            atmp, tmp, uprev, u,
+            integrator.opts.abstol, integrator.opts.reltol,
+            integrator.opts.internalnorm, t
+        )
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+end
+
+# ── MRAB perform_step! (out-of-place, ConstantCache) ──────────────────────────
+
+@muladd function perform_step!(integrator, cache::MRABConstantCache, repeat_step = false)
+    (; t, dt, uprev, f, p) = integrator
+    alg = unwrap_alg(integrator, false)
+    k = alg.k
+    m = alg.m
+    h = dt / m
+    βs = _ab_betas(k)
+
+    u_cur = uprev
+    k_slow = f.f2(u_cur, p, t)
+    integrator.stats.nf2 += 1
+
+    # History as a Vector of rate samples, newest at index 1.
+    F_history = Vector{typeof(k_slow)}(undef, k)
+    n_hist = 0
+
+    for ℓ in 1:m
+        t_fast = t + (ℓ - 1) * h
+        k_fast = f.f1(u_cur, p, t_fast)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+
+        F = k_fast + k_slow
+        # Insert at front, shift older down.
+        n_hist = min(n_hist + 1, k)
+        for j in n_hist:-1:2
+            F_history[j] = F_history[j - 1]
+        end
+        F_history[1] = F
+
+        ks = min(ℓ, k)
+        βs_use = _ab_betas(ks)
+        Δu = zero(u_cur)
+        for i in 1:ks
+            Δu = @.. broadcast = false Δu + h * βs_use[i] * F_history[i]
+        end
+        u_cur = @.. broadcast = false u_cur + Δu
+    end
+
+    integrator.u = u_cur
+
+    if integrator.opts.adaptive && k >= 2
+        # Embedded estimate: last-substep AB-k vs AB-(k-1).
+        βs_low = _ab_betas(k - 1)
+        Δu_hi = zero(u_cur)
+        for i in 1:k
+            Δu_hi = @.. broadcast = false Δu_hi + h * βs[i] * F_history[i]
+        end
+        Δu_lo = zero(u_cur)
+        for i in 1:(k - 1)
+            Δu_lo = @.. broadcast = false Δu_lo + h * βs_low[i] * F_history[i]
+        end
+        utilde = @.. broadcast = false Δu_hi - Δu_lo
+        atmp = calculate_residuals(
+            utilde, uprev, integrator.u,
+            integrator.opts.abstol, integrator.opts.reltol,
+            integrator.opts.internalnorm, t
+        )
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+end

--- a/lib/OrdinaryDiffEqMultirate/src/mrab_perform_step.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/mrab_perform_step.jl
@@ -94,24 +94,17 @@ function perform_step!(integrator, cache::MRABCache, repeat_step = false)
         end
     end
 
-    # Embedded error estimate: last-substep AB-k vs AB-(k-1).
+    # Embedded error estimate: last-substep AB-k vs AB-(k-1). Both share the same
+    # F_history, so the difference collapses into a single linear combination:
+    #   utilde = h * Σᵢ (βs[i] - βs_low[i]) * F[i]   for i in 1:(k-1)
+    #          + h * βs[k] * F[k]                    (extra term in AB-k)
     return if integrator.opts.adaptive && k >= 2
-        # Reconstruct the AB-(k-1) update for the last substep using current history.
         βs_low = _ab_betas(k - 1)
-        @.. broadcast = false tmp = zero(tmp)
-        for i in 1:(k - 1)
-            β = βs_low[i]
-            Fi = F_history[i]
-            @.. broadcast = false tmp = tmp + h * β * Fi
+        @.. broadcast = false tmp = h * (βs[1] - βs_low[1]) * F_history[1]
+        for i in 2:(k - 1)
+            @.. broadcast = false tmp = tmp + h * (βs[i] - βs_low[i]) * F_history[i]
         end
-        # Difference: (AB-k contribution) - (AB-(k-1) contribution) on last substep.
-        @.. broadcast = false k_fast = zero(k_fast)
-        for i in 1:k
-            β = βs[i]
-            Fi = F_history[i]
-            @.. broadcast = false k_fast = k_fast + h * β * Fi
-        end
-        @.. broadcast = false tmp = k_fast - tmp
+        @.. broadcast = false tmp = tmp + h * βs[k] * F_history[k]
         calculate_residuals!(
             atmp, tmp, uprev, u,
             integrator.opts.abstol, integrator.opts.reltol,
@@ -164,17 +157,13 @@ end
     integrator.u = u_cur
 
     if integrator.opts.adaptive && k >= 2
-        # Embedded estimate: last-substep AB-k vs AB-(k-1).
+        # See IIP path: utilde = h * Σᵢ (βs - βs_low) * F + h * βs[k] * F[k].
         βs_low = _ab_betas(k - 1)
-        Δu_hi = zero(u_cur)
-        for i in 1:k
-            Δu_hi = @.. broadcast = false Δu_hi + h * βs[i] * F_history[i]
+        utilde = @.. broadcast = false h * (βs[1] - βs_low[1]) * F_history[1]
+        for i in 2:(k - 1)
+            utilde = @.. broadcast = false utilde + h * (βs[i] - βs_low[i]) * F_history[i]
         end
-        Δu_lo = zero(u_cur)
-        for i in 1:(k - 1)
-            Δu_lo = @.. broadcast = false Δu_lo + h * βs_low[i] * F_history[i]
-        end
-        utilde = @.. broadcast = false Δu_hi - Δu_lo
+        utilde = @.. broadcast = false utilde + h * βs[k] * F_history[k]
         atmp = calculate_residuals(
             utilde, uprev, integrator.u,
             integrator.opts.abstol, integrator.opts.reltol,

--- a/lib/OrdinaryDiffEqMultirate/src/mrab_perform_step.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/mrab_perform_step.jl
@@ -50,12 +50,7 @@ function initialize!(integrator, cache::MRABConstantCache)
 end
 
 # ── MRAB perform_step! (in-place, MutableCache) ───────────────────────────────
-#
-# One macro step from t to t+dt with m fast substeps of length h = dt/m.
-# Slow rate f2 is evaluated once per macro step and held frozen across the m
-# fast substeps. The combined effective rate F = f1(u, t_fast) + f2_frozen is
-# advanced with explicit AB-k. Within-step history bootstrap: substep ℓ uses
-# AB-min(ℓ, k) (i.e., Euler on substep 1, AB2 on substep 2, …).
+# Substep ℓ bootstraps with AB-min(ℓ, k) before the history reaches k samples.
 
 function perform_step!(integrator, cache::MRABCache, repeat_step = false)
     (; t, dt, uprev, u, f, p) = integrator
@@ -76,9 +71,7 @@ function perform_step!(integrator, cache::MRABCache, repeat_step = false)
         f.f1(k_fast, u, p, t_fast)
         OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 
-        # Push F = f1 + f2_frozen onto history ring (newest at index 1).
         @.. broadcast = false F_history[min(n_hist + 1, k)] = k_fast + k_slow
-        # Rotate older entries down (so index 1 stays newest after we grow).
         for j in min(n_hist + 1, k):-1:2
             F_history[j], F_history[j - 1] = F_history[j - 1], F_history[j]
         end
@@ -86,7 +79,6 @@ function perform_step!(integrator, cache::MRABCache, repeat_step = false)
 
         ks = min(ℓ, k)
         βs_use = _ab_betas(ks)
-        # u <- u + h * Σ_{i=1}^ks βs_use[i] * F_history[i]
         for i in 1:ks
             β = βs_use[i]
             Fi = F_history[i]
@@ -94,10 +86,7 @@ function perform_step!(integrator, cache::MRABCache, repeat_step = false)
         end
     end
 
-    # Embedded error estimate: last-substep AB-k vs AB-(k-1). Both share the same
-    # F_history, so the difference collapses into a single linear combination:
-    #   utilde = h * Σᵢ (βs[i] - βs_low[i]) * F[i]   for i in 1:(k-1)
-    #          + h * βs[k] * F[k]                    (extra term in AB-k)
+    # Error estimate (AB-k − AB-(k-1)) folds into one linear combination over F_history.
     return if integrator.opts.adaptive && k >= 2
         βs_low = _ab_betas(k - 1)
         @.. broadcast = false tmp = h * (βs[1] - βs_low[1]) * F_history[1]
@@ -128,7 +117,6 @@ end
     k_slow = f.f2(u_cur, p, t)
     integrator.stats.nf2 += 1
 
-    # History as a Vector of rate samples, newest at index 1.
     F_history = Vector{typeof(k_slow)}(undef, k)
     n_hist = 0
 
@@ -138,7 +126,6 @@ end
         OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 
         F = k_fast + k_slow
-        # Insert at front, shift older down.
         n_hist = min(n_hist + 1, k)
         for j in n_hist:-1:2
             F_history[j] = F_history[j - 1]
@@ -157,7 +144,6 @@ end
     integrator.u = u_cur
 
     if integrator.opts.adaptive && k >= 2
-        # See IIP path: utilde = h * Σᵢ (βs - βs_low) * F + h * βs[k] * F[k].
         βs_low = _ab_betas(k - 1)
         utilde = @.. broadcast = false h * (βs[1] - βs_low[1]) * F_history[1]
         for i in 2:(k - 1)

--- a/lib/OrdinaryDiffEqMultirate/test/mrab_tests.jl
+++ b/lib/OrdinaryDiffEqMultirate/test/mrab_tests.jl
@@ -1,0 +1,53 @@
+using OrdinaryDiffEqMultirate, DiffEqDevTools, Test, LinearAlgebra
+
+@testset "MRAB" begin
+    @testset "Construction" begin
+        @test MRAB() == MRAB(2, 4)
+        @test MRAB(k = 3, m = 8) == MRAB(3, 8)
+    end
+
+    @testset "Scalar out-of-place" begin
+        prob = SplitODEProblem(
+            (u, p, t) -> -0.9 * u, (u, p, t) -> -0.1 * u, 1.0, (0.0, 1.0)
+        )
+        for k in 1:4
+            sol = solve(prob, MRAB(k = k, m = 10), dt = 0.02, adaptive = false)
+            @test abs(sol.u[end] - exp(-1.0)) < 2.0e-2
+        end
+
+        sol_a = solve(prob, MRAB(k = 2, m = 10), reltol = 1.0e-8, abstol = 1.0e-8)
+        @test abs(sol_a.u[end] - exp(-1.0)) < 1.0e-3
+    end
+
+    @testset "Vector in-place" begin
+        f1!(du, u, p, t) = (du .= -0.9 .* u)
+        f2!(du, u, p, t) = (du .= -0.1 .* u)
+        u0 = [1.0, 2.0, 3.0]
+        prob = SplitODEProblem(f1!, f2!, u0, (0.0, 1.0))
+
+        for k in 1:4
+            sol = solve(prob, MRAB(k = k, m = 10), dt = 0.02, adaptive = false)
+            @test norm(sol.u[end] - u0 .* exp(-1.0)) < 5.0e-2
+        end
+
+        sol_a = solve(prob, MRAB(k = 2, m = 10), reltol = 1.0e-8, abstol = 1.0e-8)
+        @test norm(sol_a.u[end] - u0 .* exp(-1.0)) < 1.0e-3
+    end
+
+    @testset "Convergence" begin
+        # Order is globally 1 (frozen-slow Lie splitting); higher k improves the
+        # error constant but not the asymptotic rate.
+        analytic(u0, p, t) = u0 * exp(-t)
+        prob = SplitODEProblem(
+            SplitFunction(
+                (u, p, t) -> -0.9 * u, (u, p, t) -> -0.1 * u; analytic = analytic
+            ),
+            1.0, (0.0, 1.0)
+        )
+        dts = 1 ./ 2 .^ (8:-1:4)
+        for k in 1:4
+            sim = test_convergence(dts, prob, MRAB(k = k, m = 4))
+            @test sim.𝒪est[:l∞] ≈ 1 atol = 0.2
+        end
+    end
+end

--- a/lib/OrdinaryDiffEqMultirate/test/runtests.jl
+++ b/lib/OrdinaryDiffEqMultirate/test/runtests.jl
@@ -10,6 +10,7 @@ end
 
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "MREEF Tests" include("mreef_tests.jl")
+    @time @safetestset "MRAB Tests" include("mrab_tests.jl")
 end
 
 # Run QA tests (AllocCheck) - skip on pre-release Julia


### PR DESCRIPTION
## Summary

Adds `MRAB` (Multirate Adams–Bashforth) to `OrdinaryDiffEqMultirate`, a companion to the merged `MREEF` (#3139). Based on Sandu & Constantinescu, *Multirate explicit Adams methods for time integration of conservation laws* (VT CS-TR-07-30, 2007; J. Sci. Comput. 33:239–278, 2007).

## Scheme

Solves `du/dt = f1(u,t) + f2(u,t)` (f1 = fast, f2 = slow) using **frozen-slow Lie splitting + AB-k fast substeps**:

1. Evaluate `f2` once at the start of each macro interval (length `dt`).
2. Take `m` fast substeps of length `h = dt/m`. At each substep, evaluate `f1(u, t_fast)` and advance `u` with the AB-k formula on `F = f1 + f2_frozen`.
3. Substeps 1..k-1 of the first macro interval bootstrap the history with Euler/AB-low.

Globally **order 1** (Lie-splitting limited). Higher `k` improves the fast-component local error constant. A follow-up PR can lift global order to `k` by replacing frozen-slow with AB-k extrapolation of f2-history.

## API

```julia
MRAB(; k = 2, m = 4)   # k ∈ 1..5

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
