### PR TITLE
ci: route CI through SciML/.github reusable workflows (@v1)

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,31 +1,12 @@
 name: Documentation
-
 on:
   push:
     branches:
       - master
     tags: '*'
   pull_request:
-
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: '1'
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-      - name: Build and deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
-        run: julia --project=docs/ --code-coverage=user docs/make.jl
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: lcov.info
-          fail_ci_if_error: true
-          disable_safe_directory: true
+  build-and-deploy-docs:
+    name: "Documentation"
+    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -19,27 +19,11 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.11']
-        group: ['InterfaceI']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML,Statistics,LinearAlgebra,SparseArrays,InteractiveUtils
-          julia_version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          # The downgraded manifest pins direct dependencies to their minimal
-          # versions; the test environment is allowed to resolve transitive and
-          # test-only dependencies that the downgrade step does not lock.
-          allow_reresolve: true
-        env:
-          GROUP: ${{ matrix.group }}
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.11"
+      group: "InterfaceI"
+      skip: "Pkg,TOML,Statistics,LinearAlgebra,SparseArrays,InteractiveUtils"
+      allow-reresolve: true
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,5 +1,4 @@
 name: format-check
-
 on:
   push:
     branches:
@@ -8,15 +7,8 @@ on:
       - 'release-'
     tags: '*'
   pull_request:
-
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,13 +1,7 @@
 name: Spell Check
-
 on: [pull_request]
-
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
## Centralize CI on SciML/.github reusable workflows (@v1)

This routes the **standard** bespoke workflows through the shared reusable
workflows in `SciML/.github/.github/workflows/*.yml@v1`, preserving each
workflow's triggers (branches `master`/`v7`), `paths-ignore`, `concurrency`,
and config (Julia versions, groups, downgrade skip list, etc.).

This is **pure YAML/git rewiring** — no Julia or test changes. The draft PR's
own CI exercises the new callers.

### Converted

| File | Now calls | Preserved config |
|------|-----------|------------------|
| `Downgrade.yml` | `downgrade.yml@v1` | julia `1.11`, `group: InterfaceI`, `skip: Pkg,TOML,Statistics,LinearAlgebra,SparseArrays,InteractiveUtils`, `allow-reresolve: true`, branches master/v7, paths-ignore docs/**, concurrency |
| `Documentation.yml` | `documentation.yml@v1` | push master + tags + PR triggers; `secrets: inherit` carries DOCUMENTER_KEY/CODECOV_TOKEN; reusable develops the root pkg and builds `docs/make.jl` with user coverage (identical to the old job) |
| `FormatCheck.yml` | `runic.yml@v1` | Runic format check (repo already uses Runic via `fredrikekre/runic-action`); branches master/main/release-/tags + PR |
| `SpellCheck.yml` | `spellcheck.yml@v1` | typos check on PRs |

### Already reusable (untouched)

- `SublibraryCI.yml` — already calls `sublibrary-tests.yml@v1` (auto-discovers `lib/*`).
- `DowngradeSublibraries.yml` — already calls `sublibrary-downgrade.yml@v1` (skip list + `ODEDIFFEQ_TEST_GROUP=Core` group env preserved).

### Intentionally left bespoke (reusable cannot faithfully express these)

- **`CI.yml`** — This monorepo's root `Project.toml` has 33 `[sources]` path-deps into `lib/*`. The bespoke job has a dedicated **"Develop local path deps (Julia < 1.11)"** step because Julia 1.10 (`lts`, which is in the version matrix) ignores `[sources]`; the reusable `tests.yml@v1` runs only `julia-buildpkg` and would fail to develop the sublibraries on the `lts`/1.10 matrix cells. The matrix also has non-trivial excludes (`AD` on `1`/`pre`, `ODEInterfaceRegression` on `1`/`pre`) and `continue-on-error: ${{ matrix.group == 'Downstream' }}`. Converting would drop/break coverage, so it is left as-is.
- **`Downstream.yml`** (IntegrationTest) — The bespoke job develops **all** `lib/*` sublibraries (`Pkg.develop(map(... "lib/$(path)"), readdir("./lib"))`) so downstream tests run against the PR's sublibrary versions. The reusable `downstream.yml@v1` only develops the root package (`Pkg.develop(PackageSpec(path="."))`), which for this monorepo would test downstream against **registered** sublibrary versions instead of the PR's — a real coverage difference. Left bespoke.
- **`benchmark.yml`** — Passes AirspeedVelocity options the reusable `benchmark.yml@v1` does not expose: `script: benchmark/benchmarks.jl`, `extra-pkgs: StableRNGs,StaticArrays`, `job-summary: true`, and a `["1","lts"]` version matrix. The reusable only forwards `julia-version`, so converting would drop the extra packages and script. Left bespoke.
- **`TagBot.yml`** — Non-CI release automation (TagBot for the main package plus a 56-package subpackage matrix). No reusable; left local per policy.

### ⚠️ Required-status-check NAMES change

The reusable workflows rename their jobs, so the **status-check names reported to branch protection change** for the converted workflows:

- Downgrade: old `Downgrade / test` → new `Downgrade / Downgrade Tests - InterfaceI`
- Documentation: old `Documentation / build` → new `Documentation / Build and Deploy Documentation`
- FormatCheck: old `format-check / runic` → new `format-check / Runic ...`
- SpellCheck: old `Spell Check / typos-check` → new `Spell Check / Spell Check with Typos`

**Branch protection on `master` (and `v7`) must be updated** to require the new check names; otherwise required checks will appear missing. `CI.yml`, `Downstream.yml`, `benchmark.yml`, and the sublibrary workflows are unchanged.

---

Please ignore until reviewed by @ChrisRackauckas.
