### PR TITLE
Fix broken `using SciMLBase` import (missing comma) breaking `using OrdinaryDiffEq`

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -19,7 +19,7 @@ using SciMLBase: SciMLBase,
     ODEProblem, ODEFunction, ODESolution,
     SplitODEProblem, SplitFunction,
     SecondOrderODEProblem, DynamicalODEProblem,
-    DAEProblem, DAEFunction, DAESolution, EnsembleProblem
+    DAEProblem, DAEFunction, DAESolution, EnsembleProblem,
     CallbackSet, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
     ReturnCode, set_proposed_dt!,
     remake, successful_retcode, reinit!,


### PR DESCRIPTION
**Critical: master is currently broken.** PR #3710 (commit d0daf7a8, today) dropped the trailing comma after `EnsembleProblem` on the `using SciMLBase: ...` import line in `src/OrdinaryDiffEq.jl`. As a result `CallbackSet, ContinuousCallback, ...` on the next line is parsed as a separate top-level statement, so loading the package throws:

```
UndefVarError: `CallbackSet` not defined in `OrdinaryDiffEq`
```

This breaks `using OrdinaryDiffEq` (and everything depending on it). This PR restores the trailing comma so the import list continues as intended. Verified the file parses with CallbackSet inside the SciMLBase import block; load test in progress.

Found while extending the sublibrary downgrade test-at-floor work. 🤖 Generated with [Claude Code](https://claude.com/claude-code)