### PR TITLE
ci: uniformize onto centralized CI (project-model SublibraryCI + cleanup)

### DIFF
--- a/.github/workflows/DocPreviewCleanup.yml
+++ b/.github/workflows/DocPreviewCleanup.yml
@@ -1,0 +1,17 @@
+name: Doc Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  doc-preview-cleanup:
+    uses: "SciML/.github/.github/workflows/docs-preview-cleanup.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SublibraryCI.yml
+++ b/.github/workflows/SublibraryCI.yml
@@ -13,5 +13,8 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   sublibrary-ci:
-    uses: "SciML/.github/.github/workflows/sublibrary-tests.yml@v1"
+    uses: "SciML/.github/.github/workflows/sublibrary-project-tests.yml@v1"
+    with:
+      group-env-name: ODEDIFFEQ_TEST_GROUP
+      check-bounds: auto
     secrets: "inherit"


### PR DESCRIPTION
Uniformizes this repo onto the centralized CI setup released in SciML/.github `@v1`:

- Migrate SublibraryCI to the project-model `sublibrary-project-tests.yml@v1`
- Add `DocPreviewCleanup.yml` → `docs-preview-cleanup.yml@v1`

**Deliberately excluded:** TagBot centralization (the reusable `tagbot.yml` only wraps `JuliaRegistries/TagBot@v1`, which already floats — near-zero value, and rewriting the sublib matrix risks silently dropping a package from registration); `dependabot-automerge` / `runic-suggestions` (opt-in behavior changes).

> Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)