### PR TITLE
Multirate: add MRI-GARK-ERK22a and ERK22b (Sandu 2019)

### DIFF
--- a/lib/OrdinaryDiffEqMultirate/Project.toml
+++ b/lib/OrdinaryDiffEqMultirate/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqMultirate"
 uuid = "d4b830b4-ac80-426b-8507-16693d424963"
 authors = ["singhharsh1708 <hs1663531@gmail.com>"]
-version = "2.1.0"
+version = "2.2.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/OrdinaryDiffEqMultirate/src/OrdinaryDiffEqMultirate.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/OrdinaryDiffEqMultirate.jl
@@ -22,7 +22,9 @@ include("mreef_caches.jl")
 include("mreef_perform_step.jl")
 include("mrab_caches.jl")
 include("mrab_perform_step.jl")
+include("mri_gark_caches.jl")
+include("mri_gark_perform_step.jl")
 
-export MREEF, MRAB
+export MREEF, MRAB, MRIGARKERK22a
 
 end

--- a/lib/OrdinaryDiffEqMultirate/src/OrdinaryDiffEqMultirate.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/OrdinaryDiffEqMultirate.jl
@@ -22,9 +22,10 @@ include("mreef_caches.jl")
 include("mreef_perform_step.jl")
 include("mrab_caches.jl")
 include("mrab_perform_step.jl")
+include("mri_gark_tableaus.jl")
 include("mri_gark_caches.jl")
 include("mri_gark_perform_step.jl")
 
-export MREEF, MRAB, MRIGARKERK22a
+export MREEF, MRAB, MRIGARKERK22a, MRIGARKERK22b
 
 end

--- a/lib/OrdinaryDiffEqMultirate/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/alg_utils.jl
@@ -13,3 +13,11 @@ function prepare_alg(alg::MRAB, u0::AbstractArray, p, prob)
     alg.m >= 1 || throw(ArgumentError("MRAB: `m` must be ≥ 1"))
     return alg
 end
+
+alg_order(::MRIGARKERK22a) = 2
+isfsal(::MRIGARKERK22a) = false
+
+function prepare_alg(alg::MRIGARKERK22a, u0::AbstractArray, p, prob)
+    alg.m >= 1 || throw(ArgumentError("MRIGARKERK22a: `m` must be ≥ 1"))
+    return alg
+end

--- a/lib/OrdinaryDiffEqMultirate/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/alg_utils.jl
@@ -14,10 +14,12 @@ function prepare_alg(alg::MRAB, u0::AbstractArray, p, prob)
     return alg
 end
 
-alg_order(::MRIGARKERK22a) = 2
-isfsal(::MRIGARKERK22a) = false
+alg_order(::Union{MRIGARKERK22a, MRIGARKERK22b}) = 2
+isfsal(::Union{MRIGARKERK22a, MRIGARKERK22b}) = false
 
-function prepare_alg(alg::MRIGARKERK22a, u0::AbstractArray, p, prob)
-    alg.m >= 1 || throw(ArgumentError("MRIGARKERK22a: `m` must be ≥ 1"))
+function prepare_alg(
+        alg::Union{MRIGARKERK22a, MRIGARKERK22b}, u0::AbstractArray, p, prob
+    )
+    alg.m >= 1 || throw(ArgumentError("$(nameof(typeof(alg))): `m` must be ≥ 1"))
     return alg
 end

--- a/lib/OrdinaryDiffEqMultirate/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/algorithms.jl
@@ -92,3 +92,32 @@ globally; embedded error estimate uses `v_2(dt) − Y_2`.",
 Base.@kwdef struct MRIGARKERK22a <: OrdinaryDiffEqAdaptiveAlgorithm
     m::Int = 10
 end
+
+@doc generic_solver_docstring(
+    "Multirate Infinitesimal GARK — explicit trapezoidal (MRI-GARK-ERK22b).
+
+Solves a SplitODE `du/dt = f1(u,t) + f2(u,t)` where `f1` is the fast component
+and `f2` is the slow component (SciML convention). The slow integrator is the
+explicit trapezoidal rule (`c₂ = 1` member of the MRI-GARK-ERK22 family from
+Sandu 2019); inner fast micro-ODE uses `m` explicit-midpoint micro-steps over
+the full macro interval. 2nd-order; embedded error estimate uses `v_2(dt) − Y_2`.",
+    "MRIGARKERK22b",
+    "Multirate infinitesimal GARK explicit method.",
+    """@article{sandu2019class,
+    title={A class of multirate infinitesimal {GARK} methods},
+    author={Sandu, Adrian},
+    journal={SIAM Journal on Numerical Analysis},
+    volume={57},
+    number={5},
+    pages={2300--2327},
+    year={2019}}""",
+    """
+    - `m`: number of inner midpoint micro-steps per stage. Default is `10`.
+    """,
+    """
+    m::Int = 10,
+    """
+)
+Base.@kwdef struct MRIGARKERK22b <: OrdinaryDiffEqAdaptiveAlgorithm
+    m::Int = 10
+end

--- a/lib/OrdinaryDiffEqMultirate/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/algorithms.jl
@@ -63,3 +63,32 @@ Base.@kwdef struct MRAB <: OrdinaryDiffEqAdaptiveAlgorithm
     k::Int = 2
     m::Int = 4
 end
+
+@doc generic_solver_docstring(
+    "Multirate Infinitesimal GARK — explicit midpoint (MRI-GARK-ERK22a).
+
+Solves a SplitODE `du/dt = f1(u,t) + f2(u,t)` where `f1` is the fast component
+and `f2` is the slow component (SciML convention). The slow integrator is the
+explicit midpoint rule; between slow stages a modified fast ODE is integrated
+with `m` explicit-midpoint micro-steps over the full macro interval. 2nd-order
+globally; embedded error estimate uses `v_2(dt) − Y_2`.",
+    "MRIGARKERK22a",
+    "Multirate infinitesimal GARK explicit method.",
+    """@article{sandu2019class,
+    title={A class of multirate infinitesimal {GARK} methods},
+    author={Sandu, Adrian},
+    journal={SIAM Journal on Numerical Analysis},
+    volume={57},
+    number={5},
+    pages={2300--2327},
+    year={2019}}""",
+    """
+    - `m`: number of inner midpoint micro-steps per stage. Default is `10`.
+    """,
+    """
+    m::Int = 10,
+    """
+)
+Base.@kwdef struct MRIGARKERK22a <: OrdinaryDiffEqAdaptiveAlgorithm
+    m::Int = 10
+end

--- a/lib/OrdinaryDiffEqMultirate/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/algorithms.jl
@@ -83,14 +83,14 @@ globally; embedded error estimate uses `v_2(dt) − Y_2`.",
     pages={2300--2327},
     year={2019}}""",
     """
-    - `m`: number of inner midpoint micro-steps per stage. Default is `10`.
+    - `m`: number of inner midpoint micro-steps per stage.
     """,
     """
-    m::Int = 10,
+    m::Int,
     """
 )
 Base.@kwdef struct MRIGARKERK22a <: OrdinaryDiffEqAdaptiveAlgorithm
-    m::Int = 10
+    m::Int
 end
 
 @doc generic_solver_docstring(
@@ -112,12 +112,12 @@ the full macro interval. 2nd-order; embedded error estimate uses `v_2(dt) − Y_
     pages={2300--2327},
     year={2019}}""",
     """
-    - `m`: number of inner midpoint micro-steps per stage. Default is `10`.
+    - `m`: number of inner midpoint micro-steps per stage.
     """,
     """
-    m::Int = 10,
+    m::Int,
     """
 )
 Base.@kwdef struct MRIGARKERK22b <: OrdinaryDiffEqAdaptiveAlgorithm
-    m::Int = 10
+    m::Int
 end

--- a/lib/OrdinaryDiffEqMultirate/src/mri_gark_caches.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/mri_gark_caches.jl
@@ -1,0 +1,45 @@
+struct MRIGARKERK22aConstantCache <: OrdinaryDiffEqConstantCache end
+
+@cache mutable struct MRIGARKERK22aCache{uType, rateType, uNoUnitsType} <: OrdinaryDiffEqMutableCache
+    u::uType
+    uprev::uType
+    tmp::uType
+    atmp::uNoUnitsType
+    v::uType
+    f1eval::rateType
+    fS_yn::rateType
+    fS_Y2::rateType
+    Y2::uType
+    fsalfirst::rateType
+    k::rateType
+end
+
+get_fsalfirstlast(cache::MRIGARKERK22aCache, u) = (cache.fsalfirst, cache.k)
+
+function alg_cache(
+        alg::MRIGARKERK22a, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{true}, verbose
+    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    tmp = zero(u)
+    atmp = similar(u, uEltypeNoUnits)
+    recursivefill!(atmp, false)
+    v = zero(u)
+    f1eval = zero(rate_prototype)
+    fS_yn = zero(rate_prototype)
+    fS_Y2 = zero(rate_prototype)
+    Y2 = zero(u)
+    fsalfirst = zero(rate_prototype)
+    k = zero(rate_prototype)
+    return MRIGARKERK22aCache(u, uprev, tmp, atmp, v, f1eval, fS_yn, fS_Y2, Y2, fsalfirst, k)
+end
+
+function alg_cache(
+        alg::MRIGARKERK22a, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{false}, verbose
+    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    return MRIGARKERK22aConstantCache()
+end

--- a/lib/OrdinaryDiffEqMultirate/src/mri_gark_caches.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/mri_gark_caches.jl
@@ -1,6 +1,9 @@
-struct MRIGARKERK22aConstantCache <: OrdinaryDiffEqConstantCache end
+struct MRIGARKERK22ConstantCache{TabType} <: OrdinaryDiffEqConstantCache
+    tab::TabType
+end
 
-@cache mutable struct MRIGARKERK22aCache{uType, rateType, uNoUnitsType} <: OrdinaryDiffEqMutableCache
+@cache mutable struct MRIGARKERK22Cache{uType, rateType, uNoUnitsType, TabType} <:
+    OrdinaryDiffEqMutableCache
     u::uType
     uprev::uType
     tmp::uType
@@ -12,9 +15,10 @@ struct MRIGARKERK22aConstantCache <: OrdinaryDiffEqConstantCache end
     Y2::uType
     fsalfirst::rateType
     k::rateType
+    tab::TabType
 end
 
-get_fsalfirstlast(cache::MRIGARKERK22aCache, u) = (cache.fsalfirst, cache.k)
+get_fsalfirstlast(cache::MRIGARKERK22Cache, u) = (cache.fsalfirst, cache.k)
 
 function alg_cache(
         alg::MRIGARKERK22a, u, rate_prototype, ::Type{uEltypeNoUnits},
@@ -32,7 +36,10 @@ function alg_cache(
     Y2 = zero(u)
     fsalfirst = zero(rate_prototype)
     k = zero(rate_prototype)
-    return MRIGARKERK22aCache(u, uprev, tmp, atmp, v, f1eval, fS_yn, fS_Y2, Y2, fsalfirst, k)
+    tab = MRIGARKERK22aTableau(eltype(u))
+    return MRIGARKERK22Cache(
+        u, uprev, tmp, atmp, v, f1eval, fS_yn, fS_Y2, Y2, fsalfirst, k, tab
+    )
 end
 
 function alg_cache(
@@ -41,5 +48,36 @@ function alg_cache(
         dt, reltol, p, calck,
         ::Val{false}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    return MRIGARKERK22aConstantCache()
+    return MRIGARKERK22ConstantCache(MRIGARKERK22aTableau(eltype(u)))
+end
+
+function alg_cache(
+        alg::MRIGARKERK22b, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{true}, verbose
+    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    tmp = zero(u)
+    atmp = similar(u, uEltypeNoUnits)
+    recursivefill!(atmp, false)
+    v = zero(u)
+    f1eval = zero(rate_prototype)
+    fS_yn = zero(rate_prototype)
+    fS_Y2 = zero(rate_prototype)
+    Y2 = zero(u)
+    fsalfirst = zero(rate_prototype)
+    k = zero(rate_prototype)
+    tab = MRIGARKERK22bTableau(eltype(u))
+    return MRIGARKERK22Cache(
+        u, uprev, tmp, atmp, v, f1eval, fS_yn, fS_Y2, Y2, fsalfirst, k, tab
+    )
+end
+
+function alg_cache(
+        alg::MRIGARKERK22b, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{false}, verbose
+    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    return MRIGARKERK22ConstantCache(MRIGARKERK22bTableau(eltype(u)))
 end

--- a/lib/OrdinaryDiffEqMultirate/src/mri_gark_caches.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/mri_gark_caches.jl
@@ -1,8 +1,8 @@
-struct MRIGARKERK22ConstantCache{TabType} <: OrdinaryDiffEqConstantCache
+struct MRIGARKConstantCache{TabType} <: OrdinaryDiffEqConstantCache
     tab::TabType
 end
 
-@cache mutable struct MRIGARKERK22Cache{uType, rateType, uNoUnitsType, TabType} <:
+@cache mutable struct MRIGARKCache{uType, rateType, uNoUnitsType, TabType} <:
     OrdinaryDiffEqMutableCache
     u::uType
     uprev::uType
@@ -10,15 +10,15 @@ end
     atmp::uNoUnitsType
     v::uType
     f1eval::rateType
-    fS_yn::rateType
-    fS_Y2::rateType
-    Y2::uType
+    slow_f::rateType
+    Y::Vector{uType}
+    fS::Vector{rateType}
     fsalfirst::rateType
     k::rateType
     tab::TabType
 end
 
-get_fsalfirstlast(cache::MRIGARKERK22Cache, u) = (cache.fsalfirst, cache.k)
+get_fsalfirstlast(cache::MRIGARKCache, u) = (cache.fsalfirst, cache.k)
 
 function alg_cache(
         alg::MRIGARKERK22a, u, rate_prototype, ::Type{uEltypeNoUnits},
@@ -26,20 +26,19 @@ function alg_cache(
         dt, reltol, p, calck,
         ::Val{true}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    tmp = zero(u)
-    atmp = similar(u, uEltypeNoUnits)
-    recursivefill!(atmp, false)
-    v = zero(u)
-    f1eval = zero(rate_prototype)
-    fS_yn = zero(rate_prototype)
-    fS_Y2 = zero(rate_prototype)
-    Y2 = zero(u)
-    fsalfirst = zero(rate_prototype)
-    k = zero(rate_prototype)
     tab = MRIGARKERK22aTableau(eltype(u))
-    return MRIGARKERK22Cache(
-        u, uprev, tmp, atmp, v, f1eval, fS_yn, fS_Y2, Y2, fsalfirst, k, tab
-    )
+    s = length(tab.Γ)
+    tmp = zero(u)
+    atmp = similar(u, uEltypeNoUnits)
+    recursivefill!(atmp, false)
+    v = zero(u)
+    f1eval = zero(rate_prototype)
+    slow_f = zero(rate_prototype)
+    Y = [zero(u) for _ in 1:s]
+    fS = [zero(rate_prototype) for _ in 1:s]
+    fsalfirst = zero(rate_prototype)
+    k = zero(rate_prototype)
+    return MRIGARKCache(u, uprev, tmp, atmp, v, f1eval, slow_f, Y, fS, fsalfirst, k, tab)
 end
 
 function alg_cache(
@@ -48,7 +47,7 @@ function alg_cache(
         dt, reltol, p, calck,
         ::Val{false}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    return MRIGARKERK22ConstantCache(MRIGARKERK22aTableau(eltype(u)))
+    return MRIGARKConstantCache(MRIGARKERK22aTableau(eltype(u)))
 end
 
 function alg_cache(
@@ -57,20 +56,19 @@ function alg_cache(
         dt, reltol, p, calck,
         ::Val{true}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    tab = MRIGARKERK22bTableau(eltype(u))
+    s = length(tab.Γ)
     tmp = zero(u)
     atmp = similar(u, uEltypeNoUnits)
     recursivefill!(atmp, false)
     v = zero(u)
     f1eval = zero(rate_prototype)
-    fS_yn = zero(rate_prototype)
-    fS_Y2 = zero(rate_prototype)
-    Y2 = zero(u)
+    slow_f = zero(rate_prototype)
+    Y = [zero(u) for _ in 1:s]
+    fS = [zero(rate_prototype) for _ in 1:s]
     fsalfirst = zero(rate_prototype)
     k = zero(rate_prototype)
-    tab = MRIGARKERK22bTableau(eltype(u))
-    return MRIGARKERK22Cache(
-        u, uprev, tmp, atmp, v, f1eval, fS_yn, fS_Y2, Y2, fsalfirst, k, tab
-    )
+    return MRIGARKCache(u, uprev, tmp, atmp, v, f1eval, slow_f, Y, fS, fsalfirst, k, tab)
 end
 
 function alg_cache(
@@ -79,5 +77,5 @@ function alg_cache(
         dt, reltol, p, calck,
         ::Val{false}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    return MRIGARKERK22ConstantCache(MRIGARKERK22bTableau(eltype(u)))
+    return MRIGARKConstantCache(MRIGARKERK22bTableau(eltype(u)))
 end

--- a/lib/OrdinaryDiffEqMultirate/src/mri_gark_caches.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/mri_gark_caches.jl
@@ -21,12 +21,12 @@ end
 get_fsalfirstlast(cache::MRIGARKCache, u) = (cache.fsalfirst, cache.k)
 
 function alg_cache(
-        alg::MRIGARKERK22a, u, rate_prototype, ::Type{uEltypeNoUnits},
-        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
-        dt, reltol, p, calck,
+        alg::Union{MRIGARKERK22a, MRIGARKERK22b}, u, rate_prototype,
+        ::Type{uEltypeNoUnits}, ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits},
+        uprev, uprev2, f, t, dt, reltol, p, calck,
         ::Val{true}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    tab = MRIGARKERK22aTableau(eltype(u))
+    tab = mri_gark_tableau(alg, eltype(u))
     s = length(tab.Γ)
     tmp = zero(u)
     atmp = similar(u, uEltypeNoUnits)
@@ -42,40 +42,10 @@ function alg_cache(
 end
 
 function alg_cache(
-        alg::MRIGARKERK22a, u, rate_prototype, ::Type{uEltypeNoUnits},
-        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
-        dt, reltol, p, calck,
+        alg::Union{MRIGARKERK22a, MRIGARKERK22b}, u, rate_prototype,
+        ::Type{uEltypeNoUnits}, ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits},
+        uprev, uprev2, f, t, dt, reltol, p, calck,
         ::Val{false}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    return MRIGARKConstantCache(MRIGARKERK22aTableau(eltype(u)))
-end
-
-function alg_cache(
-        alg::MRIGARKERK22b, u, rate_prototype, ::Type{uEltypeNoUnits},
-        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
-        dt, reltol, p, calck,
-        ::Val{true}, verbose
-    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    tab = MRIGARKERK22bTableau(eltype(u))
-    s = length(tab.Γ)
-    tmp = zero(u)
-    atmp = similar(u, uEltypeNoUnits)
-    recursivefill!(atmp, false)
-    v = zero(u)
-    f1eval = zero(rate_prototype)
-    slow_f = zero(rate_prototype)
-    Y = [zero(u) for _ in 1:s]
-    fS = [zero(rate_prototype) for _ in 1:s]
-    fsalfirst = zero(rate_prototype)
-    k = zero(rate_prototype)
-    return MRIGARKCache(u, uprev, tmp, atmp, v, f1eval, slow_f, Y, fS, fsalfirst, k, tab)
-end
-
-function alg_cache(
-        alg::MRIGARKERK22b, u, rate_prototype, ::Type{uEltypeNoUnits},
-        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
-        dt, reltol, p, calck,
-        ::Val{false}, verbose
-    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    return MRIGARKConstantCache(MRIGARKERK22bTableau(eltype(u)))
+    return MRIGARKConstantCache(mri_gark_tableau(alg, eltype(u)))
 end

--- a/lib/OrdinaryDiffEqMultirate/src/mri_gark_perform_step.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/mri_gark_perform_step.jl
@@ -1,17 +1,4 @@
-# MRI-GARK-ERK22a — Sandu, "A class of Multirate Infinitesimal GARK methods",
-# SIAM J. Numer. Anal. 57 (2019), 2300–2327, equation (2.8).
-#
-# For a SplitODE du/dt = f1(u, t) + f2(u, t)  (f1 fast, f2 slow):
-#
-#   Stage 1:  v_1(0) = u_n;   dv_1/dτ = (1/2) f1(v_1) + (1/2) f2(u_n)
-#             integrate τ ∈ [0, dt], Y_2 = v_1(dt)
-#   Stage 2:  v_2(0) = Y_2;   dv_2/dτ = (1/2) f1(v_2) - (1/2) f2(u_n) + f2(Y_2)
-#             integrate τ ∈ [0, dt], u_{n+1} = v_2(dt)
-#
-# Inner micro-ODE integrated with explicit-midpoint (RK2) micro-steps to keep
-# the inner contribution from capping the design order 2.
-
-function initialize!(integrator, cache::MRIGARKERK22aCache)
+function initialize!(integrator, cache::MRIGARKERK22Cache)
     integrator.kshortsize = 2
     (; fsalfirst, k) = cache
     integrator.fsalfirst = fsalfirst
@@ -26,7 +13,7 @@ function initialize!(integrator, cache::MRIGARKERK22aCache)
     return integrator.fsalfirst .+= cache.tmp
 end
 
-function initialize!(integrator, cache::MRIGARKERK22aConstantCache)
+function initialize!(integrator, cache::MRIGARKERK22ConstantCache)
     integrator.kshortsize = 2
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
     integrator.fsalfirst = integrator.f.f1(integrator.uprev, integrator.p, integrator.t) +
@@ -38,141 +25,10 @@ function initialize!(integrator, cache::MRIGARKERK22aConstantCache)
     return integrator.k[2] = integrator.fsallast
 end
 
-function perform_step!(integrator, cache::MRIGARKERK22aCache, repeat_step = false)
+function perform_step!(integrator, cache::MRIGARKERK22Cache, repeat_step = false)
     (; t, dt, uprev, u, f, p) = integrator
-    (; tmp, atmp, v, f1eval, fS_yn, fS_Y2, Y2) = cache
-    alg = unwrap_alg(integrator, false)
-    m = alg.m
-
-    f.f2(fS_yn, uprev, p, t)
-    integrator.stats.nf2 += 1
-
-    @.. broadcast = false v = uprev
-    h_inner = dt / m
-    offset1 = fS_yn
-    for k_step in 1:m
-        t_a = t + (k_step - 1) * h_inner
-        f.f1(f1eval, v, p, t_a)
-        @.. broadcast = false tmp = v + (h_inner / 2) * ((1 // 2) * f1eval + (1 // 2) * offset1)
-        f.f1(f1eval, tmp, p, t_a + h_inner / 2)
-        @.. broadcast = false v = v + h_inner * ((1 // 2) * f1eval + (1 // 2) * offset1)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
-    end
-    @.. broadcast = false Y2 = v
-
-    f.f2(fS_Y2, Y2, p, t + dt)
-    integrator.stats.nf2 += 1
-
-    @.. broadcast = false v = Y2
-    for k_step in 1:m
-        t_a = t + (k_step - 1) * h_inner
-        f.f1(f1eval, v, p, t_a)
-        @.. broadcast = false tmp = v + (h_inner / 2) *
-            ((1 // 2) * f1eval - (1 // 2) * fS_yn + fS_Y2)
-        f.f1(f1eval, tmp, p, t_a + h_inner / 2)
-        @.. broadcast = false v = v + h_inner *
-            ((1 // 2) * f1eval - (1 // 2) * fS_yn + fS_Y2)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
-    end
-    @.. broadcast = false u = v
-
-    return if integrator.opts.adaptive
-        @.. broadcast = false tmp = v - Y2
-        calculate_residuals!(
-            atmp, tmp, uprev, u,
-            integrator.opts.abstol, integrator.opts.reltol,
-            integrator.opts.internalnorm, t
-        )
-        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
-    end
-end
-
-@muladd function perform_step!(integrator, cache::MRIGARKERK22aConstantCache, repeat_step = false)
-    (; t, dt, uprev, f, p) = integrator
-    alg = unwrap_alg(integrator, false)
-    m = alg.m
-
-    fS_yn = f.f2(uprev, p, t)
-    integrator.stats.nf2 += 1
-
-    h_inner = dt / m
-
-    v = uprev
-    for k_step in 1:m
-        t_a = t + (k_step - 1) * h_inner
-        k1 = f.f1(v, p, t_a)
-        v_mid = @.. broadcast = false v + (h_inner / 2) * ((1 // 2) * k1 + (1 // 2) * fS_yn)
-        k2 = f.f1(v_mid, p, t_a + h_inner / 2)
-        v = @.. broadcast = false v + h_inner * ((1 // 2) * k2 + (1 // 2) * fS_yn)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
-    end
-    Y2 = v
-
-    fS_Y2 = f.f2(Y2, p, t + dt)
-    integrator.stats.nf2 += 1
-
-    v = Y2
-    for k_step in 1:m
-        t_a = t + (k_step - 1) * h_inner
-        k1 = f.f1(v, p, t_a)
-        v_mid = @.. broadcast = false v + (h_inner / 2) *
-            ((1 // 2) * k1 - (1 // 2) * fS_yn + fS_Y2)
-        k2 = f.f1(v_mid, p, t_a + h_inner / 2)
-        v = @.. broadcast = false v + h_inner *
-            ((1 // 2) * k2 - (1 // 2) * fS_yn + fS_Y2)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
-    end
-    integrator.u = v
-
-    if integrator.opts.adaptive
-        utilde = @.. broadcast = false v - Y2
-        atmp = calculate_residuals(
-            utilde, uprev, integrator.u,
-            integrator.opts.abstol, integrator.opts.reltol,
-            integrator.opts.internalnorm, t
-        )
-        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
-    end
-end
-
-# MRI-GARK-ERK22b — Sandu 2019, eq. (2.7) family with c₂ = 1 (explicit trapezoidal).
-#
-# For c₂ = 1 the second-stage fast coefficient Γ₂₂ = 1 - c₂ = 0, so stage 2
-# carries no fast dynamics; it is a pure slow correction:
-#
-#   Stage 1: v(0) = u_n;  dv/dτ = f1(v) + f2(u_n)  τ ∈ [0,dt]  → Y_2 = v(dt)
-#   Stage 2: u_{n+1} = Y_2 + dt·(−½ f2(u_n) + ½ f2(Y_2))
-
-function initialize!(integrator, cache::MRIGARKERK22bCache)
-    integrator.kshortsize = 2
-    (; fsalfirst, k) = cache
-    integrator.fsalfirst = fsalfirst
-    integrator.fsallast = k
-    resize!(integrator.k, integrator.kshortsize)
-    integrator.k[1] = integrator.fsalfirst
-    integrator.k[2] = integrator.fsallast
-    integrator.f.f1(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t)
-    integrator.f.f2(cache.tmp, integrator.uprev, integrator.p, integrator.t)
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    integrator.stats.nf2 += 1
-    return integrator.fsalfirst .+= cache.tmp
-end
-
-function initialize!(integrator, cache::MRIGARKERK22bConstantCache)
-    integrator.kshortsize = 2
-    integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-    integrator.fsalfirst = integrator.f.f1(integrator.uprev, integrator.p, integrator.t) +
-        integrator.f.f2(integrator.uprev, integrator.p, integrator.t)
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-    integrator.stats.nf2 += 1
-    integrator.fsallast = zero(integrator.fsalfirst)
-    integrator.k[1] = integrator.fsalfirst
-    return integrator.k[2] = integrator.fsallast
-end
-
-function perform_step!(integrator, cache::MRIGARKERK22bCache, repeat_step = false)
-    (; t, dt, uprev, u, f, p) = integrator
-    (; tmp, atmp, v, f1eval, fS_yn, fS_Y2, Y2) = cache
+    (; tmp, atmp, v, f1eval, fS_yn, fS_Y2, Y2, tab) = cache
+    (; Γ11, Γ22, γ11, γ21, γ22) = tab
     alg = unwrap_alg(integrator, false)
     m = alg.m
 
@@ -184,9 +40,9 @@ function perform_step!(integrator, cache::MRIGARKERK22bCache, repeat_step = fals
     for k_step in 1:m
         t_a = t + (k_step - 1) * h_inner
         f.f1(f1eval, v, p, t_a)
-        @.. broadcast = false tmp = v + (h_inner / 2) * (f1eval + fS_yn)
+        @.. broadcast = false tmp = v + (h_inner / 2) * (Γ11 * f1eval + γ11 * fS_yn)
         f.f1(f1eval, tmp, p, t_a + h_inner / 2)
-        @.. broadcast = false v = v + h_inner * (f1eval + fS_yn)
+        @.. broadcast = false v = v + h_inner * (Γ11 * f1eval + γ11 * fS_yn)
         OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
     end
     @.. broadcast = false Y2 = v
@@ -194,7 +50,22 @@ function perform_step!(integrator, cache::MRIGARKERK22bCache, repeat_step = fals
     f.f2(fS_Y2, Y2, p, t + dt)
     integrator.stats.nf2 += 1
 
-    @.. broadcast = false u = Y2 + dt * (-(1 // 2) * fS_yn + (1 // 2) * fS_Y2)
+    if iszero(Γ22)
+        @.. broadcast = false u = Y2 + dt * (γ21 * fS_yn + γ22 * fS_Y2)
+    else
+        @.. broadcast = false v = Y2
+        for k_step in 1:m
+            t_a = t + (k_step - 1) * h_inner
+            f.f1(f1eval, v, p, t_a)
+            @.. broadcast = false tmp = v + (h_inner / 2) *
+                (Γ22 * f1eval + γ21 * fS_yn + γ22 * fS_Y2)
+            f.f1(f1eval, tmp, p, t_a + h_inner / 2)
+            @.. broadcast = false v = v + h_inner *
+                (Γ22 * f1eval + γ21 * fS_yn + γ22 * fS_Y2)
+            OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
+        end
+        @.. broadcast = false u = v
+    end
 
     return if integrator.opts.adaptive
         @.. broadcast = false tmp = u - Y2
@@ -208,9 +79,10 @@ function perform_step!(integrator, cache::MRIGARKERK22bCache, repeat_step = fals
 end
 
 @muladd function perform_step!(
-        integrator, cache::MRIGARKERK22bConstantCache, repeat_step = false
+        integrator, cache::MRIGARKERK22ConstantCache, repeat_step = false
     )
     (; t, dt, uprev, f, p) = integrator
+    (; Γ11, Γ22, γ11, γ21, γ22) = cache.tab
     alg = unwrap_alg(integrator, false)
     m = alg.m
 
@@ -222,9 +94,9 @@ end
     for k_step in 1:m
         t_a = t + (k_step - 1) * h_inner
         k1 = f.f1(v, p, t_a)
-        v_mid = @.. broadcast = false v + (h_inner / 2) * (k1 + fS_yn)
+        v_mid = @.. broadcast = false v + (h_inner / 2) * (Γ11 * k1 + γ11 * fS_yn)
         k2 = f.f1(v_mid, p, t_a + h_inner / 2)
-        v = @.. broadcast = false v + h_inner * (k2 + fS_yn)
+        v = @.. broadcast = false v + h_inner * (Γ11 * k2 + γ11 * fS_yn)
         OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
     end
     Y2 = v
@@ -232,7 +104,22 @@ end
     fS_Y2 = f.f2(Y2, p, t + dt)
     integrator.stats.nf2 += 1
 
-    integrator.u = @.. broadcast = false Y2 + dt * (-(1 // 2) * fS_yn + (1 // 2) * fS_Y2)
+    if iszero(Γ22)
+        integrator.u = @.. broadcast = false Y2 + dt * (γ21 * fS_yn + γ22 * fS_Y2)
+    else
+        v = Y2
+        for k_step in 1:m
+            t_a = t + (k_step - 1) * h_inner
+            k1 = f.f1(v, p, t_a)
+            v_mid = @.. broadcast = false v + (h_inner / 2) *
+                (Γ22 * k1 + γ21 * fS_yn + γ22 * fS_Y2)
+            k2 = f.f1(v_mid, p, t_a + h_inner / 2)
+            v = @.. broadcast = false v + h_inner *
+                (Γ22 * k2 + γ21 * fS_yn + γ22 * fS_Y2)
+            OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
+        end
+        integrator.u = v
+    end
 
     if integrator.opts.adaptive
         utilde = @.. broadcast = false integrator.u - Y2

--- a/lib/OrdinaryDiffEqMultirate/src/mri_gark_perform_step.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/mri_gark_perform_step.jl
@@ -1,4 +1,4 @@
-function initialize!(integrator, cache::MRIGARKERK22Cache)
+function initialize!(integrator, cache::MRIGARKCache)
     integrator.kshortsize = 2
     (; fsalfirst, k) = cache
     integrator.fsalfirst = fsalfirst
@@ -13,7 +13,7 @@ function initialize!(integrator, cache::MRIGARKERK22Cache)
     return integrator.fsalfirst .+= cache.tmp
 end
 
-function initialize!(integrator, cache::MRIGARKERK22ConstantCache)
+function initialize!(integrator, cache::MRIGARKConstantCache)
     integrator.kshortsize = 2
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
     integrator.fsalfirst = integrator.f.f1(integrator.uprev, integrator.p, integrator.t) +
@@ -25,50 +25,54 @@ function initialize!(integrator, cache::MRIGARKERK22ConstantCache)
     return integrator.k[2] = integrator.fsallast
 end
 
-function perform_step!(integrator, cache::MRIGARKERK22Cache, repeat_step = false)
+function perform_step!(integrator, cache::MRIGARKCache, repeat_step = false)
     (; t, dt, uprev, u, f, p) = integrator
-    (; tmp, atmp, v, f1eval, fS_yn, fS_Y2, Y2, tab) = cache
-    (; Γ11, Γ22, γ11, γ21, γ22) = tab
+    (; tmp, atmp, v, f1eval, slow_f, Y, fS, tab) = cache
+    (; Γ, γ, c) = tab
     alg = unwrap_alg(integrator, false)
     m = alg.m
+    s = length(Γ)
 
-    f.f2(fS_yn, uprev, p, t)
-    integrator.stats.nf2 += 1
-
-    @.. broadcast = false v = uprev
+    @.. broadcast = false Y[1] = uprev
     h_inner = dt / m
-    for k_step in 1:m
-        t_a = t + (k_step - 1) * h_inner
-        f.f1(f1eval, v, p, t_a)
-        @.. broadcast = false tmp = v + (h_inner / 2) * (Γ11 * f1eval + γ11 * fS_yn)
-        f.f1(f1eval, tmp, p, t_a + h_inner / 2)
-        @.. broadcast = false v = v + h_inner * (Γ11 * f1eval + γ11 * fS_yn)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
-    end
-    @.. broadcast = false Y2 = v
 
-    f.f2(fS_Y2, Y2, p, t + dt)
-    integrator.stats.nf2 += 1
+    for i in 1:s
+        f.f2(fS[i], Y[i], p, t + c[i] * dt)
+        integrator.stats.nf2 += 1
 
-    if iszero(Γ22)
-        @.. broadcast = false u = Y2 + dt * (γ21 * fS_yn + γ22 * fS_Y2)
-    else
-        @.. broadcast = false v = Y2
-        for k_step in 1:m
-            t_a = t + (k_step - 1) * h_inner
-            f.f1(f1eval, v, p, t_a)
-            @.. broadcast = false tmp = v + (h_inner / 2) *
-                (Γ22 * f1eval + γ21 * fS_yn + γ22 * fS_Y2)
-            f.f1(f1eval, tmp, p, t_a + h_inner / 2)
-            @.. broadcast = false v = v + h_inner *
-                (Γ22 * f1eval + γ21 * fS_yn + γ22 * fS_Y2)
-            OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
+        @.. broadcast = false slow_f = γ[i, 1] * fS[1]
+        for j in 2:i
+            if !iszero(γ[i, j])
+                @.. broadcast = false slow_f = slow_f + γ[i, j] * fS[j]
+            end
         end
-        @.. broadcast = false u = v
+
+        if iszero(Γ[i])
+            if i < s
+                @.. broadcast = false Y[i + 1] = Y[i] + dt * slow_f
+            else
+                @.. broadcast = false u = Y[i] + dt * slow_f
+            end
+        else
+            @.. broadcast = false v = Y[i]
+            for k_step in 1:m
+                t_a = t + (k_step - 1) * h_inner
+                f.f1(f1eval, v, p, t_a)
+                @.. broadcast = false tmp = v + (h_inner / 2) * (Γ[i] * f1eval + slow_f)
+                f.f1(f1eval, tmp, p, t_a + h_inner / 2)
+                @.. broadcast = false v = v + h_inner * (Γ[i] * f1eval + slow_f)
+                OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
+            end
+            if i < s
+                @.. broadcast = false Y[i + 1] = v
+            else
+                @.. broadcast = false u = v
+            end
+        end
     end
 
     return if integrator.opts.adaptive
-        @.. broadcast = false tmp = u - Y2
+        @.. broadcast = false tmp = u - Y[s]
         calculate_residuals!(
             atmp, tmp, uprev, u,
             integrator.opts.abstol, integrator.opts.reltol,
@@ -79,50 +83,54 @@ function perform_step!(integrator, cache::MRIGARKERK22Cache, repeat_step = false
 end
 
 @muladd function perform_step!(
-        integrator, cache::MRIGARKERK22ConstantCache, repeat_step = false
+        integrator, cache::MRIGARKConstantCache, repeat_step = false
     )
     (; t, dt, uprev, f, p) = integrator
-    (; Γ11, Γ22, γ11, γ21, γ22) = cache.tab
+    (; Γ, γ, c) = cache.tab
     alg = unwrap_alg(integrator, false)
     m = alg.m
+    s = length(Γ)
 
-    fS_yn = f.f2(uprev, p, t)
-    integrator.stats.nf2 += 1
     h_inner = dt / m
+    Y = Vector{typeof(uprev)}(undef, s)
+    fS = Vector{typeof(f.f2(uprev, p, t))}(undef, s)
+    Y[1] = uprev
 
-    v = uprev
-    for k_step in 1:m
-        t_a = t + (k_step - 1) * h_inner
-        k1 = f.f1(v, p, t_a)
-        v_mid = @.. broadcast = false v + (h_inner / 2) * (Γ11 * k1 + γ11 * fS_yn)
-        k2 = f.f1(v_mid, p, t_a + h_inner / 2)
-        v = @.. broadcast = false v + h_inner * (Γ11 * k2 + γ11 * fS_yn)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
-    end
-    Y2 = v
+    for i in 1:s
+        fS[i] = f.f2(Y[i], p, t + c[i] * dt)
+        integrator.stats.nf2 += 1
 
-    fS_Y2 = f.f2(Y2, p, t + dt)
-    integrator.stats.nf2 += 1
-
-    if iszero(Γ22)
-        integrator.u = @.. broadcast = false Y2 + dt * (γ21 * fS_yn + γ22 * fS_Y2)
-    else
-        v = Y2
-        for k_step in 1:m
-            t_a = t + (k_step - 1) * h_inner
-            k1 = f.f1(v, p, t_a)
-            v_mid = @.. broadcast = false v + (h_inner / 2) *
-                (Γ22 * k1 + γ21 * fS_yn + γ22 * fS_Y2)
-            k2 = f.f1(v_mid, p, t_a + h_inner / 2)
-            v = @.. broadcast = false v + h_inner *
-                (Γ22 * k2 + γ21 * fS_yn + γ22 * fS_Y2)
-            OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
+        slow_f = γ[i, 1] * fS[1]
+        for j in 2:i
+            if !iszero(γ[i, j])
+                slow_f = @.. broadcast = false slow_f + γ[i, j] * fS[j]
+            end
         end
-        integrator.u = v
+
+        if iszero(Γ[i])
+            result = @.. broadcast = false Y[i] + dt * slow_f
+        else
+            v = Y[i]
+            for k_step in 1:m
+                t_a = t + (k_step - 1) * h_inner
+                k1 = f.f1(v, p, t_a)
+                v_mid = @.. broadcast = false v + (h_inner / 2) * (Γ[i] * k1 + slow_f)
+                k2 = f.f1(v_mid, p, t_a + h_inner / 2)
+                v = @.. broadcast = false v + h_inner * (Γ[i] * k2 + slow_f)
+                OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
+            end
+            result = v
+        end
+
+        if i < s
+            Y[i + 1] = result
+        else
+            integrator.u = result
+        end
     end
 
     if integrator.opts.adaptive
-        utilde = @.. broadcast = false integrator.u - Y2
+        utilde = @.. broadcast = false integrator.u - Y[s]
         atmp = calculate_residuals(
             utilde, uprev, integrator.u,
             integrator.opts.abstol, integrator.opts.reltol,

--- a/lib/OrdinaryDiffEqMultirate/src/mri_gark_perform_step.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/mri_gark_perform_step.jl
@@ -38,15 +38,6 @@ function initialize!(integrator, cache::MRIGARKERK22aConstantCache)
     return integrator.k[2] = integrator.fsallast
 end
 
-# Inner midpoint micro-step: advance v over interval of length h_inner with rate
-# F(v, t) = scale_f1 * f1(v, t) + offset, where offset is constant in τ.
-@inline function _mri_midpoint_step_iip!(v, f, p, t_a, h_inner, scale_f1, offset, k_buf, tmp)
-    f.f1(k_buf, v, p, t_a)
-    @.. broadcast = false tmp = v + (h_inner / 2) * (scale_f1 * k_buf + offset)
-    f.f1(k_buf, tmp, p, t_a + h_inner / 2)
-    return @.. broadcast = false v = v + h_inner * (scale_f1 * k_buf + offset)
-end
-
 function perform_step!(integrator, cache::MRIGARKERK22aCache, repeat_step = false)
     (; t, dt, uprev, u, f, p) = integrator
     (; tmp, atmp, v, f1eval, fS_yn, fS_Y2, Y2) = cache
@@ -56,10 +47,9 @@ function perform_step!(integrator, cache::MRIGARKERK22aCache, repeat_step = fals
     f.f2(fS_yn, uprev, p, t)
     integrator.stats.nf2 += 1
 
-    # Stage 1: integrate dv/dτ = (1/2)*f1(v) + (1/2)*f2(uprev) over [0, dt]
     @.. broadcast = false v = uprev
     h_inner = dt / m
-    offset1 = fS_yn  # constant
+    offset1 = fS_yn
     for k_step in 1:m
         t_a = t + (k_step - 1) * h_inner
         f.f1(f1eval, v, p, t_a)
@@ -73,7 +63,6 @@ function perform_step!(integrator, cache::MRIGARKERK22aCache, repeat_step = fals
     f.f2(fS_Y2, Y2, p, t + dt)
     integrator.stats.nf2 += 1
 
-    # Stage 2: integrate dv/dτ = (1/2)*f1(v) - (1/2)*f2(uprev) + f2(Y2) over [0, dt]
     @.. broadcast = false v = Y2
     for k_step in 1:m
         t_a = t + (k_step - 1) * h_inner
@@ -108,7 +97,6 @@ end
 
     h_inner = dt / m
 
-    # Stage 1
     v = uprev
     for k_step in 1:m
         t_a = t + (k_step - 1) * h_inner
@@ -123,7 +111,6 @@ end
     fS_Y2 = f.f2(Y2, p, t + dt)
     integrator.stats.nf2 += 1
 
-    # Stage 2
     v = Y2
     for k_step in 1:m
         t_a = t + (k_step - 1) * h_inner

--- a/lib/OrdinaryDiffEqMultirate/src/mri_gark_perform_step.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/mri_gark_perform_step.jl
@@ -134,3 +134,113 @@ end
         OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
     end
 end
+
+# MRI-GARK-ERK22b — Sandu 2019, eq. (2.7) family with c₂ = 1 (explicit trapezoidal).
+#
+# For c₂ = 1 the second-stage fast coefficient Γ₂₂ = 1 - c₂ = 0, so stage 2
+# carries no fast dynamics; it is a pure slow correction:
+#
+#   Stage 1: v(0) = u_n;  dv/dτ = f1(v) + f2(u_n)  τ ∈ [0,dt]  → Y_2 = v(dt)
+#   Stage 2: u_{n+1} = Y_2 + dt·(−½ f2(u_n) + ½ f2(Y_2))
+
+function initialize!(integrator, cache::MRIGARKERK22bCache)
+    integrator.kshortsize = 2
+    (; fsalfirst, k) = cache
+    integrator.fsalfirst = fsalfirst
+    integrator.fsallast = k
+    resize!(integrator.k, integrator.kshortsize)
+    integrator.k[1] = integrator.fsalfirst
+    integrator.k[2] = integrator.fsallast
+    integrator.f.f1(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t)
+    integrator.f.f2(cache.tmp, integrator.uprev, integrator.p, integrator.t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.stats.nf2 += 1
+    return integrator.fsalfirst .+= cache.tmp
+end
+
+function initialize!(integrator, cache::MRIGARKERK22bConstantCache)
+    integrator.kshortsize = 2
+    integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
+    integrator.fsalfirst = integrator.f.f1(integrator.uprev, integrator.p, integrator.t) +
+        integrator.f.f2(integrator.uprev, integrator.p, integrator.t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.stats.nf2 += 1
+    integrator.fsallast = zero(integrator.fsalfirst)
+    integrator.k[1] = integrator.fsalfirst
+    return integrator.k[2] = integrator.fsallast
+end
+
+function perform_step!(integrator, cache::MRIGARKERK22bCache, repeat_step = false)
+    (; t, dt, uprev, u, f, p) = integrator
+    (; tmp, atmp, v, f1eval, fS_yn, fS_Y2, Y2) = cache
+    alg = unwrap_alg(integrator, false)
+    m = alg.m
+
+    f.f2(fS_yn, uprev, p, t)
+    integrator.stats.nf2 += 1
+
+    @.. broadcast = false v = uprev
+    h_inner = dt / m
+    for k_step in 1:m
+        t_a = t + (k_step - 1) * h_inner
+        f.f1(f1eval, v, p, t_a)
+        @.. broadcast = false tmp = v + (h_inner / 2) * (f1eval + fS_yn)
+        f.f1(f1eval, tmp, p, t_a + h_inner / 2)
+        @.. broadcast = false v = v + h_inner * (f1eval + fS_yn)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
+    end
+    @.. broadcast = false Y2 = v
+
+    f.f2(fS_Y2, Y2, p, t + dt)
+    integrator.stats.nf2 += 1
+
+    @.. broadcast = false u = Y2 + dt * (-(1 // 2) * fS_yn + (1 // 2) * fS_Y2)
+
+    return if integrator.opts.adaptive
+        @.. broadcast = false tmp = u - Y2
+        calculate_residuals!(
+            atmp, tmp, uprev, u,
+            integrator.opts.abstol, integrator.opts.reltol,
+            integrator.opts.internalnorm, t
+        )
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+end
+
+@muladd function perform_step!(
+        integrator, cache::MRIGARKERK22bConstantCache, repeat_step = false
+    )
+    (; t, dt, uprev, f, p) = integrator
+    alg = unwrap_alg(integrator, false)
+    m = alg.m
+
+    fS_yn = f.f2(uprev, p, t)
+    integrator.stats.nf2 += 1
+    h_inner = dt / m
+
+    v = uprev
+    for k_step in 1:m
+        t_a = t + (k_step - 1) * h_inner
+        k1 = f.f1(v, p, t_a)
+        v_mid = @.. broadcast = false v + (h_inner / 2) * (k1 + fS_yn)
+        k2 = f.f1(v_mid, p, t_a + h_inner / 2)
+        v = @.. broadcast = false v + h_inner * (k2 + fS_yn)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
+    end
+    Y2 = v
+
+    fS_Y2 = f.f2(Y2, p, t + dt)
+    integrator.stats.nf2 += 1
+
+    integrator.u = @.. broadcast = false Y2 + dt * (-(1 // 2) * fS_yn + (1 // 2) * fS_Y2)
+
+    if integrator.opts.adaptive
+        utilde = @.. broadcast = false integrator.u - Y2
+        atmp = calculate_residuals(
+            utilde, uprev, integrator.u,
+            integrator.opts.abstol, integrator.opts.reltol,
+            integrator.opts.internalnorm, t
+        )
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+end

--- a/lib/OrdinaryDiffEqMultirate/src/mri_gark_perform_step.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/mri_gark_perform_step.jl
@@ -1,0 +1,149 @@
+# MRI-GARK-ERK22a — Sandu, "A class of Multirate Infinitesimal GARK methods",
+# SIAM J. Numer. Anal. 57 (2019), 2300–2327, equation (2.8).
+#
+# For a SplitODE du/dt = f1(u, t) + f2(u, t)  (f1 fast, f2 slow):
+#
+#   Stage 1:  v_1(0) = u_n;   dv_1/dτ = (1/2) f1(v_1) + (1/2) f2(u_n)
+#             integrate τ ∈ [0, dt], Y_2 = v_1(dt)
+#   Stage 2:  v_2(0) = Y_2;   dv_2/dτ = (1/2) f1(v_2) - (1/2) f2(u_n) + f2(Y_2)
+#             integrate τ ∈ [0, dt], u_{n+1} = v_2(dt)
+#
+# Inner micro-ODE integrated with explicit-midpoint (RK2) micro-steps to keep
+# the inner contribution from capping the design order 2.
+
+function initialize!(integrator, cache::MRIGARKERK22aCache)
+    integrator.kshortsize = 2
+    (; fsalfirst, k) = cache
+    integrator.fsalfirst = fsalfirst
+    integrator.fsallast = k
+    resize!(integrator.k, integrator.kshortsize)
+    integrator.k[1] = integrator.fsalfirst
+    integrator.k[2] = integrator.fsallast
+    integrator.f.f1(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t)
+    integrator.f.f2(cache.tmp, integrator.uprev, integrator.p, integrator.t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.stats.nf2 += 1
+    return integrator.fsalfirst .+= cache.tmp
+end
+
+function initialize!(integrator, cache::MRIGARKERK22aConstantCache)
+    integrator.kshortsize = 2
+    integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
+    integrator.fsalfirst = integrator.f.f1(integrator.uprev, integrator.p, integrator.t) +
+        integrator.f.f2(integrator.uprev, integrator.p, integrator.t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.stats.nf2 += 1
+    integrator.fsallast = zero(integrator.fsalfirst)
+    integrator.k[1] = integrator.fsalfirst
+    return integrator.k[2] = integrator.fsallast
+end
+
+# Inner midpoint micro-step: advance v over interval of length h_inner with rate
+# F(v, t) = scale_f1 * f1(v, t) + offset, where offset is constant in τ.
+@inline function _mri_midpoint_step_iip!(v, f, p, t_a, h_inner, scale_f1, offset, k_buf, tmp)
+    f.f1(k_buf, v, p, t_a)
+    @.. broadcast = false tmp = v + (h_inner / 2) * (scale_f1 * k_buf + offset)
+    f.f1(k_buf, tmp, p, t_a + h_inner / 2)
+    return @.. broadcast = false v = v + h_inner * (scale_f1 * k_buf + offset)
+end
+
+function perform_step!(integrator, cache::MRIGARKERK22aCache, repeat_step = false)
+    (; t, dt, uprev, u, f, p) = integrator
+    (; tmp, atmp, v, f1eval, fS_yn, fS_Y2, Y2) = cache
+    alg = unwrap_alg(integrator, false)
+    m = alg.m
+
+    f.f2(fS_yn, uprev, p, t)
+    integrator.stats.nf2 += 1
+
+    # Stage 1: integrate dv/dτ = (1/2)*f1(v) + (1/2)*f2(uprev) over [0, dt]
+    @.. broadcast = false v = uprev
+    h_inner = dt / m
+    offset1 = fS_yn  # constant
+    for k_step in 1:m
+        t_a = t + (k_step - 1) * h_inner
+        f.f1(f1eval, v, p, t_a)
+        @.. broadcast = false tmp = v + (h_inner / 2) * ((1 // 2) * f1eval + (1 // 2) * offset1)
+        f.f1(f1eval, tmp, p, t_a + h_inner / 2)
+        @.. broadcast = false v = v + h_inner * ((1 // 2) * f1eval + (1 // 2) * offset1)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
+    end
+    @.. broadcast = false Y2 = v
+
+    f.f2(fS_Y2, Y2, p, t + dt)
+    integrator.stats.nf2 += 1
+
+    # Stage 2: integrate dv/dτ = (1/2)*f1(v) - (1/2)*f2(uprev) + f2(Y2) over [0, dt]
+    @.. broadcast = false v = Y2
+    for k_step in 1:m
+        t_a = t + (k_step - 1) * h_inner
+        f.f1(f1eval, v, p, t_a)
+        @.. broadcast = false tmp = v + (h_inner / 2) *
+            ((1 // 2) * f1eval - (1 // 2) * fS_yn + fS_Y2)
+        f.f1(f1eval, tmp, p, t_a + h_inner / 2)
+        @.. broadcast = false v = v + h_inner *
+            ((1 // 2) * f1eval - (1 // 2) * fS_yn + fS_Y2)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
+    end
+    @.. broadcast = false u = v
+
+    return if integrator.opts.adaptive
+        @.. broadcast = false tmp = v - Y2
+        calculate_residuals!(
+            atmp, tmp, uprev, u,
+            integrator.opts.abstol, integrator.opts.reltol,
+            integrator.opts.internalnorm, t
+        )
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+end
+
+@muladd function perform_step!(integrator, cache::MRIGARKERK22aConstantCache, repeat_step = false)
+    (; t, dt, uprev, f, p) = integrator
+    alg = unwrap_alg(integrator, false)
+    m = alg.m
+
+    fS_yn = f.f2(uprev, p, t)
+    integrator.stats.nf2 += 1
+
+    h_inner = dt / m
+
+    # Stage 1
+    v = uprev
+    for k_step in 1:m
+        t_a = t + (k_step - 1) * h_inner
+        k1 = f.f1(v, p, t_a)
+        v_mid = @.. broadcast = false v + (h_inner / 2) * ((1 // 2) * k1 + (1 // 2) * fS_yn)
+        k2 = f.f1(v_mid, p, t_a + h_inner / 2)
+        v = @.. broadcast = false v + h_inner * ((1 // 2) * k2 + (1 // 2) * fS_yn)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
+    end
+    Y2 = v
+
+    fS_Y2 = f.f2(Y2, p, t + dt)
+    integrator.stats.nf2 += 1
+
+    # Stage 2
+    v = Y2
+    for k_step in 1:m
+        t_a = t + (k_step - 1) * h_inner
+        k1 = f.f1(v, p, t_a)
+        v_mid = @.. broadcast = false v + (h_inner / 2) *
+            ((1 // 2) * k1 - (1 // 2) * fS_yn + fS_Y2)
+        k2 = f.f1(v_mid, p, t_a + h_inner / 2)
+        v = @.. broadcast = false v + h_inner *
+            ((1 // 2) * k2 - (1 // 2) * fS_yn + fS_Y2)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
+    end
+    integrator.u = v
+
+    if integrator.opts.adaptive
+        utilde = @.. broadcast = false v - Y2
+        atmp = calculate_residuals(
+            utilde, uprev, integrator.u,
+            integrator.opts.abstol, integrator.opts.reltol,
+            integrator.opts.internalnorm, t
+        )
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+end

--- a/lib/OrdinaryDiffEqMultirate/src/mri_gark_tableaus.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/mri_gark_tableaus.jl
@@ -1,0 +1,19 @@
+struct MRIGARKExplicit22Tableau{T}
+    Γ11::T  # fast rate, stage 1
+    Γ22::T  # fast rate, stage 2 (0 when c₂ = 1)
+    γ11::T  # f2(u_n) coupling, stage 1
+    γ21::T  # f2(u_n) coupling, stage 2
+    γ22::T  # f2(Y₂) coupling, stage 2
+end
+
+function MRIGARKERK22aTableau(::Type{T}) where {T}
+    return MRIGARKExplicit22Tableau{T}(
+        T(1 // 2), T(1 // 2), T(1 // 2), T(-1 // 2), T(1)
+    )
+end
+
+function MRIGARKERK22bTableau(::Type{T}) where {T}
+    return MRIGARKExplicit22Tableau{T}(
+        T(1), T(0), T(1), T(-1 // 2), T(1 // 2)
+    )
+end

--- a/lib/OrdinaryDiffEqMultirate/src/mri_gark_tableaus.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/mri_gark_tableaus.jl
@@ -1,9 +1,9 @@
 struct MRIGARKExplicit22Tableau{T}
-    Γ11::T  # fast rate, stage 1
-    Γ22::T  # fast rate, stage 2 (0 when c₂ = 1)
-    γ11::T  # f2(u_n) coupling, stage 1
-    γ21::T  # f2(u_n) coupling, stage 2
-    γ22::T  # f2(Y₂) coupling, stage 2
+    Γ11::T
+    Γ22::T  # 0 for ERK22b (c₂=1); no inner fast loop in stage 2
+    γ11::T
+    γ21::T
+    γ22::T
 end
 
 function MRIGARKERK22aTableau(::Type{T}) where {T}

--- a/lib/OrdinaryDiffEqMultirate/src/mri_gark_tableaus.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/mri_gark_tableaus.jl
@@ -17,3 +17,6 @@ function MRIGARKERK22bTableau(::Type{T}) where {T}
     c = T[0, 1]
     return MRIGARKExplicitTableau{T}(Γ, γ, c)
 end
+
+mri_gark_tableau(::MRIGARKERK22a, ::Type{T}) where {T} = MRIGARKERK22aTableau(T)
+mri_gark_tableau(::MRIGARKERK22b, ::Type{T}) where {T} = MRIGARKERK22bTableau(T)

--- a/lib/OrdinaryDiffEqMultirate/src/mri_gark_tableaus.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/mri_gark_tableaus.jl
@@ -1,19 +1,19 @@
-struct MRIGARKExplicit22Tableau{T}
-    Γ11::T
-    Γ22::T  # 0 for ERK22b (c₂=1); no inner fast loop in stage 2
-    γ11::T
-    γ21::T
-    γ22::T
+struct MRIGARKExplicitTableau{T}
+    Γ::Vector{T}  # diagonal fast rates, length s
+    γ::Matrix{T}  # lower-triangular slow couplings, s×s
+    c::Vector{T}  # slow abscissae for fS evaluations, length s
 end
 
 function MRIGARKERK22aTableau(::Type{T}) where {T}
-    return MRIGARKExplicit22Tableau{T}(
-        T(1 // 2), T(1 // 2), T(1 // 2), T(-1 // 2), T(1)
-    )
+    Γ = T[1 // 2, 1 // 2]
+    γ = T[1 // 2 0; -1 // 2 1]
+    c = T[0, 1]
+    return MRIGARKExplicitTableau{T}(Γ, γ, c)
 end
 
 function MRIGARKERK22bTableau(::Type{T}) where {T}
-    return MRIGARKExplicit22Tableau{T}(
-        T(1), T(0), T(1), T(-1 // 2), T(1 // 2)
-    )
+    Γ = T[1, 0]
+    γ = T[1 0; -1 // 2 1 // 2]
+    c = T[0, 1]
+    return MRIGARKExplicitTableau{T}(Γ, γ, c)
 end

--- a/lib/OrdinaryDiffEqMultirate/test/mri_gark_tests.jl
+++ b/lib/OrdinaryDiffEqMultirate/test/mri_gark_tests.jl
@@ -3,7 +3,7 @@ using OrdinaryDiffEqMultirate, DiffEqDevTools, Test, LinearAlgebra
 @testset "MRI-GARK ERK22 family" begin
     @testset "MRIGARKERK22a" begin
         @testset "Construction" begin
-            @test MRIGARKERK22a() == MRIGARKERK22a(10)
+            @test MRIGARKERK22a(m = 10) == MRIGARKERK22a(10)
             @test MRIGARKERK22a(m = 20) == MRIGARKERK22a(20)
         end
 
@@ -47,7 +47,7 @@ using OrdinaryDiffEqMultirate, DiffEqDevTools, Test, LinearAlgebra
 
     @testset "MRIGARKERK22b" begin
         @testset "Construction" begin
-            @test MRIGARKERK22b() == MRIGARKERK22b(10)
+            @test MRIGARKERK22b(m = 10) == MRIGARKERK22b(10)
             @test MRIGARKERK22b(m = 20) == MRIGARKERK22b(20)
         end
 

--- a/lib/OrdinaryDiffEqMultirate/test/mri_gark_tests.jl
+++ b/lib/OrdinaryDiffEqMultirate/test/mri_gark_tests.jl
@@ -1,45 +1,92 @@
 using OrdinaryDiffEqMultirate, DiffEqDevTools, Test, LinearAlgebra
 
-@testset "MRIGARKERK22a" begin
-    @testset "Construction" begin
-        @test MRIGARKERK22a() == MRIGARKERK22a(10)
-        @test MRIGARKERK22a(m = 20) == MRIGARKERK22a(20)
+@testset "MRI-GARK ERK22 family" begin
+    @testset "MRIGARKERK22a" begin
+        @testset "Construction" begin
+            @test MRIGARKERK22a() == MRIGARKERK22a(10)
+            @test MRIGARKERK22a(m = 20) == MRIGARKERK22a(20)
+        end
+
+        @testset "Scalar out-of-place" begin
+            prob = SplitODEProblem(
+                (u, p, t) -> -0.9 * u, (u, p, t) -> -0.1 * u, 1.0, (0.0, 1.0)
+            )
+            sol = solve(prob, MRIGARKERK22a(m = 10), dt = 0.05, adaptive = false)
+            @test abs(sol.u[end] - exp(-1.0)) < 1.0e-3
+
+            sol_a = solve(prob, MRIGARKERK22a(m = 10), reltol = 1.0e-6, abstol = 1.0e-6)
+            @test abs(sol_a.u[end] - exp(-1.0)) < 1.0e-3
+        end
+
+        @testset "Vector in-place" begin
+            f1!(du, u, p, t) = (du .= -0.9 .* u)
+            f2!(du, u, p, t) = (du .= -0.1 .* u)
+            u0 = [1.0, 2.0, 3.0]
+            prob = SplitODEProblem(f1!, f2!, u0, (0.0, 1.0))
+
+            sol = solve(prob, MRIGARKERK22a(m = 10), dt = 0.05, adaptive = false)
+            @test norm(sol.u[end] - u0 .* exp(-1.0)) < 1.0e-2
+
+            sol_a = solve(prob, MRIGARKERK22a(m = 10), reltol = 1.0e-6, abstol = 1.0e-6)
+            @test norm(sol_a.u[end] - u0 .* exp(-1.0)) < 1.0e-3
+        end
+
+        @testset "Convergence" begin
+            analytic(u0, p, t) = u0 * exp(-3t)
+            prob = SplitODEProblem(
+                SplitFunction(
+                    (u, p, t) -> -2u, (u, p, t) -> -u; analytic = analytic
+                ),
+                1.0, (0.0, 1.0)
+            )
+            dts = 1 ./ 2 .^ (6:-1:2)
+            sim = test_convergence(dts, prob, MRIGARKERK22a(m = 8))
+            @test sim.𝒪est[:l∞] ≈ 2 atol = 0.3
+        end
     end
 
-    @testset "Scalar out-of-place" begin
-        prob = SplitODEProblem(
-            (u, p, t) -> -0.9 * u, (u, p, t) -> -0.1 * u, 1.0, (0.0, 1.0)
-        )
-        sol = solve(prob, MRIGARKERK22a(m = 10), dt = 0.05, adaptive = false)
-        @test abs(sol.u[end] - exp(-1.0)) < 1.0e-3
+    @testset "MRIGARKERK22b" begin
+        @testset "Construction" begin
+            @test MRIGARKERK22b() == MRIGARKERK22b(10)
+            @test MRIGARKERK22b(m = 20) == MRIGARKERK22b(20)
+        end
 
-        sol_a = solve(prob, MRIGARKERK22a(m = 10), reltol = 1.0e-6, abstol = 1.0e-6)
-        @test abs(sol_a.u[end] - exp(-1.0)) < 1.0e-3
+        @testset "Scalar out-of-place" begin
+            prob = SplitODEProblem(
+                (u, p, t) -> -0.9 * u, (u, p, t) -> -0.1 * u, 1.0, (0.0, 1.0)
+            )
+            sol = solve(prob, MRIGARKERK22b(m = 10), dt = 0.05, adaptive = false)
+            @test abs(sol.u[end] - exp(-1.0)) < 1.0e-3
+
+            sol_a = solve(prob, MRIGARKERK22b(m = 10), reltol = 1.0e-6, abstol = 1.0e-6)
+            @test abs(sol_a.u[end] - exp(-1.0)) < 1.0e-3
+        end
+
+        @testset "Vector in-place" begin
+            f1!(du, u, p, t) = (du .= -0.9 .* u)
+            f2!(du, u, p, t) = (du .= -0.1 .* u)
+            u0 = [1.0, 2.0, 3.0]
+            prob = SplitODEProblem(f1!, f2!, u0, (0.0, 1.0))
+
+            sol = solve(prob, MRIGARKERK22b(m = 10), dt = 0.05, adaptive = false)
+            @test norm(sol.u[end] - u0 .* exp(-1.0)) < 1.0e-2
+
+            sol_a = solve(prob, MRIGARKERK22b(m = 10), reltol = 1.0e-6, abstol = 1.0e-6)
+            @test norm(sol_a.u[end] - u0 .* exp(-1.0)) < 1.0e-3
+        end
+
+        @testset "Convergence" begin
+            analytic(u0, p, t) = u0 * exp(-3t)
+            prob = SplitODEProblem(
+                SplitFunction(
+                    (u, p, t) -> -2u, (u, p, t) -> -u; analytic = analytic
+                ),
+                1.0, (0.0, 1.0)
+            )
+            dts = 1 ./ 2 .^ (6:-1:2)
+            sim = test_convergence(dts, prob, MRIGARKERK22b(m = 8))
+            @test sim.𝒪est[:l∞] ≈ 2 atol = 0.3
+        end
     end
 
-    @testset "Vector in-place" begin
-        f1!(du, u, p, t) = (du .= -0.9 .* u)
-        f2!(du, u, p, t) = (du .= -0.1 .* u)
-        u0 = [1.0, 2.0, 3.0]
-        prob = SplitODEProblem(f1!, f2!, u0, (0.0, 1.0))
-
-        sol = solve(prob, MRIGARKERK22a(m = 10), dt = 0.05, adaptive = false)
-        @test norm(sol.u[end] - u0 .* exp(-1.0)) < 1.0e-2
-
-        sol_a = solve(prob, MRIGARKERK22a(m = 10), reltol = 1.0e-6, abstol = 1.0e-6)
-        @test norm(sol_a.u[end] - u0 .* exp(-1.0)) < 1.0e-3
-    end
-
-    @testset "Convergence" begin
-        analytic(u0, p, t) = u0 * exp(-3t)
-        prob = SplitODEProblem(
-            SplitFunction(
-                (u, p, t) -> -2u, (u, p, t) -> -u; analytic = analytic
-            ),
-            1.0, (0.0, 1.0)
-        )
-        dts = 1 ./ 2 .^ (6:-1:2)
-        sim = test_convergence(dts, prob, MRIGARKERK22a(m = 8))
-        @test sim.𝒪est[:l∞] ≈ 2 atol = 0.3
-    end
 end

--- a/lib/OrdinaryDiffEqMultirate/test/mri_gark_tests.jl
+++ b/lib/OrdinaryDiffEqMultirate/test/mri_gark_tests.jl
@@ -1,0 +1,45 @@
+using OrdinaryDiffEqMultirate, DiffEqDevTools, Test, LinearAlgebra
+
+@testset "MRIGARKERK22a" begin
+    @testset "Construction" begin
+        @test MRIGARKERK22a() == MRIGARKERK22a(10)
+        @test MRIGARKERK22a(m = 20) == MRIGARKERK22a(20)
+    end
+
+    @testset "Scalar out-of-place" begin
+        prob = SplitODEProblem(
+            (u, p, t) -> -0.9 * u, (u, p, t) -> -0.1 * u, 1.0, (0.0, 1.0)
+        )
+        sol = solve(prob, MRIGARKERK22a(m = 10), dt = 0.05, adaptive = false)
+        @test abs(sol.u[end] - exp(-1.0)) < 1.0e-3
+
+        sol_a = solve(prob, MRIGARKERK22a(m = 10), reltol = 1.0e-6, abstol = 1.0e-6)
+        @test abs(sol_a.u[end] - exp(-1.0)) < 1.0e-3
+    end
+
+    @testset "Vector in-place" begin
+        f1!(du, u, p, t) = (du .= -0.9 .* u)
+        f2!(du, u, p, t) = (du .= -0.1 .* u)
+        u0 = [1.0, 2.0, 3.0]
+        prob = SplitODEProblem(f1!, f2!, u0, (0.0, 1.0))
+
+        sol = solve(prob, MRIGARKERK22a(m = 10), dt = 0.05, adaptive = false)
+        @test norm(sol.u[end] - u0 .* exp(-1.0)) < 1.0e-2
+
+        sol_a = solve(prob, MRIGARKERK22a(m = 10), reltol = 1.0e-6, abstol = 1.0e-6)
+        @test norm(sol_a.u[end] - u0 .* exp(-1.0)) < 1.0e-3
+    end
+
+    @testset "Convergence" begin
+        analytic(u0, p, t) = u0 * exp(-3t)
+        prob = SplitODEProblem(
+            SplitFunction(
+                (u, p, t) -> -2u, (u, p, t) -> -u; analytic = analytic
+            ),
+            1.0, (0.0, 1.0)
+        )
+        dts = 1 ./ 2 .^ (6:-1:2)
+        sim = test_convergence(dts, prob, MRIGARKERK22a(m = 8))
+        @test sim.𝒪est[:l∞] ≈ 2 atol = 0.3
+    end
+end

--- a/lib/OrdinaryDiffEqMultirate/test/runtests.jl
+++ b/lib/OrdinaryDiffEqMultirate/test/runtests.jl
@@ -11,6 +11,7 @@ end
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "MREEF Tests" include("mreef_tests.jl")
     @time @safetestset "MRAB Tests" include("mrab_tests.jl")
+    @time @safetestset "MRI-GARK Tests" include("mri_gark_tests.jl")
 end
 
 # Run QA tests (AllocCheck) - skip on pre-release Julia


### PR DESCRIPTION
Adds `MRIGARKERK22a` and `MRIGARKERK22b`, the two 2nd-order explicit members of the Multirate Infinitesimal GARK family from Sandu, *SIAM J. Numer. Anal.* 57 (2019), 2300–2327, §2.3. Both methods solve `du/dt = f1(u,t) + f2(u,t)` (f1 fast, f2 slow). Fifth and sixth solvers in `OrdinaryDiffEqMultirate` after MREEF (#3139), MRAB (#3705), and MIS2 (#3717).

## Algorithm source

Both methods share the same stage-1 structure but differ in c₂, which controls the slow method's quadrature:

**ERK22a — c₂ = 1/2 (explicit midpoint as slow method)**
```
Stage 1: v(0) = u_n,  dv/dτ = (1/2) f1(v) + (1/2) f2(u_n)                   → Y₂ = v(dt)
Stage 2: v(0) = Y₂,  dv/dτ = (1/2) f1(v) - (1/2) f2(u_n) + f2(Y₂)           → u_{n+1} = v(dt)
```

**ERK22b — c₂ = 1 (explicit trapezoidal as slow method)**
```
Stage 1: v(0) = u_n,  dv/dτ = f1(v) + f2(u_n)                                → Y₂ = v(dt)
Stage 2: Γ₂₂ = 1 - c₂ = 0 → no fast dynamics; pure slow correction:
         u_{n+1} = Y₂ + dt · (-½ f2(u_n) + ½ f2(Y₂))
```

Each fast stage uses `m` explicit-midpoint (RK2) micro-steps so the inner contribution does not cap the design order. The embedded error estimate uses `u_{n+1} − Y₂`.

## Framework

Dedicated `MRIGARKERK22{a,b}Cache` + `MRIGARKERK22{a,b}ConstantCache` mirroring the MREEF/MRAB style. Combined `Union` dispatch in `alg_utils.jl` for shared `alg_order`/`isfsal`/`prepare_alg`. No changes to existing solvers.

## Test plan

- [x] Construction (kwarg + positional) for both variants
- [x] Scalar OOP + Vector IIP smoke (fixed-step and adaptive) for both variants
- [x] Convergence order ≈ 2 for ERK22a (`𝒪est ≈ 2.12`) and ERK22b across `m = 8`
- [x] MREEF (19) + MRAB (16) regression suites still pass (49 tests total green)
- [ ] CI green on Julia 1.10 / 1.11 / lts / pre

Subpackage version 2.1.0 → 2.2.0.