### PR TITLE
Drop now-invalid allow-reresolve input from downgrade workflow(s)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -25,5 +25,4 @@ jobs:
       julia-version: "1.11"
       group: "InterfaceI"
       skip: "Pkg,TOML,Statistics,LinearAlgebra,SparseArrays,InteractiveUtils"
-      allow-reresolve: true
     secrets: "inherit"

--- a/.github/workflows/DowngradeSublibraries.yml
+++ b/.github/workflows/DowngradeSublibraries.yml
@@ -24,5 +24,4 @@ jobs:
       skip: "Pkg,TOML,Statistics,LinearAlgebra,SparseArrays,InteractiveUtils,OrdinaryDiffEqCore,OrdinaryDiffEqNonlinearSolve,OrdinaryDiffEqDifferentiation"
       group-env-name: "ODEDIFFEQ_TEST_GROUP"
       group-env-value: "Core"
-      allow-reresolve: true
       # Every lib/* sublibrary is downgrade-tested (projects auto-discovered, no exclusions).


### PR DESCRIPTION
## What

Remove the now-invalid `allow-reresolve:` input from the downgrade workflow(s).

The centralized `SciML/.github` downgrade workflows (`downgrade.yml` and
`sublibrary-downgrade.yml`) are being changed to **always** use
`allow_reresolve: false` and to drop the `allow-reresolve` `workflow_call`
input entirely (see SciML/.github#71). Once that merges and `@v1` is retagged,
any caller still passing `allow-reresolve:` would fail with an invalid-input
error. This PR removes that line so this repo keeps working.
**Behavior note:** this repo passed `allow-reresolve: true` in one or more
downgrade files, so removing it makes the downgrade run strict
(`allow_reresolve: false`). That is the intended policy outcome, but it is a
real behavior change and may surface previously-hidden compat-floor conflicts.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>