### PR TITLE
ci: update test version matrix to new SciML convention

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,13 +53,15 @@ jobs:
           - AD
         version:
           - 'lts'
-          - '1.11'
           - '1'
           - 'pre'
         exclude:
           - group: AD
             version: '1'
           - group: AD
+            version: 'pre'
+          # QA runs only on lts and 1 per the SciML version-matrix convention.
+          - group: QA
             version: 'pre'
           # Skip ODEInterfaceRegression until ODEInterface.jl is fixed upstream
           # See: https://github.com/SciML/OrdinaryDiffEq.jl/issues/2987

--- a/lib/DelayDiffEq/test/test_groups.toml
+++ b/lib/DelayDiffEq/test/test_groups.toml
@@ -1,14 +1,14 @@
 [Interface]
-versions = ["lts", "1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [Integrators]
-versions = ["lts", "1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [Regression]
-versions = ["lts", "1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [SDDE]
-versions = ["lts", "1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]

--- a/lib/DiffEqBase/test/test_groups.toml
+++ b/lib/DiffEqBase/test/test_groups.toml
@@ -1,8 +1,8 @@
 [Core]
-versions = ["lts", "1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]
 
 [Static]
 versions = ["1"]

--- a/lib/DiffEqDevTools/test/test_groups.toml
+++ b/lib/DiffEqDevTools/test/test_groups.toml
@@ -1,5 +1,5 @@
 [Core]
-versions = ["lts", "1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]

--- a/lib/OrdinaryDiffEqAdamsBashforthMoulton/test/test_groups.toml
+++ b/lib/OrdinaryDiffEqAdamsBashforthMoulton/test/test_groups.toml
@@ -1,9 +1,9 @@
 [Core]
-versions = ["lts", "1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [Threaded]
 versions = ["1"]
 num_threads = 2
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]

--- a/lib/OrdinaryDiffEqBDF/test/test_groups.toml
+++ b/lib/OrdinaryDiffEqBDF/test/test_groups.toml
@@ -1,5 +1,5 @@
 [Core]
-versions = ["lts", "1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [GPU]
 versions = ["1"]
@@ -7,4 +7,4 @@ runner = ["self-hosted", "Linux", "X64", "gpu"]
 timeout = 60
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]

--- a/lib/OrdinaryDiffEqCore/test/test_groups.toml
+++ b/lib/OrdinaryDiffEqCore/test/test_groups.toml
@@ -1,5 +1,5 @@
 [Core]
-versions = ["lts", "1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [GPU]
 versions = ["1"]
@@ -7,4 +7,4 @@ runner = ["self-hosted", "Linux", "X64", "gpu"]
 timeout = 60
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]

--- a/lib/OrdinaryDiffEqDefault/test/test_groups.toml
+++ b/lib/OrdinaryDiffEqDefault/test/test_groups.toml
@@ -1,5 +1,5 @@
 [Core]
-versions = ["lts", "1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [GPU]
 versions = ["1"]
@@ -7,4 +7,4 @@ runner = ["self-hosted", "Linux", "X64", "gpu"]
 timeout = 60
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]

--- a/lib/OrdinaryDiffEqDifferentiation/test/test_groups.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/test/test_groups.toml
@@ -1,8 +1,8 @@
 [Core]
-versions = ["lts", "1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]
 
 [Sparse]
 versions = ["1"]

--- a/lib/OrdinaryDiffEqExtrapolation/test/test_groups.toml
+++ b/lib/OrdinaryDiffEqExtrapolation/test/test_groups.toml
@@ -1,5 +1,5 @@
 [Core]
-versions = ["lts", "1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [Multithreading]
 versions = ["1"]
@@ -8,4 +8,4 @@ num_threads = 2
 timeout = 240
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]

--- a/lib/OrdinaryDiffEqLinear/test/test_groups.toml
+++ b/lib/OrdinaryDiffEqLinear/test/test_groups.toml
@@ -1,5 +1,5 @@
 [Core]
-versions = ["lts", "1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [GPU]
 versions = ["1"]
@@ -7,4 +7,4 @@ runner = ["self-hosted", "Linux", "X64", "gpu"]
 timeout = 60
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]

--- a/lib/OrdinaryDiffEqLowStorageRK/test/test_groups.toml
+++ b/lib/OrdinaryDiffEqLowStorageRK/test/test_groups.toml
@@ -1,5 +1,5 @@
 [Core]
-versions = ["lts", "1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [GPU]
 versions = ["1"]
@@ -7,4 +7,4 @@ runner = ["self-hosted", "Linux", "X64", "gpu"]
 timeout = 60
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/test_groups.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/test_groups.toml
@@ -1,8 +1,8 @@
 [Core]
-versions = ["lts", "1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]
 
 [ModelingToolkit]
 versions = ["1"]

--- a/lib/OrdinaryDiffEqRKIP/test/test_groups.toml
+++ b/lib/OrdinaryDiffEqRKIP/test/test_groups.toml
@@ -1,5 +1,5 @@
 [Core]
-versions = ["lts", "1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [GPU]
 versions = ["1"]
@@ -7,4 +7,4 @@ runner = ["self-hosted", "Linux", "X64", "gpu"]
 timeout = 60
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]

--- a/lib/OrdinaryDiffEqRosenbrock/test/test_groups.toml
+++ b/lib/OrdinaryDiffEqRosenbrock/test/test_groups.toml
@@ -1,5 +1,5 @@
 [Core]
-versions = ["lts", "1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [GPU]
 versions = ["1"]
@@ -7,4 +7,4 @@ runner = ["self-hosted", "Linux", "X64", "gpu"]
 timeout = 60
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]

--- a/lib/OrdinaryDiffEqStabilizedRK/test/test_groups.toml
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/test_groups.toml
@@ -1,5 +1,5 @@
 [Core]
-versions = ["lts", "1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [GPU]
 versions = ["1"]
@@ -7,4 +7,4 @@ runner = ["self-hosted", "Linux", "X64", "gpu"]
 timeout = 60
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]

--- a/lib/StochasticDiffEq/test/test_groups.toml
+++ b/lib/StochasticDiffEq/test/test_groups.toml
@@ -1,11 +1,11 @@
 [Interface1]
-versions = ["1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [Interface2]
-versions = ["1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [Interface3]
-versions = ["1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [AlgConvergence]
 versions = ["1"]
@@ -62,4 +62,4 @@ versions = ["1"]
 versions = ["1"]
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]

--- a/lib/StochasticDiffEqCore/test/test_groups.toml
+++ b/lib/StochasticDiffEqCore/test/test_groups.toml
@@ -1,5 +1,5 @@
 [Core]
-versions = ["1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]

--- a/lib/StochasticDiffEqHighOrder/test/test_groups.toml
+++ b/lib/StochasticDiffEqHighOrder/test/test_groups.toml
@@ -1,5 +1,5 @@
 [Core]
-versions = ["1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]

--- a/lib/StochasticDiffEqIIF/test/test_groups.toml
+++ b/lib/StochasticDiffEqIIF/test/test_groups.toml
@@ -1,5 +1,5 @@
 [Core]
-versions = ["1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]

--- a/lib/StochasticDiffEqImplicit/test/test_groups.toml
+++ b/lib/StochasticDiffEqImplicit/test/test_groups.toml
@@ -1,5 +1,5 @@
 [Core]
-versions = ["1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]

--- a/lib/StochasticDiffEqLeaping/test/test_groups.toml
+++ b/lib/StochasticDiffEqLeaping/test/test_groups.toml
@@ -1,5 +1,5 @@
 [Core]
-versions = ["1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]

--- a/lib/StochasticDiffEqLowOrder/test/test_groups.toml
+++ b/lib/StochasticDiffEqLowOrder/test/test_groups.toml
@@ -1,5 +1,5 @@
 [Core]
-versions = ["1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]

--- a/lib/StochasticDiffEqMilstein/test/test_groups.toml
+++ b/lib/StochasticDiffEqMilstein/test/test_groups.toml
@@ -1,5 +1,5 @@
 [Core]
-versions = ["1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]

--- a/lib/StochasticDiffEqROCK/test/test_groups.toml
+++ b/lib/StochasticDiffEqROCK/test/test_groups.toml
@@ -1,5 +1,5 @@
 [Core]
-versions = ["1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 # Weak-convergence Monte-Carlo studies — too expensive to run on every
 # upstream-dependency change, so marked local_only. See
@@ -11,4 +11,4 @@ timeout = 240
 local_only = true
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]

--- a/lib/StochasticDiffEqRODE/test/test_groups.toml
+++ b/lib/StochasticDiffEqRODE/test/test_groups.toml
@@ -1,5 +1,5 @@
 [Core]
-versions = ["1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]

--- a/lib/StochasticDiffEqWeak/test/test_groups.toml
+++ b/lib/StochasticDiffEqWeak/test/test_groups.toml
@@ -1,5 +1,5 @@
 [Core]
-versions = ["1.11", "1", "pre"]
+versions = ["lts", "1", "pre"]
 
 # Weak-convergence groups are extremely expensive (Monte-Carlo trajectory
 # studies) and only exercise StochasticDiffEqWeak's own solvers, so they are
@@ -58,4 +58,4 @@ versions = ["1"]
 local_only = true
 
 [QA]
-versions = ["1"]
+versions = ["lts", "1"]


### PR DESCRIPTION
## Summary

Updates **only the test version matrix** so this canonical reference repo matches the new SciML version-matrix convention. No folder-structure or other changes.

New convention applied:
- **base / standard / `Core`-like groups:** `versions = ["lts", "1", "pre"]` — drops the explicit `"1.11"`, and adds `"lts"` to the `StochasticDiffEq*` base groups that previously lacked it.
- **`QA` groups:** `versions = ["lts", "1"]`.
- **`GPU` and all other special groups:** unchanged (`["1"]`).

Scope:
- All 26 `lib/*/test/test_groups.toml` files.
- Root `.github/workflows/CI.yml` matrix: `version` array -> `['lts', '1', 'pre']`, with `QA` excluded from `pre` so it effectively runs `['lts', '1']`.

## Verification
- Every `test_groups.toml` re-parsed with Julia's `TOML` stdlib (26/26 OK; every group still has a valid `versions` array).
- `CI.yml` re-parsed with a YAML parser; asserted `version == ['lts','1','pre']` and the new `QA`/`pre` exclude.
- Aggregate diff confirms only base-group and `QA` version lines changed; no other `["1"]`-only group was touched. The two remaining `1.11` mentions in `CI.yml` are the `Develop local path deps (Julia < 1.11)` step and the `VERSION < v"1.11.0-DEV.0"` runtime guard — not part of the version matrix, so intentionally left alone.

---

**Please ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)