### PR TITLE
Fix Spell Check (typos) failures on master

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -22,6 +22,9 @@ vectorized = "vectorized"
 extrapolant = "extrapolant"
 # Person names in citations - these are correct spellings
 Sigal = "Sigal"  # Sigal Gottlieb is a real person/author
+lamba = "lamba"  # Lamba's adaptive Euler-Maruyama method (LambaEM, LambaEulerHeun)
+Lamba = "Lamba"
+Strang = "Strang"  # Strang splitting (Gilbert Strang)
 Steinebach = "Steinebach"
 Protopapa = "Protopapa"
 Hairer = "Hairer"

--- a/docs/src/devtools/alg_dev/benchmarks.md
+++ b/docs/src/devtools/alg_dev/benchmarks.md
@@ -54,7 +54,7 @@ on each of these values.
 
 ### WorkPrecision
 
-A WorkPrecision calculates the necessary componnets of a work-precision plot. This
+A WorkPrecision calculates the necessary components of a work-precision plot. This
 shows how time scales with the user chosen tolerances on a given problem. To make
 a WorkPrecision, you give it a vector of absolute and relative tolerances:
 

--- a/docs/src/implicit/FIRK.md
+++ b/docs/src/implicit/FIRK.md
@@ -35,7 +35,7 @@ These methods are recommended for:
 
 RadauIIA methods are based on Gaussian collocation and achieve order 2s-1 for s stages, making them among the highest-order implicit methods available. They represent the ODE analog of Gaussian quadrature with a fixed right node (Gauss-Radau). They are L-stable, meaning they are stiffly accurate and handle large negative eigenvalues/stiffness ratios. For more details on recent advances in FIRK methods, see our paper: [High-Order Adaptive Time Stepping for the Incompressible Navier-Stokes Equations](https://arxiv.org/abs/2412.14362).
 
-Gauss–Legendre methods use the roots of the Legendre polynomial directly as collocation points and achieve an order of 2s, the highest order IRK available. They are also A-stable, symmetric, and can be symplectic in certain usages. They conserve energy within the system but are not L-Stable like Radau, which means they preserve oscilations instead of damping. 
+Gauss–Legendre methods use the roots of the Legendre polynomial directly as collocation points and achieve an order of 2s, the highest order IRK available. They are also A-stable, symmetric, and can be symplectic in certain usages. They conserve energy within the system but are not L-Stable like Radau, which means they preserve oscillations instead of damping. 
 
 ## Computational Considerations
 

--- a/lib/StochasticDiffEq/test/runtests.jl
+++ b/lib/StochasticDiffEq/test/runtests.jl
@@ -226,7 +226,7 @@ const is_APPVEYOR = Sys.iswindows() && haskey(ENV, "APPVEYOR")
     end
 
     if !is_APPVEYOR && TEST_GROUP == "Multithreaded"
-        @time @safetestset "Mulithreaded Jump Thread Safety Tests" begin
+        @time @safetestset "Multithreaded Jump Thread Safety Tests" begin
             include("multithreaded_jump_test.jl")
         end
     end

--- a/lib/StochasticDiffEqROCK/src/SROCK_utils.jl
+++ b/lib/StochasticDiffEqROCK/src/SROCK_utils.jl
@@ -151,7 +151,7 @@ function choose_deg!(integrator, cache::T) where {T}
     isconst || (cache = cache.constantcache)
 
     if integrator.alg isa SROCK1
-        # binary search as stability domain is monotonically incrasing with number of stages
+        # binary search as stability domain is monotonically increasing with number of stages
         mn_st, mx_st, mid_st = 3, 200, 3
         while (mx_st - mn_st > 1)
             mid_st = Int(floor((mn_st + mx_st) * 0.5))


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

The "Spell Check" CI workflow (crate-ci/typos v1.47.0) fails on unmodified master — the failure is pre-existing and unrelated to any open PR. This PR makes `typos .` exit 0, verified locally with typos-cli 1.47.0.

Note: the failure on current master is larger than a single typo — `typos .` reports six distinct issues (four genuine typos and two false-positive word families), largely because the StochasticDiffEq sublibraries were recently merged into the monorepo and brought their sources under the spell checker.

## False positives (allowlisted in `.typos.toml` `[default.extend-words]`)

- `Lamba`/`lamba` — `LambaEM` and `LambaEulerHeun` are real StochasticDiffEq solver names (Lamba's adaptive Euler-Maruyama method), plus the `lamba.jl`/`lamba_caches.jl` source files. Introduced into this repo's tree by:
  - 4ff6cf46d ("Add StochasticDiffEq umbrella package and remove SDE deps from ODE", 2026-03-17) and 39472f3f4/4900b054d (StochasticDiffEq subpackage additions)
  - 03b462151 ("Migrate DiffEqBase.jl as a sublibrary under lib/DiffEqBase", 2026-03-24) for the `lib/DiffEqBase/test/downstream/solve_error_handling.jl` occurrence
- `Strang` — Strang splitting (Gilbert Strang) in `docs/src/semiimplicit/StabilizedRK.md`. Introduced by fd723da1b ("add docs for RKL and RKG supertimestepping methods", 2026-05-10).

## Genuine typos fixed

| File | Fix | Introduced by |
|---|---|---|
| `docs/src/implicit/FIRK.md` | `oscilations` → `oscillations` | 85a8b6522 ("Update FIRK docs to add Gauss-Legendre", 2026-05-08) |
| `docs/src/devtools/alg_dev/benchmarks.md` | `componnets` → `components` | e15cb042f ("Add DiffEqDevDocs documentation section", 2026-03-30) |
| `lib/StochasticDiffEq/test/runtests.jl` | `Mulithreaded` → `Multithreaded` (testset label only; the `TEST_GROUP` key was already spelled correctly) | 4ff6cf46d |
| `lib/StochasticDiffEqROCK/src/SROCK_utils.jl` | `incrasing` → `increasing` (comment) | 4900b054d |

## Verification

```
$ typos --version
typos-cli 1.47.0
$ typos .
$ echo $?
0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)