### PR TITLE
StabilizedRK: make coefficient computations type-agnostic and add QA tests

### DIFF
--- a/lib/OrdinaryDiffEqStabilizedRK/src/rkc_caches.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/rkc_caches.jl
@@ -158,13 +158,13 @@ function alg_cache(
     return RKCConstantCache(u)
 end
 
-mutable struct RKMC2ConstantCache{zType} <: OrdinaryDiffEqConstantCache
+mutable struct RKMC2ConstantCache{zType, T} <: OrdinaryDiffEqConstantCache
     zprev::zType
     mdeg::Int
     min_stage::Int
     max_stage::Int
-    w0::Float64
-    w1::Float64
+    w0::T
+    w1::T
 end
 
 @cache struct RKMC2Cache{uType, rateType, uNoUnitsType, C <: RKMC2ConstantCache} <:
@@ -186,7 +186,8 @@ function alg_cache(
         dt, reltol, p, calck,
         ::Val{true}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    constantcache = RKMC2ConstantCache(zero(u), 0, alg.min_stages, alg.max_stages, 0.0, 0.0)
+    w = zero(tTypeNoUnits)
+    constantcache = RKMC2ConstantCache(zero(u), 0, alg.min_stages, alg.max_stages, w, w)
     gprev = zero(u)
     gprev2 = zero(u)
     tmp = zero(u)
@@ -203,7 +204,8 @@ function alg_cache(
         dt, reltol, p, calck,
         ::Val{false}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    return RKMC2ConstantCache(zero(u), 0, alg.min_stages, alg.max_stages, 0.0, 0.0)
+    w = zero(tTypeNoUnits)
+    return RKMC2ConstantCache(zero(u), 0, alg.min_stages, alg.max_stages, w, w)
 end
 
 mutable struct ESERK4ConstantCache{T, zType} <: OrdinaryDiffEqConstantCache
@@ -238,7 +240,7 @@ function alg_cache(
         dt, reltol, p, calck,
         ::Val{true}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    constantcache = ESERK4ConstantCache(u)
+    constantcache = ESERK4ConstantCache(constvalue(uBottomEltypeNoUnits), u)
     uᵢ = zero(u)
     uᵢ₋₁ = zero(u)
     uᵢ₋₂ = zero(u)
@@ -257,7 +259,7 @@ function alg_cache(
         dt, reltol, p, calck,
         ::Val{false}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    return ESERK4ConstantCache(u)
+    return ESERK4ConstantCache(constvalue(uBottomEltypeNoUnits), u)
 end
 
 mutable struct ESERK5ConstantCache{T, zType} <: OrdinaryDiffEqConstantCache
@@ -292,7 +294,7 @@ function alg_cache(
         dt, reltol, p, calck,
         ::Val{true}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    constantcache = ESERK5ConstantCache(u)
+    constantcache = ESERK5ConstantCache(constvalue(uBottomEltypeNoUnits), u)
     uᵢ = zero(u)
     uᵢ₋₁ = zero(u)
     uᵢ₋₂ = zero(u)
@@ -311,7 +313,7 @@ function alg_cache(
         dt, reltol, p, calck,
         ::Val{false}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    return ESERK5ConstantCache(u)
+    return ESERK5ConstantCache(constvalue(uBottomEltypeNoUnits), u)
 end
 
 mutable struct SERK2ConstantCache{T, zType} <: OrdinaryDiffEqConstantCache
@@ -343,7 +345,7 @@ function alg_cache(
         dt, reltol, p, calck,
         ::Val{true}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    constantcache = SERK2ConstantCache(u)
+    constantcache = SERK2ConstantCache(constvalue(uBottomEltypeNoUnits), u)
     uᵢ₋₁ = zero(u)
     uᵢ₋₂ = zero(u)
     Sᵢ = zero(u)
@@ -361,7 +363,7 @@ function alg_cache(
         dt, reltol, p, calck,
         ::Val{false}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    return SERK2ConstantCache(u)
+    return SERK2ConstantCache(constvalue(uBottomEltypeNoUnits), u)
 end
 
 mutable struct TSRKC2ConstantCache{zType, tTypeNoUnits} <: OrdinaryDiffEqConstantCache

--- a/lib/OrdinaryDiffEqStabilizedRK/src/rkc_perform_step.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/rkc_perform_step.jl
@@ -17,8 +17,9 @@ end
     (; ms, fp1, fp2, recf) = cache
     alg = unwrap_alg(integrator, true)
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
+    T = typeof(one(t))
     # The the number of degree for Chebyshev polynomial
-    mdeg = floor(Int, sqrt((1.5 + abs(dt) * integrator.eigen_est) / 0.811)) + 1
+    mdeg = floor(Int, sqrt((T(1.5) + abs(dt) * integrator.eigen_est) / T(0.811))) + 1
     mdeg = min(max(mdeg, cache.min_stage), cache.max_stage)
     cache.mdeg = max(mdeg, 3) - 2
     choosedeg!(cache)
@@ -98,8 +99,9 @@ end
     ccache = cache.constantcache
     alg = unwrap_alg(integrator, true)
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
+    T = typeof(one(t))
     # The the number of degree for Chebyshev polynomial
-    mdeg = floor(Int, sqrt((1.5 + abs(dt) * integrator.eigen_est) / 0.811)) + 1
+    mdeg = floor(Int, sqrt((T(1.5) + abs(dt) * integrator.eigen_est) / T(0.811))) + 1
     mdeg = min(max(mdeg, ccache.min_stage), ccache.max_stage)
     ccache.mdeg = max(mdeg, 3) - 2
     choosedeg!(cache)
@@ -182,8 +184,9 @@ end
     (; ms, fpa, fpb, fpbe, recf) = cache
     alg = unwrap_alg(integrator, true)
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
+    T = typeof(one(t))
     # The the number of degree for Chebyshev polynomial
-    mdeg = floor(Int, sqrt((3 + abs(dt) * integrator.eigen_est) / 0.353)) + 1
+    mdeg = floor(Int, sqrt((3 + abs(dt) * integrator.eigen_est) / T(0.353))) + 1
     mdeg = min(max(mdeg, cache.min_stage), cache.max_stage)
     cache.mdeg = max(mdeg, 5) - 4
     choosedeg!(cache)
@@ -320,8 +323,9 @@ end
     ccache = cache.constantcache
     alg = unwrap_alg(integrator, true)
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
+    T = typeof(one(t))
     # The the number of degree for Chebyshev polynomial
-    mdeg = floor(Int, sqrt((3 + abs(dt) * integrator.eigen_est) / 0.353)) + 1
+    mdeg = floor(Int, sqrt((3 + abs(dt) * integrator.eigen_est) / T(0.353))) + 1
     mdeg = min(max(mdeg, ccache.min_stage), ccache.max_stage)
     ccache.mdeg = max(mdeg, 5) - 4
     choosedeg!(cache)
@@ -451,10 +455,9 @@ end
     (; t, dt, uprev, u, f, p, fsalfirst) = integrator
     alg = unwrap_alg(integrator, true)
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
+    T = typeof(one(t))
     # The number of degree for Chebyshev polynomial
-    mdeg = floor(Int, sqrt(1.54 * abs(dt) * integrator.eigen_est + 1)) + 1
-
-    T = typeof(t)
+    mdeg = floor(Int, sqrt(T(1.54) * abs(dt) * integrator.eigen_est + 1)) + 1
 
     w0 = one(T) + T(2) / (13 * (mdeg^2))
     temp1 = w0^2 - one(T)
@@ -511,7 +514,7 @@ end
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     # error estimate
     if integrator.opts.adaptive
-        tmp = 0.8 * (uprev - u) + 0.4 * dt * (fsalfirst + integrator.fsallast)
+        tmp = T(0.8) * (uprev - u) + T(0.4) * dt * (fsalfirst + integrator.fsallast)
         atmp = calculate_residuals(
             tmp, uprev, u, integrator.opts.abstol,
             integrator.opts.reltol, integrator.opts.internalnorm, t
@@ -537,10 +540,9 @@ end
     (; k, tmp, gprev2, gprev, atmp) = cache
     alg = unwrap_alg(integrator, true)
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
+    T = typeof(one(t))
     # The number of degree for Chebyshev polynomial
-    mdeg = floor(Int, sqrt(1.54 * abs(dt) * integrator.eigen_est + 1)) + 1
-
-    T = typeof(t)
+    mdeg = floor(Int, sqrt(T(1.54) * abs(dt) * integrator.eigen_est + 1)) + 1
 
     w0 = one(T) + T(2) / (13 * (mdeg^2))
     temp1 = w0^2 - one(T)
@@ -597,7 +599,7 @@ end
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     # error estimate
     if integrator.opts.adaptive
-        @.. broadcast = false tmp = 0.8 * (uprev - u) + 0.4 * dt * (fsalfirst + integrator.fsallast)
+        @.. broadcast = false tmp = T(0.8) * (uprev - u) + T(0.4) * dt * (fsalfirst + integrator.fsallast)
         calculate_residuals!(
             atmp, tmp, uprev, u, integrator.opts.abstol,
             integrator.opts.reltol, integrator.opts.internalnorm, t
@@ -633,7 +635,8 @@ end
     mdeg = cache.mdeg
     start = cache.start
     internal_deg = cache.internal_deg
-    α = 2.0 / (mdeg^2)
+    T = typeof(one(t))
+    α = T(2) / mdeg^2
 
     u = zero(uprev)
     tmp = zero(uprev)
@@ -656,7 +659,7 @@ end
                 else
                     uᵢ = 2 * uᵢ₋₁ - uᵢ₋₂ + 2 * α * hᵢ * k
                 end
-                q = convert(Int, floor(st / internal_deg))
+                q = st ÷ internal_deg
                 r = tᵢ + α * (st^2 + q * internal_deg^2) * hᵢ
                 Sᵢ = Sᵢ + (cache.Bᵢ[start + st]) * uᵢ
                 if st < mdeg
@@ -715,7 +718,8 @@ end
     mdeg = ccache.mdeg
     start = ccache.start
     internal_deg = ccache.internal_deg
-    α = 2.0 / (mdeg^2)
+    T = typeof(one(t))
+    α = T(2) / mdeg^2
 
     @.. broadcast = false u = zero(uprev)
     @.. broadcast = false tmp = zero(uprev)
@@ -737,7 +741,7 @@ end
                 else
                     @.. broadcast = false uᵢ = 2 * uᵢ₋₁ - uᵢ₋₂ + 2 * α * hᵢ * k
                 end
-                q = convert(Int, floor(st / internal_deg))
+                q = st ÷ internal_deg
                 r = tᵢ + α * (st^2 + q * internal_deg^2) * hᵢ
                 @.. broadcast = false Sᵢ = Sᵢ + (cache.constantcache.Bᵢ[start + st]) * uᵢ
                 if st < mdeg
@@ -789,15 +793,16 @@ end
     (; ms, Cᵤ, Cₑ, Bᵢ) = cache
     alg = unwrap_alg(integrator, true)
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
+    T = typeof(one(t))
 
-    mdeg = Int(floor(sqrt(abs(dt) * integrator.eigen_est / 0.98)) + 1)
+    mdeg = Int(floor(sqrt(abs(dt) * integrator.eigen_est / T(0.98))) + 1)
     mdeg = (mdeg > 2000) ? 2000 : mdeg
     cache.mdeg = mdeg
     choosedeg_SERK!(integrator, cache)
     mdeg = cache.mdeg
     start = cache.start
     internal_deg = cache.internal_deg
-    α = 100.0 / (49.0 * mdeg^2)
+    α = T(100) / (49 * mdeg^2)
 
     u = zero(uprev)
     tmp = zero(uprev)
@@ -819,7 +824,7 @@ end
                 else
                     uᵢ = 2 * uᵢ₋₁ - uᵢ₋₂ + 2 * α * hᵢ * k
                 end
-                q = convert(Int, floor(st / internal_deg))
+                q = st ÷ internal_deg
                 r = tᵢ + α * (st^2 + q * internal_deg^2) * hᵢ
                 Sᵢ = Sᵢ + (Bᵢ[start + st]) * uᵢ
                 if st < mdeg
@@ -870,15 +875,16 @@ end
     ccache = cache.constantcache
     alg = unwrap_alg(integrator, true)
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
+    T = typeof(one(t))
 
-    mdeg = Int(floor(sqrt(abs(dt) * integrator.eigen_est / 0.98)) + 1)
+    mdeg = Int(floor(sqrt(abs(dt) * integrator.eigen_est / T(0.98))) + 1)
     mdeg = (mdeg > 2000) ? 2000 : mdeg
     ccache.mdeg = mdeg
     choosedeg_SERK!(integrator, cache)
     mdeg = ccache.mdeg
     start = ccache.start
     internal_deg = ccache.internal_deg
-    α = 100.0 / (49.0 * mdeg^2)
+    α = T(100) / (49 * mdeg^2)
 
     @.. broadcast = false u = zero(uprev)
     @.. broadcast = false tmp = zero(uprev)
@@ -900,7 +906,7 @@ end
                 else
                     @.. broadcast = false uᵢ = 2 * uᵢ₋₁ - uᵢ₋₂ + 2 * α * hᵢ * k
                 end
-                q = convert(Int, floor(st / internal_deg))
+                q = st ÷ internal_deg
                 r = tᵢ + α * (st^2 + q * internal_deg^2) * hᵢ
                 @.. broadcast = false Sᵢ = Sᵢ + (Bᵢ[start + st]) * uᵢ
                 if st < mdeg
@@ -952,15 +958,16 @@ end
     (; ms, Bᵢ) = cache
     alg = unwrap_alg(integrator, true)
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
+    T = typeof(one(t))
 
-    mdeg = Int(floor(sqrt(abs(dt) * integrator.eigen_est / 0.8)) + 1)
+    mdeg = Int(floor(sqrt(abs(dt) * integrator.eigen_est / T(0.8))) + 1)
     mdeg = (mdeg > 250) ? 250 : mdeg
     cache.mdeg = mdeg
     choosedeg_SERK!(integrator, cache)
     mdeg = cache.mdeg
     start = cache.start
     internal_deg = cache.internal_deg
-    α = 1.0 / (0.4 * mdeg^2)
+    α = one(T) / (T(0.4) * mdeg^2)
 
     uᵢ₋₁ = uprev
     uᵢ₋₂ = uprev
@@ -1017,15 +1024,16 @@ end
     ccache = cache.constantcache
     alg = unwrap_alg(integrator, true)
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
+    T = typeof(one(t))
 
-    mdeg = Int(floor(sqrt(abs(dt) * integrator.eigen_est / 0.8)) + 1)
+    mdeg = Int(floor(sqrt(abs(dt) * integrator.eigen_est / T(0.8))) + 1)
     mdeg = (mdeg > 250) ? 250 : mdeg
     ccache.mdeg = mdeg
     choosedeg_SERK!(integrator, cache)
     mdeg = ccache.mdeg
     start = ccache.start
     internal_deg = ccache.internal_deg
-    α = 1.0 / (0.4 * mdeg^2)
+    α = one(T) / (T(0.4) * mdeg^2)
 
     @.. broadcast = false uᵢ₋₁ = uprev
     @.. broadcast = false uᵢ₋₂ = uprev
@@ -1086,10 +1094,11 @@ end
 
     alg = unwrap_alg(integrator, true)
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
+    T = typeof(one(t))
     dtsw0 = zero(typeof(cache.tsw0))
     d2tsw0 = zero(typeof(cache.tsw0))
 
-    mdeg = floor(Int, sqrt(1 + 0.759782816506459 * abs(dt) * integrator.eigen_est * (onemq + sqrt(1 + q * (q - 0.598626091572911))))) + 1
+    mdeg = floor(Int, sqrt(1 + T(0.759782816506459) * abs(dt) * integrator.eigen_est * (onemq + sqrt(1 + q * (q - T(0.598626091572911)))))) + 1
     tsw0 = cache.tsw0
     acoshtsw0 = cache.acoshtsw0
     acoshtsw0dm = acoshtsw0 / mdeg
@@ -1139,7 +1148,7 @@ end
 
     # error estimate
     if integrator.opts.adaptive
-        tmp = 0.3333333333333333 * (uprev - u + dt * integrator.fsallast)
+        tmp = T(0.3333333333333333) * (uprev - u + dt * integrator.fsallast)
         atmp = calculate_residuals(
             tmp, uprev, u, integrator.opts.abstol,
             integrator.opts.reltol, integrator.opts.internalnorm, t
@@ -1169,10 +1178,11 @@ end
 
     alg = unwrap_alg(integrator, true)
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
+    T = typeof(one(t))
     dtsw0 = zero(typeof(constantcache.tsw0))
     d2tsw0 = zero(typeof(constantcache.tsw0))
 
-    mdeg = floor(Int, sqrt(1 + 0.759782816506459 * abs(dt) * integrator.eigen_est * (onemq + sqrt(1 + q * (q - 0.598626091572911))))) + 1
+    mdeg = floor(Int, sqrt(1 + T(0.759782816506459) * abs(dt) * integrator.eigen_est * (onemq + sqrt(1 + q * (q - T(0.598626091572911)))))) + 1
     tsw0 = constantcache.tsw0
     acoshtsw0 = constantcache.acoshtsw0
     acoshtsw0dm = acoshtsw0 / mdeg
@@ -1221,7 +1231,7 @@ end
 
     # error estimate
     if integrator.opts.adaptive
-        @.. broadcast = false tmp = 0.3333333333333333 * (uprev - u + dt * integrator.fsallast)
+        @.. broadcast = false tmp = T(0.3333333333333333) * (uprev - u + dt * integrator.fsallast)
         calculate_residuals!(
             atmp, tmp, uprev, u, integrator.opts.abstol,
             integrator.opts.reltol, integrator.opts.internalnorm, t
@@ -1259,11 +1269,12 @@ end
 
     alg = unwrap_alg(integrator, true)
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
+    T = typeof(one(t))
     dtsw0 = zero(typeof(cache.tsw0))
     d2tsw0 = zero(typeof(cache.tsw0))
     if (rkcstep)
-        mdeg = floor(Int, sqrt(1.54 * abs(dt) * integrator.eigen_est + 1)) + 1
-        w0 = 1 + 2 / (13 * (mdeg^2))
+        mdeg = floor(Int, sqrt(T(1.54) * abs(dt) * integrator.eigen_est + 1)) + 1
+        w0 = 1 + T(2) / (13 * (mdeg^2))
         temp1 = w0^2 - 1
         temp2 = sqrt(temp1)
         arg = mdeg * log(w0 + temp2)
@@ -1272,7 +1283,7 @@ end
         b = b1
         b2 = b1
     else
-        mdeg = floor(Int, sqrt(4 + 1.267029788142009 * abs(dt) * integrator.eigen_est * (onemq + sqrt(1 + q * (0.44256220745562963 + q))))) + 1
+        mdeg = floor(Int, sqrt(4 + T(1.267029788142009) * abs(dt) * integrator.eigen_est * (onemq + sqrt(1 + q * (T(0.44256220745562963) + q))))) + 1
         mdeg2 = mdeg^2
         tsw0 = cache.tsw0
         acoshtsw0 = cache.acoshtsw0
@@ -1285,7 +1296,7 @@ end
         d3tsw0 = ((1 + 2 * w0sq + mdeg2 * w0sqm1) * dtsw0 - 3 * mdeg2 * w0 * tsw0) / (w0sqm1^2)
         w1 = (onemq * d2tsw0 + sqrt((onemq * d2tsw0)^2 + 4 * q * dtsw0 * d3tsw0)) / (2 * d3tsw0)
 
-        b1 = 0.25 * sinh((mdeg - 2) * acoshtsw0dm) / sinh((mdeg - 1) * acoshtsw0dm)
+        b1 = T(0.25) * sinh((mdeg - 2) * acoshtsw0dm) / sinh((mdeg - 1) * acoshtsw0dm)
         b = 15 / ((8 * w0)^2)
         b2 = b1
     end
@@ -1353,9 +1364,9 @@ end
     # error estimate
     if integrator.opts.adaptive
         if (rkcstep)
-            tmp = 1.2 * (uprev - u) + 0.6 * dt * (fsalfirst + integrator.fsallast)
+            tmp = T(1.2) * (uprev - u) + T(0.6) * dt * (fsalfirst + integrator.fsallast)
         else
-            tmp = 0.6 * (uprev / q - uprev2 / (q * onepq2) - u * (2 + q) / onepq2 + dt * integrator.fsallast / onepq)
+            tmp = T(0.6) * (uprev / q - uprev2 / (q * onepq2) - u * (2 + q) / onepq2 + dt * integrator.fsallast / onepq)
         end
         atmp = calculate_residuals(
             tmp, uprev, u, integrator.opts.abstol,
@@ -1391,11 +1402,12 @@ end
 
     alg = unwrap_alg(integrator, true)
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
+    T = typeof(one(t))
     dtsw0 = zero(typeof(constantcache.tsw0))
     d2tsw0 = zero(typeof(constantcache.tsw0))
     if (rkcstep)
-        mdeg = floor(Int, sqrt(1.54 * abs(dt) * integrator.eigen_est + 1)) + 1
-        w0 = 1 + 2 / (13 * (mdeg^2))
+        mdeg = floor(Int, sqrt(T(1.54) * abs(dt) * integrator.eigen_est + 1)) + 1
+        w0 = 1 + T(2) / (13 * (mdeg^2))
         temp1 = w0^2 - 1
         temp2 = sqrt(temp1)
         arg = mdeg * log(w0 + temp2)
@@ -1404,7 +1416,7 @@ end
         b = b1
         b2 = b1
     else
-        mdeg = floor(Int, sqrt(4 + 1.267029788142009 * abs(dt) * integrator.eigen_est * (onemq + sqrt(1 + q * (0.44256220745562963 + q))))) + 1
+        mdeg = floor(Int, sqrt(4 + T(1.267029788142009) * abs(dt) * integrator.eigen_est * (onemq + sqrt(1 + q * (T(0.44256220745562963) + q))))) + 1
         mdeg2 = mdeg^2
         tsw0 = constantcache.tsw0
         acoshtsw0 = constantcache.acoshtsw0
@@ -1417,7 +1429,7 @@ end
         d3tsw0 = ((1 + 2 * w0sq + mdeg2 * w0sqm1) * dtsw0 - 3 * mdeg2 * w0 * tsw0) / (w0sqm1^2)
         w1 = (onemq * d2tsw0 + sqrt((onemq * d2tsw0)^2 + 4 * q * dtsw0 * d3tsw0)) / (2 * d3tsw0)
 
-        b1 = 0.25 * sinh((mdeg - 2) * acoshtsw0dm) / sinh((mdeg - 1) * acoshtsw0dm)
+        b1 = T(0.25) * sinh((mdeg - 2) * acoshtsw0dm) / sinh((mdeg - 1) * acoshtsw0dm)
         b = 15 / ((8 * w0)^2)
         b2 = b1
     end
@@ -1485,9 +1497,9 @@ end
     # error estimate
     if integrator.opts.adaptive
         if (rkcstep)
-            @.. broadcast = false tmp = 1.2 * (uprev - u) + 0.6 * dt * (fsalfirst + integrator.fsallast)
+            @.. broadcast = false tmp = T(1.2) * (uprev - u) + T(0.6) * dt * (fsalfirst + integrator.fsallast)
         else
-            @.. broadcast = false tmp = 0.6 * (uprev / q - uprev2 / (q * onepq2) - u * (2 + q) / onepq2 + dt * integrator.fsallast / onepq)
+            @.. broadcast = false tmp = T(0.6) * (uprev / q - uprev2 / (q * onepq2) - u * (2 + q) / onepq2 + dt * integrator.fsallast / onepq)
         end
         calculate_residuals!(
             atmp, tmp, uprev, u, integrator.opts.abstol,
@@ -1526,13 +1538,14 @@ end
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
 
     # choose s from the eigenvalue estimate; min/max_stage are odd from RKL1(; ...) constructor
-    s = ceil(Int, 0.5 * (-1.0 + sqrt(1.0 + 4.0 * abs(dt) * integrator.eigen_est)))
+    s = ceil(Int, (sqrt(1 + 4 * abs(dt) * integrator.eigen_est) - 1) / 2)
     s = max(s, cache.min_stage)
     s = isodd(s) ? s : s + 1
     s = min(s, cache.max_stage)
     cache.mdeg = s
 
-    w1 = 2.0 / (s^2 + s)
+    T = typeof(one(t))
+    w1 = T(2) / (s^2 + s)
 
     # stage 1
     uᵢ₋₂ = uprev
@@ -1540,8 +1553,8 @@ end
 
     # stages 2 to s
     for j in 2:s
-        μⱼ = (2j - 1) / j
-        νⱼ = -(j - 1) / j
+        μⱼ = T(2j - 1) / j
+        νⱼ = -T(j - 1) / j
         μ̃ⱼ = μⱼ * w1
         fYm1 = f(uᵢ₋₁, p, t)
         OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
@@ -1574,13 +1587,14 @@ end
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
 
     # choose s from the eigenvalue estimate based on the RKL1 stability bound
-    s = ceil(Int, 0.5 * (-1.0 + sqrt(1.0 + 4.0 * abs(dt) * integrator.eigen_est)))
+    s = ceil(Int, (sqrt(1 + 4 * abs(dt) * integrator.eigen_est) - 1) / 2)
     s = max(s, ccache.min_stage)
     s = isodd(s) ? s : s + 1
     s = min(s, ccache.max_stage)
     ccache.mdeg = s
 
-    w1 = 2.0 / (s^2 + s)
+    T = typeof(one(t))
+    w1 = T(2) / (s^2 + s)
 
     # stage 1
     @.. broadcast = false uᵢ₋₂ = uprev
@@ -1588,8 +1602,8 @@ end
 
     # stages 2 to s
     for j in 2:s
-        μⱼ = (2j - 1) / j
-        νⱼ = -(j - 1) / j
+        μⱼ = T(2j - 1) / j
+        νⱼ = -T(j - 1) / j
         μ̃ⱼ = μⱼ * w1
         f(k, uᵢ₋₁, p, t)
         OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
@@ -1644,38 +1658,39 @@ end
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
 
     # choose s from the eigenvalue estimate from the RKL2 stability bound
-    s = ceil(Int, 0.5 * (-1.0 + sqrt(9.0 + 8.0 * abs(dt) * integrator.eigen_est)))
+    s = ceil(Int, (sqrt(9 + 8 * abs(dt) * integrator.eigen_est) - 1) / 2)
     s = max(s, cache.min_stage)
     s = isodd(s) ? s : s + 1
     s = min(s, cache.max_stage)
     cache.mdeg = s
-    w1 = 4.0 / (s^2 + s - 2)
+    T = typeof(one(t))
+    w1 = T(4) / (s^2 + s - 2)
 
     # stage 1
-    μ̃₁ = (1.0 / 3.0) * w1
+    μ̃₁ = (T(1) / 3) * w1
     uᵢ₋₂ = uprev
     uᵢ₋₁ = uprev + (dt * μ̃₁) * fsalfirst
 
     # stages 2 to s
     for j in 2:s
-        bj = j <= 2 ? 1.0 / 3.0 : (j * j + j - 2) / (2 * j * (j + 1))
+        bj = j <= 2 ? T(1) / 3 : T(j * j + j - 2) / (2 * j * (j + 1))
         jm1 = j - 1
-        bjm1 = jm1 <= 2 ? 1.0 / 3.0 : (jm1 * jm1 + jm1 - 2) / (2 * jm1 * (jm1 + 1))
+        bjm1 = jm1 <= 2 ? T(1) / 3 : T(jm1 * jm1 + jm1 - 2) / (2 * jm1 * (jm1 + 1))
         jm2 = j - 2
-        bjm2 = jm2 <= 2 ? 1.0 / 3.0 : (jm2 * jm2 + jm2 - 2) / (2 * jm2 * (jm2 + 1))
-        aj = 1.0 - bj
+        bjm2 = jm2 <= 2 ? T(1) / 3 : T(jm2 * jm2 + jm2 - 2) / (2 * jm2 * (jm2 + 1))
+        aj = 1 - bj
 
-        μⱼ = (2j - 1) / j * bj / bjm1
-        νⱼ = -(j - 1) / j * bj / bjm2
+        μⱼ = T(2j - 1) / j * bj / bjm1
+        νⱼ = -T(j - 1) / j * bj / bjm2
         μ̃ⱼ = μⱼ * w1
 
-        ajm1 = 1.0 - bjm1
+        ajm1 = 1 - bjm1
         γ̃ⱼ = -ajm1 * μ̃ⱼ
 
         fYm1 = f(uᵢ₋₁, p, t)
         OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 
-        u = μⱼ * uᵢ₋₁ + νⱼ * uᵢ₋₂ + (1.0 - μⱼ - νⱼ) * uprev +
+        u = μⱼ * uᵢ₋₁ + νⱼ * uᵢ₋₂ + (1 - μⱼ - νⱼ) * uprev +
             dt * μ̃ⱼ * fYm1 + dt * γ̃ⱼ * fsalfirst
 
         uᵢ₋₂ = uᵢ₋₁
@@ -1709,36 +1724,37 @@ end
     alg = unwrap_alg(integrator, true)
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
 
-    s = ceil(Int, 0.5 * (-1.0 + sqrt(9.0 + 8.0 * abs(dt) * integrator.eigen_est)))
+    s = ceil(Int, (sqrt(9 + 8 * abs(dt) * integrator.eigen_est) - 1) / 2)
     s = max(s, ccache.min_stage)
     s = isodd(s) ? s : s + 1
     s = min(s, ccache.max_stage)
     ccache.mdeg = s
-    w1 = 4.0 / (s^2 + s - 2)
+    T = typeof(one(t))
+    w1 = T(4) / (s^2 + s - 2)
 
     # stage 1 uses previous stage final values for legendre polynomial
-    μ̃₁ = (1.0 / 3.0) * w1
+    μ̃₁ = (T(1) / 3) * w1
     @.. broadcast = false uᵢ₋₂ = uprev
     @.. broadcast = false uᵢ₋₁ = uprev + (dt * μ̃₁) * fsalfirst
 
     # stages 2 to s
     for j in 2:s
-        bj = j <= 2 ? 1.0 / 3.0 : (j * j + j - 2) / (2 * j * (j + 1))
+        bj = j <= 2 ? T(1) / 3 : T(j * j + j - 2) / (2 * j * (j + 1))
         jm1 = j - 1
-        bjm1 = jm1 <= 2 ? 1.0 / 3.0 : (jm1 * jm1 + jm1 - 2) / (2 * jm1 * (jm1 + 1))
+        bjm1 = jm1 <= 2 ? T(1) / 3 : T(jm1 * jm1 + jm1 - 2) / (2 * jm1 * (jm1 + 1))
         jm2 = j - 2
-        bjm2 = jm2 <= 2 ? 1.0 / 3.0 : (jm2 * jm2 + jm2 - 2) / (2 * jm2 * (jm2 + 1))
-        ajm1 = 1.0 - bjm1
+        bjm2 = jm2 <= 2 ? T(1) / 3 : T(jm2 * jm2 + jm2 - 2) / (2 * jm2 * (jm2 + 1))
+        ajm1 = 1 - bjm1
 
-        μⱼ = (2j - 1) / j * bj / bjm1
-        νⱼ = -(j - 1) / j * bj / bjm2
+        μⱼ = T(2j - 1) / j * bj / bjm1
+        νⱼ = -T(j - 1) / j * bj / bjm2
         μ̃ⱼ = μⱼ * w1
         γ̃ⱼ = -ajm1 * μ̃ⱼ
 
         f(k, uᵢ₋₁, p, t)
         OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
         @.. broadcast = false u = μⱼ * uᵢ₋₁ + νⱼ * uᵢ₋₂ +
-            (1.0 - μⱼ - νⱼ) * uprev +
+            (1 - μⱼ - νⱼ) * uprev +
             (dt * μ̃ⱼ) * k +
             (dt * γ̃ⱼ) * fsalfirst
         @.. broadcast = false uᵢ₋₂ = uᵢ₋₁
@@ -1760,6 +1776,8 @@ end
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     integrator.k[2] = integrator.fsallast
 end
+
+rkg1_b(::Type{T}, j) where {T} = T(2) / ((j + 1) * (j + 2))
 
 function initialize!(integrator, cache::RKG1ConstantCache)
     integrator.kshortsize = 2
@@ -1787,30 +1805,30 @@ end
 
     # stability bound for RKG1 is dt*λ ≤ s(s+3)/4
     # solving s² + 3s - 4*dt*λ ≥ 0 → s ≥ (-3 + sqrt(9 + 16*dt*λ))/2
-    s = ceil(Int, 0.5 * (-3.0 + sqrt(9.0 + 16.0 * abs(dt) * integrator.eigen_est)))
+    s = ceil(Int, (sqrt(9 + 16 * abs(dt) * integrator.eigen_est) - 3) / 2)
     s = max(s, cache.min_stage)
     s = min(s, cache.max_stage)
     cache.mdeg = s
-    w1 = 4.0 / (s * (s + 3))
-    rkg1_b(j) = 2.0 / ((j + 1) * (j + 2))
+    T = typeof(one(t))
+    w1 = T(4) / (s * (s + 3))
 
     # first stage coefficients
-    b0 = rkg1_b(0)
-    b1 = rkg1_b(1)
-    μ̃₁ = (3.0 * b1 / b0) * w1
+    b0 = rkg1_b(T, 0)
+    b1 = rkg1_b(T, 1)
+    μ̃₁ = (3 * b1 / b0) * w1
     uᵢ₋₂ = uprev
     uᵢ₋₁ = uprev + (dt * μ̃₁) * fsalfirst
 
     # stages 2 to s
     for j in 2:s
-        bj = rkg1_b(j)
-        bjm1 = rkg1_b(j - 1)
-        bjm2 = rkg1_b(j - 2)
+        bj = rkg1_b(T, j)
+        bjm1 = rkg1_b(T, j - 1)
+        bjm2 = rkg1_b(T, j - 2)
 
         # μⱼ = (2j+1)/j * bⱼ/bⱼ₋₁
         # νⱼ = -(j+1)/j * bⱼ/bⱼ₋₂
-        μⱼ = (2j + 1) / j * bj / bjm1
-        νⱼ = -(j + 1) / j * bj / bjm2
+        μⱼ = T(2j + 1) / j * bj / bjm1
+        νⱼ = -T(j + 1) / j * bj / bjm2
         μ̃ⱼ = μⱼ * w1
 
         fYm1 = f(uᵢ₋₁, p, t)
@@ -1847,28 +1865,28 @@ end
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
 
     # choose s from the eigenvalue estimate from the RKG1 stability bound
-    s = ceil(Int, 0.5 * (-3.0 + sqrt(9.0 + 16.0 * abs(dt) * integrator.eigen_est)))
+    s = ceil(Int, (sqrt(9 + 16 * abs(dt) * integrator.eigen_est) - 3) / 2)
     s = max(s, ccache.min_stage)
     s = min(s, ccache.max_stage)
     ccache.mdeg = s
 
-    w1 = 4.0 / (s * (s + 3))
-    rkg1_b(j) = 2.0 / ((j + 1) * (j + 2))
+    T = typeof(one(t))
+    w1 = T(4) / (s * (s + 3))
 
     # first stage coefficients
-    b0 = rkg1_b(0); b1 = rkg1_b(1)
-    μ̃₁ = (3.0 * b1 / b0) * w1
+    b0 = rkg1_b(T, 0); b1 = rkg1_b(T, 1)
+    μ̃₁ = (3 * b1 / b0) * w1
 
     @.. broadcast = false uᵢ₋₂ = uprev
     @.. broadcast = false uᵢ₋₁ = uprev + (dt * μ̃₁) * fsalfirst
 
     # stages 2 to s
     for j in 2:s
-        bj = rkg1_b(j)
-        bjm1 = rkg1_b(j - 1)
-        bjm2 = rkg1_b(j - 2)
-        μⱼ = (2j + 1) / j * bj / bjm1
-        νⱼ = -(j + 1) / j * bj / bjm2
+        bj = rkg1_b(T, j)
+        bjm1 = rkg1_b(T, j - 1)
+        bjm2 = rkg1_b(T, j - 2)
+        μⱼ = T(2j + 1) / j * bj / bjm1
+        νⱼ = -T(j + 1) / j * bj / bjm2
         μ̃ⱼ = μⱼ * w1
 
         f(k, uᵢ₋₁, p, t)
@@ -1923,11 +1941,12 @@ end
 
     # stability bound for RKG2 is dt*λ ≤ (s+4)(s-1)/6
     # Solve: s² + 3s - (4 + 6*dt*λ) ≥ 0 → s ≥ (-3 + sqrt(25 + 24*dt*λ))/2
-    s = ceil(Int, 0.5 * (-3.0 + sqrt(25.0 + 24.0 * abs(dt) * integrator.eigen_est)))
+    s = ceil(Int, (sqrt(25 + 24 * abs(dt) * integrator.eigen_est) - 3) / 2)
     s = max(s, cache.min_stage)
     s = min(s, cache.max_stage)
     cache.mdeg = s
-    w1 = 6.0 / ((s + 4) * (s - 1))
+    T = typeof(one(t))
+    w1 = T(6) / ((s + 4) * (s - 1))
 
     # first stage coefficients
     μ̃₁ = w1
@@ -1937,23 +1956,23 @@ end
     # stages 2 to s: b_0=1, b_1=1/3, b_j=4(j-1)(j+4)/(3j(j+1)(j+2)(j+3)) for j>=2
     # a_{j-1} = 1 - j(j+1)/2 * b_{j-1}
     for j in 2:s
-        bj = 4.0 * (j - 1) * (j + 4) / (3.0 * j * (j + 1) * (j + 2) * (j + 3))
-        bjm1 = j == 2 ? (1.0 / 3.0) :
-            4.0 * (j - 2) * (j + 3) / (3.0 * (j - 1) * j * (j + 1) * (j + 2))
-        bjm2 = j == 2 ? 1.0 :
-            j == 3 ? (1.0 / 3.0) :
-            4.0 * (j - 3) * (j + 2) / (3.0 * (j - 2) * (j - 1) * j * (j + 1))
-        ajm1 = 1.0 - j * (j + 1) / 2.0 * bjm1
+        bj = T(4 * (j - 1) * (j + 4)) / (3 * j * (j + 1) * (j + 2) * (j + 3))
+        bjm1 = j == 2 ? (T(1) / 3) :
+            T(4 * (j - 2) * (j + 3)) / (3 * (j - 1) * j * (j + 1) * (j + 2))
+        bjm2 = j == 2 ? one(T) :
+            j == 3 ? (T(1) / 3) :
+            T(4 * (j - 3) * (j + 2)) / (3 * (j - 2) * (j - 1) * j * (j + 1))
+        ajm1 = 1 - (j * (j + 1) ÷ 2) * bjm1
 
-        μⱼ = (2j + 1) / j * bj / bjm1
-        νⱼ = -(j + 1) / j * bj / bjm2
+        μⱼ = T(2j + 1) / j * bj / bjm1
+        νⱼ = -T(j + 1) / j * bj / bjm2
         μ̃ⱼ = μⱼ * w1
         γ̃ⱼ = -μ̃ⱼ * ajm1
 
         fYm1 = f(uᵢ₋₁, p, t)
         OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 
-        u = μⱼ * uᵢ₋₁ + νⱼ * uᵢ₋₂ + (1.0 - μⱼ - νⱼ) * uprev +
+        u = μⱼ * uᵢ₋₁ + νⱼ * uᵢ₋₂ + (1 - μⱼ - νⱼ) * uprev +
             dt * μ̃ⱼ * fYm1 + dt * γ̃ⱼ * fsalfirst
 
         uᵢ₋₂ = uᵢ₋₁
@@ -1987,11 +2006,12 @@ end
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
 
     # choose s from the eigenvalue estimate from the RKG2 stability bound
-    s = ceil(Int, 0.5 * (-3.0 + sqrt(25.0 + 24.0 * abs(dt) * integrator.eigen_est)))
+    s = ceil(Int, (sqrt(25 + 24 * abs(dt) * integrator.eigen_est) - 3) / 2)
     s = max(s, ccache.min_stage)
     s = min(s, ccache.max_stage)
     ccache.mdeg = s
-    w1 = 6.0 / ((s + 4) * (s - 1))
+    T = typeof(one(t))
+    w1 = T(6) / ((s + 4) * (s - 1))
     μ̃₁ = w1
 
     @.. broadcast = false uᵢ₋₂ = uprev
@@ -1999,16 +2019,16 @@ end
 
     # stages 2 to s
     for j in 2:s
-        bj = 4.0 * (j - 1) * (j + 4) / (3.0 * j * (j + 1) * (j + 2) * (j + 3))
-        bjm1 = j == 2 ? (1.0 / 3.0) :
-            4.0 * (j - 2) * (j + 3) / (3.0 * (j - 1) * j * (j + 1) * (j + 2))
-        bjm2 = j == 2 ? 1.0 :
-            j == 3 ? (1.0 / 3.0) :
-            4.0 * (j - 3) * (j + 2) / (3.0 * (j - 2) * (j - 1) * j * (j + 1))
-        ajm1 = 1.0 - j * (j + 1) / 2.0 * bjm1
+        bj = T(4 * (j - 1) * (j + 4)) / (3 * j * (j + 1) * (j + 2) * (j + 3))
+        bjm1 = j == 2 ? (T(1) / 3) :
+            T(4 * (j - 2) * (j + 3)) / (3 * (j - 1) * j * (j + 1) * (j + 2))
+        bjm2 = j == 2 ? one(T) :
+            j == 3 ? (T(1) / 3) :
+            T(4 * (j - 3) * (j + 2)) / (3 * (j - 2) * (j - 1) * j * (j + 1))
+        ajm1 = 1 - (j * (j + 1) ÷ 2) * bjm1
 
-        μⱼ = (2j + 1) / j * bj / bjm1
-        νⱼ = -(j + 1) / j * bj / bjm2
+        μⱼ = T(2j + 1) / j * bj / bjm1
+        νⱼ = -T(j + 1) / j * bj / bjm2
         μ̃ⱼ = μⱼ * w1
         γ̃ⱼ = -μ̃ⱼ * ajm1
 
@@ -2016,7 +2036,7 @@ end
         OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 
         @.. broadcast = false u = μⱼ * uᵢ₋₁ + νⱼ * uᵢ₋₂ +
-            (1.0 - μⱼ - νⱼ) * uprev +
+            (1 - μⱼ - νⱼ) * uprev +
             (dt * μ̃ⱼ) * k +
             (dt * γ̃ⱼ) * fsalfirst
         @.. broadcast = false uᵢ₋₂ = uᵢ₋₁
@@ -2065,7 +2085,8 @@ end
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
 
     # selects stage count from eigenvalue estimate
-    mdeg = max(3, ceil(Int, -0.8306782178712795 + 1.8547887825836553 * (abs(dt) * integrator.eigen_est)^0.533871357807877))
+    T = typeof(one(t))
+    mdeg = max(3, ceil(Int, T(-0.8306782178712795) + T(1.8547887825836553) * (abs(dt) * integrator.eigen_est)^T(0.533871357807877)))
     mdeg = min(max(mdeg, cache.min_stage), cache.max_stage)
 
     # solves the equaton for w0, the parameter used to shift the Chebyshev polynomial to be monotone, using bisection on α = acosh(w0)
@@ -2073,14 +2094,14 @@ end
         cache.mdeg = mdeg
         s = mdeg
         sign_s = iseven(s) ? 1 : -1
-        αlo, αhi = 1.0e-10, 2.0
+        αlo, αhi = T(1.0e-10), T(2)
         for _ in 1:50
             α = (αlo + αhi) / 2
             Ts = cosh(s * α)
             Tsm1 = cosh((s - 1) * α)
             Tsm2 = cosh((s - 2) * α)
             dTsm1 = (s - 1) * sinh((s - 1) * α) / sinh(α)
-            fval = 1 + sign_s / (s * (s - 2)) + cosh(α) + Ts / (2s) -
+            fval = 1 + T(sign_s) / (s * (s - 2)) + cosh(α) + Ts / (2s) -
                 Tsm2 / (2 * (s - 2)) - (1 + Tsm1)^2 / dTsm1
             fval > 0 ? (αlo = α) : (αhi = α)
         end
@@ -2158,21 +2179,22 @@ end
     alg = unwrap_alg(integrator, true)
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
 
-    mdeg = max(3, ceil(Int, -0.8306782178712795 + 1.8547887825836553 * (abs(dt) * integrator.eigen_est)^0.533871357807877))
+    T = typeof(one(t))
+    mdeg = max(3, ceil(Int, T(-0.8306782178712795) + T(1.8547887825836553) * (abs(dt) * integrator.eigen_est)^T(0.533871357807877)))
     mdeg = min(max(mdeg, ccache.min_stage), ccache.max_stage)
 
     if mdeg != ccache.mdeg
         ccache.mdeg = mdeg
         s = mdeg
         sign_s = iseven(s) ? 1 : -1
-        αlo, αhi = 1.0e-10, 2.0
+        αlo, αhi = T(1.0e-10), T(2)
         for _ in 1:50
             α = (αlo + αhi) / 2
             Ts = cosh(s * α)
             Tsm1 = cosh((s - 1) * α)
             Tsm2 = cosh((s - 2) * α)
             dTsm1 = (s - 1) * sinh((s - 1) * α) / sinh(α)
-            fval = 1 + sign_s / (s * (s - 2)) + cosh(α) + Ts / (2s) - Tsm2 / (2 * (s - 2)) - (1 + Tsm1)^2 / dTsm1
+            fval = 1 + T(sign_s) / (s * (s - 2)) + cosh(α) + Ts / (2s) - Tsm2 / (2 * (s - 2)) - (1 + Tsm1)^2 / dTsm1
             fval > 0 ? (αlo = α) : (αhi = α)
         end
         α = (αlo + αhi) / 2

--- a/lib/OrdinaryDiffEqStabilizedRK/src/rkc_tableaus_eserk4.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/rkc_tableaus_eserk4.jl
@@ -1,4 +1,4 @@
-function ESERK4ConstantCache(zprev)
+function ESERK4ConstantCache(::Type{T}, zprev) where {T}
     ms = [
         2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 30, 40, 50, 60, 70, 80, 90, 100, 150, 200,
         250, 300, 350, 400, 450, 500, 600,
@@ -46286,7 +46286,7 @@ function ESERK4ConstantCache(zprev)
         0.62906701403698332886e-54,
     ]
 
-    return ESERK4ConstantCache{eltype(Bᵢ), typeof(zprev)}(
-        Tuple(ms), Tuple(Cᵤ), Tuple(Cₑ), zprev, Bᵢ, 1, 0, 0
+    return ESERK4ConstantCache{T, typeof(zprev)}(
+        Tuple(ms), Tuple(Cᵤ), Tuple(Cₑ), zprev, T.(Bᵢ), 1, 0, 0
     )
 end

--- a/lib/OrdinaryDiffEqStabilizedRK/src/rkc_tableaus_eserk5.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/rkc_tableaus_eserk5.jl
@@ -1,4 +1,4 @@
-function ESERK5ConstantCache(zprev)
+function ESERK5ConstantCache(::Type{T}, zprev) where {T}
     ms = [
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 25, 30, 35,
         40, 45, 50, 60, 70, 80, 90,
@@ -15494,7 +15494,7 @@ function ESERK5ConstantCache(zprev)
         23.68169873246636214503,
     ]
 
-    return ESERK5ConstantCache{eltype(Bᵢ), typeof(zprev)}(
-        Tuple(ms), Tuple(Cᵤ), Tuple(Cₑ), zprev, Bᵢ, 1, 0, 0
+    return ESERK5ConstantCache{T, typeof(zprev)}(
+        Tuple(ms), Tuple(Cᵤ), Tuple(Cₑ), zprev, T.(Bᵢ), 1, 0, 0
     )
 end

--- a/lib/OrdinaryDiffEqStabilizedRK/src/rkc_tableaus_serk2.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/rkc_tableaus_serk2.jl
@@ -1,4 +1,4 @@
-function SERK2ConstantCache(zprev)
+function SERK2ConstantCache(::Type{T}, zprev) where {T}
     ms = [10, 20, 30, 40, 50, 60, 80, 100, 150, 200, 250]
     Bᵢ = [
         -0.96362760400868230359,
@@ -1004,5 +1004,5 @@ function SERK2ConstantCache(zprev)
         5.11169642004104218813,
     ]
 
-    return SERK2ConstantCache{eltype(Bᵢ), typeof(zprev)}(Tuple(ms), zprev, Bᵢ, 1, 0, 0)
+    return SERK2ConstantCache{T, typeof(zprev)}(Tuple(ms), zprev, T.(Bᵢ), 1, 0, 0)
 end

--- a/lib/OrdinaryDiffEqStabilizedRK/src/rkc_utils.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/rkc_utils.jl
@@ -7,7 +7,8 @@ function maxeig!(integrator, cache::OrdinaryDiffEqConstantCache)
     (; t, dt, uprev, u, f, p, fsalfirst) = integrator
     maxiter = (integrator.alg isa Union{ESERK4, ESERK5, SERK2}) ? 100 : 50
 
-    safe = (integrator.alg isa RKCAlgs) ? 1.0 : 1.2
+    T = typeof(integrator.eigen_est)
+    safe = (integrator.alg isa RKCAlgs) ? one(T) : T(1.2)
     # Initial guess for eigenvector `z`
     if isfirst
         if integrator.alg isa RKCAlgs
@@ -41,7 +42,7 @@ function maxeig!(integrator, cache::OrdinaryDiffEqConstantCache)
         z *= quot
     else
         dz_u = pert
-        z = dz_u * ones(z)
+        z = dz_u * one.(z)
     end # endif
     # Start power iteration
     integrator.eigen_est = 0
@@ -56,15 +57,15 @@ function maxeig!(integrator, cache::OrdinaryDiffEqConstantCache)
         if integrator.alg isa RKCAlgs # To match the constants given in the paper
             if iter >= 2 &&
                     abs(eig_prev - integrator.eigen_est) <
-                    max(integrator.eigen_est, 1.0 / integrator.opts.dtmax) * 0.01
-                integrator.eigen_est *= 1.2
+                    max(integrator.eigen_est, inv(integrator.opts.dtmax)) * T(0.01)
+                integrator.eigen_est *= T(1.2)
                 # Store the eigenvector
                 cache.zprev = z - uprev
                 return true
             end
         else
             if iter >= 2 &&
-                    abs(eig_prev - integrator.eigen_est) < integrator.eigen_est * 0.05
+                    abs(eig_prev - integrator.eigen_est) < integrator.eigen_est * T(0.05)
                 # Store the eigenvector
                 cache.zprev = z - uprev
                 return true
@@ -96,7 +97,8 @@ function maxeig!(integrator, cache::OrdinaryDiffEqMutableCache)
     fz, z, atmp = cache.k, cache.tmp, cache.atmp
     ccache = cache.constantcache
     maxiter = (integrator.alg isa Union{ESERK4, ESERK5, SERK2}) ? 100 : 50
-    safe = (integrator.alg isa RKCAlgs) ? 1.0 : 1.2
+    T = typeof(integrator.eigen_est)
+    safe = (integrator.alg isa RKCAlgs) ? one(T) : T(1.2)
     # Initial guess for eigenvector `z`
     if isfirst
         if integrator.alg isa RKCAlgs
@@ -145,15 +147,15 @@ function maxeig!(integrator, cache::OrdinaryDiffEqMutableCache)
         if integrator.alg isa RKCAlgs # To match the constants given in the paper
             if iter >= 2 &&
                     abs(eig_prev - integrator.eigen_est) <
-                    max(integrator.eigen_est, 1.0 / integrator.opts.dtmax) * 0.01
-                integrator.eigen_est *= 1.2
+                    max(integrator.eigen_est, inv(integrator.opts.dtmax)) * T(0.01)
+                integrator.eigen_est *= T(1.2)
                 # Store the eigenvector
                 @..  ccache.zprev = z - uprev
                 return true
             end
         else
             if iter >= 2 &&
-                    abs(eig_prev - integrator.eigen_est) < integrator.eigen_est * 0.05
+                    abs(eig_prev - integrator.eigen_est) < integrator.eigen_est * T(0.05)
                 # Store the eigenvector
                 @..  ccache.zprev = z - uprev
                 return true
@@ -247,7 +249,7 @@ function choosedeg_SERK!(integrator, cache::T) where {T}
     end
 
     if integrator.alg isa SERK2
-        cache.internal_deg = cache.mdeg / 10
+        cache.internal_deg = cache.mdeg ÷ 10
     end
     return nothing
 end

--- a/lib/OrdinaryDiffEqStabilizedRK/test/qa/jet.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/qa/jet.jl
@@ -1,8 +1,49 @@
 import OrdinaryDiffEqStabilizedRK
+using OrdinaryDiffEqStabilizedRK
+using OrdinaryDiffEqCore
+using SciMLBase: FullSpecialize
 using JET
+using Test
 
 @testset "JET Tests" begin
     test_package(
         OrdinaryDiffEqStabilizedRK, target_modules = (OrdinaryDiffEqStabilizedRK,), mode = :typo
     )
+
+    @testset "perform_step! type stability" begin
+        function stiff_system!(du, u, p, t)
+            du[1] = -20.0 * u[1]
+            du[2] = -10.0 * u[2]
+        end
+        prob = ODEProblem{true, FullSpecialize}(stiff_system!, [1.0, 1.0], (0.0, 1.0))
+        oop_prob = ODEProblem{false, FullSpecialize}((u, p, t) -> -20.0 * u, 1.0, (0.0, 1.0))
+
+        all_solvers = [
+            ROCK2(), ROCK4(), RKC(), RKMC2(), ESERK4(), ESERK5(), SERK2(),
+            TSRKC2(), TSRKC3(), RKL1(), RKL2(), RKG1(), RKG2(),
+        ]
+
+        for solver in all_solvers
+            @testset "$(nameof(typeof(solver))) in-place" begin
+                integrator = init(
+                    prob, solver, dt = 0.01, save_everystep = false,
+                    abstol = 1.0e-6, reltol = 1.0e-6
+                )
+                step!(integrator)
+                @test_opt target_modules = (OrdinaryDiffEqStabilizedRK,) OrdinaryDiffEqCore.perform_step!(
+                    integrator, integrator.cache
+                )
+            end
+            @testset "$(nameof(typeof(solver))) out-of-place" begin
+                integrator = init(
+                    oop_prob, solver, dt = 0.01, save_everystep = false,
+                    abstol = 1.0e-6, reltol = 1.0e-6
+                )
+                step!(integrator)
+                @test_opt target_modules = (OrdinaryDiffEqStabilizedRK,) OrdinaryDiffEqCore.perform_step!(
+                    integrator, integrator.cache
+                )
+            end
+        end
+    end
 end

--- a/lib/OrdinaryDiffEqStabilizedRK/test/qa/type_agnosticism.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/qa/type_agnosticism.jl
@@ -1,0 +1,51 @@
+using OrdinaryDiffEqStabilizedRK
+using SciMLBase
+using Test
+
+# Checks that the stabilized RK methods do not promote Float32 problems to
+# Float64 through hard-coded Float64 constants. Promotion of internal stage
+# values is not observable from the solution (the typed integrator fields
+# convert back), so instead `f` itself asserts the types it gets called with:
+# any Float64 leaking into a stage value or stage time shows up here.
+@testset "Float32 type agnosticism" begin
+    all_solvers = [
+        ROCK2(), ROCK4(), RKC(), RKMC2(), ESERK4(), ESERK5(), SERK2(),
+        TSRKC2(), TSRKC3(), RKL1(), RKL2(), RKG1(), RKG2(),
+    ]
+
+    for solver in all_solvers
+        @testset "$(nameof(typeof(solver))) out-of-place" begin
+            u_ok = Ref(true)
+            t_ok = Ref(true)
+            f = (u, p, t) -> begin
+                u isa Float32 || (u_ok[] = false)
+                t isa Float32 || (t_ok[] = false)
+                -20.0f0 * u
+            end
+            prob = ODEProblem(f, 1.0f0, (0.0f0, 1.0f0))
+            sol = solve(prob, solver, abstol = 1.0f-4, reltol = 1.0f-4)
+            @test SciMLBase.successful_retcode(sol)
+            @test eltype(sol[end]) == Float32
+            @test u_ok[]
+            @test t_ok[]
+        end
+
+        @testset "$(nameof(typeof(solver))) in-place" begin
+            u_ok = Ref(true)
+            t_ok = Ref(true)
+            f! = (du, u, p, t) -> begin
+                eltype(u) == Float32 || (u_ok[] = false)
+                t isa Float32 || (t_ok[] = false)
+                du[1] = -20.0f0 * u[1]
+                du[2] = -10.0f0 * u[2]
+                nothing
+            end
+            prob = ODEProblem(f!, Float32[1.0, 1.0], (0.0f0, 1.0f0))
+            sol = solve(prob, solver, abstol = 1.0f-4, reltol = 1.0f-4)
+            @test SciMLBase.successful_retcode(sol)
+            @test eltype(sol[end]) == Float32
+            @test u_ok[]
+            @test t_ok[]
+        end
+    end
+end

--- a/lib/OrdinaryDiffEqStabilizedRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/runtests.jl
@@ -30,6 +30,7 @@ end
 if (TEST_GROUP == "QA" || TEST_GROUP == "ALL") && isempty(VERSION.prerelease)
     activate_qa_env()
     @time @safetestset "Allocation Tests" include("qa/allocation_tests.jl")
+    @time @safetestset "Type Agnosticism Tests" include("qa/type_agnosticism.jl")
     @time @safetestset "JET Tests" include("qa/jet.jl")
     @time @safetestset "Aqua" include("qa/qa.jl")
 end


### PR DESCRIPTION
**Note: This PR should be ignored until reviewed by @ChrisRackauckas.**

Follow-up to the discussion in https://github.com/SciML/OrdinaryDiffEq.jl/issues/2616#issuecomment-4659748863: the stabilized RK methods contained hard-coded `Float64` magic numbers and `Float64`-typed tableau arrays, so `Float32` (e.g. GPU) problems silently promoted internal stage computations to `Float64`. This makes the methods type-agnostic and adds QA tests that lock the property in.

## Type-instability fixes (`OrdinaryDiffEqStabilizedRK`)

- **Magic numbers** in stage-count formulas and error estimators (`1.5`, `0.811` in ROCK2; `0.353` in ROCK4; `1.54`, `0.8`, `0.4` in RKC; `0.98`, `2.0/(mdeg^2)`, `100.0/(49.0 mdeg^2)`, `1.0/(0.4 mdeg^2)` in ESERK4/5/SERK2; the TSRKC2/TSRKC3 constants; `0.3333…`, `1.2`, `0.6` error-estimator coefficients) are now converted through `T = typeof(one(t))`, exactly the `T(1.5)` / `T(0.811)` approach suggested in the issue thread.
- **Int/Int divisions that always produce `Float64`** (`(2j-1)/j`-style recurrence coefficients in RKL1/RKL2/RKG1/RKG2, `sign_s/(s*(s-2))` in RKMC2's bisection, `2/(13 mdeg²)` in TSRKC3's RKC branch) now go through `T`.
- **`RKMC2ConstantCache` hard-coded `w0::Float64, w1::Float64`** — now parameterized on `tTypeNoUnits`.
- **`SERK2`/`ESERK4`/`ESERK5` tableau arrays (`Bᵢ`) were always `Vector{Float64}`** — the constructors now take the value type and convert via broadcast (`T.(Bᵢ)`), matching what ROCK2/ROCK4 already did with `recf`/`fp1`/`fp2`.
- **`maxeig!`** literals (`1.2` safety factor, `0.01`/`0.05` convergence constants) converted via the eigenvalue-estimate type; `cache.internal_deg = mdeg / 10` changed to integer division.
- **Latent `MethodError` fixed**: the zero-norm fallback in the constant-cache `maxeig!` called `ones(z)`, which has no method for scalars or `Vector`s and would have crashed if ever reached. Now `one.(z)`, matching the in-place version. Caught by the new JET tests on Julia 1.10 (JET 0.9).
- The `rkg1_b` inner closure captured `T` as an untyped `DataType` field (runtime dispatch on Julia 1.10); replaced by a small top-level function taking the type as an argument.

ESERK4's `Bᵢ` tail coefficients (down to ~1e-54) underflow to zero in `Float32`; those terms are below `Float32` resolution in the stage accumulation anyway.

## QA tests added

- `test/qa/jet.jl`: per-solver `JET.@test_opt` on `perform_step!` (in-place and out-of-place, `target_modules` scoped to the package) for all 13 exported solvers, as suggested in the issue thread.
- `test/qa/type_agnosticism.jl` (new, wired into the QA test group): solves each method with `Float32` in-place and out-of-place problems where `f` itself asserts the types it receives. Promotion of stage values/times is invisible in the solution (typed integrator fields convert back), but `f` sees promoted arguments, so this catches it. On unmodified master this fails for ESERK4, ESERK5, SERK2, RKL1, RKL2, RKG1, RKG2, and RKMC2.

## Verification

- `Float64` results are **bit-identical to master** for 12 of 13 solvers (in-place and out-of-place solves compared elementwise). RKL1 out-of-place differs by 1 ulp from one step onward: the methods are under `@muladd`, and `muladd` legally lets the compiler pick `fma` vs `mul+add` depending on surrounding codegen; the changed inlining context flips one contraction. The coefficient formulas themselves were verified value-identical over 10⁶ random inputs.
- New QA tests (104 type-agnosticism + 27 JET) pass locally on Julia 1.10.11 and 1.12.6.
- Core `rkc_tests.jl`, allocation tests, and Aqua pass locally.

The remaining `Float64` hazard for mixed-precision setups (`Float32` `u` with `Float64` `tspan`) is inherent to keying coefficients off the time type, which is the existing convention of these tableaus (`recf :: tTypeNoUnits`); for the GPU use case in the issue thread (uniform `Float32`), everything now stays `Float32`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
