### PR TITLE
Downgrade CI: raise root ADTypes lower bound to 1.22.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -52,7 +52,7 @@ OrdinaryDiffEqStabilizedRK = {path = "lib/OrdinaryDiffEqStabilizedRK"}
 OrdinaryDiffEqSymplecticRK = {path = "lib/OrdinaryDiffEqSymplecticRK"}
 
 [compat]
-ADTypes = "1.16.0"
+ADTypes = "1.22.0"
 CommonSolve = "0.2.6"
 DocStringExtensions = "0.9.5"
 ForwardDiff = "1.3.3"


### PR DESCRIPTION
**Note: This PR should be ignored until reviewed by @ChrisRackauckas.**

Fixes the `Downgrade / Downgrade Tests - InterfaceI` failure that has been red on master (runs 2026-06-09T10:30 and 14:40) and on every PR branch since.

## Root cause

The job fails at the resolve step, before any tests run:

```
Unsatisfiable requirements detected for package ADTypes:
 ├─ restricted to versions 1.16.0-1 by OrdinaryDiffEq
 ├─ restricted to versions 1.22.0-1 by OrdinaryDiffEqExtrapolation (fixed at 2.2.0)
 └─ restricted to versions 1.16.0 by an explicit requirement — no versions left
```

#3701 (commit 8a82eab) raised the `ADTypes` lower bound in the sublibraries (e.g. `lib/OrdinaryDiffEqExtrapolation` → `1.22.0`) but left the root `Project.toml` at `1.16.0`. The downgrade workflow pins patch-specific root compat entries to their lower bound, so the root pins `ADTypes = 1.16.0` while the path-fixed sublibraries require `>= 1.22.0` — unsatisfiable.

I audited all other root-vs-sublib compat lower bounds: ADTypes is the only conflicting *patch-specific* root entry (`1.22.0` is the max sublib bound). Major-only entries like `SciMLBase = "3"` are left loose by the downgrade tooling, so the sublibs' `SciMLBase >= 3.1/3.10` bounds resolve fine (to v3.10.0 minimal).

## Verification

Ran the downgrade scenario locally on master + this one-line change (Julia 1.11, minimal-version manifest, `Pkg.test` with `allow_reresolve=false`, `GROUP=InterfaceI`):
- Resolution succeeds, picking `ADTypes v1.22.0` and `SciMLBase v3.10.0` (the minimal versions satisfying all sublib constraints).
- The full InterfaceI suite passed: `Testing OrdinaryDiffEq tests passed`, exit code 0, zero failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)