### PR TITLE
Fix SDE ensembles skipping noise rng reseed

### DIFF
--- a/lib/StochasticDiffEq/Project.toml
+++ b/lib/StochasticDiffEq/Project.toml
@@ -28,7 +28,7 @@ StochasticDiffEqWeak = "af2a2fcd-1c36-4cbe-a6d0-5afda784a085"
 DiffEqBase = {path = "../DiffEqBase"}
 DiffEqDevTools = {path = "../DiffEqDevTools"}
 ImplicitDiscreteSolve = {path = "../ImplicitDiscreteSolve"}
-OrdinaryDiffEq = {path = "../../"}
+OrdinaryDiffEq = {path = "../.."}
 OrdinaryDiffEqCore = {path = "../OrdinaryDiffEqCore"}
 OrdinaryDiffEqNonlinearSolve = {path = "../OrdinaryDiffEqNonlinearSolve"}
 OrdinaryDiffEqRosenbrock = {path = "../OrdinaryDiffEqRosenbrock"}

--- a/lib/StochasticDiffEq/test/rng_integrator_tests.jl
+++ b/lib/StochasticDiffEq/test/rng_integrator_tests.jl
@@ -180,4 +180,17 @@ prob = SDEProblem(f, g, u0, tspan)
 
         @test jump_u1 != jump_u2
     end
+
+    @testset "Ensemble explicitly passed noise process reseeding" begin
+        using Statistics
+        # See https://github.com/SciML/OrdinaryDiffEq.jl/issues/3737
+        f_mwe = (u, p, t) -> 1.0
+        g_mwe = (u, p, t) -> 0.2
+        W_mwe = WienerProcess(0.0, 0.0)
+        prob_mwe = SDEProblem(f_mwe, g_mwe, 1.0, (0.5, 1.0), noise = W_mwe, save_noise = true)
+        ep = EnsembleProblem(prob_mwe, output_func = (sol, ctx) -> (sol.W.W[end], false), prob_func = (p, ctx) -> deepcopy(p))
+        s = solve(ep, EM(), dt = 0.1, trajectories = 100)
+        @test length(unique(s.u)) > 1
+        @test var(s.u) > 0.0
+    end
 end

--- a/lib/StochasticDiffEqCore/Project.toml
+++ b/lib/StochasticDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqCore"
 uuid = "19c5a474-6cd1-4a5f-be79-46dc34e54d7f"
-authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 version = "2.0.1"
+authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -13,7 +13,6 @@ FastPower = "a4df4552-cc26-4903-aec0-212e50a0e84b"
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 JumpProcesses = "ccbc3e58-028d-4f4c-8cd5-9ae44345cda5"
-StochasticDiffEqLevyArea = "90dbc90e-856a-4131-af2c-e8c5aa0f35b5"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
@@ -27,14 +26,12 @@ SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 SimpleNonlinearSolve = "727e6d20-b764-4bd8-a329-72de5adea6c7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-
-[extras]
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+StochasticDiffEqLevyArea = "90dbc90e-856a-4131-af2c-e8c5aa0f35b5"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+OrdinaryDiffEqCore = {path = "../OrdinaryDiffEqCore"}
+StochasticDiffEqLevyArea = {path = "../StochasticDiffEqLevyArea"}
 
 [compat]
 ADTypes = "1.22.0"
@@ -46,7 +43,6 @@ FastPower = "1.1.2"
 FiniteDiff = "2.27.0"
 ForwardDiff = "0.10.39, 1"
 JumpProcesses = "9.26.0"
-StochasticDiffEqLevyArea = "2"
 LinearAlgebra = "1.10"
 Logging = "1.10"
 MuladdMacro = "0.2.4"
@@ -55,21 +51,21 @@ Pkg = "1"
 Random = "<0.0.1, 1"
 RecursiveArrayTools = "4.2.0"
 Reexport = "1.2.2"
+SafeTestsets = "0.1.0"
 SciMLBase = "3.10.0"
 SciMLLogging = "1.10.1, 2"
 SciMLOperators = "1.15"
 SimpleNonlinearSolve = "2.11.1"
 SparseArrays = "1.10"
 StaticArrays = "1.9.14"
+StochasticDiffEqLevyArea = "2"
 Test = "<0.0.1, 1"
-SafeTestsets = "0.1.0"
 julia = "1.10"
+
+[extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Pkg", "SafeTestsets"]
-
-[sources.OrdinaryDiffEqCore]
-path = "../OrdinaryDiffEqCore"
-
-[sources.StochasticDiffEqLevyArea]
-path = "../StochasticDiffEqLevyArea"

--- a/lib/StochasticDiffEqCore/src/solve.jl
+++ b/lib/StochasticDiffEqCore/src/solve.jl
@@ -418,8 +418,8 @@ function _sde_init(
         end
 
         if W.reset
-            if !_rng_provided && W isa Union{NoiseProcess, NoiseTransport} && W.reseed
-                Random.seed!(W.rng, _seed)
+            if W isa Union{NoiseProcess, NoiseTransport} && W.reseed
+                Random.seed!(W.rng, rand(_rng, UInt64))
             end
             if W.curt != t
                 reinit!(W, t, t0 = t)


### PR DESCRIPTION
Resolves #3737.

This PR fixes the issue where SDE ensembles using an explicitly passed noise process skip reseeding of the noise process's RNG. 
It also adds a test to \ng_integrator_tests.jl\ to verify the behavior.