### PR TITLE
fix: increase Hayes SDDE trajectories 100→1000 to eliminate ~9% flakiness

### DIFF
--- a/lib/DiffEqDevTools/test/analyticless_convergence_tests.jl
+++ b/lib/DiffEqDevTools/test/analyticless_convergence_tests.jl
@@ -115,7 +115,7 @@ prob = SDDEProblem(
 dts = (1 / 2) .^ (7:-1:3)
 test_dt = 1 / 2^8
 sim2 = analyticless_test_convergence(
-    dts, prob, MethodOfSteps(RKMil()), test_dt, trajectories = 100,
+    dts, prob, MethodOfSteps(RKMil()), test_dt, trajectories = 1000,
     use_noise_grid = false
 )
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3


### PR DESCRIPTION
## Summary

Increases `trajectories` from 100 to 1000 in the `MethodOfSteps(RKMil())` Hayes SDDE convergence test.

**Root cause**: At 100 trajectories, `𝒪est[:final]` for the Hayes SDDE problem (`tspan=[0,10]`) has mean ~0.87 and std ~0.12, giving ~9% failure rate against the ±0.3 tolerance. Increasing to 1000 reduces std to ~0.038 (std ∝ 1/√N), making P(fail) < 0.001% without pinning the RNG. This mirrors the DRI1 fix (1e5→1e6 trajectories) already in master.

> **Note: Please ignore until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)