### PR TITLE
Multirate: add MRI-GARK-ERK45a (4th-order explicit)

### DIFF
--- a/lib/OrdinaryDiffEqMultirate/Project.toml
+++ b/lib/OrdinaryDiffEqMultirate/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqMultirate"
 uuid = "d4b830b4-ac80-426b-8507-16693d424963"
 authors = ["singhharsh1708 <hs1663531@gmail.com>"]
-version = "2.3.0"
+version = "2.4.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/OrdinaryDiffEqMultirate/Project.toml
+++ b/lib/OrdinaryDiffEqMultirate/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqMultirate"
 uuid = "d4b830b4-ac80-426b-8507-16693d424963"
 authors = ["singhharsh1708 <hs1663531@gmail.com>"]
-version = "2.4.0"
+version = "2.5.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/OrdinaryDiffEqMultirate/src/OrdinaryDiffEqMultirate.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/OrdinaryDiffEqMultirate.jl
@@ -23,6 +23,6 @@ include("multirate_tableaus.jl")
 include("multirate_caches.jl")
 include("multirate_perform_step.jl")
 
-export MREEF, MRAB, MRIGARKERK22a, MRIGARKERK22b, MRIGARKERK33a, MIS
+export MREEF, MRAB, MRIGARKERK22a, MRIGARKERK22b, MRIGARKERK33a, MRIGARKERK45a, MIS
 
 end

--- a/lib/OrdinaryDiffEqMultirate/src/OrdinaryDiffEqMultirate.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/OrdinaryDiffEqMultirate.jl
@@ -23,6 +23,6 @@ include("multirate_tableaus.jl")
 include("multirate_caches.jl")
 include("multirate_perform_step.jl")
 
-export MREEF, MRAB, MRIGARKERK22a, MRIGARKERK22b, MIS
+export MREEF, MRAB, MRIGARKERK22a, MRIGARKERK22b, MRIGARKERK33a, MIS
 
 end

--- a/lib/OrdinaryDiffEqMultirate/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/alg_utils.jl
@@ -16,10 +16,12 @@ end
 
 alg_order(::Union{MRIGARKERK22a, MRIGARKERK22b}) = 2
 alg_order(::MRIGARKERK33a) = 3
-isfsal(::Union{MRIGARKERK22a, MRIGARKERK22b, MRIGARKERK33a}) = false
+alg_order(::MRIGARKERK45a) = 4
+isfsal(::Union{MRIGARKERK22a, MRIGARKERK22b, MRIGARKERK33a, MRIGARKERK45a}) = false
 
 function prepare_alg(
-        alg::Union{MRIGARKERK22a, MRIGARKERK22b, MRIGARKERK33a}, u0::AbstractArray, p, prob
+        alg::Union{MRIGARKERK22a, MRIGARKERK22b, MRIGARKERK33a, MRIGARKERK45a},
+        u0::AbstractArray, p, prob
     )
     alg.m >= 1 || throw(ArgumentError("$(nameof(typeof(alg))): `m` must be ≥ 1"))
     return alg

--- a/lib/OrdinaryDiffEqMultirate/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/alg_utils.jl
@@ -15,10 +15,11 @@ function prepare_alg(alg::MRAB, u0::AbstractArray, p, prob)
 end
 
 alg_order(::Union{MRIGARKERK22a, MRIGARKERK22b}) = 2
-isfsal(::Union{MRIGARKERK22a, MRIGARKERK22b}) = false
+alg_order(::MRIGARKERK33a) = 3
+isfsal(::Union{MRIGARKERK22a, MRIGARKERK22b, MRIGARKERK33a}) = false
 
 function prepare_alg(
-        alg::Union{MRIGARKERK22a, MRIGARKERK22b}, u0::AbstractArray, p, prob
+        alg::Union{MRIGARKERK22a, MRIGARKERK22b, MRIGARKERK33a}, u0::AbstractArray, p, prob
     )
     alg.m >= 1 || throw(ArgumentError("$(nameof(typeof(alg))): `m` must be ≥ 1"))
     return alg

--- a/lib/OrdinaryDiffEqMultirate/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/algorithms.jl
@@ -68,10 +68,10 @@ end
     "Multirate Infinitesimal GARK — explicit midpoint (MRI-GARK-ERK22a).
 
 Solves a SplitODE `du/dt = f1(u,t) + f2(u,t)` where `f1` is the fast component
-and `f2` is the slow component (SciML convention). The slow integrator is the
-explicit midpoint rule; between slow stages a modified fast ODE is integrated
-with `m` explicit-midpoint micro-steps over the full macro interval. 2nd-order
-globally; embedded error estimate uses `v_2(dt) − Y_2`.",
+and `f2` is the slow component (SciML convention). 2-stage, 2nd-order explicit
+MRI-GARK method (Sandu 2019); each stage integrates the fast component over a
+sub-interval with a slow-coupling, using `m` explicit-midpoint inner micro-steps.
+Embedded 1st-order error estimate.",
     "MRIGARKERK22a",
     "Multirate infinitesimal GARK explicit method.",
     """@article{sandu2019class,
@@ -97,10 +97,10 @@ end
     "Multirate Infinitesimal GARK — explicit trapezoidal (MRI-GARK-ERK22b).
 
 Solves a SplitODE `du/dt = f1(u,t) + f2(u,t)` where `f1` is the fast component
-and `f2` is the slow component (SciML convention). The slow integrator is the
-explicit trapezoidal rule (`c₂ = 1` member of the MRI-GARK-ERK22 family from
-Sandu 2019); inner fast micro-ODE uses `m` explicit-midpoint micro-steps over
-the full macro interval. 2nd-order; embedded error estimate uses `v_2(dt) − Y_2`.",
+and `f2` is the slow component (SciML convention). 2nd-order explicit MRI-GARK
+method (the `c₂ = 1` trapezoidal member of the ERK22 family, Sandu 2019), with
+a pure slow-correction final stage. Inner fast micro-ODE uses `m` explicit-midpoint
+micro-steps. Embedded 1st-order error estimate.",
     "MRIGARKERK22b",
     "Multirate infinitesimal GARK explicit method.",
     """@article{sandu2019class,
@@ -119,6 +119,35 @@ the full macro interval. 2nd-order; embedded error estimate uses `v_2(dt) − Y_
     """
 )
 Base.@kwdef struct MRIGARKERK22b <: OrdinaryDiffEqAdaptiveAlgorithm
+    m::Int
+end
+
+@doc generic_solver_docstring(
+    "Multirate Infinitesimal GARK — 3rd-order explicit (MRI-GARK-ERK33a).
+
+Solves a SplitODE `du/dt = f1(u,t) + f2(u,t)` where `f1` is the fast component
+and `f2` is the slow component (SciML convention). 3-stage, 3rd-order explicit
+MRI-GARK method of Sandu 2019; each stage integrates the fast component over a
+sub-interval with a τ-dependent slow-coupling, using `m` explicit-RK3 inner
+micro-steps. Embedded 2nd-order error estimate.",
+    "MRIGARKERK33a",
+    "Multirate infinitesimal GARK explicit method.",
+    """@article{sandu2019class,
+    title={A class of multirate infinitesimal {GARK} methods},
+    author={Sandu, Adrian},
+    journal={SIAM Journal on Numerical Analysis},
+    volume={57},
+    number={5},
+    pages={2300--2327},
+    year={2019}}""",
+    """
+    - `m`: number of inner RK3 micro-steps per stage.
+    """,
+    """
+    m::Int,
+    """
+)
+Base.@kwdef struct MRIGARKERK33a <: OrdinaryDiffEqAdaptiveAlgorithm
     m::Int
 end
 

--- a/lib/OrdinaryDiffEqMultirate/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/algorithms.jl
@@ -152,6 +152,35 @@ Base.@kwdef struct MRIGARKERK33a <: OrdinaryDiffEqAdaptiveAlgorithm
 end
 
 @doc generic_solver_docstring(
+    "Multirate Infinitesimal GARK — 4th-order explicit (MRI-GARK-ERK45a).
+
+Solves a SplitODE `du/dt = f1(u,t) + f2(u,t)` where `f1` is the fast component
+and `f2` is the slow component (SciML convention). 5-stage, 4th-order explicit
+MRI-GARK method of Sandu 2019; each stage integrates the fast component over a
+sub-interval with a τ-dependent slow-coupling, using `m` explicit-RK4 inner
+micro-steps. Embedded 3rd-order error estimate.",
+    "MRIGARKERK45a",
+    "Multirate infinitesimal GARK explicit method.",
+    """@article{sandu2019class,
+    title={A class of multirate infinitesimal {GARK} methods},
+    author={Sandu, Adrian},
+    journal={SIAM Journal on Numerical Analysis},
+    volume={57},
+    number={5},
+    pages={2300--2327},
+    year={2019}}""",
+    """
+    - `m`: number of inner RK4 micro-steps per stage.
+    """,
+    """
+    m::Int,
+    """
+)
+Base.@kwdef struct MRIGARKERK45a <: OrdinaryDiffEqAdaptiveAlgorithm
+    m::Int
+end
+
+@doc generic_solver_docstring(
     "Multirate Infinitesimal Step (MIS).
 
 Solves a split ODE of the form `du/dt = f1(u,t) + f2(u,t)` where `f1` is the

--- a/lib/OrdinaryDiffEqMultirate/src/multirate_caches.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/multirate_caches.jl
@@ -114,7 +114,7 @@ end
 
 get_fsalfirstlast(cache::MRIGARKCache, u) = (cache.fsalfirst, cache.k)
 
-const MRIGARKAlg = Union{MRIGARKERK22a, MRIGARKERK22b, MRIGARKERK33a}
+const MRIGARKAlg = Union{MRIGARKERK22a, MRIGARKERK22b, MRIGARKERK33a, MRIGARKERK45a}
 
 function alg_cache(
         alg::MRIGARKAlg, u, rate_prototype,

--- a/lib/OrdinaryDiffEqMultirate/src/multirate_caches.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/multirate_caches.jl
@@ -101,10 +101,12 @@ end
     tmp::uType
     atmp::uNoUnitsType
     v::uType
+    vtmp::uType
     f1eval::rateType
-    slow_f::rateType
-    Y::Vector{uType}
+    kk::Vector{uType}
+    z::Vector{uType}
     fS::Vector{rateType}
+    zemb::uType
     fsalfirst::rateType
     k::rateType
     tab::TabType
@@ -112,29 +114,36 @@ end
 
 get_fsalfirstlast(cache::MRIGARKCache, u) = (cache.fsalfirst, cache.k)
 
+const MRIGARKAlg = Union{MRIGARKERK22a, MRIGARKERK22b, MRIGARKERK33a}
+
 function alg_cache(
-        alg::Union{MRIGARKERK22a, MRIGARKERK22b}, u, rate_prototype,
+        alg::MRIGARKAlg, u, rate_prototype,
         ::Type{uEltypeNoUnits}, ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits},
         uprev, uprev2, f, t, dt, reltol, p, calck,
         ::Val{true}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
     tab = mri_gark_tableau(alg, eltype(u))
-    s = length(tab.Γ)
+    s = length(tab.Δc)
     tmp = zero(u)
     atmp = similar(u, uEltypeNoUnits)
     recursivefill!(atmp, false)
     v = zero(u)
+    vtmp = zero(u)
     f1eval = zero(rate_prototype)
-    slow_f = zero(rate_prototype)
-    Y = [zero(u) for _ in 1:s]
+    kk = [zero(u) for _ in 1:(tab.q)]
+    z = [zero(u) for _ in 1:(s + 1)]
     fS = [zero(rate_prototype) for _ in 1:s]
+    zemb = zero(u)
     fsalfirst = zero(rate_prototype)
     k = zero(rate_prototype)
-    return MRIGARKCache(u, uprev, tmp, atmp, v, f1eval, slow_f, Y, fS, fsalfirst, k, tab)
+    return MRIGARKCache(
+        u, uprev, tmp, atmp, v, vtmp, f1eval, kk, z, fS, zemb,
+        fsalfirst, k, tab
+    )
 end
 
 function alg_cache(
-        alg::Union{MRIGARKERK22a, MRIGARKERK22b}, u, rate_prototype,
+        alg::MRIGARKAlg, u, rate_prototype,
         ::Type{uEltypeNoUnits}, ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits},
         uprev, uprev2, f, t, dt, reltol, p, calck,
         ::Val{false}, verbose

--- a/lib/OrdinaryDiffEqMultirate/src/multirate_perform_step.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/multirate_perform_step.jl
@@ -328,64 +328,87 @@ function initialize!(integrator, cache::MRIGARKConstantCache)
     return integrator.k[2] = integrator.fsallast
 end
 
+# Fast-IVP rate at normalized τ: kbuf = Δcᵢ·dt·f1(w, t_phys) + dt·Σⱼ ωⱼ(τ)·fS[j],
+# ωⱼ(τ) = w0[j] + w1[j]·τ (w1=nothing means constant coupling). IIP.
+function _mrigark_rate!(kbuf, f1eval, f, w, p, t, dt, Δci, cprev, τ, w0, w1, fS, upto)
+    t_phys = t + (cprev + τ * Δci) * dt
+    f.f1(f1eval, w, p, t_phys)
+    @.. broadcast = false kbuf = dt * Δci * f1eval
+    for j in 1:upto
+        ω = w1 === nothing ? w0[j] : w0[j] + w1[j] * τ
+        iszero(ω) && continue
+        @.. broadcast = false kbuf = kbuf + dt * ω * fS[j]
+    end
+    return kbuf
+end
+
+# Integrate one fast sub-stage from `vstart` over τ∈[0,1] into `out` (IIP).
+# Δcᵢ=0 ⇒ pure slow quadrature (∫₀¹ω dτ = w0 + w1/2). q = inner explicit-RK order.
+function _mrigark_substage!(
+        out, vstart, cache, f, p, t, dt, Δci, cprev, m, q, w0, w1, fS, upto, stats
+    )
+    (; v, vtmp, f1eval, kk) = cache
+    if iszero(Δci)
+        @.. broadcast = false out = vstart
+        for j in 1:upto
+            ω = w1 === nothing ? w0[j] : w0[j] + w1[j] / 2
+            iszero(ω) && continue
+            @.. broadcast = false out = out + dt * ω * fS[j]
+        end
+        return out
+    end
+    h = 1 / m
+    @.. broadcast = false v = vstart
+    for ks in 1:m
+        τ0 = (ks - 1) * h
+        _mrigark_rate!(kk[1], f1eval, f, v, p, t, dt, Δci, cprev, τ0, w0, w1, fS, upto)
+        @.. broadcast = false vtmp = v + (h / 2) * kk[1]
+        _mrigark_rate!(kk[2], f1eval, f, vtmp, p, t, dt, Δci, cprev, τ0 + h / 2, w0, w1, fS, upto)
+        if q == 2
+            @.. broadcast = false v = v + h * kk[2]
+        else
+            @.. broadcast = false vtmp = v - h * kk[1] + 2 * h * kk[2]
+            _mrigark_rate!(kk[3], f1eval, f, vtmp, p, t, dt, Δci, cprev, τ0 + h, w0, w1, fS, upto)
+            @.. broadcast = false v = v + (h / 6) * (kk[1] + 4 * kk[2] + kk[3])
+        end
+        OrdinaryDiffEqCore.increment_nf!(stats, q)
+    end
+    @.. broadcast = false out = v
+    return out
+end
+
 function perform_step!(integrator, cache::MRIGARKCache, repeat_step = false)
     (; t, dt, uprev, u, f, p) = integrator
-    (; tmp, atmp, v, f1eval, slow_f, Y, fS, tab) = cache
-    (; Γ, γ, c) = tab
+    (; tmp, atmp, z, fS, zemb, tab) = cache
+    (; Δc, W0, W1, Wemb, q) = tab
     alg = unwrap_alg(integrator, false)
     m = alg.m
-    s = length(Γ)
+    s = length(Δc)
+    stats = integrator.stats
 
-    @.. broadcast = false Y[1] = uprev
-    h_inner = dt / m
-
+    @.. broadcast = false z[1] = uprev
+    cprev = zero(eltype(Δc))
     for i in 1:s
-        f.f2(fS[i], Y[i], p, t + c[i] * dt)
-        integrator.stats.nf2 += 1
-
-        if i == 1
-            @.. broadcast = false slow_f = γ[i, 1] * fS[1]
-        elseif i == 2
-            @.. broadcast = false slow_f = γ[i, 1] * fS[1] + γ[i, 2] * fS[2]
-        elseif i == 3
-            @.. broadcast = false slow_f = γ[i, 1] * fS[1] + γ[i, 2] * fS[2] +
-                γ[i, 3] * fS[3]
-        elseif i == 4
-            @.. broadcast = false slow_f = γ[i, 1] * fS[1] + γ[i, 2] * fS[2] +
-                γ[i, 3] * fS[3] + γ[i, 4] * fS[4]
-        else
-            @.. broadcast = false slow_f = γ[i, 1] * fS[1]
-            for j in 2:i
-                @.. broadcast = false slow_f = slow_f + γ[i, j] * fS[j]
-            end
-        end
-
-        if iszero(Γ[i])
-            if i < s
-                @.. broadcast = false Y[i + 1] = Y[i] + dt * slow_f
-            else
-                @.. broadcast = false u = Y[i] + dt * slow_f
-            end
-        else
-            @.. broadcast = false v = Y[i]
-            for k_step in 1:m
-                t_a = t + (k_step - 1) * h_inner
-                f.f1(f1eval, v, p, t_a)
-                @.. broadcast = false tmp = v + (h_inner / 2) * (Γ[i] * f1eval + slow_f)
-                f.f1(f1eval, tmp, p, t_a + h_inner / 2)
-                @.. broadcast = false v = v + h_inner * (Γ[i] * f1eval + slow_f)
-                OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
-            end
-            if i < s
-                @.. broadcast = false Y[i + 1] = v
-            else
-                @.. broadcast = false u = v
-            end
-        end
+        f.f2(fS[i], z[i], p, t + cprev * dt)
+        stats.nf2 += 1
+        _mrigark_substage!(
+            z[i + 1], z[i], cache, f, p, t, dt, Δc[i], cprev, m, q,
+            view(W0, i, :), view(W1, i, :), fS, i, stats
+        )
+        cprev += Δc[i]
     end
+    @.. broadcast = false u = z[s + 1]
 
     return if integrator.opts.adaptive
-        @.. broadcast = false tmp = u - Y[s]
+        if isempty(Wemb)
+            @.. broadcast = false tmp = u - z[s]
+        else
+            _mrigark_substage!(
+                zemb, z[s], cache, f, p, t, dt, Δc[s], cprev - Δc[s], m, q,
+                Wemb, nothing, fS, s, stats
+            )
+            @.. broadcast = false tmp = u - zemb
+        end
         calculate_residuals!(
             atmp, tmp, uprev, u,
             integrator.opts.abstol, integrator.opts.reltol,
@@ -395,65 +418,83 @@ function perform_step!(integrator, cache::MRIGARKCache, repeat_step = false)
     end
 end
 
+# Fast-IVP rate, out-of-place.
+function _mrigark_rate(f, w, p, t, dt, Δci, cprev, τ, w0, w1, fS, upto)
+    t_phys = t + (cprev + τ * Δci) * dt
+    ffast = f.f1(w, p, t_phys)
+    g = @.. broadcast = false dt * Δci * ffast
+    for j in 1:upto
+        ω = w1 === nothing ? w0[j] : w0[j] + w1[j] * τ
+        iszero(ω) && continue
+        g = @.. broadcast = false g + dt * ω * fS[j]
+    end
+    return g
+end
+
+function _mrigark_substage(vstart, f, p, t, dt, Δci, cprev, m, q, w0, w1, fS, upto, stats)
+    if iszero(Δci)
+        v = vstart
+        for j in 1:upto
+            ω = w1 === nothing ? w0[j] : w0[j] + w1[j] / 2
+            iszero(ω) && continue
+            v = @.. broadcast = false v + dt * ω * fS[j]
+        end
+        return v
+    end
+    h = 1 / m
+    v = vstart
+    for ks in 1:m
+        τ0 = (ks - 1) * h
+        k1 = _mrigark_rate(f, v, p, t, dt, Δci, cprev, τ0, w0, w1, fS, upto)
+        vmid = @.. broadcast = false v + (h / 2) * k1
+        k2 = _mrigark_rate(f, vmid, p, t, dt, Δci, cprev, τ0 + h / 2, w0, w1, fS, upto)
+        if q == 2
+            v = @.. broadcast = false v + h * k2
+        else
+            vmid2 = @.. broadcast = false v - h * k1 + 2 * h * k2
+            k3 = _mrigark_rate(f, vmid2, p, t, dt, Δci, cprev, τ0 + h, w0, w1, fS, upto)
+            v = @.. broadcast = false v + (h / 6) * (k1 + 4 * k2 + k3)
+        end
+        OrdinaryDiffEqCore.increment_nf!(stats, q)
+    end
+    return v
+end
+
 @muladd function perform_step!(
         integrator, cache::MRIGARKConstantCache, repeat_step = false
     )
     (; t, dt, uprev, f, p) = integrator
-    (; Γ, γ, c) = cache.tab
+    (; Δc, W0, W1, Wemb, q) = cache.tab
     alg = unwrap_alg(integrator, false)
     m = alg.m
-    s = length(Γ)
+    s = length(Δc)
+    stats = integrator.stats
 
-    h_inner = dt / m
-    Y = Vector{typeof(uprev)}(undef, s)
+    z = Vector{typeof(uprev)}(undef, s + 1)
     fS = Vector{typeof(f.f2(uprev, p, t))}(undef, s)
-    Y[1] = uprev
-
+    z[1] = uprev
+    cprev = zero(eltype(Δc))
     for i in 1:s
-        fS[i] = f.f2(Y[i], p, t + c[i] * dt)
-        integrator.stats.nf2 += 1
-
-        slow_f = if i == 1
-            @.. broadcast = false γ[i, 1] * fS[1]
-        elseif i == 2
-            @.. broadcast = false γ[i, 1] * fS[1] + γ[i, 2] * fS[2]
-        elseif i == 3
-            @.. broadcast = false γ[i, 1] * fS[1] + γ[i, 2] * fS[2] + γ[i, 3] * fS[3]
-        elseif i == 4
-            @.. broadcast = false γ[i, 1] * fS[1] + γ[i, 2] * fS[2] +
-                γ[i, 3] * fS[3] + γ[i, 4] * fS[4]
-        else
-            acc = @.. broadcast = false γ[i, 1] * fS[1]
-            for j in 2:i
-                acc = @.. broadcast = false acc + γ[i, j] * fS[j]
-            end
-            acc
-        end
-
-        if iszero(Γ[i])
-            result = @.. broadcast = false Y[i] + dt * slow_f
-        else
-            v = Y[i]
-            for k_step in 1:m
-                t_a = t + (k_step - 1) * h_inner
-                k1 = f.f1(v, p, t_a)
-                v_mid = @.. broadcast = false v + (h_inner / 2) * (Γ[i] * k1 + slow_f)
-                k2 = f.f1(v_mid, p, t_a + h_inner / 2)
-                v = @.. broadcast = false v + h_inner * (Γ[i] * k2 + slow_f)
-                OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
-            end
-            result = v
-        end
-
-        if i < s
-            Y[i + 1] = result
-        else
-            integrator.u = result
-        end
+        fS[i] = f.f2(z[i], p, t + cprev * dt)
+        stats.nf2 += 1
+        z[i + 1] = _mrigark_substage(
+            z[i], f, p, t, dt, Δc[i], cprev, m, q,
+            view(W0, i, :), view(W1, i, :), fS, i, stats
+        )
+        cprev += Δc[i]
     end
+    integrator.u = z[s + 1]
 
     if integrator.opts.adaptive
-        utilde = @.. broadcast = false integrator.u - Y[s]
+        utilde = if isempty(Wemb)
+            @.. broadcast = false integrator.u - z[s]
+        else
+            zemb = _mrigark_substage(
+                z[s], f, p, t, dt, Δc[s], cprev - Δc[s], m, q,
+                Wemb, nothing, fS, s, stats
+            )
+            @.. broadcast = false integrator.u - zemb
+        end
         atmp = calculate_residuals(
             utilde, uprev, integrator.u,
             integrator.opts.abstol, integrator.opts.reltol,

--- a/lib/OrdinaryDiffEqMultirate/src/multirate_perform_step.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/multirate_perform_step.jl
@@ -366,10 +366,16 @@ function _mrigark_substage!(
         _mrigark_rate!(kk[2], f1eval, f, vtmp, p, t, dt, Δci, cprev, τ0 + h / 2, w0, w1, fS, upto)
         if q == 2
             @.. broadcast = false v = v + h * kk[2]
-        else
+        elseif q == 3
             @.. broadcast = false vtmp = v - h * kk[1] + 2 * h * kk[2]
             _mrigark_rate!(kk[3], f1eval, f, vtmp, p, t, dt, Δci, cprev, τ0 + h, w0, w1, fS, upto)
             @.. broadcast = false v = v + (h / 6) * (kk[1] + 4 * kk[2] + kk[3])
+        else
+            @.. broadcast = false vtmp = v + (h / 2) * kk[2]
+            _mrigark_rate!(kk[3], f1eval, f, vtmp, p, t, dt, Δci, cprev, τ0 + h / 2, w0, w1, fS, upto)
+            @.. broadcast = false vtmp = v + h * kk[3]
+            _mrigark_rate!(kk[4], f1eval, f, vtmp, p, t, dt, Δci, cprev, τ0 + h, w0, w1, fS, upto)
+            @.. broadcast = false v = v + (h / 6) * (kk[1] + 2 * kk[2] + 2 * kk[3] + kk[4])
         end
         OrdinaryDiffEqCore.increment_nf!(stats, q)
     end
@@ -380,7 +386,7 @@ end
 function perform_step!(integrator, cache::MRIGARKCache, repeat_step = false)
     (; t, dt, uprev, u, f, p) = integrator
     (; tmp, atmp, z, fS, zemb, tab) = cache
-    (; Δc, W0, W1, Wemb, q) = tab
+    (; Δc, W0, W1, Wemb0, Wemb1, q) = tab
     alg = unwrap_alg(integrator, false)
     m = alg.m
     s = length(Δc)
@@ -400,12 +406,13 @@ function perform_step!(integrator, cache::MRIGARKCache, repeat_step = false)
     @.. broadcast = false u = z[s + 1]
 
     return if integrator.opts.adaptive
-        if isempty(Wemb)
+        if isempty(Wemb0)
             @.. broadcast = false tmp = u - z[s]
         else
+            w1emb = isempty(Wemb1) ? nothing : Wemb1
             _mrigark_substage!(
                 zemb, z[s], cache, f, p, t, dt, Δc[s], cprev - Δc[s], m, q,
-                Wemb, nothing, fS, s, stats
+                Wemb0, w1emb, fS, s, stats
             )
             @.. broadcast = false tmp = u - zemb
         end
@@ -450,10 +457,16 @@ function _mrigark_substage(vstart, f, p, t, dt, Δci, cprev, m, q, w0, w1, fS, u
         k2 = _mrigark_rate(f, vmid, p, t, dt, Δci, cprev, τ0 + h / 2, w0, w1, fS, upto)
         if q == 2
             v = @.. broadcast = false v + h * k2
-        else
+        elseif q == 3
             vmid2 = @.. broadcast = false v - h * k1 + 2 * h * k2
             k3 = _mrigark_rate(f, vmid2, p, t, dt, Δci, cprev, τ0 + h, w0, w1, fS, upto)
             v = @.. broadcast = false v + (h / 6) * (k1 + 4 * k2 + k3)
+        else
+            vmid2 = @.. broadcast = false v + (h / 2) * k2
+            k3 = _mrigark_rate(f, vmid2, p, t, dt, Δci, cprev, τ0 + h / 2, w0, w1, fS, upto)
+            vmid3 = @.. broadcast = false v + h * k3
+            k4 = _mrigark_rate(f, vmid3, p, t, dt, Δci, cprev, τ0 + h, w0, w1, fS, upto)
+            v = @.. broadcast = false v + (h / 6) * (k1 + 2 * k2 + 2 * k3 + k4)
         end
         OrdinaryDiffEqCore.increment_nf!(stats, q)
     end
@@ -464,7 +477,7 @@ end
         integrator, cache::MRIGARKConstantCache, repeat_step = false
     )
     (; t, dt, uprev, f, p) = integrator
-    (; Δc, W0, W1, Wemb, q) = cache.tab
+    (; Δc, W0, W1, Wemb0, Wemb1, q) = cache.tab
     alg = unwrap_alg(integrator, false)
     m = alg.m
     s = length(Δc)
@@ -486,12 +499,13 @@ end
     integrator.u = z[s + 1]
 
     if integrator.opts.adaptive
-        utilde = if isempty(Wemb)
+        utilde = if isempty(Wemb0)
             @.. broadcast = false integrator.u - z[s]
         else
+            w1emb = isempty(Wemb1) ? nothing : Wemb1
             zemb = _mrigark_substage(
                 z[s], f, p, t, dt, Δc[s], cprev - Δc[s], m, q,
-                Wemb, nothing, fS, s, stats
+                Wemb0, w1emb, fS, s, stats
             )
             @.. broadcast = false integrator.u - zemb
         end

--- a/lib/OrdinaryDiffEqMultirate/src/multirate_tableaus.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/multirate_tableaus.jl
@@ -17,30 +17,45 @@ function MRABTableau(k::Int, ::Type{T}) where {T}
     return MRABTableau{T}(allβ[1:k])
 end
 
-# ── MRI-GARK: explicit infinitesimal GARK ─────────────────────────────────────
+# ── MRI-GARK: explicit infinitesimal GARK (Sandu 2019) ────────────────────────
+# Stage i integrates the fast IVP v' = Δcᵢ·dt·f1(v) + dt·Σⱼ ωᵢⱼ(τ)·f2(z_{j-1})
+# over normalized τ∈[0,1], where ωᵢⱼ(τ) = W0[i,j] + W1[i,j]·τ. Inner solver is an
+# explicit RK of order `q`. Wemb (length 0 if absent) gives the embedded last-stage
+# coupling for the error estimate.
 
-struct MRIGARKExplicitTableau{T}
-    Γ::Vector{T}  # diagonal fast rates, length s
-    γ::Matrix{T}  # lower-triangular slow couplings, s×s
-    c::Vector{T}  # slow abscissae for fS evaluations, length s
+struct MRIGARKTableau{T}
+    Δc::Vector{T}     # fast sub-interval length per stage, length s
+    W0::Matrix{T}     # constant coupling, s×s lower-triangular
+    W1::Matrix{T}     # linear-in-τ coupling, s×s lower-triangular
+    Wemb::Vector{T}   # embedded last-stage coupling (length s) or empty
+    q::Int            # inner RK order
 end
 
 function MRIGARKERK22aTableau(::Type{T}) where {T}
-    Γ = T[1 // 2, 1 // 2]
-    γ = T[1 // 2 0; -1 // 2 1]
-    c = T[0, 1]
-    return MRIGARKExplicitTableau{T}(Γ, γ, c)
+    Δc = T[1 // 2, 1 // 2]
+    W0 = T[1 // 2 0; -1 // 2 1]
+    W1 = zeros(T, 2, 2)
+    return MRIGARKTableau{T}(Δc, W0, W1, T[], 2)
 end
 
 function MRIGARKERK22bTableau(::Type{T}) where {T}
-    Γ = T[1, 0]
-    γ = T[1 0; -1 // 2 1 // 2]
-    c = T[0, 1]
-    return MRIGARKExplicitTableau{T}(Γ, γ, c)
+    Δc = T[1, 0]
+    W0 = T[1 0; -1 // 2 1 // 2]
+    W1 = zeros(T, 2, 2)
+    return MRIGARKTableau{T}(Δc, W0, W1, T[], 2)
+end
+
+function MRIGARKERK33aTableau(::Type{T}) where {T}
+    Δc = T[1 // 3, 1 // 3, 1 // 3]
+    W0 = T[1 // 3 0 0; -1 // 3 2 // 3 0; 0 -2 // 3 1]
+    W1 = T[0 0 0; 0 0 0; 1 // 2 0 -1 // 2]
+    Wemb = T[1 // 12, -1 // 3, 7 // 12]
+    return MRIGARKTableau{T}(Δc, W0, W1, Wemb, 3)
 end
 
 mri_gark_tableau(::MRIGARKERK22a, ::Type{T}) where {T} = MRIGARKERK22aTableau(T)
 mri_gark_tableau(::MRIGARKERK22b, ::Type{T}) where {T} = MRIGARKERK22bTableau(T)
+mri_gark_tableau(::MRIGARKERK33a, ::Type{T}) where {T} = MRIGARKERK33aTableau(T)
 
 # ── MIS: multirate infinitesimal step ─────────────────────────────────────────
 

--- a/lib/OrdinaryDiffEqMultirate/src/multirate_tableaus.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/multirate_tableaus.jl
@@ -20,14 +20,15 @@ end
 # ── MRI-GARK: explicit infinitesimal GARK (Sandu 2019) ────────────────────────
 # Stage i integrates the fast IVP v' = Δcᵢ·dt·f1(v) + dt·Σⱼ ωᵢⱼ(τ)·f2(z_{j-1})
 # over normalized τ∈[0,1], where ωᵢⱼ(τ) = W0[i,j] + W1[i,j]·τ. Inner solver is an
-# explicit RK of order `q`. Wemb (length 0 if absent) gives the embedded last-stage
-# coupling for the error estimate.
+# explicit RK of order `q`. Wemb0/Wemb1 (length 0 if absent) give the embedded
+# last-stage coupling ωᵉᵐᵇⱼ(τ) = Wemb0[j] + Wemb1[j]·τ for the error estimate.
 
 struct MRIGARKTableau{T}
     Δc::Vector{T}     # fast sub-interval length per stage, length s
     W0::Matrix{T}     # constant coupling, s×s lower-triangular
     W1::Matrix{T}     # linear-in-τ coupling, s×s lower-triangular
-    Wemb::Vector{T}   # embedded last-stage coupling (length s) or empty
+    Wemb0::Vector{T}  # embedded last-stage constant coupling (length s) or empty
+    Wemb1::Vector{T}  # embedded last-stage linear-in-τ coupling, or empty (constant)
     q::Int            # inner RK order
 end
 
@@ -35,27 +36,55 @@ function MRIGARKERK22aTableau(::Type{T}) where {T}
     Δc = T[1 // 2, 1 // 2]
     W0 = T[1 // 2 0; -1 // 2 1]
     W1 = zeros(T, 2, 2)
-    return MRIGARKTableau{T}(Δc, W0, W1, T[], 2)
+    return MRIGARKTableau{T}(Δc, W0, W1, T[], T[], 2)
 end
 
 function MRIGARKERK22bTableau(::Type{T}) where {T}
     Δc = T[1, 0]
     W0 = T[1 0; -1 // 2 1 // 2]
     W1 = zeros(T, 2, 2)
-    return MRIGARKTableau{T}(Δc, W0, W1, T[], 2)
+    return MRIGARKTableau{T}(Δc, W0, W1, T[], T[], 2)
 end
 
 function MRIGARKERK33aTableau(::Type{T}) where {T}
     Δc = T[1 // 3, 1 // 3, 1 // 3]
     W0 = T[1 // 3 0 0; -1 // 3 2 // 3 0; 0 -2 // 3 1]
     W1 = T[0 0 0; 0 0 0; 1 // 2 0 -1 // 2]
-    Wemb = T[1 // 12, -1 // 3, 7 // 12]
-    return MRIGARKTableau{T}(Δc, W0, W1, Wemb, 3)
+    Wemb0 = T[1 // 12, -1 // 3, 7 // 12]
+    return MRIGARKTableau{T}(Δc, W0, W1, Wemb0, T[], 3)
+end
+
+function MRIGARKERK45aTableau(::Type{T}) where {T}
+    Δc = T[1 // 5, 1 // 5, 1 // 5, 1 // 5, 1 // 5]
+    W0 = zeros(T, 5, 5)
+    W0[1, 1] = 1 // 5
+    W0[2, 1] = -53 // 16; W0[2, 2] = 281 // 80
+    W0[3, 1] = -36562993 // 71394880; W0[3, 2] = 34903117 // 17848720
+    W0[3, 3] = -88770499 // 71394880
+    W0[4, 1] = -7631593 // 71394880; W0[4, 2] = -166232021 // 35697440
+    W0[4, 3] = 6068517 // 1519040; W0[4, 4] = 8644289 // 8924360
+    W0[5, 1] = 277061 // 303808; W0[5, 2] = -209323 // 1139280
+    W0[5, 3] = -1360217 // 1139280; W0[5, 4] = -148789 // 56964; W0[5, 5] = 147889 // 45120
+    W1 = zeros(T, 5, 5)
+    W1[2, 1] = 503 // 80; W1[2, 2] = -503 // 80
+    W1[3, 1] = -1365537 // 35697440; W1[3, 2] = 4963773 // 7139488
+    W1[3, 3] = -1465833 // 2231090
+    W1[4, 1] = 66974357 // 35697440; W1[4, 2] = 21445367 // 7139488
+    W1[4, 3] = -3; W1[4, 4] = -8388609 // 4462180
+    W1[5, 1] = -18227 // 7520; W1[5, 2] = 2; W1[5, 3] = 1; W1[5, 4] = 5
+    W1[5, 5] = -41933 // 7520
+    Wemb0 = T[
+        -88227 // 47470, 756870829 // 340217490, -713704111 // 1360869960,
+        -31967827 // 340217490, 129673 // 286680,
+    ]
+    Wemb1 = T[6213 // 1880, -6213 // 1880, 0, 0, 0]
+    return MRIGARKTableau{T}(Δc, W0, W1, Wemb0, Wemb1, 4)
 end
 
 mri_gark_tableau(::MRIGARKERK22a, ::Type{T}) where {T} = MRIGARKERK22aTableau(T)
 mri_gark_tableau(::MRIGARKERK22b, ::Type{T}) where {T} = MRIGARKERK22bTableau(T)
 mri_gark_tableau(::MRIGARKERK33a, ::Type{T}) where {T} = MRIGARKERK33aTableau(T)
+mri_gark_tableau(::MRIGARKERK45a, ::Type{T}) where {T} = MRIGARKERK45aTableau(T)
 
 # ── MIS: multirate infinitesimal step ─────────────────────────────────────────
 

--- a/lib/OrdinaryDiffEqMultirate/test/mri_gark_tests.jl
+++ b/lib/OrdinaryDiffEqMultirate/test/mri_gark_tests.jl
@@ -90,3 +90,47 @@ using OrdinaryDiffEqMultirate, DiffEqDevTools, Test, LinearAlgebra
     end
 
 end
+
+@testset "MRIGARKERK33a" begin
+    @testset "Construction" begin
+        @test MRIGARKERK33a(m = 10) == MRIGARKERK33a(10)
+        @test MRIGARKERK33a(m = 20) == MRIGARKERK33a(20)
+    end
+
+    @testset "Scalar out-of-place" begin
+        prob = SplitODEProblem(
+            (u, p, t) -> -0.9 * u, (u, p, t) -> -0.1 * u, 1.0, (0.0, 1.0)
+        )
+        sol = solve(prob, MRIGARKERK33a(m = 10), dt = 0.05, adaptive = false)
+        @test abs(sol.u[end] - exp(-1.0)) < 1.0e-4
+
+        sol_a = solve(prob, MRIGARKERK33a(m = 10), reltol = 1.0e-6, abstol = 1.0e-6)
+        @test abs(sol_a.u[end] - exp(-1.0)) < 1.0e-3
+    end
+
+    @testset "Vector in-place" begin
+        f1!(du, u, p, t) = (du .= -0.9 .* u)
+        f2!(du, u, p, t) = (du .= -0.1 .* u)
+        u0 = [1.0, 2.0, 3.0]
+        prob = SplitODEProblem(f1!, f2!, u0, (0.0, 1.0))
+
+        sol = solve(prob, MRIGARKERK33a(m = 10), dt = 0.05, adaptive = false)
+        @test norm(sol.u[end] - u0 .* exp(-1.0)) < 1.0e-3
+
+        sol_a = solve(prob, MRIGARKERK33a(m = 10), reltol = 1.0e-6, abstol = 1.0e-6)
+        @test norm(sol_a.u[end] - u0 .* exp(-1.0)) < 1.0e-3
+    end
+
+    @testset "Convergence" begin
+        analytic(u0, p, t) = u0 * exp(-3t)
+        prob = SplitODEProblem(
+            SplitFunction(
+                (u, p, t) -> -2u, (u, p, t) -> -u; analytic = analytic
+            ),
+            1.0, (0.0, 1.0)
+        )
+        dts = 1 ./ 2 .^ (6:-1:2)
+        sim = test_convergence(dts, prob, MRIGARKERK33a(m = 8))
+        @test sim.𝒪est[:l∞] ≈ 3 atol = 0.3
+    end
+end

--- a/lib/OrdinaryDiffEqMultirate/test/mri_gark_tests.jl
+++ b/lib/OrdinaryDiffEqMultirate/test/mri_gark_tests.jl
@@ -134,3 +134,47 @@ end
         @test sim.𝒪est[:l∞] ≈ 3 atol = 0.3
     end
 end
+
+@testset "MRIGARKERK45a" begin
+    @testset "Construction" begin
+        @test MRIGARKERK45a(m = 10) == MRIGARKERK45a(10)
+        @test MRIGARKERK45a(m = 20) == MRIGARKERK45a(20)
+    end
+
+    @testset "Scalar out-of-place" begin
+        prob = SplitODEProblem(
+            (u, p, t) -> -0.9 * u, (u, p, t) -> -0.1 * u, 1.0, (0.0, 1.0)
+        )
+        sol = solve(prob, MRIGARKERK45a(m = 10), dt = 0.05, adaptive = false)
+        @test abs(sol.u[end] - exp(-1.0)) < 1.0e-5
+
+        sol_a = solve(prob, MRIGARKERK45a(m = 10), reltol = 1.0e-6, abstol = 1.0e-6)
+        @test abs(sol_a.u[end] - exp(-1.0)) < 1.0e-3
+    end
+
+    @testset "Vector in-place" begin
+        f1!(du, u, p, t) = (du .= -0.9 .* u)
+        f2!(du, u, p, t) = (du .= -0.1 .* u)
+        u0 = [1.0, 2.0, 3.0]
+        prob = SplitODEProblem(f1!, f2!, u0, (0.0, 1.0))
+
+        sol = solve(prob, MRIGARKERK45a(m = 10), dt = 0.05, adaptive = false)
+        @test norm(sol.u[end] - u0 .* exp(-1.0)) < 1.0e-4
+
+        sol_a = solve(prob, MRIGARKERK45a(m = 10), reltol = 1.0e-6, abstol = 1.0e-6)
+        @test norm(sol_a.u[end] - u0 .* exp(-1.0)) < 1.0e-3
+    end
+
+    @testset "Convergence" begin
+        analytic(u0, p, t) = u0 * exp(-3t)
+        prob = SplitODEProblem(
+            SplitFunction(
+                (u, p, t) -> -2u, (u, p, t) -> -u; analytic = analytic
+            ),
+            1.0, (0.0, 1.0)
+        )
+        dts = 1 ./ 2 .^ (6:-1:2)
+        sim = test_convergence(dts, prob, MRIGARKERK45a(m = 8))
+        @test sim.𝒪est[:l∞] ≈ 4 atol = 0.3
+    end
+end


### PR DESCRIPTION
**Stacked on #3747** — the first commit in this PR is #3747 (ERK33a + the unified MRI-GARK formulation); please review that one first. Once #3747 merges, this rebases down to a single ERK45a commit.

Adds **MRIGARKERK45a**, the 4th-order explicit MRI-GARK method of Sandu 2019, completing the explicit MRI-GARK family (orders 2/3/4) in the unified W-form. Coefficients transcribed from SUNDIALS ARKODE.

## What it needed
The general formulation from #3747 already supported it — only two small additions:
- An **RK4 inner** path (`q = 4`) in the substage integrator.
- A **τ-dependent embedded coupling** (`Wemb0 + Wemb1·τ`) — ERK45a's embedding row has linear-in-τ terms, unlike ERK33a's constant one — for the order-3 error estimate.

5 fast stages (Δc = 1/5 each). Demonstrates the framework generalizes: higher orders drop in as a new tableau + inner order.

## Tests
Convergence verified — **order 4** (IIP + OOP); full multirate suite green (MRI-GARK 28 tests). Version 2.4.0 → 2.5.0.