### PR TITLE
Fix extrapolation error-estimate denominator to use step endpoints (#3226)

### DIFF
--- a/lib/OrdinaryDiffEqExtrapolation/Project.toml
+++ b/lib/OrdinaryDiffEqExtrapolation/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExtrapolation"
 uuid = "becaefa8-8ca2-5cf9-886d-c06f3d2bd2c4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqExtrapolation/src/extrapolation_perform_step.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/extrapolation_perform_step.jl
@@ -456,8 +456,9 @@ function perform_step!(
             @.. broadcast = false integrator.u = T[i + 1, i + 1]
             @.. broadcast = false cache.utilde = T[i + 1, i]
 
+            @.. broadcast = false cache.tmp = integrator.u - cache.utilde
             calculate_residuals!(
-                cache.atmp, integrator.u, cache.utilde,
+                cache.atmp, cache.tmp, integrator.uprev, integrator.u,
                 integrator.opts.abstol, integrator.opts.reltol,
                 integrator.opts.internalnorm, t
             )
@@ -536,8 +537,9 @@ function perform_step!(
                 @.. broadcast = false integrator.u = T[n_curr + 1, n_curr + 1]
                 @.. broadcast = false cache.utilde = T[n_curr + 1, n_curr]
 
+                @.. broadcast = false cache.tmp = integrator.u - cache.utilde
                 calculate_residuals!(
-                    cache.atmp, integrator.u, cache.utilde,
+                    cache.atmp, cache.tmp, integrator.uprev, integrator.u,
                     integrator.opts.abstol, integrator.opts.reltol,
                     integrator.opts.internalnorm, t
                 )
@@ -695,7 +697,7 @@ function perform_step!(
             utilde = T[i + 1, i]
             # FIXME this should be stored in the controller cache
             res = calculate_residuals(
-                u, utilde, integrator.opts.abstol,
+                u - utilde, integrator.uprev, u, integrator.opts.abstol,
                 integrator.opts.reltol, integrator.opts.internalnorm,
                 t
             )
@@ -755,7 +757,7 @@ function perform_step!(
                 utilde = T[n_curr + 1, n_curr]
                 # FIXME this should be stored in the controller cache
                 res = calculate_residuals(
-                    u, utilde, integrator.opts.abstol,
+                    u - utilde, integrator.uprev, u, integrator.opts.abstol,
                     integrator.opts.reltol,
                     integrator.opts.internalnorm, t
                 )
@@ -928,8 +930,9 @@ function perform_step!(
             @.. broadcast = false integrator.u = extrapolation_scalars[i + 1] * u_temp1
             @.. broadcast = false cache.utilde = extrapolation_scalars_2[i] * u_temp2
 
+            @.. broadcast = false cache.tmp = integrator.u - cache.utilde
             calculate_residuals!(
-                cache.atmp, integrator.u, cache.utilde,
+                cache.atmp, cache.tmp, integrator.uprev, integrator.u,
                 integrator.opts.abstol, integrator.opts.reltol,
                 integrator.opts.internalnorm, t
             )
@@ -983,8 +986,9 @@ function perform_step!(
                 @.. broadcast = false integrator.u = extrapolation_scalars[n_curr + 1] * u_temp1
                 @.. broadcast = false cache.utilde = extrapolation_scalars_2[n_curr] * u_temp2
 
+                @.. broadcast = false cache.tmp = integrator.u - cache.utilde
                 calculate_residuals!(
-                    cache.atmp, integrator.u, cache.utilde,
+                    cache.atmp, cache.tmp, integrator.uprev, integrator.u,
                     integrator.opts.abstol, integrator.opts.reltol,
                     integrator.opts.internalnorm, t
                 )
@@ -1147,7 +1151,7 @@ function perform_step!(
             ) # and its internal counterpart
             # FIXME this should be stored in the controller cache
             res = calculate_residuals(
-                u, utilde, integrator.opts.abstol,
+                u - utilde, integrator.uprev, u, integrator.opts.abstol,
                 integrator.opts.reltol, integrator.opts.internalnorm,
                 t
             )
@@ -1211,7 +1215,7 @@ function perform_step!(
                 ) # and its internal counterpart
                 # FIXME this should be stored in the controller cache
                 res = calculate_residuals(
-                    u, utilde, integrator.opts.abstol,
+                    u - utilde, integrator.uprev, u, integrator.opts.abstol,
                     integrator.opts.reltol,
                     integrator.opts.internalnorm, t
                 )
@@ -1600,8 +1604,9 @@ function perform_step!(
             @.. broadcast = false integrator.u = extrapolation_scalars[i + 1] * u_temp1
             @.. broadcast = false cache.utilde = extrapolation_scalars_2[i] * u_temp2
 
+            @.. broadcast = false cache.tmp = integrator.u - cache.utilde
             calculate_residuals!(
-                cache.atmp, integrator.u, cache.utilde,
+                cache.atmp, cache.tmp, integrator.uprev, integrator.u,
                 integrator.opts.abstol, integrator.opts.reltol,
                 integrator.opts.internalnorm, t
             )
@@ -1679,8 +1684,9 @@ function perform_step!(
                 @.. broadcast = false integrator.u = extrapolation_scalars[n_curr + 1] * u_temp1
                 @.. broadcast = false cache.utilde = extrapolation_scalars_2[n_curr] * u_temp2
 
+                @.. broadcast = false cache.tmp = integrator.u - cache.utilde
                 calculate_residuals!(
-                    cache.atmp, integrator.u, cache.utilde,
+                    cache.atmp, cache.tmp, integrator.uprev, integrator.u,
                     integrator.opts.abstol, integrator.opts.reltol,
                     integrator.opts.internalnorm, t
                 )
@@ -1928,7 +1934,7 @@ function perform_step!(
             ) # and its internal counterpart
             # FIXME this should be stored in the controller cache
             res = calculate_residuals(
-                u, utilde, integrator.opts.abstol,
+                u - utilde, integrator.uprev, u, integrator.opts.abstol,
                 integrator.opts.reltol, integrator.opts.internalnorm,
                 t
             )
@@ -2004,7 +2010,7 @@ function perform_step!(
                 ) # and its internal counterpart
                 # FIXME this should be stored in the controller cache
                 res = calculate_residuals(
-                    u, utilde, integrator.opts.abstol,
+                    u - utilde, integrator.uprev, u, integrator.opts.abstol,
                     integrator.opts.reltol,
                     integrator.opts.internalnorm, t
                 )
@@ -2190,8 +2196,9 @@ function perform_step!(
             @.. broadcast = false integrator.u = extrapolation_scalars[i + 1] * u_temp1
             @.. broadcast = false cache.utilde = extrapolation_scalars_2[i] * u_temp2
 
+            @.. broadcast = false cache.tmp = integrator.u - cache.utilde
             calculate_residuals!(
-                cache.atmp, integrator.u, cache.utilde,
+                cache.atmp, cache.tmp, integrator.uprev, integrator.u,
                 integrator.opts.abstol, integrator.opts.reltol,
                 integrator.opts.internalnorm, t
             )
@@ -2249,8 +2256,9 @@ function perform_step!(
                 @.. broadcast = false integrator.u = extrapolation_scalars[n_curr + 1] * u_temp1
                 @.. broadcast = false cache.utilde = extrapolation_scalars_2[n_curr] * u_temp2
 
+                @.. broadcast = false cache.tmp = integrator.u - cache.utilde
                 calculate_residuals!(
-                    cache.atmp, integrator.u, cache.utilde,
+                    cache.atmp, cache.tmp, integrator.uprev, integrator.u,
                     integrator.opts.abstol, integrator.opts.reltol,
                     integrator.opts.internalnorm, t
                 )
@@ -2413,7 +2421,7 @@ function perform_step!(
             ) # and its internal counterpart
             # FIXME this should be stored in the controller cache
             res = calculate_residuals(
-                u, utilde, integrator.opts.abstol,
+                u - utilde, integrator.uprev, u, integrator.opts.abstol,
                 integrator.opts.reltol, integrator.opts.internalnorm,
                 t
             )
@@ -2481,7 +2489,7 @@ function perform_step!(
                 ) # and its internal counterpart
                 # FIXME this should be stored in the controller cache
                 res = calculate_residuals(
-                    u, utilde, integrator.opts.abstol,
+                    u - utilde, integrator.uprev, u, integrator.opts.abstol,
                     integrator.opts.reltol,
                     integrator.opts.internalnorm, t
                 )
@@ -2751,7 +2759,7 @@ function perform_step!(
             ) # and its internal counterpart
             # FIXME this should be stored in the controller cache
             res = calculate_residuals(
-                u, utilde, integrator.opts.abstol,
+                u - utilde, integrator.uprev, u, integrator.opts.abstol,
                 integrator.opts.reltol, integrator.opts.internalnorm,
                 t
             )
@@ -2833,7 +2841,7 @@ function perform_step!(
                 ) # and its internal counterpart
                 # FIXME this should be stored in the controller cache
                 res = calculate_residuals(
-                    u, utilde, integrator.opts.abstol,
+                    u - utilde, integrator.uprev, u, integrator.opts.abstol,
                     integrator.opts.reltol,
                     integrator.opts.internalnorm, t
                 )
@@ -3215,8 +3223,9 @@ function perform_step!(
             @.. broadcast = false integrator.u = extrapolation_scalars[i + 1] * u_temp1
             @.. broadcast = false cache.utilde = extrapolation_scalars_2[i] * u_temp2
 
+            @.. broadcast = false cache.tmp = integrator.u - cache.utilde
             calculate_residuals!(
-                cache.atmp, integrator.u, cache.utilde,
+                cache.atmp, cache.tmp, integrator.uprev, integrator.u,
                 integrator.opts.abstol, integrator.opts.reltol,
                 integrator.opts.internalnorm, t
             )
@@ -3313,8 +3322,9 @@ function perform_step!(
                 @.. broadcast = false integrator.u = extrapolation_scalars[n_curr + 1] * u_temp1
                 @.. broadcast = false cache.utilde = extrapolation_scalars_2[n_curr] * u_temp2
 
+                @.. broadcast = false cache.tmp = integrator.u - cache.utilde
                 calculate_residuals!(
-                    cache.atmp, integrator.u, cache.utilde,
+                    cache.atmp, cache.tmp, integrator.uprev, integrator.u,
                     integrator.opts.abstol, integrator.opts.reltol,
                     integrator.opts.internalnorm, t
                 )
@@ -3569,7 +3579,7 @@ function perform_step!(
             ) # and its internal counterpart
             # FIXME this should be stored in the controller cache
             res = calculate_residuals(
-                u, utilde, integrator.opts.abstol,
+                u - utilde, integrator.uprev, u, integrator.opts.abstol,
                 integrator.opts.reltol, integrator.opts.internalnorm,
                 t
             )
@@ -3649,7 +3659,7 @@ function perform_step!(
                 ) # and its internal counterpart
                 # FIXME this should be stored in the controller cache
                 res = calculate_residuals(
-                    u, utilde, integrator.opts.abstol,
+                    u - utilde, integrator.uprev, u, integrator.opts.abstol,
                     integrator.opts.reltol,
                     integrator.opts.internalnorm, t
                 )
@@ -4051,8 +4061,9 @@ function perform_step!(
             @.. broadcast = false integrator.u = extrapolation_scalars[i + 1] * u_temp1
             @.. broadcast = false cache.utilde = extrapolation_scalars_2[i] * u_temp2
 
+            @.. broadcast = false cache.tmp = integrator.u - cache.utilde
             calculate_residuals!(
-                cache.atmp, integrator.u, cache.utilde,
+                cache.atmp, cache.tmp, integrator.uprev, integrator.u,
                 integrator.opts.abstol, integrator.opts.reltol,
                 integrator.opts.internalnorm, t
             )
@@ -4147,8 +4158,9 @@ function perform_step!(
                 @.. broadcast = false integrator.u = extrapolation_scalars[n_curr + 1] * u_temp1
                 @.. broadcast = false cache.utilde = extrapolation_scalars_2[n_curr] * u_temp2
 
+                @.. broadcast = false cache.tmp = integrator.u - cache.utilde
                 calculate_residuals!(
-                    cache.atmp, integrator.u, cache.utilde,
+                    cache.atmp, cache.tmp, integrator.uprev, integrator.u,
                     integrator.opts.abstol, integrator.opts.reltol,
                     integrator.opts.internalnorm, t
                 )


### PR DESCRIPTION
Closes #3226.

The form-#2 `calculate_residuals(u₀, u₁, …)` calls in the extrapolation methods
use the difference `u₁ - u₀` as the error estimate but also normalize by
`max(|u₀|, |u₁|)`. Since `u₁`/`utilde` is the lower-order *non-stepped*
extrapolation candidate, its magnitude (and stability) leaked into step-size
control. Per the issue, the denominator should use the actual step endpoints
`max(|uprev|, |u|)`.

## Fix
Self-contained in `OrdinaryDiffEqExtrapolation` (no DiffEqBase change), 24 call sites:
- out-of-place: `calculate_residuals(u - utilde, integrator.uprev, u, …)`
- in-place: stage the difference in `cache.tmp` (a `uType` scratch present in every
  extrapolation cache) and call the explicit-error form
  `calculate_residuals!(cache.atmp, cache.tmp, integrator.uprev, integrator.u, …)`.
  `cache.utilde` is left intact because the convergence monitor reads it afterward.

## Verification
- All seven extrapolation methods (AitkenNeville, Extrapolation/Implicit Midpoint
  Deuflhard & HairerWanner, ImplicitEuler, ImplicitEulerBarycentric) solve
  adaptively with correct accuracy and sensible step/rejection counts, OOP and IIP.
- The full `OrdinaryDiffEqExtrapolation` test suite passes (284/284).
- Before/after adaptive step counts stay in the same ballpark ("not a huge deal",
  as noted in the issue); the corrected denominator actually reduces rejected steps
  for `ImplicitDeuflhardExtrapolation` (46 → 15 on a Van der Pol smoke test).
- Fixed-step convergence tests are unaffected (the change is inside the
  `integrator.opts.adaptive` branch).