### PR TITLE
Document EulerHeun as the two-stage Stratonovich Heun method (#3167)

### DIFF
--- a/lib/StochasticDiffEqLowOrder/Project.toml
+++ b/lib/StochasticDiffEqLowOrder/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqLowOrder"
 uuid = "d15fe365-ce7f-450a-828a-7985bd5b681b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.0"
+version = "2.0.1"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/StochasticDiffEqLowOrder/src/algorithms.jl
+++ b/lib/StochasticDiffEqLowOrder/src/algorithms.jl
@@ -3,6 +3,45 @@ EM(split = true) = EM{split}()
 
 struct SplitEM <: StochasticDiffEqAlgorithm end
 
+"""
+    EulerHeun()
+
+**EulerHeun: Stochastic Euler-Heun Method**
+
+A two-stage predictor-corrector (Heun-type) method for Stratonovich SDEs, the Stratonovich
+analogue of Euler-Maruyama. An Euler step forms the predictor `ũ`, then the drift and
+diffusion are re-evaluated there and trapezoidally averaged to form the update:
+
+  - predictor: `ũ = uₙ + f(uₙ)·Δt + g(uₙ)·ΔW`
+  - corrector: `uₙ₊₁ = uₙ + ½(f(uₙ) + f(ũ))·Δt + ½(g(uₙ) + g(ũ))·ΔW`
+
+This corresponds to the improved-Euler scheme of Roberts (2012). Note this is a genuine
+two-stage scheme (two drift and two diffusion evaluations per step), not a single-stage
+predictor-corrector.
+
+## Method Properties
+
+  - **Strong Order**: 1.0 for Stratonovich SDEs with commutative noise (e.g. scalar,
+    diagonal, or additive); 1/2 for general non-commutative noise, which is the value
+    reported by `alg_order` (the same convention as `EM`)
+  - **Weak Order**: 1.0
+  - **Time stepping**: Fixed step size
+  - **Noise types**: General (scalar, diagonal, non-diagonal)
+  - **SDE interpretation**: Stratonovich
+
+## When to Use
+
+  - For Stratonovich SDEs where a simple, low-cost method is sufficient
+  - As the Stratonovich counterpart to `EM` for Itô problems
+  - When adaptive time stepping is not required; see `LambaEulerHeun` for an adaptive variant
+
+## References
+
+  - Roberts, A.J., "Modify the improved Euler scheme to integrate stochastic differential
+    equations", arXiv:1210.0933 (2012)
+  - Kloeden, P.E., Platen, E., Numerical Solution of Stochastic Differential Equations,
+    Springer, Berlin Heidelberg, p. 373 (1992)
+"""
 struct EulerHeun <: StochasticDiffEqAlgorithm end
 
 struct LambaEM{split} <: StochasticDiffEqAdaptiveAlgorithm end


### PR DESCRIPTION
Fixes #3167.

`EulerHeun`'s implementation is a two-stage Heun predictor-corrector (the Roberts 2012 improved-Euler scheme for Stratonovich SDEs), but its documentation was lost in the migration to `StochasticDiffEqLowOrder` and the original described it as a single-stage predictor-corrector.

This adds an accurate docstring describing:
- the two-stage predictor/corrector (trapezoidal averaging of both drift and diffusion),
- Stratonovich interpretation,
- strong order 1.0 for commutative noise / 1/2 general (matching `alg_order` and the `EM` convention),
- references (Roberts 2012 arXiv:1210.0933; Kloeden & Platen 1992, p. 373).

The order claim is already verified by the existing `stratonovich_convergence_tests.jl` (`𝒪est[:l2] ≈ 1.0` on the linear Stratonovich problems). No behavior or test changes; documentation only. Patch version bump 2.0.0 → 2.0.1.