### PR TITLE
Fix pre-existing Runic formatting failures in callbacks.jl and multi_vcc_mask_tests.jl

### DIFF
--- a/lib/DiffEqBase/src/callbacks.jl
+++ b/lib/DiffEqBase/src/callbacks.jl
@@ -149,15 +149,17 @@ end
     any_vcc = any(is_vcc)
 
     snapshot_winner(i) = is_vcc[i] ? quote
-        copyto!(integrator.callback_cache.winning_simultaneous_events,
-            integrator.callback_cache.simultaneous_events)
-    end : :()
+            copyto!(
+                integrator.callback_cache.winning_simultaneous_events,
+                integrator.callback_cache.simultaneous_events
+            )
+        end : :()
 
     setup = any_vcc ? quote
-        cache = integrator.callback_cache
-        @. cache.prev_simultaneous_events = !iszero(cache.simultaneous_events)
-        fill!(cache.winning_simultaneous_events, Int8(0))
-    end : :()
+            cache = integrator.callback_cache
+            @. cache.prev_simultaneous_events = !iszero(cache.simultaneous_events)
+            fill!(cache.winning_simultaneous_events, Int8(0))
+        end : :()
 
     ex = quote
         $setup
@@ -192,11 +194,13 @@ end
         end
     end
     finalize = any_vcc ? quote
-        if event_occurred
-            copyto!(integrator.callback_cache.simultaneous_events,
-                integrator.callback_cache.winning_simultaneous_events)
+            if event_occurred
+                copyto!(
+                    integrator.callback_cache.simultaneous_events,
+                    integrator.callback_cache.winning_simultaneous_events
+                )
         end
-    end : :()
+        end : :()
     ex = quote
         $ex
         $finalize

--- a/test/Integrators_I/multi_vcc_mask_tests.jl
+++ b/test/Integrators_I/multi_vcc_mask_tests.jl
@@ -49,13 +49,13 @@ using OrdinaryDiffEq, Test
         @test all(length(m) == 1 for (_, m) in fired2)
 
         # cb1's first firing is at u=3 (idx 1), second at u=5 (idx 2)
-        @test fired1[1][1] ≈ 3.0 atol=1e-10
+        @test fired1[1][1] ≈ 3.0 atol = 1.0e-10
         @test fired1[1][2] == Int8[1, 0]
-        @test fired1[2][1] ≈ 5.0 atol=1e-10
+        @test fired1[2][1] ≈ 5.0 atol = 1.0e-10
         @test fired1[2][2] == Int8[0, 1]
 
         # cb2 fires at u=8 (idx 1)
-        @test fired2[1][1] ≈ 8.0 atol=1e-10
+        @test fired2[1][1] ≈ 8.0 atol = 1.0e-10
         @test fired2[1][2] == Int8[1]
     end
 
@@ -69,15 +69,15 @@ using OrdinaryDiffEq, Test
         @test all(length(m) == 2 for (_, m) in fired1)
         @test all(length(m) == 3 for (_, m) in fired3)
 
-        @test fired1[1][1] ≈ 3.0 atol=1e-10
+        @test fired1[1][1] ≈ 3.0 atol = 1.0e-10
         @test fired1[1][2] == Int8[1, 0]
-        @test fired1[2][1] ≈ 5.0 atol=1e-10
+        @test fired1[2][1] ≈ 5.0 atol = 1.0e-10
         @test fired1[2][2] == Int8[0, 1]
 
         # cb3's idx 1 fires at u=4, idx 2 at u=6, idx 3 at u=8
-        idx4 = findfirst(((t, _),) -> isapprox(t, 4.0; atol=1e-10), fired3)
-        idx6 = findfirst(((t, _),) -> isapprox(t, 6.0; atol=1e-10), fired3)
-        idx8 = findfirst(((t, _),) -> isapprox(t, 8.0; atol=1e-10), fired3)
+        idx4 = findfirst(((t, _),) -> isapprox(t, 4.0; atol = 1.0e-10), fired3)
+        idx6 = findfirst(((t, _),) -> isapprox(t, 6.0; atol = 1.0e-10), fired3)
+        idx8 = findfirst(((t, _),) -> isapprox(t, 8.0; atol = 1.0e-10), fired3)
         @test idx4 !== nothing
         @test idx6 !== nothing
         @test idx8 !== nothing


### PR DESCRIPTION
Fixes two pre-existing Runic formatting failures that appear on all open PRs:

- `lib/DiffEqBase/src/callbacks.jl`: re-indent the `quote` block contents inside `snapshot_winner`, `setup`, and `finalize` ternary expressions to match Runic's expected indentation; expand multi-argument `copyto!` calls to one-argument-per-line form
- `test/Integrators_I/multi_vcc_mask_tests.jl`: `atol=1e-10` → `atol = 1.0e-10` and `isapprox(t, v; atol=1e-10)` → `isapprox(t, v; atol = 1.0e-10)` (keyword argument spacing + float literal style)

No logic changes.