### PR TITLE
Make rand_prototype dense for a sparse noise_rate_prototype

### DIFF
--- a/lib/StochasticDiffEq/test/runtests.jl
+++ b/lib/StochasticDiffEq/test/runtests.jl
@@ -132,6 +132,9 @@ const is_APPVEYOR = Sys.iswindows() && haskey(ENV, "APPVEYOR")
         @time @safetestset "Non-diagonal EulerHeun sparse alloc" begin
             include("nondiag_noise_eulerheun_test.jl")
         end
+        @time @safetestset "Sparse noise_rate_prototype Tests" begin
+            include("sparse_noise_tests.jl")
+        end
         @time @safetestset "No Index Tests" begin
             include("noindex_tests.jl")
         end

--- a/lib/StochasticDiffEq/test/sparse_noise_tests.jl
+++ b/lib/StochasticDiffEq/test/sparse_noise_tests.jl
@@ -1,11 +1,5 @@
 using StochasticDiffEq, SparseArrays, Test, Random
 
-Random.seed!(42)
-
-# 4-state system driven by 2 independent Wiener processes.
-# Only states 1 and 3 are coupled to noise; states 2 and 4 are purely deterministic.
-# The noise matrix is 4×2 sparse: g[1,1] = 0.1*u[1], g[3,2] = 0.1*u[3], rest zero.
-
 function f_sparse!(du, u, p, t)
     return du .= -u
 end
@@ -25,23 +19,29 @@ noise_prototype[3, 2] = 1.0
 prob = SDEProblem(f_sparse!, g_sparse!, u0, tspan, noise_rate_prototype = noise_prototype)
 
 @testset "Sparse noise_rate_prototype — EM IIP" begin
+    Random.seed!(42)
     sol = solve(prob, EM(), dt = 0.01)
     @test sol.retcode == ReturnCode.Success
     @test length(sol) > 1
-    # States 2 and 4 have zero noise rows → evolve purely as du/dt = -u → u(1) = exp(-1)
+    # Dimensions 2 and 4 have no noise: pure drift exp(-t)
     @test sol.u[end][2] ≈ exp(-1.0) rtol = 0.02
     @test sol.u[end][4] ≈ exp(-1.0) rtol = 0.02
+    # Dimensions 1 and 3 receive noise: path must deviate from pure drift
+    @test !isapprox(sol.u[end][1], exp(-1.0), rtol = 0.005)
+    @test !isapprox(sol.u[end][3], exp(-1.0), rtol = 0.005)
 end
 
 @testset "Sparse noise_rate_prototype — EulerHeun IIP" begin
+    Random.seed!(42)
     sol = solve(prob, EulerHeun(), dt = 0.01)
     @test sol.retcode == ReturnCode.Success
     @test length(sol) > 1
     @test sol.u[end][2] ≈ exp(-1.0) rtol = 0.02
     @test sol.u[end][4] ≈ exp(-1.0) rtol = 0.02
+    @test !isapprox(sol.u[end][1], exp(-1.0), rtol = 0.005)
+    @test !isapprox(sol.u[end][3], exp(-1.0), rtol = 0.005)
 end
 
-# OOP variant
 function f_sparse_oop(u, p, t)
     return -u
 end
@@ -56,8 +56,11 @@ end
 prob_oop = SDEProblem(f_sparse_oop, g_sparse_oop, u0, tspan, noise_rate_prototype = noise_prototype)
 
 @testset "Sparse noise_rate_prototype — EM OOP" begin
+    Random.seed!(42)
     sol = solve(prob_oop, EM(), dt = 0.01)
     @test sol.retcode == ReturnCode.Success
     @test sol.u[end][2] ≈ exp(-1.0) rtol = 0.02
     @test sol.u[end][4] ≈ exp(-1.0) rtol = 0.02
+    @test !isapprox(sol.u[end][1], exp(-1.0), rtol = 0.005)
+    @test !isapprox(sol.u[end][3], exp(-1.0), rtol = 0.005)
 end

--- a/lib/StochasticDiffEq/test/sparse_noise_tests.jl
+++ b/lib/StochasticDiffEq/test/sparse_noise_tests.jl
@@ -1,0 +1,63 @@
+using StochasticDiffEq, SparseArrays, Test, Random
+
+Random.seed!(42)
+
+# 4-state system driven by 2 independent Wiener processes.
+# Only states 1 and 3 are coupled to noise; states 2 and 4 are purely deterministic.
+# The noise matrix is 4×2 sparse: g[1,1] = 0.1*u[1], g[3,2] = 0.1*u[3], rest zero.
+
+function f_sparse!(du, u, p, t)
+    return du .= -u
+end
+
+function g_sparse!(du, u, p, t)
+    du[1, 1] = 0.1 * u[1]
+    return du[3, 2] = 0.1 * u[3]
+end
+
+u0 = ones(4)
+tspan = (0.0, 1.0)
+
+noise_prototype = spzeros(4, 2)
+noise_prototype[1, 1] = 1.0
+noise_prototype[3, 2] = 1.0
+
+prob = SDEProblem(f_sparse!, g_sparse!, u0, tspan, noise_rate_prototype = noise_prototype)
+
+@testset "Sparse noise_rate_prototype — EM IIP" begin
+    sol = solve(prob, EM(), dt = 0.01)
+    @test sol.retcode == ReturnCode.Success
+    @test length(sol) > 1
+    # States 2 and 4 have zero noise rows → evolve purely as du/dt = -u → u(1) = exp(-1)
+    @test sol.u[end][2] ≈ exp(-1.0) rtol = 0.02
+    @test sol.u[end][4] ≈ exp(-1.0) rtol = 0.02
+end
+
+@testset "Sparse noise_rate_prototype — EulerHeun IIP" begin
+    sol = solve(prob, EulerHeun(), dt = 0.01)
+    @test sol.retcode == ReturnCode.Success
+    @test length(sol) > 1
+    @test sol.u[end][2] ≈ exp(-1.0) rtol = 0.02
+    @test sol.u[end][4] ≈ exp(-1.0) rtol = 0.02
+end
+
+# OOP variant
+function f_sparse_oop(u, p, t)
+    return -u
+end
+
+function g_sparse_oop(u, p, t)
+    du = spzeros(4, 2)
+    du[1, 1] = 0.1 * u[1]
+    du[3, 2] = 0.1 * u[3]
+    return du
+end
+
+prob_oop = SDEProblem(f_sparse_oop, g_sparse_oop, u0, tspan, noise_rate_prototype = noise_prototype)
+
+@testset "Sparse noise_rate_prototype — EM OOP" begin
+    sol = solve(prob_oop, EM(), dt = 0.01)
+    @test sol.retcode == ReturnCode.Success
+    @test sol.u[end][2] ≈ exp(-1.0) rtol = 0.02
+    @test sol.u[end][4] ≈ exp(-1.0) rtol = 0.02
+end

--- a/lib/StochasticDiffEq/test/sparse_noise_tests.jl
+++ b/lib/StochasticDiffEq/test/sparse_noise_tests.jl
@@ -1,0 +1,96 @@
+using StochasticDiffEq, SparseArrays, Test, Random
+
+# Four states driven by two independent Wiener processes. g is structurally sparse:
+# channel 1 drives state 1, channel 2 drives state 3, states 2 and 4 are pure drift.
+
+function f_sparse!(du, u, p, t)
+    return du .= -u
+end
+
+function g_sparse!(du, u, p, t)
+    du[1, 1] = 0.1 * u[1]
+    return du[3, 2] = 0.1 * u[3]
+end
+
+u0 = ones(4)
+tspan = (0.0, 1.0)
+
+noise_prototype = spzeros(4, 2)
+noise_prototype[1, 1] = 1.0
+noise_prototype[3, 2] = 1.0
+
+prob = SDEProblem(f_sparse!, g_sparse!, u0, tspan, noise_rate_prototype = noise_prototype)
+# The same problem with a dense g prototype: the reference the sparse run has to match.
+prob_dense = SDEProblem(
+    f_sparse!, g_sparse!, u0, tspan, noise_rate_prototype = Matrix(noise_prototype)
+)
+
+@testset "Sparse noise_rate_prototype — dW is dense" begin
+    integrator = init(prob, EM(), dt = 0.01)
+    @test !issparse(integrator.W.dW)
+    @test integrator.W.dW isa Vector{Float64}
+end
+
+@testset "Sparse noise_rate_prototype — caches with a dense dZ" begin
+    # W2Ito1 sizes dZ densely no matter what dW is and stores both under one cache
+    # field type, so a sparse dW leaves the cache constructor unresolvable.
+    @test solve(prob, W2Ito1(), dt = 0.01, adaptive = false).retcode == ReturnCode.Success
+end
+
+@testset "Sparse noise_rate_prototype — same path as a dense prototype" begin
+    # RKMilGeneral draws a long dZ for the Lévy area terms. Sparse and dense arrays of
+    # that length take different randn! methods, so the same seed gives a different
+    # realisation unless the prototype is dense.
+    Random.seed!(42)
+    sol_sparse = solve(prob, RKMilGeneral(p = 10), dt = 0.01, adaptive = false)
+    Random.seed!(42)
+    sol_dense = solve(prob_dense, RKMilGeneral(p = 10), dt = 0.01, adaptive = false)
+    @test sol_sparse.u[end] == sol_dense.u[end]
+end
+
+@testset "Sparse noise_rate_prototype — EM IIP" begin
+    Random.seed!(42)
+    sol = solve(prob, EM(), dt = 0.01)
+    @test sol.retcode == ReturnCode.Success
+    @test length(sol) > 1
+    # Dimensions 2 and 4 have no noise: pure drift exp(-t)
+    @test sol.u[end][2] ≈ exp(-1.0) rtol = 0.02
+    @test sol.u[end][4] ≈ exp(-1.0) rtol = 0.02
+    # Dimensions 1 and 3 receive noise: path must deviate from pure drift
+    @test !isapprox(sol.u[end][1], exp(-1.0), rtol = 0.005)
+    @test !isapprox(sol.u[end][3], exp(-1.0), rtol = 0.005)
+end
+
+@testset "Sparse noise_rate_prototype — EulerHeun IIP" begin
+    Random.seed!(42)
+    sol = solve(prob, EulerHeun(), dt = 0.01)
+    @test sol.retcode == ReturnCode.Success
+    @test length(sol) > 1
+    @test sol.u[end][2] ≈ exp(-1.0) rtol = 0.02
+    @test sol.u[end][4] ≈ exp(-1.0) rtol = 0.02
+    @test !isapprox(sol.u[end][1], exp(-1.0), rtol = 0.005)
+    @test !isapprox(sol.u[end][3], exp(-1.0), rtol = 0.005)
+end
+
+function f_sparse_oop(u, p, t)
+    return -u
+end
+
+function g_sparse_oop(u, p, t)
+    du = spzeros(4, 2)
+    du[1, 1] = 0.1 * u[1]
+    du[3, 2] = 0.1 * u[3]
+    return du
+end
+
+prob_oop = SDEProblem(f_sparse_oop, g_sparse_oop, u0, tspan, noise_rate_prototype = noise_prototype)
+
+@testset "Sparse noise_rate_prototype — EM OOP" begin
+    Random.seed!(42)
+    sol = solve(prob_oop, EM(), dt = 0.01)
+    @test sol.retcode == ReturnCode.Success
+    @test sol.u[end][2] ≈ exp(-1.0) rtol = 0.02
+    @test sol.u[end][4] ≈ exp(-1.0) rtol = 0.02
+    @test !isapprox(sol.u[end][1], exp(-1.0), rtol = 0.005)
+    @test !isapprox(sol.u[end][3], exp(-1.0), rtol = 0.005)
+end

--- a/lib/StochasticDiffEqCore/src/solve.jl
+++ b/lib/StochasticDiffEqCore/src/solve.jl
@@ -357,6 +357,10 @@ function _sde_init(
                 rand_prototype = adapt(
                     DiffEqBase.parameterless_type(u), zeros(randElType, size(noise_rate_prototype, 2))
                 )
+            elseif issparse(noise_rate_prototype)
+                # Wiener increments must always be a dense vector regardless of whether
+                # the noise matrix g is sparse; sparse dW has no defined mul! with sparse g.
+                rand_prototype = zeros(randElType, size(noise_rate_prototype, 2))
             else
                 rand_prototype = false .* noise_rate_prototype[1, :]
             end

--- a/lib/StochasticDiffEqCore/src/solve.jl
+++ b/lib/StochasticDiffEqCore/src/solve.jl
@@ -358,8 +358,6 @@ function _sde_init(
                     DiffEqBase.parameterless_type(u), zeros(randElType, size(noise_rate_prototype, 2))
                 )
             elseif issparse(noise_rate_prototype)
-                # Wiener increments must always be a dense vector regardless of whether
-                # the noise matrix g is sparse; sparse dW has no defined mul! with sparse g.
                 rand_prototype = zeros(randElType, size(noise_rate_prototype, 2))
             else
                 rand_prototype = false .* noise_rate_prototype[1, :]

--- a/lib/StochasticDiffEqCore/src/solve.jl
+++ b/lib/StochasticDiffEqCore/src/solve.jl
@@ -400,7 +400,14 @@ function _sde_init(
                 rand_prototype = (u .- u) ./ sqrt(oneunit(t))
             end
         elseif prob isa SciMLBase.AbstractSDEProblem
-            if issparse(u)
+            if issparse(u) || issparse(noise_rate_prototype)
+                # Sparsity in g records which states a channel drives, not which
+                # channels are idle: every column still draws an increment, so dW has
+                # no structural zeros. A sparse dW also breaks caches that keep it and
+                # an unconditionally dense dZ in one field type, and it sends randn!
+                # through the generic AbstractArray loop, which consumes the RNG
+                # differently from the Array method and so changes the path drawn
+                # from a given seed.
                 rand_prototype = adapt(
                     SciMLBase.parameterless_type(u), zeros(randElType, size(noise_rate_prototype, 2))
                 )


### PR DESCRIPTION
When an `SDEProblem` is given a sparse `noise_rate_prototype`, `_sde_init` built the Wiener increment prototype as `false .* noise_rate_prototype[1, :]`, which is a `SparseVector`. That is the wrong shape for the object: the sparsity pattern of `g` records which states a channel drives, not which channels are idle, so every column still draws an increment and `dW` fills in completely on the first step.

Most solvers cope with this, but two do not.

`W2Ito1` fails outright. Its cache keeps `_dW`, `_dZ` and `chi1` under a single `randType` field, and builds `_dZ = zeros(eltype(ΔW), 2)` unconditionally. With a sparse `dW` the three arguments have two different types and there is no applicable constructor:

```julia
using StochasticDiffEq, SparseArrays

f!(du, u, p, t) = (du .= -u)
function g!(du, u, p, t)
    du[1, 1] = 0.1 * u[1]
    du[3, 2] = 0.1 * u[3]
end

np = spzeros(4, 2); np[1, 1] = 1.0; np[3, 2] = 1.0
prob = SDEProblem(f!, g!, ones(4), (0.0, 1.0), noise_rate_prototype = np)

solve(prob, W2Ito1(), dt = 0.01, adaptive = false)
```

```
ERROR: MethodError: no method matching StochasticDiffEqWeak.W2Ito1Cache(
  ::Vector{Float64}, ::Vector{Float64}, ::Vector{Float64},
  ::SparseVector{Float64, Int64}, ::Vector{Float64},
  ::SparseVector{Float64, Int64}, ...)
```

`RKMilGeneral` fails silently, which is worse. It derives its Lévy area `dZ` from the increment prototype through `similar`, so a sparse prototype gives a sparse `dZ` of length 43 for `p = 10` and two noise channels. `randn!` has a specialized method for `Array{Float64}` and a generic `AbstractArray` loop for everything else, and past a small length the two consume the RNG in a different order. Same problem, same seed, sparse versus dense `noise_rate_prototype`:

```
sparse prototype: u[end][1] = 0.34044131290011104
dense  prototype: u[end][1] = 0.34940768585718085
```

The fix folds the sparse `noise_rate_prototype` case into the existing `issparse(u)` branch, which already builds a dense increment through `adapt(SciMLBase.parameterless_type(u), zeros(...))`. Reusing that branch rather than a bare `zeros` keeps the array type of `u`, so a GPU `u` still gets a device-resident increment.

Keeping the increment dense is also cheaper, because the increment type is what the saved noise history stores. 400 states over 200 channels, `EM` at `dt = 1e-3` out to `t = 10`:

```
master: 136.71 MiB, 58 ms
branch:  33.25 MiB, 25 ms
```

## Testing

New file `lib/StochasticDiffEq/test/sparse_noise_tests.jl`, registered in `runtests.jl`. Run against unmodified master it gives 17 passed, 3 failed, 1 errored; on this branch 21 passed. The four that move are the ones above: `integrator.W.dW` is a `Vector{Float64}` rather than a `SparseVector`, `W2Ito1` reaches `ReturnCode.Success` instead of throwing, and `RKMilGeneral(p = 10)` produces the same trajectory from a sparse prototype as from `Matrix(noise_prototype)` with the same seed. The remaining testsets cover `EM` and `EulerHeun` in place and out of place and pass either way.

Also ran the nearby suites on the branch with no change: `nondiag_noise_eulerheun_test` 2/2, `sparsediff_tests` 5/5, `nondiagonal_tests` 5 passed 2 broken, `noise_type_test` 2024/2024, `scalar_noise` 1/1.

This addresses part of #3178. That issue also asks for sparse noise processes that only generate the channels a problem actually uses, which this does not do, so I have not marked it closed.

Two adjacent instances of the same `false .* noise_rate_prototype[1, :]` pattern are left alone, both in DelayDiffEq: `ext/DelayDiffEqStochasticDiffEqCoreExt.jl:48` and `src/utils.jl:435` (`dW_dummy`). They have the identical defect but sit in a different sublibrary, so they are out of scope here.

## AI Disclosure

Claude was used to help investigate the failure and draft this change.
