### PR TITLE
Fix Runic formatting failures in 3 files (callbacks.jl, make.jl, multi_vcc_mask_tests.jl)

### DIFF
--- a/lib/DiffEqBase/src/callbacks.jl
+++ b/lib/DiffEqBase/src/callbacks.jl
@@ -149,15 +149,17 @@ end
     any_vcc = any(is_vcc)
 
     snapshot_winner(i) = is_vcc[i] ? quote
-        copyto!(integrator.callback_cache.winning_simultaneous_events,
-            integrator.callback_cache.simultaneous_events)
-    end : :()
+            copyto!(
+                integrator.callback_cache.winning_simultaneous_events,
+                integrator.callback_cache.simultaneous_events
+            )
+        end : :()
 
     setup = any_vcc ? quote
-        cache = integrator.callback_cache
-        @. cache.prev_simultaneous_events = !iszero(cache.simultaneous_events)
-        fill!(cache.winning_simultaneous_events, Int8(0))
-    end : :()
+            cache = integrator.callback_cache
+            @. cache.prev_simultaneous_events = !iszero(cache.simultaneous_events)
+            fill!(cache.winning_simultaneous_events, Int8(0))
+        end : :()
 
     ex = quote
         $setup
@@ -192,11 +194,13 @@ end
         end
     end
     finalize = any_vcc ? quote
-        if event_occurred
-            copyto!(integrator.callback_cache.simultaneous_events,
-                integrator.callback_cache.winning_simultaneous_events)
+            if event_occurred
+                copyto!(
+                    integrator.callback_cache.simultaneous_events,
+                    integrator.callback_cache.winning_simultaneous_events
+                )
         end
-    end : :()
+        end : :()
     ex = quote
         $ex
         $finalize

--- a/lib/StochasticDiffEq/docs/make.jl
+++ b/lib/StochasticDiffEq/docs/make.jl
@@ -8,8 +8,10 @@ using StochasticDiffEqCore, StochasticDiffEqHighOrder, StochasticDiffEqIIF,
     StochasticDiffEqMilstein, StochasticDiffEqROCK, StochasticDiffEqRODE,
     StochasticDiffEqWeak
 
-cp(joinpath(@__DIR__, "Project.toml"), joinpath(@__DIR__, "src", "assets", "Project.toml"),
-    force = true)
+cp(
+    joinpath(@__DIR__, "Project.toml"), joinpath(@__DIR__, "src", "assets", "Project.toml"),
+    force = true
+)
 
 # Keep pages.jl separate so DiffEqDocs.jl can include it when aggregating these docs.
 include("pages.jl")
@@ -19,10 +21,12 @@ makedocs(
     authors = "Chris Rackauckas et al.",
     clean = true,
     doctest = false,
-    modules = [StochasticDiffEq, StochasticDiffEqCore, StochasticDiffEqHighOrder,
+    modules = [
+        StochasticDiffEq, StochasticDiffEqCore, StochasticDiffEqHighOrder,
         StochasticDiffEqIIF, StochasticDiffEqImplicit, StochasticDiffEqLeaping,
         StochasticDiffEqLowOrder, StochasticDiffEqMilstein, StochasticDiffEqROCK,
-        StochasticDiffEqRODE, StochasticDiffEqWeak],
+        StochasticDiffEqRODE, StochasticDiffEqWeak,
+    ],
     warnonly = [:docs_block, :missing_docs, :eval_block],
     format = Documenter.HTML(
         assets = ["assets/favicon.ico"],

--- a/test/Integrators_I/multi_vcc_mask_tests.jl
+++ b/test/Integrators_I/multi_vcc_mask_tests.jl
@@ -49,13 +49,13 @@ using OrdinaryDiffEq, Test
         @test all(length(m) == 1 for (_, m) in fired2)
 
         # cb1's first firing is at u=3 (idx 1), second at u=5 (idx 2)
-        @test fired1[1][1] ≈ 3.0 atol=1e-10
+        @test fired1[1][1] ≈ 3.0 atol = 1.0e-10
         @test fired1[1][2] == Int8[1, 0]
-        @test fired1[2][1] ≈ 5.0 atol=1e-10
+        @test fired1[2][1] ≈ 5.0 atol = 1.0e-10
         @test fired1[2][2] == Int8[0, 1]
 
         # cb2 fires at u=8 (idx 1)
-        @test fired2[1][1] ≈ 8.0 atol=1e-10
+        @test fired2[1][1] ≈ 8.0 atol = 1.0e-10
         @test fired2[1][2] == Int8[1]
     end
 
@@ -69,15 +69,15 @@ using OrdinaryDiffEq, Test
         @test all(length(m) == 2 for (_, m) in fired1)
         @test all(length(m) == 3 for (_, m) in fired3)
 
-        @test fired1[1][1] ≈ 3.0 atol=1e-10
+        @test fired1[1][1] ≈ 3.0 atol = 1.0e-10
         @test fired1[1][2] == Int8[1, 0]
-        @test fired1[2][1] ≈ 5.0 atol=1e-10
+        @test fired1[2][1] ≈ 5.0 atol = 1.0e-10
         @test fired1[2][2] == Int8[0, 1]
 
         # cb3's idx 1 fires at u=4, idx 2 at u=6, idx 3 at u=8
-        idx4 = findfirst(((t, _),) -> isapprox(t, 4.0; atol=1e-10), fired3)
-        idx6 = findfirst(((t, _),) -> isapprox(t, 6.0; atol=1e-10), fired3)
-        idx8 = findfirst(((t, _),) -> isapprox(t, 8.0; atol=1e-10), fired3)
+        idx4 = findfirst(((t, _),) -> isapprox(t, 4.0; atol = 1.0e-10), fired3)
+        idx6 = findfirst(((t, _),) -> isapprox(t, 6.0; atol = 1.0e-10), fired3)
+        idx8 = findfirst(((t, _),) -> isapprox(t, 8.0; atol = 1.0e-10), fired3)
         @test idx4 !== nothing
         @test idx6 !== nothing
         @test idx8 !== nothing


### PR DESCRIPTION
## What this fixes

The **Runic Format Check** on `master` (HEAD `0bda310`) fails because three files are not Runic-formatted:

- `lib/DiffEqBase/src/callbacks.jl` — `quote`-block indentation inside the `snapshot_winner` / `setup` / `finalize` ternaries, and multi-argument `copyto!` splitting
- `lib/StochasticDiffEq/docs/make.jl` — multi-argument `cp(...)` and the `makedocs` `modules = [...]` array
- `test/Integrators_I/multi_vcc_mask_tests.jl` — `atol=1e-10` → `atol = 1.0e-10`

Ran Runic v1 (`--inplace`). The diff is **pure formatting**, no semantic change (`1e-10 == 1.0e-10`).

### Local verification (Julia 1.10, Runic 1.7.0)
- `Runic.main(["--check", f])` passes on each of the three files after the change.
- `Runic.main(["--check", "."])` on the whole repo returns exit `0` — i.e. the Runic Format Check job will go green.

## Scope note — other `master` reds NOT addressed here

This PR only makes the Runic check green. The remaining `master` failures are out of scope for an in-repo OrdinaryDiffEq formatting change and are tracked separately:

- **`tests / InterfaceIV` (all Julia versions)** — `FieldError: type StaticArrays.LU has no field 'factors'`. Originates in `LinearSolve` `init_cacheval` for `GenericLUFactorization` (`luinst.factors` on a `StaticArrays.LU`, via `ArrayInterface.lu_instance`). StaticArrays 1.9.18's `LU` has fields `L`/`U`/`p`, never `factors`. This is an upstream LinearSolve/ArrayInterface vs StaticArrays issue, not OrdinaryDiffEq code.
- **`tests / AD` (lts)** — Mooncake gradients are numerically wrong (`[-1.0, 0.0]` vs finite-diff `[-0.59, 4.43]`) and an Enzyme `@test_broken` unexpectedly passes. Upstream AD-package behavior.
- **`tests / Regression_II` (lts)** — `UndefVarError: TSRKC2 not defined` in `iipvsoop_tests.jl` on Julia 1.10 only (passes on 1.12 / pre). Under investigation.
- **`tests / Integrators_I` (lts)** — `multi_vcc_mask_tests.jl` callback-firing counts (4 vs expected 2). Needs solver-behavior judgment.
- **`downgrade-sublibraries`** — heterogeneous downgrade-resolution conflicts (TruncatedStacktraces 1.0.0 lacking `@truncate_stacktrace`; SciMLLogging / OrdinaryDiffEqDifferentiation version floors). Cross-repo version coordination.
- **Downstream** (ModelingToolkit, DiffEqCallbacks, PositiveIntegrators, ProbNumDiffEq, SciMLSensitivity) and **TagBot-Subpackages** — downstream / release-automation noise.

Note: PR #3758 fixes two of these three files (callbacks.jl, multi_vcc_mask_tests.jl) but not `lib/StochasticDiffEq/docs/make.jl`; this PR fixes all three so the Runic check goes fully green on its own.

Please ignore until reviewed by @ChrisRackauckas
