### PR TITLE
Export SciMLLogging

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -54,7 +54,7 @@ export CallbackSet, ContinuousCallback, DiscreteCallback, VectorContinuousCallba
 
 # Utilities
 export ReturnCode, derivative_discontinuity!, add_tstop!, ODEAliasSpecifier
-export SciMLBase, remake, successful_retcode, reinit!, set_proposed_dt!
+export SciMLBase, SciMLLogging, remake, successful_retcode, reinit!, set_proposed_dt!
 
 # ADTypes
 export AutoForwardDiff, AutoFiniteDiff, AutoSparse


### PR DESCRIPTION
Think this was supposed to be exported here: https://github.com/SciML/OrdinaryDiffEq.jl/pull/3710/changes, but the export statement was actually never added.