### PR TITLE
Bump DiffEqBase (7.5.6) and OrdinaryDiffEqStabilizedRK (2.3.0): register unreleased TSRKC2 + VCC-mask fixes (lts CI)

### DIFF
--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.5.5"
+version = "7.5.6"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/OrdinaryDiffEqStabilizedRK/Project.toml
+++ b/lib/OrdinaryDiffEqStabilizedRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqStabilizedRK"
 uuid = "358294b1-0aab-51c3-aafe-ad5ab194a2ad"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.0"
+version = "2.3.0"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"


### PR DESCRIPTION
## What this fixes

Two `master` CI test groups fail **only on Julia lts (1.10)**:

- `tests / Regression_II (julia lts)` — `UndefVarError: TSRKC2 not defined` in `test/Regression_II/iipvsoop_tests.jl:149`
- `tests / Integrators_I (julia lts)` — wrong VectorContinuousCallback firing counts/masks (`length(fired1) == 2` evaluated `4 == 2`, etc.) in `test/Integrators_I/multi_vcc_mask_tests.jl`

Both have the **same root cause**: a sublibrary's source was changed but its version was never bumped. On Julia 1.10 the root test groups ignore the `Project.toml` `[sources]` section (unsupported on Julia < 1.11), so `Pkg.test` resolves the **registered** sublibrary builds, which predate the unreleased source changes:

| Sublibrary | Registered version (stale) | Missing source | Symptom |
|---|---|---|---|
| `OrdinaryDiffEqStabilizedRK` | `2.2.0` (tree `f071e65`) | `TSRKC2` method (#3719, added 2026-06-09 after the 2.2.0 bump on 2026-05-14) | `UndefVarError: TSRKC2` |
| `DiffEqBase` | `7.5.5` (tree `c3ab0a3`) | VCC mask fix `snapshot_winner` (#3675) | wrong callback masks/counts |

On Julia 1.12/pre the `[sources]` local paths are honored, so the local (fixed) source is used and both groups pass — exactly matching the observed lts-only failures.

I verified the registered trees directly: registered `OrdinaryDiffEqStabilizedRK 2.2.0` `algorithms.jl` has `for Alg in [:ESERK4, :ESERK5, :RKC, :TSRKC3]` (no `TSRKC2`, zero occurrences), and registered `DiffEqBase 7.5.5` `callbacks.jl` has zero occurrences of `snapshot_winner` (vs 3 in the repo).

## The fix

- `OrdinaryDiffEqStabilizedRK`: `2.2.0` -> `2.3.0` (new exported solver `TSRKC2` = minor bump).
- `DiffEqBase`: `7.5.5` -> `7.5.6` (callback bug fix = patch bump).

Once these versions are registered, Julia 1.10 will resolve builds that contain the fixes and both groups go green. No tests were weakened.

### Local verification (Julia 1.10.11)
With the local `lib/*` sources developed (i.e. what a registered 2.3.0 / 7.5.6 will contain):
- `rkc_algs = [RKC(), ROCK2(), ROCK4(), SERK2(), TSRKC2(), TSRKC3()]` constructs and all six solve (`ReturnCode.Success`).
- `test/Integrators_I/multi_vcc_mask_tests.jl` passes `28/28` with `DiffEqBase 7.5.6` resolved.

## Scope note — other `master` reds NOT addressed here

These are not fixed by this PR because they are upstream / out of scope:

- `tests / InterfaceIV` (all Julia versions) — `FieldError/LoadError: type LU has no field factors` in `sized_matrix_tests.jl`. Originates upstream in LinearSolve/ArrayInterface `lu_instance` for `StaticArrays.LU` (which has `L`/`U`/`p`, not `factors`), not OrdinaryDiffEq code.
- `tests / AD (lts)` — Mooncake gradients numerically wrong and an Enzyme `@test_broken` unexpectedly passing in `autodiff_events.jl`. Upstream AD-package behavior.
- `format-check` (Runic) — handled separately by #3765.
- `Downgrade Sublibraries`, `IntegrationTest` (downstream MTK/SciMLSensitivity/etc.), `TagBot-Subpackages` — cross-repo / downstream / release-automation.

Please ignore until reviewed by @ChrisRackauckas
