### PR TITLE
Fix derivative_discontinuity! breaking integrators without the new field

### DIFF
--- a/lib/DelayDiffEq/src/integrators/interface.jl
+++ b/lib/DelayDiffEq/src/integrators/interface.jl
@@ -214,8 +214,8 @@ identically to the `ODEIntegrator` method, including the order-independent,
 any-`true`-wins merge across simultaneous callbacks; see that method for details.
 """
 function SciMLBase.derivative_discontinuity!(integrator::DDEIntegrator, bool::Bool)
-    # See ODEIntegrator counterpart: plain assignment, merging lives in apply_callback!.
-    integrator.user_set_discontinuity = true
+    # See ODEIntegrator counterpart: plain assignment; the order-independent merge
+    # lives in apply_callback! / apply_discrete_callback!.
     return integrator.derivative_discontinuity = bool
 end
 
@@ -510,7 +510,6 @@ function DiffEqBase.reinit!(
     integrator.iter = 0
     integrator.success_iter = 0
     integrator.derivative_discontinuity = false
-    integrator.user_set_discontinuity = false
 
     # full re-initialize the controller in timestepping
     OrdinaryDiffEqCore.reinit_controller!(integrator, integrator.controller_cache)
@@ -668,7 +667,7 @@ function DiffEqBase.reeval_internals_due_to_modification!(
         ode_integrator.u = integrator.u
     end
 
-    return nothing
+    return integrator.derivative_discontinuity = false
 end
 
 # perform one step

--- a/lib/DelayDiffEq/src/integrators/type.jl
+++ b/lib/DelayDiffEq/src/integrators/type.jl
@@ -90,7 +90,6 @@ mutable struct DDEIntegrator{
     isout::Bool
     reeval_fsal::Bool
     derivative_discontinuity::Bool
-    user_set_discontinuity::Bool
     isdae::Bool
     opts::O
     stats::SciMLBase.DEStats

--- a/lib/DelayDiffEq/src/solve.jl
+++ b/lib/DelayDiffEq/src/solve.jl
@@ -429,7 +429,6 @@ function SciMLBase.__init(
     kshortsize = 0
     reeval_fsal = false
     derivative_discontinuity = false
-    user_set_discontinuity = false
     EEst = oneunit(EEstT) # https://github.com/JuliaPhysics/Measurements.jl/pull/135
     just_hit_tstop = false
     next_step_tstop = false
@@ -509,7 +508,6 @@ function SciMLBase.__init(
         isout,
         reeval_fsal,
         derivative_discontinuity,
-        user_set_discontinuity,
         isdae,
         opts,
         stats,
@@ -641,9 +639,7 @@ function OrdinaryDiffEqCore.initialize_callbacks!(
     end
 
     # reset this as it is now handled so the integrators should proceed as normal
-    integrator.derivative_discontinuity = false
-    integrator.user_set_discontinuity = false
-    return integrator.derivative_discontinuity
+    return integrator.derivative_discontinuity = false
 end
 
 function initialize_tstops_d_discontinuities_propagated(

--- a/lib/DiffEqBase/src/callbacks.jl
+++ b/lib/DiffEqBase/src/callbacks.jl
@@ -558,15 +558,11 @@ function apply_callback!(
         savedexactly || savevalues!(integrator, true)
     end
 
-    # Save step-level state and isolate this callback so we can detect what
-    # *this* affect! said, independent of siblings. After affect! we OR-merge
-    # back so step-level sticky-on-true semantics are preserved across callbacks.
-    prev_dd = integrator.derivative_discontinuity
-    prev_user_set = integrator.user_set_discontinuity
-    integrator.derivative_discontinuity = false
-    integrator.user_set_discontinuity = false
+    # Assume the affect! introduces a derivative discontinuity unless it says
+    # otherwise via derivative_discontinuity!(integrator, false). A `nothing`
+    # affect! makes no modification.
+    integrator.derivative_discontinuity = true
 
-    affect_ran = false
     if callback isa VectorContinuousCallback
         if callback.affect! === nothing
             integrator.derivative_discontinuity = false
@@ -575,40 +571,28 @@ function apply_callback!(
                 integrator,
                 @view(integrator.callback_cache.simultaneous_events[1:(callback.len)])
             )
-            affect_ran = true
         end
     else
         if prev_sign < 0
-            if callback.affect! !== nothing
+            if callback.affect! === nothing
+                integrator.derivative_discontinuity = false
+            else
                 callback.affect!(integrator)
-                affect_ran = true
             end
         elseif prev_sign > 0
-            if callback.affect_neg! !== nothing
+            if callback.affect_neg! === nothing
+                integrator.derivative_discontinuity = false
+            else
                 callback.affect_neg!(integrator)
-                affect_ran = true
             end
         end
     end
 
-    cb_dd = integrator.derivative_discontinuity
-    cb_spoke = integrator.user_set_discontinuity
-    # Default-on if a user affect! ran but did not call derivative_discontinuity!.
-    # If no affect! ran (nothing branch), there is no modification to handle.
-    did_modify = affect_ran && (!cb_spoke || cb_dd)
-
-    if did_modify
+    if integrator.derivative_discontinuity
         reeval_internals_due_to_modification!(
             integrator, callback_initializealg = callback.initializealg
         )
-    end
 
-    # OR-merge step-level state with this callback's contribution. This is what
-    # makes a `true` from any callback survive a sibling's later `false`.
-    integrator.derivative_discontinuity = prev_dd || cb_dd
-    integrator.user_set_discontinuity = prev_user_set || cb_spoke
-
-    if did_modify
         @inbounds if callback.save_positions[2]
             savevalues!(integrator, true)
             if !isdefined(integrator.opts, :save_discretes) || integrator.opts.save_discretes
@@ -638,27 +622,20 @@ end
             savedexactly || savevalues!(integrator, true)
         end
 
-        # See apply_callback! for the rationale of the save / isolate / merge dance.
-        prev_dd = integrator.derivative_discontinuity
-        prev_user_set = integrator.user_set_discontinuity
-        integrator.derivative_discontinuity = false
-        integrator.user_set_discontinuity = false
-
+        # Assume a derivative discontinuity unless the affect! clears it.
+        integrator.derivative_discontinuity = true
         callback.affect!(integrator)
-
-        cb_dd = integrator.derivative_discontinuity
-        cb_spoke = integrator.user_set_discontinuity
-        # Default-on if affect! did not call derivative_discontinuity!.
-        did_modify = !cb_spoke || cb_dd
-
+        # Capture this callback's verdict BEFORE reeval_internals_due_to_modification!
+        # resets derivative_discontinuity to false. Returning the captured value (rather
+        # than re-reading the field) is what makes the OR-fold across simultaneous
+        # callbacks order independent: a true-flagging callback that triggers a reeval
+        # still reports true to the fold in handle_callbacks!.
+        did_modify = integrator.derivative_discontinuity
         if did_modify
             reeval_internals_due_to_modification!(
                 integrator, false, callback_initializealg = callback.initializealg
             )
         end
-
-        integrator.derivative_discontinuity = prev_dd || cb_dd
-        integrator.user_set_discontinuity = prev_user_set || cb_spoke
 
         @inbounds if callback.save_positions[2]
             savevalues!(integrator, true)

--- a/lib/DiffEqBase/test/downstream/callback_merging.jl
+++ b/lib/DiffEqBase/test/downstream/callback_merging.jl
@@ -162,13 +162,13 @@ end
     @test_throws SciMLBase.CommonKwargError sol = solve(prob, Tsit5())
 end
 
-@testset "derivative_discontinuity! sticky-on-true across callbacks" begin
+@testset "derivative_discontinuity! order-independent across callbacks" begin
     # When several callbacks fire on the same step, a derivative discontinuity
     # flagged by *any* callback must survive, regardless of evaluation order and
-    # regardless of other callbacks declaring no discontinuity. The integrator
-    # field is sticky-on-true within a step; an explicit `false` only sticks when
-    # no callback flagged `true`. If no callback calls the setter at all, the
-    # safe default (treat as discontinuity) is preserved.
+    # regardless of other callbacks declaring no discontinuity (any-true-wins). An
+    # explicit `false` only takes effect when no callback flagged `true`. If no
+    # callback calls the setter at all, the safe default (treat as discontinuity)
+    # is preserved.
     prob = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 1.0))
 
     flag_true = DiscreteCallback(
@@ -181,25 +181,30 @@ end
     )
     silent = DiscreteCallback((u, t, integ) -> true, integ -> nothing)
 
-    # Helper: step once and read the post-callback step-level state.
-    function step_flags(cbset)
+    # Helper: step once and read the post-callback step-level discontinuity flag.
+    function step_flag(cbset)
         integ = init(prob, Tsit5(); callback = cbset)
         step!(integ)
-        return integ.derivative_discontinuity, integ.user_set_discontinuity
+        return integ.derivative_discontinuity
     end
 
     # true wins regardless of order
-    @test step_flags(CallbackSet(flag_true, flag_false)) == (true, true)
-    @test step_flags(CallbackSet(flag_false, flag_true)) == (true, true)
+    @test step_flag(CallbackSet(flag_true, flag_false)) == true
+    @test step_flag(CallbackSet(flag_false, flag_true)) == true
 
-    # all-false: explicit false sticks, no recomputation flagged
-    @test step_flags(CallbackSet(flag_false, flag_false)) == (false, true)
+    # all-false: no recomputation flagged
+    @test step_flag(CallbackSet(flag_false, flag_false)) == false
 
-    # no setter call at all: safe default keeps discontinuity, marked unset
-    @test step_flags(CallbackSet(silent)) == (true, false)
+    # no setter call at all: safe default keeps discontinuity
+    @test step_flag(CallbackSet(silent)) == true
 
-    # a silent callback does not suppress another callback's explicit false
-    @test step_flags(CallbackSet(silent, flag_false)) == (true, true)
+    # a silent callback (default-on) is not suppressed by another callback's false
+    @test step_flag(CallbackSet(silent, flag_false)) == true
+
+    # a single true-flagging callback must still register at step level even though
+    # it triggers reeval_internals_due_to_modification! (regression: the verdict was
+    # previously re-read after reeval had cleared the flag, reporting false).
+    @test step_flag(CallbackSet(flag_true)) == true
 
     # full solves complete in both orders
     @test solve(prob, Tsit5(); callback = CallbackSet(flag_true, flag_false)).retcode ==

--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
@@ -74,6 +74,7 @@ function SciMLBase.reeval_internals_due_to_modification!(
         end
     end
 
+    integrator.derivative_discontinuity = false
     return integrator.reeval_fsal = true
 end
 
@@ -167,11 +168,9 @@ without having to account for what sibling callbacks did. Within a single callba
 last call wins.
 """
 function SciMLBase.derivative_discontinuity!(integrator::ODEIntegrator, bool::Bool)
-    # Record the user's request and mark that a callback spoke this step.
-    # Cross-callback any-true-wins merging is handled in apply_callback! /
-    # apply_discrete_callback!, so this setter is a plain assignment: a callback
-    # may freely set false (e.g. callback initialization clears the flag).
-    integrator.user_set_discontinuity = true
+    # A plain assignment: a callback may freely set false. The order-independent
+    # any-true-wins merge across simultaneous callbacks is handled by the per-callback
+    # verdict folding in apply_callback! / apply_discrete_callback!.
     return integrator.derivative_discontinuity = bool
 end
 
@@ -574,7 +573,6 @@ function SciMLBase.reinit!(
     integrator.iter = 0
     integrator.success_iter = 0
     integrator.derivative_discontinuity = false
-    integrator.user_set_discontinuity = false
 
     # full re-initialize the controller in timestepping
     reinit_controller!(integrator, integrator.controller_cache)

--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
@@ -586,8 +586,7 @@ function loopfooter_reset!(integrator)
     # This is set to true if derivative_discontinuity requires callback FSAL reset
     # But not set to false when reset so algorithms can check if reset occurred
     integrator.reeval_fsal = false
-    integrator.derivative_discontinuity = false
-    return integrator.user_set_discontinuity = false
+    return integrator.derivative_discontinuity = false
 end
 
 # Handle force_stepfail in adaptive mode: reduce dt after Newton failure.

--- a/lib/OrdinaryDiffEqCore/src/integrators/type.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/type.jl
@@ -166,7 +166,6 @@ mutable struct ODEIntegrator{
     isout::Bool
     reeval_fsal::Bool
     derivative_discontinuity::Bool
-    user_set_discontinuity::Bool
     reinitialize::Bool
     isdae::Bool
     opts::O

--- a/lib/OrdinaryDiffEqCore/src/solve.jl
+++ b/lib/OrdinaryDiffEqCore/src/solve.jl
@@ -631,7 +631,6 @@ Base.@constprop :aggressive function _ode_init(
     kshortsize = 0
     reeval_fsal = false
     derivative_discontinuity = false
-    user_set_discontinuity = false
     EEst = oneunit(EEstT) # https://github.com/JuliaPhysics/Measurements.jl/pull/135
     just_hit_tstop = false
     next_step_tstop = false
@@ -720,7 +719,7 @@ Base.@constprop :aggressive function _ode_init(
         vector_event_last_time,
         last_event_error, accept_step,
         isout, reeval_fsal,
-        derivative_discontinuity, user_set_discontinuity, reinitialize, isdae,
+        derivative_discontinuity, reinitialize, isdae,
         opts, stats, initializealg, differential_vars,
         fsalfirst, fsallast, _rng,
         W, P, sqdt,
@@ -1062,7 +1061,6 @@ function initialize_callbacks!(integrator, initialize_save = true)
 
     # reset this as it is now handled so the integrators should proceed as normal
     integrator.derivative_discontinuity = false
-    integrator.user_set_discontinuity = false
 
     return if initialize_save
         SciMLBase.save_discretes_if_enabled!(integrator, integrator.opts.callback; skip_duplicates = true)


### PR DESCRIPTION
Note: at the moment, this is a draft AI-assisted PR, I have not yet done an in-depth check. Will open once the logic is verified. Automatic summary below:

------------

PR #3708 added a `user_set_discontinuity` field to ODEIntegrator/DDEIntegrator and made DiffEqBase's apply_callback! / apply_discrete_callback! read and write `integrator.user_set_discontinuity`. Because DiffEqBase depends on no integrator package, that access is an unenforceable cross-package contract: every integrator flowing through the callback dispatch must now carry the field, but no [compat] bound can require it. Integrators lacking it crash with

    type ODEIntegrator has no field user_set_discontinuity

This hit Trixi.jl CI (run 28020198962) via new-DiffEqBase + older-OrdinaryDiffEqCore version skew, and would also break Sundials, StochasticDiffEq, and third-party integrators.

The second field was never necessary. The order-dependence bug #3708 set out to fix lived entirely in apply_discrete_callback!: it returned integrator.derivative_discontinuity AFTER reeval_internals_due_to_modification! had reset it to false, so a true-flagging discrete callback that triggered a reeval reported false and the ||-fold across callbacks lost the discontinuity.

Fix: capture each callback's verdict into a local BEFORE reeval and return that, using only the universal `derivative_discontinuity` field. This keeps the order-independent, any-true-wins behavior (and its test) while removing the cross-package hazard. The `user_set_discontinuity` field, its setters, resets, and constructor args are removed, and the reeval_internals_due_to_modification! clears are restored, so the net change versus pre-#3708 upstream is the one-line capture-before-reeval in apply_discrete_callback!.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
