### PR TITLE
Raise OrdinaryDiffEqCore floor to 4.4 in disco/CommonControllerOptions importers

### DIFF
--- a/lib/ImplicitDiscreteSolve/Project.toml
+++ b/lib/ImplicitDiscreteSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "ImplicitDiscreteSolve"
 uuid = "3263718b-31ed-49cf-8a0f-35a466e8af96"
 authors = ["vyudu <vincent.duyuan@gmail.com>"]
-version = "2.1.1"
+version = "2.1.2"
 
 [deps]
 NonlinearSolveBase = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
@@ -29,7 +29,7 @@ NonlinearSolveBase = "2.23.0"
 OrdinaryDiffEqSDIRK = "2"
 SafeTestsets = "0.1.0"
 SciMLBase = "3.10.0"
-OrdinaryDiffEqCore = "4.1"
+OrdinaryDiffEqCore = "4.4"
 ConcreteStructs = "0.2.3"
 NonlinearSolveFirstOrder = "2.1.1"
 SymbolicIndexingInterface = "0.3.43"

--- a/lib/OrdinaryDiffEqBDF/Project.toml
+++ b/lib/OrdinaryDiffEqBDF/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqBDF"
 uuid = "6ad6398a-0878-4a85-9266-38940aa047c8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.1"
+version = "2.2.2"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -61,7 +61,7 @@ OrdinaryDiffEqDifferentiation = "3"
 OrdinaryDiffEqSDIRK = "2.5"
 TruncatedStacktraces = "1.4"
 SciMLBase = "3.10.0"
-OrdinaryDiffEqCore = "4.1"
+OrdinaryDiffEqCore = "4.4"
 ArrayInterface = "7.19"
 Enzyme = "0.13"
 Preferences = "1.5.0"

--- a/lib/OrdinaryDiffEqExtrapolation/Project.toml
+++ b/lib/OrdinaryDiffEqExtrapolation/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExtrapolation"
 uuid = "becaefa8-8ca2-5cf9-886d-c06f3d2bd2c4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -39,7 +39,7 @@ MuladdMacro = "0.2.1"
 LinearSolve = "3.75.0"
 OrdinaryDiffEqDifferentiation = "3"
 SciMLBase = "3.10.0"
-OrdinaryDiffEqCore = "4.1"
+OrdinaryDiffEqCore = "4.4"
 julia = "1.10"
 ADTypes = "1.22.0"
 RecursiveArrayTools = "4.2.0"

--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFIRK"
 uuid = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.3.0"
+version = "2.3.1"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -46,7 +46,7 @@ LinearSolve = "3.75.0"
 LinearAlgebra = "1.10"
 OrdinaryDiffEqDifferentiation = "3"
 SciMLBase = "3.10.0"
-OrdinaryDiffEqCore = "4.1"
+OrdinaryDiffEqCore = "4.4"
 GenericSchur = "0.5"
 julia = "1.10"
 ADTypes = "1.22.0"

--- a/lib/OrdinaryDiffEqNordsieck/Project.toml
+++ b/lib/OrdinaryDiffEqNordsieck/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNordsieck"
 uuid = "c9986a66-5c92-4813-8696-a7ec84c806c8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
@@ -36,7 +36,7 @@ DiffEqDevTools = "3"
 MuladdMacro = "0.2.1"
 LinearAlgebra = "1.10"
 SciMLBase = "3.10.0"
-OrdinaryDiffEqCore = "4.1"
+OrdinaryDiffEqCore = "4.4"
 julia = "1.10"
 RecursiveArrayTools = "4.2.0"
 ODEProblemLibrary = "1"


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Draft.

## Problem

The `fresh-disco` merge (#3121) added `set_discontinuity` (`OrdinaryDiffEqCore/src/disco.jl`) and a **second type parameter** to `CommonControllerOptions{T, NLPType}` in OrdinaryDiffEqCore, and #3773 released those as **OrdinaryDiffEqCore v4.4.0**. However, the sublibraries that import those new symbols still carried `OrdinaryDiffEqCore = "4.1"` in `[compat]`. That lets the resolver pick a registered OrdinaryDiffEqCore in `[4.1, 4.4)` — e.g. **4.3.0**, which predates the disco merge — that lacks `set_discontinuity` and has the old **one-parameter** `CommonControllerOptions`. The dependents then fail to precompile:

```
WARNING: could not import OrdinaryDiffEqCore.set_discontinuity into OrdinaryDiffEqBDF
ERROR: LoadError: too many parameters for type
  @ .../OrdinaryDiffEqBDF/src/controllers.jl
```

This is the root cause of the master CI **AD (julia lts)** and **ODEInterfaceRegression (julia lts)** failures (both an `OrdinaryDiffEqBDF` precompile error).

## Fix

Raise the `OrdinaryDiffEqCore` floor to `"4.4"` (the version that introduced the imported symbols) in every sublib that imports them, plus a patch version bump:

| sublib | new symbol used |
|---|---|
| OrdinaryDiffEqBDF | `set_discontinuity` + 2-param `CommonControllerOptions` |
| OrdinaryDiffEqFIRK | `set_discontinuity` |
| OrdinaryDiffEqNordsieck | 2-param `CommonControllerOptions` |
| OrdinaryDiffEqExtrapolation | 2-param `CommonControllerOptions` |
| ImplicitDiscreteSolve | 2-param `CommonControllerOptions` |

## Verification (local, Julia 1.10 / lts)

- **Reproduced**: path-`OrdinaryDiffEqBDF` (current master) + registered `OrdinaryDiffEqCore 4.3.0` (allowed by the old `4.1` floor) gives the identical `could not import set_discontinuity` / `too many parameters for type` precompile failure.
- **Fix confirmed**: with the floor at `4.4`, the resolver rejects the bad Core —
  `Unsatisfiable requirements detected for package OrdinaryDiffEqCore: restricted to versions 4.4.0-4 by OrdinaryDiffEqBDF — no versions left`.
- **Positive**: full root env (all path libs, floors bumped) precompiles cleanly and `solve(prob, FBDF())` returns `retcode=Success`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)