### PR TITLE
Handle empty u0 (zero continuous states) in DefaultODEAlgorithm (fixes #3779)

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.4.0"
+version = "4.4.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqCore/src/initdt.jl
+++ b/lib/OrdinaryDiffEqCore/src/initdt.jl
@@ -30,7 +30,7 @@
 
     # With zero continuous states there is nothing to estimate from (and indexing
     # into the empty state would throw), so fall back to a finite default dt.
-    if length(u0) == 0
+    if isempty(u0)
         result_dt = tdir * max(smalldt, dtmin)
         @SciMLMessage(
             lazy"Empty initial state, using default small timestep: dt = $(result_dt)",
@@ -344,7 +344,7 @@ end
 
     # With zero continuous states there is nothing to estimate from, so fall back
     # to a finite default dt rather than indexing into the empty state.
-    if length(u0) == 0
+    if isempty(u0)
         return tdir * max(smalldt, dtmin)
     end
 

--- a/lib/OrdinaryDiffEqCore/src/initdt.jl
+++ b/lib/OrdinaryDiffEqCore/src/initdt.jl
@@ -28,6 +28,17 @@
         return result_dt
     end
 
+    # With zero continuous states there is nothing to estimate from (and indexing
+    # into the empty state would throw), so fall back to a finite default dt.
+    if length(u0) == 0
+        result_dt = tdir * max(smalldt, dtmin)
+        @SciMLMessage(
+            lazy"Empty initial state, using default small timestep: dt = $(result_dt)",
+            integrator.opts.verbose, :shampine_dt
+        )
+        return result_dt
+    end
+
     if eltype(u0) <: Number && !(integrator.alg isa CompositeAlgorithm)
         cache = get_tmp_cache(integrator)
         sk = first(cache)
@@ -328,6 +339,12 @@ end
     smalldt = max(dtmin, convert(_tType, oneunit_tType * 1 // 10^(6)))
 
     if integrator.isdae
+        return tdir * max(smalldt, dtmin)
+    end
+
+    # With zero continuous states there is nothing to estimate from, so fall back
+    # to a finite default dt rather than indexing into the empty state.
+    if length(u0) == 0
         return tdir * max(smalldt, dtmin)
     end
 

--- a/lib/OrdinaryDiffEqTsit5/Project.toml
+++ b/lib/OrdinaryDiffEqTsit5/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqTsit5"
 uuid = "b1df2697-797e-41e3-8120-5422d3b24e4a"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 
 [deps]

--- a/lib/OrdinaryDiffEqTsit5/src/tsit_perform_step.jl
+++ b/lib/OrdinaryDiffEqTsit5/src/tsit_perform_step.jl
@@ -156,9 +156,11 @@ end
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 6)
     if integrator.alg isa CompositeAlgorithm
         g7 = u
-        # Hairer II, page 22 modified to use the Inf norm
+        # Hairer II, page 22 modified to use the Inf norm.
+        # `norm(_, Inf)` rather than `maximum(abs, _)` so an empty state (zero
+        # continuous unknowns) yields 0 instead of reducing over an empty collection.
         integrator.eigen_est = integrator.opts.internalnorm(
-            maximum(abs.((k7 .- k6) ./ (g7 .- g6))), t
+            norm((k7 .- k6) ./ (g7 .- g6), Inf), t
         )
     end
     if integrator.opts.adaptive

--- a/test/InterfaceI/ode_initdt_tests.jl
+++ b/test/InterfaceI/ode_initdt_tests.jl
@@ -72,3 +72,19 @@ integ = init(ODEProblem(((u, p, t) -> u), 0.0f0, (20.0f0, 0.0f0)), Tsit5())
 @test abs(integ.dt) > eps(integ.t)
 integ = init(ODEProblem(((du, u, p, t) -> du .= u), [0.0f0], (20.0f0, 0.0f0)), Tsit5())
 @test abs(integ.dt) > eps(integ.t)
+
+# https://github.com/SciML/OrdinaryDiffEq.jl/issues/3779
+# Automatic dt selection must not index into an empty state vector (zero
+# continuous unknowns), which arises e.g. for purely-discrete/clocked models.
+let
+    empty_iip = ODEProblem((du, u, p, t) -> nothing, Float64[], (0.0, 0.5))
+    empty_oop = ODEProblem((u, p, t) -> u, Float64[], (0.0, 0.5))
+    for prob in (empty_iip, empty_oop)
+        # in-place and out-of-place init-dt paths
+        integ = init(prob, Tsit5())
+        @test isfinite(integ.dt) && integ.dt > 0
+        @test SciMLBase.successful_retcode(solve(prob, Tsit5()))
+        # the default algorithm is a CompositeAlgorithm and used to BoundsError here
+        @test SciMLBase.successful_retcode(solve(prob, DefaultODEAlgorithm()))
+    end
+end


### PR DESCRIPTION
## Summary

Fixes #3779. `solve(prob, DefaultODEAlgorithm())` crashed with a `BoundsError` on an `ODEProblem` with **zero continuous unknowns** (empty `u0`), as produced by purely-discrete/clocked models (MTK + SynchToolkit). `Tsit5()` and `FunctionMap()` solved the same problem fine; only the default algorithm's path crashed.

Investigation surfaced **two** empty-collection bugs on the default-algorithm path (the reported `_ode_initdt` one, plus a second one in the out-of-place Tsit5 step that the first fix exposed):

1. **`_ode_initdt_iip` / `_ode_initdt_oop`** (`OrdinaryDiffEqCore/src/initdt.jl`) indexed into the empty state via `first(u0)` during automatic `dt` selection → `BoundsError`. The iip path only reaches that branch for a `CompositeAlgorithm` (which `DefaultODEAlgorithm` is), which is why plain `Tsit5()` was unaffected. Now guards `length(u0) == 0` and returns a finite default `dt` (`tdir * max(smalldt, dtmin)`), reusing the existing DAE fallback value.

2. **Tsit5 out-of-place stiffness estimate** (`OrdinaryDiffEqTsit5/src/tsit_perform_step.jl`) used `maximum(abs.((k7 .- k6) ./ (g7 .- g6)))`, which errors when reducing over an empty collection. Switched to `norm(_, Inf)`, consistent with the in-place cache a few lines below (which already uses `norm(utilde, Inf)` and so tolerated empty state). The two are equal for non-empty states, so there is **no numerical change** for normal problems; `norm` simply yields `0` for an empty one.

## Verification (run locally, Julia 1.12)

- Reproduced the original `BoundsError` on unmodified source (`DefaultODEAlgorithm()` on empty `u0`).
- With the fix, both `Tsit5()` and `DefaultODEAlgorithm()` return `Success` for empty in-place **and** out-of-place problems.
- New regression test in `test/InterfaceI/ode_initdt_tests.jl` passes (6/6).

```
Test Summary:         | Pass  Total   Time
empty u0 (issue 3779) |    6      6  13.4s
```

Patch-bumped `OrdinaryDiffEqCore` (4.4.0 → 4.4.1) and `OrdinaryDiffEqTsit5` (2.0.0 → 2.0.1). Runic-formatted.

---

**Please ignore until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3M9r7ni3tjdaXqkBq9CUs
