### PR TITLE
OrdinaryDiffEqCore: declare documented API public (downstream ExplicitImports)

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.4.1"
+version = "4.4.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
+++ b/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
@@ -150,6 +150,20 @@ isdiscretecache(cache) = false
 
 unitfulvalue(x) = DiffEqBase.unitfulvalue(x)
 
+# Declare the documented custom-stepsize-controller author interface `public` so downstream
+# packages can drop their `OrdinaryDiffEqCore.X` non-public ExplicitImports ignores. These
+# are the documented "Required methods" of the controller API (docs/src/api/controllers.md).
+# The `public` keyword only parses on Julia >= 1.11.0-DEV.469, so it is gated to keep the
+# 1.10 floor parsing.
+@static if VERSION >= v"1.11.0-DEV.469"
+    eval(
+        Expr(
+            :public,
+            :stepsize_controller!, :step_accept_controller!, :step_reject_controller!
+        )
+    )
+end
+
 include("doc_utils.jl")
 include("misc_utils.jl")
 


### PR DESCRIPTION
Declare OrdinaryDiffEqCore-owned, documented public-API names `public` so downstream packages can drop their `OrdinaryDiffEqCore.X` non-public ExplicitImports ignores. Follows the sibling DiffEqBase public-API declaration (#3785) in this repo.

## Made public (OrdinaryDiffEqCore-owned + documented)

- **`stepsize_controller!`, `step_accept_controller!`, `step_reject_controller!`** — the documented "Required methods" of the custom-stepsize-controller author interface. They appear in the `@docs` block of `docs/src/api/controllers.md` ("Required methods") and each carries a docstring in `src/integrators/controllers.jl`. This is the public interface a downstream package implements to author a custom controller.

## Skipped (with reason)

- **`isdtchangeable`** — a plain algorithm trait (`isdtchangeable(alg) = true`) in `alg_utils.jl` with no docstring and not in any `@docs` block, so it is not documented public API.
- **`fix_dt_at_bounds!`, `increment_reject!`, `initialize_tstops`** — internal step helpers, not documented.

## Rationale

These three are the documented, stable author-interface methods that downstream solver packages reference as `OrdinaryDiffEqCore.X`. Declaring them `public` lets those downstreams drop the corresponding non-public-access ignores from their ExplicitImports QA configuration. Matches the version-gated `@static if VERSION >= v"1.11.0-DEV.469"; eval(Expr(:public, ...)); end` style already used by the DiffEqBase declaration in this repo (the `public` keyword only parses on Julia >= 1.11, so it is gated to keep the 1.10 floor parsing). Bumps `OrdinaryDiffEqCore` 4.4.1 -> 4.4.2 (public-API addition).

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)