### PR TITLE
StochasticDiffEqCore: drop undefined exports checkSRIOrder/checkSRAOrder

### DIFF
--- a/lib/StochasticDiffEqCore/src/StochasticDiffEqCore.jl
+++ b/lib/StochasticDiffEqCore/src/StochasticDiffEqCore.jl
@@ -193,7 +193,4 @@ export TauLeapingDrift
 # General functions
 export solve, init, solve!, step!
 
-# Export misc tools (check functions)
-export checkSRIOrder, checkSRAOrder
-
 end # module


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Problem

The Sublibrary CI fan-out has Aqua **"Undefined exports"** failures across the StochasticDiffEq QA jobs: `StochasticDiffEqCore`, `StochasticDiffEqIIF`, `StochasticDiffEqImplicit`, `StochasticDiffEqLeaping`, `StochasticDiffEqLowOrder`, `StochasticDiffEqMilstein`, `StochasticDiffEqRODE`, `StochasticDiffEqROCK`, `StochasticDiffEqWeak`.

Aqua flags e.g.:
```
Undefined exports: Test Failed
  Evaluated: isempty([Symbol("StochasticDiffEqIIF.checkSRAOrder"), Symbol("StochasticDiffEqIIF.checkSRIOrder")])
```

## Root cause

`lib/StochasticDiffEqCore/src/StochasticDiffEqCore.jl` exported `checkSRIOrder` and `checkSRAOrder` but **never defined them** — they are defined and exported in `StochasticDiffEqHighOrder` (`src/tableaus.jl`). Because most StochasticDiffEq sublibraries do `@reexport using StochasticDiffEqCore`, the bogus export propagated into each of them, so Aqua's undefined-exports check failed everywhere the reexport reached.

## Fix

Remove the `export checkSRIOrder, checkSRAOrder` line from `StochasticDiffEqCore`. The umbrella `StochasticDiffEq` package still exports both functions via its `@reexport using StochasticDiffEqHighOrder`, so the **user-facing API is unchanged**.

This fully greens the QA jobs whose only failing Aqua check was undefined-exports (IIF, Implicit, LowOrder, Milstein, RODE) and removes the undefined-exports failure from Core/Leaping/ROCK/Weak (those have additional, separate Aqua failures tracked elsewhere).

## Verification

Locally on Julia 1.11 (`Aqua.test_all`):
- **Before:** `StochasticDiffEqIIF` undefined-exports check fails (flags `checkSRAOrder`, `checkSRIOrder`).
- **After:** `Aqua.test_all(StochasticDiffEqIIF)` passes **11/11**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)