### PR TITLE
AD: promote Enzyme gradient callback test from @test_broken to @test

### DIFF
--- a/test/AD/autodiff_events.jl
+++ b/test/AD/autodiff_events.jl
@@ -143,7 +143,7 @@ end
 # Enzyme fails on ContinuousCallback with "mixed activity for jl_new_struct"
 if JULIA_VERSION_ALLOWS_ENZYME_ZYGOTE
     @testset "Enzyme callback limitation (gradient)" begin
-        @test_broken (
+        @test (
             g = DI.gradient(θ -> test_f2(θ, ForwardDiffSensitivity()), AutoEnzyme(mode = Enzyme.set_runtime_activity(Enzyme.Reverse)), p);
             g ≈ findiff[2, 1:2]
         )


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Problem

The master **AD** CI job (Julia lts) fails. The "Enzyme callback limitation (gradient)" test in `test/AD/autodiff_events.jl` now returns the correct result, so its `@test_broken` reports an **Unexpected Pass** and errors the whole AD group:

```
Enzyme callback limitation (gradient): Error During Test at test/AD/autodiff_events.jl:146
 Unexpected Pass
 Got correct result, please change to @test if no longer broken.
ERROR: Some tests did not pass: 10 passed, 0 failed, 1 errored, 3 broken.
```

This is a persistent failure (reproduced in the two most recent master CI runs).

## Fix

Promote that single gradient block from `@test_broken` to `@test`. The separate jacobian `@test_broken` (Enzyme "mixed activity for jl_new_struct") is still genuinely broken and is **left untouched**.

## Verification

Reproduced and verified locally on Julia 1.10 (`GROUP=AD` `Pkg.test`):
- **Before:** `Autodiff Events Tests` = 10 pass, **1 error (Unexpected Pass)**, 3 broken → group errors (exit 1).
- **After:** `Autodiff Events Tests` = **11 pass, 3 broken** → `Testing OrdinaryDiffEq tests passed` (exit 0).

> Note for reviewer: the comment above the block (`# Enzyme fails on ContinuousCallback ...`) and the testset name ("...limitation...") are now somewhat stale since this case works. Left as-is to keep the diff minimal — happy to update the wording if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)