### PR TITLE
InterfaceII: shrink AutoSparse OOM-guard problem from 1e7 to 1e6

### DIFF
--- a/test/InterfaceII/autosparse_detection_tests.jl
+++ b/test/InterfaceII/autosparse_detection_tests.jl
@@ -15,7 +15,10 @@ prob = prob_ode_2Dlinear
 
 @test_nowarn solve(prob, FBDF(autodiff = ad))
 
-# Test that no dense matrices are made sparse
-diag_prob = ODEProblem((du, u, p, t) -> du .= -1.0 .* u, rand(Int(1.0e7)), (0, 1.0))
+# Test that no dense matrices are made sparse. The dimension must stay large
+# enough that materializing an N×N Jacobian would be catastrophic (1e6 ⇒ ~8 TB
+# dense), but small enough not to exhaust CI runners on the legitimate
+# matrix-free path (1e7 peaked at ~9 GB and was OOMing self-hosted runners).
+diag_prob = ODEProblem((du, u, p, t) -> du .= -1.0 .* u, rand(Int(1.0e6)), (0, 1.0))
 
 @test_nowarn solve(diag_prob, Rodas5P(autodiff = ad, linsolve = LinearSolve.KrylovJL_GMRES()))


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Problem

The master **InterfaceII** CI jobs (julia 1 and pre) intermittently fail with:
> The self-hosted runner lost communication with the server. ... Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error.

The test step never completes (null conclusion) — **no assertion fails; the runner dies mid-test.** (This is why the job logs were unavailable/incomplete.) It passed minutes earlier on identical code, so it's resource-driven, not a code bug.

## Root cause (measured)

`test/InterfaceII/autosparse_detection_tests.jl` solves a **10⁷-dimensional** diagonal ODE with `Rodas5P` + matrix-free `KrylovJL_GMRES` + `AutoSparse(TracerSparsityDetector())`. The dimension is deliberately huge to guard against a regression where sparsity detection / the linsolve materializes an N×N Jacobian (which would be catastrophic).

But the **legitimate** matrix-free path at 1e7 peaks at **~9.3 GB RSS** (measured locally). On a shared self-hosted runner also running other jobs, that starves the box → "lost communication."

## Fix

Drop the dimension to **1e6**. The guard is unchanged — a materialized 1e6×1e6 Jacobian is ~8 TB and would still blow up immediately, so the regression is still caught. This is a resource right-sizing, not a weakened assertion (same `@test_nowarn solve(...)`).

## Verification (local, Julia 1.11, `GROUP=InterfaceII`)

| | Peak RSS | AutoSparse testset | Result |
|---|---|---|---|
| 1e7 (before) | **9.29 GB** | 4/4 pass, 1m46s | passes |
| 1e6 (after) | **1.90 GB** | 4/4 pass, 1m05s | passes |

4.9× less memory; group still passes.

> Follow-up worth considering: the guard relies on "OOM if wrong" rather than a clean assertion — a real densification regression would still take down the runner instead of failing as a red test. A more robust version would assert the linsolve cache stays matrix-free at a modest N. Left out of this PR to keep it minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)