### PR TITLE
NonlinearSolveAlg: drop duplicate nnonliniter and guard resize firstcall write

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -43,7 +43,6 @@ function initialize!(
     (; ustep, tstep, k, invγdt) = cache
     if SciMLBase.has_stats(integrator)
         integrator.stats.nf += cache.cache.stats.nf
-        integrator.stats.nnonliniter += cache.cache.stats.nsteps
         integrator.stats.njacs += cache.cache.stats.njacs
     end
     if f isa DAEFunction
@@ -70,7 +69,6 @@ function initialize!(
 
     if SciMLBase.has_stats(integrator)
         integrator.stats.nf += cache.cache.stats.nf
-        integrator.stats.nnonliniter += cache.cache.stats.nsteps
         integrator.stats.njacs += cache.cache.stats.njacs
     end
 

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -716,7 +716,7 @@ function resize_nlsolver!(integrator::SciMLBase.DEIntegrator, i::Int)
     nlsolver.alg isa NLNewton && resize!(nlsolver.cache.linsolve, i)
 
     # make it reset everything since the caches changed size!
-    nlsolver.cache.firstcall = true
+    isnewton(nlsolver) && (nlsolver.cache.firstcall = true)
 
     return nothing
 end


### PR DESCRIPTION
Two small correctness fixes in the `NonlinearSolveAlg` path.

## 1. `nnonliniter` stats double-count

`initialize!` for `NLSolver{<:NonlinearSolveAlg}` (both OOP and IIP) accumulates the inner NonlinearSolve cache's stats into `integrator.stats`:

```julia
integrator.stats.nf += cache.cache.stats.nf
integrator.stats.nnonliniter += cache.cache.stats.nsteps
integrator.stats.njacs += cache.cache.stats.njacs
```

But the universal `postamble!` also does `integrator.stats.nnonliniter += nlsolver.iter`. Each outer loop iter triggers exactly one inner `step!(nlcache)`, so `nlsolver.iter == cache.cache.stats.nsteps` — both lines increment by the same N every step, reporting `nnonliniter` ~2× actual. NLNewton doesn't have this since only `postamble!` accounts for it.

Drop the `nnonliniter` line in both `initialize!` sites; keep `nf` and `njacs` since the `postamble!` doesn't cover those for the NonlinearSolveAlg path.

## 2. `resize_nlsolver!` unguarded `firstcall` write

`nlsolver.cache.firstcall = true` is written unconditionally in `resize_nlsolver!`, but only `NLNewtonCache`/`NLNewtonConstantCache` have a `firstcall` field — `NonlinearSolveCache`, `NLFunctionalCache`, `NLAndersonCache` don't. The same write at `postamble!` line 197 is correctly guarded with `isnewton(nlsolver) && (...)`. Match that pattern so resize doesn't blow up on those alg types.