### PR TITLE
NonlinearSolveAlg: pipe wrapprecs into inner alg and update weight per step

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -59,11 +59,19 @@ function initialize!(
         nlsolver::NLSolver{<:NonlinearSolveAlg, true},
         integrator::SciMLBase.DEIntegrator
     )
-    (; uprev, t, p, dt, opts, f) = integrator
+    (; u, uprev, t, p, dt, opts, f) = integrator
     (; z, tmp, ztmp, γ, α, iter, cache, method, alg) = nlsolver
 
     cache.invγdt = inv(dt * nlsolver.γ)
     cache.tstep = integrator.t + nlsolver.c * dt
+
+    if cache.weight !== nothing
+        weight = cache.weight
+        calculate_residuals!(
+            weight, fill!(weight, one(eltype(u))), uprev, u,
+            opts.abstol, opts.reltol, opts.internalnorm, t
+        )
+    end
 
     (; ustep, atmp, tstep, k, invγdt) = cache
 

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -688,6 +688,7 @@ function Base.resize!(nlcache::NonlinearSolveCache, ::AbstractNLSolver, integrat
     nlcache.k === nothing || resize!(nlcache.k, i)
     nlcache.atmp === nothing || resize!(nlcache.atmp, i)
     nlcache.du1 === nothing || resize!(nlcache.du1, i)
+    nlcache.weight === nothing || resize!(nlcache.weight, i)
     nlcache.jac_config === nothing || resize_jac_config!(nlcache, integrator)
     nlcache.W === nothing || resize_J_W!(nlcache, integrator, i)
     nlcache.W_γdt = zero(nlcache.W_γdt)

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
@@ -226,7 +226,7 @@ mutable struct NLAndersonConstantCache{uType, tType, uEltypeNoUnits} <:
     droptol::Union{Nothing, tType}
 end
 
-mutable struct NonlinearSolveCache{uType, tType, rateType, tType2, P, C, JType, WType, ufType, jcType, du1Type} <:
+mutable struct NonlinearSolveCache{uType, tType, rateType, tType2, P, C, JType, WType, ufType, jcType, du1Type, weightType} <:
     AbstractNLSolverCache
     ustep::uType
     tstep::tType
@@ -240,6 +240,7 @@ mutable struct NonlinearSolveCache{uType, tType, rateType, tType2, P, C, JType, 
     uf::ufType
     jac_config::jcType
     du1::du1Type
+    weight::weightType
     W_γdt::tType
     new_W::Bool
 end

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -362,7 +362,7 @@ function build_nlsolver(
                     )
                 end
             end
-            inner_alg = _nlalg_with_linsolve(nlalg.alg, alg.linsolve)
+            inner_alg = _nlalg_with_linsolve(nlalg.alg, wrapprecs(alg.linsolve, W, weight))
             cache = init(prob, inner_alg, verbose = verbose.nonlinear_verbosity)
             nlcache = NonlinearSolveCache(
                 ustep, tstep, k, atmp, invγdt, prob, cache,
@@ -371,6 +371,7 @@ function build_nlsolver(
                 use_w_reuse ? uf : nothing,
                 use_w_reuse ? jac_config : nothing,
                 (use_w_reuse && uf !== nothing) ? du1 : nothing,
+                weight,
                 zero(tstep), true
             )
         else
@@ -512,7 +513,7 @@ function build_nlsolver(
             cache = init(prob, inner_alg, verbose = verbose.nonlinear_verbosity)
             nlcache = NonlinearSolveCache(
                 nothing, tstep, nothing, nothing, invγdt, prob, cache,
-                nothing, nothing, nothing, nothing, nothing,
+                nothing, nothing, nothing, nothing, nothing, nothing,
                 zero(tstep), true
             )
         else

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/linear_nonlinear_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/linear_nonlinear_tests.jl
@@ -1,5 +1,7 @@
 using OrdinaryDiffEqSDIRK, OrdinaryDiffEqBDF, OrdinaryDiffEqRosenbrock, Test, Random,
     LinearAlgebra, LinearSolve, ADTypes
+using OrdinaryDiffEqNonlinearSolve: NonlinearSolveAlg
+using NonlinearSolve: NewtonRaphson
 Random.seed!(123)
 
 A = 0.01 * rand(3, 3)
@@ -162,3 +164,23 @@ sol = @test_nowarn solve(
     )
 );
 @test length(sol.t) < 20
+
+sol = @test_nowarn solve(
+    prob,
+    TRBDF2(
+        autodiff = AutoFiniteDiff(),
+        nlsolve = NonlinearSolveAlg(NewtonRaphson())
+    )
+);
+@test length(sol.t) < 20
+let integ = init(
+        prob,
+        TRBDF2(
+            autodiff = AutoFiniteDiff(),
+            nlsolve = NonlinearSolveAlg(NewtonRaphson())
+        )
+    )
+    @test integ.cache.nlsolver.cache.weight !== nothing
+    step!(integ)
+    @test !iszero(integ.cache.nlsolver.cache.weight)
+end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/linear_nonlinear_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/linear_nonlinear_tests.jl
@@ -184,3 +184,27 @@ let integ = init(
     step!(integ)
     @test !iszero(integ.cache.nlsolver.cache.weight)
 end
+
+sol = @test_nowarn solve(
+    prob,
+    TRBDF2(
+        autodiff = AutoFiniteDiff(),
+        linsolve = KrylovJL_GMRES(),
+        nlsolve = NonlinearSolveAlg(NewtonRaphson()),
+        concrete_jac = true
+    )
+);
+@test length(sol.t) < 20
+let integ = init(
+        prob,
+        TRBDF2(
+            autodiff = AutoFiniteDiff(),
+            linsolve = KrylovJL_GMRES(),
+            nlsolve = NonlinearSolveAlg(NewtonRaphson()),
+            concrete_jac = true
+        )
+    )
+    @test integ.cache.nlsolver.cache.weight !== nothing
+    step!(integ)
+    @test !iszero(integ.cache.nlsolver.cache.weight)
+end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/linear_nonlinear_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/linear_nonlinear_tests.jl
@@ -190,7 +190,7 @@ sol = @test_nowarn solve(
     TRBDF2(
         autodiff = AutoFiniteDiff(),
         linsolve = KrylovJL_GMRES(),
-        nlsolve = NonlinearSolveAlg(NewtonRaphson()),
+        nlsolve = NonlinearSolveAlg(NewtonRaphson(autodiff = AutoFiniteDiff())),
         concrete_jac = true
     )
 );
@@ -200,7 +200,7 @@ let integ = init(
         TRBDF2(
             autodiff = AutoFiniteDiff(),
             linsolve = KrylovJL_GMRES(),
-            nlsolve = NonlinearSolveAlg(NewtonRaphson()),
+            nlsolve = NonlinearSolveAlg(NewtonRaphson(autodiff = AutoFiniteDiff())),
             concrete_jac = true
         )
     )


### PR DESCRIPTION
The NonlinearSolveAlg path builds the same `weight` buffer and `wrapprecs(alg.linsolve, W, weight)` as the NLNewton path, but then drops both:

- `_nlalg_with_linsolve(nlalg.alg, alg.linsolve)` pipes the **bare** `alg.linsolve` into the inner NonlinearSolve, discarding the `wrapprecs` wrapper that NLNewton uses.
- `initialize!` for `NLSolver{<:NonlinearSolveAlg, true}` never calls `calculate_residuals!(weight, ...)`, so even if the precs were piped through they'd be acting on a buffer of zeros.

Net effect: every NonlinearSolveAlg user loses the weight-based diagonal preconditioner that NLNewton enjoys on stiff problems — quietly worse Newton convergence with no warning.

## Fix

1. Add a `weight` field to `NonlinearSolveCache` (parametrized as `weightType` so OOP can pass `nothing`).
2. IIP `build_nlsolver`: pipe `wrapprecs(alg.linsolve, W, weight)` into `_nlalg_with_linsolve`, and store `weight` on the cache.
3. OOP `build_nlsolver`: pass `nothing` for weight, matching the existing OOP NLNewton path which also has no weight buffer.
4. IIP `initialize!` for `NonlinearSolveAlg`: update the `weight` buffer via `calculate_residuals!`, mirroring `initialize!` for `NLSolver{<:NLNewton, true}`.

After this, the precs closure built by `wrapprecs` (a `Returns((Pl, Pr))` that captures `_vec(weight)` by reference) sees fresh weights every step, exactly as for NLNewton.

Diff: +14/−4 across `newton.jl`, `type.jl`, `utils.jl`. OOP path is untouched semantically (only the `NonlinearSolveCache` constructor call gets an extra `nothing` arg).