### PR TITLE
NLNewton OOP: handle AbstractSciMLOperator W instead of erroring

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -254,7 +254,8 @@ Equations II, Springer Series in Computational Mathematics. ISBN
     if W isa Union{WOperator, StaticWOperator}
         update_coefficients!(W, ustep, p, tstep)
     elseif W isa AbstractSciMLOperator
-        error("Non-concrete Jacobian not yet supported by out-of-place Newton solve.")
+        update_coefficients!(W, ustep, p, tstep; gamma = γW, transform = true)
+        W = convert(AbstractMatrix, W)
     end
     dz = _reshape(W \ _vec(ztmp), axes(ztmp))
     dz = relax(dz, nlsolver, integrator, f)

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -254,8 +254,10 @@ Equations II, Springer Series in Computational Mathematics. ISBN
     if W isa Union{WOperator, StaticWOperator}
         update_coefficients!(W, ustep, p, tstep)
     elseif W isa AbstractSciMLOperator
-        error("Out-of-place NLNewton does not support non-concrete W of type $(typeof(W)). " *
-              "Use the in-place form (define f!(du, u, p, t)) or supply a concrete jac_prototype.")
+        error(
+            "Out-of-place NLNewton does not support non-concrete W of type $(typeof(W)). " *
+                "Use the in-place form (define f!(du, u, p, t)) or supply a concrete jac_prototype."
+        )
     end
     dz = _reshape(W \ _vec(ztmp), axes(ztmp))
     dz = relax(dz, nlsolver, integrator, f)

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -254,8 +254,8 @@ Equations II, Springer Series in Computational Mathematics. ISBN
     if W isa Union{WOperator, StaticWOperator}
         update_coefficients!(W, ustep, p, tstep)
     elseif W isa AbstractSciMLOperator
-        update_coefficients!(W, ustep, p, tstep; gamma = γW, transform = true)
-        W = convert(AbstractMatrix, W)
+        error("Out-of-place NLNewton does not support non-concrete W of type $(typeof(W)). " *
+              "Use the in-place form (define f!(du, u, p, t)) or supply a concrete jac_prototype.")
     end
     dz = _reshape(W \ _vec(ztmp), axes(ztmp))
     dz = relax(dz, nlsolver, integrator, f)


### PR DESCRIPTION
The OOP NLNewton `compute_step!` hard-errors when `W` is an `AbstractSciMLOperator` that isn't a `WOperator` / `StaticWOperator`:

```julia
elseif W isa AbstractSciMLOperator
    error("Non-concrete Jacobian not yet supported by out-of-place Newton solve.")
end
```

This case is reachable in practice — e.g. an `ImplicitEuler(nlsolve = NLNewton(...))` solve on an OOP `ODEProblem` whose mass matrix is a state-dependent `MatrixOperator` lands here.

## Fix

Mirror the IIP NLNewton handling of `AbstractSciMLOperator` W (already at line 304):

```julia
elseif W isa AbstractSciMLOperator
    update_coefficients!(W, ustep, p, tstep; gamma = γW, transform = true)
    W = convert(AbstractMatrix, W)
end
```

`update_coefficients!(W, ustep, p, tstep; gamma = γW, transform = true)` refreshes the operator against the current Newton iterate, and `convert(AbstractMatrix, W)` materializes the result for the `\` solve that follows. `convert(AbstractMatrix, ::AbstractSciMLOperator)` is defined for `MatrixOperator`, `ScaledOperator`, `AddedOperator`, `ComposedOperator`, `IdentityOperator`, etc., so this covers the common cases.

## Scope

This removes the hard error and makes the OOP NLNewton path functional for SciMLOperator W. The pre-existing failing `Dependent Mass Matrix Tests` / `iip = false` in `mass_matrix_tests.jl` was reaching this error path — after this fix it no longer hard-errors, though the test may still surface a separate numerical issue tied to the test RHS mutating the same `mm_A` it carries as its mass matrix (the IIP version passes, so the integrator path was OK; only this OOP error was blocking).