### PR TITLE
OOP NonlinearSolveAlg: reuse W with SimpleNonlinearSolve solvers

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.9.3"
+version = "2.9.4"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
@@ -68,7 +68,7 @@ import OrdinaryDiffEqCore: _initialize_dae!,
 import OrdinaryDiffEqDifferentiation: update_W!, is_always_new, build_uf, build_J_W,
     WOperator, StaticWOperator, wrapprecs, default_krylov_warm_start,
     build_jac_config, dolinsolve, set_linear_reltol!,
-    resize_jac_config!, jacobian2W!, jacobian!
+    resize_jac_config!, jacobian2W!, jacobian!, calc_J
 
 import StaticArraysCore: StaticArray
 

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -44,21 +44,42 @@ function initialize!(
     # A no-init cache has no `stats` (SimpleNonlinearSolve builds every solution with
     # `stats === nothing`), and its `reinit!` only remakes the problem without evaluating
     # the residual, so neither the copies below nor the `+1` apply: nothing is counted and
-    # nothing is invented.
+    # nothing is invented. `njacs`/`nw` for a reused `W` are still recorded by
+    # `_update_nlsolvealg_W_oop!` — that assembly is the integrator's own work.
     if SciMLBase.has_stats(integrator) && !(cache.cache isa NonlinearSolveNoInitCache)
         # The `reinit!` below evaluates the residual at the new `z` and *then* zeroes the
         # inner cache's counters, so that evaluation is never visible in
         # `cache.cache.stats.nf`. Left uncounted it loses one `f` call per stage.
         integrator.stats.nf += cache.cache.stats.nf + 1
-        # Under `W` reuse the inner solver's "Jacobian" is `WReuseJac`, which copies the
-        # `W` assembled here rather than evaluating anything, so its `njacs` counts copies
-        # (it tracks `nw`, not Jacobian evaluations). `_update_nlsolvealg_W!` counts the
-        # real ones. Without reuse the inner solver owns the Jacobian and its count stands.
+        # Under `W` reuse the inner solver's "Jacobian" is the `W_ref` closure, which hands
+        # back the `W` assembled here rather than evaluating anything, so its `njacs` counts
+        # reads, not Jacobian evaluations; `calc_J` inside `_update_nlsolvealg_W_oop!`
+        # counts the real ones. Without reuse the inner solver owns the Jacobian and its
+        # count stands.
         if cache.W === nothing
             integrator.stats.njacs += cache.cache.stats.njacs
         end
         integrator.stats.nsolve += cache.cache.stats.nsolve
     end
+
+    if cache.W !== nothing
+        dtgamma = method === DIRK ? γ * dt : γ * dt / α
+        W_γdt = cache.W_γdt
+        first_call = iszero(W_γdt)
+        # No stored `J` on this path (`W` is rebuilt from a fresh Jacobian), so a
+        # dt/gamma drift past the cutoff costs a Jacobian evaluation, not just a
+        # reassembly as in the in-place `new_jac`/`new_w` split.
+        should_update = first_call || alg.always_new ||
+            nlsolver.status === Divergence ||
+            abs(inv(dtgamma) / inv(W_γdt) - 1) > oftype(dtgamma, alg.new_W_dt_cutoff)
+        if should_update
+            _update_nlsolvealg_W_oop!(cache, integrator, dtgamma)
+            cache.new_W = true
+        else
+            cache.new_W = false
+        end
+    end
+
     if f isa DAEFunction
         nlp_params = (tmp, α, tstep, invγdt, p, get_dae_uprev(integrator, uprev), f)
     else
@@ -440,6 +461,17 @@ function residual_to_z_scale(nlsolver, isdae)
         inv(cache.invγdt)
 end
 
+function _update_nlsolvealg_W_oop!(nlcache, integrator, dtgamma)
+    # Same construction as the `StaticWOperator` branch of `calc_W`: `calc_J` picks
+    # user `jac` vs differentiation through `nlcache.uf` and records the evaluation
+    # in `integrator.stats.njacs` — the only njacs the reused-`W` path can count.
+    J_new = calc_J(integrator, nlcache)
+    nlcache.W[] = J_new - integrator.f.mass_matrix * inv(dtgamma)
+    nlcache.W_γdt = dtgamma
+    integrator.stats.nw += 1
+    return nothing
+end
+
 ## compute_step!
 
 @muladd function compute_step!(nlsolver::NLSolver{<:NonlinearSolveAlg, false}, integrator)
@@ -456,6 +488,9 @@ end
         # inner solve; an unsuccessful one is a genuine failure and reaches the step
         # controller the way `NLNewton` reports a failed linear solve. A complete solve
         # leaves no half-taken step behind, so there is nothing for the residual to veto.
+        # The inner residual and linear-solve work is uncounted (no `stats`);
+        # `_update_nlsolvealg_W_oop!` counts the Jacobian and `W` assemblies, which are
+        # the integrator's own share of the work.
         innersol = solve!(nlcache)
         if !SciMLBase.successful_retcode(innersol.retcode)
             return convert(eltype(z), Inf)
@@ -1106,7 +1141,8 @@ function Base.resize!(nlcache::NonlinearSolveCache, ::AbstractNLSolver, integrat
     nlcache.weight === nothing || resize!(nlcache.weight, i)
     nlcache.dz === nothing || resize!(nlcache.dz, i)
     nlcache.jac_config === nothing || resize_jac_config!(nlcache, integrator)
-    nlcache.W === nothing || resize_J_W!(nlcache, integrator, i)
+    # The reused out-of-place `W` is a `Ref` over a static matrix, which has no `resize!`.
+    nlcache.W === nothing || nlcache.W isa Ref || resize_J_W!(nlcache, integrator, i)
     resize_conditioner!(nlcache.precondition, i)
     resize_conditioner!(nlcache.postcondition, i)
     # `nlcache.linsolve` is re-pointed by `initialize!` when it rebuilds the inner cache on the

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -44,18 +44,11 @@ function initialize!(
     # A no-init cache has no `stats` (SimpleNonlinearSolve builds every solution with
     # `stats === nothing`), and its `reinit!` only remakes the problem without evaluating
     # the residual, so neither the copies below nor the `+1` apply: nothing is counted and
-    # nothing is invented. `njacs`/`nw` for a reused `W` are still recorded by
-    # `_update_nlsolvealg_W_oop!` — that assembly is the integrator's own work.
     if SciMLBase.has_stats(integrator) && !(cache.cache isa NonlinearSolveNoInitCache)
         # The `reinit!` below evaluates the residual at the new `z` and *then* zeroes the
         # inner cache's counters, so that evaluation is never visible in
         # `cache.cache.stats.nf`. Left uncounted it loses one `f` call per stage.
         integrator.stats.nf += cache.cache.stats.nf + 1
-        # Under `W` reuse the inner solver's "Jacobian" is the `W_ref` closure, which hands
-        # back the `W` assembled here rather than evaluating anything, so its `njacs` counts
-        # reads, not Jacobian evaluations; `calc_J` inside `_update_nlsolvealg_W_oop!`
-        # counts the real ones. Without reuse the inner solver owns the Jacobian and its
-        # count stands.
         if cache.W === nothing
             integrator.stats.njacs += cache.cache.stats.njacs
         end
@@ -66,9 +59,6 @@ function initialize!(
         dtgamma = method === DIRK ? γ * dt : γ * dt / α
         W_γdt = cache.W_γdt
         first_call = iszero(W_γdt)
-        # No stored `J` on this path (`W` is rebuilt from a fresh Jacobian), so a
-        # dt/gamma drift past the cutoff costs a Jacobian evaluation, not just a
-        # reassembly as in the in-place `new_jac`/`new_w` split.
         should_update = first_call || alg.always_new ||
             nlsolver.status === Divergence ||
             abs(inv(dtgamma) / inv(W_γdt) - 1) > oftype(dtgamma, alg.new_W_dt_cutoff)
@@ -78,6 +68,10 @@ function initialize!(
         else
             cache.new_W = false
         end
+    end
+
+    if cache.cache isa NonlinearSolveNoInitCache
+        return nothing
     end
 
     if f isa DAEFunction
@@ -462,9 +456,6 @@ function residual_to_z_scale(nlsolver, isdae)
 end
 
 function _update_nlsolvealg_W_oop!(nlcache, integrator, dtgamma)
-    # Same construction as the `StaticWOperator` branch of `calc_W`: `calc_J` picks
-    # user `jac` vs differentiation through `nlcache.uf` and records the evaluation
-    # in `integrator.stats.njacs` — the only njacs the reused-`W` path can count.
     J_new = calc_J(integrator, nlcache)
     nlcache.W[] = J_new - integrator.f.mass_matrix * inv(dtgamma)
     nlcache.W_γdt = dtgamma
@@ -482,16 +473,14 @@ end
     nlcache = nlsolver.cache.cache
     if nlcache isa NonlinearSolveNoInitCache
         # A no-init cache holds no iteration state, so it cannot be driven one `step!` at a
-        # time: `solve!` runs the complete inner solve and its returned solution is the only
-        # trustworthy record of it (`get_u` on the cache still reads the *initial* iterate,
-        # and `.stats`/`get_fu` do not exist). Each outer iteration therefore costs one full
-        # inner solve; an unsuccessful one is a genuine failure and reaches the step
         # controller the way `NLNewton` reports a failed linear solve. A complete solve
         # leaves no half-taken step behind, so there is nothing for the residual to veto.
-        # The inner residual and linear-solve work is uncounted (no `stats`);
-        # `_update_nlsolvealg_W_oop!` counts the Jacobian and `W` assemblies, which are
-        # the integrator's own share of the work.
-        innersol = solve!(nlcache)
+        if integrator.f isa DAEFunction
+            nlp_params = (tmp, α, tstep, invγdt, p, dt, uprev, integrator.f)
+        else
+            nlp_params = (tmp, γ, α, tstep, invγdt, method, p, dt, integrator.f)
+        end
+        innersol = solve(NonlinearProblem(nlcache.prob.f, z, nlp_params), nlcache.alg)
         if !SciMLBase.successful_retcode(innersol.retcode)
             return convert(eltype(z), Inf)
         end
@@ -1141,7 +1130,6 @@ function Base.resize!(nlcache::NonlinearSolveCache, ::AbstractNLSolver, integrat
     nlcache.weight === nothing || resize!(nlcache.weight, i)
     nlcache.dz === nothing || resize!(nlcache.dz, i)
     nlcache.jac_config === nothing || resize_jac_config!(nlcache, integrator)
-    # The reused out-of-place `W` is a `Ref` over a static matrix, which has no `resize!`.
     nlcache.W === nothing || nlcache.W isa Ref || resize_J_W!(nlcache, integrator, i)
     resize_conditioner!(nlcache.precondition, i)
     resize_conditioner!(nlcache.postcondition, i)

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -1083,11 +1083,11 @@ function build_nlsolver(
             else
                 (tmp, γ, α, tstep, invγdt, DIRK, p, dt, f)
             end
+            inner_alg = _nlalg_with_linsolve(nlalg.alg, alg.linsolve)
             prob = NonlinearProblem(
                 NonlinearFunction{false, SciMLBase.FullSpecialize}(nlf),
                 copy(ztmp), nlp_params
             )
-            inner_alg = _nlalg_with_linsolve(nlalg.alg, alg.linsolve)
             # Zero tolerances: the integrator owns convergence (see the in-place branch above).
             cache = init(
                 prob, inner_alg; verbose = verbose.nonlinear_verbosity,
@@ -1098,7 +1098,26 @@ function build_nlsolver(
                 ),
                 conditioning_kwargs(precondition, postcondition)...
             )
+            W_ref = nothing
             if cache isa NonlinearSolveNoInitCache
+                # This cache only records the arguments a `solve!` will forward, so
+                # building one is the cheapest way to ask whether the inner solver
+                # iterates, and the answer stays right as SimpleNonlinearSolve grows.
+                if !isdae && f.nlstep_data === nothing && W isa StaticWOperator
+                    # StaticWOperator stores inv(W) in its W field for n <= 7, so the
+                    # Ref holds the plain W matrix; initialize! rewrites it before the
+                    # first solve (W_γdt starts at zero).
+                    W_ref = Ref(W.W)
+                    nlf_jac = let W_ref = W_ref
+                        (z, p) -> W_ref[]
+                    end
+                    prob = NonlinearProblem(
+                        NonlinearFunction{false, SciMLBase.FullSpecialize}(
+                            nlf; jac = nlf_jac, jac_prototype = W.W
+                        ),
+                        copy(ztmp), nlp_params
+                    )
+                end
                 # `solve!`-driven fallback cache: it must keep terminating on its own
                 # default (nonzero) tolerances (see the in-place branch above).
                 cache = init(
@@ -1108,7 +1127,8 @@ function build_nlsolver(
             end
             nlcache = NonlinearSolveCache(
                 nothing, tstep, nothing, nothing, invγdt, prob, cache,
-                nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing,
+                nothing, W_ref, W_ref === nothing ? nothing : uf,
+                nothing, nothing, nothing, nothing, nothing,
                 zero(tstep), true, false, precondition, postcondition
             )
         else

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -1100,13 +1100,7 @@ function build_nlsolver(
             )
             W_ref = nothing
             if cache isa NonlinearSolveNoInitCache
-                # This cache only records the arguments a `solve!` will forward, so
-                # building one is the cheapest way to ask whether the inner solver
-                # iterates, and the answer stays right as SimpleNonlinearSolve grows.
                 if !isdae && f.nlstep_data === nothing && W isa StaticWOperator
-                    # StaticWOperator stores inv(W) in its W field for n <= 7, so the
-                    # Ref holds the plain W matrix; initialize! rewrites it before the
-                    # first solve (W_γdt starts at zero).
                     W_ref = Ref(W.W)
                     nlf_jac = let W_ref = W_ref
                         (z, p) -> W_ref[]

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/linear_nonlinear_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/linear_nonlinear_tests.jl
@@ -212,6 +212,7 @@ end
 
 using StaticArrays
 vdp_static(u, p, t) = SVector(u[2], p[1] * ((1 - u[1]^2) * u[2] - u[1]))
+step_allocs(integ) = @allocated step!(integ)
 let
     prob = ODEProblem(
         vdp_static, SVector(2.0, 0.0), (0.0, 1.0), SVector(1.0e3)
@@ -224,15 +225,17 @@ let
         integ = init(
             prob,
             TRBDF2(nlsolve = NonlinearSolveAlg(inner), concrete_jac = true);
-            reltol = 1.0e-8, abstol = 1.0e-10
+            reltol = 1.0e-8, abstol = 1.0e-10, save_everystep = false
         )
         @test integ.cache.nlsolver.cache.W isa Base.RefValue
+        for _ in 1:50
+            step!(integ)
+        end
+        step_allocs(integ)  # compile the measurement wrapper itself
+        @test step_allocs(integ) == 0
         sol = solve!(integ)
         @test SciMLBase.successful_retcode(sol.retcode)
         @test maximum(abs.(sol.u[end] .- solref.u[end])) < 1.0e-3
-        # These inner solvers report no counters of their own, so every Jacobian the
-        # integrator sees comes from the reused `W`: one evaluation per assembly, and
-        # fewer assemblies than nonlinear iterations because the `W` is held across them.
         @test sol.stats.njacs == sol.stats.nw
         @test 0 < sol.stats.nw < sol.stats.nnonliniter
     end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/linear_nonlinear_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/linear_nonlinear_tests.jl
@@ -1,7 +1,8 @@
 using OrdinaryDiffEqSDIRK, OrdinaryDiffEqBDF, OrdinaryDiffEqRosenbrock, Test, Random,
-    LinearAlgebra, LinearSolve, ADTypes
+    LinearAlgebra, LinearSolve, ADTypes, SciMLBase
 using OrdinaryDiffEqNonlinearSolve: NonlinearSolveAlg
 using NonlinearSolve: NewtonRaphson
+using SimpleNonlinearSolve: SimpleNewtonRaphson, SimpleTrustRegion
 Random.seed!(123)
 
 A = 0.01 * rand(3, 3)
@@ -207,4 +208,32 @@ let integ = init(
     @test integ.cache.nlsolver.cache.weight !== nothing
     step!(integ)
     @test !iszero(integ.cache.nlsolver.cache.weight)
+end
+
+using StaticArrays
+vdp_static(u, p, t) = SVector(u[2], p[1] * ((1 - u[1]^2) * u[2] - u[1]))
+let
+    prob = ODEProblem(
+        vdp_static, SVector(2.0, 0.0), (0.0, 1.0), SVector(1.0e3)
+    )
+    solref = solve(prob, TRBDF2(); reltol = 1.0e-8, abstol = 1.0e-10)
+    for inner in (
+            SimpleNewtonRaphson(; autodiff = AutoForwardDiff()),
+            SimpleTrustRegion(; autodiff = AutoForwardDiff()),
+        )
+        integ = init(
+            prob,
+            TRBDF2(nlsolve = NonlinearSolveAlg(inner), concrete_jac = true);
+            reltol = 1.0e-8, abstol = 1.0e-10
+        )
+        @test integ.cache.nlsolver.cache.W isa Base.RefValue
+        sol = solve!(integ)
+        @test SciMLBase.successful_retcode(sol.retcode)
+        @test maximum(abs.(sol.u[end] .- solref.u[end])) < 1.0e-3
+        # These inner solvers report no counters of their own, so every Jacobian the
+        # integrator sees comes from the reused `W`: one evaluation per assembly, and
+        # fewer assemblies than nonlinear iterations because the `W` is held across them.
+        @test sol.stats.njacs == sol.stats.nw
+        @test 0 < sol.stats.nw < sol.stats.nnonliniter
+    end
 end


### PR DESCRIPTION
Out-of-place `NonlinearSolveAlg` rebuilt the stage Jacobian on every inner iteration; when the inner solver is a SimpleNonlinearSolve algorithm and `W` is a `StaticWOperator`, it now hands the integrator's assembled `W` to the inner solver and keeps it across the step's outer iterations.

On the `SVector` van der Pol (`p = 1e3`, TRBDF2, `reltol = 1e-8`) SimpleNewtonRaphson drops from 22532 inner iterations to 14026 over 1343 `W` assemblies; `@allocated step!(integ) == 0` holds for both inner solvers behind a function barrier. The `njacs` column is not a regression, those inner solvers return `stats = nothing` on master.

`WOperator` is left out until SciMLOperators gains `similar` and `copyto!` for it; the remaining allocation overhead is in `NonlinearSolveNoInitCache`'s `solve!`.

AI Disclosure: Claude assisted with this change.