### PR TITLE
NonlinearSolveCache: define Base.resize! and guard firstcall write

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -670,3 +670,18 @@ function Base.resize!(nlcache::NLNewtonCache, ::AbstractNLSolver, integrator, i:
 
     return nothing
 end
+
+function Base.resize!(nlcache::NonlinearSolveCache, ::AbstractNLSolver, integrator, i::Int)
+    nlcache.ustep === nothing || resize!(nlcache.ustep, i)
+    nlcache.k === nothing || resize!(nlcache.k, i)
+    nlcache.atmp === nothing || resize!(nlcache.atmp, i)
+    nlcache.du1 === nothing || resize!(nlcache.du1, i)
+    nlcache.jac_config === nothing || resize_jac_config!(nlcache, integrator)
+    nlcache.W === nothing || resize_J_W!(nlcache, integrator, i)
+    if nlcache.ustep isa AbstractArray
+        new_prob = SciMLBase.remake(nlcache.prob; u0 = zero(nlcache.ustep))
+        nlcache.prob = new_prob
+        nlcache.cache = init(new_prob, nlcache.cache.alg)
+    end
+    return nothing
+end

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -716,7 +716,7 @@ function resize_nlsolver!(integrator::SciMLBase.DEIntegrator, i::Int)
     nlsolver.alg isa NLNewton && resize!(nlsolver.cache.linsolve, i)
 
     # make it reset everything since the caches changed size!
-    nlsolver.cache.firstcall = true
+    isnewton(nlsolver) && (nlsolver.cache.firstcall = true)
 
     return nothing
 end

--- a/test/Integrators_II/ode_cache_tests.jl
+++ b/test/Integrators_II/ode_cache_tests.jl
@@ -3,6 +3,8 @@ using Random
 using OrdinaryDiffEqDefault
 using ElasticArrays, LinearSolve
 using OrdinaryDiffEqBDF, OrdinaryDiffEqExtrapolation, OrdinaryDiffEqFeagin, OrdinaryDiffEqHighOrderRK, OrdinaryDiffEqLowOrderRK, OrdinaryDiffEqLowStorageRK, OrdinaryDiffEqRosenbrock, OrdinaryDiffEqSDIRK, OrdinaryDiffEqSSPRK
+using OrdinaryDiffEqNonlinearSolve: NonlinearSolveAlg
+using NonlinearSolve: NewtonRaphson
 Random.seed!(213)
 CACHE_TEST_ALGS = [
     Euler(), Midpoint(), RK4(), SSPRK22(), SSPRK33(), SSPRK43(), SSPRK104(),
@@ -75,6 +77,11 @@ sol = solve(prob, TRBDF2(), callback = callback, dt = 1 / 2)
 sol = solve(
     prob, TRBDF2(linsolve = LinearSolve.KrylovJL_GMRES()),
     callback = callback
+)
+@test length(sol.u[end]) > 1
+sol = solve(
+    prob, TRBDF2(nlsolve = NonlinearSolveAlg(NewtonRaphson())),
+    callback = callback, dt = 1 / 2
 )
 @test length(sol.u[end]) > 1
 


### PR DESCRIPTION
`resize!(integrator, N)` on an integrator using `NonlinearSolveAlg` blows up two ways before reaching the actual nlsolver work:

1. `resize!(nlsolver.cache, nlsolver, integrator, i)` falls through to the default at `utils.jl:740`, which calls `Base.resize!(cache::NonlinearSolveCache, i::Int)` — undefined, so MethodError.
2. Then `resize_nlsolver!` does `nlsolver.cache.firstcall = true` unconditionally, but `NonlinearSolveCache` has no `firstcall` field (only `NLNewtonCache`/`NLNewtonConstantCache` do — `NLFunctionalCache` and `NLAndersonCache` also lack it).

## Fix

1. Define `Base.resize!(::NonlinearSolveCache, ::AbstractNLSolver, integrator, i::Int)` mirroring the existing `NLNewtonCache` resize: resize the buffer fields that are populated (`ustep`, `k`, `atmp`, `du1`, `jac_config`, `J/W` via `resize_J_W!`), then `SciMLBase.reinit!(nlcache.cache, zero(nlcache.ustep))` to bring the inner NonlinearSolve cache's `u`/`fu`/`J` to the new size.
2. Guard the `firstcall` write in `resize_nlsolver!` with `isnewton(nlsolver) && (...)`, matching the same pattern already in `postamble!` at `nlsolve.jl:197`.

The `===` `nothing` guards on each field handle both IIP (fields populated) and OOP (most fields `nothing`).

Note: the `firstcall` guard line overlaps with PR #3794 — same one-line change to the same site. Settles cleanly on merge regardless of order.