### PR TITLE
Fix non-inferred Rosenbrock perform_step!

### DIFF
--- a/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_perform_step.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_perform_step.jl
@@ -62,10 +62,11 @@ end
         integrator.opts.internalnorm, t
     )
 
-    linres = dolinsolve(
-        integrator, cache.linsolve;
-        A = (repeat_step || !new_W) ? nothing : W, b = _vec(linsolve_tmp)
-    )
+    if repeat_step || !new_W
+        linres = dolinsolve(integrator, cache.linsolve; b = _vec(linsolve_tmp))
+    else
+        linres = dolinsolve(integrator, cache.linsolve; A = W, b = _vec(linsolve_tmp))
+    end
 
     vecu = _vec(linres.u)
     veck₁ = _vec(k₁)
@@ -177,10 +178,11 @@ end
         integrator.opts.internalnorm, t
     )
 
-    linres = dolinsolve(
-        integrator, cache.linsolve;
-        A = (repeat_step || !new_W) ? nothing : W, b = _vec(linsolve_tmp)
-    )
+    if repeat_step || !new_W
+        linres = dolinsolve(integrator, cache.linsolve; b = _vec(linsolve_tmp))
+    else
+        linres = dolinsolve(integrator, cache.linsolve; A = W, b = _vec(linsolve_tmp))
+    end
 
     vecu = _vec(linres.u)
     veck₁ = _vec(k₁)
@@ -600,10 +602,11 @@ end
         integrator.opts.internalnorm, t
     )
 
-    linres = dolinsolve(
-        integrator, cache.linsolve;
-        A = (repeat_step || !new_W) ? nothing : W, b = _vec(linsolve_tmp)
-    )
+    if repeat_step || !new_W
+        linres = dolinsolve(integrator, cache.linsolve; b = _vec(linsolve_tmp))
+    else
+        linres = dolinsolve(integrator, cache.linsolve; A = W, b = _vec(linsolve_tmp))
+    end
 
     @.. $(_vec(ks[1])) = -linres.u
     integrator.stats.nsolve += 1


### PR DESCRIPTION
Fixes https://github.com/SciML/OrdinaryDiffEq.jl/issues/3800. Flamegraph of perform_step! is blue now:

<img width="2854" height="1910" alt="image" src="https://github.com/user-attachments/assets/bef6dae2-1420-4b49-97c0-a99a7b32d3a1" />
