### PR TITLE
NonlinearSolveCache resize: reset W_γdt and new_W to force fresh W

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -106,7 +106,13 @@ function initialize!(
         else
             nlp_params = (tmp, ustep, γ, α, tstep, k, invγdt, method, p, dt, f)
         end
-        SciMLBase.reinit!(cache.cache, z, p = nlp_params)
+        if length(cache.cache.u) != length(z)
+            new_prob = SciMLBase.remake(cache.prob; u0 = copy(z), p = nlp_params)
+            cache.prob = new_prob
+            cache.cache = init(new_prob, cache.cache.alg)
+        else
+            SciMLBase.reinit!(cache.cache, z, p = nlp_params)
+        end
     end
     return nothing
 end
@@ -678,10 +684,5 @@ function Base.resize!(nlcache::NonlinearSolveCache, ::AbstractNLSolver, integrat
     nlcache.W === nothing || resize_J_W!(nlcache, integrator, i)
     nlcache.W_γdt = zero(nlcache.W_γdt)
     nlcache.new_W = true
-    if nlcache.ustep isa AbstractArray
-        new_prob = SciMLBase.remake(nlcache.prob; u0 = zero(nlcache.ustep))
-        nlcache.prob = new_prob
-        nlcache.cache = init(new_prob, nlcache.cache.alg)
-    end
     return nothing
 end

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -676,6 +676,8 @@ function Base.resize!(nlcache::NonlinearSolveCache, ::AbstractNLSolver, integrat
     nlcache.du1 === nothing || resize!(nlcache.du1, i)
     nlcache.jac_config === nothing || resize_jac_config!(nlcache, integrator)
     nlcache.W === nothing || resize_J_W!(nlcache, integrator, i)
+    nlcache.W_γdt = zero(nlcache.W_γdt)
+    nlcache.new_W = true
     if nlcache.ustep isa AbstractArray
         new_prob = SciMLBase.remake(nlcache.prob; u0 = zero(nlcache.ustep))
         nlcache.prob = new_prob


### PR DESCRIPTION
## Summary

Follow-up to #3799. After resizing the `NonlinearSolveCache`, two things were broken:

1. `W_γdt` and `new_W` were left stale, so the next `initialize!` did not refresh W (the should_update check passed) and the next step worked with a W sized to the old system. Fixed by resetting both in `Base.resize!`.

2. The inner `NonlinearSolveCache.cache` (the NonlinearSolve cache) held internal buffers sized to the old system, and a `remake(prob; u0=...)` + `init` rebuild from inside `Base.resize!` doesn't see the actually-current `nlp_params` (e.g. `ImplicitEuler` reassigns `nlsolver.tmp = uprev` during `perform_step!`, leaving the old build-time `tmp` Array stranded). Fixed by detecting the length mismatch in `initialize!` and rebuilding the inner cache there, where `nlp_params` is freshly assembled from the current `nlsolver` state.

## Test plan
- [x] TRBDF2 + NonlinearSolveAlg + ContinuousCallback resize → `retcode=Success`, `length(sol.u[end]) > 1` (the test added in #3799).
- [x] KenCarp4 + NonlinearSolveAlg + ContinuousCallback resize → `Success`, len > 1.
- [x] ImplicitEuler + NonlinearSolveAlg + ContinuousCallback resize → `Success`, len > 1 (was hard-erroring with `DimensionMismatch` before this fix).