### PR TITLE
ode_cache_tests: cover KenCarp4 and ImplicitEuler with NonlinearSolveAlg

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -106,7 +106,13 @@ function initialize!(
         else
             nlp_params = (tmp, ustep, γ, α, tstep, k, invγdt, method, p, dt, f)
         end
-        SciMLBase.reinit!(cache.cache, z, p = nlp_params)
+        if length(cache.cache.u) != length(z)
+            new_prob = SciMLBase.remake(cache.prob; u0 = copy(z), p = nlp_params)
+            cache.prob = new_prob
+            cache.cache = init(new_prob, cache.cache.alg)
+        else
+            SciMLBase.reinit!(cache.cache, z, p = nlp_params)
+        end
     end
     return nothing
 end
@@ -678,10 +684,5 @@ function Base.resize!(nlcache::NonlinearSolveCache, ::AbstractNLSolver, integrat
     nlcache.W === nothing || resize_J_W!(nlcache, integrator, i)
     nlcache.W_γdt = zero(nlcache.W_γdt)
     nlcache.new_W = true
-    if nlcache.ustep isa AbstractArray
-        new_prob = SciMLBase.remake(nlcache.prob; u0 = zero(nlcache.ustep))
-        nlcache.prob = new_prob
-        nlcache.cache = init(new_prob, nlcache.cache.alg)
-    end
     return nothing
 end

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -676,6 +676,8 @@ function Base.resize!(nlcache::NonlinearSolveCache, ::AbstractNLSolver, integrat
     nlcache.du1 === nothing || resize!(nlcache.du1, i)
     nlcache.jac_config === nothing || resize_jac_config!(nlcache, integrator)
     nlcache.W === nothing || resize_J_W!(nlcache, integrator, i)
+    nlcache.W_γdt = zero(nlcache.W_γdt)
+    nlcache.new_W = true
     if nlcache.ustep isa AbstractArray
         new_prob = SciMLBase.remake(nlcache.prob; u0 = zero(nlcache.ustep))
         nlcache.prob = new_prob

--- a/test/Integrators_II/ode_cache_tests.jl
+++ b/test/Integrators_II/ode_cache_tests.jl
@@ -84,6 +84,16 @@ sol = solve(
     callback = callback, dt = 1 / 2
 )
 @test length(sol.u[end]) > 1
+sol = solve(
+    prob, KenCarp4(nlsolve = NonlinearSolveAlg(NewtonRaphson())),
+    callback = callback, dt = 1 / 2
+)
+@test length(sol.u[end]) > 1
+sol = solve(
+    prob, ImplicitEuler(nlsolve = NonlinearSolveAlg(NewtonRaphson())),
+    callback = callback, dt = 1 / 2
+)
+@test length(sol.u[end]) > 1
 
 for alg in CACHE_TEST_ALGS
     @show alg


### PR DESCRIPTION
## Summary
- Extends the cache resize coverage in [ode_cache_tests.jl](test/Integrators_II/ode_cache_tests.jl) so the TRBDF2+NonlinearSolveAlg case added in #3799 isn't the only implicit method exercised. KenCarp4 and ImplicitEuler now run with `NonlinearSolveAlg(NewtonRaphson())` through the same `ContinuousCallback` resize.
- Stacks on #3803 — both new cases hit the post-resize staleness / size-mismatch path that #3803 fixes. Without #3803 in master, ImplicitEuler errors with `DimensionMismatch` and KenCarp4 returns `retcode=Unstable` instead of `Success`.

## Test plan
- [x] TRBDF2+NSA + resize: existing test from #3799, still passes.
- [x] KenCarp4+NSA + resize: `retcode=Success`, `length(sol.u[end]) > 1`.
- [x] ImplicitEuler+NSA + resize: `length(sol.u[end]) > 1`.