### PR TITLE
QNDFCache: add u/uprev fields so resize! propagates to integrator.u/uprev

### DIFF
--- a/lib/OrdinaryDiffEqBDF/src/bdf_caches.jl
+++ b/lib/OrdinaryDiffEqBDF/src/bdf_caches.jl
@@ -460,6 +460,8 @@ end
         gammaType, uType, uNoUnitsType, StepLimiter,
     } <:
     BDFMutableCache
+    u::uType
+    uprev::uType
     fsalfirst::rateType
     dd::uType
     utilde::uType
@@ -540,8 +542,8 @@ function alg_cache(
     dense = [zero(u) for _ in 1:max_order]
 
     return QNDFCache(
-        fsalfirst, dd, utilde, utildem1, utildep1, ϕ, u₀, nlsolver, U, R, RU, D, Dtmp,
-        tmp2, prevD, 1, 1, Val(max_order), dtprev, 0, 0, EEst1, EEst2, γₖ, atmp,
+        u, uprev, fsalfirst, dd, utilde, utildem1, utildep1, ϕ, u₀, nlsolver, U, R, RU,
+        D, Dtmp, tmp2, prevD, 1, 1, Val(max_order), dtprev, 0, 0, EEst1, EEst2, γₖ, atmp,
         atmpm1, atmpp1, dense, alg.step_limiter!
     )
 end


### PR DESCRIPTION
## Summary

`QNDFCache` was missing `u::uType` and `uprev::uType` fields. The integrator's `resize!(integrator, i)` resizes only the values yielded by `full_cache(cache)`; it does not touch `integrator.u`/`integrator.uprev` directly. Every other implicit cache (`ABDF2Cache`, `SBDFCache`, `MEBDF2Cache`, etc.) keeps refs to the integrator's `u`/`uprev` as struct fields so the `@cache`-generated `full_cache` walks them and `Base.resize!` on the aliased Array updates them in place.

`QNDFCache` omitted those fields, so on a `resize!` callback `integrator.u` stayed at the old length and downstream code (`resize_jac_config!`, perform_step `@.. u = z`) hit `DimensionMismatch`. This is why `QNDF()` lives in `broken_CACHE_TEST_ALGS` in `test/Integrators_II/ode_cache_tests.jl`.

This PR adds the two fields and threads them through `alg_cache`. `perform_step!(integrator, ::QNDFCache, ...)` references `integrator.u`/`uprev` directly (not `cache.u`), so no perform-step changes are needed; the aliasing is purely for the `full_cache` resize walk.

## Test plan

- [ ] CI: the existing `@test_broken` for `QNDF()` in `ode_cache_tests.jl` should now pass (will need a follow-up to promote it to `@test` and remove from `broken_CACHE_TEST_ALGS` once this lands).