### PR TITLE
Allow CUDA.jl v6 in GPU test environments

### DIFF
--- a/lib/OrdinaryDiffEqBDF/test/gpu/Project.toml
+++ b/lib/OrdinaryDiffEqBDF/test/gpu/Project.toml
@@ -7,5 +7,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 path = "../../../OrdinaryDiffEqBDF"
 
 [compat]
-CUDA = "4, 5"
+CUDA = "6"
 OrdinaryDiffEqBDF = "2"

--- a/lib/OrdinaryDiffEqCore/test/gpu/Project.toml
+++ b/lib/OrdinaryDiffEqCore/test/gpu/Project.toml
@@ -24,7 +24,7 @@ path = "../../../DiffEqBase"
 [compat]
 ADTypes = "1"
 Adapt = "4"
-CUDA = "4, 5"
+CUDA = "6"
 ComponentArrays = "0.15"
 DiffEqBase = "7"
 FastBroadcast = "1.3"

--- a/lib/OrdinaryDiffEqDefault/test/gpu/Project.toml
+++ b/lib/OrdinaryDiffEqDefault/test/gpu/Project.toml
@@ -11,6 +11,6 @@ path = "../../../.."
 path = "../../../OrdinaryDiffEqLowOrderRK"
 
 [compat]
-CUDA = "4, 5"
+CUDA = "6"
 OrdinaryDiffEq = "7"
 OrdinaryDiffEqLowOrderRK = "2"

--- a/lib/OrdinaryDiffEqLinear/test/gpu/Project.toml
+++ b/lib/OrdinaryDiffEqLinear/test/gpu/Project.toml
@@ -14,7 +14,7 @@ path = "../../../.."
 path = "../.."
 
 [compat]
-CUDA = "4, 5"
+CUDA = "6"
 OrdinaryDiffEq = "7"
 OrdinaryDiffEqLinear = "2"
 SciMLOperators = "1.4"

--- a/lib/OrdinaryDiffEqLowStorageRK/test/gpu/Project.toml
+++ b/lib/OrdinaryDiffEqLowStorageRK/test/gpu/Project.toml
@@ -12,7 +12,7 @@ path = "../../../.."
 path = "../.."
 
 [compat]
-CUDA = "4, 5"
+CUDA = "6"
 OrdinaryDiffEq = "7"
 OrdinaryDiffEqLowStorageRK = "3"
 SciMLBase = "3"

--- a/lib/OrdinaryDiffEqRKIP/test/gpu/Project.toml
+++ b/lib/OrdinaryDiffEqRKIP/test/gpu/Project.toml
@@ -11,7 +11,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 path = "../../../OrdinaryDiffEqRKIP"
 
 [compat]
-CUDA = "4, 5"
+CUDA = "6"
 FFTW = "1.8"
 OrdinaryDiffEqRKIP = "2"
 SciMLBase = "3"

--- a/lib/OrdinaryDiffEqRosenbrock/test/gpu/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrock/test/gpu/Project.toml
@@ -13,6 +13,6 @@ OrdinaryDiffEqRosenbrock = {path = "../../../OrdinaryDiffEqRosenbrock"}
 
 [compat]
 Adapt = "4"
-CUDA = "4, 5"
+CUDA = "6"
 OrdinaryDiffEqNonlinearSolve = "2"
 OrdinaryDiffEqRosenbrock = "2"

--- a/lib/OrdinaryDiffEqStabilizedRK/test/gpu/Project.toml
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/gpu/Project.toml
@@ -17,7 +17,7 @@ path = "../../../OrdinaryDiffEqLowOrderRK"
 path = "../.."
 
 [compat]
-CUDA = "4, 5"
+CUDA = "6"
 OrdinaryDiffEq = "7"
 OrdinaryDiffEqLowOrderRK = "2"
 OrdinaryDiffEqStabilizedRK = "2"

--- a/lib/StochasticDiffEq/test/gpu/Project.toml
+++ b/lib/StochasticDiffEq/test/gpu/Project.toml
@@ -5,5 +5,5 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-CUDA = "4, 5"
+CUDA = "6"
 DiffEqGPU = "3, 4"

--- a/test/gpu/Project.toml
+++ b/test/gpu/Project.toml
@@ -23,7 +23,7 @@ OrdinaryDiffEqRosenbrock = {path = "../../lib/OrdinaryDiffEqRosenbrock"}
 
 [compat]
 Adapt = "4"
-CUDA = "4, 5"
+CUDA = "6"
 ComponentArrays = "0.15"
 DiffEqBase = "7"
 FastBroadcast = "1.3"


### PR DESCRIPTION
## Summary

The GPU test environments pin CUDA.jl to `"4, 5"`. The V100 GPU CI runners now run nvidia driver 580, which requires CUDA.jl **v6.2+** — versions below 6.2 select the CUDA runtime based on the driver version and pick an incompatible runtime, causing GPU CI to fail (e.g. [this run](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/28388992836/job/84170145141)). The fix landed in [JuliaGPU/CUDA.jl#3134](https://github.com/JuliaGPU/CUDA.jl/pull/3134) (see also [issue #3079](https://github.com/JuliaGPU/CUDA.jl/issues/3079)).

This widens the CUDA compat in the GPU test environments to `"6"` so the resolver picks the latest 6.x (currently ≥6.2), which contains the runtime-selection fix.

## Changes

- Bump `CUDA` compat from `"4, 5"` to `"6"` in the 10 `test/gpu/Project.toml` files: the root test env plus `OrdinaryDiffEqBDF`, `OrdinaryDiffEqCore`, `OrdinaryDiffEqDefault`, `OrdinaryDiffEqLinear`, `OrdinaryDiffEqLowStorageRK`, `OrdinaryDiffEqRKIP`, `OrdinaryDiffEqRosenbrock`, `OrdinaryDiffEqStabilizedRK`, and `StochasticDiffEq`.

Test-environment-only; no package compat or version is affected.
