### PR TITLE
Multirate: add solve-decoupled implicit MRI-GARK-IRK21a (order 2) (#961)

### DIFF
--- a/lib/OrdinaryDiffEqMultirate/Project.toml
+++ b/lib/OrdinaryDiffEqMultirate/Project.toml
@@ -1,20 +1,24 @@
 name = "OrdinaryDiffEqMultirate"
 uuid = "d4b830b4-ac80-426b-8507-16693d424963"
 authors = ["singhharsh1708 <hs1663531@gmail.com>"]
-version = "2.3.0"
+version = "2.4.0"
 
 [deps]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+OrdinaryDiffEqDifferentiation = "4302a76b-040a-498a-8c04-15b101fed76b"
 OrdinaryDiffEqLowOrderRK = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
+OrdinaryDiffEqNonlinearSolve = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [compat]
+ADTypes = "1.22.0"
 Aqua = "0.8.11"
 DiffEqBase = "7"
 DiffEqDevTools = "3"
@@ -22,7 +26,9 @@ FastBroadcast = "1.3"
 JET = "0.9, 0.11"
 MuladdMacro = "0.2.1"
 OrdinaryDiffEqCore = "4"
+OrdinaryDiffEqDifferentiation = "3"
 OrdinaryDiffEqLowOrderRK = "2"
+OrdinaryDiffEqNonlinearSolve = "2"
 Pkg = "1"
 RecursiveArrayTools = "4.2.0"
 Reexport = "1.2.2"
@@ -50,8 +56,14 @@ path = "../DiffEqDevTools"
 [sources.OrdinaryDiffEqCore]
 path = "../OrdinaryDiffEqCore"
 
+[sources.OrdinaryDiffEqDifferentiation]
+path = "../OrdinaryDiffEqDifferentiation"
+
 [sources.OrdinaryDiffEqLowOrderRK]
 path = "../OrdinaryDiffEqLowOrderRK"
+
+[sources.OrdinaryDiffEqNonlinearSolve]
+path = "../OrdinaryDiffEqNonlinearSolve"
 
 [targets]
 test = ["DiffEqDevTools", "LinearAlgebra", "OrdinaryDiffEqLowOrderRK", "SafeTestsets", "Test", "Pkg"]

--- a/lib/OrdinaryDiffEqMultirate/src/OrdinaryDiffEqMultirate.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/OrdinaryDiffEqMultirate.jl
@@ -1,18 +1,23 @@
 module OrdinaryDiffEqMultirate
 
 import OrdinaryDiffEqCore: alg_order, isfsal,
-    OrdinaryDiffEqAdaptiveAlgorithm,
+    OrdinaryDiffEqAdaptiveAlgorithm, OrdinaryDiffEqNewtonAdaptiveAlgorithm,
     generic_solver_docstring,
     unwrap_alg, initialize!, perform_step!,
     calculate_residuals, calculate_residuals!,
     OrdinaryDiffEqMutableCache, OrdinaryDiffEqConstantCache,
-    @cache, alg_cache, full_cache, get_fsalfirstlast
+    @cache, alg_cache, full_cache, get_fsalfirstlast,
+    nlsolve_f, issplit, _fixup_ad, _unwrap_val
 import OrdinaryDiffEqCore
 import FastBroadcast: @..
 import MuladdMacro: @muladd
 import RecursiveArrayTools: recursivefill!
 import DiffEqBase: prepare_alg
 import LinearAlgebra
+using SciMLBase: SplitFunction
+using OrdinaryDiffEqNonlinearSolve: build_nlsolver, nlsolve!, nlsolvefail,
+    markfirststage!, isnewton, set_new_W!, NLNewton
+import ADTypes: AutoForwardDiff
 
 using Reexport
 @reexport using SciMLBase
@@ -23,6 +28,7 @@ include("multirate_tableaus.jl")
 include("multirate_caches.jl")
 include("multirate_perform_step.jl")
 
-export MREEF, MRAB, MRIGARKERK22a, MRIGARKERK22b, MRIGARKERK33a, MRIGARKERK45a, MIS
+export MREEF, MRAB, MRIGARKERK22a, MRIGARKERK22b, MRIGARKERK33a, MRIGARKERK45a,
+    MRIGARKIRK21a, MIS
 
 end

--- a/lib/OrdinaryDiffEqMultirate/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/alg_utils.jl
@@ -27,6 +27,16 @@ function prepare_alg(
     return alg
 end
 
+alg_order(::MRIGARKIRK21a) = 2
+isfsal(::MRIGARKIRK21a) = false
+
+function prepare_alg(alg::MRIGARKIRK21a, u0::AbstractArray, p, prob)
+    alg.m >= 1 || throw(ArgumentError("MRIGARKIRK21a: `m` must be ≥ 1"))
+    return alg
+end
+
+nlsolve_f(f, ::MRIGARKIRK21a) = f isa SplitFunction ? f.f2 : f
+
 alg_order(::MIS) = 2
 isfsal(::MIS) = false
 

--- a/lib/OrdinaryDiffEqMultirate/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/algorithms.jl
@@ -181,6 +181,49 @@ Base.@kwdef struct MRIGARKERK45a <: OrdinaryDiffEqAdaptiveAlgorithm
 end
 
 @doc generic_solver_docstring(
+    "Multirate Infinitesimal GARK — 2nd-order solve-decoupled implicit (MRI-GARK-IRK21a).
+
+Solves a SplitODE `du/dt = f1(u,t) + f2(u,t)` where `f1` is the fast component
+and `f2` is the slow component (SciML convention). 2nd-order solve-decoupled
+implicit MRI-GARK method of Sandu 2019: the fast component is integrated over the
+step with `m` explicit-midpoint inner micro-steps and a frozen slow forcing, then
+a final `Δc = 0` stage applies an implicit trapezoidal correction that requires a
+nonlinear solve in the slow rate `f2`. Suited to problems whose slow component is
+itself stiff — the case explicit MRI-GARK cannot handle.",
+    "MRIGARKIRK21a",
+    "Multirate infinitesimal GARK solve-decoupled implicit method.",
+    """@article{sandu2019class,
+    title={A class of multirate infinitesimal {GARK} methods},
+    author={Sandu, Adrian},
+    journal={SIAM Journal on Numerical Analysis},
+    volume={57},
+    number={5},
+    pages={2300--2327},
+    year={2019}}""",
+    """
+    - `m`: number of inner midpoint micro-steps for the fast stage.
+    """,
+    """
+    m::Int,
+    """
+)
+struct MRIGARKIRK21a{AD, F, F2, CJ} <: OrdinaryDiffEqNewtonAdaptiveAlgorithm
+    m::Int
+    linsolve::F
+    nlsolve::F2
+    autodiff::AD
+    concrete_jac::CJ
+end
+
+function MRIGARKIRK21a(;
+        m::Int, autodiff = AutoForwardDiff(), concrete_jac = nothing,
+        linsolve = nothing, nlsolve = NLNewton()
+    )
+    autodiff = _fixup_ad(autodiff)
+    return MRIGARKIRK21a(m, linsolve, nlsolve, autodiff, _unwrap_val(concrete_jac))
+end
+
+@doc generic_solver_docstring(
     "Multirate Infinitesimal Step (MIS).
 
 Solves a split ODE of the form `du/dt = f1(u,t) + f2(u,t)` where `f1` is the

--- a/lib/OrdinaryDiffEqMultirate/src/multirate_caches.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/multirate_caches.jl
@@ -151,6 +151,79 @@ function alg_cache(
     return MRIGARKConstantCache(mri_gark_tableau(alg, eltype(u)))
 end
 
+mutable struct MRIGARKImplicitConstantCache{N, TabType} <: OrdinaryDiffEqConstantCache
+    nlsolver::N
+    tab::TabType
+end
+
+@cache mutable struct MRIGARKImplicitCache{uType, rateType, uNoUnitsType, N, TabType} <:
+    OrdinaryDiffEqMutableCache
+    u::uType
+    uprev::uType
+    tmp::uType
+    atmp::uNoUnitsType
+    v::uType
+    vtmp::uType
+    f1eval::rateType
+    kk::Vector{uType}
+    z::Vector{uType}
+    fS::Vector{rateType}
+    fsalfirst::rateType
+    k::rateType
+    nlsolver::N
+    tab::TabType
+end
+
+get_fsalfirstlast(cache::MRIGARKImplicitCache, u) = (cache.fsalfirst, cache.k)
+
+_mrigark_impl_γ(tab) = tab.γ0[findfirst(!iszero, tab.γ0)]
+
+function alg_cache(
+        alg::MRIGARKIRK21a, u, rate_prototype,
+        ::Type{uEltypeNoUnits}, ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits},
+        uprev, uprev2, f, t, dt, reltol, p, calck,
+        ::Val{true}, verbose
+    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    tab = mri_gark_tableau(alg, eltype(u))
+    s = length(tab.Δc)
+    γ = _mrigark_impl_γ(tab)
+    c = one(tTypeNoUnits)
+    nlsolver = build_nlsolver(
+        alg, u, uprev, p, t, dt, f, rate_prototype, uEltypeNoUnits,
+        uBottomEltypeNoUnits, tTypeNoUnits, γ, c, Val(true), verbose
+    )
+    tmp = zero(u)
+    atmp = similar(u, uEltypeNoUnits)
+    recursivefill!(atmp, false)
+    v = zero(u)
+    vtmp = zero(u)
+    f1eval = zero(rate_prototype)
+    kk = [zero(u) for _ in 1:(tab.q)]
+    z = [zero(u) for _ in 1:(s + 1)]
+    fS = [zero(rate_prototype) for _ in 1:s]
+    fsalfirst = zero(rate_prototype)
+    k = zero(rate_prototype)
+    return MRIGARKImplicitCache(
+        u, uprev, tmp, atmp, v, vtmp, f1eval, kk, z, fS, fsalfirst, k, nlsolver, tab
+    )
+end
+
+function alg_cache(
+        alg::MRIGARKIRK21a, u, rate_prototype,
+        ::Type{uEltypeNoUnits}, ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits},
+        uprev, uprev2, f, t, dt, reltol, p, calck,
+        ::Val{false}, verbose
+    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    tab = mri_gark_tableau(alg, eltype(u))
+    γ = _mrigark_impl_γ(tab)
+    c = one(tTypeNoUnits)
+    nlsolver = build_nlsolver(
+        alg, u, uprev, p, t, dt, f, rate_prototype, uEltypeNoUnits,
+        uBottomEltypeNoUnits, tTypeNoUnits, γ, c, Val(false), verbose
+    )
+    return MRIGARKImplicitConstantCache(nlsolver, tab)
+end
+
 struct MISConstantCache{TabType} <: OrdinaryDiffEqConstantCache
     tab::TabType
 end

--- a/lib/OrdinaryDiffEqMultirate/src/multirate_perform_step.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/multirate_perform_step.jl
@@ -518,6 +518,138 @@ end
     end
 end
 
+function initialize!(integrator, cache::MRIGARKImplicitCache)
+    integrator.kshortsize = 2
+    (; fsalfirst, k) = cache
+    integrator.fsalfirst = fsalfirst
+    integrator.fsallast = k
+    resize!(integrator.k, integrator.kshortsize)
+    integrator.k[1] = integrator.fsalfirst
+    integrator.k[2] = integrator.fsallast
+    integrator.f.f1(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t)
+    integrator.f.f2(cache.tmp, integrator.uprev, integrator.p, integrator.t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.stats.nf2 += 1
+    return integrator.fsalfirst .+= cache.tmp
+end
+
+function initialize!(integrator, cache::MRIGARKImplicitConstantCache)
+    integrator.kshortsize = 2
+    integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
+    integrator.fsalfirst = integrator.f.f1(integrator.uprev, integrator.p, integrator.t) +
+        integrator.f.f2(integrator.uprev, integrator.p, integrator.t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.stats.nf2 += 1
+    integrator.fsallast = zero(integrator.fsalfirst)
+    integrator.k[1] = integrator.fsalfirst
+    return integrator.k[2] = integrator.fsallast
+end
+
+function perform_step!(integrator, cache::MRIGARKImplicitCache, repeat_step = false)
+    (; t, dt, uprev, u, f, p) = integrator
+    (; tmp, atmp, z, fS, nlsolver, tab) = cache
+    (; Δc, W0, W1, γ0, q) = tab
+    alg = unwrap_alg(integrator, true)
+    m = alg.m
+    s = length(Δc)
+    stats = integrator.stats
+
+    markfirststage!(nlsolver)
+
+    @.. broadcast = false z[1] = uprev
+    cprev = zero(eltype(Δc))
+    for i in 1:s
+        f.f2(fS[i], z[i], p, t + cprev * dt)
+        stats.nf2 += 1
+        cnext = cprev + Δc[i]
+        if iszero(γ0[i])
+            _mrigark_substage!(
+                z[i + 1], z[i], cache, f, p, t, dt, Δc[i], cprev, m, q,
+                view(W0, i, :), view(W1, i, :), fS, i, stats
+            )
+        else
+            @.. broadcast = false nlsolver.tmp = z[i]
+            for j in 1:i
+                ω̄ = W0[i, j] + W1[i, j] / 2
+                iszero(ω̄) && continue
+                @.. broadcast = false nlsolver.tmp = nlsolver.tmp + dt * ω̄ * fS[j]
+            end
+            nlsolver.c = cnext
+            @.. broadcast = false nlsolver.z = dt * fS[i]
+            w = nlsolve!(nlsolver, integrator, cache, repeat_step)
+            nlsolvefail(nlsolver) && return
+            @.. broadcast = false z[i + 1] = nlsolver.tmp + nlsolver.γ * w
+        end
+        cprev = cnext
+    end
+    @.. broadcast = false u = z[s + 1]
+
+    return if integrator.opts.adaptive
+        @.. broadcast = false tmp = u - z[s]
+        calculate_residuals!(
+            atmp, tmp, uprev, u,
+            integrator.opts.abstol, integrator.opts.reltol,
+            integrator.opts.internalnorm, t
+        )
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+end
+
+@muladd function perform_step!(
+        integrator, cache::MRIGARKImplicitConstantCache, repeat_step = false
+    )
+    (; t, dt, uprev, f, p) = integrator
+    (; nlsolver, tab) = cache
+    (; Δc, W0, W1, γ0, q) = tab
+    alg = unwrap_alg(integrator, true)
+    m = alg.m
+    s = length(Δc)
+    stats = integrator.stats
+
+    markfirststage!(nlsolver)
+
+    z = Vector{typeof(uprev)}(undef, s + 1)
+    fS = Vector{typeof(f.f2(uprev, p, t))}(undef, s)
+    z[1] = uprev
+    cprev = zero(eltype(Δc))
+    for i in 1:s
+        fS[i] = f.f2(z[i], p, t + cprev * dt)
+        stats.nf2 += 1
+        cnext = cprev + Δc[i]
+        if iszero(γ0[i])
+            z[i + 1] = _mrigark_substage(
+                z[i], f, p, t, dt, Δc[i], cprev, m, q,
+                view(W0, i, :), view(W1, i, :), fS, i, stats
+            )
+        else
+            tmp = z[i]
+            for j in 1:i
+                ω̄ = W0[i, j] + W1[i, j] / 2
+                iszero(ω̄) && continue
+                tmp = @.. broadcast = false tmp + dt * ω̄ * fS[j]
+            end
+            nlsolver.tmp = tmp
+            nlsolver.c = cnext
+            nlsolver.z = dt * fS[i]
+            w = nlsolve!(nlsolver, integrator, cache, repeat_step)
+            nlsolvefail(nlsolver) && return
+            z[i + 1] = @.. broadcast = false nlsolver.tmp + nlsolver.γ * w
+        end
+        cprev = cnext
+    end
+    integrator.u = z[s + 1]
+
+    if integrator.opts.adaptive
+        utilde = @.. broadcast = false integrator.u - z[s]
+        atmp = calculate_residuals(
+            utilde, uprev, integrator.u,
+            integrator.opts.abstol, integrator.opts.reltol,
+            integrator.opts.internalnorm, t
+        )
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+end
+
 # Stage 1 is identity (Y_1 = u_n); inner ODE active only for i ≥ 2.
 
 function initialize!(integrator, cache::MISCache)

--- a/lib/OrdinaryDiffEqMultirate/src/multirate_tableaus.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/multirate_tableaus.jl
@@ -29,6 +29,7 @@ struct MRIGARKTableau{T}
     W1::Matrix{T}     # linear-in-τ coupling, s×s lower-triangular
     Wemb0::Vector{T}  # embedded last-stage constant coupling (length s) or empty
     Wemb1::Vector{T}  # embedded last-stage linear-in-τ coupling, or empty (constant)
+    γ0::Vector{T}     # implicit endpoint coupling per stage (0 ⇒ explicit stage), length s
     q::Int            # inner RK order
 end
 
@@ -36,14 +37,14 @@ function MRIGARKERK22aTableau(::Type{T}) where {T}
     Δc = T[1 // 2, 1 // 2]
     W0 = T[1 // 2 0; -1 // 2 1]
     W1 = zeros(T, 2, 2)
-    return MRIGARKTableau{T}(Δc, W0, W1, T[], T[], 2)
+    return MRIGARKTableau{T}(Δc, W0, W1, T[], T[], zeros(T, 2), 2)
 end
 
 function MRIGARKERK22bTableau(::Type{T}) where {T}
     Δc = T[1, 0]
     W0 = T[1 0; -1 // 2 1 // 2]
     W1 = zeros(T, 2, 2)
-    return MRIGARKTableau{T}(Δc, W0, W1, T[], T[], 2)
+    return MRIGARKTableau{T}(Δc, W0, W1, T[], T[], zeros(T, 2), 2)
 end
 
 function MRIGARKERK33aTableau(::Type{T}) where {T}
@@ -51,7 +52,7 @@ function MRIGARKERK33aTableau(::Type{T}) where {T}
     W0 = T[1 // 3 0 0; -1 // 3 2 // 3 0; 0 -2 // 3 1]
     W1 = T[0 0 0; 0 0 0; 1 // 2 0 -1 // 2]
     Wemb0 = T[1 // 12, -1 // 3, 7 // 12]
-    return MRIGARKTableau{T}(Δc, W0, W1, Wemb0, T[], 3)
+    return MRIGARKTableau{T}(Δc, W0, W1, Wemb0, T[], zeros(T, 3), 3)
 end
 
 function MRIGARKERK45aTableau(::Type{T}) where {T}
@@ -78,13 +79,22 @@ function MRIGARKERK45aTableau(::Type{T}) where {T}
         -31967827 // 340217490, 129673 // 286680,
     ]
     Wemb1 = T[6213 // 1880, -6213 // 1880, 0, 0, 0]
-    return MRIGARKTableau{T}(Δc, W0, W1, Wemb0, Wemb1, 4)
+    return MRIGARKTableau{T}(Δc, W0, W1, Wemb0, Wemb1, zeros(T, 5), 4)
+end
+
+function MRIGARKIRK21aTableau(::Type{T}) where {T}
+    Δc = T[1, 0]
+    W0 = T[1 0; -1 // 2 0]
+    W1 = zeros(T, 2, 2)
+    γ0 = T[0, 1 // 2]
+    return MRIGARKTableau{T}(Δc, W0, W1, T[], T[], γ0, 2)
 end
 
 mri_gark_tableau(::MRIGARKERK22a, ::Type{T}) where {T} = MRIGARKERK22aTableau(T)
 mri_gark_tableau(::MRIGARKERK22b, ::Type{T}) where {T} = MRIGARKERK22bTableau(T)
 mri_gark_tableau(::MRIGARKERK33a, ::Type{T}) where {T} = MRIGARKERK33aTableau(T)
 mri_gark_tableau(::MRIGARKERK45a, ::Type{T}) where {T} = MRIGARKERK45aTableau(T)
+mri_gark_tableau(::MRIGARKIRK21a, ::Type{T}) where {T} = MRIGARKIRK21aTableau(T)
 
 # ── MIS: multirate infinitesimal step ─────────────────────────────────────────
 

--- a/lib/OrdinaryDiffEqMultirate/test/mri_gark_tests.jl
+++ b/lib/OrdinaryDiffEqMultirate/test/mri_gark_tests.jl
@@ -178,3 +178,61 @@ end
         @test sim.𝒪est[:l∞] ≈ 4 atol = 0.3
     end
 end
+
+@testset "MRIGARKIRK21a" begin
+    @testset "Construction" begin
+        @test MRIGARKIRK21a(m = 10).m == 10
+        @test MRIGARKIRK21a(m = 20).m == 20
+    end
+
+    @testset "Scalar out-of-place" begin
+        prob = SplitODEProblem(
+            (u, p, t) -> -0.9 * u, (u, p, t) -> -0.1 * u, 1.0, (0.0, 1.0)
+        )
+        sol = solve(prob, MRIGARKIRK21a(m = 10), dt = 0.05, adaptive = false)
+        @test abs(sol.u[end] - exp(-1.0)) < 1.0e-3
+
+        sol_a = solve(prob, MRIGARKIRK21a(m = 10), reltol = 1.0e-6, abstol = 1.0e-6)
+        @test abs(sol_a.u[end] - exp(-1.0)) < 1.0e-3
+    end
+
+    @testset "Vector in-place" begin
+        f1!(du, u, p, t) = (du .= -0.9 .* u)
+        f2!(du, u, p, t) = (du .= -0.1 .* u)
+        u0 = [1.0, 2.0, 3.0]
+        prob = SplitODEProblem(f1!, f2!, u0, (0.0, 1.0))
+
+        sol = solve(prob, MRIGARKIRK21a(m = 10), dt = 0.05, adaptive = false)
+        @test norm(sol.u[end] - u0 .* exp(-1.0)) < 1.0e-2
+
+        sol_a = solve(prob, MRIGARKIRK21a(m = 10), reltol = 1.0e-6, abstol = 1.0e-6)
+        @test norm(sol_a.u[end] - u0 .* exp(-1.0)) < 1.0e-3
+    end
+
+    @testset "Stiff slow component" begin
+        analytic(u0, p, t) = u0 * exp(-51t)
+        prob = SplitODEProblem(
+            SplitFunction(
+                (u, p, t) -> -u, (u, p, t) -> -50u; analytic = analytic
+            ),
+            1.0, (0.0, 1.0)
+        )
+        sol = solve(prob, MRIGARKIRK21a(m = 4), dt = 0.02, adaptive = false)
+        @test abs(sol.u[end] - exp(-51.0)) < 1.0e-3
+        @test solve(prob, MRIGARKIRK21a(m = 4), reltol = 1.0e-6, abstol = 1.0e-8).retcode ==
+            ReturnCode.Success
+    end
+
+    @testset "Convergence" begin
+        analytic(u0, p, t) = u0 * exp(-3t)
+        prob = SplitODEProblem(
+            SplitFunction(
+                (u, p, t) -> -2u, (u, p, t) -> -u; analytic = analytic
+            ),
+            1.0, (0.0, 1.0)
+        )
+        dts = 1 ./ 2 .^ (6:-1:2)
+        sim = test_convergence(dts, prob, MRIGARKIRK21a(m = 8))
+        @test sim.𝒪est[:l∞] ≈ 2 atol = 0.3
+    end
+end


### PR DESCRIPTION
## Summary

Adds the first **implicit** member of the MRI-GARK family (Sandu 2019), `MRIGARKIRK21a` — a 2nd-order **solve-decoupled implicit** multirate infinitesimal method — to `OrdinaryDiffEqMultirate`. This is a step toward #961.

It solves `SplitODEProblem`s `du/dt = f1(u,t) + f2(u,t)` where `f1` is the fast component and `f2` the slow component (SciML convention). Unlike the explicit MRI-GARK methods already in the package, the slow stages couple implicitly to `f2` at the stage endpoint, so it stays stable when the **slow** subsystem is itself stiff — the case explicit MRI-GARK cannot handle.

## Approach

Because the SUNDIALS/Sandu implicit MRI-GARK methods are *solve-decoupled*, the implicit diagonal coupling only appears on the `Δc = 0` quadrature stages, which reduce to the algebraic implicit solve

```
z_{i+1} - dt*γ*f2(z_{i+1}) = z_i + dt*Σ_j ω̄_ij*f2(z_j)
```

So the fast sub-integration remains fully explicit and reuses the existing substage kernels verbatim; only the `Δc = 0` stage adds a nonlinear solve.

- `MRIGARKTableau` gains a per-stage implicit endpoint-coupling vector `γ0`, all-zero for the four existing explicit methods (which keep their exact previous code path).
- `MRIGARKIRK21a` is an `OrdinaryDiffEqNewtonAdaptiveAlgorithm`; the implicit stage is solved with `build_nlsolver`/`nlsolve!`. Since multirate solves implicitly in the **slow** part, `nlsolve_f` is specialized to target `f.f2` (rather than the usual `f.f1`).
- IIP and OOP `perform_step!`, cache, and tableau added.

Coefficients transcribed from SUNDIALS `arkode_mri_tables.def` (`MIStoMRI` of the underlying DIRK Butcher table).

## Tests

Added a `MRIGARKIRK21a` testset (construction, scalar OOP, vector IIP, stiff slow component, convergence). Convergence **order 2** verified for both OOP and IIP; the existing explicit MRI-GARK methods are unchanged and still pass. Full `OrdinaryDiffEqMultirate` suite (Core + QA/AllocCheck) is green.
