### PR TITLE
Allow LinearSolve v4

### DIFF
--- a/lib/DelayDiffEq/Project.toml
+++ b/lib/DelayDiffEq/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.0.5"
+version = "6.0.6"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -71,7 +71,7 @@ FastBroadcast = "1.3"
 FiniteDiff = "2.27"
 ForwardDiff = "1.3.3"
 LinearAlgebra = "1"
-LinearSolve = "3.75.0"
+LinearSolve = "3.75.0, 4"
 Logging = "1"
 OrdinaryDiffEqBDF = "2"
 OrdinaryDiffEqCore = "4"

--- a/lib/OrdinaryDiffEqAMF/Project.toml
+++ b/lib/OrdinaryDiffEqAMF/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqAMF"
 uuid = "08082164-f6a1-4363-b3df-3aa6fcf571ad"
 authors = ["Utkarsh <rajpututkarsh530@gmail.com>"]
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -14,7 +14,7 @@ SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 [compat]
 LinearAlgebra = "1.10"
 SafeTestsets = "0.1.0"
-LinearSolve = "3.75.0"
+LinearSolve = "3.75.0, 4"
 OrdinaryDiffEqCore = "4"
 Reexport = "1.2.2"
 SciMLBase = "3.10.0"

--- a/lib/OrdinaryDiffEqBDF/Project.toml
+++ b/lib/OrdinaryDiffEqBDF/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqBDF"
 uuid = "6ad6398a-0878-4a85-9266-38940aa047c8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.2"
+version = "2.2.3"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -54,7 +54,7 @@ Random = "<0.0.1, 1"
 DiffEqDevTools = "3"
 DifferentiationInterface = "0.7.18"
 MuladdMacro = "0.2.1"
-LinearSolve = "3.75.0"
+LinearSolve = "3.75.0, 4"
 PrecompileTools = "1.2.1, 1.3"
 LinearAlgebra = "1.10"
 OrdinaryDiffEqDifferentiation = "3"

--- a/lib/OrdinaryDiffEqDefault/Project.toml
+++ b/lib/OrdinaryDiffEqDefault/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqDefault"
 uuid = "50262376-6c5a-4cf5-baba-aaf4f84d72d7"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.1"
+version = "2.2.2"
 
 [deps]
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
@@ -45,7 +45,7 @@ Random = "<0.0.1, 1"
 DiffEqDevTools = "3"
 OrdinaryDiffEqBDF = "2"
 OrdinaryDiffEqVerner = "2"
-LinearSolve = "3.75.0"
+LinearSolve = "3.75.0, 4"
 PrecompileTools = "1.2.1, 1.3"
 EnumX = "1.0.4"
 LinearAlgebra = "1.10"

--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "3.2.1"
+version = "3.2.2"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 
@@ -20,7 +20,7 @@ DiffEqDevTools = "3"
 Test = "<0.0.1, 1"
 FiniteDiff = "2.27"
 DifferentiationInterface = "0.7.18"
-LinearSolve = "3.75.0"
+LinearSolve = "3.75.0, 4"
 ConstructionBase = "1.5.8"
 LinearAlgebra = "1.10"
 SciMLBase = "3.10.0"

--- a/lib/OrdinaryDiffEqDifferentiation/test/sparse/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/test/sparse/Project.toml
@@ -13,5 +13,5 @@ OrdinaryDiffEqSDIRK = {path = "../../../OrdinaryDiffEqSDIRK"}
 
 [compat]
 ComponentArrays = "0.15, 1"
-LinearSolve = "3"
+LinearSolve = "3, 4"
 OrdinaryDiffEq = "7"

--- a/lib/OrdinaryDiffEqExponentialRK/Project.toml
+++ b/lib/OrdinaryDiffEqExponentialRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExponentialRK"
 uuid = "e0540318-69ee-4070-8777-9e2de6de23de"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -46,7 +46,7 @@ Random = "<0.0.1, 1"
 DiffEqDevTools = "3"
 MuladdMacro = "0.2.1"
 OrdinaryDiffEqVerner = "2"
-LinearSolve = "3.75.0"
+LinearSolve = "3.75.0, 4"
 ExponentialUtilities = "1.27"
 LinearAlgebra = "1.10"
 OrdinaryDiffEqDifferentiation = "3"

--- a/lib/OrdinaryDiffEqExtrapolation/Project.toml
+++ b/lib/OrdinaryDiffEqExtrapolation/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExtrapolation"
 uuid = "becaefa8-8ca2-5cf9-886d-c06f3d2bd2c4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.2.1"
+version = "2.2.2"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -36,7 +36,7 @@ FastBroadcast = "1.3"
 Random = "<0.0.1, 1"
 DiffEqDevTools = "3"
 MuladdMacro = "0.2.1"
-LinearSolve = "3.75.0"
+LinearSolve = "3.75.0, 4"
 OrdinaryDiffEqDifferentiation = "3"
 SciMLBase = "3.10.0"
 OrdinaryDiffEqCore = "4.4"

--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFIRK"
 uuid = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.3.1"
+version = "2.3.2"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -42,7 +42,7 @@ Random = "<0.0.1, 1"
 DiffEqDevTools = "3"
 FastGaussQuadrature = "1.2"
 MuladdMacro = "0.2.1"
-LinearSolve = "3.75.0"
+LinearSolve = "3.75.0, 4"
 LinearAlgebra = "1.10"
 OrdinaryDiffEqDifferentiation = "3"
 SciMLBase = "3.10.0"

--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
@@ -53,7 +53,7 @@ FastBroadcast = "1.3"
 Random = "<0.0.1, 1"
 DiffEqDevTools = "3"
 MuladdMacro = "0.2.1"
-LinearSolve = "3.75.0"
+LinearSolve = "3.75.0, 4"
 LineSearches = "7.5.1"
 LinearAlgebra = "1.10"
 OrdinaryDiffEqDifferentiation = "3"

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/Project.toml
@@ -25,7 +25,7 @@ OrdinaryDiffEqSDIRK = {path = "../../../OrdinaryDiffEqSDIRK"}
 DiffEqDevTools = "3"
 ImplicitDiscreteSolve = "2"
 IncompleteLU = "0.2"
-LinearSolve = "3"
+LinearSolve = "3, 4"
 ModelingToolkit = "10.10, 11"
 NonlinearSolve = "4.10"
 OrdinaryDiffEq = "7"

--- a/lib/OrdinaryDiffEqRosenbrock/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrock/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqRosenbrock"
 uuid = "43230ef6-c299-4910-a778-202eb28ce4ce"
-version = "2.3.1"
+version = "2.3.2"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 
 [deps]
@@ -41,7 +41,7 @@ FastBroadcast = "1.3"
 FiniteDiff = "2.27"
 ForwardDiff = "1.3.3"
 LinearAlgebra = "1.10"
-LinearSolve = "3.75.0"
+LinearSolve = "3.75.0, 4"
 MacroTools = "0.5.6"
 MuladdMacro = "0.2.1"
 ODEProblemLibrary = "1"

--- a/lib/OrdinaryDiffEqRosenbrockTableaus/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrockTableaus/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqRosenbrockTableaus"
 uuid = "b4bd8bb3-f80f-41d2-9b21-73a655b304b9"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.1.1"
+version = "2.1.2"
 
 [extras]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -19,7 +19,7 @@ ADTypes = "1.22.0"
 DiffEqDevTools = "3"
 Enzyme = "0.13"
 LinearAlgebra = "1.10"
-LinearSolve = "3.46"
+LinearSolve = "3.46, 4"
 ODEProblemLibrary = "1"
 OrdinaryDiffEqRosenbrock = "2"
 Pkg = "1"


### PR DESCRIPTION
Widens \`LinearSolve\` compat to include **v4** across the affected subpackages and bumps their patch versions.

## Context

LinearSolve **v4.0.0** ([SciML/LinearSolve.jl#1072](https://github.com/SciML/LinearSolve.jl/pull/1072)) adds batched (matrix) right-hand side support. The only breaking aspects are (1) the `u0` shape for a **matrix** `b` changes from a flattened length-`n` vector to `n×k`, and (2) matrix-`b` + iterative solvers now error at `init`.

The #1072 downstream audit found OrdinaryDiffEq **functionally unaffected**: every call site passes `_vec(...)`/`safe_vec`-flattened vectors with explicit `u0` (~60 sites audited across the OrdinaryDiffEq libs). So this PR is compat-only.

## Changes

- `LinearSolve = "3.75.0"` → `"3.75.0, 4"` in 10 subpackages (ExponentialRK, Differentiation, Default, Rosenbrock, AMF, DelayDiffEq, BDF, FIRK, NonlinearSolve, Extrapolation)
- `LinearSolve = "3.46"` → `"3.46, 4"` in RosenbrockTableaus
- `LinearSolve = "3"` → `"3, 4"` in 2 test envs (Differentiation/test/sparse, NonlinearSolve/test/modelingtoolkit)
- Patch version bump on each affected **registered** subpackage so this is registration-ready (test envs not bumped)

CI here will go green once LinearSolve v4.0.0 finishes propagating into the General registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)