### PR TITLE
NonlinearSolveAlg: pull nsolve from inner NonlinearSolve stats

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -44,6 +44,7 @@ function initialize!(
     if SciMLBase.has_stats(integrator)
         integrator.stats.nf += cache.cache.stats.nf
         integrator.stats.njacs += cache.cache.stats.njacs
+        integrator.stats.nsolve += cache.cache.stats.nsolve
     end
     if f isa DAEFunction
         nlp_params = (tmp, α, tstep, invγdt, p, dt, uprev, f)
@@ -70,6 +71,7 @@ function initialize!(
     if SciMLBase.has_stats(integrator)
         integrator.stats.nf += cache.cache.stats.nf
         integrator.stats.njacs += cache.cache.stats.njacs
+        integrator.stats.nsolve += cache.cache.stats.nsolve
     end
 
     nlstep_data = f.nlstep_data


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Draft opened by an agent.

The NSA `initialize!` forwards `nf` and `njacs` from the inner NonlinearSolve cache stats to the integrator stats, but drops `nsolve` — so `integrator.stats.nsolve` always reads 0 under `NonlinearSolveAlg` while `NLNewton` increments it per linear solve. Forward it the same way (the inner stats reset on each per-stage `reinit!`, so the pull-before-reinit pattern accumulates deltas correctly — same as the existing `nf`/`njacs` pulls).

Verified locally: TRBDF2+NSA on ROBER at 1e-8 now reports `nsolve = 16674` (≈ `nnonliniter = 16912`); was 0.

Part of a series closing NonlinearSolveAlg↔NLNewton parity gaps (with the sparse `jac_prototype` fix and the J/W update split; see also SciML/NonlinearSolve.jl#1003).

🤖 Generated with [Claude Code](https://claude.com/claude-code)