### PR TITLE
NonlinearSolveAlg: let inner solver refresh J when no W is reused (fixes master nlstep order failures)

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -145,7 +145,13 @@ end
     (; tstep, invγdt) = cache
 
     nlcache = nlsolver.cache.cache
-    recompute_jacobian = nlsolver.iter == 1 && (cache.W === nothing || cache.new_W)
+    # When no reusable W exists (nlstep/DAE/OOP), the inner NonlinearSolve must be
+    # allowed to refresh its Jacobian every outer iteration: freezing it after iter 1
+    # degrades the inner solve to modified Newton while the outer η·ndz < κ test still
+    # assumes its calibration, leaving a dt-independent unconverged remainder per step
+    # (FBDF nlstep convergence order collapsed to ~0.6). With a reused W the Jacobian
+    # is the ODE-side W by construction, so refreshing beyond iter 1 is pointless.
+    recompute_jacobian = cache.W === nothing || (nlsolver.iter == 1 && cache.new_W)
     step!(nlcache; recompute_jacobian)
     nlsolver.ztmp = nlcache.u
 
@@ -170,7 +176,13 @@ end
 
     nlstep_data = integrator.f.nlstep_data
     nlcache = nlsolver.cache.cache
-    recompute_jacobian = nlsolver.iter == 1 && (cache.W === nothing || cache.new_W)
+    # When no reusable W exists (nlstep/DAE/OOP), the inner NonlinearSolve must be
+    # allowed to refresh its Jacobian every outer iteration: freezing it after iter 1
+    # degrades the inner solve to modified Newton while the outer η·ndz < κ test still
+    # assumes its calibration, leaving a dt-independent unconverged remainder per step
+    # (FBDF nlstep convergence order collapsed to ~0.6). With a reused W the Jacobian
+    # is the ODE-side W by construction, so refreshing beyond iter 1 is pointless.
+    recompute_jacobian = cache.W === nothing || (nlsolver.iter == 1 && cache.new_W)
     step!(nlcache; recompute_jacobian)
 
     if nlstep_data !== nothing


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Draft opened by an agent.

## Fixes two failing tests on master

`test/modelingtoolkit/nlstep_tests.jl` currently fails on master (17 pass / **2 fail** / 6 broken): the FBDF + NSA(TrustRegion) Robertson order assertions at lines 60 and 116 measure order **0.6152** against bounds `|𝒪est−1| < 0.3 / 0.35`. (#3807 read this as "order 1.38" — it's `1 + 0.3848` in the test output; the order collapsed *below* 1.)

## Root cause

#3703 changed both `compute_step!` methods from

```julia
recompute_jacobian = cache.W === nothing || (nlsolver.iter == 1 && cache.new_W)
```
to
```julia
recompute_jacobian = nlsolver.iter == 1 && (cache.W === nothing || cache.new_W)
```

which freezes the inner NonlinearSolve Jacobian after outer iteration 1 on the paths **without** a reusable W (MTK nlstep, DAE, OOP). The inner solve silently degrades to modified Newton while the outer `η·ndz < κ` termination keeps its calibration, so every step carries a dt-independent unconverged remainder. Measured l∞ errors over `dts = 2^-15…2^-18`: master `[2.22e-7, 1.12e-7, 5.60e-8, 6.18e-8]` (error stops halving, then **rises**); with this fix `[…, 1.38e-7, 5.60e-8, 2.80e-8]` (clean halving). Warmed TrustRegion and NewtonRaphson give bit-identical trajectories — not TR-specific, and consistent with the principle that a *converged* inner solve must not change the ODE solution.

## Fix

Restore the pre-#3703 condition: `W === nothing` paths let the inner solver refresh J every outer iteration; the W-reuse (modified-Newton) path is untouched — with a reused W the inner Jacobian *is* the ODE-side W by construction, so refreshing beyond iter 1 remains pointless there.

## Verification (local)

- A/B on master: this exact change turns `nlstep_tests.jl` from 17 pass / 2 fail into **19 pass / 0 fail**, with orders 1.2576 and 1.3035 back inside their bounds.
- `newton_tests.jl` + `linear_nonlinear_tests.jl` pass against this branch.

## Related findings from the same investigation (separate issues)

- #3817: NSA(TrustRegion)+W-reuse can declare convergence from displacement-`ndz` on a rejected TR step → constant 4.7e-2 error across dts (not fixed by this PR).
- SciML/NonlinearSolve.jl#1004: `reinit!` resets the trust radius to its build-time value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)