### PR TITLE
NonlinearSolveAlg: give inner NonlinearFunction W's structure as jac_prototype

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -121,7 +121,16 @@ function initialize!(
             nlp_params = (tmp, ustep, γ, α, tstep, k, invγdt, method, p, dt, f)
         end
         if length(cache.cache.u) != length(z)
-            new_prob = SciMLBase.remake(cache.prob; u0 = copy(z), p = nlp_params)
+            new_prob = if cache.W !== nothing
+                # The problem was resized: point the WReuseJac at the resized W and give
+                # the NonlinearFunction a matching jac_prototype. Both keep their types
+                # (only array sizes change), so cache.prob's concrete type is preserved.
+                cache.prob.f.jac.W[] = cache.W
+                new_f = SciMLBase.remake(cache.prob.f; jac_prototype = similar(cache.W))
+                SciMLBase.remake(cache.prob; f = new_f, u0 = copy(z), p = nlp_params)
+            else
+                SciMLBase.remake(cache.prob; u0 = copy(z), p = nlp_params)
+            end
             cache.prob = new_prob
             cache.cache = init(new_prob, cache.cache.alg)
         else

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
@@ -366,6 +366,16 @@ mutable struct HomotopyNonlinearSolveCache{uType, tType, rateType, tType2, F, R}
     nf::R
 end
 
+# Analytic-jac callback handing the ODE-side W to the inner NonlinearSolve under
+# W-reuse. Deliberately a struct holding a Ref rather than a closure: its type depends
+# only on W's type, not on a captured binding, so when `resize!` replaces the W array
+# the same NonlinearFunction/NonlinearProblem types remain valid and `initialize!` just
+# swaps the Ref target.
+struct WReuseJac{W} <: Function
+    W::Base.RefValue{W}
+end
+(j::WReuseJac)(J_out, z, p) = (copyto!(J_out, j.W[]); J_out)
+
 mutable struct NonlinearSolveCache{uType, tType, rateType, tType2, P, C, JType, WType, ufType, jcType, du1Type, weightType} <:
     AbstractNLSolverCache
     ustep::uType

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -391,9 +391,7 @@ function build_nlsolver(
                     (tmp, ustep, γ, α, tstep, k, invγdt, DIRK, p, dt, f)
                 end
                 if use_w_reuse
-                    nlf_jac! = let W = W_for_reuse
-                        (J_out, z, p) -> (copyto!(J_out, W); J_out)
-                    end
+                    nlf_jac! = WReuseJac(Ref(W_for_reuse))
                     # Without a `jac_prototype`, NonlinearSolve allocates a dense J for an
                     # analytic-jac function, so a sparse/structured W degrades to dense LU
                     # and sparse-only linsolves (e.g. KLU) crash. Mirror W's structure.

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -394,10 +394,14 @@ function build_nlsolver(
                     nlf_jac! = let W = W_for_reuse
                         (J_out, z, p) -> (copyto!(J_out, W); J_out)
                     end
+                    # Without a `jac_prototype`, NonlinearSolve allocates a dense J for an
+                    # analytic-jac function, so a sparse/structured W degrades to dense LU
+                    # and sparse-only linsolves (e.g. KLU) crash. Mirror W's structure.
                     NonlinearProblem(
                         NonlinearFunction{true, SciMLBase.FullSpecialize}(
                             nlf;
-                            jac = nlf_jac!
+                            jac = nlf_jac!,
+                            jac_prototype = similar(W_for_reuse)
                         ),
                         ztmp, nlp_params
                     )

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_sparse_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_sparse_tests.jl
@@ -68,3 +68,43 @@ end
         @test sol.u[end] ≈ refsol.u[end] rtol = 1.0e-5
     end
 end
+
+# Resizing the integrator must rebuild the inner Jacobian at the new size: the jac
+# closure and jac_prototype are fixed at build time, so the length-mismatch path in
+# initialize! has to refresh both against the resized W (this crashed with
+# `DimensionMismatch: B has leading dimension 2, but needs 1` when jac_prototype
+# followed the W structure).
+@testset "resize with W-reuse rebuilds inner Jacobian" begin
+    fgrow = function (du, u, p, t)
+        for i in 1:length(u)
+            du[i] = (0.3 / length(u)) * u[i]
+        end
+        return nothing
+    end
+    condition = (u, t, integrator) -> 1 - maximum(u)
+    affect! = function (integrator)
+        u = integrator.u
+        maxidx = findmax(u)[2]
+        resize!(integrator, length(u) + 1)
+        Θ = 0.3
+        u[maxidx] = Θ
+        u[end] = 1 - Θ
+        return nothing
+    end
+    cb = ContinuousCallback(condition, affect!)
+    probg = ODEProblem(fgrow, [0.2], (0.0, 10.0))
+    # NOTE: assert the resize worked and nothing crashed (mirroring
+    # test/Integrators_II/ode_cache_tests.jl). Whether the marginally-stable
+    # grow-a-cell dynamics finishes with Success is method- and
+    # rounding-sensitive (ImplicitEuler+NLNewton is Unstable on it too), so
+    # retcode is only checked for TRBDF2.
+    for alg in (
+            TRBDF2(nlsolve = nsa), KenCarp4(nlsolve = nsa),
+            ImplicitEuler(nlsolve = nsa),
+        )
+        sol = solve(probg, alg; callback = cb, dt = 1 / 2)
+        @test length(sol.u[end]) > 1
+    end
+    sol = solve(probg, TRBDF2(nlsolve = nsa); callback = cb, dt = 1 / 2)
+    @test SciMLBase.successful_retcode(sol)
+end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_sparse_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_sparse_tests.jl
@@ -1,0 +1,70 @@
+using OrdinaryDiffEqBDF, OrdinaryDiffEqSDIRK
+using OrdinaryDiffEqNonlinearSolve
+using OrdinaryDiffEqNonlinearSolve: NonlinearSolveAlg
+using NonlinearSolve: NewtonRaphson
+using LinearSolve, LinearAlgebra, SparseArrays, ADTypes
+using SciMLBase
+using Test
+
+# 1D Brusselator with a hand-assembled sparse Jacobian pattern (tridiagonal blocks).
+const N_b = 8
+function bruss1d!(du, u, p, t)
+    A, B, alpha, dx = p
+    a = alpha / dx^2
+    n = N_b
+    @inbounds for i in 1:n
+        im1 = i == 1 ? n : i - 1
+        ip1 = i == n ? 1 : i + 1
+        x = u[i]
+        y = u[n + i]
+        du[i] = a * (u[im1] + u[ip1] - 2x) + B + x^2 * y - (A + 1) * x
+        du[n + i] = a * (u[n + im1] + u[n + ip1] - 2y) + A * x - x^2 * y
+    end
+    return nothing
+end
+function bruss1d_jacproto(n)
+    Is = Int[]
+    Js = Int[]
+    for i in 1:n
+        im1 = i == 1 ? n : i - 1
+        ip1 = i == n ? 1 : i + 1
+        for (r, c) in (
+                (i, im1), (i, i), (i, ip1), (i, n + i),
+                (n + i, n + im1), (n + i, n + i), (n + i, n + ip1), (n + i, i),
+            )
+            push!(Is, r)
+            push!(Js, c)
+        end
+    end
+    return sparse(Is, Js, ones(length(Is)), 2n, 2n)
+end
+u0 = vcat(
+    [22 * (i / (N_b + 1) * (1 - i / (N_b + 1)))^(3 / 2) for i in 1:N_b],
+    [27 * (i / (N_b + 1) * (1 - i / (N_b + 1)))^(3 / 2) for i in 1:N_b]
+)
+p = (3.4, 1.0, 10.0, 1 / N_b)
+f_sparse = ODEFunction(bruss1d!; jac_prototype = bruss1d_jacproto(N_b))
+prob = ODEProblem(f_sparse, u0, (0.0, 2.0), p)
+
+refsol = solve(prob, FBDF(); reltol = 1.0e-10, abstol = 1.0e-12)
+
+nsa = NonlinearSolveAlg(NewtonRaphson(; autodiff = AutoForwardDiff()))
+
+@testset "NSA W-reuse keeps inner Jacobian sparse" begin
+    integ = init(prob, FBDF(nlsolve = nsa); reltol = 1.0e-8, abstol = 1.0e-10)
+    nsacache = integ.cache.nlsolver.cache
+    @test nsacache.W isa SparseMatrixCSC
+    # The inner NonlinearSolve Jacobian must mirror W's structure, not densify.
+    @test integ.cache.nlsolver.cache.cache.jac_cache.J isa SparseMatrixCSC
+end
+
+@testset "NSA + sparse-only linsolve (KLU) solves" begin
+    for alg in (
+            FBDF(linsolve = KLUFactorization(), nlsolve = nsa),
+            TRBDF2(linsolve = KLUFactorization(), nlsolve = nsa),
+        )
+        sol = solve(prob, alg; reltol = 1.0e-8, abstol = 1.0e-10)
+        @test SciMLBase.successful_retcode(sol)
+        @test sol.u[end] ≈ refsol.u[end] rtol = 1.0e-5
+    end
+end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
@@ -37,6 +37,7 @@ if TEST_GROUP ∉ ("QA", "ModelingToolkit")
     @time @safetestset "Nested AD over NonlinearSolveAlg" include("nested_ad_nlsolvealg_tests.jl")
     @time @safetestset "NonlinearSolveAlg Jacobian Reuse Tests" include("nsa_jacobian_reuse_tests.jl")
     @time @safetestset "Homotopy Nonlinear Solver Tests" include("homotopy_nlsolve_tests.jl")
+    @time @safetestset "NonlinearSolveAlg Sparse Jacobian Tests" include("nsa_sparse_tests.jl")
 end
 
 # Run QA tests (JET, Aqua)


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Draft opened by an agent.

## Bug

Under W-reuse (#3693/#3753) the inner `NonlinearFunction` gets the analytic-jac closure `copyto!(J_out, W)` but **no `jac_prototype`**. NonlinearSolveBase allocates a **dense** J for analytic-jac functions without a prototype (`jacobian.jl`: `safe_similar(fu, n, n)`), so for sparse/structured W:

- with the ODE's sparse-only linsolve piped in (`_nlalg_with_linsolve`): **hard crash** — `FBDF(linsolve = KLUFactorization(), nlsolve = NonlinearSolveAlg(NewtonRaphson()))` on a sparse-`jac_prototype` brusselator dies with `FieldError: Matrix has no field nzval`;
- with the default linsolve: silent dense LU on a sparse system.

## Fix

Pass `jac_prototype = similar(W_for_reuse)` so the inner Jacobian mirrors W's type and structure; the `copyto!` closure is then structure-preserving and sparse factorizations work.

Verified on the 512-unknown sparse brusselator (before → after): inner J `Matrix{Float64}` → `SparseMatrixCSC` (nnz=3072), KLU crash → clean solve. Combined with the J/W-update split and SciML/NonlinearSolve.jl#1003, `FBDF+NSA+KLU` reaches **1.00×** of `FBDF+NLNewton+KLU` wall time (220.3 vs 219.5 ms) — from a crash/3.9× before.

## Tests

New `nsa_sparse_tests.jl`: asserts the inner NonlinearSolve J is `SparseMatrixCSC` under W-reuse, and that FBDF/TRBDF2 + NSA + `KLUFactorization` solve a sparse-`jac_prototype` problem to the reference (6/6 pass locally). Local suite runs on this branch (Julia 1.12): Newton 6/6, Linear Nonlinear 36/36, W-Operator Prototype, NSA Sparse 6/6, Sparse Algebraic 12/12, Sparse DAE Init 27/27, Linear Solver 113/113, Split ODE 10/10 — no failures (full Core group exceeds a 1h local window; remaining suites left to CI).

Part of a series: #3816 (nsolve stat), #3818 (recompute_jacobian on W===nothing paths), SciML/NonlinearSolve.jl#1003 (refactorization reuse), and a J/W-update-split PR to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Rebased 2026-07-12 onto current master (6c3eac08).** Resolved conflicts with #3795 (new `weight` field on `NonlinearSolveCache`) and #3876 (new `HomotopyNonlinearSolveCache`) — both preserved. Verified still needed: master's NSA build still installs the old capturing jac closure with no `jac_prototype`, so the sparse-W → dense-J degradation and the `KLUFactorization` crash still exist on master.

The resize commit (`WReuseJac`) is retained: giving the inner Jacobian a `jac_prototype` freezes its size, so the type-stable `WReuseJac` Ref-swap is what keeps `resize!(integrator, n)` from hitting `DimensionMismatch`.

---
**Confirmed on current master (2026-07-12):** `NonlinearSolveAlg` + `KLUFactorization` on a sparse-`jac_prototype` problem **crashes on master** with `FieldError: type Nothing has no field nzval` (both `AutoFiniteDiff` and `AutoForwardDiff` inner autodiff). With this PR it returns `Success`. Characterization on a sparse 2D brusselator:

| inner autodiff | +GMRES | +KLU | +LU(default) |
|---|---|---|---|
| master, FiniteDiff | ✅ | ❌ crash (`nzval`) | ✅ |
| master, ForwardDiff | ❌ crash¹ | ❌ crash (`nzval`) | ✅ |
| **this PR**, FiniteDiff | ✅ | ✅ | ✅ |
| **this PR**, ForwardDiff | ❌ crash¹ | ✅ | ✅ |

¹ The remaining `AutoForwardDiff + GMRES` crash is a *separate*, pre-existing bug on the matrix-free AD-JVP path (NonlinearSolve rebuilds the Jacobian by differentiating the ODE residual → nested FunctionWrappers tag), untouched by this PR — tracked separately.