### PR TITLE
NonlinearSolveAlg: reuse stored J on dt-only W updates (do_newJW parity)

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -91,11 +91,15 @@ function initialize!(
             dtgamma = method === DIRK ? γ * dt : γ * dt / α
             W_γdt = cache.W_γdt
             first_call = iszero(W_γdt)
-            should_update = first_call || alg.always_new ||
-                nlsolver.status === Divergence ||
+            # Mirror the legacy do_newJW split: a fresh Jacobian is only needed when the
+            # iteration failed or on first use, while a dt/gamma change merely requires
+            # reassembling W = J - M/γdt from the stored J (jacobian2W! is O(nnz), a
+            # Jacobian evaluation is not).
+            new_jac = first_call || alg.always_new || nlsolver.status === Divergence
+            new_w = new_jac ||
                 abs(inv(dtgamma) / inv(W_γdt) - 1) > alg.new_W_dt_cutoff
-            if should_update
-                _update_nlsolvealg_W!(cache, integrator, dtgamma, tstep)
+            if new_w
+                _update_nlsolvealg_W!(cache, integrator, dtgamma, tstep, new_jac)
                 cache.new_W = true
             else
                 cache.new_W = false
@@ -117,19 +121,21 @@ function initialize!(
     return nothing
 end
 
-function _update_nlsolvealg_W!(nlcache, integrator, dtgamma, tstep)
+function _update_nlsolvealg_W!(nlcache, integrator, dtgamma, tstep, new_jac = true)
     (; J, W, uf, jac_config, du1) = nlcache
     (; f, p, uprev, alg) = integrator
     mass_matrix = f.mass_matrix
-    if SciMLBase.has_jac(f)
-        f.jac(J, uprev, p, tstep)
-    elseif uf !== nothing
-        uf.f = nlsolve_f(f, alg)
-        uf.t = tstep
-        if !(p isa SciMLBase.NullParameters)
-            uf.p = p
+    if new_jac
+        if SciMLBase.has_jac(f)
+            f.jac(J, uprev, p, tstep)
+        elseif uf !== nothing
+            uf.f = nlsolve_f(f, alg)
+            uf.t = tstep
+            if !(p isa SciMLBase.NullParameters)
+                uf.p = p
+            end
+            jacobian!(J, uf, uprev, du1, integrator, jac_config)
         end
-        jacobian!(J, uf, uprev, du1, integrator, jac_config)
     end
     jacobian2W!(W, mass_matrix, dtgamma, J)
     nlcache.W_γdt = dtgamma

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_jacobian_reuse_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_jacobian_reuse_tests.jl
@@ -1,0 +1,50 @@
+using OrdinaryDiffEqBDF, OrdinaryDiffEqSDIRK
+using OrdinaryDiffEqNonlinearSolve
+using OrdinaryDiffEqNonlinearSolve: NonlinearSolveAlg
+using NonlinearSolve: NewtonRaphson
+using ADTypes, LinearAlgebra, SciMLBase
+using Test
+
+function rober!(du, u, p, t)
+    y₁, y₂, y₃ = u
+    k₁, k₂, k₃ = p
+    du[1] = -k₁ * y₁ + k₃ * y₂ * y₃
+    du[2] = k₁ * y₁ - k₂ * y₂^2 - k₃ * y₂ * y₃
+    du[3] = k₂ * y₂^2
+    return nothing
+end
+const JAC_CALLS = Ref(0)
+function rober_jac!(J, u, p, t)
+    JAC_CALLS[] += 1
+    y₁, y₂, y₃ = u
+    k₁, k₂, k₃ = p
+    J[1, 1] = -k₁
+    J[1, 2] = k₃ * y₃
+    J[1, 3] = k₃ * y₂
+    J[2, 1] = k₁
+    J[2, 2] = -2k₂ * y₂ - k₃ * y₃
+    J[2, 3] = -k₃ * y₂
+    J[3, 1] = 0
+    J[3, 2] = 2k₂ * y₂
+    J[3, 3] = 0
+    return nothing
+end
+f = ODEFunction(rober!; jac = rober_jac!)
+prob = ODEProblem(f, [1.0, 0.0, 0.0], (0.0, 1.0e5), [0.04, 3.0e7, 1.0e4])
+nsa = NonlinearSolveAlg(NewtonRaphson(; autodiff = AutoForwardDiff()))
+refsol = solve(prob, FBDF(); reltol = 1.0e-12, abstol = 1.0e-14)
+
+@testset "dt-only W updates reuse the stored Jacobian" begin
+    for alg in (FBDF(nlsolve = nsa), TRBDF2(nlsolve = nsa))
+        JAC_CALLS[] = 0
+        sol = solve(prob, alg; reltol = 1.0e-8, abstol = 1.0e-10)
+        @test SciMLBase.successful_retcode(sol)
+        @test norm(sol.u[end] .- refsol.u[end]) / norm(refsol.u[end]) < 1.0e-4
+        # W is reassembled on dt changes throughout (stats.nw ~ O(100) here), but a
+        # fresh Jacobian evaluation is only needed on first use and after divergences.
+        # Before the J/W split every W update called the user jac, so this tracked
+        # stats.nw one-to-one.
+        @test JAC_CALLS[] < sol.stats.nw / 3
+        @test JAC_CALLS[] >= 1
+    end
+end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
@@ -36,6 +36,7 @@ if TEST_GROUP ∉ ("QA", "ModelingToolkit")
     @time @safetestset "DAE Initialization Tests" include("dae_initialization_tests.jl")
     @time @safetestset "CheckInit Tests" include("checkinit_tests.jl")
     @time @safetestset "Nested AD over NonlinearSolveAlg" include("nested_ad_nlsolvealg_tests.jl")
+    @time @safetestset "NonlinearSolveAlg Jacobian Reuse Tests" include("nsa_jacobian_reuse_tests.jl")
 end
 
 # Run QA tests (JET, Aqua)


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Draft opened by an agent.

## Problem

The W-reuse path recomputes the Jacobian on **every** W update, including pure dt/γ changes. The legacy `do_newJW` policy separates the two decisions: a dt change only reassembles `W = J - M/γdt` from the stored J via `jacobian2W!` (O(nnz)); a fresh Jacobian evaluation is reserved for first use, `always_new`, or a diverged iteration.

Measured on the dense-AD 512-unknown brusselator at rtol 1e-8 (master): `FBDF+NLNewton` evaluates **1 Jacobian for the whole solve** (nf = 2,764) while `FBDF+NSA` evaluates **295** (nf = 152,393) — every dt-driven W refresh pays a full 512-dim AD Jacobian.

## Fix

`_update_nlsolvealg_W!` takes a `new_jac` flag; `initialize!` computes `new_jac = first_call || always_new || status === Divergence` separately from the dt-change test, mirroring `do_newJW`'s `jbad`/`wbad` split. dt-only updates reuse `cache.J` and only rerun `jacobian2W!`.

The expected trade (same one NLNewton makes) is visible on cheap-J ROBER: user-jac calls drop ~100 → ~4, iteration counts rise to NLNewton's level (1433 vs NLNewton's 1320, from 911 with always-fresh J), wall time unchanged. On expensive-J problems it's decisive — dense brusselator NSA/NLNewton time ratios, master → with this series:

| alg | rtol 1e-4 | 1e-6 | 1e-8 |
|---|---|---|---|
| FBDF | 5.0× → **0.96×** | 5.6× → 1.10× | 7.5× → 1.29× |
| QNDF | 4.1× → **0.92×** | 6.8× → 1.16× | 7.9× → **0.88×** |
| KenCarp4 | 17× → 1.20× | 39× → 1.79× | 66× → 1.72× |
| TRBDF2 | 20× → 1.65× | 55× → 2.24× | 70× → 1.49× |

(together with #3819 and SciML/NonlinearSolve.jl#1003; the remaining TRBDF2/KenCarp4 gap is step-count inflation from dt-controller/η coupling, a separate issue.)

## Tests

New `nsa_jacobian_reuse_tests.jl` counts calls to a user-supplied `jac` on ROBER (the `njacs` stat can't observe this — it's dominated by the inner analytic-jac closure copies, one per W update): asserts `JAC_CALLS < stats.nw / 3`. Verified the test **fails without this change** (JAC_CALLS ≈ nw, 2 failures) and passes with it. Solution accuracy asserted against a 1e-12 reference. Full-stack sparse brusselator + KLU reaches 1.00× of NLNewton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)