### PR TITLE
ExplicitRK: retain stages + fused interpolant for dense output

### DIFF
--- a/lib/OrdinaryDiffEqExplicitRK/Project.toml
+++ b/lib/OrdinaryDiffEqExplicitRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExplicitRK"
 uuid = "9286f039-9fbf-40e8-bf65-aa933bdc4db0"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqExplicitRK/src/explicit_rk_perform_step.jl
+++ b/lib/OrdinaryDiffEqExplicitRK/src/explicit_rk_perform_step.jl
@@ -1,5 +1,9 @@
 function initialize!(integrator, cache::ExplicitRKConstantCache)
-    integrator.kshortsize = 2
+    # When a B_interp matrix is present we keep every stage derivative in
+    # integrator.k so the dense-output addsteps! is a no-op (no re-evaluation
+    # of f). Otherwise only the two FSAL endpoints are needed for the Hermite
+    # fallback.
+    integrator.kshortsize = isnothing(cache.B_interp) ? 2 : cache.stages
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
     integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
@@ -7,7 +11,11 @@ function initialize!(integrator, cache::ExplicitRKConstantCache)
     # Avoid undefined entries if k is an array of arrays
     integrator.fsallast = zero(integrator.fsalfirst)
     integrator.k[1] = integrator.fsalfirst
-    return integrator.k[2] = integrator.fsallast
+    @inbounds for i in 2:(integrator.kshortsize - 1)
+        integrator.k[i] = zero(integrator.fsalfirst)
+    end
+    integrator.k[integrator.kshortsize] = integrator.fsallast
+    return nothing
 end
 
 @muladd function perform_step!(
@@ -16,7 +24,7 @@ end
     )
     (; t, dt, uprev, u, f, p) = integrator
     alg = unwrap_alg(integrator, false)
-    (; A, c, α, αEEst, stages) = cache
+    (; A, c, α, αEEst, stages, B_interp) = cache
     (; kk) = cache
 
     # Calc First
@@ -29,7 +37,6 @@ end
             utilde = utilde + A[j, i] * kk[j]
         end
         kk[i] = f(uprev + dt * utilde, p, t + c[i] * dt)
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     end
 
     #Calc Last
@@ -39,7 +46,7 @@ end
     end
     u_beforefinal = uprev + dt * utilde_last
     kk[end] = f(u_beforefinal, p, t + c[end] * dt)
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.stats.nf += stages - 1
     integrator.fsallast = kk[end] # Uses fsallast as temp even if not fsal
 
     # Accumulate Result
@@ -72,16 +79,37 @@ end
         OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     end
 
-    integrator.k[1] = integrator.fsalfirst
-    integrator.k[2] = integrator.fsallast
+    if isnothing(B_interp)
+        integrator.k[1] = integrator.fsalfirst
+        integrator.k[2] = integrator.fsallast
+    else
+        # Retain the stage derivatives so dense-output addsteps! is a no-op
+        # rather than re-evaluating f for every stage.
+        @inbounds for i in 1:stages
+            integrator.k[i] = kk[i]
+        end
+    end
     integrator.u = u
+    return nothing
 end
 
 function initialize!(integrator, cache::ExplicitRKCache)
-    integrator.kshortsize = 2
-    resize!(integrator.k, integrator.kshortsize)
-    integrator.k[1] = integrator.fsalfirst
-    integrator.k[2] = integrator.fsallast
+    # With a B_interp matrix, point integrator.k at the stage buffers so dense
+    # output uses the already-computed stages instead of re-evaluating f in
+    # addsteps! (same pattern as the hardcoded RK methods). Otherwise only the
+    # two FSAL endpoints are needed for the Hermite fallback.
+    if isnothing(cache.tab.B_interp)
+        integrator.kshortsize = 2
+        resize!(integrator.k, integrator.kshortsize)
+        integrator.k[1] = integrator.fsalfirst
+        integrator.k[2] = integrator.fsallast
+    else
+        integrator.kshortsize = cache.tab.stages
+        resize!(integrator.k, integrator.kshortsize)
+        @inbounds for i in 1:(integrator.kshortsize)
+            integrator.k[i] = cache.kk[i]
+        end
+    end
     integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
     return OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 end
@@ -363,6 +391,55 @@ end
 
 In-place version of generic interpolation for Runge-Kutta methods.
 """
+# Single-pass in-place interpolant for a statically known stage count: the
+# stage contributions are summed inside one fused broadcast instead of one
+# broadcast per stage (which walked `out` `nstages` times).
+@generated function fused_rk_interpolant!(
+        out, Θ, dt, y₀, k, B_interp, inv_dt_factor, order, ::Val{ns}
+    ) where {ns}
+    bexprs = Any[
+        :($(Symbol(:b_, i)) = eval_poly_derivative(Θ, @view(B_interp[$i, :]), order))
+            for i in 1:ns
+    ]
+    kterms = Any[:(k[$i] * $(Symbol(:b_, i))) for i in 1:ns]
+    ksum = length(kterms) == 1 ? kterms[1] : Expr(:call, :+, kterms...)
+    return quote
+        $(bexprs...)
+        if order == 0
+            @.. broadcast = false out = y₀ + dt * $ksum
+        else
+            @.. broadcast = false out = ($ksum) * inv_dt_factor
+        end
+        return out
+    end
+end
+
+function fused_rk_interpolant_fallback!(out, Θ, dt, y₀, k, B_interp, inv_dt_factor, order, nstages)
+    if order == 0
+        @.. broadcast = false out = y₀
+        for i in 1:nstages
+            bi_i = eval_poly_derivative(Θ, @view(B_interp[i, :]), order)
+            @.. broadcast = false out += dt * k[i] * bi_i
+        end
+    else
+        @.. broadcast = false out = zero(eltype(out))
+        for i in 1:nstages
+            bi_i = eval_poly_derivative(Θ, @view(B_interp[i, :]), order)
+            @.. broadcast = false out += k[i] * bi_i
+        end
+        @.. broadcast = false out *= inv_dt_factor
+    end
+    return out
+end
+
+@inline function fused_rk_interpolant_split!(out, Θ, dt, y₀, k, B_interp, inv_dt_factor, order, nstages)
+    return Base.@nif 17 (s -> s == nstages) (
+        s -> fused_rk_interpolant!(out, Θ, dt, y₀, k, B_interp, inv_dt_factor, order, Val(s))
+    ) (
+        s -> fused_rk_interpolant_fallback!(out, Θ, dt, y₀, k, B_interp, inv_dt_factor, order, nstages)
+    )
+end
+
 function generic_rk_interpolant!(out, Θ, dt, y₀, k, B_interp, bi; idxs = nothing, order = 0)
     if isnothing(B_interp)
         throw(DerivativeOrderNotPossibleError())
@@ -376,25 +453,13 @@ function generic_rk_interpolant!(out, Θ, dt, y₀, k, B_interp, bi; idxs = noth
 
     inv_dt_factor = order <= 1 ? one(dt) : inv(dt)^(order - 1)
 
-    # Fill pre-allocated bi buffer with polynomial weights
-    for i in 1:nstages
-        bi[i] = eval_poly_derivative(Θ, @view(B_interp[i, :]), order)
-    end
-
     if isnothing(idxs)
-        if order == 0
-            @.. out = y₀
-            for i in 1:nstages
-                @.. out += dt * k[i] * bi[i]
-            end
-        else
-            @.. out = zero(eltype(out))
-            for i in 1:nstages
-                @.. out += k[i] * bi[i]
-            end
-            @.. out *= inv_dt_factor
-        end
+        fused_rk_interpolant_split!(out, Θ, dt, y₀, k, B_interp, inv_dt_factor, order, nstages)
     else
+        # Fill pre-allocated bi buffer with polynomial weights
+        for i in 1:nstages
+            bi[i] = eval_poly_derivative(Θ, @view(B_interp[i, :]), order)
+        end
         if order == 0
             @views @.. out = y₀[idxs]
             for i in 1:nstages


### PR DESCRIPTION
## Summary

Closes most of the dense-output performance gap between the generic `ExplicitRK`
and the equivalent hardcoded methods, and enables dense output on the
out-of-place `ExplicitRK` path (which previously re-evaluated every stage).

**Please ignore until reviewed by @ChrisRackauckas.** Draft.

Two independent causes, both in `OrdinaryDiffEqExplicitRK`:

1. **Stage retention.** `_ode_addsteps!` re-evaluated `f` for every stage to
   rebuild the dense-output `k` vectors, even though `perform_step!` had just
   computed them. When the tableau carries a `B_interp` matrix, keep the stage
   derivatives in `integrator.k` (point at the cache stage buffers for the
   mutable cache, store the stage values for the constant cache), sized to
   `stages` instead of `2`, so `addsteps!` is a no-op. The out-of-place path,
   which had no stage retention at all, now gets dense output without
   recomputation.

2. **Fused interpolant.** `generic_rk_interpolant!` summed the stage
   contributions with one broadcast per stage, walking `out` `nstages` times. A
   `@generated` single-pass evaluator (dispatched on the static stage count)
   fuses the whole sum into one broadcast; a loop fallback covers stage counts
   above the unroll limit and the `idxs` path.

Stepping is unchanged: the OOP stage loop is left as-is. Its residual gap vs
hardcoded methods is dominated by the runtime tableau-coefficient array loads
(no compile-time constant folding / FMA contraction), not loop structure, so
unrolling it gave no measurable improvement — this PR does not touch it.

## Benchmarks

Julia 1.10, `ExplicitRK(OrdinaryDiffEqExplicitRK.constructTsit5ExplicitRK())`
vs hardcoded `Tsit5()` (same tableau), min times over `@benchmark`:

| case | before | after | `Tsit5()` |
|---|---|---|---|
| in-place 50-dim, dense `saveat=0.01` | 572 µs / 1359 alloc | **420 µs / 1059 alloc** | 327 µs / 1053 alloc |
| out-of-place StaticArray, dense `saveat=0.02` | (recomputed stages) | **166 µs / 34 alloc** | 110 µs / 29 alloc |
| in-place 50-dim step (no dense) | 72.8 µs | 73.6 µs | 67.1 µs |
| out-of-place StaticArray step (no dense) | 57.9 µs | 59.1 µs | 48.5 µs |

Dense-output allocations now match the hardcoded method; the remaining time gap
is the runtime `B_interp` coefficient evaluation (`eval_poly_derivative` Horner
per stage) vs hardcoded compile-time coefficients.

## Tests

Local, Julia 1.10: `interpolation_tests.jl` (Basic Solve, Interpolation, L2
convergence order > 3.5 for scalar & vector) and the `AllocCheck`
`perform_step!` allocation test all pass. `perform_step!` remains
allocation-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
