### PR TITLE
OOP build_J_W: route MatrixOperator mass matrix through WOperator

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -39,7 +39,7 @@ julia = "1.10"
 ADTypes = "1.22.0"
 DiffEqBase = "7"
 SafeTestsets = "0.1.0"
-SciMLOperators = "1.15"
+SciMLOperators = "1.23"
 
 [weakdeps]
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -1212,6 +1212,8 @@ function build_J_W(
             similar(J)
         elseif J isa StaticMatrix
             StaticWOperator(J - f.mass_matrix * invdtgamma_prototype, false)
+        elseif f.mass_matrix isa MatrixOperator
+            WOperator{IIP}(f.mass_matrix, dtgamma_prototype, J, _vec(u))
         else
             ArrayInterface.lu_instance(J - f.mass_matrix * invdtgamma_prototype)
         end


### PR DESCRIPTION
Restores support for OOP implicit solvers when `f.mass_matrix` is a `SciMLOperators.MatrixOperator`.

### Motivation

Before this PR, `build_J_W`'s OOP fall-through built W via `ArrayInterface.lu_instance(J - f.mass_matrix * inv(dtgamma))`. When `f.mass_matrix isa MatrixOperator`, the expression `J - MatrixOperator * Number` produces an `AddedOperator` (not a concrete `Matrix`), which has no `lu_instance` method — so the solve immediately errored out at cache construction (or, on the NLNewton path, hit the informative error at `newton.jl:275` documented in #3796).

This was the root cause of the `mass_matrix_tests:283 "Dependent Mass Matrix Tests"` failures for `iip=false` on master. See issue #3814 for the full scope audit.

### Change

One new branch in `build_J_W` (the OOP path in the fall-through):

```julia
elseif f.mass_matrix isa MatrixOperator
    WOperator{IIP}(f.mass_matrix, dtgamma_prototype, J, _vec(u))
```

That routes OOP + MatrixOperator mass matrix through the same `WOperator` construction the concrete-J path already uses, so downstream `calc_W`/`newton.jl`/etc. handle it uniformly. No informative error to drop yet — I'm leaving `newton.jl:275` in place as a fallback for genuinely-generic `AbstractSciMLOperator` W (e.g. `DiagonalOperator`), which is a separate follow-up.

### SciMLOperators compat bump

Depends on SciMLOperators v1.23.0 (SciML/SciMLOperators.jl#397), which fixed `convert(AbstractMatrix, W::WOperator{!IIP})` to also materialize a `MatrixOperator` mass matrix. Without that fix, the OOP `WOperator \ b` path would produce an `AddedOperator` at refresh time and crash.

`lib/OrdinaryDiffEqDifferentiation/Project.toml` compat floor bumped from `\"1.15\"` to `\"1.23\"`.

### Verification

Locally, the previously-failing OOP dependent-mass-matrix case at `mass_matrix_tests:283` now runs cleanly with `retcode = Success` and matches the reference solve to `|diff| = 5.8e-7` at reltol=1e-10.

### Test plan

- [x] `mass_matrix_tests:283` `iip=false` no longer errors — CI on this PR should turn the two erroring cells green
- [x] No regression on `iip=true` (was passing; still passes locally)
- [x] `mass_matrix_tests` non-operator (`I`, dense Matrix, Diagonal, UniformScaling) cases still pass

### Related

- SciML/SciMLOperators.jl#397 (merged, tagged v1.23.0) — the upstream fix this depends on
- SciML/SciMLOperators.jl#396 (closed by #397) — original bug report with root cause
- #3814 — full scope audit for the broader operator/mass-matrix rework
- #3796 — introduced the informative error this PR partially obsoletes