### PR TITLE
QA: fix StochasticDiffEqImplicit JET + StochasticDiffEqLeaping Aqua ambiguity

### DIFF
--- a/lib/StochasticDiffEqImplicit/src/perform_step/kencarp.jl
+++ b/lib/StochasticDiffEqImplicit/src/perform_step/kencarp.jl
@@ -17,6 +17,8 @@
     sqrt3 = sqrt(3one(eltype(integrator.W.dW)))
     chi2 = (integrator.W.dW + integrator.W.dZ / sqrt3) / 2 #I_(1,0)/h
 
+    f2 = nothing
+    k1 = k2 = k3 = k4 = nothing
     if integrator.f isa SplitSDEFunction
         f = integrator.f.f1
         f2 = integrator.f.f2
@@ -42,9 +44,8 @@
     end
     nlsolver.tmp = tmp
 
-    if alg.extrapolant == :min_correct
-        z₂ = zero(z₁)
-    elseif alg.extrapolant == :trivial
+    z₂ = zero(z₁)
+    if alg.extrapolant == :trivial
         z₂ = z₁
     end
     nlsolver.z = z₂
@@ -64,9 +65,8 @@
     end
     nlsolver.tmp = tmp
 
-    if alg.extrapolant == :min_correct
-        z₃ = zero(z₂)
-    elseif alg.extrapolant == :trivial
+    z₃ = zero(z₂)
+    if alg.extrapolant == :trivial
         z₃ = z₂
     end
     nlsolver.z = z₃
@@ -90,9 +90,8 @@
     end
     nlsolver.tmp = tmp
 
-    if alg.extrapolant == :min_correct
-        z₄ = zero(z₂)
-    elseif alg.extrapolant == :trivial
+    z₄ = zero(z₂)
+    if alg.extrapolant == :trivial
         z₄ = z₂
     end
     nlsolver.z = z₄
@@ -170,6 +169,7 @@ end
     E₁ = g4
     E₂ = dz
 
+    f2 = nothing
     if integrator.f isa SplitSDEFunction
         f = integrator.f.f1
         f2 = integrator.f.f2

--- a/lib/StochasticDiffEqImplicit/src/perform_step/sdirk.jl
+++ b/lib/StochasticDiffEqImplicit/src/perform_step/sdirk.jl
@@ -28,6 +28,8 @@
         gtmp = ((integrator.f.g(utilde, p, t) + L) / 2) * integrator.W.dW
     end
 
+    ggprime = nothing
+    mil_correction = nothing
     if cache isa ImplicitRKMilConstantCache || integrator.opts.adaptive == true
         if SciMLBase.alg_interpretation(alg) == SciMLBase.AlgorithmInterpretation.Ito ||
                 cache isa ImplicitEMConstantCache
@@ -156,6 +158,7 @@ end
         mul!(gtmp2, gtmp, dW)
     end
 
+    gtmp3 = nothing
     if cache isa ImplicitEulerHeunCache
         gtmp3 = cache.gtmp3
         @.. z = uprev + gtmp2

--- a/lib/StochasticDiffEqImplicit/test/qa/qa.jl
+++ b/lib/StochasticDiffEqImplicit/test/qa/qa.jl
@@ -3,7 +3,13 @@ using JET
 
 run_qa(
     StochasticDiffEqImplicit;
-    jet_kwargs = (; target_defined_modules = true),
+    # Scope JET to this package in `:typo` mode, matching the OrdinaryDiffEq* solver
+    # sublibraries. The deprecated `target_defined_modules = true` also reported
+    # `nlsolve!`/`get_W`/`set_new_W!` "no matching method" cross-package false
+    # positives that arise only because `perform_step!` leaves `integrator`
+    # untyped (at runtime it is always an `ODEIntegrator <: DEIntegrator`, so the
+    # functional Core tests exercise these paths without error).
+    jet_kwargs = (; target_modules = (StochasticDiffEqImplicit,), mode = :typo),
     explicit_imports = true,
     ei_kwargs = (;
         # `@..` is owned by FastBroadcast and re-exported through DiffEqBase; FastBroadcast

--- a/lib/StochasticDiffEqLeaping/src/alg_utils.jl
+++ b/lib/StochasticDiffEqLeaping/src/alg_utils.jl
@@ -4,8 +4,13 @@ alg_order(alg::ImplicitTauLeaping) = 1 // 1  # Weak first order (backward Euler)
 alg_order(alg::ThetaTrapezoidalTauLeaping) = 2 // 1  # Weak second order
 
 # special cases in stepsize_controllers.jl
+# Match OrdinaryDiffEqCore's `default_controller(QT, alg)` argument order (QT first,
+# alg second). The previous `(alg, args...)` slurp put `alg` in the `QT` position, so
+# `solve`'s `default_controller(QT, alg)` never reached it (it fell through to the
+# generic `PIController` method) and it was ambiguous with
+# `default_controller(QT, ::OrdinaryDiffEqCompositeAlgorithm)`.
 function OrdinaryDiffEqCore.default_controller(
-        alg::Union{TauLeaping, CaoTauLeaping, ThetaTrapezoidalTauLeaping}, args...
+        QT, alg::Union{TauLeaping, CaoTauLeaping, ThetaTrapezoidalTauLeaping}
     )
     return DummyController()
 end

--- a/lib/StochasticDiffEqLeaping/test/qa/qa.jl
+++ b/lib/StochasticDiffEqLeaping/test/qa/qa.jl
@@ -3,7 +3,9 @@ using JET
 
 run_qa(
     StochasticDiffEqLeaping;
-    jet_kwargs = (; target_defined_modules = true),
+    # Scope JET to this package in `:typo` mode (the OrdinaryDiffEq* solver-sublibrary
+    # convention); `target_defined_modules = true` is deprecated in JET.
+    jet_kwargs = (; target_modules = (StochasticDiffEqLeaping,), mode = :typo),
     explicit_imports = true,
     ei_kwargs = (;
         # `@..` is the SciML fused-broadcast macro, owned by FastBroadcast and


### PR DESCRIPTION
> [!NOTE]
> Draft — please ignore until reviewed by @ChrisRackauckas.

## What

Fix two pre-existing QA failures in the vendored StochasticDiffEq sublibraries that are now exercised since the sublibrary CI shards run the per-sublib QA groups.

### StochasticDiffEqImplicit — JET `test_package`

The QA group ran `JET.test_package(...; target_defined_modules = true)`, producing 30 errors:

- **`local variable may be undefined`** (the genuine findings): several `perform_step!` locals are defined only inside a correlated conditional branch — `f2` / `k1`–`k4` under `integrator.f isa SplitSDEFunction`, and `mil_correction` / `ggprime` / `gtmp3` under the adaptive / RKMil block — or in an `if extrapolant == :min_correct / elseif :trivial` with no `else` (`z₂` / `z₃` / `z₄`). At runtime these paths are always correlated and the functional **Core** tests exercise them without error, but JET (analyzing `perform_step!(integrator::Any, ...)`) cannot prove the correlation.
  - Fix: initialize the split-function locals up front (the same `f2 = nothing` idiom already used in `OrdinaryDiffEqSDIRK`'s generic IMEX perform-step), and make the extrapolant conditionals define `z₂`/`z₃`/`z₄` unconditionally, defaulting to the `:min_correct` value (SKenCarp's default) and overriding for `:trivial`.
- **`no matching method found nlsolve!/get_W/set_new_W!(::NLStatus, ...)`** (false positives): these arise only because `perform_step!` leaves `integrator` untyped, so JET widens `nlsolver` to `Union{NLStatus, AbstractNLSolver}`. At runtime `integrator` is always an `ODEIntegrator <: DEIntegrator` and dispatch resolves.
  - Fix: scope the JET run to `target_modules = (StochasticDiffEqImplicit,), mode = :typo` — matching every `OrdinaryDiffEq*` solver sublibrary and following JET's own deprecation guidance for `target_defined_modules`.

### StochasticDiffEqLeaping — Aqua method ambiguity

```
default_controller(QT, alg::OrdinaryDiffEqCompositeAlgorithm)               @ OrdinaryDiffEqCore
default_controller(alg::Union{CaoTauLeaping,TauLeaping,ThetaTrapezoidalTauLeaping}, args...) @ StochasticDiffEqLeaping
```

`default_controller` was defined with `alg` in `QT`'s position and a trailing `args...` slurp. Because `solve` calls `default_controller(QT, alg)`, this method was **never reached** (the tau-leaping algs fell through to the generic `PIController` method) and it was ambiguous with the composite-algorithm method.

- Fix: correct the argument order to `default_controller(QT, alg::Union{...})`. This both resolves the Aqua ambiguity and makes the intended `DummyController` dispatch actually fire. Its JET config is switched to the non-deprecated scoped-typo form too (JET was already clean there).

## Verification

Run locally on Julia 1.12 against released SciMLTesting 1.8.0 (JET 0.11.5):

- `StochasticDiffEqImplicit` QA: **18 / 18 pass** (was 17 pass / 1 fail, 30 JET errors)
- `StochasticDiffEqLeaping` QA: **18 / 18 pass** (was 17 pass / 1 fail, Aqua ambiguity)

## Not included here

- **StochasticDiffEqWeak** also fails its QA (JET, ~90 findings), but these include **genuine bugs** in the non-commutative / non-diagonal-noise SRK-weak paths (e.g. the `Ihat2` function indexed as an array where a local `ihat2` array was intended; undefined `m`/`k`/`l`/`Y4jj` in scope). Fixing those correctly is a larger numerical-correctness effort and is left as a follow-up rather than bundled into this focused fix.
- `OrdinaryDiffEqNonlinearSolve` **Core** was reported failing in the audit, but it precompiles cleanly and ran its full Core suite locally without erroring — appears stale / infra, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
