### PR TITLE
Add public API package split regression tests

### DIFF
--- a/test/InterfaceI/public_api_package_split.jl
+++ b/test/InterfaceI/public_api_package_split.jl
@@ -1,0 +1,51 @@
+using DiffEqCallbacks: FunctionCallingCallback
+using OrdinaryDiffEqBDF: FBDF
+using OrdinaryDiffEqLowOrderRK: DP5
+using OrdinaryDiffEqRosenbrock: Rodas5P
+using OrdinaryDiffEqSDIRK: TRBDF2
+using OrdinaryDiffEqTsit5: Tsit5
+using OrdinaryDiffEqVerner: AutoVern9, Vern9
+using RecursiveArrayTools: ArrayPartition
+using SciMLBase: ODEProblem, ReturnCode, solve, successful_retcode, terminate!
+using Test
+
+@testset "Public API package splits" begin
+    linear_prob = ODEProblem((u, p, t) -> p .* u, [1.0], (0.0, 1.0), -1.0)
+
+    for (name, alg) in (
+            ("Tsit5", Tsit5()),
+            ("DP5", DP5()),
+            ("Vern9", Vern9()),
+            ("Rodas5P", Rodas5P()),
+            ("TRBDF2", TRBDF2()),
+            ("FBDF", FBDF()),
+        )
+        @testset "$name" begin
+            sol = solve(linear_prob, alg; abstol = 1.0e-8, reltol = 1.0e-8)
+
+            @test successful_retcode(sol)
+            @test sol.u[end][1] ≈ exp(-1) rtol = 1.0e-4
+        end
+    end
+
+    function chart_exp_problem(u, p, t)
+        return ArrayPartition(u.x[2], zero(u.x[2]))
+    end
+
+    function terminate_after_tstop(u, t, integrator)
+        t >= 0.6 && terminate!(integrator)
+        return u
+    end
+
+    u0 = ArrayPartition([0.0], [1.0])
+    callback = FunctionCallingCallback(terminate_after_tstop; func_start = false)
+    prob = ODEProblem(chart_exp_problem, u0, (0.0, 1.0); callback)
+
+    @testset "Auto-switch callback and structured state" begin
+        sol = solve(prob, AutoVern9(Rodas5P()); save_everystep = false, tstops = [0.6])
+
+        @test sol.retcode === ReturnCode.Terminated
+        @test sol.u[end] isa ArrayPartition
+        @test sol.t[end] ≈ 0.6 atol = 1.0e-10
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,6 +46,7 @@ function interface_i()
     @time @safetestset "Inplace Interpolation Tests" include("InterfaceI/inplace_interpolation.jl")
     @time @safetestset "Algebraic Interpolation Tests" include("InterfaceI/algebraic_interpolation.jl")
     @time @safetestset "Interpolation and Cache Stripping Tests" include("InterfaceI/ode_strip_test.jl")
+    @time @safetestset "Public API Package Splits" include("InterfaceI/public_api_package_split.jl")
     @time @safetestset "Aliasing Tests" include("InterfaceI/aliasing_tests.jl")
     return @time @safetestset "Solution Memory Release" include("InterfaceI/solution_memory_tests.jl")
 end


### PR DESCRIPTION
## Summary
- add focused public API/package split regression tests that solve through `SciMLBase`
- cover owner-package imports for `OrdinaryDiffEqTsit5`, `OrdinaryDiffEqLowOrderRK`, `OrdinaryDiffEqVerner`, `OrdinaryDiffEqRosenbrock`, `OrdinaryDiffEqSDIRK`, `OrdinaryDiffEqBDF`, `DiffEqCallbacks`, and `RecursiveArrayTools`
- wire the test into the existing InterfaceI group

## Testing
- `julia -e 'using Pkg; Pkg.activate(; temp = true); Pkg.develop([PackageSpec(path = "lib/OrdinaryDiffEqBDF"), PackageSpec(path = "lib/OrdinaryDiffEqLowOrderRK"), PackageSpec(path = "lib/OrdinaryDiffEqRosenbrock"), PackageSpec(path = "lib/OrdinaryDiffEqSDIRK"), PackageSpec(path = "lib/OrdinaryDiffEqTsit5"), PackageSpec(path = "lib/OrdinaryDiffEqVerner")]); Pkg.add(["DiffEqCallbacks", "RecursiveArrayTools", "SciMLBase"]); include("test/InterfaceI/public_api_package_split.jl")'`
- previous version of this PR: `julia --project=. -e 'using Pkg; withenv("GROUP" => "InterfaceI") do; Pkg.test(; julia_args = ["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version = false, allow_reresolve = true); end'` reached the old regression test; a second full rerun was interrupted during the long existing Static Array Tests block after earlier InterfaceI testsets passed again.
