### PR TITLE
Initialize sparse Jacobian caches with stored values

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -1134,6 +1134,13 @@ function build_J_W(
         # If factorization, then just use the jac_prototype
         J = similar(f.jac_prototype)
         W = similar(J)
+        if is_sparse(J)
+            set_all_nzval!(J, one(eltype(J)))
+            set_all_nzval!(W, one(eltype(W)))
+        else
+            fill!(J, one(eltype(J)))
+            fill!(W, one(eltype(W)))
+        end
     elseif (
             IIP && (concrete_jac(alg) === nothing || !concrete_jac(alg)) &&
                 alg.linsolve !== nothing &&

--- a/lib/OrdinaryDiffEqDifferentiation/test/sparse/nonfulldiagonal_sparse_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/sparse/nonfulldiagonal_sparse_tests.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq, SparseArrays, LinearSolve, LinearAlgebra
+using OrdinaryDiffEq, SparseArrays, LinearSolve, LinearAlgebra, Test
 using OrdinaryDiffEqSDIRK
 using ComponentArrays
 
@@ -153,3 +153,21 @@ solve(odeprob, TRBDF2());
 solve(sparseodeprob, TRBDF2());
 solve(sparseodeprob, Rosenbrock23(linsolve = KLUFactorization()));
 solve(sparseodeprob, KenCarp47(linsolve = KrylovJL_GMRES()));
+
+@testset "Sparse Jacobian caches are initialized with stored values" begin
+    function sparse_cache_f!(du, u, p, t)
+        return du .= u
+    end
+
+    N = 8
+    jac_prototype = sparse(1:N, 1:N, ones(N), N, N)
+    prob = ODEProblem(
+        ODEFunction(sparse_cache_f!; jac_prototype),
+        ones(N),
+        (0.0, 1.0)
+    )
+    integ = init(prob, Rodas5P())
+
+    @test all(==(1), nonzeros(integ.cache.J))
+    @test all(==(1), nonzeros(integ.cache.W))
+end


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- initialize Jacobian and W caches with nonzero stored values before LinearSolve setup
- preserve sparse prototype structure by setting only existing `nzval` entries for sparse matrices
- add a sparse Rosenbrock cache regression test that checks `J` and `W` keep their sparse pattern and stored values immediately after `init`

Fixes #3830.

## Local verification
- `~/.juliaup/bin/julia +1.12 --project=. -e 'using OrdinaryDiffEqRosenbrock, SparseArrays, LinearAlgebra; function f!(du,u,p,t); du .= u; end; jacproto = sparse(1.0I, 4, 4); prob = ODEProblem(ODEFunction(f!; jac_prototype=jacproto), ones(4), (0.0, 1.0)); integ = init(prob, Rodas5P()); @show nnz(integ.cache.J) nnz(integ.cache.W); @show nonzeros(integ.cache.J); @show nonzeros(integ.cache.W); @assert nnz(integ.cache.J) == 4; @assert nnz(integ.cache.W) == 4; @assert all(==(1), nonzeros(integ.cache.J)); @assert all(==(1), nonzeros(integ.cache.W))'`
- `ODEDIFFEQ_TEST_GROUP=Sparse ~/.juliaup/bin/julia +1.12 --project=lib/OrdinaryDiffEqDifferentiation -e 'using Pkg; Pkg.test(; test_args=String[])'`
- `~/.juliaup/bin/julia +1.12 -e 'using Runic; exit(Runic.main(ARGS))' -- --check lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl lib/OrdinaryDiffEqDifferentiation/test/sparse/nonfulldiagonal_sparse_tests.jl`

Note: repository-wide Runic check was also run with `--check --diff --verbose .`; it fails on unrelated files. A clean-master check reproduced that failure and bisected it to `661f605637` / PR #3777.
