### PR TITLE
Fix sublibrary CI regressions

### DIFF
--- a/lib/OrdinaryDiffEqBDF/test/inference_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/inference_tests.jl
@@ -1,4 +1,5 @@
 using OrdinaryDiffEqBDF, ADTypes, Test
+using OrdinaryDiffEqNonlinearSolve: NonlinearSolveAlg
 using NonlinearSolve: TrustRegion
 import OrdinaryDiffEqCore.SciMLLogging as SciMLLogging
 using OrdinaryDiffEqCore: DEVerbosity
@@ -6,7 +7,7 @@ using OrdinaryDiffEqCore: DEVerbosity
 prob = ODEProblem((du, u, p, t) -> du .= u, zeros(1), (0.0, 1.0))
 nlalg = FBDF(
     autodiff = AutoFiniteDiff(),
-    nlsolve = OrdinaryDiffEqBDF.NonlinearSolveAlg(TrustRegion(autodiff = AutoFiniteDiff()))
+    nlsolve = NonlinearSolveAlg(TrustRegion(autodiff = AutoFiniteDiff()))
 )
 basicalg = FBDF(autodiff = AutoFiniteDiff())
 basicalgad = FBDF()

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -93,8 +93,8 @@ function _rosenbrock_jac_reuse_decision(integrator, cache, dtgamma)
     # constraint derivatives must remain accurate. See Steinebach (2024).
     naccept = integrator.stats.naccept
     if integrator.f.mass_matrix !== I
-        if naccept > jac_reuse.last_naccept 
-           jac_reuse.last_naccept = naccept
+        if naccept > jac_reuse.last_naccept
+            jac_reuse.last_naccept = naccept
             return (true, true)
         else
             return (false, true)

--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -58,7 +58,7 @@ Polyester = "0.7"
 DiffEqBase = "7"
 Reexport = "1.2.2"
 SafeTestsets = "0.1.0"
-SciMLOperators = "1.15.0"
+SciMLOperators = "1.23"
 
 [targets]
 test = ["DiffEqDevTools", "GenericSchur", "Random", "SafeTestsets", "Test", "ODEProblemLibrary", "Pkg"]

--- a/lib/StochasticDiffEqCore/src/StochasticDiffEqCore.jl
+++ b/lib/StochasticDiffEqCore/src/StochasticDiffEqCore.jl
@@ -51,6 +51,7 @@ using SparseArrays: SparseArrays, issparse
 # DEVerbosity is owned (and made public) by DiffEqBase but also re-exported
 # through OrdinaryDiffEqCore; import it from the owner.
 using DiffEqBase: DEVerbosity
+using SciMLLogging: AbstractVerbosityPreset, Standard
 
 using LinearAlgebra: LinearAlgebra, I, mul!
 using Random: Random


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- fix BDF inference test to import `NonlinearSolveAlg` from its owning package
- import `AbstractVerbosityPreset` in StochasticDiffEqCore for verbose handling
- fix a Runic whitespace/indentation issue in `derivative_utils.jl`
- relax `OrdinaryDiffEqFIRK` SciMLOperators compat to the lower bound required by `OrdinaryDiffEqDifferentiation`

The sparse Jacobian cache fix and regression test are already in #3833. This PR only keeps the follow-on CI fixes exposed by that merge.

## Verification
- `ODEDIFFEQ_TEST_GROUP=Core julia +1.11 --project=lib/OrdinaryDiffEqFIRK --check-bounds=yes --compiled-modules=yes --depwarn=yes -e 'using Pkg; Pkg.test(; coverage=true, force_latest_compatible_version=false, allow_reresolve=false)'`\n  - `FIRK Tests | 105 pass / 105 total`\n- targeted BDF inference test passed in a temp env with local in-repo packages\n- targeted Stochastic default-solver failure path passed in a temp env with local in-repo packages\n- Runic check passed on touched Julia files\n- `git diff --check` passed\n\nCo-authored-by: Chris Rackauckas <accounts@chrisrackauckas.com>