### PR TITLE
`get_differential_vars`: accept `IdentityOperator` and `ScalarOperator` mass matrices

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/misc_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/misc_utils.jl
@@ -208,8 +208,11 @@ function get_differential_vars(f, u)
         mm = f.mass_matrix
         mm = mm isa MatrixOperator ? mm.A : mm
 
-        if mm isa UniformScaling
+        if mm isa UniformScaling || mm isa SciMLOperators.IdentityOperator
             return nothing
+        elseif mm isa SciMLOperators.ScalarOperator
+            # λ·I: every variable is algebraic when λ is zero.
+            return iszero(mm.val) ? falses(size(u)) : nothing
         elseif all(!iszero, mm)
             return trues(size(mm, 1))
         elseif !(mm isa SciMLOperators.AbstractSciMLOperator) && _isdiag(mm)

--- a/lib/OrdinaryDiffEqCore/test/algebraic_vars_detection_tests.jl
+++ b/lib/OrdinaryDiffEqCore/test/algebraic_vars_detection_tests.jl
@@ -1,7 +1,9 @@
 using Test
 using SparseArrays
-using OrdinaryDiffEqCore: find_algebraic_vars_eqs
+using OrdinaryDiffEqCore: find_algebraic_vars_eqs, get_differential_vars
 using LinearAlgebra
+using SciMLBase: ODEFunction
+using SciMLOperators: IdentityOperator, ScalarOperator
 
 @testset "Sparse Algebraic Detection Performance" begin
     # Test 1: Correctness - results should match between sparse and dense methods
@@ -99,4 +101,15 @@ using LinearAlgebra
         # compare to dense
         @test find_algebraic_vars_eqs(M_diag) == find_algebraic_vars_eqs(collect(M_diag))
     end
+end
+
+@testset "get_differential_vars: operator mass matrix" begin
+    f!(du, u, p, t) = (du .= -u; nothing)
+    u = ones(3)
+    ff_id = ODEFunction(f!, mass_matrix = IdentityOperator(3))
+    @test get_differential_vars(ff_id, u) === nothing
+    ff_scalar = ODEFunction(f!, mass_matrix = ScalarOperator(2.0))
+    @test get_differential_vars(ff_scalar, u) === nothing
+    ff_singular = ODEFunction(f!, mass_matrix = ScalarOperator(0.0))
+    @test get_differential_vars(ff_singular, u) == falses(3)
 end


### PR DESCRIPTION
Follow-up to #3814. Once SciML/SciMLOperators.jl#400 lands the `issingular` methods, `IdentityOperator` and `ScalarOperator` mass matrices still hit `MethodError: no method matching iterate(::IdentityOperator)` inside `get_differential_vars` at `lib/OrdinaryDiffEqCore/src/misc_utils.jl:143`.

Root cause: the function reaches `elseif all(!iszero, mm)` and tries to iterate the operator.

Fix: treat `IdentityOperator` and `ScalarOperator` the same as `UniformScaling` (both represent scalar-uniform mass matrices) and return `nothing` early.

```julia
if mm isa UniformScaling ||
        mm isa SciMLOperators.IdentityOperator ||
        mm isa SciMLOperators.ScalarOperator
    return nothing
elseif ...
```

End-to-end verified against the #3814 repro with both fixes in place:

```
IdentityOperator + TRBDF2 (IIP) => OK, retcode=Success
ScalarOperator   + TRBDF2 (IIP) => (DimensionMismatch further down — separate downstream bug, out of scope here)
```

Direct regression test added in `algebraic_vars_detection_tests.jl` calls `get_differential_vars` on both operator kinds and asserts `nothing`.

Depends on SciML/SciMLOperators.jl#400 for full end-to-end.