### PR TITLE
Fix NonlinearSolve DAE initialization compat

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
@@ -45,8 +45,7 @@ using OrdinaryDiffEqCore: resize_nlsolver!, _initialize_dae!,
     Convergence,
     Divergence, NLStatus,
     MethodType, error_constant,
-    alg_extrapolates, resize_J_W!, alg_autodiff,
-    find_algebraic_vars_eqs
+    alg_extrapolates, resize_J_W!, alg_autodiff
 
 import OrdinaryDiffEqCore: _initialize_dae!,
     isnewton, get_W, isfirstcall, isfirststage,

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/initialize_dae.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/initialize_dae.jl
@@ -71,6 +71,39 @@ function default_nlsolve(
     )
 end
 
+function find_algebraic_vars_eqs(M::LinearAlgebra.Diagonal)
+    idxs = map(iszero, LinearAlgebra.diag(M))
+    return idxs, idxs
+end
+
+function find_algebraic_vars_eqs(M::SparseMatrixCSC)
+    n_cols = size(M, 2)
+    n_rows = size(M, 1)
+    algebraic_vars = fill(true, n_cols)
+    algebraic_eqs = fill(true, n_rows)
+
+    @inbounds for j in 1:n_cols
+        for idx in M.colptr[j]:(M.colptr[j + 1] - 1)
+            if !iszero(M.nzval[idx])
+                algebraic_vars[j] = false
+                algebraic_eqs[M.rowval[idx]] = false
+            end
+        end
+    end
+
+    return algebraic_vars, algebraic_eqs
+end
+
+function find_algebraic_vars_eqs(M::AbstractMatrix)
+    algebraic_vars = vec(all(iszero, M, dims = 1))
+    algebraic_eqs = vec(all(iszero, M, dims = 2))
+    return algebraic_vars, algebraic_eqs
+end
+
+function find_algebraic_vars_eqs(M::AbstractSciMLOperator)
+    return find_algebraic_vars_eqs(convert(AbstractMatrix, M))
+end
+
 ## ShampineCollocationInit
 
 #=

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/qa/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/qa/Project.toml
@@ -1,30 +1,23 @@
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrdinaryDiffEqBDF = "6ad6398a-0878-4a85-9266-38940aa047c8"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+OrdinaryDiffEqDifferentiation = "4302a76b-040a-498a-8c04-15b101fed76b"
+OrdinaryDiffEqFIRK = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 OrdinaryDiffEqNonlinearSolve = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
+OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[sources.OrdinaryDiffEqCore]
-path = "../../../OrdinaryDiffEqCore"
-
-[sources.OrdinaryDiffEqNonlinearSolve]
-path = "../.."
-
-[sources.OrdinaryDiffEqBDF]
-path = "../../../OrdinaryDiffEqBDF"
-
-[sources.OrdinaryDiffEqRosenbrock]
-path = "../../../OrdinaryDiffEqRosenbrock"
 
 [compat]
 ADTypes = "1.16"
 Aqua = "0.8.11"
+ConstructionBase = "1"
 JET = "0.9, 0.11"
 OrdinaryDiffEqBDF = "2"
 OrdinaryDiffEqCore = "4"
@@ -32,3 +25,24 @@ OrdinaryDiffEqNonlinearSolve = "2"
 OrdinaryDiffEqRosenbrock = "2"
 SciMLTesting = "1.7"
 julia = "1.10"
+
+[sources.OrdinaryDiffEqBDF]
+path = "../../../OrdinaryDiffEqBDF"
+
+[sources.OrdinaryDiffEqCore]
+path = "../../../OrdinaryDiffEqCore"
+
+[sources.OrdinaryDiffEqDifferentiation]
+path = "../../../OrdinaryDiffEqDifferentiation"
+
+[sources.OrdinaryDiffEqFIRK]
+path = "../../../OrdinaryDiffEqFIRK"
+
+[sources.OrdinaryDiffEqNonlinearSolve]
+path = "../.."
+
+[sources.OrdinaryDiffEqRosenbrock]
+path = "../../../OrdinaryDiffEqRosenbrock"
+
+[sources.OrdinaryDiffEqSDIRK]
+path = "../../../OrdinaryDiffEqSDIRK"

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
@@ -3,6 +3,21 @@ using Pkg
 
 const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
 
+function develop_local_solver_env()
+    lib_dir = dirname(dirname(@__DIR__))
+    Pkg.develop(
+        [
+            PackageSpec(path = joinpath(lib_dir, "OrdinaryDiffEqCore")),
+            PackageSpec(path = joinpath(lib_dir, "OrdinaryDiffEqDifferentiation")),
+            PackageSpec(path = joinpath(lib_dir, "OrdinaryDiffEqBDF")),
+            PackageSpec(path = joinpath(lib_dir, "OrdinaryDiffEqFIRK")),
+            PackageSpec(path = joinpath(lib_dir, "OrdinaryDiffEqRosenbrock")),
+            PackageSpec(path = joinpath(lib_dir, "OrdinaryDiffEqSDIRK")),
+        ]
+    )
+    return Pkg.instantiate()
+end
+
 function activate_modelingtoolkit_env()
     Pkg.activate(joinpath(@__DIR__, "modelingtoolkit"))
     lib_dir = dirname(dirname(@__DIR__))
@@ -20,11 +35,13 @@ end
 
 function activate_qa_env()
     Pkg.activate(joinpath(@__DIR__, "qa"))
+    develop_local_solver_env()
     return Pkg.instantiate()
 end
 
 # Run functional tests
 if TEST_GROUP ∉ ("QA", "ModelingToolkit")
+    develop_local_solver_env()
     @time @safetestset "Newton Tests" include("newton_tests.jl")
     @time @safetestset "Sparse DAE Initialization" include("sparse_dae_initialization_tests.jl")
     @time @safetestset "Linear Nonlinear Solver Tests" include("linear_nonlinear_tests.jl")


### PR DESCRIPTION
This is a draft PR and should be ignored until reviewed by @ChrisRackauckas.

## Summary

Fixes the Julia 1.10 `OrdinaryDiffEqNonlinearSolve` base-branch precompile failure:

```julia
UndefVarError: `find_algebraic_vars_eqs` not defined
```

The culprit is `5e1bd9329` (`Fix GPU compat of sparse dae solvers (#3073)`), which moved `find_algebraic_vars_eqs` into `OrdinaryDiffEqCore` and made `OrdinaryDiffEqNonlinearSolve` import it. On Julia 1.10, the reported subpackage test command still resolves registered `OrdinaryDiffEqCore v4.5.0`, which does not define that binding, while testing the local unreleased `OrdinaryDiffEqNonlinearSolve` source.

## Changes

- Restores `find_algebraic_vars_eqs` as a local `OrdinaryDiffEqNonlinearSolve` helper for DAE initialization.
- Keeps dense, diagonal, sparse CSC, and `AbstractSciMLOperator` handling.
- Develops local sibling OrdinaryDiffEq subpackages before functional/QA safetestsets so Julia 1.10 does not test an unreleased local subpackage against a mixed registered solver stack.
- Adds `ConstructionBase` and local sibling QA deps/sources to the QA test environment.

## Validation

Passed:

- `Runic --check` on touched Julia files.
- `git diff --check`.
- Reproduced the original failure on clean `342617a63` with the exact reported command.
- After this patch, the exact command gets past the original `find_algebraic_vars_eqs` failure and local functional tests pass through:
  - `Newton Tests`: 6/6
  - `Sparse DAE Initialization`: 27/27
  - `Linear Nonlinear Solver Tests`: 44/44
  - `Linear Solver Tests`: 113/113
  - `Linear Solver Split ODE Tests`: 10/10
  - `Mass Matrix Tests`: 225 pass, 42 existing broken
  - `W-Operator Prototype Tests`: 18/18
  - `DAE Initialization Tests`: 19/19
  - `CheckInit Tests`: 4/4
  - `Nested AD over NonlinearSolveAlg`: 5/5
  - `NonlinearSolveAlg Jacobian Reuse Tests`: 8/8

Remaining blocker:

- Full `Pkg.test()` still fails in QA JET after the precompile issue is fixed:
  - `JET Tests`: 5 passed, 8 failed, 33 broken.
  - The failures are type-stability reports in `test/qa/jet.jl:70` around BDF/Rosenbrock init paths through `SciMLLogging`/`Base.CoreLogging`.
  - I did not skip, silence, or mark these broken.
