### PR TITLE
Run Runic after ODEDiff downgrade cleanup

### DIFF
--- a/lib/OrdinaryDiffEqAdamsBashforthMoulton/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqAdamsBashforthMoulton/test/qa/qa.jl
@@ -9,6 +9,7 @@ run_qa(
                 # OrdinaryDiffEqCore internal limiter hook (owner-internal;
                 # deliberately not declared public, like the @fold/@threaded codegen macros).
                 :trivial_limiter!,
-            )),
+            ),
+        ),
     ),
 )

--- a/lib/OrdinaryDiffEqDifferentiation/src/OrdinaryDiffEqDifferentiation.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/OrdinaryDiffEqDifferentiation.jl
@@ -80,13 +80,17 @@ include("operators.jl")
 # differentiation-config hooks that downstream OrdinaryDiffEq solver sublibraries
 # build on. Codegen/perf internals are intentionally left non-public.
 @static if VERSION >= v"1.11.0-DEV.469"
-    eval(Expr(:public,
-        :build_J_W, :build_grad_config, :build_jac_config, :build_uf,
-        :calc_J, :calc_J!, :calc_tderivative, :calc_tderivative!,
-        :calc_rosenbrock_differentiation, :calc_rosenbrock_differentiation!,
-        :jacobian!, :jacobian2W!, :update_W!,
-        :resize_grad_config!, :resize_jac_config!,
-        :dolinsolve, :wrapprecs, :is_always_new, :islinearfunction, :issuccess_W))
+    eval(
+        Expr(
+            :public,
+            :build_J_W, :build_grad_config, :build_jac_config, :build_uf,
+            :calc_J, :calc_J!, :calc_tderivative, :calc_tderivative!,
+            :calc_rosenbrock_differentiation, :calc_rosenbrock_differentiation!,
+            :jacobian!, :jacobian2W!, :update_W!,
+            :resize_grad_config!, :resize_jac_config!,
+            :dolinsolve, :wrapprecs, :is_always_new, :islinearfunction, :issuccess_W
+        )
+    )
 end
 
 end

--- a/lib/OrdinaryDiffEqExponentialRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/test/qa/qa.jl
@@ -11,6 +11,7 @@ run_qa(
                 :_fixup_ad, :fsal_typeof,
                 # SciMLBase internal; pending a `public` declaration (SciMLBase#1412).
                 :_unwrap_val,
-            )),
+            ),
+        ),
     ),
 )

--- a/lib/OrdinaryDiffEqFeagin/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFeagin/test/qa/qa.jl
@@ -13,6 +13,7 @@ run_qa(
                 :CompiledFloats, :trivial_limiter!,
                 # DiffEqBase-owned internal macro, deliberately not `public`.
                 Symbol("@tight_loop_macros"),
-            )),
+            ),
+        ),
     ),
 )

--- a/lib/OrdinaryDiffEqLowOrderRK/src/OrdinaryDiffEqLowOrderRK.jl
+++ b/lib/OrdinaryDiffEqLowOrderRK/src/OrdinaryDiffEqLowOrderRK.jl
@@ -54,8 +54,12 @@ export Euler, SplitEuler, Heun, Ralston, Midpoint, RK4,
 # these low-order RK steps. Marked public so those references are recognized as
 # a supported extension API rather than internal access.
 @static if VERSION >= v"1.11.0-DEV.469"
-    eval(Expr(:public,
-        :BS3Cache, :BS3ConstantCache, :RK4Cache, :RK4ConstantCache))
+    eval(
+        Expr(
+            :public,
+            :BS3Cache, :BS3ConstantCache, :RK4Cache, :RK4ConstantCache
+        )
+    )
 end
 
 end

--- a/lib/OrdinaryDiffEqLowStorageRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/test/qa/qa.jl
@@ -13,11 +13,13 @@ run_qa(
                 :lorenz, :lorenz_oop,
                 # Base.Broadcast internals used in ArrayFuse copyto!/materialize!
                 :Broadcasted, :materialize!,
-            )),
+            ),
+        ),
         all_explicit_imports_are_public = (;
             ignore = (
                 # OrdinaryDiffEqCore default no-op limiter (owner-internal)
                 :trivial_limiter!,
-            )),
+            ),
+        ),
     ),
 )

--- a/lib/OrdinaryDiffEqVerner/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqVerner/test/qa/qa.jl
@@ -15,7 +15,8 @@ run_qa(
                 :has_lazy_interpolation,
                 # OrdinaryDiffEqCore test-only helpers (deliberately kept non-public)
                 :lorenz, :lorenz_oop,
-            )),
+            ),
+        ),
         # Explicit imports of names not (yet) declared public by their owners.
         all_explicit_imports_are_public = (;
             ignore = (
@@ -29,6 +30,7 @@ run_qa(
                 Symbol("@def"), :_unwrap_val,
                 # TruncatedStacktraces internal macro
                 Symbol("@truncate_stacktrace"),
-            )),
+            ),
+        ),
     ),
 )

--- a/lib/StochasticDiffEqImplicit/test/qa/qa.jl
+++ b/lib/StochasticDiffEqImplicit/test/qa/qa.jl
@@ -25,6 +25,7 @@ run_qa(
                 :current_extrapolant!, :isnewton, :_fixup_ad,
                 # SciMLBase internals (not yet `public` on registered SciMLBase).
                 :has_Wfact, :_vec, :_reshape, :_unwrap_val,
-            )),
+            ),
+        ),
     ),
 )

--- a/lib/StochasticDiffEqLeaping/test/qa/qa.jl
+++ b/lib/StochasticDiffEqLeaping/test/qa/qa.jl
@@ -20,7 +20,7 @@ run_qa(
                 Symbol("@.."),
                 # StochasticDiffEqCore internal cache-alloc macro (non-public).
                 Symbol("@cache"),
-            )
+            ),
         ),
         all_qualified_accesses_are_public = (;
             ignore = (
@@ -29,7 +29,7 @@ run_qa(
                 :isaposteriori,
                 # PoissonRandom sampler, re-exported via JumpProcesses (non-public).
                 :pois_rand,
-            )
+            ),
         ),
     ),
 )


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

Follow-up to #3840. That PR merged the downgrade resolver fixes before the formatter-only cleanup commit could land, and CI's full-repo Runic check reported these public-API cleanup files.

Changes:
- Runic-format the OrdinaryDiffEqDifferentiation and OrdinaryDiffEqLowOrderRK public blocks.
- Runic-format QA `ignore = (...)` named-tuple closing syntax in the files reported by the CI Runic log.

Local verification:
- Full-repo `Runic.main(["--check", "--diff", "."])` passed with Runic v1.7.0.
- `git diff --check origin/master..HEAD` passed.

This is formatter-only; the behavioral/package tests for the resolver changes were run and documented in #3840 before it merged.
