### PR TITLE
Fix strip_cache constructorof via ConstructionBase

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.6.0"
+version = "4.6.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -9,6 +9,7 @@ Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 BinaryHeaps = "b2a6c25c-c996-4615-94ab-6e519ffb8690"
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
@@ -49,6 +50,7 @@ OrdinaryDiffEqCoreSparseArraysExt = "SparseArrays"
 [compat]
 ADTypes = "1.22.0"
 Accessors = "0.1.42"
+ConstructionBase = "1.5.8"
 Adapt = "4.3"
 ArrayInterface = "7.19"
 BinaryHeaps = "1"

--- a/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
+++ b/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
@@ -95,6 +95,7 @@ import DiffEqBase: timedepentdtmin, calculate_residuals, calculate_residuals!
 # using MacroTools, Adapt
 import ADTypes: AutoFiniteDiff, AutoForwardDiff, AutoSparse, dense_ad
 import Accessors: @reset
+import ConstructionBase
 
 # SciMLStructures symbols imported but not directly used in OrdinaryDiffEqCore
 # using SciMLStructures: canonicalize, Tunable, isscimlstructure

--- a/lib/OrdinaryDiffEqCore/src/interp_func.jl
+++ b/lib/OrdinaryDiffEqCore/src/interp_func.jl
@@ -87,7 +87,7 @@ end
 
 function strip_cache(cache)
     if !(cache isa OrdinaryDiffEqCore.DefaultCache)
-        cache = SciMLBase.constructorof(typeof(cache))(
+        cache = ConstructionBase.constructorof(typeof(cache))(
             [
                 nothing
                     for name in

--- a/lib/OrdinaryDiffEqCore/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqCore/test/qa/qa.jl
@@ -23,17 +23,12 @@ run_qa(
                 :calculate_residuals, :calculate_residuals!,
             ),
         ),
-        # `constructorof` is owned by ConstructionBase but reached through SciMLBase
-        # (not a direct dependency); accessing it via SciMLBase is intentional.
-        all_qualified_accesses_via_owners = (; ignore = (:constructorof,)),
         # Internal (non-`public`) names of upstream packages that OrdinaryDiffEqCore
         # genuinely needs and that have no public replacement yet.
         all_qualified_accesses_are_public = (;
             ignore = (
                 # Base / Core internals
                 Symbol("@max_methods"), :Experimental, :Typeof, :promote_op,
-                # ConstructionBase (owned there, accessed via SciMLBase)
-                :constructorof,
                 # SciMLOperators internal
                 :AbstractSciMLOperator,
                 # EnzymeCore / EnzymeCore.EnzymeRules internals

--- a/lib/OrdinaryDiffEqSDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqSDIRK/Project.toml
@@ -4,6 +4,7 @@ authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 version = "2.8.0"
 
 [deps]
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -35,6 +36,7 @@ DiffEqBase = {path = "../DiffEqBase"}
 DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
+ConstructionBase = "1.5.8"
 Pkg = "1"
 Test = "<0.0.1, 1"
 FastBroadcast = "1.3"

--- a/lib/OrdinaryDiffEqSDIRK/src/OrdinaryDiffEqSDIRK.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/OrdinaryDiffEqSDIRK.jl
@@ -42,6 +42,7 @@ using OrdinaryDiffEqNonlinearSolve: du_alias_or_new, markfirststage!, build_nlso
 import ADTypes: AutoForwardDiff
 using CommonSolve: solve
 
+import ConstructionBase
 using Reexport: Reexport, @reexport
 @reexport using SciMLBase
 

--- a/lib/OrdinaryDiffEqSDIRK/src/sdirk_caches.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/sdirk_caches.jl
@@ -73,7 +73,7 @@ end
 
 function OrdinaryDiffEqCore.strip_cache(cache::ESDIRKIMEXCache)
     s = length(cache.zs)
-    return SciMLBase.constructorof(typeof(cache))(
+    return ConstructionBase.constructorof(typeof(cache))(
         nothing, nothing, nothing,
         Vector{Nothing}(undef, s),
         Vector{Nothing}(undef, s),

--- a/lib/OrdinaryDiffEqSDIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/qa/qa.jl
@@ -8,19 +8,14 @@ using SciMLTesting, OrdinaryDiffEqSDIRK, Test
 #     (the `lorenz`/`lorenz_oop` precompile-workload fixtures and the
 #     `trivial_limiter!` default limiter).
 #   * SciMLBase private helpers (`_reshape`/`_unwrap_val`/`_vec`).
-#   * External packages whose names have no public export (ConstructionBase's
-#     `constructorof`, TruncatedStacktraces' `@truncate_stacktrace`).
+#   * External packages whose names have no public export (TruncatedStacktraces'
+#     `@truncate_stacktrace`).
 run_qa(
     OrdinaryDiffEqSDIRK;
     explicit_imports = true,
     ei_kwargs = (
-        # `constructorof` is owned by ConstructionBase (not a direct dep) and is
-        # reached through SciMLBase's re-export; it is the only non-owner access.
-        all_qualified_accesses_via_owners = (; ignore = (:constructorof,)),
         all_qualified_accesses_are_public = (;
             ignore = (
-                # non-public in ConstructionBase (via SciMLBase re-export)
-                :constructorof,
                 # non-public OrdinaryDiffEqCore precompile-workload fixtures
                 :lorenz, :lorenz_oop,
             ),


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

## Summary

`strip_cache` / `strip_solution` InterfaceI tests fail on master with:

```
UndefVarError: `constructorof` not defined in `SciMLBase`
```

SciMLBase only defines `ConstructionBase.constructorof` methods; it does not bind `constructorof` in its own namespace. OrdinaryDiffEqCore and OrdinaryDiffEqSDIRK were calling `SciMLBase.constructorof`.

## Changes

- Call `ConstructionBase.constructorof` (add ConstructionBase as a direct dep)
- Bump OrdinaryDiffEqCore `4.6.0` → `4.6.1`
- OrdinaryDiffEqSDIRK stays at unreleased `2.8.0` (includes the fix)
- Drop stale ExplicitImports ignores that excused the SciMLBase path

## Verified

```
STRIP_OK  # Tsit5 + Rosenbrock23 strip_solution locally
```

## Follow-up

Many OrdinaryDiffEq sublibrary TagBot registration PRs on General are AutoMerge-blocked because they were registered from the pre-squash branch commit (not on master). After this merges, re-register all unreleased monorepo packages from `master` HEAD.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>