### PR TITLE
Use SciMLTesting.activate_group_env for AD/Downstream/ODEInterface LTS

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -137,28 +137,30 @@ function algconvergence_iii()
     return @time @safetestset "Split Methods Tests" include("AlgConvergence_III/split_methods_tests.jl")
 end
 
-# AD / Downstream / ODEInterfaceRegression activate their own per-group
-# Project.toml exactly as the previous `activate_*_env` helpers did:
-# `Pkg.activate(dir)`, `Pkg.develop(path = repo root)`, `Pkg.instantiate()`.
-# They are kept as thunks (not `env =` group specs) so the develop/instantiate
-# behavior — in particular NOT transitively developing the sub-env's `[sources]`
-# on Julia < 1.11 — stays byte-for-byte identical to before the refactor.
+# AD / Downstream / ODEInterfaceRegression: use SciMLTesting.activate_group_env
+# so Julia < 1.11 gets `develop_sources!` (the `[sources]` LTS backport already
+# shipped in SciMLTesting). Developing only the monorepo root left registry
+# Rosenbrock ≤2.3.2 paired with monorepo Differentiation 3.3.0 (unsatisfiable
+# after the General retrocap).
 function activate_downstream_env()
-    Pkg.activate("Downstream")
-    Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
-    return Pkg.instantiate()
+    return activate_group_env(
+        joinpath(@__DIR__, "Downstream");
+        parent = dirname(@__DIR__),
+    )
 end
 
 function activate_odeinterface_env()
-    Pkg.activate("ODEInterfaceRegression")
-    Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
-    return Pkg.instantiate()
+    return activate_group_env(
+        joinpath(@__DIR__, "ODEInterfaceRegression");
+        parent = dirname(@__DIR__),
+    )
 end
 
 function activate_ad_env()
-    Pkg.activate("AD")
-    Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
-    return Pkg.instantiate()
+    return activate_group_env(
+        joinpath(@__DIR__, "AD");
+        parent = dirname(@__DIR__),
+    )
 end
 
 function downstream_group()


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

## Problem

On master CI (Julia LTS), **AD** / **Downstream** fail with unsatisfiable Rosenbrock ≤2.3.2 + Differentiation 3.3.0 after the General retrocap.

Those groups only `Pkg.develop`'d the monorepo root. On Julia < 1.11, `[sources]` is ignored, so path Differentiation mixed with registry Rosenbrock.

## Fix (not a SciMLTesting / .github change)

`SciMLTesting` already exports `develop_sources!` / `activate_group_env` as the LTS `[sources]` backport. Wire AD/Downstream/ODEInterfaceRegression through `activate_group_env(...; parent = repo_root)` instead of hand-rolled activate helpers.

No new helper in OrdinaryDiffEq; no change needed in SciML/.github or SciMLTesting for this bug — only call the existing API.

## Verified (Julia 1.10.11)

```
activate_group_env(test/AD; parent = repo)
OrdinaryDiffEqRosenbrock => 2.4.0 path=true
OrdinaryDiffEqDifferentiation => 3.3.0 path=true
ACTIVATE_GROUP_ENV_OK
```