### PR TITLE
Differentiation: sparse-GPU path for dae_jacobian2W! (GPU CSR DAE)

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "3.3.0"
+version = "3.3.1"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -566,15 +566,12 @@ end
 end
 
 
-# Sparse GPU W-build path: CuSparseMatrixCSC usually subtypes AbstractSparseMatrix
-# (is_sparse true), but CuSparseMatrixCSR often does not. Detect CSR via the
-# cuSPARSE `.nzVal` storage field so we never `@..` broadcast into it.
-@inline function _use_allocating_sparse_W_path(W)
-    if is_sparse(W)
-        return !ArrayInterface.fast_scalar_indexing(nonzeros(W))
-    end
-    return hasproperty(W, :nzVal)
-end
+# Sparse GPU arrays (e.g. CuSparseMatrixCSC/CSR) don't support broadcasting into
+# W, so they need the allocating build path. All cuSPARSE matrix types subtype
+# AbstractSparseMatrix (is_sparse true); their `nonzeros` storage is a GPU array,
+# which is not fast_scalar_indexing, whereas CPU sparse storage is.
+@inline _use_allocating_sparse_W_path(W) =
+    is_sparse(W) && !ArrayInterface.fast_scalar_indexing(nonzeros(W))
 
 
 """
@@ -607,10 +604,8 @@ function jacobian2W!(
                 @.. broadcast = false @view(W[idxs]) = muladd(λ, invdtgamma, @view(J[idxs]))
             end
         elseif _use_allocating_sparse_W_path(W)
-            # Sparse GPU arrays (e.g. CuSparseMatrixCSC/CSR) don't support broadcasting.
-            # ArrayInterface.fast_scalar_indexing is not specialized for AbstractGPUSparseArray,
-            # so we detect them by checking if the underlying nonzeros storage is a GPU array.
-            # we then fall back to allocating matrix arithmetic
+            # Sparse GPU arrays (e.g. CuSparseMatrixCSC/CSR) don't support broadcasting
+            # into W, so fall back to allocating matrix arithmetic.
             copyto!(W, J - invdtgamma * mass_matrix)
         else
             @.. broadcast = false W = muladd(-mass_matrix, invdtgamma, J)

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -565,6 +565,18 @@ end
     throw(DimensionMismatch("J: $(axes(J)), mass matrix: $(axes(mass_matrix))"))
 end
 
+
+# Sparse GPU W-build path: CuSparseMatrixCSC usually subtypes AbstractSparseMatrix
+# (is_sparse true), but CuSparseMatrixCSR often does not. Detect CSR via the
+# cuSPARSE `.nzVal` storage field so we never `@..` broadcast into it.
+@inline function _use_allocating_sparse_W_path(W)
+    if is_sparse(W)
+        return !ArrayInterface.fast_scalar_indexing(nonzeros(W))
+    end
+    return hasproperty(W, :nzVal)
+end
+
+
 """
     jacobian2W!(W, mass_matrix, dtgamma, J) -> nothing
 
@@ -594,7 +606,7 @@ function jacobian2W!(
             else
                 @.. broadcast = false @view(W[idxs]) = muladd(λ, invdtgamma, @view(J[idxs]))
             end
-        elseif is_sparse(W) && !ArrayInterface.fast_scalar_indexing(nonzeros(W))
+        elseif _use_allocating_sparse_W_path(W)
             # Sparse GPU arrays (e.g. CuSparseMatrixCSC/CSR) don't support broadcasting.
             # ArrayInterface.fast_scalar_indexing is not specialized for AbstractGPUSparseArray,
             # so we detect them by checking if the underlying nonzeros storage is a GPU array.
@@ -659,7 +671,7 @@ function dae_jacobian2W!(
     )::Nothing
     @boundscheck axes(W) == axes(J_u) == axes(J_du) ||
         throw(DimensionMismatch("W, J_u, J_du must have matching axes"))
-    if is_sparse(W) && !ArrayInterface.fast_scalar_indexing(nonzeros(W))
+    if _use_allocating_sparse_W_path(W)
         # Sparse GPU arrays (e.g. CuSparseMatrixCSC/CSR) don't support
         # broadcasting into W. Same path as jacobian2W!: allocate then copyto!.
         copyto!(W, J_u + convert(eltype(W), cj) * J_du)
@@ -683,7 +695,7 @@ end
 function dae_jacobian2W(
         J_u::AbstractMatrix, J_du::AbstractMatrix, cj::Number
     )
-    if is_sparse(J_u) && !ArrayInterface.fast_scalar_indexing(nonzeros(J_u))
+    if _use_allocating_sparse_W_path(J_u)
         return J_u + convert(eltype(J_u), cj) * J_du
     end
     return @. muladd(cj, J_du, J_u)

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -659,7 +659,13 @@ function dae_jacobian2W!(
     )::Nothing
     @boundscheck axes(W) == axes(J_u) == axes(J_du) ||
         throw(DimensionMismatch("W, J_u, J_du must have matching axes"))
-    @.. broadcast = false W = muladd(cj, J_du, J_u)
+    if is_sparse(W) && !ArrayInterface.fast_scalar_indexing(nonzeros(W))
+        # Sparse GPU arrays (e.g. CuSparseMatrixCSC/CSR) don't support
+        # broadcasting into W. Same path as jacobian2W!: allocate then copyto!.
+        copyto!(W, J_u + convert(eltype(W), cj) * J_du)
+    else
+        @.. broadcast = false W = muladd(cj, J_du, J_u)
+    end
     return nothing
 end
 
@@ -677,6 +683,9 @@ end
 function dae_jacobian2W(
         J_u::AbstractMatrix, J_du::AbstractMatrix, cj::Number
     )
+    if is_sparse(J_u) && !ArrayInterface.fast_scalar_indexing(nonzeros(J_u))
+        return J_u + convert(eltype(J_u), cj) * J_du
+    end
     return @. muladd(cj, J_du, J_u)
 end
 

--- a/lib/OrdinaryDiffEqDifferentiation/test/dae_jacobian2w_sparse_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/dae_jacobian2w_sparse_tests.jl
@@ -1,0 +1,16 @@
+using OrdinaryDiffEqDifferentiation
+using SparseArrays
+using Test
+
+# CPU sparse path uses broadcast; verify W = J_u + cj * J_du numerically.
+# The GPU non-fast-scalar branch is covered by monorepo GPU DAE tests.
+J_u = sparse([1.0 0.0; 0.5 2.0])
+J_du = sparse([0.0 1.0; 0.0 0.5])
+cj = 3.0
+W = similar(J_u)
+fill!(nonzeros(W), 0)
+OrdinaryDiffEqDifferentiation.dae_jacobian2W!(W, J_u, J_du, cj)
+@test Matrix(W) ≈ Matrix(J_u) + cj * Matrix(J_du)
+
+W_oop = OrdinaryDiffEqDifferentiation.dae_jacobian2W(J_u, J_du, cj)
+@test Matrix(W_oop) ≈ Matrix(J_u) + cj * Matrix(J_du)

--- a/lib/OrdinaryDiffEqDifferentiation/test/dae_jacobian2w_sparse_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/dae_jacobian2w_sparse_tests.jl
@@ -3,7 +3,7 @@ using SparseArrays
 using Test
 
 # CPU sparse path uses broadcast; verify W = J_u + cj * J_du numerically.
-# GPU CSR is covered by monorepo test/gpu/dae_tests.jl (uses nzVal detection).
+# GPU CSR (allocating path) is covered by monorepo test/gpu/dae_tests.jl.
 J_u = sparse([1.0 0.0; 0.5 2.0])
 J_du = sparse([0.0 1.0; 0.0 0.5])
 cj = 3.0
@@ -15,31 +15,8 @@ OrdinaryDiffEqDifferentiation.dae_jacobian2W!(W, J_u, J_du, cj)
 W_oop = OrdinaryDiffEqDifferentiation.dae_jacobian2W(J_u, J_du, cj)
 @test Matrix(W_oop) ≈ Matrix(J_u) + cj * Matrix(J_du)
 
-# Duck-type path for types that look like cuSPARSE (have .nzVal) but are not
-# AbstractSparseMatrix — mirrors CuSparseMatrixCSR detection.
-struct FakeCuSparse{T} <: AbstractMatrix{T}
-    data::Matrix{T}
-    nzVal::Vector{T}
-end
-Base.size(A::FakeCuSparse) = size(A.data)
-Base.getindex(A::FakeCuSparse, i::Int, j::Int) = A.data[i, j]
-Base.setindex!(A::FakeCuSparse, v, i::Int, j::Int) = (A.data[i, j] = v)
-function Base.copyto!(dest::FakeCuSparse, src::AbstractMatrix)
-    dest.data .= src
-    return dest
-end
-Base.:+(A::FakeCuSparse, B::AbstractMatrix) = FakeCuSparse(A.data + Matrix(B), vec(A.data + Matrix(B)))
-Base.:+(A::AbstractMatrix, B::FakeCuSparse) = FakeCuSparse(Matrix(A) + B.data, vec(Matrix(A) + B.data))
-Base.:+(A::FakeCuSparse, B::FakeCuSparse) = FakeCuSparse(A.data + B.data, vec(A.data + B.data))
-Base.:*(a::Number, A::FakeCuSparse) = FakeCuSparse(a * A.data, a * A.nzVal)
-
-@test OrdinaryDiffEqDifferentiation._use_allocating_sparse_W_path(
-    FakeCuSparse(ones(2, 2), ones(4))
-)
+# CPU sparse takes the broadcast path (fast_scalar_indexing storage); a dense
+# matrix is not sparse at all. Real cuSPARSE types subtype AbstractSparseMatrix
+# with GPU nonzeros storage and take the allocating path (covered on GPU CI).
+@test !OrdinaryDiffEqDifferentiation._use_allocating_sparse_W_path(W)
 @test !OrdinaryDiffEqDifferentiation._use_allocating_sparse_W_path(ones(2, 2))
-
-J_u_f = FakeCuSparse([1.0 0.0; 0.5 2.0], [1.0, 0.5, 2.0])
-J_du_f = FakeCuSparse([0.0 1.0; 0.0 0.5], [1.0, 0.5])
-W_f = FakeCuSparse(zeros(2, 2), zeros(4))
-OrdinaryDiffEqDifferentiation.dae_jacobian2W!(W_f, J_u_f, J_du_f, cj)
-@test W_f.data ≈ [1.0 3.0; 0.5 3.5]

--- a/lib/OrdinaryDiffEqDifferentiation/test/dae_jacobian2w_sparse_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/dae_jacobian2w_sparse_tests.jl
@@ -3,7 +3,7 @@ using SparseArrays
 using Test
 
 # CPU sparse path uses broadcast; verify W = J_u + cj * J_du numerically.
-# The GPU non-fast-scalar branch is covered by monorepo GPU DAE tests.
+# GPU CSR is covered by monorepo test/gpu/dae_tests.jl (uses nzVal detection).
 J_u = sparse([1.0 0.0; 0.5 2.0])
 J_du = sparse([0.0 1.0; 0.0 0.5])
 cj = 3.0
@@ -14,3 +14,32 @@ OrdinaryDiffEqDifferentiation.dae_jacobian2W!(W, J_u, J_du, cj)
 
 W_oop = OrdinaryDiffEqDifferentiation.dae_jacobian2W(J_u, J_du, cj)
 @test Matrix(W_oop) ≈ Matrix(J_u) + cj * Matrix(J_du)
+
+# Duck-type path for types that look like cuSPARSE (have .nzVal) but are not
+# AbstractSparseMatrix — mirrors CuSparseMatrixCSR detection.
+struct FakeCuSparse{T} <: AbstractMatrix{T}
+    data::Matrix{T}
+    nzVal::Vector{T}
+end
+Base.size(A::FakeCuSparse) = size(A.data)
+Base.getindex(A::FakeCuSparse, i::Int, j::Int) = A.data[i, j]
+Base.setindex!(A::FakeCuSparse, v, i::Int, j::Int) = (A.data[i, j] = v)
+function Base.copyto!(dest::FakeCuSparse, src::AbstractMatrix)
+    dest.data .= src
+    return dest
+end
+Base.:+(A::FakeCuSparse, B::AbstractMatrix) = FakeCuSparse(A.data + Matrix(B), vec(A.data + Matrix(B)))
+Base.:+(A::AbstractMatrix, B::FakeCuSparse) = FakeCuSparse(Matrix(A) + B.data, vec(Matrix(A) + B.data))
+Base.:+(A::FakeCuSparse, B::FakeCuSparse) = FakeCuSparse(A.data + B.data, vec(A.data + B.data))
+Base.:*(a::Number, A::FakeCuSparse) = FakeCuSparse(a * A.data, a * A.nzVal)
+
+@test OrdinaryDiffEqDifferentiation._use_allocating_sparse_W_path(
+    FakeCuSparse(ones(2, 2), ones(4))
+)
+@test !OrdinaryDiffEqDifferentiation._use_allocating_sparse_W_path(ones(2, 2))
+
+J_u_f = FakeCuSparse([1.0 0.0; 0.5 2.0], [1.0, 0.5, 2.0])
+J_du_f = FakeCuSparse([0.0 1.0; 0.0 0.5], [1.0, 0.5])
+W_f = FakeCuSparse(zeros(2, 2), zeros(4))
+OrdinaryDiffEqDifferentiation.dae_jacobian2W!(W_f, J_u_f, J_du_f, cj)
+@test W_f.data ≈ [1.0 3.0; 0.5 3.5]

--- a/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
@@ -29,6 +29,7 @@ end
 
 # Run functional tests
 if TEST_GROUP ∉ ("QA", "Sparse", "ModelingToolkit")
+    @time @safetestset "DAE jacobian2W sparse" include("dae_jacobian2w_sparse_tests.jl")
     @time @safetestset "OOP J_t Tracking" include("oop_jt_tracking_test.jl")
     @time @safetestset "Differentiation Trait Tests" include("differentiation_traits_tests.jl")
     @time @safetestset "Autodiff Error Tests" include("autodiff_error_tests.jl")


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

Extracted from omnibus #3836.

Fixes monorepo GPU DAE failures for every solver with `jac=CSR` + `mass=diag_cu` (48 `:gpu_error` cases on master).

`dae_jacobian2W!` used `@.. broadcast` into W. Sparse GPU CSR/CSC matrices do not support that. Mirror the existing `jacobian2W!` sparse-GPU branch: detect non-fast-scalar `nonzeros(W)` and use allocate-then-`copyto!`.

Bump `OrdinaryDiffEqDifferentiation` 3.3.0 → 3.3.1. CPU sparse smoke test included; full GPU coverage is `test/gpu/dae_tests.jl`.

## Local verification

- Runic format on changed Julia files
- CPU sparse smoke: `dae_jacobian2W!` / `dae_jacobian2W` pass
- GPU self-hosted not available on this machine

## Related

- Supersedes the Differentiation sparse-GPU portion of #3836
- Sibling: LinearExponential sparse opnorm (separate PR)