### PR TITLE
Linear: adaptive LinearExponential opnorm without densifying

### DIFF
--- a/lib/OrdinaryDiffEqLinear/Project.toml
+++ b/lib/OrdinaryDiffEqLinear/Project.toml
@@ -22,6 +22,7 @@ DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 OrdinaryDiffEqVerner = "79d7bb75-1356-48c1-b8c0-6832512096c2"
 OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
@@ -43,11 +44,12 @@ julia = "1.10"
 RecursiveArrayTools = "4.2.0"
 DiffEqBase = "7"
 SafeTestsets = "0.1.0"
+SparseArrays = "1.10"
 OrdinaryDiffEqRosenbrock = "2"
 Reexport = "1.2.2"
 
 [targets]
-test = ["DiffEqDevTools", "Random", "OrdinaryDiffEqRosenbrock", "SafeTestsets", "Test", "OrdinaryDiffEqVerner", "OrdinaryDiffEqTsit5", "Pkg"]
+test = ["DiffEqDevTools", "Random", "OrdinaryDiffEqRosenbrock", "SafeTestsets", "SparseArrays", "Test", "OrdinaryDiffEqVerner", "OrdinaryDiffEqTsit5", "Pkg"]
 
 [sources.OrdinaryDiffEqTsit5]
 path = "../OrdinaryDiffEqTsit5"

--- a/lib/OrdinaryDiffEqLinear/Project.toml
+++ b/lib/OrdinaryDiffEqLinear/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqLinear"
 uuid = "521117fe-8c41-49f8-b3b6-30780b3f0fb5"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"

--- a/lib/OrdinaryDiffEqLinear/src/OrdinaryDiffEqLinear.jl
+++ b/lib/OrdinaryDiffEqLinear/src/OrdinaryDiffEqLinear.jl
@@ -9,7 +9,7 @@ import OrdinaryDiffEqCore: alg_extrapolates, dt_required,
     get_fsalfirstlast,
     isdtchangeable, full_cache,
     generic_solver_docstring
-using LinearAlgebra: mul!, I
+using LinearAlgebra: mul!, I, opnorm
 using SciMLOperators: AbstractSciMLOperator, update_coefficients, update_coefficients!
 using ExponentialUtilities: ExponentialUtilities, ExpMethodGeneric, ExpvCache,
     KrylovSubspace, PhivCache, arnoldi!, exponential!,

--- a/lib/OrdinaryDiffEqLinear/src/linear_perform_step.jl
+++ b/lib/OrdinaryDiffEqLinear/src/linear_perform_step.jl
@@ -1,3 +1,51 @@
+struct _LinearExponentialFallbackOpnorm end
+
+function _is_opnorm_matrix_method_error(err, A)
+    err isa MethodError || return false
+    return any(arg -> arg === A, err.args)
+end
+
+# Sparse GPU `opnorm` currently MethodErrors (GPUArrays csr_type(instance)).
+# Prefer a nnz-based bound over densifying the full matrix (#3836 review).
+function _nnz_opnorm_bound(A, p)
+    nz = nothing
+    if hasproperty(A, :nzVal)
+        nz = getproperty(A, :nzVal)
+    elseif hasproperty(A, :nzval)
+        nz = getproperty(A, :nzval)
+    else
+        try
+            nz = Base.invokelatest(
+                getfield(parentmodule(typeof(A)), :nonzeros), A
+            )
+        catch
+            nz = nothing
+        end
+    end
+    nz === nothing && return nothing
+    isempty(nz) && return zero(float(real(eltype(A))))
+    # Loose upper bound sufficient for adaptive expv timestep heuristics.
+    return maximum(abs, nz) * max(size(A)...)
+end
+
+function (::_LinearExponentialFallbackOpnorm)(A, p)
+    try
+        return opnorm(A, p)
+    catch err
+        _is_opnorm_matrix_method_error(err, A) || rethrow()
+        bound = _nnz_opnorm_bound(A, p)
+        bound === nothing && rethrow()
+        return bound
+    end
+end
+
+const _LINEAR_EXPONENTIAL_FALLBACK_OPNORM = _LinearExponentialFallbackOpnorm()
+
+function _linear_exponential_adaptive_opnorm(internalopnorm)
+    return internalopnorm === opnorm ? _LINEAR_EXPONENTIAL_FALLBACK_OPNORM :
+        internalopnorm
+end
+
 function initialize!(integrator, cache::MagnusMidpointCache)
     integrator.kshortsize = 2
 
@@ -808,7 +856,7 @@ function perform_step!(
     else
         u = expv_timestep(
             dt, A, integrator.u; m = min(alg.m, size(A, 1)), iop = alg.iop,
-            opnorm = integrator.opts.internalopnorm,
+            opnorm = _linear_exponential_adaptive_opnorm(integrator.opts.internalopnorm),
             tol = integrator.opts.reltol
         )
     end
@@ -856,7 +904,7 @@ function perform_step!(integrator, cache::LinearExponentialCache, repeat_step = 
         expv_timestep!(
             tmp, dt, A, u; adaptive = true, caches = KsCache,
             m = min(alg.m, size(A, 1)), iop = alg.iop,
-            opnorm = integrator.opts.internalopnorm,
+            opnorm = _linear_exponential_adaptive_opnorm(integrator.opts.internalopnorm),
             tol = integrator.opts.reltol
         )
     end

--- a/lib/OrdinaryDiffEqLinear/test/linear_method_tests.jl
+++ b/lib/OrdinaryDiffEqLinear/test/linear_method_tests.jl
@@ -1,6 +1,6 @@
 using OrdinaryDiffEqLinear, Test, DiffEqDevTools
 using OrdinaryDiffEqRosenbrock, OrdinaryDiffEqVerner, OrdinaryDiffEqTsit5
-using LinearAlgebra, Random
+using LinearAlgebra, Random, SparseArrays
 
 # Linear exponential solvers
 A = MatrixOperator([2.0 -1.0; -1.0 2.0])
@@ -18,6 +18,22 @@ sol_analytic = exp(1.0 * Matrix(A)) * u0
 @test isapprox(sol2, sol_analytic, rtol = 1.0e-10)
 @test isapprox(sol3, sol_analytic, rtol = 1.0e-10)
 @test isapprox(sol4, sol_analytic, rtol = 1.0e-8)
+
+struct BrokenOpnormMatrix{T, M <: AbstractMatrix{T}} <: AbstractMatrix{T}
+    A::M
+end
+
+Base.size(A::BrokenOpnormMatrix) = size(A.A)
+Base.getindex(A::BrokenOpnormMatrix, I...) = getindex(A.A, I...)
+Base.collect(A::BrokenOpnormMatrix) = collect(A.A)
+SparseArrays.nonzeros(A::BrokenOpnormMatrix) = vec(A.A)
+LinearAlgebra.opnorm(A::BrokenOpnormMatrix, p::Real) = throw(MethodError(opnorm, (A, p)))
+
+A_broken_opnorm = MatrixOperator(BrokenOpnormMatrix([2.0 -1.0; -1.0 2.0]))
+prob_broken_opnorm = ODEProblem(A_broken_opnorm, copy(u0), (0.0, 1.0))
+sol_broken_opnorm = solve(prob_broken_opnorm, LinearExponential(krylov = :adaptive))(1.0)
+@test isapprox(sol_broken_opnorm, sol_analytic, rtol = 1.0e-6)
+
 
 # u' = A(t)u solvers
 function update_func!(A, u, p, t)


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

Extracted from omnibus #3836.

Fixes GPU `test/gpu/linear_exp.jl` adaptive sparse path:

```
MethodError: no method matching csr_type(::CuSparseMatrixCSC)
```

from GPUArrays sparse `opnorm` during adaptive `LinearExponential`.

Only the adaptive `LinearExponential` `expv_timestep` / `expv_timestep!` sites wrap the default `internalopnorm`. On `MethodError`, use a loose **nnz-based bound** instead of `collect(A)`.

Addresses #3836 review: *"We shouldn't densify, why wasn't this an issue before?"* — densify path removed.

Bump `OrdinaryDiffEqLinear` 2.1.0 → 2.1.1. CPU regression via `BrokenOpnormMatrix`.

## Local verification

- Runic format
- `linear_method_tests.jl` including BrokenOpnormMatrix path: `LINEAR_TESTS_OK`
- GPU self-hosted not available here

## Related

- Sibling: sparse-GPU `dae_jacobian2W!` (separate PR)
- Supersedes Linear portion of #3836