### PR TITLE
NonlinearSolve tests: stabilize nlstep MTK trajectory checks

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/nlstep_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/nlstep_tests.jl
@@ -20,6 +20,11 @@ prob2 = ODEProblem(rober, [[y₁, y₂, y₃] .=> [1.0; 0.0; 0.0]; [k₁, k₂, 
 
 nlalg = NonlinearSolveAlg(NewtonRaphson(autodiff = AutoFiniteDiff()));
 nlalgrobust = NonlinearSolveAlg(TrustRegion(autodiff = AutoFiniteDiff()));
+
+function maximum_saved_trajectory_delta(sol1, sol2)
+    return maximum(abs, Array(sol1(sol1.t)) .- Array(sol2(sol1.t)))
+end
+
 sol1 = solve(prob, FBDF(autodiff = AutoFiniteDiff(), nlsolve = nlalg));
 sol2 = solve(prob2, FBDF(autodiff = AutoFiniteDiff(), nlsolve = nlalg));
 
@@ -55,9 +60,11 @@ dts = 2.0 .^ (-13:-1:-16)
 sim = analyticless_test_convergence(dts, testprob, QNDF2(autodiff = AutoFiniteDiff(), nlsolve = nlalgrobust), test_setup);
 @test_broken abs(sim.𝒪est[:l∞] - 2.5) < 0.2 # Superconvergence
 
-dts = 2.0 .^ (-15:-1:-18)
+dts = 2.0 .^ (-14:-1:-17)
 sim = analyticless_test_convergence(dts, testprob, FBDF(autodiff = AutoFiniteDiff(), nlsolve = nlalgrobust), test_setup);
-@test abs(sim.𝒪est[:l∞] - 1) < 0.3 # Only first order because adaptive order starts with Euler!
+# Keep the FBDF window above the reference-solution error floor; at 2^-18
+# the l∞ error stops decreasing monotonically, which corrupts the order fit.
+@test abs(sim.𝒪est[:l∞] - 1) < 0.05 # Only first order because adaptive order starts with Euler!
 
 eqs_nonaut = [
     D(y₁) ~ -k₁ * y₁ + (t + 1) * k₃ * y₂ * y₃,
@@ -73,22 +80,20 @@ sol2 = solve(prob2, FBDF(autodiff = AutoFiniteDiff(), nlsolve = nlalg));
 
 @test sol1.t != sol2.t
 @test sol1.u != sol2.u
-# Non-autonomous Robertson: the `nlstep = true` path Newton-solves the
-# reduced (1D) MTK-teared inner nlsystem for y₂ and reconstructs y₁/y₃ via
-# the nlprobmap observed-function, while the baseline path Newton-solves
-# the full (3D) system. Those are not numerically equivalent, and over the
-# stiff [0, 1e5] window the two trajectories drift by ~1e-3 in 2-norm —
-# that is the inherent algorithmic gap, not a solver regression.
-@test sol1(sol1.t) ≈ sol2(sol1.t) atol = 2.0e-3
+# Non-autonomous Robertson: the `nlstep = true` path Newton-solves the reduced
+# MTK-teared inner nlsystem and reconstructs the full state, while the baseline
+# path Newton-solves the full system. Check pointwise trajectory agreement here:
+# `isapprox` aggregates over the whole saved trajectory, so its norm grows with
+# the number of saved points even when every component is close.
+@test maximum_saved_trajectory_delta(sol1, sol2) < 5.0e-4
 
 sol1 = solve(prob, TRBDF2(autodiff = AutoFiniteDiff(), nlsolve = nlalg));
 sol2 = solve(prob2, TRBDF2(autodiff = AutoFiniteDiff(), nlsolve = nlalg));
 
 @test sol1.t != sol2.t
 @test sol1 != sol2
-# See comment above on `FBDF` — the 1D-reduced nlsystem path and the 3D
-# baseline path diverge by ~2e-4 for TRBDF2 on this problem.
-@test sol1(sol1.t) ≈ sol2(sol1.t) atol = 5.0e-4
+# See comment above on `FBDF` — compare the pointwise saved-trajectory delta.
+@test maximum_saved_trajectory_delta(sol1, sol2) < 2.0e-4
 
 testprob = ODEProblem(rober_nonaut, [[y₁, y₂, y₃] .=> [1.0; 0.0; 0.0]; [k₁, k₂, k₃] .=> (0.04, 3.0e7, 1.0e4)], (0.0, 1.0), nlstep = true)
 @test testprob.f.nlstep_data !== nothing
@@ -111,6 +116,8 @@ dts = 2.0 .^ (-13:-1:-16)
 sim = analyticless_test_convergence(dts, testprob, QNDF2(autodiff = AutoFiniteDiff(), nlsolve = nlalgrobust), test_setup);
 @test_broken abs(sim.𝒪est[:l∞] - 2.5) < 0.2 # Superconvergence
 
-dts = 2.0 .^ (-15:-1:-18)
+dts = 2.0 .^ (-14:-1:-17)
 sim = analyticless_test_convergence(dts, testprob, FBDF(autodiff = AutoFiniteDiff(), nlsolve = nlalgrobust), test_setup);
-@test abs(sim.𝒪est[:l∞] - 1) < 0.35 # Only first order because adaptive order starts with Euler!
+# Keep the FBDF window above the reference-solution error floor; at 2^-18
+# the l∞ error stops decreasing monotonically, which corrupts the order fit.
+@test abs(sim.𝒪est[:l∞] - 1) < 0.05 # Only first order because adaptive order starts with Euler!


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

Extracted from omnibus #3836. **Test-only** (no package version bump).

- Pointwise max trajectory delta instead of `isapprox` over the full saved vector (norm grows with save count).
- FBDF analyticless order windows shifted to `2^-14…2^-17` so the finest step stays above the reference error floor that flattened l∞ at `2^-18`.
- Tighten expected first-order FBDF band accordingly.

Does not touch solver code. Pre-existing `@test_broken` QNDF2 superconvergence left as-is.