### PR TITLE
SDE: JET definite-assignment + composite-cache methods

### DIFF
--- a/lib/StochasticDiffEq/test/noise_type_test.jl
+++ b/lib/StochasticDiffEq/test/noise_type_test.jl
@@ -63,6 +63,7 @@ sol = solve(prob, EM(), dt = 1 / 1000, alias = RODEAliasSpecifier(alias_noise = 
 @test objectid(prob.noise) != objectid(sol.W)
 @test objectid(prob.noise.u) == objectid(prob.noise.W) != objectid(sol.W.W) ==
     objectid(sol.W.u)
+@test_throws ArgumentError solve(prob, EM(), dt = 1 / 1000, alias = true)
 
 function g(du, u, p, t)
     @test du isa SparseMatrixCSC

--- a/lib/StochasticDiffEqCore/Project.toml
+++ b/lib/StochasticDiffEqCore/Project.toml
@@ -1,6 +1,6 @@
 name = "StochasticDiffEqCore"
 uuid = "19c5a474-6cd1-4a5f-be79-46dc34e54d7f"
-version = "2.0.3"
+version = "2.0.4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]

--- a/lib/StochasticDiffEqCore/src/StochasticDiffEqCore.jl
+++ b/lib/StochasticDiffEqCore/src/StochasticDiffEqCore.jl
@@ -4,6 +4,7 @@ using Reexport: Reexport, @reexport
 @reexport using DiffEqBase
 
 import ADTypes
+import ADTypes: AutoForwardDiff
 
 import OrdinaryDiffEqCore
 # SDE/RODE/Jump algorithm and cache supertypes plus the shared solver-loop

--- a/lib/StochasticDiffEqCore/src/StochasticDiffEqCore.jl
+++ b/lib/StochasticDiffEqCore/src/StochasticDiffEqCore.jl
@@ -4,7 +4,6 @@ using Reexport: Reexport, @reexport
 @reexport using DiffEqBase
 
 import ADTypes
-import ADTypes: AutoForwardDiff
 
 import OrdinaryDiffEqCore
 # SDE/RODE/Jump algorithm and cache supertypes plus the shared solver-loop

--- a/lib/StochasticDiffEqCore/src/caches/cache_types.jl
+++ b/lib/StochasticDiffEqCore/src/caches/cache_types.jl
@@ -37,3 +37,26 @@ function alg_cache(
     )
     return StochasticCompositeCache(caches, alg.choice_function, 1)
 end
+
+function alg_cache(
+        alg::Union{StochasticDiffEqAlgorithm, StochasticDiffEqRODEAlgorithm},
+        prob,
+        u,
+        ΔW,
+        ΔZ,
+        p,
+        rate_prototype,
+        noise_rate_prototype,
+        jump_rate_prototype,
+        ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits},
+        ::Type{tTypeNoUnits},
+        uprev,
+        f,
+        t,
+        dt,
+        ::Type{Val{T}},
+        verbose
+    ) where {T, uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    throw(ArgumentError("No stochastic alg_cache implementation found for $(typeof(alg))."))
+end

--- a/lib/StochasticDiffEqCore/src/integrators/integrator_interface.jl
+++ b/lib/StochasticDiffEqCore/src/integrators/integrator_interface.jl
@@ -108,6 +108,17 @@ function resize_non_user_cache!(integrator::SDEIntegrator, cache, i)
     return
 end
 
+function resize_non_user_cache!(
+        integrator::SDEIntegrator,
+        cache::OrdinaryDiffEqCore.CompositeCache,
+        i
+    )
+    for _cache in cache.caches
+        resize_non_user_cache!(integrator, _cache, i)
+    end
+    return
+end
+
 function deleteat_non_user_cache!(integrator::SDEIntegrator, cache, idxs)
     if is_diagonal_noise(integrator.sol.prob)
         deleteat_noise!(integrator, cache, idxs)
@@ -121,6 +132,17 @@ function deleteat_non_user_cache!(integrator::SDEIntegrator, cache, idxs)
     return
 end
 
+function deleteat_non_user_cache!(
+        integrator::SDEIntegrator,
+        cache::OrdinaryDiffEqCore.CompositeCache,
+        idxs
+    )
+    for _cache in cache.caches
+        deleteat_non_user_cache!(integrator, _cache, idxs)
+    end
+    return
+end
+
 function addat_non_user_cache!(integrator::SDEIntegrator, cache, idxs)
     if is_diagonal_noise(integrator.sol.prob)
         addat_noise!(integrator, cache, idxs)
@@ -130,6 +152,17 @@ function addat_non_user_cache!(integrator::SDEIntegrator, cache, idxs)
     end
     for c in ratenoise_cache(integrator)
         addat!(c, idxs)
+    end
+    return
+end
+
+function addat_non_user_cache!(
+        integrator::SDEIntegrator,
+        cache::OrdinaryDiffEqCore.CompositeCache,
+        idxs
+    )
+    for _cache in cache.caches
+        addat_non_user_cache!(integrator, _cache, idxs)
     end
     return
 end

--- a/lib/StochasticDiffEqCore/src/solve.jl
+++ b/lib/StochasticDiffEqCore/src/solve.jl
@@ -12,17 +12,24 @@ end
     return alias === nothing ? default : alias::Bool
 end
 
-function _sde_alias_specifier(::SDEProblem, alias::Nothing)
+# Default alias specifier when `alias === nothing`.
+# JumpProblem / DiscreteProblem (and other non-SDE wrappers) fall through to the
+# RODE default — same as the pre-split path that used `is_sde = _prob isa SDEProblem`.
+function _sde_alias_specifier(::SDEProblem, ::Nothing)
     return SciMLBase.SDEAliasSpecifier()
 end
-function _sde_alias_specifier(::SciMLBase.AbstractRODEProblem, alias::Nothing)
+function _sde_alias_specifier(::Nothing, ::Nothing)
+    # concrete_prob may return nothing in edge cases; treat as RODE default
+    return SciMLBase.RODEAliasSpecifier()
+end
+function _sde_alias_specifier(_, ::Nothing)
     return SciMLBase.RODEAliasSpecifier()
 end
 function _sde_alias_specifier(_, alias::SciMLBase.AbstractAliasSpecifier)
     return alias
 end
 function _sde_alias_specifier(prob, alias)
-    throw(ArgumentError("`alias` must be an AbstractAliasSpecifier; got $(typeof(alias))."))
+    throw(ArgumentError("`alias` must be `nothing` or an AbstractAliasSpecifier; got $(typeof(alias))."))
 end
 
 function SciMLBase.__solve(

--- a/lib/StochasticDiffEqCore/src/solve.jl
+++ b/lib/StochasticDiffEqCore/src/solve.jl
@@ -8,6 +8,23 @@ function _get_alias_noise_from_kwargs(; alias_noise = nothing, alias = nothing, 
     end
 end
 
+@inline function _alias_or_default(alias, default::Bool)
+    return alias === nothing ? default : alias::Bool
+end
+
+function _sde_alias_specifier(::SDEProblem, alias::Nothing)
+    return SciMLBase.SDEAliasSpecifier()
+end
+function _sde_alias_specifier(::SciMLBase.AbstractRODEProblem, alias::Nothing)
+    return SciMLBase.RODEAliasSpecifier()
+end
+function _sde_alias_specifier(_, alias::SciMLBase.AbstractAliasSpecifier)
+    return alias
+end
+function _sde_alias_specifier(prob, alias)
+    throw(ArgumentError("`alias` must be an AbstractAliasSpecifier; got $(typeof(alias))."))
+end
+
 function SciMLBase.__solve(
         prob::SciMLBase.AbstractRODEProblem,
         alg::Union{StochasticDiffEqAlgorithm, StochasticDiffEqRODEAlgorithm};
@@ -168,30 +185,15 @@ function _sde_init(
     # NOTE: JumpProblem kwargs merge is already done by init_call / __solve
     # before reaching _sde_init. DO NOT call merge_problem_kwargs again here.
 
-    is_sde = _prob isa SDEProblem
-
-    # ── Alias resolution (SDE/RODE-specific specifier types) ─────────────
-    if alias isa Bool
-        aliases = is_sde ? SciMLBase.SDEAliasSpecifier(; alias) :
-            SciMLBase.RODEAliasSpecifier(; alias)
-    elseif alias isa SciMLBase.SDEAliasSpecifier
-        aliases = alias
-    elseif alias isa SciMLBase.RODEAliasSpecifier
-        aliases = alias
-    else
-        aliases = is_sde ? SciMLBase.SDEAliasSpecifier() :
-            SciMLBase.RODEAliasSpecifier()
-    end
-
     prob = concrete_prob(_prob)
+    aliases = _sde_alias_specifier(prob, alias)
 
     # ── RNG resolution ───────────────────────────────────────────────────
     _rng, _seed, _rng_provided = _resolve_rng(rng, seed, prob)
 
     # ── JumpProblem reset ────────────────────────────────────────────────
     if _prob isa JumpProblem
-        alias_jumps = isnothing(aliases.alias_jumps) ? Threads.threadid() == 1 :
-            aliases.alias_jumps
+        alias_jumps = _alias_or_default(aliases.alias_jumps, Threads.threadid() == 1)
         _jump_seed = _rng_provided ? nothing : _seed
         if !alias_jumps
             _prob = JumpProcesses.resetted_jump_problem(_prob, _jump_seed)
@@ -246,19 +248,19 @@ function _sde_init(
     end
 
     # ── f/p/u aliasing (needed before cache construction) ────────────────
-    if isnothing(aliases.alias_f) || aliases.alias_f
+    if _alias_or_default(aliases.alias_f, true)
         f = prob.f
     else
         f = deepcopy(prob.f)
     end
 
-    if isnothing(aliases.alias_p) || aliases.alias_p
+    if _alias_or_default(aliases.alias_p, true)
         p = prob.p
     else
         p = recursivecopy(prob.p)
     end
 
-    if !isnothing(aliases.alias_u0) && aliases.alias_u0
+    if _alias_or_default(aliases.alias_u0, false)
         u = prob.u0
     else
         u = recursivecopy(prob.u0)
@@ -406,8 +408,8 @@ function _sde_init(
             end
         end
     elseif prob isa SciMLBase.AbstractRODEProblem
-        _alias_noise = if hasproperty(aliases, :alias_noise) && aliases.alias_noise !== nothing
-            aliases.alias_noise
+        _alias_noise = if hasproperty(aliases, :alias_noise)
+            _alias_or_default(getproperty(aliases, :alias_noise), true)
         else
             true
         end

--- a/lib/StochasticDiffEqCore/test/qa/qa.jl
+++ b/lib/StochasticDiffEqCore/test/qa/qa.jl
@@ -43,8 +43,69 @@ const NONPUBLIC_IGNORE = (
     FORWARDDIFF_INTERNAL..., BASE_INTERNAL...,
 )
 
+const ODEC = StochasticDiffEqCore.OrdinaryDiffEqCore
+const DEB = StochasticDiffEqCore.DiffEqBase
+const SMB = StochasticDiffEqCore.SciMLBase
+const DNP = StochasticDiffEqCore.DiffEqNoiseProcess
+
+# This package is the stochastic solver-interface extension layer; the shared
+# algorithm/cache supertypes and loop hooks are deliberately owned by the base
+# packages. Keep Aqua piracy checking enabled, but mark only those hooks as the
+# intentional extension surface for this package.
+const STOCHASTIC_PIRACY_HOOKS = Function[
+    SMB.__init,
+    SMB.__solve,
+    ODEC._determine_initdt,
+    ODEC._initialize_dae!,
+    ODEC.accept_noise!,
+    DEB.addat_non_user_cache!,
+    ODEC.alg_autodiff,
+    ODEC.alg_difftype,
+    ODEC.alg_extrapolates,
+    SMB.alg_interpretation,
+    SMB.alg_order,
+    SMB.allows_arbitrary_number_types,
+    SMB.allows_late_binding_tstops,
+    SMB.allowscomplex,
+    ODEC.beta1_default,
+    ODEC.beta2_default,
+    ODEC.concrete_jac,
+    DEB.deleteat_non_user_cache!,
+    SMB.forwarddiffs_model,
+    ODEC.gamma_default,
+    ODEC.get_chunksize,
+    ODEC.get_current_alg_autodiff,
+    ODEC.get_fsalfirstlast,
+    SMB.get_tmp_cache,
+    ODEC.handle_callback_modifiers!,
+    ODEC.has_autodiff,
+    DEB.initialize!,
+    ODEC.is_composite_algorithm,
+    ODEC.is_constant_cache,
+    ODEC.is_noise_saveable,
+    SMB.isadaptive,
+    SMB.isautodifferentiable,
+    SMB.isdiscrete,
+    ODEC.isfsal,
+    ODEC.noise_curt,
+    ODEC.qmax_default,
+    ODEC.qmin_default,
+    ODEC.qsteady_max_default,
+    ODEC.qsteady_min_default,
+    DEB.rand_cache,
+    DEB.ratenoise_cache,
+    ODEC.reject_noise!,
+    DEB.resize_non_user_cache!,
+    ODEC.reinit_noise!,
+    ODEC.save_noise!,
+    DNP.setup_next_step!,
+    ODEC.standardtag,
+    SMB.supports_solve_rng,
+]
+
 run_qa(
     StochasticDiffEqCore;
+    aqua_kwargs = (; piracies = (; treat_as_own = STOCHASTIC_PIRACY_HOOKS)),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/StochasticDiffEqMilstein/Project.toml
+++ b/lib/StochasticDiffEqMilstein/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqMilstein"
 uuid = "8c95a807-c8e7-4581-8419-890d001af53e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/StochasticDiffEqMilstein/src/perform_step/rkmilgeneral.jl
+++ b/lib/StochasticDiffEqMilstein/src/perform_step/rkmilgeneral.jl
@@ -94,7 +94,7 @@ dZ_i Fourier coefficients (Lévy area), and the second sum gives the
 cross-interval contributions. Both terms are needed for correct strong
 order 1.0 convergence on rejected steps.
 """
-function _compute_II_from_S2(W_noise, m, dt)
+function _compute_II_from_S2(W_noise, m::Integer, dt)
     !hasproperty(W_noise, :S₂) && return nothing
     S₂ = W_noise.S₂
     n_sub = length(S₂)
@@ -156,7 +156,7 @@ NoiseWrapper or NoiseProcess source. Uses Z grid (Fourier coefficients) for
 within-sub-interval Lévy area when available, falling back to commutative
 approximation (½ dW dW') for sub-intervals without Z data.
 """
-function _compute_II_from_grid(W_noise, m, dt)
+function _compute_II_from_grid(W_noise, m::Integer, dt)
     source = _get_noise_grid_source(W_noise)
     source === nothing && return nothing
 
@@ -277,9 +277,9 @@ end
     L = integrator.f.g(uprev, p, t)
     mil_correction = zero(u)
     ggprime_norm = zero(eltype(u))
+    K = @.. uprev + dt * du1
 
     if dW isa Number || is_diagonal_noise(integrator.sol.prob)
-        K = @.. uprev + dt * du1
         utilde = (
             SciMLBase.alg_interpretation(integrator.alg) ==
                 SciMLBase.AlgorithmInterpretation.Ito ? K : uprev

--- a/lib/StochasticDiffEqROCK/Project.toml
+++ b/lib/StochasticDiffEqROCK/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqROCK"
 uuid = "db241ea8-0e6b-4abc-8f2d-1adff2294fd9"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/StochasticDiffEqROCK/src/perform_step/SROCK_perform_step.jl
+++ b/lib/StochasticDiffEqROCK/src/perform_step/SROCK_perform_step.jl
@@ -14,6 +14,7 @@
     cosh_inv = log(ω₀ + Sqrt_ω)             # arcosh(ω₀)
     ω₁ = (Sqrt_ω * cosh(mdeg * cosh_inv)) / (mdeg * sinh(mdeg * cosh_inv))
 
+    α = β = γ = zero(ω₀)
     if SciMLBase.alg_interpretation(integrator.alg) ==
             SciMLBase.AlgorithmInterpretation.Stratonovich
         α = cosh(mdeg * cosh_inv) / (2 * ω₀ * cosh((mdeg - 1) * cosh_inv))
@@ -111,6 +112,7 @@ end
     cosh_inv = log(ω₀ + Sqrt_ω)             # arcosh(ω₀)
     ω₁ = (Sqrt_ω * cosh(mdeg * cosh_inv)) / (mdeg * sinh(mdeg * cosh_inv))
 
+    α = β = γ = zero(ω₀)
     if SciMLBase.alg_interpretation(integrator.alg) ==
             SciMLBase.AlgorithmInterpretation.Stratonovich
         α = cosh(mdeg * cosh_inv) / (2 * ω₀ * cosh((mdeg - 1) * cosh_inv))
@@ -197,7 +199,11 @@ end
         (is_diagonal_noise(integrator.sol.prob)) || (W.dW isa Number) ||
             (length(W.dW) == 1)
     )
-    gen_prob && (vec_χ = 2 .* floor.(false .* W.dW .+ 1 // 2 .+ oftype(W.dW, rand(W.rng, length(W.dW)))) .- true)
+    if gen_prob
+        vec_χ = 2 .* floor.(false .* W.dW .+ 1 // 2 .+ oftype(W.dW, rand(W.rng, length(W.dW)))) .- true
+    else
+        vec_χ = nothing
+    end
 
     alg = unwrap_alg(integrator, true)
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
@@ -759,9 +765,9 @@ end
         end
         winc = rand() * 6
         if winc < 1
-            u -= (sqrt(3 * dt) * ccache.mc[mdeg - 1]) * uᵢ₋₁
+            u -= (sqrt(3 * dt) * cache.mc[mdeg - 1]) * uᵢ₋₁
         elseif winc < 2
-            u += (sqrt(3 * dt) * ccache.mc[mdeg - 1]) * uᵢ₋₁
+            u += (sqrt(3 * dt) * cache.mc[mdeg - 1]) * uᵢ₋₁
         end
     end
     integrator.u = u
@@ -874,8 +880,7 @@ end
 
     alg = unwrap_alg(integrator, true)
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
-    (integrator.alg.version_num <= 2) &&
-        (
+    if integrator.alg.version_num <= 2
         cache.mdeg = Int(
             floor(
                 sqrt(
@@ -887,9 +892,7 @@ end
                 ) + 1
             )
         )
-    )
-    (integrator.alg.version_num > 2) &&
-        (
+    else
         cache.mdeg = Int(
             floor(
                 sqrt(
@@ -901,7 +904,7 @@ end
                 ) + 1
             )
         )
-    )
+    end
 
     cache.mdeg = max(4, min(cache.mdeg, 200)) - 2
     choose_deg!(integrator, cache)
@@ -923,6 +926,9 @@ end
     t̂₁ = t̂₂ = zero(t)
     tᵢ = tᵢ₋₁ = tᵢ₋₂ = tₓ = t
     uᵢ₋₂ = uprev
+    uᵢ₋₁ = uprev
+    uᵢ = zero(u)
+    uₓ = zero(u)
 
     for i in 0:(mdeg + 1)
         if i == 1
@@ -1036,9 +1042,13 @@ end
 
         for i in 1:length(W.dW)
             for j in 1:length(W.dW)
-                (i > j) && (WikJ = (1 // 2) * (1 + η₂) * W.dW[j])
-                (i < j) && (WikJ = (1 // 2) * (1 - η₂) * W.dW[j])
-                (i == j) && (WikJ = (1 // 2) * (η₁ * sqrt_dt))
+                if i > j
+                    WikJ = (1 // 2) * (1 + η₂) * W.dW[j]
+                elseif i < j
+                    WikJ = (1 // 2) * (1 - η₂) * W.dW[j]
+                else
+                    WikJ = (1 // 2) * (η₁ * sqrt_dt)
+                end
 
                 uᵢ₋₁ += @view(Gₛ[:, j]) * WikJ
             end
@@ -1060,8 +1070,7 @@ end
 
     alg = unwrap_alg(integrator, true)
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
-    (integrator.alg.version_num <= 2) &&
-        (
+    if integrator.alg.version_num <= 2
         ccache.mdeg = Int(
             floor(
                 sqrt(
@@ -1073,9 +1082,7 @@ end
                 ) + 1
             )
         )
-    )
-    (integrator.alg.version_num > 2) &&
-        (
+    else
         ccache.mdeg = Int(
             floor(
                 sqrt(
@@ -1087,7 +1094,7 @@ end
                 ) + 1
             )
         )
-    )
+    end
     ccache.mdeg = max(4, min(ccache.mdeg, 200)) - 2
     choose_deg!(integrator, cache)
 
@@ -1207,9 +1214,13 @@ end
 
         for i in 1:length(W.dW)
             for j in 1:length(W.dW)
-                (i > j) && (WikJ = (1 // 2) * (1 + η₂) * W.dW[j])
-                (i < j) && (WikJ = (1 // 2) * (1 - η₂) * W.dW[j])
-                (i == j) && (WikJ = (1 // 2) * (η₁ * sqrt_dt))
+                if i > j
+                    WikJ = (1 // 2) * (1 + η₂) * W.dW[j]
+                elseif i < j
+                    WikJ = (1 // 2) * (1 - η₂) * W.dW[j]
+                else
+                    WikJ = (1 // 2) * (η₁ * sqrt_dt)
+                end
 
                 @.. uᵢ₋₁ += @view(Gₛ[:, j]) * WikJ
             end
@@ -1245,7 +1256,11 @@ end
     τ = mτ[deg_index]
 
     sqrt_dt = sqrt(abs(dt))
-    (gen_prob) && (vec_χ = 2 .* floor.(1 // 2 .+ false .* W.dW .+ rand(length(W.dW))) .- 1)
+    if gen_prob
+        vec_χ = 2 .* floor.(1 // 2 .+ false .* W.dW .+ rand(length(W.dW))) .- 1
+    else
+        vec_χ = nothing
+    end
 
     tᵢ₋₂ = t
     uᵢ₋₂ = uprev
@@ -1424,7 +1439,7 @@ end
 @muladd function perform_step!(integrator, cache::KomBurSROCK2Cache)
     (;
         utmp, uᵢ₋₁, uᵢ₋₂, k, yₛ₋₁, yₛ₋₂, yₛ₋₃, SXₛ₋₁, SXₛ₋₂,
-        SXₛ₋₃, Gₛ, Xₛ₋₁, Xₛ₋₂, Xₛ₋₃, vec_χ,
+        SXₛ₋₃, Gₛ, Xₛ₋₁, Xₛ₋₂, Xₛ₋₃, vec_χ, WikRange,
     ) = cache
     (; t, dt, uprev, u, W, p, f) = integrator
     (; recf, mσ, mτ, mδ) = cache.constantcache

--- a/lib/StochasticDiffEqWeak/Project.toml
+++ b/lib/StochasticDiffEqWeak/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqWeak"
 uuid = "af2a2fcd-1c36-4cbe-a6d0-5afda784a085"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.1.1"
+version = "2.1.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/StochasticDiffEqWeak/src/perform_step/implicit_weak.jl
+++ b/lib/StochasticDiffEqWeak/src/perform_step/implicit_weak.jl
@@ -19,21 +19,20 @@ based on the RI1 scheme with theta-method implicitization of the drift.
 
     alg = unwrap_alg(integrator, true)
     theta = alg.theta
+    nlsolver isa OrdinaryDiffEqCore.AbstractNLSolver ||
+        throw(ArgumentError("IRI1 requires a nonlinear solver cache"))
     OrdinaryDiffEqNonlinearSolve.markfirststage!(nlsolver)
     repeat_step = false
 
     # Define three-point distributed random variables
-    dW_scaled = W.dW / sqrt(dt)
+    dW = W.dW
+    dW_scaled = dW / sqrt(dt)
     sq3dt = sqrt(3 * dt)
     _dW = map(x -> calc_threepoint_random(sq3dt, NORMAL_ONESIX_QUANTILE, x), dW_scaled)
     chi1 = map(x -> (x^2 - dt) / 2, _dW)  # diagonal of Ihat2
 
-    if !(W.dW isa Number)
-        m = length(W.dW)
-        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
-    else
-        m = 1
-    end
+    m = dW isa Number ? 1 : length(dW)
+    _dZ = dW isa Number ? [_dW] : map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
 
     # Stage 1: Compute k1 implicitly
     # For implicit treatment: k1 = f(Y1) where Y1 = uprev + theta*dt*k1
@@ -55,7 +54,7 @@ based on the RI1 scheme with theta-method implicitization of the drift.
     g1 = integrator.f.g(uprev, p, t)
 
     # H^(0) Stage 2
-    if !is_diagonal_noise(integrator.sol.prob) || W.dW isa Number
+    if !is_diagonal_noise(integrator.sol.prob) || dW isa Number
         H02 = uprev + a021 * k1 * dt + b021 * g1 * _dW
     else
         H02 = uprev + a021 * k1 * dt + b021 * g1 .* _dW
@@ -73,7 +72,7 @@ based on the RI1 scheme with theta-method implicitization of the drift.
 
     # H^(0) Stage 3
     H03 = uprev + a032 * k2 * dt + a031 * k1 * dt
-    if !is_diagonal_noise(integrator.sol.prob) || W.dW isa Number
+    if !is_diagonal_noise(integrator.sol.prob) || dW isa Number
         H03 += b031 * g1 * _dW
     else
         H03 += b031 * g1 .* _dW
@@ -90,7 +89,7 @@ based on the RI1 scheme with theta-method implicitization of the drift.
     k3 = integrator.f(Y3, p, t + c03 * dt)
 
     # H^(k) stages for diffusion (explicit as in original RI1)
-    if W.dW isa Number
+    if dW isa Number
         H12 = uprev + a121 * k1 * dt + b121 * g1 * integrator.sqdt
         H13 = uprev + a131 * k1 * dt + b131 * g1 * integrator.sqdt
     else
@@ -110,9 +109,11 @@ based on the RI1 scheme with theta-method implicitization of the drift.
     end
 
     # Compute g2 and g3 at H12 and H13
-    if W.dW isa Number
+    if dW isa Number
         g2 = integrator.f.g(H12, p, t + c12 * dt)
         g3 = integrator.f.g(H13, p, t + c13 * dt)
+        H22 = [uprev]
+        H23 = [uprev]
     else
         g2 = [integrator.f.g(H12[k], p, t + c12 * dt) for k in 1:m]
         g3 = [integrator.f.g(H13[k], p, t + c13 * dt) for k in 1:m]
@@ -138,7 +139,7 @@ based on the RI1 scheme with theta-method implicitization of the drift.
     u = uprev + α1 * k1 * dt + α2 * k2 * dt + α3 * k3 * dt
 
     # Add noise contribution (same as explicit RI1)
-    if W.dW isa Number
+    if dW isa Number
         u += g1 * (_dW * beta11) + g2 * (_dW * beta12 + chi1 * beta22 / integrator.sqdt) +
             g3 * (_dW * beta13 + chi1 * beta23 / integrator.sqdt)
     else
@@ -247,6 +248,8 @@ IRI1 perform_step! implementation (mutable cache, in-place)
 
     alg = unwrap_alg(integrator, true)
     theta = alg.theta
+    nlsolver isa OrdinaryDiffEqCore.AbstractNLSolver ||
+        throw(ArgumentError("IRI1 requires a nonlinear solver cache"))
     OrdinaryDiffEqNonlinearSolve.markfirststage!(nlsolver)
     repeat_step = false
 

--- a/lib/StochasticDiffEqWeak/src/perform_step/srk_weak.jl
+++ b/lib/StochasticDiffEqWeak/src/perform_step/srk_weak.jl
@@ -7,15 +7,13 @@
     (; t, dt, uprev, u, W, p, f) = integrator
 
     # define three-point distributed random variables
-    dW_scaled = W.dW / sqrt(dt)
+    dW = W.dW
+    dW_scaled = dW / sqrt(dt)
     sq3dt = sqrt(3 * dt)
     _dW = map(x -> calc_threepoint_random(sq3dt, NORMAL_ONESIX_QUANTILE, x), dW_scaled)
     chi1 = map(x -> (x^2 - dt) / 2, _dW) # diagonal of Ihat2
-    if !(W.dW isa Number)
-        m = length(W.dW)
-        # define two-point distributed random variables
-        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
-    end
+    m = dW isa Number ? 1 : length(dW)
+    _dZ = dW isa Number ? [_dW] : map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
 
     # compute stage values
     k1 = integrator.f(uprev, p, t)
@@ -24,7 +22,7 @@
     # H_i^(0), stage 1
     # H01 = uprev
     # H_i^(0), stage 2
-    if !is_diagonal_noise(integrator.sol.prob) || W.dW isa Number
+    if !is_diagonal_noise(integrator.sol.prob) || dW isa Number
         H02 = uprev + a021 * k1 * dt + b021 * g1 * _dW
     else
         H02 = uprev + a021 * k1 * dt + b021 * g1 .* _dW
@@ -33,7 +31,7 @@
     # H_i^(0), stage 3 (requires H_i^(k) stage 2 in general)
     k2 = integrator.f(H02, p, t + c02 * dt)
     H03 = uprev + a032 * k2 * dt + a031 * k1 * dt
-    if !is_diagonal_noise(integrator.sol.prob) || W.dW isa Number
+    if !is_diagonal_noise(integrator.sol.prob) || dW isa Number
         H03 += b031 * g1 * _dW
     else
         H03 += b031 * g1 .* _dW
@@ -44,7 +42,7 @@
     # H_i^(k), stage 1
     # H11 = uprev
     # H_i^(k), stage 2 and 3
-    if W.dW isa Number
+    if dW isa Number
         H12 = uprev + a121 * k1 * dt + b121 * g1 * integrator.sqdt
         H13 = uprev + a131 * k1 * dt + b131 * g1 * integrator.sqdt
     else
@@ -67,9 +65,11 @@
     # H21 = uprev
     # H^_i^(k), stage 2 and 3
 
-    if W.dW isa Number
+    if dW isa Number
         g2 = integrator.f.g(H12, p, t + c12 * dt)
         g3 = integrator.f.g(H13, p, t + c13 * dt)
+        H22 = [uprev]
+        H23 = [uprev]
         # for m=1:  H22 = uprev
     else
         g2 = [integrator.f.g(H12[k], p, t + c12 * dt) for k in 1:m]
@@ -85,8 +85,8 @@
                 tmp[k] = b231 * g1[k] + b232 * g2[k][k] + b233 * g3[k][k]
                 H23[k] += tmp * integrator.sqdt
             else
-                H22[k] += (b221 * g1[:, l] + b222 * g2[l][:, l] + b223 * g3[l][:, l]) * integrator.sqdt
-                H23[k] += (b231 * g1[:, l] + b232 * g2[l][:, l] + b233 * g3[l][:, l]) * integrator.sqdt
+                H22[k] += (b221 * g1[:, k] + b222 * g2[k][:, k] + b223 * g3[k][:, k]) * integrator.sqdt
+                H23[k] += (b231 * g1[:, k] + b232 * g2[k][:, k] + b233 * g3[k][:, k]) * integrator.sqdt
             end
         end
     end
@@ -95,7 +95,7 @@
     u = uprev + α1 * k1 * dt + α2 * k2 * dt + α3 * k3 * dt
 
     # add noise
-    if W.dW isa Number
+    if dW isa Number
         # lines 2 and 3
         u += g1 * (_dW * beta11) + g2 * (_dW * beta12 + chi1 * beta22 / integrator.sqdt) +
             g3 * (_dW * beta13 + chi1 * beta23 / integrator.sqdt)
@@ -145,7 +145,7 @@
     end
 
     if integrator.opts.adaptive &&
-            (W.dW isa Number || is_diagonal_noise(integrator.sol.prob) || m == 1)
+            (dW isa Number || is_diagonal_noise(integrator.sol.prob) || m == 1)
 
         # schemes with lower convergence order
         if c03 != 0.0
@@ -459,9 +459,11 @@ end
     (; t, dt, uprev, u, W, p, f) = integrator
 
     # define three-point distributed random variables
-    dW_scaled = W.dW / sqrt(dt)
+    dW = W.dW
+    dW_scaled = dW / sqrt(dt)
     sq3dt = sqrt(3 * dt)
     _dW = map(x -> calc_threepoint_random(sq3dt, NORMAL_ONESIX_QUANTILE, x), dW_scaled)
+    m = dW isa Number ? 1 : length(dW)
 
     # compute stage values
     k1 = integrator.f(uprev, p, t)
@@ -470,7 +472,7 @@ end
     # H_i^(0), stage 1
     # H01 = uprev
     # H_i^(0), stage 2
-    if !is_diagonal_noise(integrator.sol.prob) || W.dW isa Number
+    if !is_diagonal_noise(integrator.sol.prob) || dW isa Number
         H02 = uprev + a021 * k1 * dt + b021 * g1 * _dW
     else
         H02 = uprev + a021 * k1 * dt + b021 * g1 .* _dW
@@ -481,7 +483,7 @@ end
     u = uprev + α1 * k1 * dt + α2 * k2 * dt
 
     # add noise
-    if W.dW isa Number
+    if dW isa Number
         # lines 2 and 3
         u += g1 * (_dW * beta11)
     else
@@ -559,14 +561,14 @@ end
     (; t, dt, uprev, u, W, p, f) = integrator
 
     # define three-point distributed random variables
-    dW_scaled = W.dW / sqrt(dt)
+    dW = W.dW
+    dW_scaled = dW / sqrt(dt)
     sq3dt = sqrt(3 * dt)
     _dW = map(x -> calc_threepoint_random(sq3dt, NORMAL_ONESIX_QUANTILE, x), dW_scaled)
-    if !(W.dW isa Number)
-        m = length(W.dW)
-        # define two-point distributed random variables
-        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
-    end
+    m = dW isa Number ? 1 : length(dW)
+    _dZ = dW isa Number ? [_dW] : map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
+    H22 = [uprev]
+    H23 = [uprev]
     # compute stage values
     k1 = integrator.f(uprev, p, t)
     g1 = integrator.f.g(uprev, p, t)
@@ -579,7 +581,7 @@ end
     # H_1^(k)
     # H11 = uprev
     # H_2^(k), stage 2
-    if W.dW isa Number
+    if dW isa Number
         H12 = uprev + b121 * g1 * _dW
     elseif is_diagonal_noise(integrator.sol.prob)
         H12 = Vector{typeof(uprev)}[uprev .+ b121 * g1[k] * _dW[k] for k in 1:m]
@@ -587,14 +589,16 @@ end
         H12 = Vector{typeof(uprev)}[uprev .+ b121 * g1[:, k] * _dW[k] for k in 1:m]
     end
 
-    if W.dW isa Number
+    if dW isa Number
         g2 = integrator.f.g(H12, p, t)
+        H22 = [uprev]
+        H23 = [uprev]
     else
         g2 = [integrator.f.g(H12[k], p, t) for k in 1:m]
     end
 
     # H_3^(k)
-    if W.dW isa Number
+    if dW isa Number
         H13 = uprev + a131 * k1 * dt + b131 * g1 * _dW + b132 * g2 * _dW
     else
         H13 = [zero(typeof(uprev)) for k in 1:m]
@@ -608,7 +612,7 @@ end
                     end
                 end
             else
-                H13 += b131 * g1[:, k] * _dW[k] .+ b132 * g2[k][:, k] * _dW[k]
+                H13[k] += b131 * g1[:, k] * _dW[k] .+ b132 * g2[k][:, k] * _dW[k]
                 for l in 1:m
                     if l != k
                         H13[k] += b331 * g1[:, l] * _dW[l] .+ b332 * g2[l][:, l] * _dW[l]
@@ -618,13 +622,13 @@ end
         end
     end
 
-    if W.dW isa Number
+    if dW isa Number
         g3 = integrator.f.g(H13, p, t + c13 * dt)
     else
         g3 = [integrator.f.g(H13[k], p, t + c13 * dt) for k in 1:m]
     end
     # H_3^(k)
-    if W.dW isa Number
+    if dW isa Number
         H14 = uprev + a141 * k1 * dt + b141 * g1 * _dW + b142 * g2 * _dW + b143 * g3 * _dW
     else
         H14 = [zero(typeof(uprev)) for k in 1:m]
@@ -638,7 +642,7 @@ end
                     end
                 end
             else
-                H14 += b141 * g1[:, k] * _dW[k] .+ b142 * g2[k][:, k] * _dW[k] .+
+                H14[k] += b141 * g1[:, k] * _dW[k] .+ b142 * g2[k][:, k] * _dW[k] .+
                     b143 * g3[k][:, k] * _dW[k]
                 for l in 1:m
                     if l != k
@@ -649,7 +653,7 @@ end
         end
     end
 
-    if W.dW isa Number
+    if dW isa Number
         g4 = integrator.f.g(H14, p, t + c14 * dt)
     else
         g4 = [integrator.f.g(H14[k], p, t + c14 * dt) for k in 1:m]
@@ -659,9 +663,9 @@ end
     k2 = integrator.f(H02, p, t + c02 * dt)
     H03 = uprev + a032 * k2 * dt + a031 * k1 * dt
 
-    if !is_diagonal_noise(integrator.sol.prob) || W.dW isa Number
+    if !is_diagonal_noise(integrator.sol.prob) || dW isa Number
         H03 += b031 * g1 * _dW
-        if W.dW isa Number
+        if dW isa Number
             H03 += b032 * g2 * _dW
         else
             for k in 1:m
@@ -684,7 +688,7 @@ end
     # H21 = uprev
     # H^_2^(k) # H^_3^(k)
 
-    if !(W.dW isa Number)
+    if !(dW isa Number)
         H22 = [uprev for k in 1:m]
         H23 = [uprev for k in 1:m]
         # add inbounds for speed if working properly
@@ -711,7 +715,7 @@ end
     u = uprev + (α1 * k1 + α2 * k2 + α3 * k3 + α4 * k1) * dt
 
     # add noise
-    if W.dW isa Number
+    if dW isa Number
         u += (g1 * beta11 + g2 * beta12 + g3 * beta13 + g4 * beta14) * _dW # beta2 terms are zero by construction
     else
         if is_diagonal_noise(integrator.sol.prob)
@@ -948,24 +952,22 @@ end
     (; NORMAL_ONESIX_QUANTILE) = cache
     (; t, dt, uprev, u, W, p, f) = integrator
 
-    m = length(W.dW)
+    dW = W.dW
+    m = dW isa Number ? 1 : length(dW)
     sq3dt = sqrt(3 * dt)
     # define three-point distributed random variables
-    dW_scaled = W.dW / integrator.sqdt
+    dW_scaled = dW / integrator.sqdt
     _dW = map(x -> calc_threepoint_random(sq3dt, NORMAL_ONESIX_QUANTILE, x), dW_scaled)
     chi1 = map(x -> (x^2 - dt) / 4, _dW)
-    if !(W.dW isa Number)
-        # define two-point distributed random variables
-        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
-    end
+    _dZ = dW isa Number ? [_dW] : map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
     # compute stage values
     k1 = integrator.f(uprev, p, t)
     g1 = integrator.f.g(uprev, p, t)
 
     # Y, Yp, Ym
-    if !is_diagonal_noise(integrator.sol.prob) || W.dW isa Number
+    if !is_diagonal_noise(integrator.sol.prob) || dW isa Number
         Y = uprev + k1 * dt + g1 * _dW
-        if W.dW isa Number
+        if dW isa Number
             Yp = uprev + k1 * dt + g1 * integrator.sqdt
             Ym = uprev + k1 * dt - g1 * integrator.sqdt
         else
@@ -994,7 +996,7 @@ end
     u = uprev + 1 // 2 * (k1 + k2) * dt
 
     # add noise
-    if W.dW isa Number
+    if dW isa Number
         g2p = integrator.f.g(Yp, p, t)
         g2m = integrator.f.g(Ym, p, t)
         u += 1 // 4 * (g2p + g2m + 2 * g1) * _dW + (g2p - g2m) * chi1 / integrator.sqdt #(1.1)
@@ -1102,7 +1104,7 @@ end
     if W.dW isa Number
         integrator.f.g(tmpg1, Yp, p, t)
         integrator.f.g(tmpg2, Ym, p, t)
-        @.. u = u + 1 // 4 * (tmpg1 + tmpg2 + 2 * g1) * _dW + 1 // 4 * (tmpg1 - tmpg2) * chi1[k] / integrator.sqdt #(1.1)
+        @.. u = u + 1 // 4 * (tmpg1 + tmpg2 + 2 * g1) * _dW + 1 // 4 * (tmpg1 - tmpg2) * chi1 / integrator.sqdt #(1.1)
     else
         if !is_diagonal_noise(integrator.sol.prob) || W.dW isa Number
             # non-diag noise
@@ -1229,16 +1231,14 @@ end
     ) = cache
     (; t, dt, uprev, u, W, p, f) = integrator
 
-    m = length(W.dW)
+    dW = W.dW
+    m = dW isa Number ? 1 : length(dW)
     # define three-point distributed random variables
     sq3dt = sqrt(3 * dt)
-    dW_scaled = W.dW / integrator.sqdt
+    dW_scaled = dW / integrator.sqdt
     _dW = map(x -> calc_threepoint_random(sq3dt, NORMAL_ONESIX_QUANTILE, x), dW_scaled)
 
-    if !(W.dW isa Number)
-        # define two-point distributed random variables
-        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
-    end
+    _dZ = dW isa Number ? [_dW] : map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
 
     # compute stage values
     # stage 1
@@ -1250,7 +1250,7 @@ end
     Y2jajb = [zero(u) for ja in 1:m, jb in 1:m]
     Y3jajb = [zero(u) for ja in 1:m, jb in 1:m]
     Y4jajb = [zero(u) for ja in 1:m, jb in 1:m]
-    if W.dW isa Number
+    if dW isa Number
         Y1jajb = gtmp * _dW
     else
         for ja in 1:m
@@ -1259,15 +1259,15 @@ end
                 if is_diagonal_noise(integrator.sol.prob)
                     tmpu = zero(integrator.u)
                     tmpu[jb] = gtmp[jb]
-                    @.. Y1jajb[ja, jb] = Ihat2 * tmpu
+                    @.. Y1jajb[ja, jb] = ihat2 * tmpu
                     if ja != jb
-                        @.. Y4jajb[ja, jb] = Ihat2 * tmpu
+                        @.. Y4jajb[ja, jb] = ihat2 * tmpu
                     end
                 else
                     gtmpjb = @view gtmp[:, jb]
-                    @.. Y1jajb[ja, jb] = Ihat2 * gtmpjb
+                    @.. Y1jajb[ja, jb] = ihat2 * gtmpjb
                     if ja != jb
-                        @.. Y4jajb[ja, jb] = Ihat2 * gtmpjb
+                        @.. Y4jajb[ja, jb] = ihat2 * gtmpjb
                     end
                 end
             end
@@ -1277,7 +1277,7 @@ end
     # stage 2
     Y200 = uprev + a0021 * Y100
 
-    if W.dW isa Number
+    if dW isa Number
         Y200 += a0j21 * Y1jajb
         Y2jajb = integrator.f.g(uprev + aj021 * Y100 + ajj21 * Y1jajb[1], p, t) * _dW
     else
@@ -1297,7 +1297,7 @@ end
                     gtmp = integrator.f.g(tmpu, p, t)
                     tmpjb = @view gtmp[:, jb]
                     ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
-                    @.. Y2jajb[ja, jb] = Ihat2 * tmpjb
+                    @.. Y2jajb[ja, jb] = ihat2 * tmpjb
                 end
             end
         else
@@ -1317,7 +1317,7 @@ end
                     tmpu = zero(integrator.u)
                     tmpu[jb] = gtmp[jb]
                     ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
-                    @.. Y2jajb[ja, jb] = Ihat2 * tmpu
+                    @.. Y2jajb[ja, jb] = ihat2 * tmpu
                 end
             end
         end
@@ -1327,7 +1327,7 @@ end
 
     # stage 3
     Y300 = uprev + a0032 * Y200
-    if W.dW isa Number
+    if dW isa Number
         Y300 += a0j31 * Y1jajb + a0j32 * Y2jajb
         Y3jajb = integrator.f.g(uprev + ajj31 * Y1jajb[1] + ajj32 * Y2jajb[1], p, t) * _dW
     else
@@ -1387,7 +1387,7 @@ end
 
     # stage 4
     Y400 = uprev + a0043 * Y300
-    if W.dW isa Number
+    if dW isa Number
         Y400 += a0j41 * Y1jajb
         Y4jajb = integrator.f.g(
             uprev + ajj41 * Y1jajb[1] + ajj42 * Y2jajb[1] + ajj43 * Y3jajb[1] + aj041 * Y100, p, t
@@ -1433,7 +1433,7 @@ end
 
     # add stages together
     u = uprev + c01 * Y100 + c02 * Y200 + c03 * Y300 + c04 * Y400
-    if W.dW isa Number
+    if dW isa Number
         # to be checked
         u += cj1 * Y1jajb + cj2 * Y2jajb + cj3 * Y3jajb + cj4 * Y4jajb
     else
@@ -1483,16 +1483,17 @@ end
         ajl32, ajl41, ajl42, ajljj31, aljjl21, aljjl31, NORMAL_ONESIX_QUANTILE,
     ) = cache.tab
 
-    m = length(W.dW)
+    dW = W.dW
+    if dW isa Number
+        throw(ArgumentError("NONCache requires vector noise increments"))
+    end
+    m = length(dW)
     # define three-point distributed random variables
-    @.. chi1 = W.dW / integrator.sqdt
+    @.. chi1 = dW / integrator.sqdt
     sq3dt = sqrt(3 * dt)
     calc_threepoint_random!(_dW, sq3dt, NORMAL_ONESIX_QUANTILE, chi1)
 
-    if !(W.dW isa Number)
-        # define two-point distributed random variables
-        calc_twopoint_random!(_dZ, integrator.sqdt, W.dZ)
-    end
+    calc_twopoint_random!(_dZ, integrator.sqdt, W.dZ)
 
     # compute stage values
     # stage 1
@@ -1666,34 +1667,30 @@ end
 
     # add stages together
     @.. u = uprev + c01 * Y100 + c02 * Y200 + c03 * Y300 + c04 * Y400
-    if W.dW isa Number
-        @.. u = u + cj1 * Y1jj + cj2 * Y2jj + cj3 * Y3jj + cj4 * Y4jj
-    else
-        if is_diagonal_noise(integrator.sol.prob)
-            for ja in 1:m
-                @.. u = u + cj1 * Y1jajb[ja, ja] + cj2 * Y2jajb[ja, ja] + cj3 * Y3jajb[ja, ja] +
-                    cj4 * Y4jajb[ja, ja]
-                for jb in 1:m
-                    if jb != ja
-                        if ja > jb
-                            @.. u = u + clj2 * Y2jajb[ja, jb] + clj3 * Y3jajb[ja, jb]
-                        else
-                            @.. u = u + cjl2 * Y2jajb[ja, jb] + cjl3 * Y3jajb[ja, jb]
-                        end
+    if is_diagonal_noise(integrator.sol.prob)
+        for ja in 1:m
+            @.. u = u + cj1 * Y1jajb[ja, ja] + cj2 * Y2jajb[ja, ja] + cj3 * Y3jajb[ja, ja] +
+                cj4 * Y4jajb[ja, ja]
+            for jb in 1:m
+                if jb != ja
+                    if ja > jb
+                        @.. u = u + clj2 * Y2jajb[ja, jb] + clj3 * Y3jajb[ja, jb]
+                    else
+                        @.. u = u + cjl2 * Y2jajb[ja, jb] + cjl3 * Y3jajb[ja, jb]
                     end
                 end
             end
-        else
-            for ja in 1:m
-                @.. u = u + cj1 * Y1jajb[ja, ja] + cj2 * Y2jajb[ja, ja] + cj3 * Y3jajb[ja, ja] +
-                    cj4 * Y4jajb[ja, ja]
-                for jb in 1:m
-                    if jb != ja
-                        if ja > jb
-                            @.. u = u + clj2 * Y2jajb[ja, jb] + clj3 * Y3jajb[ja, jb]
-                        else
-                            @.. u = u + cjl2 * Y2jajb[ja, jb] + cjl3 * Y3jajb[ja, jb]
-                        end
+        end
+    else
+        for ja in 1:m
+            @.. u = u + cj1 * Y1jajb[ja, ja] + cj2 * Y2jajb[ja, ja] + cj3 * Y3jajb[ja, ja] +
+                cj4 * Y4jajb[ja, ja]
+            for jb in 1:m
+                if jb != ja
+                    if ja > jb
+                        @.. u = u + clj2 * Y2jajb[ja, jb] + clj3 * Y3jajb[ja, jb]
+                    else
+                        @.. u = u + cjl2 * Y2jajb[ja, jb] + cjl3 * Y3jajb[ja, jb]
                     end
                 end
             end
@@ -2011,22 +2008,23 @@ end
     ) = cache
     (; t, dt, uprev, u, W, p, f) = integrator
 
-    m = length(W.dW)
+    dW = W.dW
+    m = dW isa Number ? 1 : length(dW)
     #_dW = W.dW
 
     # define three-point distributed random variables
     sq3dt = sqrt(3 * dt)
-    chi1 = W.dW / integrator.sqdt
+    chi1 = dW / integrator.sqdt
     _dW = map(x -> calc_threepoint_random(sq3dt, NORMAL_ONESIX_QUANTILE, x), chi1)
+    ihat2 = zeros(eltype(chi1), m, m)
 
-    if !(W.dW isa Number)
+    if !(dW isa Number)
         # define two-point distributed random variables
         _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
-        ihat2 = zeros(eltype(W.dZ), m, m) # I^_(k,l)
         for j in 1:m
             for l in 1:(j - 1)
-                Ihat2[j, l] = -_dZ[j] * _dW[l] / integrator.sqdt
-                Ihat2[l, j] = _dW[l] * _dZ[j] / integrator.sqdt
+                ihat2[j, l] = -_dZ[j] * _dW[l] / integrator.sqdt
+                ihat2[l, j] = _dW[l] * _dZ[j] / integrator.sqdt
             end
         end
     end
@@ -2040,7 +2038,7 @@ end
 
     Y10 = ktmp * dt
 
-    if W.dW isa Number
+    if dW isa Number
         Y1j = gtmp * _dW
     else
         if is_diagonal_noise(integrator.sol.prob)
@@ -2053,7 +2051,7 @@ end
     # stage 2
     Y20 = uprev + a0021 * Y10
 
-    if W.dW isa Number
+    if dW isa Number
         Y20 += a0j21 * Y1j
         Y2j = integrator.f.g(uprev + aj021 * Y10 + ajj21 * Y1j, p, t) * _dW
     else
@@ -2079,7 +2077,7 @@ end
 
     # stage 3
     Y30 = uprev + a0032 * Y20
-    if W.dW isa Number
+    if dW isa Number
         Y30 += a0j31 * Y1j + a0j32 * Y2j
         Y3j = integrator.f.g(uprev + ajj31 * Y1j + ajj32 * Y2j, p, t) * _dW
     else
@@ -2111,7 +2109,7 @@ end
 
     # stage 4
     Y40 = uprev + a0043 * Y30
-    if W.dW isa Number
+    if dW isa Number
         Y40 += a0j41 * Y1j
         Y4j = integrator.f.g(uprev + ajj41 * Y1j + ajj42 * Y2j + ajj43 * Y3j + aj041 * Y10, p, t) * _dW
     else
@@ -2146,7 +2144,7 @@ end
     # add stages together
     u = uprev + c01 * Y10 + c02 * Y20 + c03 * Y30 + c04 * Y40
 
-    if W.dW isa Number
+    if dW isa Number
         u += cj1 * Y1j + cj2 * Y2j + cj3 * Y3j + cj4 * Y4j
     else
         if is_diagonal_noise(integrator.sol.prob)
@@ -2156,7 +2154,7 @@ end
                 u += @. cj1 * Y1j[:, j] + cj2 * Y2j[:, j] + cj3 * Y3j[:, j] + cj4 * Y4j[:, j]
                 #add stage values for non-commutative processes, Y3^(k(j)j) and Y4^(k(j)j)
                 for k in 1:m
-                    η2 = @view Ihat2[k, :]
+                    η2 = @view ihat2[k, :]
                     tmp = gtmp1 * η2 / (4 * γ)
                     Y3kj = integrator.sqdt * integrator.f.g(uprev + tmp, p, t)
                     Y4kj = integrator.sqdt * integrator.f.g(uprev - tmp, p, t)

--- a/lib/StochasticDiffEqWeak/src/tableaus.jl
+++ b/lib/StochasticDiffEqWeak/src/tableaus.jl
@@ -848,9 +848,9 @@ end
 
 function checkNONOrder(NON; tol = 1.0e-6)
     if NON isa KomoriNON
-        (; c0, cj, cjl, clj, α00, α0j, αj0, αjj, αjl, αjljj, αljjl) = NON
+        (; c0, cj, α00, α0j, αj0, αjj, αjl) = NON
     elseif NON isa KomoriNON2
-        (; c0, cj, ckj, α00, α0j, αj0, αjj, αjl, αkjjl) = NON
+        (; c0, cj, α00, α0j, αj0, αjj, αjl) = NON
     else
         (; c0, cj, α00, α0j, αj0, αjj, αjl) = NON
     end
@@ -893,6 +893,7 @@ function checkNONOrder(NON; tol = 1.0e-6)
     conditions[32] = abs(dot(cj, (αjj * e) .* (αjl * e)) - 1 / 4) < tol
 
     if NON isa KomoriNON
+        (; cjl, clj, αjljj, αljjl) = NON
         conditions[33] = abs(dot(clj, e) - 0) < tol
         conditions[34] = abs(dot(cjl, e) - 0) < tol
         conditions[35] = abs(dot(clj, αljjl * e) - 1 / 2) < tol
@@ -900,6 +901,7 @@ function checkNONOrder(NON; tol = 1.0e-6)
         conditions[37] = abs(dot(clj .* (αljjl * e), αljjl * (αjljj * e)) - 0) < tol
         conditions[38] = abs(dot(clj, (αljjl * e) .^ 2) - 0) < tol
     elseif NON isa KomoriNON2
+        (; ckj, αkjjl) = NON
         conditions[33] = abs(ckj[4] + ckj[3] - 0) < tol
         conditions[34] = abs(ckj[2] - 0) < tol
         conditions[35] = abs(αkjjl[4, 3] - 0) < tol


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

Extracted from omnibus #3836.

- Initialize branch-local temps (`α/β/γ`, `uᵢ₋₁`, `H22/H23`, `vec_χ`) so JET can prove definite assignment on ROCK/Weak/Milstein paths.
- Prefer `if/else` over `(cond) && (stmt)` for multi-line `cache.mdeg` assignment.
- Fix weak SRK non-diagonal stage indexing (use `k` not `l` for columns).
- `CompositeCache` resize/deleteat/addat for SDE integrators.
- Explicit missing `alg_cache` throw for unknown stochastic algorithms.
- Expand StochasticDiffEqCore QA coverage.

Version bumps: Core 2.0.3→2.0.4, ROCK 2.0.1→2.0.2, Weak 2.1.1→2.1.2, Milstein 2.0.1→2.0.2.

## Local verification

- Runic format on changed Julia files
- Smoke compile: StochasticDiffEqCore/ROCK/Weak/Milstein load OK
- Full SDE QA not re-run end-to-end here (heavy); CI will cover