### PR TITLE
Document public API: add docstrings + docs entries

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -8,6 +8,7 @@ OrdinaryDiffEqAdamsBashforthMoulton = "89bda076-bce5-4f1c-845f-551c83cdda9a"
 OrdinaryDiffEqBDF = "6ad6398a-0878-4a85-9266-38940aa047c8"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 OrdinaryDiffEqDefault = "50262376-6c5a-4cf5-baba-aaf4f84d72d7"
+OrdinaryDiffEqDifferentiation = "4302a76b-040a-498a-8c04-15b101fed76b"
 OrdinaryDiffEqExplicitRK = "9286f039-9fbf-40e8-bf65-aa933bdc4db0"
 OrdinaryDiffEqExponentialRK = "e0540318-69ee-4070-8777-9e2de6de23de"
 OrdinaryDiffEqExtrapolation = "becaefa8-8ca2-5cf9-886d-c06f3d2bd2c4"
@@ -18,6 +19,7 @@ OrdinaryDiffEqIMEXMultistep = "9f002381-b378-40b7-97a6-27a27c83f129"
 OrdinaryDiffEqLinear = "521117fe-8c41-49f8-b3b6-30780b3f0fb5"
 OrdinaryDiffEqLowOrderRK = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
 OrdinaryDiffEqLowStorageRK = "b0944070-b475-4768-8dec-fb6eb410534d"
+OrdinaryDiffEqNonlinearSolve = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 OrdinaryDiffEqNordsieck = "c9986a66-5c92-4813-8696-a7ec84c806c8"
 OrdinaryDiffEqPDIRK = "5dd0a6cf-3d4b-4314-aa06-06d4e299bc89"
 OrdinaryDiffEqPRK = "5b33eab2-c0f1-4480-b2c3-94bc1e80bda1"
@@ -40,6 +42,7 @@ OrdinaryDiffEqAdamsBashforthMoulton = {path = "../lib/OrdinaryDiffEqAdamsBashfor
 OrdinaryDiffEqBDF = {path = "../lib/OrdinaryDiffEqBDF"}
 OrdinaryDiffEqCore = {path = "../lib/OrdinaryDiffEqCore"}
 OrdinaryDiffEqDefault = {path = "../lib/OrdinaryDiffEqDefault"}
+OrdinaryDiffEqDifferentiation = {path = "../lib/OrdinaryDiffEqDifferentiation"}
 OrdinaryDiffEqExplicitRK = {path = "../lib/OrdinaryDiffEqExplicitRK"}
 OrdinaryDiffEqExponentialRK = {path = "../lib/OrdinaryDiffEqExponentialRK"}
 OrdinaryDiffEqExtrapolation = {path = "../lib/OrdinaryDiffEqExtrapolation"}
@@ -50,6 +53,7 @@ OrdinaryDiffEqIMEXMultistep = {path = "../lib/OrdinaryDiffEqIMEXMultistep"}
 OrdinaryDiffEqLinear = {path = "../lib/OrdinaryDiffEqLinear"}
 OrdinaryDiffEqLowOrderRK = {path = "../lib/OrdinaryDiffEqLowOrderRK"}
 OrdinaryDiffEqLowStorageRK = {path = "../lib/OrdinaryDiffEqLowStorageRK"}
+OrdinaryDiffEqNonlinearSolve = {path = "../lib/OrdinaryDiffEqNonlinearSolve"}
 OrdinaryDiffEqNordsieck = {path = "../lib/OrdinaryDiffEqNordsieck"}
 OrdinaryDiffEqPDIRK = {path = "../lib/OrdinaryDiffEqPDIRK"}
 OrdinaryDiffEqPRK = {path = "../lib/OrdinaryDiffEqPRK"}
@@ -74,6 +78,7 @@ OrdinaryDiffEqAdamsBashforthMoulton = "2.0.0"
 OrdinaryDiffEqBDF = "2.0.0"
 OrdinaryDiffEqCore = "4.1"
 OrdinaryDiffEqDefault = "2.0.0"
+OrdinaryDiffEqDifferentiation = "3"
 OrdinaryDiffEqExplicitRK = "2.0.0"
 OrdinaryDiffEqExponentialRK = "2.0.0"
 OrdinaryDiffEqExtrapolation = "2.0.0"
@@ -84,6 +89,7 @@ OrdinaryDiffEqIMEXMultistep = "2.0.0"
 OrdinaryDiffEqLinear = "2.0.0"
 OrdinaryDiffEqLowOrderRK = "2.0.0"
 OrdinaryDiffEqLowStorageRK = "3.0.0"
+OrdinaryDiffEqNonlinearSolve = "2"
 OrdinaryDiffEqNordsieck = "2.0.0"
 OrdinaryDiffEqPDIRK = "2.0.0"
 OrdinaryDiffEqPRK = "2.0.0"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,6 +5,13 @@ using OrdinaryDiffEqCore
 # OrdinaryDiffEqCore but are documented public API.
 using OrdinaryDiffEqCore: default_controller, resolve_basic,
     get_EEst, set_EEst!, CompositeController
+using OrdinaryDiffEqDifferentiation
+using OrdinaryDiffEqNonlinearSolve
+# Bring the non-exported nonlinear-solver public names referenced by unqualified
+# `@ref` links in the docstrings into Main so those links resolve, matching the
+# controller-symbol pattern above.
+using OrdinaryDiffEqNonlinearSolve: build_nlsolver, nlsolve!, nlsolvefail,
+    anderson, anderson!, NLNewton, NLFunctional, NLAnderson
 using ImplicitDiscreteSolve
 using OrdinaryDiffEqAMF
 using OrdinaryDiffEqAdamsBashforthMoulton
@@ -48,6 +55,8 @@ makedocs(
     modules = [
         OrdinaryDiffEq,
         OrdinaryDiffEqCore,
+        OrdinaryDiffEqDifferentiation,
+        OrdinaryDiffEqNonlinearSolve,
         OrdinaryDiffEqAdamsBashforthMoulton,
         OrdinaryDiffEqBDF,
         OrdinaryDiffEqDefault,

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -54,6 +54,7 @@ pages = [
     ],
     "APIs" => [
         "api/controllers.md",
+        "api/solver_author.md",
     ],
     "Developer Documentation" => [
         "devtools/index.md",

--- a/docs/src/api/solver_author.md
+++ b/docs/src/api/solver_author.md
@@ -1,0 +1,347 @@
+# Solver-author extension API
+
+This page documents the `public` extension API of the OrdinaryDiffEq.jl core and
+solver sublibraries — the names that downstream solver packages (the OrdinaryDiffEq
+solver sublibs, StochasticDiffEq.jl, DelayDiffEq.jl, …) subtype, extend, or call
+when adding a new solver. These are *not exported*: they are marked `public` so
+they are recognized as a supported extension surface rather than internal access.
+
+Everyday users do not need this page; it is for people writing new solvers. The
+step-size controller interface has its own dedicated page, the
+[Controller API](@ref).
+
+## Algorithm type hierarchy
+
+Every solver subtypes one of these abstract algorithm types.
+
+```@docs
+OrdinaryDiffEqCore.OrdinaryDiffEqAlgorithm
+OrdinaryDiffEqCore.OrdinaryDiffEqAdaptiveAlgorithm
+OrdinaryDiffEqCore.OrdinaryDiffEqCompositeAlgorithm
+OrdinaryDiffEqCore.OrdinaryDiffEqImplicitAlgorithm
+OrdinaryDiffEqCore.OrdinaryDiffEqAdaptiveImplicitAlgorithm
+OrdinaryDiffEqCore.OrdinaryDiffEqNewtonAlgorithm
+OrdinaryDiffEqCore.OrdinaryDiffEqNewtonAdaptiveAlgorithm
+OrdinaryDiffEqCore.OrdinaryDiffEqRosenbrockAlgorithm
+OrdinaryDiffEqCore.OrdinaryDiffEqRosenbrockAdaptiveAlgorithm
+OrdinaryDiffEqCore.NewtonAlgorithm
+OrdinaryDiffEqCore.RosenbrockAlgorithm
+OrdinaryDiffEqCore.OrdinaryDiffEqExponentialAlgorithm
+OrdinaryDiffEqCore.OrdinaryDiffEqAdaptiveExponentialAlgorithm
+OrdinaryDiffEqCore.OrdinaryDiffEqLinearExponentialAlgorithm
+OrdinaryDiffEqCore.ExponentialAlgorithm
+OrdinaryDiffEqCore.OrdinaryDiffEqAdamsVarOrderVarStepAlgorithm
+OrdinaryDiffEqCore.DAEAlgorithm
+OrdinaryDiffEqCore.OrdinaryDiffEqPartitionedAlgorithm
+OrdinaryDiffEqCore.OrdinaryDiffEqAdaptivePartitionedAlgorithm
+OrdinaryDiffEqCore.PartitionedAlgorithm
+OrdinaryDiffEqCore.OrdinaryDiffEqImplicitSecondOrderAlgorithm
+OrdinaryDiffEqCore.OrdinaryDiffEqAdaptiveImplicitSecondOrderAlgorithm
+OrdinaryDiffEqCore.ImplicitSecondOrderAlgorithm
+```
+
+### SDE / RODE algorithm hierarchy
+
+Subtyped by StochasticDiffEq.jl; defined in the core so the shared machinery can
+dispatch on them.
+
+```@docs
+OrdinaryDiffEqCore.StochasticDiffEqAlgorithm
+OrdinaryDiffEqCore.StochasticDiffEqAdaptiveAlgorithm
+OrdinaryDiffEqCore.StochasticDiffEqCompositeAlgorithm
+OrdinaryDiffEqCore.StochasticDiffEqNewtonAlgorithm
+OrdinaryDiffEqCore.StochasticDiffEqNewtonAdaptiveAlgorithm
+OrdinaryDiffEqCore.StochasticDiffEqRODEAlgorithm
+OrdinaryDiffEqCore.StochasticDiffEqRODEAdaptiveAlgorithm
+OrdinaryDiffEqCore.StochasticDiffEqRODECompositeAlgorithm
+OrdinaryDiffEqCore.StochasticDiffEqJumpAlgorithm
+OrdinaryDiffEqCore.StochasticDiffEqJumpAdaptiveAlgorithm
+OrdinaryDiffEqCore.StochasticDiffEqJumpNewtonAdaptiveAlgorithm
+OrdinaryDiffEqCore.StochasticDiffEqJumpDiffusionAlgorithm
+OrdinaryDiffEqCore.StochasticDiffEqJumpDiffusionAdaptiveAlgorithm
+OrdinaryDiffEqCore.StochasticDiffEqJumpNewtonDiffusionAdaptiveAlgorithm
+```
+
+## Cache type hierarchy
+
+```@docs
+OrdinaryDiffEqCore.OrdinaryDiffEqCache
+OrdinaryDiffEqCore.OrdinaryDiffEqConstantCache
+OrdinaryDiffEqCore.OrdinaryDiffEqMutableCache
+OrdinaryDiffEqCore.CompositeCache
+OrdinaryDiffEqCore.DefaultCache
+OrdinaryDiffEqCore.AutoSwitchCache
+OrdinaryDiffEqCore.StochasticDiffEqCache
+OrdinaryDiffEqCore.StochasticDiffEqConstantCache
+OrdinaryDiffEqCore.StochasticDiffEqMutableCache
+OrdinaryDiffEqCore.@cache
+OrdinaryDiffEqCore.strip_cache
+OrdinaryDiffEqCore.is_constant_cache
+OrdinaryDiffEqCore.is_composite_cache
+OrdinaryDiffEqCore.is_composite_algorithm
+OrdinaryDiffEqCore.isdiscretecache
+OrdinaryDiffEqCore.get_fsalfirstlast
+OrdinaryDiffEqCore.alg_cache
+```
+
+Example solver-sublibrary caches that are declared public so other sublibraries
+can reuse their step:
+
+```@docs
+OrdinaryDiffEqLowOrderRK.BS3Cache
+OrdinaryDiffEqLowOrderRK.BS3ConstantCache
+OrdinaryDiffEqLowOrderRK.RK4Cache
+OrdinaryDiffEqLowOrderRK.RK4ConstantCache
+OrdinaryDiffEqTsit5.Tsit5Cache
+OrdinaryDiffEqTsit5.Tsit5ConstantCache
+OrdinaryDiffEqSDIRK.ESDIRKIMEXCache
+OrdinaryDiffEqSDIRK.ESDIRKIMEXConstantCache
+OrdinaryDiffEqSDIRK.ImplicitEulerESDIRKIMEXTableau
+OrdinaryDiffEqRosenbrock.RosenbrockMutableCache
+```
+
+## Composite algorithms and automatic switching
+
+```@docs
+OrdinaryDiffEqCore.CompositeAlgorithm
+OrdinaryDiffEqCore.AutoSwitch
+OrdinaryDiffEqCore.AutoAlgSwitch
+OrdinaryDiffEqCore.isautoswitch
+OrdinaryDiffEqCore.default_autoswitch
+OrdinaryDiffEqCore.unwrap_alg
+OrdinaryDiffEqCore.isdefaultalg
+```
+
+## Algorithm trait functions
+
+Solver sublibraries specialize these to describe their algorithm.
+
+```@docs
+OrdinaryDiffEqCore.alg_order
+OrdinaryDiffEqCore.alg_maximum_order
+OrdinaryDiffEqCore.alg_adaptive_order
+OrdinaryDiffEqCore.alg_stability_size
+OrdinaryDiffEqCore.alg_extrapolates
+OrdinaryDiffEqCore.alg_can_repeat_jac
+OrdinaryDiffEqCore.alg_autodiff
+OrdinaryDiffEqCore.alg_difftype
+OrdinaryDiffEqCore.isfsal
+OrdinaryDiffEqCore.fsal_typeof
+OrdinaryDiffEqCore.isimplicit
+OrdinaryDiffEqCore.isadaptive
+OrdinaryDiffEqCore.isdtchangeable
+OrdinaryDiffEqCore.ismultistep
+OrdinaryDiffEqCore.dt_required
+OrdinaryDiffEqCore.uses_uprev
+OrdinaryDiffEqCore.has_autodiff
+OrdinaryDiffEqCore.has_special_newton_error
+OrdinaryDiffEqCore.has_dtnew_modification
+OrdinaryDiffEqCore.has_stiff_interpolation
+OrdinaryDiffEqCore.allows_null_u0
+OrdinaryDiffEqCore.isaposteriori
+OrdinaryDiffEqCore.isdiscretealg
+OrdinaryDiffEqCore.isdp8
+OrdinaryDiffEqCore.isesdirk
+OrdinaryDiffEqCore.isfirk
+OrdinaryDiffEqCore.isnewton
+OrdinaryDiffEqCore.isWmethod
+OrdinaryDiffEqCore.is_mass_matrix_alg
+OrdinaryDiffEqCore.issplit
+OrdinaryDiffEqCore.only_diagonal_mass_matrix
+OrdinaryDiffEqCore.standardtag
+OrdinaryDiffEqCore.concrete_jac
+OrdinaryDiffEqCore.ssp_coefficient
+OrdinaryDiffEqCore.fac_default_gamma
+OrdinaryDiffEqCore.default_linear_interpolation
+```
+
+## Order / step-size / autodiff-config accessors
+
+```@docs
+OrdinaryDiffEqCore.get_current_alg_order
+OrdinaryDiffEqCore.get_current_adaptive_order
+OrdinaryDiffEqCore.get_current_alg_autodiff
+OrdinaryDiffEqCore.get_chunksize
+OrdinaryDiffEqCore._get_fdtype
+OrdinaryDiffEqCore._get_fwd_chunksize
+OrdinaryDiffEqCore._get_fwd_chunksize_int
+OrdinaryDiffEqCore._fixup_ad
+OrdinaryDiffEqCore.diffdir
+OrdinaryDiffEqCore.error_constant
+OrdinaryDiffEqCore.constvalue
+OrdinaryDiffEqCore.unitfulvalue
+```
+
+## Threading options
+
+```@docs
+OrdinaryDiffEqCore.AbstractThreadingOption
+OrdinaryDiffEqCore.Sequential
+OrdinaryDiffEqCore.BaseThreads
+OrdinaryDiffEqCore.PolyesterThreads
+OrdinaryDiffEqCore.isthreaded
+```
+
+## Enums and status types
+
+```@docs
+OrdinaryDiffEqCore.DIRK
+OrdinaryDiffEqCore.COEFFICIENT_MULTISTEP
+OrdinaryDiffEqCore.NORDSIECK_MULTISTEP
+OrdinaryDiffEqCore.GLM
+OrdinaryDiffEqCore.FastConvergence
+OrdinaryDiffEqCore.Convergence
+OrdinaryDiffEqCore.SlowConvergence
+OrdinaryDiffEqCore.VerySlowConvergence
+OrdinaryDiffEqCore.Divergence
+OrdinaryDiffEqCore.TryAgain
+```
+
+## Error and sentinel types
+
+```@docs
+OrdinaryDiffEqCore.CompiledFloats
+OrdinaryDiffEqCore.DerivativeOrderNotPossibleError
+OrdinaryDiffEqCore.DifferentialVarsUndefined
+```
+
+## Nonlinear solver interface
+
+The nonlinear-solver types and hooks live in `OrdinaryDiffEqNonlinearSolve`; the
+abstract types and W-matrix hook stubs live in the core.
+
+```@docs
+OrdinaryDiffEqCore.AbstractNLSolver
+OrdinaryDiffEqCore.AbstractNLSolverAlgorithm
+OrdinaryDiffEqCore.AbstractNLSolverCache
+OrdinaryDiffEqCore.nlsolve_f
+OrdinaryDiffEqCore.MethodType
+OrdinaryDiffEqCore.NLStatus
+OrdinaryDiffEqNonlinearSolve.NLNewton
+OrdinaryDiffEqNonlinearSolve.NLFunctional
+OrdinaryDiffEqNonlinearSolve.NLAnderson
+OrdinaryDiffEqNonlinearSolve.build_nlsolver
+OrdinaryDiffEqNonlinearSolve.nlsolve!
+OrdinaryDiffEqNonlinearSolve.compute_step!
+OrdinaryDiffEqNonlinearSolve.nlsolvefail
+OrdinaryDiffEqNonlinearSolve.initial_η
+OrdinaryDiffEqNonlinearSolve.markfirststage!
+OrdinaryDiffEqNonlinearSolve.du_alias_or_new
+OrdinaryDiffEqNonlinearSolve.anderson
+OrdinaryDiffEqNonlinearSolve.anderson!
+OrdinaryDiffEqCore.get_W
+OrdinaryDiffEqCore.set_new_W!
+OrdinaryDiffEqCore.set_W_γdt!
+OrdinaryDiffEqCore.get_new_W_γdt_cutoff
+OrdinaryDiffEqCore.isfirstcall
+OrdinaryDiffEqCore.isfirststage
+OrdinaryDiffEqCore.isJcurrent
+OrdinaryDiffEqCore.resize_J_W!
+OrdinaryDiffEqCore.resize_nlsolver!
+OrdinaryDiffEqCore.default_nlsolve
+```
+
+## Jacobian / W-matrix / differentiation configuration
+
+Provided by `OrdinaryDiffEqDifferentiation`.
+
+```@docs
+OrdinaryDiffEqDifferentiation.build_J_W
+OrdinaryDiffEqDifferentiation.build_uf
+OrdinaryDiffEqDifferentiation.build_jac_config
+OrdinaryDiffEqDifferentiation.build_grad_config
+OrdinaryDiffEqDifferentiation.calc_J
+OrdinaryDiffEqDifferentiation.calc_J!
+OrdinaryDiffEqDifferentiation.calc_tderivative
+OrdinaryDiffEqDifferentiation.calc_tderivative!
+OrdinaryDiffEqDifferentiation.calc_rosenbrock_differentiation
+OrdinaryDiffEqDifferentiation.calc_rosenbrock_differentiation!
+OrdinaryDiffEqDifferentiation.jacobian!
+OrdinaryDiffEqDifferentiation.jacobian2W!
+OrdinaryDiffEqDifferentiation.update_W!
+OrdinaryDiffEqDifferentiation.resize_jac_config!
+OrdinaryDiffEqDifferentiation.resize_grad_config!
+OrdinaryDiffEqDifferentiation.dolinsolve
+OrdinaryDiffEqDifferentiation.wrapprecs
+OrdinaryDiffEqDifferentiation.is_always_new
+OrdinaryDiffEqDifferentiation.islinearfunction
+OrdinaryDiffEqDifferentiation.issuccess_W
+```
+
+## Integrator step and initialization hooks
+
+```@docs
+OrdinaryDiffEqCore.ODEIntegrator
+OrdinaryDiffEqCore.DEOptions
+OrdinaryDiffEqCore.perform_step!
+OrdinaryDiffEqCore.apply_step!
+OrdinaryDiffEqCore.postamble!
+OrdinaryDiffEqCore.last_step_failed
+OrdinaryDiffEqCore.handle_callback_modifiers!
+OrdinaryDiffEqCore.set_discontinuity
+OrdinaryDiffEqCore.increment_accept!
+OrdinaryDiffEqCore.increment_reject!
+OrdinaryDiffEqCore.increment_nf!
+OrdinaryDiffEqCore.ode_determine_initdt
+OrdinaryDiffEqCore._determine_initdt
+OrdinaryDiffEqCore._ode_init
+OrdinaryDiffEqCore._initialize_dae!
+OrdinaryDiffEqCore.get_differential_vars
+```
+
+## Dense output / interpolation
+
+```@docs
+OrdinaryDiffEqCore.OrdinaryDiffEqInterpolation
+OrdinaryDiffEqCore.InterpolationData
+OrdinaryDiffEqCore.ode_interpolant
+OrdinaryDiffEqCore.ode_interpolant!
+OrdinaryDiffEqCore.hermite_interpolant
+OrdinaryDiffEqCore.hermite_interpolant!
+OrdinaryDiffEqCore.interpolation_differential_vars
+OrdinaryDiffEqCore.current_interpolant
+OrdinaryDiffEqCore.current_extrapolant
+OrdinaryDiffEqCore.current_extrapolant!
+OrdinaryDiffEqCore.ode_addsteps!
+OrdinaryDiffEqCore._ode_interpolant
+OrdinaryDiffEqCore._ode_interpolant!
+OrdinaryDiffEqCore._ode_addsteps!
+```
+
+## Controller caches
+
+Per-solve caches for the built-in step-size controllers (see the
+[Controller API](@ref) for the controllers themselves).
+
+```@docs
+OrdinaryDiffEqCore.IControllerCache
+OrdinaryDiffEqCore.PIControllerCache
+OrdinaryDiffEqCore.PIDControllerCache
+OrdinaryDiffEqCore.PredictiveControllerCache
+OrdinaryDiffEqCore.CompositeControllerCache
+OrdinaryDiffEqCore.DummyController
+OrdinaryDiffEqCore.DummyControllerCache
+```
+
+## Noise-process hooks
+
+Used by the SDE/RODE solver sublibraries; no-ops for pure ODEs.
+
+```@docs
+OrdinaryDiffEqCore.accept_noise!
+OrdinaryDiffEqCore.reject_noise!
+OrdinaryDiffEqCore.save_noise!
+OrdinaryDiffEqCore.reinit_noise!
+OrdinaryDiffEqCore.noise_curt
+OrdinaryDiffEqCore.is_noise_saveable
+```
+
+## Docstring builders
+
+Helpers that build consistent algorithm docstrings.
+
+```@docs
+OrdinaryDiffEqCore.generic_solver_docstring
+OrdinaryDiffEqCore.explicit_rk_docstring
+OrdinaryDiffEqCore.differentiation_rk_docstring
+```

--- a/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
+++ b/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
@@ -124,23 +124,114 @@ import EnzymeCore
 end
 export Predictor
 
+"""
+    CompiledFloats
+
+`Union{Float32, Float64}` — the floating-point element types for which the solvers
+provide fully precompiled specializations.
+"""
 const CompiledFloats = Union{Float32, Float64}
 import Preferences
 
+"""
+    AbstractNLSolverCache
+
+Abstract supertype of the mutable cache held by an [`AbstractNLSolver`](@ref),
+storing the W-matrix, factorizations, residual buffers, and per-iteration state.
+"""
 abstract type AbstractNLSolverCache end
+"""
+    AbstractNLSolverAlgorithm
+
+Abstract supertype of the algorithm objects that configure a nonlinear solver
+(e.g. `NLNewton`, `NLFunctional`, `NLAnderson`). Passed as the `nlsolve` keyword
+of an implicit algorithm and consumed by [`OrdinaryDiffEqNonlinearSolve.build_nlsolver`](@ref).
+"""
 abstract type AbstractNLSolverAlgorithm end
+"""
+    AbstractNLSolver{algType, iip}
+
+Abstract supertype of the nonlinear solver object that implicit algorithms use to
+solve their implicit stage equations. Concrete subtypes (e.g. `NLSolver` in
+OrdinaryDiffEqNonlinearSolve) are built with [`OrdinaryDiffEqNonlinearSolve.build_nlsolver`](@ref) and driven
+with [`OrdinaryDiffEqNonlinearSolve.nlsolve!`](@ref). The type parameters are the nonlinear-solver algorithm
+type and the in-place flag `iip`.
+"""
 abstract type AbstractNLSolver{algType, iip} end
 
+"""
+    set_new_W!(nlsolver, val::Bool) -> Bool
+
+Set the flag recording whether a fresh `W` was just computed for this step and
+return `val`. Read via `get_new_W!` to decide whether to reset the Newton
+convergence estimate.
+"""
 function set_new_W! end
+"""
+    set_W_γdt!(nlsolver, W_γdt)
+
+Store the `γΔt` value at which the current `W` was formed and return it. A change
+in `γΔt` beyond [`get_new_W_γdt_cutoff`](@ref) triggers a `W` refactorization.
+"""
 function set_W_γdt! end
+"""
+    get_W(nlsolver)
+
+Return the `W = M/(γΔt) - J` matrix (or its factorization) held by the nonlinear
+solver's cache.
+"""
 function get_W end
+"""
+    isfirstcall(nlsolver) -> Bool
+
+Return whether this is the first nonlinear solve of the current step (so a fresh
+`W`/initial guess is needed).
+"""
 function isfirstcall end
+"""
+    isfirststage(nlsolver) -> Bool
+
+Return whether the nonlinear solver is on the first implicit stage of a multi-stage
+method (used to decide predictor/W reuse).
+"""
 function isfirststage end
+"""
+    isJcurrent(nlsolver, integrator) -> Bool
+
+Return whether the Jacobian stored on the solver is current for the present
+`integrator` state (so it need not be recomputed).
+"""
 function isJcurrent end
+"""
+    get_new_W_γdt_cutoff(nlsolver)
+
+Return the relative-change threshold on `γΔt` above which the nonlinear solver
+recomputes/refactorizes `W` rather than reusing the existing one.
+"""
 function get_new_W_γdt_cutoff end
+"""
+    resize_J_W!(nlsolver, integrator, i)
+
+Resize the Jacobian and `W` matrices held by `nlsolver` to length `i` after the
+state size changes (e.g. from a `resize!` callback). No-op fallback.
+"""
 resize_J_W!(args...) = nothing
+"""
+    resize_nlsolver!(integrator, i)
+
+Resize the nonlinear solver's internal buffers to state length `i` after the state
+size changes. No-op fallback.
+"""
 resize_nlsolver!(args...) = nothing
 
+"""
+    MethodType
+
+`@enum` classifying how an implicit algorithm forms its `W = M/(γΔt) - J` matrix
+and stage system. One of [`DIRK`](@ref), [`COEFFICIENT_MULTISTEP`](@ref),
+[`NORDSIECK_MULTISTEP`](@ref), or [`GLM`](@ref). The nonlinear solver uses it to
+scale `γW` appropriately in [`OrdinaryDiffEqNonlinearSolve.nlsolve!`](@ref).
+"""
 @enum MethodType begin
     DIRK
     COEFFICIENT_MULTISTEP
@@ -148,6 +239,43 @@ resize_nlsolver!(args...) = nothing
     GLM
 end
 
+"""
+    DIRK
+
+[`MethodType`](@ref) value for diagonally-implicit Runge–Kutta stage systems.
+"""
+DIRK
+
+"""
+    COEFFICIENT_MULTISTEP
+
+[`MethodType`](@ref) value for coefficient-form multistep (e.g. BDF) methods.
+"""
+COEFFICIENT_MULTISTEP
+
+"""
+    NORDSIECK_MULTISTEP
+
+[`MethodType`](@ref) value for Nordsieck-form multistep methods.
+"""
+NORDSIECK_MULTISTEP
+
+"""
+    GLM
+
+[`MethodType`](@ref) value for general linear methods.
+"""
+GLM
+
+"""
+    NLStatus
+
+`@enum` reporting the outcome/convergence quality of a nonlinear solve, ordered
+from best to worst: [`FastConvergence`](@ref) (`2`), [`Convergence`](@ref) (`1`),
+[`SlowConvergence`](@ref) (`0`), [`VerySlowConvergence`](@ref) (`-1`),
+[`Divergence`](@ref) (`-2`). A non-positive value means the solve failed
+([`OrdinaryDiffEqNonlinearSolve.nlsolvefail`](@ref)).
+"""
 @enum NLStatus::Int8 begin
     FastConvergence = 2
     Convergence = 1
@@ -155,10 +283,68 @@ end
     VerySlowConvergence = -1
     Divergence = -2
 end
+
+"""
+    FastConvergence
+
+[`NLStatus`](@ref) value (`2`) indicating the nonlinear solve converged quickly.
+"""
+FastConvergence
+
+"""
+    Convergence
+
+[`NLStatus`](@ref) value (`1`) indicating the nonlinear solve converged.
+"""
+Convergence
+
+"""
+    SlowConvergence
+
+[`NLStatus`](@ref) value (`0`) indicating slow convergence. Also aliased as
+[`TryAgain`](@ref).
+"""
+SlowConvergence
+
+"""
+    VerySlowConvergence
+
+[`NLStatus`](@ref) value (`-1`) indicating very slow convergence; treated as a
+failure.
+"""
+VerySlowConvergence
+
+"""
+    Divergence
+
+[`NLStatus`](@ref) value (`-2`) indicating the nonlinear iteration diverged.
+"""
+Divergence
+
+"""
+    TryAgain
+
+Alias for [`SlowConvergence`](@ref); a sentinel [`NLStatus`](@ref) signalling that
+the step should be retried (e.g. with a fresh Jacobian).
+"""
 const TryAgain = SlowConvergence
 
+"""
+    isdiscretecache(cache) -> Bool
+
+Return whether `cache` belongs to a discrete-time / map-iteration algorithm rather
+than a continuous ODE solver (`false` by default). Companion to
+[`isdiscretealg`](@ref).
+"""
 isdiscretecache(cache) = false
 
+"""
+    unitfulvalue(x)
+
+Return the unit-stripped numeric value of `x` (delegates to
+`SciMLBase.unitfulvalue`). Used where a bare number is needed from a possibly
+`Unitful` quantity.
+"""
 unitfulvalue(x) = SciMLBase.unitfulvalue(x)
 
 # Declare the documented custom-stepsize-controller author interface `public` so downstream

--- a/lib/OrdinaryDiffEqCore/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/alg_utils.jl
@@ -69,6 +69,14 @@ SciMLBase.supports_solve_rng(
 
 ## OrdinaryDiffEq Internal Traits
 
+"""
+    isfsal(alg) -> Bool
+
+Return whether `alg` is a FSAL ("first same as last") method, i.e. the last stage
+derivative of one step equals the first of the next so it can be reused. Explicit
+RK methods are FSAL by default (`true`); the integrator reuses `fsallast` as the
+next `fsalfirst` accordingly.
+"""
 isfsal(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm}) = true
 isfsal(tab::DiffEqBase.ExplicitRKTableau) = tab.fsal
 
@@ -76,15 +84,46 @@ isfsal(tab::DiffEqBase.ExplicitRKTableau) = tab.fsal
 # Pseudo Non-FSAL
 #isfsal(alg::RKM) = false
 
+"""
+    isfirk(alg) -> Bool
+
+Return whether `alg` is a fully-implicit Runge–Kutta (FIRK) method
+(`false` by default).
+"""
 isfirk(alg) = false
 
 get_current_isfsal(alg, cache) = isfsal(alg)
 
+"""
+    dt_required(alg) -> Bool
+
+Return whether `alg` requires the user to supply a `dt` (`true` by default). Only
+fully-adaptive or callback-driven algorithms may relax this.
+"""
 dt_required(alg) = true
 
+"""
+    isdiscretealg(alg) -> Bool
+
+Return whether `alg` is a discrete-time / map-iteration algorithm rather than a
+continuous ODE solver (`false` by default).
+"""
 isdiscretealg(alg) = false
 
+"""
+    alg_stability_size(alg) -> Real
+
+Return the (real-axis) linear stability region size of `alg`, used by
+stabilized/auto-switching heuristics to decide whether an explicit method is
+stable for the current step. Solver sublibraries define it per algorithm.
+"""
 function alg_stability_size end
+"""
+    has_stiff_interpolation(alg) -> Bool
+
+Return whether `alg` provides a special interpolant for its stiff branch
+(`false` by default).
+"""
 has_stiff_interpolation(alg) = false
 
 # evaluates f(t[i])
@@ -113,6 +152,12 @@ all_fsal(alg::CompositeAlgorithm, cache) = _all_fsal(alg.algs)
     return :(all($ex))
 end
 
+"""
+    issplit(alg) -> Bool
+
+Return whether `alg` treats the RHS as a split function (e.g. IMEX `f = f1 + f2`).
+`false` by default.
+"""
 issplit(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm}) = false
 issplit(alg::StochasticDiffEqAlgorithm) = false
 
@@ -172,6 +217,13 @@ end
     return expr
 end
 
+"""
+    fsal_typeof(alg, rate_prototype)
+
+Return the type used to store the FSAL derivative for `alg` given a
+`rate_prototype`. Defaults to `typeof(rate_prototype)`; overridden by algorithms
+whose FSAL slot differs from the ordinary rate type.
+"""
 function fsal_typeof(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm}, rate_prototype)
     return typeof(rate_prototype)
 end
@@ -182,25 +234,56 @@ function fsal_typeof(alg::CompositeAlgorithm, rate_prototype)
     return fsal[1]
 end
 
+"""
+    isimplicit(alg) -> Bool
+
+Return whether `alg` solves an implicit (nonlinear) system each step. `false` for
+explicit methods; `true` for implicit ones. For a [`CompositeAlgorithm`](@ref) it
+is `true` if any constituent is implicit.
+"""
 isimplicit(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm}) = false
 isimplicit(alg::OrdinaryDiffEqAdaptiveImplicitAlgorithm) = true
 isimplicit(alg::OrdinaryDiffEqImplicitAlgorithm) = true
 isimplicit(alg::CompositeAlgorithm) = any(isimplicit.(alg.algs))
 
+"""
+    isdtchangeable(alg) -> Bool
+
+Return whether `alg` allows the step size `dt` to change between steps (`true` by
+default). Multistep-style methods that require a fixed grid set this to `false`.
+"""
 isdtchangeable(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm}) = true
 isdtchangeable(alg::CompositeAlgorithm) = all(isdtchangeable.(alg.algs))
 # Generic fallback for non-ODE algorithms (SDE, RODE) calling __init
 isdtchangeable(alg) = true
 
+"""
+    ismultistep(alg) -> Bool
+
+Return whether `alg` is a multistep method (uses solution history from more than
+the previous step). `false` by default.
+"""
 ismultistep(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm}) = false
 ismultistep(alg::CompositeAlgorithm) = any(ismultistep.(alg.algs))
 
+"""
+    isadaptive(alg) -> Bool
+
+Return whether `alg` performs adaptive step-size control. `true` for algorithms
+subtyping an `…Adaptive…` abstract type, `false` otherwise.
+"""
 isadaptive(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm}) = false
 isadaptive(alg::OrdinaryDiffEqAdaptiveAlgorithm) = true
 isadaptive(alg::OrdinaryDiffEqCompositeAlgorithm) = all(isadaptive.(alg.algs))
 # Generic fallback for non-ODE algorithms (SDE, RODE) calling __init
 isadaptive(alg) = false
 
+"""
+    has_special_newton_error(alg) -> Bool
+
+Return whether `alg` supplies its own Newton-iteration error estimate rather than
+the generic one (`false` by default).
+"""
 has_special_newton_error(alg) = false
 
 anyadaptive(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm}) = isadaptive(alg)
@@ -208,6 +291,12 @@ anyadaptive(alg::OrdinaryDiffEqCompositeAlgorithm) = any(isadaptive, alg.algs)
 # Generic fallback for non-ODE algorithms (SDE, RODE) calling __init
 anyadaptive(alg) = isadaptive(alg)
 
+"""
+    has_dtnew_modification(alg) -> Bool
+
+Return whether `alg` post-processes the controller's proposed `dtnew` via a
+`dtnew_modification` hook (`false` by default).
+"""
 has_dtnew_modification(alg) = false
 dtnew_modification(integrator, alg, dtnew) = dtnew
 
@@ -216,17 +305,53 @@ dtnew_modification(integrator, alg, dtnew) = dtnew
 # (zero(u), similar(u), broadcasts) still works. Solvers that want to preserve the
 # `nothing` signal — e.g., to bypass nonlinear solvers or skip allocation — override
 # to true.
+"""
+    allows_null_u0(alg) -> Bool
+
+Return whether `alg` supports an empty (zero-length) initial condition `u0`
+(`false` by default).
+"""
 allows_null_u0(alg) = false
 
 # Whether an algorithm uses a posteriori dt estimates (always accepts, then picks next dt).
 # Default is false. CaoTauLeaping overrides to true.
+"""
+    isaposteriori(alg) -> Bool
+
+Return whether `alg` uses a-posteriori (rather than embedded) error estimation
+(`false` by default).
+"""
 isaposteriori(alg) = false
 
+"""
+    isautoswitch(alg) -> Bool
+
+Return whether `alg` is a composite algorithm whose choice function is an
+[`AutoSwitch`](@ref) stiffness detector.
+"""
 isautoswitch(alg) = false
 isautoswitch(alg::CompositeAlgorithm) = alg.choice_function isa AutoSwitch
 
+"""
+    only_diagonal_mass_matrix(alg) -> Bool
+
+Return whether `alg` only supports diagonal (not general) mass matrices
+(`false` by default). Used to decide FSAL reevaluation.
+"""
 only_diagonal_mass_matrix(alg) = false
+"""
+    isdp8(alg) -> Bool
+
+Return whether `alg` is the `DP8` method. Used to special-case its FSAL / dense
+handling (`false` by default).
+"""
 isdp8(alg) = false
+"""
+    isdefaultalg(alg) -> Bool
+
+Return whether `alg` is the automatic default algorithm wrapper. Used to route the
+stiffness auto-switching logic through its specialized default path.
+"""
 isdefaultalg(alg) = false
 
 """
@@ -253,12 +378,30 @@ qmax_default(alg::CompositeAlgorithm) = minimum(qmax_default.(alg.algs))
 # Generic fallback for non-ODE algorithms (SDE, RODE) calling __init
 qmax_default(alg) = 10
 
+"""
+    get_chunksize(alg) -> Val
+
+Return the ForwardDiff chunk size configured on `alg`'s autodiff choice, as a
+`Val`. `Val(0)` means "let ForwardDiff choose".
+"""
 function get_chunksize(alg::OrdinaryDiffEqAlgorithm)
     error("This algorithm does not have a chunk size defined.")
 end
 
+"""
+    _get_fwd_chunksize(AD) -> Val
+
+Return, as a `Val`, the ForwardDiff chunk size encoded in the `AutoForwardDiff`
+type/instance `AD` (`Val(0)` when unspecified).
+"""
 _get_fwd_chunksize(::Type{<:AutoForwardDiff{nothing}}) = Val(0)
 _get_fwd_chunksize(::Type{<:AutoForwardDiff{CS}}) where {CS} = Val(CS)
+"""
+    _get_fwd_chunksize_int(AD) -> Int
+
+Return the ForwardDiff chunk size encoded in the `AutoForwardDiff` type/instance
+`AD` as a plain `Int` (`0` when unspecified).
+"""
 _get_fwd_chunksize_int(::Type{<:AutoForwardDiff{nothing}}) = 0
 _get_fwd_chunksize_int(::Type{<:AutoForwardDiff{CS}}) where {CS} = CS
 _get_fwd_chunksize(AD) = Val(0)
@@ -267,6 +410,12 @@ _get_fwd_chunksize_int(::AutoForwardDiff{nothing}) = 0
 _get_fwd_chunksize_int(::AutoForwardDiff{CS}) where {CS} = CS
 _get_fwd_tag(::AutoForwardDiff{CS, T}) where {CS, T} = T
 
+"""
+    _get_fdtype(AD)
+
+Return the finite-difference type parameter (e.g. `Val{:forward}`) of an
+`AutoFiniteDiff` type/instance `AD`.
+"""
 _get_fdtype(::AutoFiniteDiff{T1}) where {T1} = T1
 _get_fdtype(::Type{<:AutoFiniteDiff{T1}}) where {T1} = T1
 
@@ -302,6 +451,13 @@ end
 
 # get_chunksize(alg::CompositeAlgorithm) = get_chunksize(alg.algs[alg.current_alg])
 
+"""
+    alg_autodiff(alg)
+
+Return the automatic-differentiation choice (an ADTypes.jl `AbstractADType`) that
+`alg` uses to build Jacobians. Implicit-solver sublibraries define this for their
+algorithms; see also [`get_current_alg_autodiff`](@ref) for composite algorithms.
+"""
 function alg_autodiff end
 
 # Linear Exponential doesn't have any of the AD stuff
@@ -334,6 +490,12 @@ function _prepare_autoswitch_alg(algs::Tuple, u0, p, prob)
     return map(a -> DiffEqBase.prepare_alg(a, u0, p, prob), algs)
 end
 
+"""
+    has_autodiff(alg) -> Bool
+
+Return whether `alg` carries an `autodiff` field configuring Jacobian
+differentiation (`false` for explicit methods).
+"""
 has_autodiff(alg::OrdinaryDiffEqAlgorithm) = false
 function has_autodiff(
         alg::Union{
@@ -350,11 +512,25 @@ has_autodiff(alg::ExponentialAlgorithm) = hasfield(typeof(alg), :autodiff)
 # end
 
 # alg_autodiff(alg::CompositeAlgorithm) = alg_autodiff(alg.algs[alg.current_alg])
+"""
+    get_current_alg_autodiff(alg, cache)
+
+Return the autodiff choice active for the current step. Equals
+[`alg_autodiff`](@ref)`(alg)` for simple algorithms; for a
+[`CompositeAlgorithm`](@ref) it selects the currently-active constituent via
+`cache.current`.
+"""
 get_current_alg_autodiff(alg, cache) = alg_autodiff(alg)
 function get_current_alg_autodiff(alg::CompositeAlgorithm, cache)
     return _eval_index(alg_autodiff, alg.algs, cache.current)::Bool
 end
 
+"""
+    alg_difftype(alg)
+
+Return the finite-difference type (e.g. `Val{:forward}`) configured on `alg`'s
+`AutoFiniteDiff` autodiff choice, used when differentiating by finite differences.
+"""
 function alg_difftype(
         alg::Union{
             OrdinaryDiffEqAdaptiveImplicitAlgorithm,
@@ -368,6 +544,13 @@ function alg_difftype(
     return _get_fdtype(alg.autodiff)
 end
 
+"""
+    standardtag(alg) -> Bool
+
+Return whether `alg` uses the standard ForwardDiff tagging (a custom tag type for
+Dual numbers) when building Jacobians. Used by the differentiation machinery to
+pick the AD config.
+"""
 standardtag(
     alg::Union{
         OrdinaryDiffEqAdaptiveImplicitAlgorithm,
@@ -378,6 +561,13 @@ standardtag(
     }
 ) = true
 
+"""
+    concrete_jac(alg)
+
+Return the `concrete_jac` setting of `alg`: `true`/`false` forces whether a
+concrete Jacobian matrix is materialized, `nothing` lets the solver decide (e.g.
+based on the chosen linear solver).
+"""
 concrete_jac(
     alg::Union{
         OrdinaryDiffEqAdaptiveImplicitAlgorithm,
@@ -388,15 +578,36 @@ concrete_jac(
     }
 ) = alg.concrete_jac
 
+"""
+    alg_extrapolates(alg) -> Bool
+
+Return whether `alg` needs an extrapolated initial guess for its implicit/predictor
+stage (`false` by default). Algorithms that do set this to `true` so the
+integrator computes `uprev2`/extrapolant state for them.
+"""
 alg_extrapolates(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm}) = false
 alg_extrapolates(alg::CompositeAlgorithm) = any(alg_extrapolates.(alg.algs))
 # Generic fallback for non-ODE algorithms (SDE, RODE) calling __init
 alg_extrapolates(alg) = false
+"""
+    alg_order(alg) -> Int
+
+Return the order of accuracy of `alg`. Solver sublibraries define this for each
+concrete algorithm; for a [`CompositeAlgorithm`](@ref) it is the maximum over the
+constituent algorithms.
+"""
 function alg_order(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm})
     error("Order is not defined for this algorithm")
 end
 alg_order(alg::CompositeAlgorithm) = maximum(alg_order, alg.algs)
 
+"""
+    get_current_alg_order(alg, cache) -> Int
+
+Return the order currently in effect for `alg` given its `cache`. Equal to
+[`alg_order`](@ref) for fixed-order methods; for variable-order methods
+(Adams/BDF) it reads the order stored on the cache.
+"""
 function get_current_alg_order(
         alg::Union{
             OrdinaryDiffEqAlgorithm, DAEAlgorithm,
@@ -411,6 +622,13 @@ function get_current_alg_order(alg::CompositeAlgorithm, cache)
 end
 
 get_current_alg_order(alg::OrdinaryDiffEqAdamsVarOrderVarStepAlgorithm, cache) = cache.order
+"""
+    get_current_adaptive_order(alg, cache) -> Int
+
+Return the order used for the current step's adaptive error estimate given `alg`
+and its `cache` (order-aware analogue of [`alg_adaptive_order`](@ref) for
+variable-order methods).
+"""
 function get_current_adaptive_order(alg::OrdinaryDiffEqAdamsVarOrderVarStepAlgorithm, cache)
     return cache.order
 end
@@ -423,9 +641,23 @@ function get_current_adaptive_order(alg::CompositeAlgorithm, cache)
     return _eval_index(alg_adaptive_order, alg.algs, cache.current)::Int
 end
 
+"""
+    alg_maximum_order(alg) -> Int
+
+Return the maximum order the algorithm can attain. Equal to [`alg_order`](@ref)
+for fixed-order methods; for composite algorithms it is the maximum over the
+constituents.
+"""
 alg_maximum_order(alg) = alg_order(alg)
 alg_maximum_order(alg::CompositeAlgorithm) = maximum(alg_order(x) for x in alg.algs)
 
+"""
+    alg_adaptive_order(alg) -> Int
+
+Return the order used for the adaptive error estimate of `alg`. The generic
+fallback is `alg_order(alg) - 1`; it is deliberately conservative because it
+tracks the realized error better than the embedded-estimate order.
+"""
 alg_adaptive_order(alg) = alg_order(alg) - 1
 
 # this is actually incorrect and is purposefully decreased as this tends
@@ -499,6 +731,13 @@ gamma_default(alg) = isadaptive(alg) ? 9 // 10 : 0
 
 # Whether `PredictiveController.stepsize_controller!` should use the
 # plain `gamma` factor without the Newton-iter correction (used by FIRK).
+"""
+    fac_default_gamma(alg) -> Bool
+
+Return whether the [`PredictiveController`](@ref) should apply the plain `gamma`
+safety factor without the Newton-iteration correction for `alg` (`false` by
+default; `true` for FIRK methods).
+"""
 fac_default_gamma(alg) = false
 
 """
@@ -564,9 +803,24 @@ ssp_coefficient(alg) = error("$alg is not a strong stability preserving method."
 # We shouldn't do this probably.
 #ssp_coefficient(alg::ImplicitEuler) = Inf
 
+"""
+    alg_can_repeat_jac(alg) -> Bool
+
+Return whether `alg` may reuse a Jacobian/W factorization across steps rather than
+recomputing every step. `true` for adaptive Newton algorithms, `false` otherwise.
+"""
 alg_can_repeat_jac(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm}) = false
 alg_can_repeat_jac(alg::OrdinaryDiffEqNewtonAdaptiveAlgorithm) = true
 
+"""
+    unwrap_alg(integrator, is_stiff)
+    unwrap_alg(alg, is_stiff)
+
+Return the concrete algorithm actually driving the current step. For a
+non-composite algorithm this is `alg` itself; for a [`CompositeAlgorithm`](@ref)
+it selects the active constituent based on the current cache index or, for a
+two-member auto-switch pair, on the `is_stiff` flag.
+"""
 function unwrap_alg(alg::SciMLBase.AbstractDEAlgorithm, is_stiff)
     if !is_composite_algorithm(alg)
         return alg
@@ -616,16 +870,42 @@ function throwautoswitch(alg)
 end
 
 # Whether `uprev` is used in the algorithm directly.
+"""
+    uses_uprev(alg, adaptive::Bool) -> Bool
+
+Return whether `alg` uses the previous step value `uprev` directly (as opposed to
+only via the FSAL history). `true` by default; used to decide whether the `uprev`
+cache slot must be maintained.
+"""
 uses_uprev(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm}, adaptive::Bool) = true
 uses_uprev(alg::OrdinaryDiffEqAdaptiveAlgorithm, adaptive::Bool) = true
 # Generic fallback for non-ODE algorithms (SDE, RODE) calling __init
 uses_uprev(alg, adaptive) = true
 
 
+"""
+    isWmethod(alg) -> Bool
+
+Return whether `alg` is a W-method, i.e. it remains correct with an inexact
+(stale) Jacobian in its `W` matrix (`false` by default). Rosenbrock-W methods set
+this `true`.
+"""
 isWmethod(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm}) = false
 
+"""
+    isesdirk(alg) -> Bool
+
+Return whether `alg` is an ESDIRK (explicit-first-stage singly-diagonally-implicit
+Runge–Kutta) method (`false` by default).
+"""
 isesdirk(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm}) = false
 
+"""
+    is_mass_matrix_alg(alg) -> Bool
+
+Return whether `alg` supports solving mass-matrix ODEs/DAEs `M u' = f`
+(`false` by default; `true` for Rosenbrock and appropriate Newton methods).
+"""
 is_mass_matrix_alg(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm}) = false
 is_mass_matrix_alg(alg::CompositeAlgorithm) = all(is_mass_matrix_alg, alg.algs)
 is_mass_matrix_alg(alg::RosenbrockAlgorithm) = true
@@ -641,6 +921,13 @@ function Base.show(io::IO, ::MIME"text/plain", alg::OrdinaryDiffEqAlgorithm)
 end
 
 # Defaults in the current system: currently opt out DAEAlgorithms until complete
+"""
+    default_linear_interpolation(alg, prob) -> Bool
+
+Return whether the solver should default to (cheaper) linear interpolation instead
+of the algorithm's Hermite/dense interpolant for `alg` on `prob`. `true` for DAEs,
+discrete problems, and RODE/SDE problems.
+"""
 default_linear_interpolation(alg, prob) = alg isa DAEAlgorithm || prob isa DiscreteProblem
 # RODE/SDE always uses linear interpolation (no dense output)
 default_linear_interpolation(prob::SciMLBase.AbstractRODEProblem, alg) = true

--- a/lib/OrdinaryDiffEqCore/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqCore/src/algorithms.jl
@@ -1,86 +1,324 @@
+"""
+    OrdinaryDiffEqAlgorithm <: SciMLBase.AbstractODEAlgorithm
+
+Abstract supertype of every ODE algorithm defined in the OrdinaryDiffEq.jl
+ecosystem. A solver sublibrary defines a concrete algorithm by subtyping one of
+the more specific abstract types below (adaptive / implicit / exponential / …)
+rather than this root directly. Trait functions such as [`isadaptive`](@ref),
+[`isimplicit`](@ref), [`isfsal`](@ref), and [`alg_order`](@ref) dispatch on this
+hierarchy.
+"""
 abstract type OrdinaryDiffEqAlgorithm <: SciMLBase.AbstractODEAlgorithm end
+"""
+    OrdinaryDiffEqAdaptiveAlgorithm <: OrdinaryDiffEqAlgorithm
+
+Abstract supertype for explicit ODE algorithms that support adaptive step-size
+control (they carry an embedded error estimate). Subtyping this makes
+[`isadaptive`](@ref) return `true`.
+"""
 abstract type OrdinaryDiffEqAdaptiveAlgorithm <: OrdinaryDiffEqAlgorithm end
+"""
+    OrdinaryDiffEqCompositeAlgorithm <: OrdinaryDiffEqAlgorithm
+
+Abstract supertype for algorithms that dispatch between several sub-algorithms at
+runtime (see [`CompositeAlgorithm`](@ref)). Used by automatic stiffness switching
+and by the default solver.
+"""
 abstract type OrdinaryDiffEqCompositeAlgorithm <: OrdinaryDiffEqAlgorithm end
 
 # SDE/RODE algorithm type hierarchy (used by StochasticDiffEq)
+"""
+    StochasticDiffEqAlgorithm <: SciMLBase.AbstractSDEAlgorithm
+
+Abstract supertype of every SDE algorithm in the StochasticDiffEq.jl ecosystem.
+Defined here in OrdinaryDiffEqCore so that the shared integrator machinery can
+dispatch on it.
+"""
 abstract type StochasticDiffEqAlgorithm <: SciMLBase.AbstractSDEAlgorithm end
+"""
+    StochasticDiffEqAdaptiveAlgorithm <: StochasticDiffEqAlgorithm
+
+Abstract supertype for SDE algorithms supporting adaptive step-size control.
+"""
 abstract type StochasticDiffEqAdaptiveAlgorithm <: StochasticDiffEqAlgorithm end
+"""
+    StochasticDiffEqCompositeAlgorithm <: StochasticDiffEqAlgorithm
+
+Abstract supertype for composite (runtime-switching) SDE algorithms.
+"""
 abstract type StochasticDiffEqCompositeAlgorithm <: StochasticDiffEqAlgorithm end
 
+"""
+    StochasticDiffEqRODEAlgorithm <: SciMLBase.AbstractRODEAlgorithm
+
+Abstract supertype for random ODE (RODE) algorithms.
+"""
 abstract type StochasticDiffEqRODEAlgorithm <: SciMLBase.AbstractRODEAlgorithm end
+"""
+    StochasticDiffEqRODEAdaptiveAlgorithm <: StochasticDiffEqRODEAlgorithm
+
+Abstract supertype for adaptive RODE algorithms.
+"""
 abstract type StochasticDiffEqRODEAdaptiveAlgorithm <: StochasticDiffEqRODEAlgorithm end
+"""
+    StochasticDiffEqRODECompositeAlgorithm <: StochasticDiffEqRODEAlgorithm
+
+Abstract supertype for composite (runtime-switching) RODE algorithms.
+"""
 abstract type StochasticDiffEqRODECompositeAlgorithm <: StochasticDiffEqRODEAlgorithm end
 
 # SDE Newton/Jump algorithm subtypes (used by StochasticDiffEq implicit solvers)
+"""
+    StochasticDiffEqNewtonAdaptiveAlgorithm <: StochasticDiffEqAdaptiveAlgorithm
+
+Abstract supertype for adaptive implicit SDE algorithms solved with a Newton
+nonlinear solver.
+"""
 abstract type StochasticDiffEqNewtonAdaptiveAlgorithm <:
 StochasticDiffEqAdaptiveAlgorithm end
+"""
+    StochasticDiffEqNewtonAlgorithm <: StochasticDiffEqAlgorithm
+
+Abstract supertype for fixed-step implicit SDE algorithms solved with a Newton
+nonlinear solver.
+"""
 abstract type StochasticDiffEqNewtonAlgorithm <:
 StochasticDiffEqAlgorithm end
 
+"""
+    StochasticDiffEqJumpAlgorithm <: StochasticDiffEqAlgorithm
+
+Abstract supertype for SDE algorithms that additionally integrate jump terms.
+"""
 abstract type StochasticDiffEqJumpAlgorithm <: StochasticDiffEqAlgorithm end
+"""
+    StochasticDiffEqJumpAdaptiveAlgorithm <: StochasticDiffEqAlgorithm
+
+Abstract supertype for adaptive jump-SDE algorithms.
+"""
 abstract type StochasticDiffEqJumpAdaptiveAlgorithm <: StochasticDiffEqAlgorithm end
+"""
+    StochasticDiffEqJumpNewtonAdaptiveAlgorithm <: StochasticDiffEqJumpAdaptiveAlgorithm
+
+Abstract supertype for adaptive implicit (Newton) jump-SDE algorithms.
+"""
 abstract type StochasticDiffEqJumpNewtonAdaptiveAlgorithm <: StochasticDiffEqJumpAdaptiveAlgorithm end
 
+"""
+    StochasticDiffEqJumpDiffusionAlgorithm <: StochasticDiffEqAlgorithm
+
+Abstract supertype for jump-diffusion algorithms.
+"""
 abstract type StochasticDiffEqJumpDiffusionAlgorithm <: StochasticDiffEqAlgorithm end
+"""
+    StochasticDiffEqJumpDiffusionAdaptiveAlgorithm <: StochasticDiffEqAlgorithm
+
+Abstract supertype for adaptive jump-diffusion algorithms.
+"""
 abstract type StochasticDiffEqJumpDiffusionAdaptiveAlgorithm <: StochasticDiffEqAlgorithm end
+"""
+    StochasticDiffEqJumpNewtonDiffusionAdaptiveAlgorithm <: StochasticDiffEqJumpDiffusionAdaptiveAlgorithm
+
+Abstract supertype for adaptive implicit (Newton) jump-diffusion algorithms.
+"""
 abstract type StochasticDiffEqJumpNewtonDiffusionAdaptiveAlgorithm <: StochasticDiffEqJumpDiffusionAdaptiveAlgorithm end
 
 # SDE/RODE cache type hierarchy (used by StochasticDiffEq)
+"""
+    StochasticDiffEqCache <: SciMLBase.DECache
+
+Abstract supertype of every SDE/RODE solver cache. Analogue of
+[`OrdinaryDiffEqCache`](@ref) for the StochasticDiffEq.jl solvers; concrete caches
+subtype [`StochasticDiffEqConstantCache`](@ref) or
+[`StochasticDiffEqMutableCache`](@ref).
+"""
 abstract type StochasticDiffEqCache <: SciMLBase.DECache end
+"""
+    StochasticDiffEqConstantCache <: StochasticDiffEqCache
+
+Abstract supertype for out-of-place SDE/RODE caches (immutable state).
+"""
 abstract type StochasticDiffEqConstantCache <: StochasticDiffEqCache end
+"""
+    StochasticDiffEqMutableCache <: StochasticDiffEqCache
+
+Abstract supertype for in-place SDE/RODE caches (preallocated, mutated in place).
+"""
 abstract type StochasticDiffEqMutableCache <: StochasticDiffEqCache end
 
+"""
+    OrdinaryDiffEqAdaptiveImplicitAlgorithm <: OrdinaryDiffEqAdaptiveAlgorithm
+
+Abstract supertype for implicit ODE algorithms with adaptive step-size control.
+"""
 abstract type OrdinaryDiffEqAdaptiveImplicitAlgorithm <:
 OrdinaryDiffEqAdaptiveAlgorithm end
+"""
+    OrdinaryDiffEqNewtonAdaptiveAlgorithm <: OrdinaryDiffEqAdaptiveImplicitAlgorithm
+
+Abstract supertype for adaptive implicit algorithms solved with a Newton
+nonlinear solver. Distinguished from [`OrdinaryDiffEqNewtonAlgorithm`](@ref) by
+supporting Jacobian reuse across steps ([`alg_can_repeat_jac`](@ref) is `true`).
+"""
 abstract type OrdinaryDiffEqNewtonAdaptiveAlgorithm <:
 OrdinaryDiffEqAdaptiveImplicitAlgorithm end
+"""
+    OrdinaryDiffEqRosenbrockAdaptiveAlgorithm <: OrdinaryDiffEqAdaptiveImplicitAlgorithm
+
+Abstract supertype for adaptive Rosenbrock / Rosenbrock-W methods.
+"""
 abstract type OrdinaryDiffEqRosenbrockAdaptiveAlgorithm <:
 OrdinaryDiffEqAdaptiveImplicitAlgorithm end
 
+"""
+    OrdinaryDiffEqImplicitAlgorithm <: OrdinaryDiffEqAlgorithm
+
+Abstract supertype for implicit ODE algorithms (those that solve a nonlinear
+system each step). Subtyping this makes [`isimplicit`](@ref) return `true`.
+"""
 abstract type OrdinaryDiffEqImplicitAlgorithm <:
 OrdinaryDiffEqAlgorithm end
+"""
+    OrdinaryDiffEqNewtonAlgorithm <: OrdinaryDiffEqImplicitAlgorithm
+
+Abstract supertype for fixed-step implicit algorithms whose implicit stages are
+solved with a (quasi-)Newton nonlinear solver (see [`AbstractNLSolver`](@ref)).
+"""
 abstract type OrdinaryDiffEqNewtonAlgorithm <:
 OrdinaryDiffEqImplicitAlgorithm end
+"""
+    OrdinaryDiffEqRosenbrockAlgorithm <: OrdinaryDiffEqImplicitAlgorithm
+
+Abstract supertype for fixed-step Rosenbrock (and Rosenbrock-W) methods, which
+use the Jacobian directly through linear solves rather than a Newton iteration.
+"""
 abstract type OrdinaryDiffEqRosenbrockAlgorithm <:
 OrdinaryDiffEqImplicitAlgorithm end
+"""
+    NewtonAlgorithm
+
+`Union` of [`OrdinaryDiffEqNewtonAlgorithm`](@ref) and
+[`OrdinaryDiffEqNewtonAdaptiveAlgorithm`](@ref), i.e. every implicit algorithm
+that drives its stages with a Newton nonlinear solver. Used as a dispatch handle
+for the Newton/W-matrix machinery.
+"""
 const NewtonAlgorithm = Union{
     OrdinaryDiffEqNewtonAlgorithm,
     OrdinaryDiffEqNewtonAdaptiveAlgorithm,
 }
+"""
+    RosenbrockAlgorithm
+
+`Union` of [`OrdinaryDiffEqRosenbrockAlgorithm`](@ref) and
+[`OrdinaryDiffEqRosenbrockAdaptiveAlgorithm`](@ref), i.e. every Rosenbrock /
+Rosenbrock-W method.
+"""
 const RosenbrockAlgorithm = Union{
     OrdinaryDiffEqRosenbrockAlgorithm,
     OrdinaryDiffEqRosenbrockAdaptiveAlgorithm,
 }
 
+"""
+    OrdinaryDiffEqExponentialAlgorithm <: OrdinaryDiffEqAlgorithm
+
+Abstract supertype for exponential integrators that evaluate matrix-function
+(e.g. `exp`, `φ`) actions of the (linearized) operator each step.
+"""
 abstract type OrdinaryDiffEqExponentialAlgorithm <:
 OrdinaryDiffEqAlgorithm end
+"""
+    OrdinaryDiffEqAdaptiveExponentialAlgorithm <: OrdinaryDiffEqAdaptiveAlgorithm
+
+Abstract supertype for exponential integrators with adaptive step-size control.
+"""
 abstract type OrdinaryDiffEqAdaptiveExponentialAlgorithm <:
 OrdinaryDiffEqAdaptiveAlgorithm end
+"""
+    OrdinaryDiffEqLinearExponentialAlgorithm <: OrdinaryDiffEqExponentialAlgorithm
+
+Abstract supertype for exponential integrators specialized to (semi)linear
+problems `u' = A u (+ B(t))` where the operator action can be applied directly.
+"""
 abstract type OrdinaryDiffEqLinearExponentialAlgorithm <:
 OrdinaryDiffEqExponentialAlgorithm end
+"""
+    ExponentialAlgorithm
+
+`Union` of [`OrdinaryDiffEqExponentialAlgorithm`](@ref) and
+[`OrdinaryDiffEqAdaptiveExponentialAlgorithm`](@ref).
+"""
 const ExponentialAlgorithm = Union{
     OrdinaryDiffEqExponentialAlgorithm,
     OrdinaryDiffEqAdaptiveExponentialAlgorithm,
 }
 
+"""
+    OrdinaryDiffEqAdamsVarOrderVarStepAlgorithm <: OrdinaryDiffEqAdaptiveAlgorithm
+
+Abstract supertype for variable-order variable-step Adams (multistep) methods.
+For these algorithms the current order lives on the cache, so
+[`get_current_alg_order`](@ref) / [`get_current_adaptive_order`](@ref) read
+`cache.order` rather than a fixed algorithm order.
+"""
 abstract type OrdinaryDiffEqAdamsVarOrderVarStepAlgorithm <: OrdinaryDiffEqAdaptiveAlgorithm end
 
 # DAE Specific Algorithms
+"""
+    DAEAlgorithm <: SciMLBase.AbstractDAEAlgorithm
+
+Abstract supertype for fully-implicit DAE algorithms (solving
+`f(du, u, p, t) = 0`), e.g. `DFBDF`, `DImplicitEuler`. Distinct from the mass-matrix
+DAE path, which reuses the ODE algorithm types with a singular mass matrix.
+"""
 abstract type DAEAlgorithm <: SciMLBase.AbstractDAEAlgorithm end
 
 # Partitioned ODE Specific Algorithms
+"""
+    OrdinaryDiffEqPartitionedAlgorithm <: OrdinaryDiffEqAlgorithm
+
+Abstract supertype for partitioned / dynamical-ODE algorithms (e.g. symplectic
+and Nyström methods) that split the state into position/velocity partitions.
+"""
 abstract type OrdinaryDiffEqPartitionedAlgorithm <: OrdinaryDiffEqAlgorithm end
+"""
+    OrdinaryDiffEqAdaptivePartitionedAlgorithm <: OrdinaryDiffEqAdaptiveAlgorithm
+
+Abstract supertype for partitioned / dynamical-ODE algorithms with adaptive
+step-size control.
+"""
 abstract type OrdinaryDiffEqAdaptivePartitionedAlgorithm <: OrdinaryDiffEqAdaptiveAlgorithm end
+"""
+    PartitionedAlgorithm
+
+`Union` of [`OrdinaryDiffEqPartitionedAlgorithm`](@ref) and
+[`OrdinaryDiffEqAdaptivePartitionedAlgorithm`](@ref).
+"""
 const PartitionedAlgorithm = Union{
     OrdinaryDiffEqPartitionedAlgorithm,
     OrdinaryDiffEqAdaptivePartitionedAlgorithm,
 }
 
 # Second order ODE Specific Algorithms
+"""
+    OrdinaryDiffEqImplicitSecondOrderAlgorithm <: OrdinaryDiffEqImplicitAlgorithm
+
+Abstract supertype for implicit second-order (dynamical) ODE algorithms.
+"""
 abstract type OrdinaryDiffEqImplicitSecondOrderAlgorithm <:
 OrdinaryDiffEqImplicitAlgorithm end
+"""
+    OrdinaryDiffEqAdaptiveImplicitSecondOrderAlgorithm <: OrdinaryDiffEqAdaptiveImplicitAlgorithm
+
+Abstract supertype for adaptive implicit second-order (dynamical) ODE algorithms.
+"""
 abstract type OrdinaryDiffEqAdaptiveImplicitSecondOrderAlgorithm <:
 OrdinaryDiffEqAdaptiveImplicitAlgorithm end
+"""
+    ImplicitSecondOrderAlgorithm
+
+`Union` of [`OrdinaryDiffEqImplicitSecondOrderAlgorithm`](@ref) and
+[`OrdinaryDiffEqAdaptiveImplicitSecondOrderAlgorithm`](@ref).
+"""
 const ImplicitSecondOrderAlgorithm = Union{
     OrdinaryDiffEqImplicitSecondOrderAlgorithm,
     OrdinaryDiffEqAdaptiveImplicitSecondOrderAlgorithm,
@@ -139,6 +377,17 @@ if isdefined(Base, :Experimental) && isdefined(Base.Experimental, :silence!)
     Base.Experimental.silence!(CompositeAlgorithm)
 end
 
+"""
+    AutoSwitchCache
+
+Mutable state backing a stiffness-based [`AutoSwitch`](@ref) choice function. It
+counts consecutive stiff/nonstiff step diagnostics (`count`,
+`successive_switches`), stores the two candidate algorithms
+(`nonstiffalg`/`stiffalg`), the switching thresholds
+(`maxstiffstep`/`maxnonstiffstep`, `nonstifftol`/`stifftol`), and which branch is
+currently active (`is_stiffalg`, `current`). Called on the integrator to return
+the index of the algorithm to use for the next step.
+"""
 mutable struct AutoSwitchCache{nAlg, sAlg, tolType, T}
     count::Int
     successive_switches::Int

--- a/lib/OrdinaryDiffEqCore/src/cache_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/cache_utils.jl
@@ -1,3 +1,9 @@
+"""
+    is_constant_cache(cache) -> Bool
+
+Return whether `cache` is an out-of-place ([`OrdinaryDiffEqConstantCache`](@ref))
+cache. For composite/default caches it reflects the active constituent cache.
+"""
 is_constant_cache(::OrdinaryDiffEqConstantCache) = true
 is_constant_cache(::OrdinaryDiffEqCache) = false
 is_constant_cache(cache::CompositeCache) = is_constant_cache(cache.caches[1])

--- a/lib/OrdinaryDiffEqCore/src/caches/basic_caches.jl
+++ b/lib/OrdinaryDiffEqCore/src/caches/basic_caches.jl
@@ -1,5 +1,26 @@
+"""
+    OrdinaryDiffEqCache <: SciMLBase.DECache
+
+Abstract supertype of every solver cache. A cache holds the per-solve scratch
+state (stage values, temporaries, tableau, nonlinear solver, …) associated with
+an algorithm. Concrete caches are built by [`alg_cache`](@ref) and subtype either
+[`OrdinaryDiffEqConstantCache`](@ref) or [`OrdinaryDiffEqMutableCache`](@ref).
+"""
 abstract type OrdinaryDiffEqCache <: SciMLBase.DECache end
+"""
+    OrdinaryDiffEqConstantCache <: OrdinaryDiffEqCache
+
+Abstract supertype for out-of-place ("constant") caches used when the state is
+immutable (e.g. `Number`s, `StaticArray`s). These allocate fresh values each step
+instead of mutating in place. [`is_constant_cache`](@ref) returns `true` for them.
+"""
 abstract type OrdinaryDiffEqConstantCache <: OrdinaryDiffEqCache end
+"""
+    OrdinaryDiffEqMutableCache <: OrdinaryDiffEqCache
+
+Abstract supertype for in-place ("mutable") caches used when the state is a
+mutable array. Their scratch fields are preallocated and reused each step.
+"""
 abstract type OrdinaryDiffEqMutableCache <: OrdinaryDiffEqCache end
 struct ODEEmptyCache <: OrdinaryDiffEqConstantCache end
 struct ODEChunkCache{CS} <: OrdinaryDiffEqConstantCache end
@@ -8,8 +29,22 @@ ismutablecache(cache::OrdinaryDiffEqMutableCache) = true
 ismutablecache(cache::OrdinaryDiffEqConstantCache) = false
 
 # Don't worry about the potential alloc on a constant cache
+"""
+    get_fsalfirstlast(cache, u)
+
+Return the `(fsalfirst, fsallast)` derivative buffers for `cache`, allocating
+zeros of the shape of `u` for constant caches. Used to set up FSAL storage when
+initializing the integrator.
+"""
 get_fsalfirstlast(cache::OrdinaryDiffEqConstantCache, u) = (zero(u), zero(u))
 
+"""
+    CompositeCache(caches, choice_function, current) <: OrdinaryDiffEqCache
+
+Cache used by [`CompositeAlgorithm`](@ref). Holds the tuple of sub-`caches`, the
+`choice_function` that selects the active algorithm, and the index `current` of
+the currently-active sub-cache.
+"""
 mutable struct CompositeCache{T, F} <: OrdinaryDiffEqCache
     caches::T
     choice_function::F
@@ -29,6 +64,14 @@ function get_fsalfirstlast(cache::CompositeCache, u)
     end
 end
 
+"""
+    DefaultCache <: OrdinaryDiffEqCache
+
+Specialized composite cache used by the automatic default solver. It lazily holds
+up to six candidate sub-caches (`cache1`…`cache6`) constructed on demand from
+`args`, together with the `choice_function` and the `current` selected index,
+avoiding compilation of every candidate up front.
+"""
 mutable struct DefaultCache{T1, T2, T3, T4, T5, T6, A, F, uType} <: OrdinaryDiffEqCache
     args::A
     choice_function::F
@@ -61,6 +104,15 @@ function ismutablecache(
     return T1 <: OrdinaryDiffEqMutableCache
 end
 
+"""
+    alg_cache(alg, u, rate_prototype, uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits, uprev, uprev2, f, t, dt, reltol, p, calck, ::Val{iip}, verbose)
+
+Construct and return the solver cache for `alg`. Each solver sublibrary defines a
+method for its algorithm type, allocating stage buffers, tableau, nonlinear
+solver, etc. The `Val{iip}` argument selects the in-place
+([`OrdinaryDiffEqMutableCache`](@ref)) or out-of-place
+([`OrdinaryDiffEqConstantCache`](@ref)) branch.
+"""
 function alg_cache(
         alg::CompositeAlgorithm, u, rate_prototype, ::Type{uEltypeNoUnits},
         ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,

--- a/lib/OrdinaryDiffEqCore/src/composite_algs.jl
+++ b/lib/OrdinaryDiffEqCore/src/composite_algs.jl
@@ -42,6 +42,13 @@ function is_stiff(integrator, alg, ntol, stol, is_stiffalg)
     return bool
 end
 
+"""
+    default_autoswitch(AS::AutoSwitchCache, integrator) -> Int
+
+Choose, for the automatic default solver, the index of the algorithm to use next
+given the auto-switch state `AS` and the current `integrator`. Extended by the
+default-solver sublibrary; the generic method is only a stub.
+"""
 function default_autoswitch end
 
 function (AS::AutoSwitchCache)(integrator)
@@ -83,6 +90,15 @@ function (AS::AutoSwitchCache)(integrator)
     return AS.current
 end
 
+"""
+    AutoAlgSwitch(nonstiffalg, stiffalg; kwargs...)
+    AutoAlgSwitch(nonstiffalgs::Tuple, stiffalgs::Tuple; kwargs...)
+
+Build a [`CompositeAlgorithm`](@ref) whose choice function is an
+[`AutoSwitch`](@ref), i.e. an algorithm that automatically switches between a
+nonstiff and a stiff solver based on runtime stiffness detection. Keyword
+arguments are forwarded to [`AutoSwitch`](@ref).
+"""
 function AutoAlgSwitch(
         nonstiffalg::OrdinaryDiffEqAlgorithm, stiffalg::OrdinaryDiffEqAlgorithm; kwargs...
     )

--- a/lib/OrdinaryDiffEqCore/src/dense/generic_dense.jl
+++ b/lib/OrdinaryDiffEqCore/src/dense/generic_dense.jl
@@ -22,6 +22,12 @@ You can find the list of available ODE/DAE solvers with their documented interpo
 
 using SciMLBase: SENSITIVITY_INTERP_MESSAGE
 
+"""
+    DerivativeOrderNotPossibleError <: Exception
+
+Thrown when a dense-output interpolation is asked for a derivative order higher
+than the interpolant supports (Hermite interpolation supports up to order 3).
+"""
 struct DerivativeOrderNotPossibleError <: Exception end
 
 function Base.showerror(io::IO, e::DerivativeOrderNotPossibleError)
@@ -65,6 +71,14 @@ end
     return lo
 end
 
+"""
+    ode_addsteps!(k, integrator, ...)
+    ode_addsteps!(k, t, uprev, u, dt, f, p, cache, always_calc_begin = false, allow_calc_end = true, force_calc_end = false)
+
+Ensure the stage-derivative array `k` for the current step is fully populated so
+the dense-output interpolant can be evaluated. Solver sublibraries add methods
+that compute their method-specific extra `k` stages on demand.
+"""
 @inline function ode_addsteps!(
         integrator, f = integrator.f, always_calc_begin = false,
         allow_calc_end = true, force_calc_end = false
@@ -386,6 +400,13 @@ end
     return expr
 end
 
+"""
+    current_interpolant(t, integrator, idxs, deriv)
+
+Evaluate the dense-output interpolant of the *current* step at absolute time(s)
+`t` (mapping to `Θ = (t - tprev)/dt`), for components `idxs` and derivative order
+`deriv`. Out-of-place.
+"""
 @inline function current_interpolant(
         t::Number, integrator::SciMLBase.DEIntegrator, idxs,
         deriv
@@ -426,6 +447,13 @@ end
     return [ode_interpolant!(val, ϕ, integrator, idxs, deriv) for ϕ in Θ]
 end
 
+"""
+    current_extrapolant(t, integrator, idxs = nothing, deriv = Val{0})
+
+Evaluate the extrapolant of the current step at absolute time(s) `t`, i.e. the
+continuous extension used to extrapolate beyond an accepted step (maps to
+`Θ = (t - tprev)/(t_cur - tprev)`). Out-of-place.
+"""
 @inline function current_extrapolant(
         t::Number, integrator::SciMLBase.DEIntegrator,
         idxs = nothing, deriv = Val{0}
@@ -434,6 +462,11 @@ end
     return ode_extrapolant(Θ, integrator, idxs, deriv)
 end
 
+"""
+    current_extrapolant!(val, t, integrator, idxs = nothing, deriv = Val{0})
+
+In-place version of [`current_extrapolant`](@ref): write the result into `val`.
+"""
 @inline function current_extrapolant!(
         val, t::Number, integrator::SciMLBase.DEIntegrator,
         idxs = nothing, deriv = Val{0}
@@ -1273,8 +1306,13 @@ end
     return nothing
 end
 
+# By default, Hermite interpolant so update the derivative at the two ends
 """
-By default, Hermite interpolant so update the derivative at the two ends
+    _ode_addsteps!(k, t, uprev, u, dt, f, p, cache, always_calc_begin = false, allow_calc_end = true, force_calc_end = false)
+
+Generic fallback for [`ode_addsteps!`](@ref) that fills `k[1]`, `k[2]` with the
+RHS at the step endpoints (`f(uprev, p, t)` and `f(u, p, t+dt)`), sufficient for
+cubic-Hermite dense output.
 """
 function _ode_addsteps!(
         k, t, uprev, u, dt, f, p, cache, always_calc_begin = false,
@@ -1295,8 +1333,16 @@ function _ode_addsteps!(
     return nothing
 end
 
+# ode_interpolant and ode_interpolant! dispatch
 """
-ode_interpolant and ode_interpolant! dispatch
+    ode_interpolant(Θ, dt, y₀, y₁, k, cache, idxs, T::Type{Val{deriv}}, differential_vars)
+
+Evaluate the out-of-place dense-output interpolant at fraction `Θ ∈ [0, 1]` of a
+step of length `dt` from `y₀` to `y₁`, using the stage-derivative history `k` and
+the algorithm `cache`. `idxs` selects components (or `nothing` for all), `deriv`
+is the derivative order, and `differential_vars` masks algebraic components for
+DAEs. Solver sublibraries add methods for their cache types; the fallback is
+Hermite (or linear when `k` is empty).
 """
 function ode_interpolant(
         Θ, dt, y₀, y₁, k, cache, idxs, T::Type{Val{TI}}, differential_vars
@@ -1338,6 +1384,12 @@ function ode_interpolant(
     end
 end
 
+"""
+    ode_interpolant!(out, Θ, dt, y₀, y₁, k, cache, idxs, T::Type{Val{deriv}}, differential_vars)
+
+In-place version of [`ode_interpolant`](@ref): write the interpolated value into
+`out`.
+"""
 function ode_interpolant!(
         out, Θ, dt, y₀, y₁, k, cache, idxs, T::Type{Val{TI}}, differential_vars
     ) where {TI}
@@ -1351,6 +1403,15 @@ end
 @inline _dv(dv::Bool, _) = dv
 @inline _dv(dv, i) = dv[i]
 
+"""
+    interpolation_differential_vars(differential_vars, y₀, idxs)
+
+Resolve the per-component differential-vs-algebraic mask actually used by the
+interpolant, given the problem's `differential_vars`, the value `y₀`, and the
+selected `idxs`. Returns `true` when all selected components are differential,
+`false` when the mask is undefined (forcing linear interpolation), or the
+appropriate (sub)mask otherwise.
+"""
 function interpolation_differential_vars(differential_vars, y₀, idxs)
     if isnothing(differential_vars)
         if y₀ isa Number
@@ -1382,6 +1443,14 @@ function interpolation_differential_vars(differential_vars, y₀, idxs)
 end
 
 # If no dispatch found, assume Hermite (or linear when k is empty, e.g. SDE)
+"""
+    _ode_interpolant(Θ, dt, y₀, y₁, k, cache, idxs, T, differential_vars)
+
+Low-level out-of-place interpolation kernel dispatched on the `cache` type. The
+generic fallback performs cubic Hermite interpolation (linear when there are fewer
+than two stage derivatives). Solver sublibraries specialize this for their own
+dense-output formulas.
+"""
 function _ode_interpolant(
         Θ, dt, y₀, y₁, k, cache, idxs, T::Type{Val{TI}}, differential_vars
     ) where {TI}
@@ -1400,6 +1469,11 @@ function _ode_interpolant(
     )
 end
 
+"""
+    _ode_interpolant!(out, Θ, dt, y₀, y₁, k, cache, idxs, T, differential_vars)
+
+In-place counterpart of [`_ode_interpolant`](@ref); writes into `out`.
+"""
 function _ode_interpolant!(
         out, Θ, dt, y₀, y₁, k, cache, idxs, T::Type{Val{TI}}, differential_vars
     ) where {TI}
@@ -1414,10 +1488,14 @@ function _ode_interpolant!(
     return hermite_interpolant!(out, Θ, dt, y₀, y₁, k, idxs, T, differential_vars)
 end
 
+# Hairer Norsett Wanner Solving Ordinary Differential Euations I - Nonstiff Problems Page 190
+# Hermite Interpolation, chosen if no other dispatch for ode_interpolant
 """
-Hairer Norsett Wanner Solving Ordinary Differential Euations I - Nonstiff Problems Page 190
+    hermite_interpolant(Θ, dt, y₀, y₁, k, ::Val{mutable}, idxs, T::Type{Val{deriv}}, differential_vars)
 
-Herimte Interpolation, chosen if no other dispatch for ode_interpolant
+Evaluate the cubic-Hermite interpolant (or its `deriv`-th derivative) between `y₀`
+and `y₁` from the endpoint derivatives `k[1]`, `k[2]`. Algebraic components
+(`differential_vars` false) fall back to linear interpolation.
 """
 @muladd function hermite_interpolant(
         Θ, dt, y₀, y₁, k, ::Type{Val{false}}, idxs::Nothing,
@@ -1492,6 +1570,12 @@ end
     end
 end
 
+"""
+    hermite_interpolant!(out, Θ, dt, y₀, y₁, k, idxs, T::Type{Val{deriv}}, differential_vars)
+
+In-place cubic-Hermite interpolation, writing into `out`. See
+[`hermite_interpolant`](@ref).
+"""
 @muladd function hermite_interpolant!(
         out, Θ, dt, y₀, y₁, k, idxs::Nothing, T::Type{Val{0}}, differential_vars
     )

--- a/lib/OrdinaryDiffEqCore/src/disco.jl
+++ b/lib/OrdinaryDiffEqCore/src/disco.jl
@@ -1,3 +1,10 @@
+"""
+    set_discontinuity(u, uprev, integrator) -> dt
+
+Return the sub-step `Δt` at which a continuous callback's root lies within the
+current step (a discontinuity to stop at), or a negative value if there is none in
+`(0, 1)·dt`.
+"""
 function set_discontinuity(u, uprev, integrator)
     breakpointθ = find_discontinuity(u, uprev, integrator)
     dt = integrator.dt

--- a/lib/OrdinaryDiffEqCore/src/doc_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/doc_utils.jl
@@ -1,7 +1,7 @@
+# TODO we should add a consistency check using the string $name(; $keyword_default) against the standard console output of name()
 """
 Utility function to help generating consistent docstrings across the package.
 """
-# TODO we should add a consistency check using the string $name(; $keyword_default) against the standard console output of name()
 function generic_solver_docstring(
         description::String,
         name::String,
@@ -54,6 +54,14 @@ function generic_solver_docstring(
         "## References\n" * references
 end
 
+"""
+    explicit_rk_docstring(description, name; references = "", extra_keyword_description = "", extra_keyword_default = "") -> String
+
+Convenience wrapper over [`generic_solver_docstring`](@ref) for explicit
+Runge–Kutta methods. Prepends the standard `stage_limiter!` / `step_limiter!` /
+`thread` keywords (and any `extra_keyword_*`) and fills in the "Explicit
+Runge-Kutta Method" solver class.
+"""
 function explicit_rk_docstring(
         description::String,
         name::String;
@@ -78,6 +86,14 @@ function explicit_rk_docstring(
         keyword_default_description, keyword_default
     )
 end
+"""
+    differentiation_rk_docstring(description, name, solver_class; references = "", extra_keyword_description = "", extra_keyword_default = "") -> String
+
+Convenience wrapper over [`generic_solver_docstring`](@ref) for implicit /
+Rosenbrock methods that take differentiation options. Prepends the standard
+`autodiff`, `concrete_jac`, and `linsolve` keywords (and any `extra_keyword_*`)
+with their descriptions.
+"""
 function differentiation_rk_docstring(
         description::String,
         name::String,

--- a/lib/OrdinaryDiffEqCore/src/initdt.jl
+++ b/lib/OrdinaryDiffEqCore/src/initdt.jl
@@ -287,6 +287,13 @@
 end
 
 # ODE iip entry point
+"""
+    ode_determine_initdt(u0, t, tdir, dtmax, abstol, reltol, internalnorm, prob, integrator) -> dt
+
+Compute an automatic initial step size for `prob` using the standard
+Hairer–Nørsett–Wanner heuristic (based on the norms of `f` and its derivative at
+`u0`), respecting `dtmax`, the tolerances, and the integration direction `tdir`.
+"""
 function ode_determine_initdt(
         u0, t, tdir, dtmax, abstol, reltol, internalnorm,
         prob::SciMLBase.AbstractODEProblem{uType, tType, true},

--- a/lib/OrdinaryDiffEqCore/src/initialize_dae.jl
+++ b/lib/OrdinaryDiffEqCore/src/initialize_dae.jl
@@ -27,6 +27,14 @@ end
 ## Default algorithm is CheckInit
 ## Changed in v7--previously was BrownFullBasicInit or ShampineCollocationInit
 
+"""
+    _initialize_dae!(integrator, prob, alg, ::Val{iip})
+
+Run the DAE / mass-matrix initialization: adjust `u0` (and `du0`) so the algebraic
+constraints and initialization equations of `prob` are satisfied to tolerance,
+using the initialization algorithm `alg` (e.g. `CheckInit`, `BrownFullBasicInit`,
+`OverrideInit`). `Val{iip}` selects the in-place branch.
+"""
 function _initialize_dae!(
         integrator::ODEIntegrator, prob::Union{ODEProblem, DAEProblem},
         alg::DefaultInit, x::Union{Val{true}, Val{false}}
@@ -60,6 +68,13 @@ end
 default_nlsolve(alg, isinplace, u, initprob, autodiff = false, chunksize = Val(0)) = alg
 
 ## If the initialization is trivial just use nothing alg
+"""
+    default_nlsolve(alg, isinplace, u, initprob, autodiff = false, chunksize = Val(0))
+
+Return the nonlinear solver to use for a DAE-initialization problem `initprob`. If
+`alg` is already a concrete nonlinear-solve algorithm it is returned as-is;
+otherwise a sensible default is constructed from the arguments.
+"""
 function default_nlsolve(
         ::Nothing, isinplace::Val{true}, u::Nothing, ::AbstractNonlinearProblem,
         autodiff = false, chunksize = Val(0)

--- a/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
@@ -535,6 +535,13 @@ IController(alg; kwargs...) = IController(Float64, alg; kwargs...)
 IController(::Type{QT}, alg; kwargs...) where {QT} =
     IController(resolve_basic(NamedTuple(kwargs), alg, QT))
 
+"""
+    IControllerCache <: AbstractControllerCache
+
+Per-solve cache for the integral ([`IController`](@ref)) step-size controller. It
+holds the resolved `controller`, the last rejected step size `dtreject`, and the
+scalar error estimate `EEst`.
+"""
 mutable struct IControllerCache{T, E, NLPType} <: AbstractControllerCache
     controller::IController{CommonControllerOptions{T, NLPType}}
     dtreject::T
@@ -667,6 +674,13 @@ function PIController(
     return PIController{typeof(basic), QT}(basic, QT(beta1), QT(beta2), QT(qoldinit))
 end
 
+"""
+    PIControllerCache <: AbstractControllerCache
+
+Per-solve cache for the PI ([`PIController`](@ref)) step-size controller. In
+addition to the resolved `controller` and the scalar `EEst`, it stores the cached
+`q11 = εₙ^β₁` factor and the previous error `errold` used by the PI update.
+"""
 mutable struct PIControllerCache{T, E, NLPType} <: AbstractControllerCache
     controller::PIController{CommonControllerOptions{T, NLPType}, T}
     # Cached εₙ₊₁^β₁
@@ -871,6 +885,12 @@ function Base.show(io::IO, controller::PIDController)
     )
 end
 
+"""
+    PIDControllerCache <: AbstractControllerCache
+
+Per-solve cache for the PID ([`PIDController`](@ref)) step-size controller, storing
+the resolved `controller`, its limiter, the error history, and the scalar `EEst`.
+"""
 mutable struct PIDControllerCache{T, Limiter, E, NLPType} <: AbstractControllerCache
     controller::PIDController{CommonControllerOptions{T, NLPType}, T, Limiter}
     err::Vector{T} # history of the error estimates
@@ -1047,6 +1067,13 @@ PredictiveController(alg; kwargs...) = PredictiveController(Float64, alg; kwargs
 PredictiveController(::Type{QT}, alg; kwargs...) where {QT} =
     PredictiveController(resolve_basic(NamedTuple(kwargs), alg, QT))
 
+"""
+    PredictiveControllerCache <: AbstractControllerCache
+
+Per-solve cache for the predictive ([`PredictiveController`](@ref)) step-size
+controller (Gustafsson predictive control, common for implicit solvers), holding
+the resolved `controller` and the scalar `EEst`.
+"""
 mutable struct PredictiveControllerCache{T, E, NLPType} <: AbstractControllerCache
     controller::PredictiveController{CommonControllerOptions{T, NLPType}}
     dtacc::T
@@ -1158,6 +1185,13 @@ struct CompositeController{T} <: AbstractController
     controllers::T
 end
 
+"""
+    CompositeControllerCache <: AbstractControllerCache
+
+Per-solve cache for the [`CompositeController`](@ref) used by composite algorithms.
+Holds the tuple of sub-controller `caches` (one per constituent algorithm) and the
+scalar `EEst`; accessor calls delegate to the currently-active sub-cache.
+"""
 mutable struct CompositeControllerCache{T, E} <: AbstractControllerCache
     caches::T
     EEst::E

--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
@@ -613,6 +613,12 @@ end
 
 # Extensible initdt hook: ODE defaults to ode_determine_initdt.
 # SDE extends this in StochasticDiffEq to pass the stochastic order.
+"""
+    _determine_initdt(integrator) -> dt
+
+Convenience wrapper that calls [`ode_determine_initdt`](@ref) with the fields of
+`integrator` (state, tolerances, norm, problem).
+"""
 function _determine_initdt(integrator)
     return ode_determine_initdt(
         integrator.u, integrator.t,
@@ -629,6 +635,11 @@ function SciMLBase.auto_dt_reset!(integrator::ODEIntegrator)
     return increment_nf!(integrator.stats, 2)
 end
 
+"""
+    increment_nf!(stats, amt = 1)
+
+Increment the RHS-evaluation counter `stats.nf` by `amt`.
+"""
 function increment_nf!(stats, amt = 1)
     return stats.nf += amt
 end

--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
@@ -1,10 +1,48 @@
 # Noise interface functions — no-ops when W/P are nothing (pure ODE).
 # StochasticDiffEq extends these with methods for NoiseProcess types.
+"""
+    accept_noise!(W, dt, u, p, setup)
+
+Advance/accept the noise process `W` over the accepted step of size `dt` (the
+Brownian bridge/random values for `[t, t+dt]` are committed). No-op when `W` is
+`nothing` (pure ODE). Extended by StochasticDiffEq for `NoiseProcess` types.
+"""
 accept_noise!(::Nothing, args...) = nothing
+"""
+    reject_noise!(W, dt, u, p)
+
+Roll back the noise process `W` after a rejected step of size `dt` so it can be
+re-sampled consistently on the retry. No-op when `W` is `nothing`.
+"""
 reject_noise!(::Nothing, args...) = nothing
+"""
+    save_noise!(W)
+
+Persist the current value of the noise process `W` into its saved history. No-op
+when `W` is `nothing`.
+"""
 save_noise!(::Nothing) = nothing
+"""
+    noise_curt(W)
+
+Return the current time of the noise process `W`, or `nothing` when `W` is
+`nothing`. Used to check whether the noise has already advanced to the current
+integrator time.
+"""
 noise_curt(::Nothing) = nothing
+"""
+    is_noise_saveable(W) -> Bool
+
+Return whether the noise process `W` supports saving its trajectory
+(`false` when `W` is `nothing`).
+"""
 is_noise_saveable(::Nothing) = false
+"""
+    reinit_noise!(W, dt)
+
+Reset the noise process `W` to its initial state for a fresh integration with step
+`dt` (used by `reinit!`). No-op when `W` is `nothing`.
+"""
 reinit_noise!(::Nothing, dt) = nothing
 
 # Noise field accessors — safe for any integrator type.
@@ -97,6 +135,14 @@ function on_derivative_discontinuity_at_init!(integrator)
     return update_fsal!(integrator)
 end
 
+"""
+    apply_step!(integrator)
+
+Commit an accepted step: copy `u` into `uprev`, advance `dt` to the proposed step
+size (if allowed), refresh the FSAL derivative, shorten `dt` to the next `tstop`,
+and accept any noise process. Called by the integrator loop after a step is
+accepted.
+"""
 function apply_step!(integrator)
     update_uprev!(integrator)
 
@@ -153,6 +199,13 @@ function update_fsal!(integrator)
     return nothing
 end
 
+"""
+    last_step_failed(integrator) -> Bool
+
+Return whether the previous step failed and cannot be retried adaptively (i.e. the
+step failed while `adaptive` is `false`). Used by the iterator interface to decide
+whether to stop.
+"""
 function last_step_failed(integrator::ODEIntegrator)
     return integrator.last_stepfail && !integrator.opts.adaptive
 end
@@ -388,6 +441,14 @@ function post_savevalues!(integrator, reduce_size)
 end
 
 # Want to extend postamble! for DDEIntegrator
+"""
+    postamble!(integrator)
+
+Run the end-of-solve finalization for `integrator`: save the final point, finalize
+the noise process, and emit any remaining progress/log messages. Extended for
+`DDEIntegrator`; the `ODEIntegrator` method delegates to the internal
+`_postamble!`.
+"""
 postamble!(integrator::ODEIntegrator) = _postamble!(integrator)
 
 function _postamble!(integrator)
@@ -574,9 +635,21 @@ function _loopfooter!(integrator)
 end
 
 # Trait: is this a composite algorithm cache? Override to include SDE composite caches.
+"""
+    is_composite_cache(cache) -> Bool
+
+Return whether `cache isa CompositeCache`, i.e. whether it wraps several
+sub-caches for a composite algorithm.
+"""
 is_composite_cache(cache) = cache isa CompositeCache
 
 # Trait: is this a composite algorithm? Override to include SDE composite algorithms.
+"""
+    is_composite_algorithm(alg) -> Bool
+
+Return whether `alg isa OrdinaryDiffEqCompositeAlgorithm`, i.e. whether it
+dispatches between several sub-algorithms at runtime.
+"""
 is_composite_algorithm(alg) = alg isa OrdinaryDiffEqCompositeAlgorithm
 
 # Reset integrator flags at the start of loopfooter.
@@ -593,10 +666,20 @@ end
 # post_newton_controller! does dt = dt / failfactor, which works for both ODE and SDE.
 handle_force_stepfail!(integrator) = post_newton_controller!(integrator, integrator.alg)
 
+"""
+    increment_accept!(stats)
+
+Increment the accepted-step counter `stats.naccept` by one.
+"""
 function increment_accept!(stats)
     return stats.naccept += 1
 end
 
+"""
+    increment_reject!(stats)
+
+Increment the rejected-step counter `stats.nreject` by one.
+"""
 function increment_reject!(stats)
     return stats.nreject += 1
 end
@@ -821,6 +904,13 @@ function handle_tstop!(integrator)
     return nothing
 end
 
+"""
+    handle_callback_modifiers!(integrator)
+
+Hook invoked after a callback modifies the integrator state, letting the algorithm
+react (e.g. re-evaluate FSAL). No-op for a plain `ODEIntegrator`; extended by
+integrators that need to respond to callback-induced changes.
+"""
 handle_callback_modifiers!(integrator::ODEIntegrator) = nothing
 
 function reset_fsal!(integrator)
@@ -841,6 +931,13 @@ function reset_fsal!(integrator)
     # integrator.reeval_fsal = false
 end
 
+"""
+    nlsolve_f(f, alg)
+
+Return the RHS function that the nonlinear solver should use for `alg`. For split
+problems (e.g. IMEX) this selects the implicit part `f.f1`; otherwise it returns
+`f` unchanged.
+"""
 function nlsolve_f(f, alg::OrdinaryDiffEqAlgorithm)
     return f isa SplitFunction && issplit(alg) ? f.f1 : f
 end

--- a/lib/OrdinaryDiffEqCore/src/integrators/type.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/type.jl
@@ -1,3 +1,16 @@
+"""
+    DEOptions
+
+Mutable container holding the resolved common solver options for a running
+integrator, reachable as `integrator.opts`. Fields include the tolerances
+(`abstol`, `reltol`), the norm (`internalnorm`), step-size bounds
+(`dtmax`, `dtmin`, `failfactor`), the saving controls (`saveat`, `save_everystep`,
+`dense`, `save_start`, `save_end`, …), the `tstops`/`d_discontinuities` schedules
+and their caches, callback (`callback`), domain/stability checks
+(`isoutofdomain`, `unstable_check`), progress-logging options, and the
+`verbose`/`maxiters` settings. Mutating a field changes the solver behavior for
+subsequent steps.
+"""
 mutable struct DEOptions{
         absType, relType, QT, tType, F1, F2, F3, F4, F5, F6,
         F7, tstopsType, discType, ECType, SType, MI, tcache, savecache,

--- a/lib/OrdinaryDiffEqCore/src/interp_func.jl
+++ b/lib/OrdinaryDiffEqCore/src/interp_func.jl
@@ -1,6 +1,23 @@
+"""
+    OrdinaryDiffEqInterpolation{cacheType} <: SciMLBase.AbstractDiffEqInterpolation
+
+Abstract supertype for the dense-output interpolation object attached to a
+solution. Given a saved timeseries plus derivative (`k`) history it evaluates the
+continuous extension. See [`InterpolationData`](@ref) for the concrete type.
+"""
 abstract type OrdinaryDiffEqInterpolation{cacheType} <:
 SciMLBase.AbstractDiffEqInterpolation end
 
+"""
+    InterpolationData(f, timeseries, ts, ks, alg_choice, dense, cache, differential_vars, sensitivitymode)
+
+Concrete [`OrdinaryDiffEqInterpolation`](@ref) storing everything needed to
+evaluate the continuous solution: the RHS `f`, the saved states `timeseries` at
+times `ts`, the stage-derivative history `ks`, the per-step `alg_choice` (for
+composite algorithms), whether `dense` output is available, the solver `cache`,
+the `differential_vars` mask (for DAEs), and a `sensitivitymode` flag. Calling
+`(interp)(tvals, idxs, deriv, p, continuity)` performs the interpolation.
+"""
 struct InterpolationData{
         F, uType, tType, kType, algType <: Union{Nothing, Vector{Int}}, cacheType, DV,
     } <:
@@ -85,6 +102,14 @@ function SciMLBase.strip_interpolation(id::InterpolationData)
     )
 end
 
+"""
+    strip_cache(cache)
+
+Return a lightweight copy of `cache` with all fields set to `nothing`, used by
+`SciMLBase.strip_interpolation` to drop the (potentially large) working buffers
+from a solution's interpolation object before serialization. Has a special path
+for [`DefaultCache`](@ref).
+"""
 function strip_cache(cache)
     if !(cache isa OrdinaryDiffEqCore.DefaultCache)
         cache = ConstructionBase.constructorof(typeof(cache))(

--- a/lib/OrdinaryDiffEqCore/src/misc_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/misc_utils.jl
@@ -6,6 +6,16 @@ macro swap!(x, y)
     end
 end
 
+"""
+    @cache struct MyCache ... end
+
+Macro used to define a mutable solver cache. It emits the given `struct` definition
+and additionally generates a `full_cache(c::MyCache)` method returning the tuple of
+its resizable buffer fields (those typed `uType`, `rateType`, `kType`,
+`uNoUnitsType`, or the `du`/`dual_du` of a `DiffCacheType`). That `full_cache`
+tuple is what the `resize!`/`deleteat!` integrator interface iterates over when the
+state length changes.
+"""
 macro cache(expr)
     name = expr.args[2].args[1].args[1]
     fields = [x for x in expr.args[3].args if typeof(x) != LineNumberNode]
@@ -28,6 +38,13 @@ end
 
 # Nest one layer of value in order to get rid of possible Dual{Complex} or Complex{Dual} issues
 # value should recurse for anything else.
+"""
+    constvalue(x)
+
+Strip any ForwardDiff/unit wrapper from `x` (or a type `T`) down to its underlying
+numeric value, taking the real part for `Complex` so that a scalar constant can be
+compared/used unambiguously. Used e.g. for eigenvalue estimates.
+"""
 function constvalue(::Type{T}) where {T}
     _T = SciMLBase.value(T)
     return _T <: Complex ? SciMLBase.value(real(_T)) : SciMLBase.value(_T)
@@ -37,6 +54,13 @@ function constvalue(x)
     return _x isa Complex ? SciMLBase.value(real(_x)) : SciMLBase.value(_x)
 end
 
+"""
+    diffdir(integrator) -> Int
+
+Return the finite-difference direction (`+1` or `-1`) to use for time
+derivatives, chosen so the stencil stays inside the integration interval near an
+endpoint.
+"""
 function diffdir(integrator::SciMLBase.DEIntegrator)
     difference = maximum(abs, integrator.uprev) * sqrt(eps(typeof(integrator.t)))
     return dir = integrator.tdir > zero(integrator.tdir) ?
@@ -44,13 +68,52 @@ function diffdir(integrator::SciMLBase.DEIntegrator)
         integrator.t < integrator.sol.prob.tspan[2] + difference ? 1 : -1
 end
 
+"""
+    error_constant(integrator, order) -> Real
+
+Return the leading error constant of the current method at the given `order`, used
+when scaling the local error estimate. Dispatches on `integrator.alg`.
+"""
 error_constant(integrator, order) = error_constant(integrator, integrator.alg, order)
 
+"""
+    AbstractThreadingOption
+
+Abstract supertype for the `thread = …` option controlling internal broadcasting.
+The concrete choices are [`Sequential`](@ref), [`BaseThreads`](@ref), and
+[`PolyesterThreads`](@ref); [`isthreaded`](@ref) reports whether a given option
+enables multithreading.
+"""
 abstract type AbstractThreadingOption end
+"""
+    Sequential() <: AbstractThreadingOption
+
+Threading option that disables internal multithreading — all per-element work runs
+on a single thread. [`isthreaded`](@ref)`(Sequential())` is `false`.
+"""
 struct Sequential <: AbstractThreadingOption end
+"""
+    BaseThreads() <: AbstractThreadingOption
+
+Threading option that parallelizes internal broadcasting with Julia's built-in
+`Threads.@threads`. [`isthreaded`](@ref)`(BaseThreads())` is `true`.
+"""
 struct BaseThreads <: AbstractThreadingOption end
+"""
+    PolyesterThreads() <: AbstractThreadingOption
+
+Threading option that parallelizes internal broadcasting with Polyester.jl's
+low-overhead `@batch`. [`isthreaded`](@ref)`(PolyesterThreads())` is `true`.
+"""
 struct PolyesterThreads <: AbstractThreadingOption end
 
+"""
+    isthreaded(opt) -> Bool
+
+Return whether the threading option `opt` enables multithreaded internal
+broadcasting. `true` for [`BaseThreads`](@ref)/[`PolyesterThreads`](@ref) (and
+`true` for a `Bool` `opt` equal to `true`), `false` for [`Sequential`](@ref).
+"""
 isthreaded(b::Bool) = b
 isthreaded(::Sequential) = false
 isthreaded(::BaseThreads) = true
@@ -123,6 +186,13 @@ macro fold(arg)
     return esc(:(Base.@assume_effects :foldable $arg))
 end
 
+"""
+    DifferentialVarsUndefined
+
+Sentinel returned by [`get_differential_vars`](@ref) when the differential vs
+algebraic split cannot be determined (the mass matrix is not diagonal). In that
+case dense output falls back to linear interpolation.
+"""
 struct DifferentialVarsUndefined end
 
 """
@@ -180,6 +250,13 @@ function find_algebraic_vars_eqs(M::SciMLOperators.AbstractSciMLOperator)
     return find_algebraic_vars_eqs(convert(AbstractMatrix, M))
 end
 
+"""
+    isnewton(nlsolver) -> Bool
+
+Return whether the nonlinear solver `nlsolver` is a Newton-type solver (as opposed
+to a fixed-point / functional iteration), which determines whether a W-matrix is
+formed and updated.
+"""
 isnewton(::Any) = false
 
 # Extract the chunk size integer from an ADType for use as a type parameter.
@@ -196,6 +273,13 @@ _ad_fdtype(::AutoSparse{<:AutoFiniteDiff{FD}}) where {FD} = FD
 _ad_fdtype(_) = Val{:forward}()
 
 # Fix AutoFiniteDiff dir: default dir of true (Bool) makes integration non-reversible
+"""
+    _fixup_ad(ad, args...)
+
+Internal helper that adjusts an autodiff choice `ad` to be consistent with the
+problem/solver context (e.g. disabling AD when it is not applicable). Returns the
+possibly-modified autodiff choice.
+"""
 function _fixup_ad(ad_alg::AutoFiniteDiff)
     if ad_alg.dir isa Bool
         @reset ad_alg.dir = Int(ad_alg.dir)

--- a/lib/OrdinaryDiffEqCore/src/perform_step/composite_perform_step.jl
+++ b/lib/OrdinaryDiffEqCore/src/perform_step/composite_perform_step.jl
@@ -140,6 +140,14 @@ function ensure_behaving_adaptivity!(integrator, cache::Union{DefaultCache, Comp
     end
 end
 
+"""
+    perform_step!(integrator, cache, repeat_step = false)
+
+Advance the integrator by one step using algorithm `cache`, writing the proposed
+new state into `integrator.u` and the error estimate into `integrator.EEst`. This
+is the core routine each solver sublibrary implements for its cache type;
+`repeat_step` indicates the step is being retried after a rejection.
+"""
 function perform_step!(integrator, cache::DefaultCache, repeat_step = false)
     algs = integrator.alg.algs
     init_ith_default_cache(cache, algs, cache.current)

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -170,6 +170,14 @@ function _rosenbrock_jac_reuse_decision(integrator, cache, dtgamma)
     return (false, true)
 end
 
+"""
+    calc_tderivative!(integrator, cache, dtd1, repeat_step)
+
+Compute the time derivative `dT = ∂f/∂t` in place (using the analytic `tgrad` when
+available, else autodiff/finite differences) and store the Rosenbrock right-hand
+side `linsolve_tmp = fsalfirst + dtd1·dT` on the cache. Skipped when `repeat_step`
+is `true`.
+"""
 function calc_tderivative!(integrator, cache, dtd1, repeat_step)
     return @inbounds begin
         (; t, dt, uprev, u, f, p) = integrator
@@ -218,6 +226,12 @@ function calc_tderivative!(integrator, cache, dtd1, repeat_step)
     end
 end
 
+"""
+    calc_tderivative(integrator, cache) -> dT
+
+Out-of-place counterpart of [`calc_tderivative!`](@ref): compute and return the
+time derivative `∂f/∂t` at the current step.
+"""
 function calc_tderivative(integrator, cache)
     (; t, dt, uprev, u, f, p, alg) = integrator
 
@@ -551,6 +565,13 @@ end
     throw(DimensionMismatch("J: $(axes(J)), mass matrix: $(axes(mass_matrix))"))
 end
 
+"""
+    jacobian2W!(W, mass_matrix, dtgamma, J) -> nothing
+
+Form the linear-system matrix `W = M/dtgamma - J` in place from the Jacobian `J`
+and mass matrix `M` (with `M = I` handled specially), using scalar-indexed,
+broadcast, or allocating paths depending on the array type (dense, sparse, GPU).
+"""
 function jacobian2W!(
         W::AbstractMatrix, mass_matrix, dtgamma::Number, J::AbstractMatrix
     )::Nothing
@@ -664,6 +685,13 @@ function dae_jacobian2W(J_u::Number, J_du::Number, cj::Number)
     return muladd(cj, J_du, J_u)
 end
 
+"""
+    is_always_new(alg) -> Bool
+
+Return whether `alg` (or its nonlinear-solver algorithm) requests a fresh `W`
+computed on every solve, i.e. its `always_new` field is `true` (`false` when the
+field is absent).
+"""
 is_always_new(alg) = isdefined(alg, :always_new) ? alg.always_new : false
 
 function calc_W!(
@@ -860,6 +888,13 @@ end
     return W
 end
 
+"""
+    calc_rosenbrock_differentiation!(integrator, cache, dtd1, dtgamma, repeat_step) -> new_W
+
+Compute (in place) the Jacobian, the factorized `W = M/(dtgamma) - J`, and the
+time derivative needed by a Rosenbrock step, honoring Jacobian reuse for W-methods.
+Returns whether a fresh `W` was formed. Skips the work on a repeated step.
+"""
 function calc_rosenbrock_differentiation!(integrator, cache, dtd1, dtgamma, repeat_step)
     nlsolver = nothing
     alg = OrdinaryDiffEqCore.unwrap_alg(integrator, true)
@@ -962,6 +997,14 @@ function calc_rosenbrock_differentiation(integrator, cache, dtgamma, repeat_step
 end
 
 # update W matrix (only used in Newton method)
+"""
+    update_W!(integrator, cache, dtgamma, repeat_step, newJW = nothing)
+    update_W!(nlsolver, integrator, cache, dtgamma, repeat_step, newJW = nothing)
+
+Recompute/refactorize the nonlinear solver's `W = M/dtgamma - J` when needed for a
+Newton solve, deciding whether the Jacobian and/or the factorization must be
+refreshed (`newJW` can force the decision). No-op for non-Newton solvers.
+"""
 function update_W!(integrator, cache, dtgamma, repeat_step, newJW = nothing)
     return update_W!(cache.nlsolver, integrator, cache, dtgamma, repeat_step, newJW)
 end
@@ -1093,6 +1136,16 @@ as-is.
 end
 @inline _dtgamma_prototype(t, dt, ::Type{T}) where {T} = promote(t, dt)[2]
 
+"""
+    build_J_W(alg, u, uprev, p, t, dt, f, jac_config, ::Type{uEltypeNoUnits}, ::Val{iip}) -> (J, W)
+
+Allocate and return the Jacobian `J` and the linear-system matrix
+`W = M/(γΔt) - J` (or their operator/factorization prototypes) for algorithm
+`alg`. Handles user-provided `jac_prototype` / `W_prototype` `SciMLOperator`s, the
+mass matrix `M`, and the linear vs nonlinear function case; the resulting `W`
+carries the eltype that `calc_W`/`calc_W!` will later produce. `Val{iip}` selects
+the in-place branch.
+"""
 function build_J_W(
         alg, u, uprev, p, t, dt, f::F, jac_config, ::Type{uEltypeNoUnits},
         ::Val{IIP}
@@ -1234,6 +1287,14 @@ function build_J_W(
     return J, W
 end
 
+"""
+    build_uf(alg, nf, t, p, ::Val{iip})
+
+Return the wrapper object used to differentiate the RHS `nf` with respect to the
+state: a `UJacobianWrapper` for the in-place case (`Val{true}`) or a
+`UDerivativeWrapper` for the out-of-place case (`Val{false}`). Carries the current
+`t` and `p`, which are updated before each Jacobian evaluation.
+"""
 build_uf(alg, nf, t, p, ::Val{true}) = UJacobianWrapper(nf, t, p)
 build_uf(alg, nf, t, p, ::Val{false}) = UDerivativeWrapper(nf, t, p)
 

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_wrappers.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_wrappers.jl
@@ -185,6 +185,13 @@ function jacobian(f::F, x, integrator) where {F}
     return jac
 end
 
+"""
+    jacobian!(J, f, x, fx, integrator, jac_config)
+
+Compute the Jacobian of `f` at `x` into `J` in place, using the AD backend or
+finite differences configured in `jac_config` (respecting the finite-difference
+direction). `fx` is a preallocated RHS buffer. No-op for an empty state.
+"""
 function jacobian!(
         J::AbstractMatrix{<:Number}, f::F, x::AbstractArray{<:Number},
         fx::AbstractArray{<:Number}, integrator::SciMLBase.DEIntegrator,
@@ -253,6 +260,15 @@ function jacobian!(
     return nothing
 end
 
+"""
+    build_jac_config(alg, f, uf, du1, uprev, u, tmp, du2)
+
+Construct the differentiation configuration used to compute the state Jacobian of
+`f` via [`jacobian!`](@ref) (a DifferentiationInterface preparation, or `nothing`
+when the problem supplies its own `jac`/`Wfact`). For finite differencing it
+returns forward/backward-direction configs so [`diffdir`](@ref) can pick the
+in-domain stencil.
+"""
 function build_jac_config(
         alg, f::F1, uf::F2, du1, uprev,
         u, tmp, du2
@@ -332,6 +348,13 @@ function get_chunksize(
     return Val(N)
 end # don't degrade compile time information to runtime information
 
+"""
+    resize_jac_config!(cache, integrator)
+
+Resize the Jacobian differentiation configuration on `cache` to match a changed
+state length (e.g. after a `resize!` callback), rebuilding the AD/finite-difference
+configs for the new size.
+"""
 function resize_jac_config!(cache, integrator)
     if !isnothing(cache.jac_config) && !isnothing(cache.jac_config[1])
         uf = cache.uf
@@ -361,6 +384,12 @@ function resize_jac_config!(cache, integrator)
     return cache.jac_config
 end
 
+"""
+    resize_grad_config!(cache, integrator)
+
+Resize the time-derivative differentiation configuration on `cache` to match a
+changed state length.
+"""
 function resize_grad_config!(cache, integrator)
     if !isnothing(cache.grad_config) && !isnothing(cache.grad_config[1])
 
@@ -407,6 +436,14 @@ end
 # Fallback for other AD backends
 gpu_safe_autodiff(backend, u) = backend
 
+"""
+    build_grad_config(alg, f, tf, du1, t)
+
+Construct the differentiation configuration used to compute the time derivative
+`∂f/∂t` (needed by Rosenbrock methods) via the `tf` time-gradient wrapper. Returns
+`nothing` when `f` provides an analytic `tgrad`; for finite differencing it returns
+forward/backward-direction configs.
+"""
 function build_grad_config(alg, f::F1, tf::F2, du1, t) where {F1, F2}
     if !SciMLBase.has_tgrad(f)
         ad = ADTypes.dense_ad(alg_autodiff(alg))

--- a/lib/OrdinaryDiffEqDifferentiation/src/linsolve_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/linsolve_utils.jl
@@ -1,7 +1,22 @@
+"""
+    issuccess_W(W) -> Bool
+
+Return whether the factorized system matrix `W` is nonsingular / the factorization
+succeeded. For a `Factorization` it forwards to `LinearAlgebra.issuccess`; for a
+scalar `W` it checks `!iszero(W)`; otherwise it returns `true`.
+"""
 issuccess_W(W::LinearAlgebra.Factorization) = LinearAlgebra.issuccess(W)
 issuccess_W(W::Number) = !iszero(W)
 issuccess_W(::Any) = true
 
+"""
+    dolinsolve(integrator, linsolve; A = nothing, linu = nothing, b = nothing, reltol = …) -> linres
+
+Solve the linear system with the LinearSolve.jl cache `linsolve`, optionally
+resetting its matrix `A`, unknown `linu`, right-hand side `b`, and tolerance
+`reltol`. Updates the RHS-evaluation count for matrix-free/iterative solvers and
+returns the LinearSolve result.
+"""
 function dolinsolve(
         integrator, linsolve; A = nothing, linu = nothing, b = nothing,
         reltol = integrator === nothing ? nothing : integrator.opts.reltol
@@ -37,6 +52,13 @@ function dolinsolve(
     return linres
 end
 
+"""
+    wrapprecs(linsolver, W, weight) -> linsolver
+
+Attach a diagonal (`weight`-based) left/right preconditioner to `linsolver` when it
+supports `precs` and none was supplied, returning the reconfigured solver;
+otherwise return `linsolver` unchanged.
+"""
 function wrapprecs(linsolver, W, weight)
     if hasproperty(linsolver, :precs) && isnothing(linsolver.precs)
         Pl = LinearSolve.InvPreconditioner(Diagonal(_vec(weight)))

--- a/lib/OrdinaryDiffEqLowOrderRK/src/low_order_rk_caches.jl
+++ b/lib/OrdinaryDiffEqLowOrderRK/src/low_order_rk_caches.jl
@@ -199,6 +199,23 @@ end
     thread::Thread
 end
 
+# `@cache struct` expands to the struct plus a `full_cache` method, which a docstring
+# on the macrocall cannot wrap, so the docstring attaches to the type binding here.
+"""
+    RK4Cache <: OrdinaryDiffEqMutableCache
+
+In-place solver cache for the classical 4th-order Runge–Kutta method (`RK4`),
+holding its four stage buffers, error/temporary buffers, and the stage/step
+limiters and threading option.
+"""
+RK4Cache
+
+"""
+    RK4ConstantCache <: OrdinaryDiffEqConstantCache
+
+Out-of-place solver cache for the classical 4th-order Runge–Kutta method (`RK4`).
+Carries no state (the coefficients are compile-time constants).
+"""
 struct RK4ConstantCache <: OrdinaryDiffEqConstantCache end
 
 function alg_cache(
@@ -248,6 +265,18 @@ end
     step_limiter!::StepLimiter
     thread::Thread
 end
+
+# `@cache struct` expands to the struct plus a `full_cache` method, which a docstring
+# on the macrocall cannot wrap, so the docstring attaches to the type binding here.
+"""
+    BS3Cache <: OrdinaryDiffEqMutableCache
+
+In-place solver cache for the Bogacki–Shampine 3(2) method (`BS3`), holding its
+stage buffers, embedded-error temporaries, tableau ([`BS3ConstantCache`](@ref)),
+and the stage/step limiters and threading option. Declared public because other
+sublibraries (e.g. the Adams–Bashforth–Moulton starters) reuse the `BS3` step.
+"""
+BS3Cache
 
 function alg_cache(
         alg::BS3, u, rate_prototype, ::Type{uEltypeNoUnits},

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/nlsolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/nlsolve.jl
@@ -167,6 +167,13 @@ end
 
 initialize!(::AbstractNLSolver, integrator::SciMLBase.DEIntegrator) = nothing
 
+"""
+    initial_η(nlsolver, integrator) -> η
+
+Return the initial convergence-rate estimate `η` for a fresh nonlinear solve.
+Functional/Anderson solvers reuse the previous `ηold`; the Newton solver method
+derives it from the tolerance. Consumed by [`nlsolve!`](@ref).
+"""
 function initial_η(nlsolver::NLSolver, integrator)
     return max(nlsolver.ηold, eps(eltype(integrator.opts.reltol)))^(0.8)
 end

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
@@ -1,4 +1,17 @@
 # algorithms
+"""
+    NLFunctional(; κ = 1//100, max_iter = 10, fast_convergence_cutoff = 1//5)
+
+Functional (fixed-point) iteration solver for the implicit stage equations,
+`z ← g(z)`. No Jacobian/`W` is formed, so it is cheap per iteration but only
+converges for mildly stiff problems.
+
+# Keyword arguments
+
+  - `κ`: relative tolerance on the increment used in the convergence test.
+  - `max_iter`: maximum number of fixed-point iterations per solve.
+  - `fast_convergence_cutoff`: convergence-rate threshold for fast convergence.
+"""
 struct NLFunctional{K, C} <: AbstractNLSolverAlgorithm
     κ::K
     fast_convergence_cutoff::C
@@ -9,6 +22,22 @@ function NLFunctional(; κ = 1 // 100, max_iter = 10, fast_convergence_cutoff = 
     return NLFunctional(κ, fast_convergence_cutoff, max_iter)
 end
 
+"""
+    NLAnderson(; κ = 1//100, max_iter = 10, max_history = 5, aa_start = 1,
+               droptol = nothing, fast_convergence_cutoff = 1//5)
+
+Anderson-accelerated fixed-point iteration for the implicit stage equations. Like
+[`NLFunctional`](@ref) but mixes in `max_history` previous residuals via a
+least-squares update to accelerate convergence (see [`anderson`](@ref) /
+[`anderson!`](@ref)).
+
+# Keyword arguments
+
+  - `κ`, `max_iter`, `fast_convergence_cutoff`: as in [`NLFunctional`](@ref).
+  - `max_history`: number of past iterates kept for the acceleration.
+  - `aa_start`: iteration at which acceleration starts.
+  - `droptol`: optional condition-number threshold for dropping history columns.
+"""
 struct NLAnderson{K, D, C} <: AbstractNLSolverAlgorithm
     κ::K
     fast_convergence_cutoff::C
@@ -25,6 +54,25 @@ function NLAnderson(;
     return NLAnderson(κ, fast_convergence_cutoff, max_iter, max_history, aa_start, droptol)
 end
 
+"""
+    NLNewton(; κ = 1//100, max_iter = 10, fast_convergence_cutoff = 1//5,
+             new_W_dt_cutoff = 1//5, always_new = false, check_div = true, relax = nothing)
+
+Quasi-Newton nonlinear solver for the implicit stage equations. Uses the
+`W = M/(γΔt) - J` matrix (reused/refactorized across steps and stages when
+possible) to solve `g(z) = 0`.
+
+# Keyword arguments
+
+  - `κ`: relative tolerance on the Newton increment used in the convergence test.
+  - `max_iter`: maximum number of Newton iterations per solve.
+  - `fast_convergence_cutoff`: convergence-rate threshold below which convergence
+    is deemed fast (allowing `W` reuse).
+  - `new_W_dt_cutoff`: relative change in `γΔt` above which `W` is refactorized.
+  - `always_new`: force recomputation of `W` on every solve.
+  - `check_div`: enable early divergence detection.
+  - `relax`: optional relaxation parameter in `[0, 1)` damping the Newton update.
+"""
 struct NLNewton{K, C1, C2, R} <: AbstractNLSolverAlgorithm
     κ::K
     max_iter::Int

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -7,6 +7,13 @@ get_new_W_γdt_cutoff(nlsolver::AbstractNLSolver) = nlsolver.cache.new_W_γdt_cu
 # handle FIRK
 get_new_W_γdt_cutoff(alg::NewtonAlgorithm) = alg.new_W_γdt_cutoff
 
+"""
+    nlsolvefail(nlsolver) -> Bool
+    nlsolvefail(status::NLStatus) -> Bool
+
+Return whether a nonlinear solve failed, i.e. whether the solver's
+[`NLStatus`](@ref) is non-positive (`SlowConvergence` or worse).
+"""
 nlsolvefail(nlsolver::AbstractNLSolver) = nlsolvefail(get_status(nlsolver))
 nlsolvefail(status::NLStatus) = Int8(status) <= 0
 
@@ -30,6 +37,13 @@ function setfirststage!(nlcache::Union{NLNewtonCache, NLNewtonConstantCache}, va
     return (nlcache.firststage = val)
 end
 setfirststage!(::Any, val::Bool) = nothing
+"""
+    markfirststage!(nlsolver)
+
+Mark the nonlinear solver as being on the first implicit stage of the current
+step (sets the cache's `firststage` flag to `true`). Used so predictor/`W`-reuse
+logic can distinguish the first stage from later ones.
+"""
 markfirststage!(nlsolver::AbstractNLSolver) = setfirststage!(nlsolver, true)
 
 getnfails(_) = 0
@@ -55,6 +69,12 @@ du_cache(nlsolver::AbstractNLSolver) = du_cache(nlsolver.cache)
 du_cache(::AbstractNLSolverCache) = nothing
 du_cache(nlcache::Union{NLFunctionalCache, NLAndersonCache, NLNewtonCache}) = (nlcache.k,)
 
+"""
+    du_alias_or_new(nlsolver, rate_prototype)
+
+Return a derivative buffer for the nonlinear solve: reuse the solver cache's
+existing `du` buffer when it has one, otherwise allocate `zero(rate_prototype)`.
+"""
 function du_alias_or_new(nlsolver::AbstractNLSolver, rate_prototype)
     _du_cache = du_cache(nlsolver)
     return if _du_cache === nothing
@@ -228,6 +248,18 @@ function _nlalg_with_linsolve(inner_alg, linsolve)
     return remake(inner_alg; descent = remake(descent; linsolve = linsolve))
 end
 
+"""
+    build_nlsolver(alg, [nlalg,] u, uprev, p, t, dt, f, rate_prototype,
+                   uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits, γ, c, [α,]
+                   iip, verbose) -> AbstractNLSolver
+
+Construct the nonlinear solver object (an [`AbstractNLSolver`](@ref)) that an
+implicit algorithm `alg` uses to solve its stage equations. `γ` and `c` are the
+stage's diagonal coefficient and abscissa, `α` an optional scaling, `iip` the
+in-place flag; the nonlinear-solver algorithm defaults to `alg.nlsolve`. Allocates
+the appropriate cache (Newton `W`/factorization, functional/Anderson buffers, …)
+for the chosen `nlalg`.
+"""
 function build_nlsolver(
         alg, u, uprev, p, t, dt, f::F, rate_prototype,
         ::Type{uEltypeNoUnits},

--- a/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_caches.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_caches.jl
@@ -1,3 +1,13 @@
+"""
+    RosenbrockMutableCache <: OrdinaryDiffEqMutableCache
+
+Abstract supertype for the in-place caches of the Rosenbrock (and Rosenbrock-W)
+methods. Concrete Rosenbrock caches subtype this; the shared integrator interface
+dispatches on it to access the stage buffers, Jacobian/`W` matrices, and
+differentiation configs common to the Rosenbrock family. Declared public so
+cross-sublibrary references to the Rosenbrock cache hierarchy are recognized as a
+supported extension point.
+"""
 abstract type RosenbrockMutableCache <: OrdinaryDiffEqMutableCache end
 abstract type RosenbrockConstantCache <: OrdinaryDiffEqConstantCache end
 

--- a/lib/OrdinaryDiffEqSDIRK/src/imex_tableaus.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/imex_tableaus.jl
@@ -2608,6 +2608,13 @@ function ImplicitMidpointESDIRKIMEXTableau(T, T2)
     )
 end
 
+"""
+    ImplicitEulerESDIRKIMEXTableau(T, T2)
+
+Construct the single-stage ESDIRK-IMEX Butcher tableau whose implicit part is the
+implicit Euler method (element types `T` for coefficients, `T2` for abscissae).
+Used as the base tableau for the implicit-Euler IMEX splitting scheme.
+"""
 function ImplicitEulerESDIRKIMEXTableau(T, T2)
     s = 1
     Ai = fill(one(T), 1, 1)

--- a/lib/OrdinaryDiffEqSDIRK/src/sdirk_caches.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/sdirk_caches.jl
@@ -21,6 +21,14 @@ _esdirk_smooth_est(alg::OrdinaryDiffEqNewtonAdaptiveESDIRKAlgorithm) = alg.smoot
 _esdirk_smooth_est(alg::OrdinaryDiffEqNewtonAdaptiveSDIRKAlgorithm) = alg.smooth_est
 _esdirk_smooth_est(alg) = false
 
+"""
+    ESDIRKIMEXConstantCache <: OrdinaryDiffEqConstantCache
+
+Out-of-place solver cache for the ESDIRK-IMEX methods. Holds the nonlinear solver
+`nlsolver`, the Butcher tableau `tab`, and the extra history slots `uprev3` /
+`tprev2` used by the embedded error estimate. Declared public so downstream IMEX
+solvers can reuse the ESDIRK-IMEX step.
+"""
 mutable struct ESDIRKIMEXConstantCache{Tab, N, U3, T2} <: OrdinaryDiffEqConstantCache
     nlsolver::N
     tab::Tab
@@ -32,6 +40,14 @@ function ESDIRKIMEXConstantCache(nlsolver, tab)
     return ESDIRKIMEXConstantCache(nlsolver, tab, nothing, nothing)
 end
 
+"""
+    ESDIRKIMEXCache <: SDIRKMutableCache
+
+In-place solver cache for the ESDIRK-IMEX methods. Holds the stage values `zs`,
+stage-derivative buffers `ks`, error temporary `atmp`, nonlinear solver
+`nlsolver`, tableau `tab`, step limiter, and the extra history slots
+(`uprev2`/`uprev3`/`tprev2`) and `algebraic_vars` mask.
+"""
 mutable struct ESDIRKIMEXCache{
         uType, rateType, uNoUnitsType, N, Tab, kType, StepLimiter, U2, AV, U3, T2,
     } <: SDIRKMutableCache

--- a/lib/OrdinaryDiffEqTsit5/src/tsit_caches.jl
+++ b/lib/OrdinaryDiffEqTsit5/src/tsit_caches.jl
@@ -16,6 +16,18 @@
     thread::Thread
 end
 
+# `@cache struct` expands to the struct plus a `full_cache` method, which a docstring
+# on the macrocall cannot wrap, so the docstring attaches to the type binding here.
+"""
+    Tsit5Cache <: OrdinaryDiffEqMutableCache
+
+In-place solver cache for the Tsitouras 5(4) method (`Tsit5`), holding its stage
+buffers `k1`…`k7`, temporaries, embedded-error buffer, and the stage/step limiters
+and threading option. Declared public so other sublibraries can reuse the `Tsit5`
+step.
+"""
+Tsit5Cache
+
 @truncate_stacktrace Tsit5Cache 1
 
 function alg_cache(

--- a/lib/OrdinaryDiffEqTsit5/src/tsit_tableaus.jl
+++ b/lib/OrdinaryDiffEqTsit5/src/tsit_tableaus.jl
@@ -1,3 +1,9 @@
+"""
+    Tsit5ConstantCache <: OrdinaryDiffEqConstantCache
+
+Out-of-place solver cache for the Tsitouras 5(4) method (`Tsit5`). Carries no
+mutable state (the tableau coefficients are generated on demand).
+"""
 struct Tsit5ConstantCache <: OrdinaryDiffEqConstantCache end
 struct Tsit5ConstantCacheActual{T, T2}
     c1::T2


### PR DESCRIPTION
## Summary

Several names across OrdinaryDiffEq.jl are declared `public` (the solver-author extension API) but were missing a docstring and/or a rendered-docs entry. This PR documents all of them.

An authoritative check (loading each package on Julia 1.12 and inspecting `Base.Docs.meta`) confirmed **176** undocumented `public` names in `OrdinaryDiffEqCore` plus a handful in the solver sublibraries. This PR adds docstrings for every one and a docs entry for every audited name.

## What changed

- **`public_api_docstrings.jl` per affected package** (`OrdinaryDiffEqCore`, `OrdinaryDiffEqNonlinearSolve`, `OrdinaryDiffEqDifferentiation`, `OrdinaryDiffEqLowOrderRK`, `OrdinaryDiffEqTsit5`, `OrdinaryDiffEqSDIRK`, `OrdinaryDiffEqRosenbrock`): attaches a docstring to each previously-undocumented `public` binding using the "docstring for an existing binding" form, so no definitions move. Docstrings are written from the actual implementations (algorithm/cache type hierarchies, trait functions, nonlinear-solver + W-matrix/differentiation hooks, interpolation kernels, threading/enum/sentinel types, noise hooks, controller caches, docstring builders).
- **`docs/src/api/solver_author.md`**: a new "Solver-author extension API" reference page with `@docs` blocks for every such name (excluding names already documented on the Controller API / misc pages, to avoid duplicate-docs errors), registered in `docs/pages.jl` under "APIs".
- **docs wiring**: `OrdinaryDiffEqDifferentiation` and `OrdinaryDiffEqNonlinearSolve` added to `docs/Project.toml`, `docs/make.jl` (`using` + `modules`), so their `@docs` entries resolve.

## Verification

- Julia 1.12: every `public` name now has an attached docstring (`Base.Docs.meta`) — `OrdinaryDiffEqCore` reports **0** missing; all sublibrary names report `DOC`.
- Ran a Documenter build of the new page with `warnonly = false`: all `@docs` entries resolve and all `@ref` links resolve, with no docstring-not-found / missing-docs errors. No `warnonly`/silencing was added.

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)