### PR TITLE
Fix the six failing StochasticDiffEq* sublibrary QA lanes (Aqua ambiguity/piracy, JET, ei_broken Unexpected Pass)

### DIFF
--- a/lib/StochasticDiffEqCore/src/caches/cache_types.jl
+++ b/lib/StochasticDiffEqCore/src/caches/cache_types.jl
@@ -9,7 +9,8 @@ end
 # (JET) and turns a missing implementation into a descriptive error instead of a
 # `MethodError`.
 function alg_cache(
-        alg, prob, u, ΔW, ΔZ, p, rate_prototype, noise_rate_prototype,
+        alg::Union{StochasticDiffEqAlgorithm, StochasticDiffEqRODEAlgorithm},
+        prob, u, ΔW, ΔZ, p, rate_prototype, noise_rate_prototype,
         jump_rate_prototype, ::Type, ::Type, ::Type, uprev, f, t, dt, ::Type, verbose
     )
     throw(

--- a/lib/StochasticDiffEqCore/src/caches/cache_types.jl
+++ b/lib/StochasticDiffEqCore/src/caches/cache_types.jl
@@ -4,6 +4,22 @@ mutable struct StochasticCompositeCache{T, F} <: StochasticDiffEqCache
     current::Int
 end
 
+# Concrete `alg_cache` methods live in the solver subpackages. This fallback makes
+# the `alg_cache` call in `_sde_init` statically resolvable for any algorithm
+# (JET) and turns a missing implementation into a descriptive error instead of a
+# `MethodError`.
+function alg_cache(
+        alg, prob, u, ΔW, ΔZ, p, rate_prototype, noise_rate_prototype,
+        jump_rate_prototype, ::Type, ::Type, ::Type, uprev, f, t, dt, ::Type, verbose
+    )
+    throw(
+        ArgumentError(
+            "`alg_cache` is not implemented for algorithm $(typeof(alg)). " *
+                "Load the solver subpackage that implements this algorithm."
+        )
+    )
+end
+
 function alg_cache(
         alg::algType,
         prob,

--- a/lib/StochasticDiffEqCore/src/integrators/integrator_interface.jl
+++ b/lib/StochasticDiffEqCore/src/integrators/integrator_interface.jl
@@ -94,7 +94,7 @@ end
     end
 end
 
-function resize_non_user_cache!(integrator::SDEIntegrator, cache, i)
+function _sde_resize_non_user_cache!(integrator::SDEIntegrator, cache, i)
     bot_idx = length(integrator.u) + 1
     if is_diagonal_noise(integrator.sol.prob)
         resize_noise!(integrator, cache, bot_idx, i)
@@ -108,7 +108,7 @@ function resize_non_user_cache!(integrator::SDEIntegrator, cache, i)
     return
 end
 
-function deleteat_non_user_cache!(integrator::SDEIntegrator, cache, idxs)
+function _sde_deleteat_non_user_cache!(integrator::SDEIntegrator, cache, idxs)
     if is_diagonal_noise(integrator.sol.prob)
         deleteat_noise!(integrator, cache, idxs)
         for c in rand_cache(integrator)
@@ -121,7 +121,7 @@ function deleteat_non_user_cache!(integrator::SDEIntegrator, cache, idxs)
     return
 end
 
-function addat_non_user_cache!(integrator::SDEIntegrator, cache, idxs)
+function _sde_addat_non_user_cache!(integrator::SDEIntegrator, cache, idxs)
     if is_diagonal_noise(integrator.sol.prob)
         addat_noise!(integrator, cache, idxs)
         for c in rand_cache(integrator)
@@ -132,6 +132,41 @@ function addat_non_user_cache!(integrator::SDEIntegrator, cache, idxs)
         addat!(c, idxs)
     end
     return
+end
+
+function resize_non_user_cache!(integrator::SDEIntegrator, cache, i)
+    return _sde_resize_non_user_cache!(integrator, cache, i)
+end
+
+function deleteat_non_user_cache!(integrator::SDEIntegrator, cache, idxs)
+    return _sde_deleteat_non_user_cache!(integrator, cache, idxs)
+end
+
+function addat_non_user_cache!(integrator::SDEIntegrator, cache, idxs)
+    return _sde_addat_non_user_cache!(integrator, cache, idxs)
+end
+
+# OrdinaryDiffEqCore defines `(::ODEIntegrator, ::CompositeCache, i)` methods for
+# these three functions, which are ambiguous with the `(::SDEIntegrator, cache, i)`
+# methods above. An SDE integrator's composite cache is `StochasticCompositeCache`,
+# never `OrdinaryDiffEqCore.CompositeCache`, and the SDE bodies ignore `cache`
+# anyway, so the disambiguating methods share the general SDE bodies.
+function resize_non_user_cache!(
+        integrator::SDEIntegrator, cache::OrdinaryDiffEqCore.CompositeCache, i
+    )
+    return _sde_resize_non_user_cache!(integrator, cache, i)
+end
+
+function deleteat_non_user_cache!(
+        integrator::SDEIntegrator, cache::OrdinaryDiffEqCore.CompositeCache, idxs
+    )
+    return _sde_deleteat_non_user_cache!(integrator, cache, idxs)
+end
+
+function addat_non_user_cache!(
+        integrator::SDEIntegrator, cache::OrdinaryDiffEqCore.CompositeCache, idxs
+    )
+    return _sde_addat_non_user_cache!(integrator, cache, idxs)
 end
 
 function deleteat_noise!(integrator, cache, idxs)

--- a/lib/StochasticDiffEqCore/src/solve.jl
+++ b/lib/StochasticDiffEqCore/src/solve.jl
@@ -190,8 +190,10 @@ function _sde_init(
 
     # ── JumpProblem reset ────────────────────────────────────────────────
     if _prob isa JumpProblem
-        alias_jumps = isnothing(aliases.alias_jumps) ? Threads.threadid() == 1 :
-            aliases.alias_jumps
+        # Hoist the field read into a local so the `nothing` check narrows the
+        # `Union{Nothing, Bool}` field type (JET).
+        _alias_jumps = aliases.alias_jumps
+        alias_jumps = _alias_jumps === nothing ? Threads.threadid() == 1 : _alias_jumps
         _jump_seed = _rng_provided ? nothing : _seed
         if !alias_jumps
             _prob = JumpProcesses.resetted_jump_problem(_prob, _jump_seed)
@@ -246,19 +248,24 @@ function _sde_init(
     end
 
     # ── f/p/u aliasing (needed before cache construction) ────────────────
-    if isnothing(aliases.alias_f) || aliases.alias_f
+    # The field reads are hoisted into locals so the `nothing` checks narrow
+    # the `Union{Nothing, Bool}` field types (JET).
+    alias_f = aliases.alias_f
+    if alias_f === nothing || alias_f
         f = prob.f
     else
         f = deepcopy(prob.f)
     end
 
-    if isnothing(aliases.alias_p) || aliases.alias_p
+    alias_p = aliases.alias_p
+    if alias_p === nothing || alias_p
         p = prob.p
     else
         p = recursivecopy(prob.p)
     end
 
-    if !isnothing(aliases.alias_u0) && aliases.alias_u0
+    alias_u0 = aliases.alias_u0
+    if alias_u0 !== nothing && alias_u0
         u = prob.u0
     else
         u = recursivecopy(prob.u0)

--- a/lib/StochasticDiffEqCore/test/qa/qa.jl
+++ b/lib/StochasticDiffEqCore/test/qa/qa.jl
@@ -1,5 +1,6 @@
 using SciMLTesting, StochasticDiffEqCore, Test
 using JET
+using OrdinaryDiffEqCore: OrdinaryDiffEqCore
 
 # StochasticDiffEqCore extends OrdinaryDiffEqCore's solver loop and dispatches on
 # a handful of still-internal SciMLBase/DiffEqBase interface names. The base
@@ -43,9 +44,47 @@ const NONPUBLIC_IGNORE = (
     FORWARDDIFF_INTERNAL..., BASE_INTERNAL...,
 )
 
+# The SDE/RODE/Jump algorithm and cache supertypes are declared in
+# OrdinaryDiffEqCore purely as dispatch hooks for the StochasticDiffEq family;
+# StochasticDiffEqCore is their de-facto owner, and its methods on them are the
+# intended implementations of the shared solver loop's extension points, not
+# piracy. Likewise the noise hooks (`accept_noise!` & co.) are declared in
+# OrdinaryDiffEqCore with `::Nothing` fallbacks precisely so this package can
+# implement them for real noise processes.
+const TREAT_AS_OWN = [
+    OrdinaryDiffEqCore.StochasticDiffEqAlgorithm,
+    OrdinaryDiffEqCore.StochasticDiffEqAdaptiveAlgorithm,
+    OrdinaryDiffEqCore.StochasticDiffEqCompositeAlgorithm,
+    OrdinaryDiffEqCore.StochasticDiffEqRODEAlgorithm,
+    OrdinaryDiffEqCore.StochasticDiffEqRODEAdaptiveAlgorithm,
+    OrdinaryDiffEqCore.StochasticDiffEqRODECompositeAlgorithm,
+    OrdinaryDiffEqCore.StochasticDiffEqNewtonAlgorithm,
+    OrdinaryDiffEqCore.StochasticDiffEqNewtonAdaptiveAlgorithm,
+    OrdinaryDiffEqCore.StochasticDiffEqJumpAlgorithm,
+    OrdinaryDiffEqCore.StochasticDiffEqJumpAdaptiveAlgorithm,
+    OrdinaryDiffEqCore.StochasticDiffEqJumpDiffusionAlgorithm,
+    OrdinaryDiffEqCore.StochasticDiffEqJumpDiffusionAdaptiveAlgorithm,
+    OrdinaryDiffEqCore.StochasticDiffEqJumpNewtonAdaptiveAlgorithm,
+    OrdinaryDiffEqCore.StochasticDiffEqJumpNewtonDiffusionAdaptiveAlgorithm,
+    OrdinaryDiffEqCore.StochasticDiffEqCache,
+    OrdinaryDiffEqCore.StochasticDiffEqConstantCache,
+    OrdinaryDiffEqCore.StochasticDiffEqMutableCache,
+    # `_initialize_dae!` is likewise an OrdinaryDiffEqCore-owned hook; this
+    # package implements it for the RODE/SDDE problem types the ODE loop does
+    # not know about.
+    OrdinaryDiffEqCore._initialize_dae!,
+    OrdinaryDiffEqCore.accept_noise!,
+    OrdinaryDiffEqCore.reinit_noise!,
+    OrdinaryDiffEqCore.reject_noise!,
+    OrdinaryDiffEqCore.save_noise!,
+    OrdinaryDiffEqCore.noise_curt,
+    OrdinaryDiffEqCore.is_noise_saveable,
+]
+
 run_qa(
     StochasticDiffEqCore;
     jet_kwargs = (; target_defined_modules = true),
+    aqua_kwargs = (; piracies = (; treat_as_own = TREAT_AS_OWN)),
     explicit_imports = true,
     ei_kwargs = (;
         # `@..` reaches StochasticDiffEqCore via DiffEqBase's re-export of

--- a/lib/StochasticDiffEqLowOrder/test/qa/qa.jl
+++ b/lib/StochasticDiffEqLowOrder/test/qa/qa.jl
@@ -5,5 +5,5 @@ run_qa(
     StochasticDiffEqLowOrder;
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
-    ei_broken = (:no_implicit_imports, :all_explicit_imports_via_owners, :all_qualified_accesses_are_public, :all_explicit_imports_are_public),  # known-broken; see SciML/OrdinaryDiffEq.jl#3776
+    ei_broken = (:no_implicit_imports, :all_explicit_imports_via_owners, :all_explicit_imports_are_public),  # known-broken; see SciML/OrdinaryDiffEq.jl#3776
 )

--- a/lib/StochasticDiffEqMilstein/src/perform_step/rkmilgeneral.jl
+++ b/lib/StochasticDiffEqMilstein/src/perform_step/rkmilgeneral.jl
@@ -48,7 +48,7 @@ function _compute_iterated_I(dt, dW, dZ, W_noise, alg)
     # Only for non-diagonal vector noise (dW must be a Vector, not Matrix or Number)
     dW isa AbstractVector || return nothing
 
-    m = length(dW)
+    m = length(dW)::Int
 
     # Strategy 1: RSwM3 S₂ stack (adaptive, post-rejection)
     J_s2 = _compute_II_from_S2(W_noise, m, dt)
@@ -116,31 +116,31 @@ function _compute_II_from_S2(W_noise, m, dt)
                 Wn_i = dWn / √dt_i
                 A_i = levyarea(Wn_i, coeffs_i.n, MronRoe(), coeffs_i)
                 # J^(i) = ½ dW_i dW_i' + dt_i * A_i  (Stratonovich within sub-interval)
-                for k in 1:m
-                    for j in 1:m
+                for k in axes(I, 2)
+                    for j in axes(I, 1)
                         I[j, k] += 1 // 2 * dWn[j] * dWn[k] + dt_i * A_i[j, k]
                     end
                 end
             else
                 # No usable coefficients — add ½ dW_i dW_i' as best approximation
-                for k in 1:m
-                    for j in 1:m
+                for k in axes(I, 2)
+                    for j in axes(I, 1)
                         I[j, k] += 1 // 2 * dWn[j] * dWn[k]
                     end
                 end
             end
         else
             # No dZ available for this sub-interval — commutative approximation
-            for k in 1:m
-                for j in 1:m
+            for k in axes(I, 2)
+                for j in axes(I, 1)
                     I[j, k] += 1 // 2 * dWn[j] * dWn[k]
                 end
             end
         end
 
         # Cross-interval contribution: W_cumsum_j * dW^(i)_k
-        for k in 1:m
-            for j in 1:m
+        for k in axes(I, 2)
+            for j in axes(I, 1)
                 I[j, k] += W_cumsum[j] * dWn[k]
             end
         end
@@ -191,37 +191,37 @@ function _compute_II_from_grid(W_noise, m, dt)
                 if coeffs_n !== nothing
                     Wn_n = dWn / √dt_n
                     A_n = levyarea(Wn_n, coeffs_n.n, MronRoe(), coeffs_n)
-                    for k in 1:m
-                        for j in 1:m
+                    for k in axes(I, 2)
+                        for j in axes(I, 1)
                             I[j, k] += 1 // 2 * dWn[j] * dWn[k] + dt_n * A_n[j, k]
                         end
                     end
                 else
-                    for k in 1:m
-                        for j in 1:m
+                    for k in axes(I, 2)
+                        for j in axes(I, 1)
                             I[j, k] += 1 // 2 * dWn[j] * dWn[k]
                         end
                     end
                 end
             else
-                for k in 1:m
-                    for j in 1:m
+                for k in axes(I, 2)
+                    for j in axes(I, 1)
                         I[j, k] += 1 // 2 * dWn[j] * dWn[k]
                     end
                 end
             end
         else
             # No Z data — commutative approximation
-            for k in 1:m
-                for j in 1:m
+            for k in axes(I, 2)
+                for j in axes(I, 1)
                     I[j, k] += 1 // 2 * dWn[j] * dWn[k]
                 end
             end
         end
 
         # Cross-interval contribution
-        for k in 1:m
-            for j in 1:m
+        for k in axes(I, 2)
+            for j in axes(I, 1)
                 I[j, k] += W_cumsum[j] * dWn[k]
             end
         end
@@ -278,8 +278,12 @@ end
     mil_correction = zero(u)
     ggprime_norm = zero(eltype(u))
 
+    # `K` is hoisted out of the branches below: both the diagonal-noise path and
+    # the adaptive error estimate need it, and a branch-local assignment leaves it
+    # undefined on some paths as far as inference is concerned (JET).
+    K = @.. uprev + dt * du1
+
     if dW isa Number || is_diagonal_noise(integrator.sol.prob)
-        K = @.. uprev + dt * du1
         utilde = (
             SciMLBase.alg_interpretation(integrator.alg) ==
                 SciMLBase.AlgorithmInterpretation.Ito ? K : uprev
@@ -289,8 +293,8 @@ end
         u = K + L .* dW + mil_correction
     else
         for i in 1:length(dW)
-            K = uprev + dt * du1 + integrator.sqdt * @view(L[:, i])
-            gtmp = integrator.f.g(K, p, t)
+            Ktmp = uprev + dt * du1 + integrator.sqdt * @view(L[:, i])
+            gtmp = integrator.f.g(Ktmp, p, t)
             ggprime = @.. (gtmp - L) / integrator.sqdt
             ggprime_norm = zero(eltype(u))
             if integrator.opts.adaptive
@@ -299,7 +303,6 @@ end
             mil_correction += ggprime * @view(J[i, :])
         end
         if integrator.opts.adaptive
-            K = @.. uprev + dt * du1
             u = K + L * dW + mil_correction
         else
             u = uprev + dt * du1 + L * dW + mil_correction

--- a/lib/StochasticDiffEqROCK/src/perform_step/SROCK_perform_step.jl
+++ b/lib/StochasticDiffEqROCK/src/perform_step/SROCK_perform_step.jl
@@ -14,12 +14,10 @@
     cosh_inv = log(ω₀ + Sqrt_ω)             # arcosh(ω₀)
     ω₁ = (Sqrt_ω * cosh(mdeg * cosh_inv)) / (mdeg * sinh(mdeg * cosh_inv))
 
-    if SciMLBase.alg_interpretation(integrator.alg) ==
-            SciMLBase.AlgorithmInterpretation.Stratonovich
-        α = cosh(mdeg * cosh_inv) / (2 * ω₀ * cosh((mdeg - 1) * cosh_inv))
-        γ = 1 / (2 * α)
-        β = -γ
-    end
+    # only used on the Stratonovich paths, but computed unconditionally (cheap scalars)
+    α = cosh(mdeg * cosh_inv) / (2 * ω₀ * cosh((mdeg - 1) * cosh_inv))
+    γ = 1 / (2 * α)
+    β = -γ
 
     uᵢ₋₂ = copy(uprev)
     k = integrator.f(uprev, p, t)
@@ -111,12 +109,10 @@ end
     cosh_inv = log(ω₀ + Sqrt_ω)             # arcosh(ω₀)
     ω₁ = (Sqrt_ω * cosh(mdeg * cosh_inv)) / (mdeg * sinh(mdeg * cosh_inv))
 
-    if SciMLBase.alg_interpretation(integrator.alg) ==
-            SciMLBase.AlgorithmInterpretation.Stratonovich
-        α = cosh(mdeg * cosh_inv) / (2 * ω₀ * cosh((mdeg - 1) * cosh_inv))
-        γ = 1 / (2 * α)
-        β = -γ
-    end
+    # only used on the Stratonovich paths, but computed unconditionally (cheap scalars)
+    α = cosh(mdeg * cosh_inv) / (2 * ω₀ * cosh((mdeg - 1) * cosh_inv))
+    γ = 1 / (2 * α)
+    β = -γ
 
     @.. uᵢ₋₂ = uprev
     Tᵢ₋₂ = oneunit(t)
@@ -192,12 +188,6 @@ end
 @muladd function perform_step!(integrator, cache::SROCK2ConstantCache)
     (; t, dt, uprev, u, W, p, f) = integrator
     (; recf, recf2, mα, mσ, mτ) = cache
-
-    gen_prob = !(
-        (is_diagonal_noise(integrator.sol.prob)) || (W.dW isa Number) ||
-            (length(W.dW) == 1)
-    )
-    gen_prob && (vec_χ = 2 .* floor.(false .* W.dW .+ 1 // 2 .+ oftype(W.dW, rand(W.rng, length(W.dW)))) .- true)
 
     alg = unwrap_alg(integrator, true)
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
@@ -289,6 +279,8 @@ end
         Gₛ₁ = integrator.f.g(uᵢ₋₂, p, tᵢ)
         u += 1 // 4 .* W.dW .* Gₛ₁
     else
+        vec_χ = 2 .* floor.(false .* W.dW .+ 1 // 2 .+ oftype(W.dW, rand(W.rng, length(W.dW)))) .- true
+
         Gₛ = integrator.f.g(uᵢ₋₁, p, tᵢ₋₁)
         u += Gₛ * W.dW
 
@@ -759,9 +751,12 @@ end
         end
         winc = rand() * 6
         if winc < 1
-            u -= (sqrt(3 * dt) * ccache.mc[mdeg - 1]) * uᵢ₋₁
+            # cache IS the constant cache here (cf. the SKSROCKCache method, which
+            # accesses this through ccache = cache.constantcache); `ccache` was an
+            # undefined-variable bug on this path
+            u -= (sqrt(3 * dt) * cache.mc[mdeg - 1]) * uᵢ₋₁
         elseif winc < 2
-            u += (sqrt(3 * dt) * ccache.mc[mdeg - 1]) * uᵢ₋₁
+            u += (sqrt(3 * dt) * cache.mc[mdeg - 1]) * uᵢ₋₁
         end
     end
     integrator.u = u
@@ -922,7 +917,7 @@ end
     Û₂ = zero(u)
     t̂₁ = t̂₂ = zero(t)
     tᵢ = tᵢ₋₁ = tᵢ₋₂ = tₓ = t
-    uᵢ₋₂ = uprev
+    uᵢ = uᵢ₋₁ = uₓ = uᵢ₋₂ = uprev
 
     for i in 0:(mdeg + 1)
         if i == 1
@@ -1036,9 +1031,8 @@ end
 
         for i in 1:length(W.dW)
             for j in 1:length(W.dW)
-                (i > j) && (WikJ = (1 // 2) * (1 + η₂) * W.dW[j])
-                (i < j) && (WikJ = (1 // 2) * (1 - η₂) * W.dW[j])
-                (i == j) && (WikJ = (1 // 2) * (η₁ * sqrt_dt))
+                WikJ = i > j ? (1 // 2) * (1 + η₂) * W.dW[j] :
+                    i < j ? (1 // 2) * (1 - η₂) * W.dW[j] : (1 // 2) * (η₁ * sqrt_dt)
 
                 uᵢ₋₁ += @view(Gₛ[:, j]) * WikJ
             end
@@ -1207,9 +1201,8 @@ end
 
         for i in 1:length(W.dW)
             for j in 1:length(W.dW)
-                (i > j) && (WikJ = (1 // 2) * (1 + η₂) * W.dW[j])
-                (i < j) && (WikJ = (1 // 2) * (1 - η₂) * W.dW[j])
-                (i == j) && (WikJ = (1 // 2) * (η₁ * sqrt_dt))
+                WikJ = i > j ? (1 // 2) * (1 + η₂) * W.dW[j] :
+                    i < j ? (1 // 2) * (1 - η₂) * W.dW[j] : (1 // 2) * (η₁ * sqrt_dt)
 
                 @.. uᵢ₋₁ += @view(Gₛ[:, j]) * WikJ
             end
@@ -1226,11 +1219,6 @@ end
     (; t, dt, uprev, u, W, p, f) = integrator
     (; recf, mσ, mτ, mδ) = cache
 
-    gen_prob = !(
-        (is_diagonal_noise(integrator.sol.prob)) || (W.dW isa Number) ||
-            (length(W.dW) == 1)
-    )
-
     alg = unwrap_alg(integrator, true)
     alg.eigen_est === nothing ? maxeig!(integrator, cache) : alg.eigen_est(integrator)
     cache.mdeg = Int(floor(sqrt((2 * abs(dt) * integrator.opts.internalnorm(integrator.eigen_est, t) + 1.5) / 0.811) + 1))
@@ -1245,7 +1233,6 @@ end
     τ = mτ[deg_index]
 
     sqrt_dt = sqrt(abs(dt))
-    (gen_prob) && (vec_χ = 2 .* floor.(1 // 2 .+ false .* W.dW .+ rand(length(W.dW))) .- 1)
 
     tᵢ₋₂ = t
     uᵢ₋₂ = uprev
@@ -1330,6 +1317,8 @@ end
         Xₛ₋₁ = integrator.f.g(utmp, p, ttmp)
         u += 1 // 8 .* W.dW .* Xₛ₋₁
     else
+        vec_χ = 2 .* floor.(1 // 2 .+ false .* W.dW .+ rand(length(W.dW))) .- 1
+
         # stage s-3
         yₛ₋₃ = integrator.f(uᵢ₋₁, p, tᵢ₋₁)
         utmp = uᵢ₋₁ + μₛ₋₃ * yₛ₋₃
@@ -1424,7 +1413,7 @@ end
 @muladd function perform_step!(integrator, cache::KomBurSROCK2Cache)
     (;
         utmp, uᵢ₋₁, uᵢ₋₂, k, yₛ₋₁, yₛ₋₂, yₛ₋₃, SXₛ₋₁, SXₛ₋₂,
-        SXₛ₋₃, Gₛ, Xₛ₋₁, Xₛ₋₂, Xₛ₋₃, vec_χ,
+        SXₛ₋₃, Gₛ, Xₛ₋₁, Xₛ₋₂, Xₛ₋₃, vec_χ, WikRange,
     ) = cache
     (; t, dt, uprev, u, W, p, f) = integrator
     (; recf, mσ, mτ, mδ) = cache.constantcache

--- a/lib/StochasticDiffEqROCK/test/qa/qa.jl
+++ b/lib/StochasticDiffEqROCK/test/qa/qa.jl
@@ -5,5 +5,5 @@ run_qa(
     StochasticDiffEqROCK;
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
-    ei_broken = (:no_implicit_imports, :no_stale_explicit_imports, :all_explicit_imports_via_owners, :all_qualified_accesses_are_public, :all_explicit_imports_are_public),  # known-broken; see SciML/OrdinaryDiffEq.jl#3776
+    ei_broken = (:no_implicit_imports, :no_stale_explicit_imports, :all_explicit_imports_via_owners, :all_explicit_imports_are_public),  # known-broken; see SciML/OrdinaryDiffEq.jl#3776
 )

--- a/lib/StochasticDiffEqRODE/test/qa/qa.jl
+++ b/lib/StochasticDiffEqRODE/test/qa/qa.jl
@@ -5,5 +5,5 @@ run_qa(
     StochasticDiffEqRODE;
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
-    ei_broken = (:no_implicit_imports, :all_explicit_imports_via_owners, :all_qualified_accesses_via_owners, :all_explicit_imports_are_public),  # known-broken; see SciML/OrdinaryDiffEq.jl#3776
+    ei_broken = (:no_implicit_imports, :all_explicit_imports_via_owners, :all_explicit_imports_are_public),  # known-broken; see SciML/OrdinaryDiffEq.jl#3776
 )

--- a/lib/StochasticDiffEqWeak/src/caches/implicit_weak_caches.jl
+++ b/lib/StochasticDiffEqWeak/src/caches/implicit_weak_caches.jl
@@ -8,7 +8,9 @@
 Constant cache for the IRI1 (Implicit Rößler 1) method.
 Contains the nlsolver for implicit drift treatment and the RI1 tableau coefficients.
 """
-mutable struct IRI1ConstantCache{N, T, T2} <: StochasticDiffEqConstantCache
+mutable struct IRI1ConstantCache{
+        N <: OrdinaryDiffEqCore.AbstractNLSolver, T, T2,
+    } <: StochasticDiffEqConstantCache
     nlsolver::N
     # RI1 Tableau coefficients (same as DRI1ConstantCache but stored directly)
     a021::T
@@ -119,7 +121,8 @@ end
 # IRI1Cache: Mutable cache for the IRI1 (Implicit Rößler 1) method (in-place version).
 # Contains all the working arrays needed for the implicit weak order 2 SRK method.
 @cache mutable struct IRI1Cache{
-        uType, randType, rateNoiseType, rateType, noUnitsType, N, T, T2,
+        uType, randType, rateNoiseType, rateType, noUnitsType,
+        N <: OrdinaryDiffEqCore.AbstractNLSolver, T, T2,
     } <:
     StochasticDiffEqMutableCache
     u::uType

--- a/lib/StochasticDiffEqWeak/src/perform_step/implicit_weak.jl
+++ b/lib/StochasticDiffEqWeak/src/perform_step/implicit_weak.jl
@@ -28,12 +28,7 @@ based on the RI1 scheme with theta-method implicitization of the drift.
     _dW = map(x -> calc_threepoint_random(sq3dt, NORMAL_ONESIX_QUANTILE, x), dW_scaled)
     chi1 = map(x -> (x^2 - dt) / 2, _dW)  # diagonal of Ihat2
 
-    if !(W.dW isa Number)
-        m = length(W.dW)
-        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
-    else
-        m = 1
-    end
+    m = length(W.dW)
 
     # Stage 1: Compute k1 implicitly
     # For implicit treatment: k1 = f(Y1) where Y1 = uprev + theta*dt*k1
@@ -109,11 +104,17 @@ based on the RI1 scheme with theta-method implicitization of the drift.
         end
     end
 
-    # Compute g2 and g3 at H12 and H13
+    # Final update: combine drift (implicit) and diffusion (explicit)
+    u = uprev + α1 * k1 * dt + α2 * k2 * dt + α3 * k3 * dt
+
+    # Compute g2 and g3 at H12 and H13, then add noise contribution (same as explicit RI1)
     if W.dW isa Number
         g2 = integrator.f.g(H12, p, t + c12 * dt)
         g3 = integrator.f.g(H13, p, t + c13 * dt)
+        u += g1 * (_dW * beta11) + g2 * (_dW * beta12 + chi1 * beta22 / integrator.sqdt) +
+            g3 * (_dW * beta13 + chi1 * beta23 / integrator.sqdt)
     else
+        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
         g2 = [integrator.f.g(H12[k], p, t + c12 * dt) for k in 1:m]
         g3 = [integrator.f.g(H13[k], p, t + c13 * dt) for k in 1:m]
         H22 = [copy(uprev) for k in 1:m]
@@ -132,16 +133,6 @@ based on the RI1 scheme with theta-method implicitization of the drift.
                     integrator.sqdt
             end
         end
-    end
-
-    # Final update: combine drift (implicit) and diffusion (explicit)
-    u = uprev + α1 * k1 * dt + α2 * k2 * dt + α3 * k3 * dt
-
-    # Add noise contribution (same as explicit RI1)
-    if W.dW isa Number
-        u += g1 * (_dW * beta11) + g2 * (_dW * beta12 + chi1 * beta22 / integrator.sqdt) +
-            g3 * (_dW * beta13 + chi1 * beta23 / integrator.sqdt)
-    else
         if is_diagonal_noise(integrator.sol.prob)
             u += g1 .* _dW * beta11
             for k in 1:m

--- a/lib/StochasticDiffEqWeak/src/perform_step/srk_weak.jl
+++ b/lib/StochasticDiffEqWeak/src/perform_step/srk_weak.jl
@@ -1253,15 +1253,15 @@ end
                 if is_diagonal_noise(integrator.sol.prob)
                     tmpu = zero(integrator.u)
                     tmpu[jb] = gtmp[jb]
-                    @.. Y1jajb[ja, jb] = Ihat2 * tmpu
+                    @.. Y1jajb[ja, jb] = ihat2 * tmpu
                     if ja != jb
-                        @.. Y4jajb[ja, jb] = Ihat2 * tmpu
+                        @.. Y4jajb[ja, jb] = ihat2 * tmpu
                     end
                 else
                     gtmpjb = @view gtmp[:, jb]
-                    @.. Y1jajb[ja, jb] = Ihat2 * gtmpjb
+                    @.. Y1jajb[ja, jb] = ihat2 * gtmpjb
                     if ja != jb
-                        @.. Y4jajb[ja, jb] = Ihat2 * gtmpjb
+                        @.. Y4jajb[ja, jb] = ihat2 * gtmpjb
                     end
                 end
             end
@@ -1291,7 +1291,7 @@ end
                     gtmp = integrator.f.g(tmpu, p, t)
                     tmpjb = @view gtmp[:, jb]
                     ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
-                    @.. Y2jajb[ja, jb] = Ihat2 * tmpjb
+                    @.. Y2jajb[ja, jb] = ihat2 * tmpjb
                 end
             end
         else
@@ -1311,7 +1311,7 @@ end
                     tmpu = zero(integrator.u)
                     tmpu[jb] = gtmp[jb]
                     ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
-                    @.. Y2jajb[ja, jb] = Ihat2 * tmpu
+                    @.. Y2jajb[ja, jb] = ihat2 * tmpu
                 end
             end
         end

--- a/lib/StochasticDiffEqWeak/src/perform_step/srk_weak.jl
+++ b/lib/StochasticDiffEqWeak/src/perform_step/srk_weak.jl
@@ -11,11 +11,7 @@
     sq3dt = sqrt(3 * dt)
     _dW = map(x -> calc_threepoint_random(sq3dt, NORMAL_ONESIX_QUANTILE, x), dW_scaled)
     chi1 = map(x -> (x^2 - dt) / 2, _dW) # diagonal of Ihat2
-    if !(W.dW isa Number)
-        m = length(W.dW)
-        # define two-point distributed random variables
-        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
-    end
+    m = length(W.dW)
 
     # compute stage values
     k1 = integrator.f(uprev, p, t)
@@ -67,11 +63,22 @@
     # H21 = uprev
     # H^_i^(k), stage 2 and 3
 
+    # add stages together Eq. (3)
+    u = uprev + α1 * k1 * dt + α2 * k2 * dt + α3 * k3 * dt
+
     if W.dW isa Number
         g2 = integrator.f.g(H12, p, t + c12 * dt)
         g3 = integrator.f.g(H13, p, t + c13 * dt)
         # for m=1:  H22 = uprev
+
+        # add noise, lines 2 and 3
+        u += g1 * (_dW * beta11) + g2 * (_dW * beta12 + chi1 * beta22 / integrator.sqdt) +
+            g3 * (_dW * beta13 + chi1 * beta23 / integrator.sqdt)
+        # lines 4 and 5 are zero by construction
+        # u += g1*(_dW*(beta31+beta32+beta33)+chi1*integrator.sqdt*(beta42+beta43))
     else
+        # define two-point distributed random variables
+        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
         g2 = [integrator.f.g(H12[k], p, t + c12 * dt) for k in 1:m]
         g3 = [integrator.f.g(H13[k], p, t + c13 * dt) for k in 1:m]
         H22 = [copy(uprev) for k in 1:m]
@@ -85,23 +92,12 @@
                 tmp[k] = b231 * g1[k] + b232 * g2[k][k] + b233 * g3[k][k]
                 H23[k] += tmp * integrator.sqdt
             else
-                H22[k] += (b221 * g1[:, l] + b222 * g2[l][:, l] + b223 * g3[l][:, l]) * integrator.sqdt
-                H23[k] += (b231 * g1[:, l] + b232 * g2[l][:, l] + b233 * g3[l][:, l]) * integrator.sqdt
+                H22[k] += (b221 * g1[:, k] + b222 * g2[k][:, k] + b223 * g3[k][:, k]) * integrator.sqdt
+                H23[k] += (b231 * g1[:, k] + b232 * g2[k][:, k] + b233 * g3[k][:, k]) * integrator.sqdt
             end
         end
-    end
 
-    # add stages together Eq. (3)
-    u = uprev + α1 * k1 * dt + α2 * k2 * dt + α3 * k3 * dt
-
-    # add noise
-    if W.dW isa Number
-        # lines 2 and 3
-        u += g1 * (_dW * beta11) + g2 * (_dW * beta12 + chi1 * beta22 / integrator.sqdt) +
-            g3 * (_dW * beta13 + chi1 * beta23 / integrator.sqdt)
-        # lines 4 and 5 are zero by construction
-        # u += g1*(_dW*(beta31+beta32+beta33)+chi1*integrator.sqdt*(beta42+beta43))
-    else
+        # add noise
         if is_diagonal_noise(integrator.sol.prob)
             u += g1 .* _dW * beta11
             for k in 1:m
@@ -458,6 +454,7 @@ end
     (; a021, b021, α1, α2, c02, beta11, NORMAL_ONESIX_QUANTILE) = cache
     (; t, dt, uprev, u, W, p, f) = integrator
 
+    m = length(W.dW)
     # define three-point distributed random variables
     dW_scaled = W.dW / sqrt(dt)
     sq3dt = sqrt(3 * dt)
@@ -562,11 +559,7 @@ end
     dW_scaled = W.dW / sqrt(dt)
     sq3dt = sqrt(3 * dt)
     _dW = map(x -> calc_threepoint_random(sq3dt, NORMAL_ONESIX_QUANTILE, x), dW_scaled)
-    if !(W.dW isa Number)
-        m = length(W.dW)
-        # define two-point distributed random variables
-        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
-    end
+    m = length(W.dW)
     # compute stage values
     k1 = integrator.f(uprev, p, t)
     g1 = integrator.f.g(uprev, p, t)
@@ -684,7 +677,18 @@ end
     # H21 = uprev
     # H^_2^(k) # H^_3^(k)
 
-    if !(W.dW isa Number)
+    # H^_4^(k)
+    # H24 = uprev
+
+    if W.dW isa Number
+        # add stages together Eq. (5.1)
+        u = uprev + (α1 * k1 + α2 * k2 + α3 * k3 + α4 * k1) * dt
+
+        # add noise
+        u += (g1 * beta11 + g2 * beta12 + g3 * beta13 + g4 * beta14) * _dW # beta2 terms are zero by construction
+    else
+        # define two-point distributed random variables
+        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
         H22 = [uprev for k in 1:m]
         H23 = [uprev for k in 1:m]
         # add inbounds for speed if working properly
@@ -703,17 +707,11 @@ end
                 end
             end
         end
-    end
-    # H^_4^(k)
-    # H24 = uprev
 
-    # add stages together Eq. (5.1)
-    u = uprev + (α1 * k1 + α2 * k2 + α3 * k3 + α4 * k1) * dt
+        # add stages together Eq. (5.1)
+        u = uprev + (α1 * k1 + α2 * k2 + α3 * k3 + α4 * k1) * dt
 
-    # add noise
-    if W.dW isa Number
-        u += (g1 * beta11 + g2 * beta12 + g3 * beta13 + g4 * beta14) * _dW # beta2 terms are zero by construction
-    else
+        # add noise
         if is_diagonal_noise(integrator.sol.prob)
             u += g1 .* _dW * beta11
             for k in 1:m
@@ -954,10 +952,6 @@ end
     dW_scaled = W.dW / integrator.sqdt
     _dW = map(x -> calc_threepoint_random(sq3dt, NORMAL_ONESIX_QUANTILE, x), dW_scaled)
     chi1 = map(x -> (x^2 - dt) / 4, _dW)
-    if !(W.dW isa Number)
-        # define two-point distributed random variables
-        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
-    end
     # compute stage values
     k1 = integrator.f(uprev, p, t)
     g1 = integrator.f.g(uprev, p, t)
@@ -999,6 +993,8 @@ end
         g2m = integrator.f.g(Ym, p, t)
         u += 1 // 4 * (g2p + g2m + 2 * g1) * _dW + (g2p - g2m) * chi1 / integrator.sqdt #(1.1)
     else
+        # define two-point distributed random variables
+        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
         if is_diagonal_noise(integrator.sol.prob)
             for k in 1:m
                 tmpg1 = integrator.f.g(Yp[k], p, t)
@@ -1102,7 +1098,7 @@ end
     if W.dW isa Number
         integrator.f.g(tmpg1, Yp, p, t)
         integrator.f.g(tmpg2, Ym, p, t)
-        @.. u = u + 1 // 4 * (tmpg1 + tmpg2 + 2 * g1) * _dW + 1 // 4 * (tmpg1 - tmpg2) * chi1[k] / integrator.sqdt #(1.1)
+        @.. u = u + 1 // 4 * (tmpg1 + tmpg2 + 2 * g1) * _dW + 1 // 4 * (tmpg1 - tmpg2) * chi1 / integrator.sqdt #(1.1)
     else
         if !is_diagonal_noise(integrator.sol.prob) || W.dW isa Number
             # non-diag noise
@@ -1235,10 +1231,8 @@ end
     dW_scaled = W.dW / integrator.sqdt
     _dW = map(x -> calc_threepoint_random(sq3dt, NORMAL_ONESIX_QUANTILE, x), dW_scaled)
 
-    if !(W.dW isa Number)
-        # define two-point distributed random variables
-        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
-    end
+    # define two-point distributed random variables (only consumed on the vector-noise paths)
+    _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
 
     # compute stage values
     # stage 1
@@ -1667,6 +1661,11 @@ end
     # add stages together
     @.. u = uprev + c01 * Y100 + c02 * Y200 + c03 * Y300 + c04 * Y400
     if W.dW isa Number
+        # scalar noise: m == 1, so the only stage values are the [1, 1] entries
+        Y1jj = Y1jajb[1, 1]
+        Y2jj = Y2jajb[1, 1]
+        Y3jj = Y3jajb[1, 1]
+        Y4jj = Y4jajb[1, 1]
         @.. u = u + cj1 * Y1jj + cj2 * Y2jj + cj3 * Y3jj + cj4 * Y4jj
     else
         if is_diagonal_noise(integrator.sol.prob)
@@ -2019,17 +2018,6 @@ end
     chi1 = W.dW / integrator.sqdt
     _dW = map(x -> calc_threepoint_random(sq3dt, NORMAL_ONESIX_QUANTILE, x), chi1)
 
-    if !(W.dW isa Number)
-        # define two-point distributed random variables
-        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
-        ihat2 = zeros(eltype(W.dZ), m, m) # I^_(k,l)
-        for j in 1:m
-            for l in 1:(j - 1)
-                Ihat2[j, l] = -_dZ[j] * _dW[l] / integrator.sqdt
-                Ihat2[l, j] = _dW[l] * _dZ[j] / integrator.sqdt
-            end
-        end
-    end
     # compute stage values
     # stage 1
     ktmp = integrator.f(uprev, p, t)
@@ -2152,6 +2140,16 @@ end
         if is_diagonal_noise(integrator.sol.prob)
             u += @. cj1 * Y1j + cj2 * Y2j + cj3 * Y3j + cj4 * Y4j
         else
+            # define two-point distributed random variables
+            _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
+            # I^_(k,l); local matrix shadows the Ihat2 function, matching the NON2Cache field
+            Ihat2 = zeros(eltype(W.dZ), m, m)
+            for j in 1:m
+                for l in 1:(j - 1)
+                    Ihat2[j, l] = -_dZ[j] * _dW[l] / integrator.sqdt
+                    Ihat2[l, j] = _dW[l] * _dZ[j] / integrator.sqdt
+                end
+            end
             for j in 1:m
                 u += @. cj1 * Y1j[:, j] + cj2 * Y2j[:, j] + cj3 * Y3j[:, j] + cj4 * Y4j[:, j]
                 #add stage values for non-commutative processes, Y3^(k(j)j) and Y4^(k(j)j)

--- a/lib/StochasticDiffEqWeak/src/tableaus.jl
+++ b/lib/StochasticDiffEqWeak/src/tableaus.jl
@@ -847,13 +847,7 @@ function constructNON(::Type{T} = Float64) where {T}
 end
 
 function checkNONOrder(NON; tol = 1.0e-6)
-    if NON isa KomoriNON
-        (; c0, cj, cjl, clj, α00, α0j, αj0, αjj, αjl, αjljj, αljjl) = NON
-    elseif NON isa KomoriNON2
-        (; c0, cj, ckj, α00, α0j, αj0, αjj, αjl, αkjjl) = NON
-    else
-        (; c0, cj, α00, α0j, αj0, αjj, αjl) = NON
-    end
+    (; c0, cj, α00, α0j, αj0, αjj, αjl) = NON
     e = ones(size(c0))
 
     conditions = Vector{Bool}(undef, 44) # 38 conditions for second order, 6 extra conditions for fourth deterministic order, 44 in total
@@ -893,6 +887,7 @@ function checkNONOrder(NON; tol = 1.0e-6)
     conditions[32] = abs(dot(cj, (αjj * e) .* (αjl * e)) - 1 / 4) < tol
 
     if NON isa KomoriNON
+        (; cjl, clj, αjljj, αljjl) = NON
         conditions[33] = abs(dot(clj, e) - 0) < tol
         conditions[34] = abs(dot(cjl, e) - 0) < tol
         conditions[35] = abs(dot(clj, αljjl * e) - 1 / 2) < tol
@@ -900,12 +895,17 @@ function checkNONOrder(NON; tol = 1.0e-6)
         conditions[37] = abs(dot(clj .* (αljjl * e), αljjl * (αjljj * e)) - 0) < tol
         conditions[38] = abs(dot(clj, (αljjl * e) .^ 2) - 0) < tol
     elseif NON isa KomoriNON2
+        (; ckj, αkjjl) = NON
         conditions[33] = abs(ckj[4] + ckj[3] - 0) < tol
         conditions[34] = abs(ckj[2] - 0) < tol
         conditions[35] = abs(αkjjl[4, 3] - 0) < tol
         conditions[36] = true # we set alpha^(k(j),j,0,0) = 0
         conditions[37] = abs(ckj[3] * αkjjl[3, 2]^2 + ckj[4] * αkjjl[4, 2]^2 - 0) < tol
         conditions[38] = abs(ckj[3] * αkjjl[3, 2] + ckj[4] * αkjjl[4, 2] - 1 / 2) < tol
+    else
+        # tableaus without the extra noise coefficients cannot satisfy conditions 33-38;
+        # previously these entries were left undefined (uninitialized memory)
+        conditions[33:38] .= false
     end
     # deterministic fourth order
     conditions[39] = abs(dot(c0, α00 * α00 * (α00 * e)) - 1 / 24) < tol


### PR DESCRIPTION
> [!NOTE]
> **This PR should be ignored until reviewed by @ChrisRackauckas.**

Fixes the six StochasticDiffEq* `[QA] / Julia 1 / Tests - QA` sublibrary CI jobs that currently fail on every branch that touches `lib/OrdinaryDiffEqCore` (e.g. run [29058475133](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/29058475133), and identically on unrelated branches): **StochasticDiffEqCore, StochasticDiffEqLowOrder, StochasticDiffEqMilstein, StochasticDiffEqROCK, StochasticDiffEqRODE, StochasticDiffEqWeak**.

## When did these start failing?

They have never been green: the Core/Milstein/ROCK/Weak QA jobs fail all the way back to the run that introduced the per-sublib QA groups (#3738, run [27541105218](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/27541105218)) — the findings (Aqua ambiguities/piracy, JET reports) were imported with the StochasticDiffEq monorepo merge and were exercised only once the QA lanes were added. The RODE/LowOrder jobs *were* green as recently as #3788's run (Jun 28) and started erroring when upstream releases (SciMLBase/DiffEqBase public-API declarations, compat floor bump #3828) flipped their `ei_broken` ExplicitImports checks from Broken to **Unexpected Pass**.

## Per-sublibrary root cause and fix

### StochasticDiffEqCore — Aqua ambiguity (3) + Aqua piracy (66 methods) + JET (5 reports)

- **Ambiguities**: `resize_non_user_cache!`/`deleteat_non_user_cache!`/`addat_non_user_cache!` `(::SDEIntegrator, cache, i)` were ambiguous with OrdinaryDiffEqCore's `(::ODEIntegrator, ::CompositeCache, i)` methods. Added the three disambiguating `(::SDEIntegrator, ::CompositeCache, i)` methods; the SDE bodies ignore `cache` (they operate on noise/rate caches), so the composite forms share the general bodies via `_sde_*` helpers. (SDE integrators use `StochasticCompositeCache`, never `OrdinaryDiffEqCore.CompositeCache`, so the intersection is vacuous at runtime — the methods exist purely to resolve dispatch.)
- **Piracy**: every flagged method dispatches on the SDE/RODE/Jump algorithm & cache supertypes (`StochasticDiffEqAlgorithm`, `StochasticDiffEqRODEAlgorithm`, `StochasticDiffEqCache`, …) that are *declared* in OrdinaryDiffEqCore purely as hooks for the StochasticDiffEq family, or implements OrdinaryDiffEqCore's noise/init hooks (`accept_noise!`, `save_noise!`, `reject_noise!`, `reinit_noise!`, `noise_curt`, `is_noise_saveable`, `_initialize_dae!` — all declared upstream with `::Nothing` fallbacks or as loop hooks precisely so this package can implement them). This is intended monorepo design, not piracy, so the qa.jl now passes an explicit, documented `treat_as_own` list to Aqua (`aqua_kwargs = (; piracies = (; treat_as_own = …))`). No blanket disables — the piracy check still runs and would catch any *new* piracy on genuinely foreign types. **Flagging for review**: if you'd rather move the supertype declarations into StochasticDiffEqCore itself (making it the literal owner), that is the deeper fix; `treat_as_own` documents the current intent without a restructuring.
- **JET**: in `_sde_init`, the `Union{Nothing, Bool}` alias-specifier fields (`alias_jumps`/`alias_f`/`alias_p`/`alias_u0`) were read twice (`isnothing(aliases.x) || aliases.x`), which inference cannot narrow — hoisted each read into a local. The `alg_cache` call was statically unresolvable for `StochasticDiffEqRODEAlgorithm` (concrete `alg_cache` methods live in the solver subpackages) — added a generic fallback that throws a descriptive `ArgumentError` instead of a `MethodError`.

### StochasticDiffEqMilstein — JET (15 reports)

- `perform_step!(_, ::RKMilGeneralConstantCache)`: `K` was assigned only inside branches but used by the adaptive error estimate — hoisted the (identical) `K = @.. uprev + dt * du1` above the branch and renamed the unrelated loop-local to `Ktmp`. Pure code movement.
- `_compute_II_from_S2`/`_compute_II_from_grid`: `for k in 1:m` loops where inference widens `m` to `Union{Integer, AbstractUnitRange}` — switched to `axes(I, 1)`/`axes(I, 2)` (identical iteration space, `I = zeros(T, m, m)`), and gave `_compute_iterated_I` a `length(dW)::Int` assert.

### StochasticDiffEqROCK — JET + ei_broken Unexpected Pass

- **JET (~50 reports in `SROCK_perform_step.jl`)**: SROCK1's Stratonovich `α`/`γ`/`β` scalars are now computed unconditionally (cheap, pure) instead of under a conditional correlated with their later uses; SROCK2/KomBurSROCK2's `vec_χ` draw moved inside the general-noise branch that consumes it (identical guard condition and RNG stream — `W.rng` is not consumed in between); TangXiaoSROCK2's `uᵢ`/`uᵢ₋₁`/`uₓ` rotation variables get their `uprev` starting values up front and `WikJ` became a single ternary assignment.
- **Real bugs found by JET** (previously guaranteed `UndefVarError` at runtime): `perform_step!(_, ::SKSROCKConstantCache)` with `post_processing = true` referenced `ccache`, which only exists in the mutable-cache method — fixed to `cache` (the constant-cache method's cache *is* the constant cache); `perform_step!(_, ::KomBurSROCK2Cache)` used `WikRange` without destructuring it from the cache (the field exists — mirror of TangXiaoSROCK2Cache).
- **ei_broken**: dropped the now-passing `:all_qualified_accesses_are_public` (Unexpected Pass), same as RODE/LowOrder.
- **Out of scope, found during verification**: `KomBurSROCK2` out-of-place with general (non-diagonal) noise throws `DimensionMismatch` (`Xₛ₋₂ .+= Gₛ .* WikRange` broadcasts an `n×m` matrix against an `m`-vector). Verified to fail identically on unmodified master, so it is pre-existing and untouched here; being filed as a separate issue since the intended math needs a check against the Komori–Burrage paper.

### StochasticDiffEqWeak — JET

- **Correlated-conditional restructures** (pure code movement; the moved `_dZ` construction is a deterministic `map` over the already-sampled `W.dZ`, so RNG streams are unchanged): hoisted `m = length(W.dW)` unconditionally and moved `_dZ`/`H22`/`H23` construction into the single vector-noise branch that consumes them, across the DRI1/RI1/RI3/RI5/RS1/RS2, IRI1 (implicit), and NON/NON2 constant-cache `perform_step!` methods; `checkNONOrder` now destructures each tableau type's extra fields inside the branch that uses them.
- **Real bugs found by JET** (each previously a guaranteed `UndefVarError`/crash on its path):
  - DRI1ConstantCache, non-diagonal `H22`/`H23` construction: undefined `l` → `k` (the in-place implementation of the same tableau update uses per-`k` views `g1[:, k]`, `g2[k][:, k]`, `g3[k][:, k]`).
  - RDI1WMConstantCache: `m` was never defined but used as a loop bound.
  - SIESMECache scalar path: `chi1[k]` with undefined `k` → `chi1` (scalar).
  - NONConstantCache scalar path: `Y1jj`…`Y4jj` were undefined names; defined from the `[1, 1]` stage values, matching the branch's existing `Y1jajb[1]` scalar-indexing convention.
  - NON2ConstantCache: the `Ihat2` iterated-integral matrix was assigned to lowercase `ihat2` but *written* into `Ihat2` — the *function* of that name — a case typo; a local matrix is now built in the branch that consumes it.
  - `checkNONOrder`: `conditions[33:38]` were read uninitialized (`Vector{Bool}(undef, 44)`) for tableaus that are neither `KomoriNON` nor `KomoriNON2`; now set explicitly.
  - IRI1ConstantCache/IRI1Cache: the `nlsolver` type parameter is now constrained to `OrdinaryDiffEqCore.AbstractNLSolver`, making the `nlsolve!` call statically resolvable.

### StochasticDiffEqRODE / StochasticDiffEqLowOrder — ei_broken Unexpected Pass

Upstream now declares the relevant names public, so `all_qualified_accesses_via_owners` (RODE) and `all_qualified_accesses_are_public` (LowOrder, ROCK) pass and SciMLTesting's auto-flagging `ei_broken` machinery correctly demands promotion: removed exactly those entries from the `ei_broken` tuples (the remaining entries are still genuinely broken and untouched).

## Verification (all local, Julia 1.12.6 = CI's "Julia 1")

QA group (`ODEDIFFEQ_TEST_GROUP=QA`) for each sublibrary:

```
StochasticDiffEqCore      QA (Aqua and JET) |   18            18  (was: 15 passed, 3 failed — ambiguity + piracy + JET)
StochasticDiffEqMilstein  QA (Aqua and JET) |   14  4 broken  18  (was: 13 passed, 1 failed — JET)
StochasticDiffEqROCK      QA (Aqua and JET) |   14  4 broken  18  (was: 12 passed, 1 failed, 1 errored — JET + Unexpected Pass)
StochasticDiffEqRODE      QA (Aqua and JET) |   15  3 broken  18  (was: 14 passed, 1 errored — Unexpected Pass)
StochasticDiffEqLowOrder  QA (Aqua and JET) |   15  3 broken  18  (was: 14 passed, 1 errored — Unexpected Pass)
StochasticDiffEqWeak      QA (Aqua and JET) |   13  5 broken  18  (was: 12 passed, 1 failed — JET)

(0 Fail / 0 Error everywhere; the Broken entries are the remaining curated
ei_broken ExplicitImports markers, unchanged where still genuinely broken.)
```

Core test groups (`ODEDIFFEQ_TEST_GROUP=Core`):

```
StochasticDiffEqCore      Module loads and types        | 13/13
StochasticDiffEqMilstein  Module loads and constructors |  7/7
StochasticDiffEqROCK      Module loads and constructors |  7/7
StochasticDiffEqWeak      Module loads and constructors | 23/23
```

Functional smoke tests through the umbrella `lib/StochasticDiffEq` (local path sources), exercising every touched numerical path — RKMilGeneral (scalar/diagonal/non-diagonal × oop/ip × adaptive/fixed, accuracy vs. analytical solution), SROCK1 (Ito + Stratonovich), SKSROCK with `post_processing = true` (previously guaranteed `UndefVarError: ccache`), DRI1 diagonal + non-diagonal (previously guaranteed `UndefVarError: l`, plus a 2000-trajectory weak-mean accuracy check), RDI1WM with vector noise (previously guaranteed `UndefVarError: m`), and `resize!` + `step!` on plain and `StochasticCompositeAlgorithm` SDE integrators (the disambiguated methods):

```
Test Summary: | Pass  Total   Time
Smoke         |   30     30  44.6s
SMOKE OK
```

Note on the `lts` rows in `test_groups.toml`: current Sublibrary CI runs no lts QA jobs (checked the latest master run — zero `lts` jobs), and on Julia 1.10 the per-sublib `test/qa` environments resolve the *registered* packages because path `[sources]` requires Pkg ≥ 1.11, so a local 1.10 QA run does not exercise this branch's code at all. The failing lane this PR targets (and verifies against) is Julia 1 = 1.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uzZhKZV2ameiUL8ouYknd
