### PR TITLE
Use targeted monorepo TagBot routing

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -2,12 +2,13 @@ name: TagBot
 
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
   workflow_dispatch:
     inputs:
-      lookback:
-        default: "3"
+      package:
+        description: "Package name to tag; empty audits every package"
+        required: false
+        type: string
 
 permissions:
   actions: read
@@ -24,83 +25,8 @@ permissions:
   statuses: read
 
 jobs:
-  TagBot-OrdinaryDiffEq:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Tag OrdinaryDiffEq
-        uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
-
-  TagBot-Subpackages:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        package:
-          - DelayDiffEq
-          - DiffEqBase
-          - DiffEqDevTools
-          - ImplicitDiscreteSolve
-          - OrdinaryDiffEqAMF
-          - OrdinaryDiffEqAdamsBashforthMoulton
-          - OrdinaryDiffEqBDF
-          - OrdinaryDiffEqCore
-          - OrdinaryDiffEqDefault
-          - OrdinaryDiffEqDifferentiation
-          - OrdinaryDiffEqExplicitRK
-          - OrdinaryDiffEqExplicitTableaus
-          - OrdinaryDiffEqExponentialRK
-          - OrdinaryDiffEqExtrapolation
-          - OrdinaryDiffEqFIRK
-          - OrdinaryDiffEqFeagin
-          - OrdinaryDiffEqFunctionMap
-          - OrdinaryDiffEqHighOrderRK
-          - OrdinaryDiffEqIMEXMultistep
-          - OrdinaryDiffEqImplicitTableaus
-          - OrdinaryDiffEqLinear
-          - OrdinaryDiffEqLowOrderRK
-          - OrdinaryDiffEqLowStorageRK
-          - OrdinaryDiffEqMultirate
-          - OrdinaryDiffEqNewmark
-          - OrdinaryDiffEqNonlinearSolve
-          - OrdinaryDiffEqNordsieck
-          - OrdinaryDiffEqPDIRK
-          - OrdinaryDiffEqPRK
-          - OrdinaryDiffEqQPRK
-          - OrdinaryDiffEqRKIP
-          - OrdinaryDiffEqRKN
-          - OrdinaryDiffEqRosenbrock
-          - OrdinaryDiffEqRosenbrockTableaus
-          - OrdinaryDiffEqSDIRK
-          - OrdinaryDiffEqSIMDRK
-          - OrdinaryDiffEqSSPRK
-          - OrdinaryDiffEqStabilizedIRK
-          - OrdinaryDiffEqStabilizedRK
-          - OrdinaryDiffEqSymplecticRK
-          - OrdinaryDiffEqTaylorSeries
-          - OrdinaryDiffEqTsit5
-          - OrdinaryDiffEqVerner
-          - SimpleImplicitDiscreteSolve
-          - StochasticDiffEq
-          - StochasticDiffEqCore
-          - StochasticDiffEqHighOrder
-          - StochasticDiffEqIIF
-          - StochasticDiffEqImplicit
-          - StochasticDiffEqLeaping
-          - StochasticDiffEqLevyArea
-          - StochasticDiffEqLowOrder
-          - StochasticDiffEqMilstein
-          - StochasticDiffEqROCK
-          - StochasticDiffEqRODE
-          - StochasticDiffEqWeak
-    steps:
-      - name: Tag ${{ matrix.package }}
-        uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
-          subdir: "lib/${{ matrix.package }}"
+  tagbot:
+    uses: "SciML/.github/.github/workflows/monorepo-tagbot.yml@v1"
+    with:
+      package: "${{ inputs.package }}"
+    secrets: "inherit"


### PR DESCRIPTION
## Summary

- replace the root-plus-57-package TagBot fan-out with the shared targeted monorepo workflow
- route JuliaTagBot registration comments to the single package named by the linked General registry PR
- retain an explicit manual package input and preserve the existing caller token permissions

The current matrix starts 58 TagBot jobs for every registration. Each job performs the full TagBot historical release scan for its package, so a normal registration creates substantial redundant work. The shared resolver validates the registered package against Project.toml and lib/*/Project.toml, then invokes TagBot only for that package. Retry notifications without a registry PR URL and manual runs without a package remain serialized full audits.

## Dependency

Resolved: SciML/.github#111 is merged and published as v1.22.0. The moving v1 tag points to its merge commit, so SciML/.github/.github/workflows/monorepo-tagbot.yml@v1 and the composite resolver are available.

## Local validation

- Pkg.test() with Julia 1.12: passed; final output was Testing OrdinaryDiffEq tests passed after 13,607.79 seconds
- first one-hour and second two-hour attempts ended only at their Bash timeout limits; the four-hour attempt completed with exit code 0
- the full suite ran immediately before a clean, non-overlapping rebase onto two new upstream commits; after rebase, actionlint, YAML parsing, git diff --check, and Runic.jl 1.7.0 all passed
- the central resolver was exercised against General PR 160472 and selected only lib/OrdinaryDiffEqBDF

> Ignore this PR until reviewed by @ChrisRackauckas.