### PR TITLE
Fix DiffEqBase docs dependency

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ImplicitDiscreteSolve = "3263718b-31ed-49cf-8a0f-35a466e8af96"
@@ -35,6 +36,7 @@ OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 OrdinaryDiffEqVerner = "79d7bb75-1356-48c1-b8c0-6832512096c2"
 
 [sources]
+DiffEqBase = {path = "../lib/DiffEqBase"}
 DiffEqDevTools = {path = "../lib/DiffEqDevTools"}
 ImplicitDiscreteSolve = {path = "../lib/ImplicitDiscreteSolve"}
 OrdinaryDiffEqAMF = {path = "../lib/OrdinaryDiffEqAMF"}
@@ -69,6 +71,7 @@ OrdinaryDiffEqTsit5 = {path = "../lib/OrdinaryDiffEqTsit5"}
 OrdinaryDiffEqVerner = {path = "../lib/OrdinaryDiffEqVerner"}
 
 [compat]
+DiffEqBase = "7"
 DiffEqDevTools = "3, 4.0"
 Documenter = "0.27, 1"
 ImplicitDiscreteSolve = "2"


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- declare DiffEqBase as a direct docs dependency
- resolve it from the monorepo subpackage
- constrain the docs environment to DiffEqBase 7

Upstream master commit e1db9b088 added `using DiffEqBase` to `docs/make.jl` without adding DiffEqBase to `docs/Project.toml`. This caused the Documentation check observed on #3866 to fail before Documenter started.

## Verification

- On clean upstream master e1db9b088 with Julia 1.12.6, the exact CI install command exited 0, then `julia --project=docs/ --code-coverage=user docs/make.jl` exited 1 with `Package DiffEqBase not found in current path`.
- With this patch, the exact CI install command exited 0 and resolved local DiffEqBase v7.6.1.
- With this patch, the exact docs build command exited 0 and rendered the documentation.
- Runic.jl v1.7.0: `julia +1.12 --project=.runic -m Runic --check .` exited 0.
- `git diff --check` exited 0.

This PR is intentionally limited to the missing docs-environment dependency.