### PR TITLE
Honor ImplicitEuler first-stage predictor

### DIFF
--- a/lib/OrdinaryDiffEqSDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqSDIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSDIRK"
 uuid = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.8.0"
+version = "2.8.1"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/lib/OrdinaryDiffEqSDIRK/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/alg_utils.jl
@@ -91,8 +91,8 @@ isesdirk(alg::BHR553) = true
 # usually direct. The `hasproperty` fallback is for downstream algorithms that
 # reuse `ESDIRKIMEXCache` (e.g. OrdinaryDiffEqBDF's `ABDF2`, which uses the
 # Implicit Euler tableau as a starter step via `cache.eulercache`) without
-# carrying a `predictor` field of their own — `Predictor.Trivial` matches the
-# zero-seed branch they already take through the `alg isa Union{...}` gates.
+# carrying a `predictor` field of their own. The Implicit Euler bootstrap path
+# detects this fallback separately because BDF methods require a linear seed.
 _predictor(alg) = hasproperty(alg, :predictor) ? alg.predictor : Predictor.Trivial
 
 # The interpolant predictors use the Hermite power form; a method with a custom

--- a/lib/OrdinaryDiffEqSDIRK/src/generic_imex_perform_step.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/generic_imex_perform_step.jl
@@ -94,18 +94,14 @@ end
             @.. broadcast = false ks[1] = dt * integrator.fsalfirst - zs[1]
         end
     else
-        # Implicit first stage requires nlsolve. The IE tableau (E === :ie_dd2)
-        # is the only configuration that reaches this branch (Trapezoid and
-        # the other Newton-SDIRKs all have `explicit_first_stage = true` and
-        # take the `if` arm above), and for IE the linear extrapolant
-        # z = dt·f(uprev) is always the right nlsolve initial guess. Gating
-        # on the tableau (not the calling alg) also covers BDF callers that
-        # reuse the ImplicitEuler ESDIRKIMEXCache as a first-step bootstrap
-        # (e.g. ABDF2 via `cache.eulercache`) — which otherwise would have
-        # fallen through to `zs[1] = 0` and lost their second-order
-        # convergence under the loose NonlinearSolveAlg `iter==1 && ndz<1e-5`
-        # early-exit at small dt.
-        if E === :ie_dd2
+        if E === :ie_dd2 && integrator.success_iter > 0 &&
+                !integrator.reeval_fsal && predictor == Predictor.MaxOrder
+            current_extrapolant!(u, t + dt, integrator)
+            @.. broadcast = false zs[1] = u - uprev
+        elseif E === :ie_dd2 && tab.stage1_extrapolation &&
+                (predictor == Predictor.Linear || !hasproperty(alg, :predictor))
+            # BDF methods reuse this tableau without a predictor field and need
+            # the linear seed to retain their bootstrap convergence order.
             @.. broadcast = false zs[1] = dt * integrator.fsalfirst
         else
             zs[1] .= zero(eltype(zs[1]))
@@ -1380,8 +1376,12 @@ end
             z1 = dt * integrator.fsalfirst
         end
     else
-        # See matching branch in `_perform_step_iip!` above.
-        if E === :ie_dd2
+        if E === :ie_dd2 && integrator.success_iter > 0 &&
+                !integrator.reeval_fsal && predictor == Predictor.MaxOrder
+            current_extrapolant!(u, t + dt, integrator)
+            z1 = u - uprev
+        elseif E === :ie_dd2 && tab.stage1_extrapolation &&
+                (predictor == Predictor.Linear || !hasproperty(alg, :predictor))
             z1 = dt * integrator.fsalfirst
         else
             z1 = zero(u)

--- a/lib/OrdinaryDiffEqSDIRK/test/predictor_tests.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/predictor_tests.jl
@@ -29,6 +29,39 @@ predictors = [
     end
 end
 
+@testset "ImplicitEuler first-stage predictor" begin
+    for isinplace in (false, true)
+        calls = Float64[]
+        if isinplace
+            function f!(du, u, p, t)
+                eltype(u) === Float64 && push!(calls, u[1])
+                du[1] = 2u[1] - u[1]^2 + 2
+                return nothing
+            end
+            local_prob = ODEProblem(f!, [0.0], (0.0, 1.0))
+        else
+            function f(u, p, t)
+                u isa Float64 && push!(calls, u)
+                return 2u - u^2 + 2
+            end
+            local_prob = ODEProblem(f, 0.0, (0.0, 1.0))
+        end
+
+        solve(
+            local_prob, ImplicitEuler(predictor = Predictor.Trivial);
+            adaptive = false, dt = 1.0
+        )
+        @test calls[1:2] == [0.0, 0.0]
+
+        empty!(calls)
+        solve(
+            local_prob, ImplicitEuler(predictor = Predictor.Linear);
+            adaptive = false, dt = 1.0
+        )
+        @test calls[1:2] == [0.0, 2.0]
+    end
+end
+
 # deprecated `extrapolant` keyword still maps onto a predictor
 @testset "extrapolant deprecation" begin
     @test ImplicitEuler(extrapolant = :linear).predictor == Predictor.Linear


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- honor `Predictor.Trivial`, `Predictor.Linear`, and `Predictor.MaxOrder` when seeding the implicit first stage of direct `ImplicitEuler` solves
- retain the linear seed for BDF algorithms that reuse the Implicit Euler tableau without exposing a predictor field
- add in-place and out-of-place regression coverage
- bump OrdinaryDiffEqSDIRK to v2.8.1

## Investigation

PositiveIntegrators downstream failed at `test/runtests.jl:1037` for the stratospheric PDS with `ImplicitEuler(predictor = Predictor.Trivial)`: 125363 passed / 1 failed in [run 29112034545](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/29112034545/job/86426426040).

A clean `git bisect` identified `67d9cd21942832c7da48044714d771ca7cc78183` (#3694) as the first bad commit. That change made the IE-tableau path always use the linear `dt * fsalfirst` seed, overriding the public predictor selection. This targeted fix restores the pre-regression direct-IE semantics without changing the global `NLNewton` tolerance discussed in #3855, and preserves #3694's ABDF2 bootstrap behavior.

## Local verification (Julia 1.10.11)

- exact PositiveIntegrators stratospheric reproducer: all three solves had 30426 saved steps; both pairwise `isapprox` checks passed
- `Pkg.test()` for OrdinaryDiffEqSDIRK with the QA group excluded because of the independently reproduced master QA-environment leak: 57 tableau, 109 predictor, 102 convergence (+2 pre-existing broken), and 8 DAE tests passed
- ABDF2 and ABDF2 + NLFunctional convergence orders remained approximately 1.99 for final, L2, and Linf norms
- Runic v1.7.0 `--check` passed on all changed Julia files

The full PositiveIntegrators downstream suite passed locally: 125364/125364; see the follow-up comment for exact output.