### PR TITLE
Restore SDIRK test environment after QA setup

### DIFF
--- a/lib/OrdinaryDiffEqSDIRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/runtests.jl
@@ -4,8 +4,10 @@ using SafeTestsets
 const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
 
 function activate_qa_env()
+    test_project = Base.active_project()
     Pkg.activate(joinpath(@__DIR__, "qa"))
-    return Pkg.instantiate()
+    Pkg.instantiate()
+    return Pkg.activate(dirname(test_project))
 end
 
 # Run QA tests (AllocCheck, JET, Aqua) - skip on pre-release Julia

--- a/lib/OrdinaryDiffEqSDIRK/test/tableau_consistency_tests.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/tableau_consistency_tests.jl
@@ -1,6 +1,8 @@
 using OrdinaryDiffEqSDIRK
 using Test
 
+@test pkgdir(OrdinaryDiffEqSDIRK) == dirname(@__DIR__)
+
 const SDIRK = OrdinaryDiffEqSDIRK
 
 all_algs = [


### PR DESCRIPTION
## Summary

- preserve and restore the temporary Pkg.test project around SDIRK QA-environment setup
- assert that functional tests load OrdinaryDiffEqSDIRK from the package-under-test directory

## Cause

On Julia 1.10, activating test/qa left that project active. Its resolution selected registered OrdinaryDiffEqSDIRK v2.7.1, so subsequent functional safetestsets did not test the local v2.8.0 package and failed on ESDIRK325L2SA.

## Bisect

- good: 661f60563; full OrdinaryDiffEqSDIRK Pkg.test passed
- first bad: 4a4f41f3a; exact test failed after test/qa selected v2.7.1

The first-bad commit added ESDIRK325L2SA and made the older latent environment leak observable.

## Validation

- Julia 1.10.11: timeout 7200 julia +1.10 --color=yes --project=lib/OrdinaryDiffEqSDIRK -e "using Pkg; Pkg.test()" — passed (tableau 58/58, predictors 105/105, convergence 102/102 plus two pre-existing broken markers, DAE 8/8)
- Runic 1.7.0 --check . — passed before and after rebase
- post-rebase environment regression — passed 57/57 tableau checks and loaded SDIRK from the local package directory

The full package test ran immediately before clean rebases over upstream 950e4d8ed and 521923a2b. The latter only raises the SDIRK OrdinaryDiffEqCore compat floor to 4.6, which is the same Core 4.6.0 resolved by the full passing run.

Ignore this PR until it has been reviewed by @ChrisRackauckas.