### PR TITLE
Respect ImplicitEuler predictor in IE tableau bootstrap

### DIFF
--- a/lib/OrdinaryDiffEqSDIRK/src/generic_imex_perform_step.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/generic_imex_perform_step.jl
@@ -101,8 +101,10 @@ end
             current_extrapolant!(u, t + dt, integrator)
             @.. broadcast = false zs[1] = u - uprev
         elseif E === :ie_dd2 && tab.stage1_extrapolation &&
-                (predictor == Predictor.Linear ||
-                 (!(alg isa ImplicitEuler) && predictor == Predictor.Trivial))
+                (
+                predictor == Predictor.Linear ||
+                    (!(alg isa ImplicitEuler) && predictor == Predictor.Trivial)
+            )
             @.. broadcast = false zs[1] = dt * integrator.fsalfirst
         else
             zs[1] .= zero(eltype(zs[1]))
@@ -1383,8 +1385,10 @@ end
             current_extrapolant!(u, t + dt, integrator)
             z1 = u - uprev
         elseif E === :ie_dd2 && tab.stage1_extrapolation &&
-                (predictor == Predictor.Linear ||
-                 (!(alg isa ImplicitEuler) && predictor == Predictor.Trivial))
+                (
+                predictor == Predictor.Linear ||
+                    (!(alg isa ImplicitEuler) && predictor == Predictor.Trivial)
+            )
             z1 = dt * integrator.fsalfirst
         else
             z1 = zero(u)

--- a/lib/OrdinaryDiffEqSDIRK/src/generic_imex_perform_step.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/generic_imex_perform_step.jl
@@ -94,18 +94,15 @@ end
             @.. broadcast = false ks[1] = dt * integrator.fsalfirst - zs[1]
         end
     else
-        # Implicit first stage requires nlsolve. The IE tableau (E === :ie_dd2)
-        # is the only configuration that reaches this branch (Trapezoid and
-        # the other Newton-SDIRKs all have `explicit_first_stage = true` and
-        # take the `if` arm above), and for IE the linear extrapolant
-        # z = dt·f(uprev) is always the right nlsolve initial guess. Gating
-        # on the tableau (not the calling alg) also covers BDF callers that
-        # reuse the ImplicitEuler ESDIRKIMEXCache as a first-step bootstrap
-        # (e.g. ABDF2 via `cache.eulercache`) — which otherwise would have
-        # fallen through to `zs[1] = 0` and lost their second-order
-        # convergence under the loose NonlinearSolveAlg `iter==1 && ndz<1e-5`
-        # early-exit at small dt.
-        if E === :ie_dd2
+        # Preserve ImplicitEuler's requested predictor while keeping the linear
+        # seed for BDF bootstraps that reuse the IE tableau.
+        if E === :ie_dd2 && integrator.success_iter > 0 && !integrator.reeval_fsal &&
+                predictor == Predictor.MaxOrder
+            current_extrapolant!(u, t + dt, integrator)
+            @.. broadcast = false zs[1] = u - uprev
+        elseif E === :ie_dd2 && tab.stage1_extrapolation &&
+                (predictor == Predictor.Linear ||
+                 (!(alg isa ImplicitEuler) && predictor == Predictor.Trivial))
             @.. broadcast = false zs[1] = dt * integrator.fsalfirst
         else
             zs[1] .= zero(eltype(zs[1]))
@@ -1381,7 +1378,13 @@ end
         end
     else
         # See matching branch in `_perform_step_iip!` above.
-        if E === :ie_dd2
+        if E === :ie_dd2 && integrator.success_iter > 0 && !integrator.reeval_fsal &&
+                predictor == Predictor.MaxOrder
+            current_extrapolant!(u, t + dt, integrator)
+            z1 = u - uprev
+        elseif E === :ie_dd2 && tab.stage1_extrapolation &&
+                (predictor == Predictor.Linear ||
+                 (!(alg isa ImplicitEuler) && predictor == Predictor.Trivial))
             z1 = dt * integrator.fsalfirst
         else
             z1 = zero(u)

--- a/lib/OrdinaryDiffEqSDIRK/test/predictor_tests.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/predictor_tests.jl
@@ -29,6 +29,21 @@ predictors = [
     end
 end
 
+@testset "ImplicitEuler stage 1 predictor" begin
+    stiff_prob = ODEProblem((du, u, p, t) -> (du[1] = -1000 * u[1]^3 + sin(t); nothing),
+        [1.0], (0.0, 1.0))
+    sol_trivial = solve(stiff_prob, ImplicitEuler(predictor = Predictor.Trivial);
+        abstol = 1.0e-4, reltol = 1.0e-4, dt = 1.0e-3)
+    sol_linear = solve(stiff_prob, ImplicitEuler(predictor = Predictor.Linear);
+        abstol = 1.0e-4, reltol = 1.0e-4, dt = 1.0e-3)
+
+    @test all(isfinite, sol_trivial.u[end])
+    @test all(isfinite, sol_linear.u[end])
+    @test sol_trivial.t != sol_linear.t
+    ts = range(0.0, 1.0; length = 50)
+    @test maximum(abs, Array(sol_trivial(ts)) .- Array(sol_linear(ts))) < 1.0e-2
+end
+
 # deprecated `extrapolant` keyword still maps onto a predictor
 @testset "extrapolant deprecation" begin
     @test ImplicitEuler(extrapolant = :linear).predictor == Predictor.Linear

--- a/lib/OrdinaryDiffEqSDIRK/test/predictor_tests.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/predictor_tests.jl
@@ -30,12 +30,18 @@ predictors = [
 end
 
 @testset "ImplicitEuler stage 1 predictor" begin
-    stiff_prob = ODEProblem((du, u, p, t) -> (du[1] = -1000 * u[1]^3 + sin(t); nothing),
-        [1.0], (0.0, 1.0))
-    sol_trivial = solve(stiff_prob, ImplicitEuler(predictor = Predictor.Trivial);
-        abstol = 1.0e-4, reltol = 1.0e-4, dt = 1.0e-3)
-    sol_linear = solve(stiff_prob, ImplicitEuler(predictor = Predictor.Linear);
-        abstol = 1.0e-4, reltol = 1.0e-4, dt = 1.0e-3)
+    stiff_prob = ODEProblem(
+        (du, u, p, t) -> (du[1] = -1000 * u[1]^3 + sin(t); nothing),
+        [1.0], (0.0, 1.0)
+    )
+    sol_trivial = solve(
+        stiff_prob, ImplicitEuler(predictor = Predictor.Trivial);
+        abstol = 1.0e-4, reltol = 1.0e-4, dt = 1.0e-3
+    )
+    sol_linear = solve(
+        stiff_prob, ImplicitEuler(predictor = Predictor.Linear);
+        abstol = 1.0e-4, reltol = 1.0e-4, dt = 1.0e-3
+    )
 
     @test all(isfinite, sol_trivial.u[end])
     @test all(isfinite, sol_linear.u[end])


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- restore ImplicitEuler stage-1 predictor semantics for the IE tableau instead of always seeding with the linear `dt * fsalfirst` guess
- keep the linear seed for BDF bootstraps that reuse the IE tableau, preserving the ABDF2/NLStep behavior from #3694
- add a regression test that distinguishes `Predictor.Trivial` from `Predictor.Linear` for ImplicitEuler

## Investigation
- reproduced the PositiveIntegrators downstream failure on current `master` with the stratospheric reaction problem
- clean bisect, skipping resolver-incompatible commits, found `67d9cd21942832c7da48044714d771ca7cc78183` as first bad
- after the fix, the focused PositiveIntegrators reproducer returns `ok12=true ok23=true` with matching step counts `(30426, 30426, 30426)`
- CI `PositiveIntegrators.jl/Downstream/1.10` passed on commit `af4ca8fd6`; follow-up commit `771fa73ec` is Runic formatting only

## Tests
- `JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/.julia_depot_ode_positiveintegrators_master timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=downstream repro_positiveintegrators_stratreac.jl` passed after the code fix and after the Runic formatting follow-up
- `GROUP=Downstream JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/.julia_depot_ode_positiveintegrators_master timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --color=yes --project=downstream -e 'using Pkg; try; Pkg.develop(map(path -> Pkg.PackageSpec(; path = "lib/$(path)"), readdir("./lib"))); Pkg.test(coverage=true); catch err; err isa Pkg.Resolve.ResolverError || rethrow(); @info "Not compatible with this release. No problem." exception=err; exit(0); end'` timed out at 3600s, but reached `downstream/test/runtests.jl:2345`, past the former failing assertion at line 1037
- `JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/.julia_depot_ode_positiveintegrators_master timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit -e 'using Pkg; lib_dir = abspath("lib"); Pkg.develop([PackageSpec(path = abspath(".")), PackageSpec(path = abspath("lib/OrdinaryDiffEqNonlinearSolve")), PackageSpec(path = joinpath(lib_dir, "OrdinaryDiffEqBDF")), PackageSpec(path = joinpath(lib_dir, "OrdinaryDiffEqRosenbrock")), PackageSpec(path = joinpath(lib_dir, "OrdinaryDiffEqSDIRK"))]); Pkg.instantiate(); include("lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/nlstep_tests.jl")'` passed
- `ODEDIFFEQ_TEST_GROUP=Core JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/.julia_depot_ode_positiveintegrators_master timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=lib/OrdinaryDiffEqSDIRK -e 'using Pkg; Pkg.test()'` passed
- `JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/.julia_depot_ode_positiveintegrators_master timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=lib/OrdinaryDiffEqSDIRK -e 'include("lib/OrdinaryDiffEqSDIRK/test/predictor_tests.jl")'` passed after the code fix and after the Runic formatting follow-up
- `JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/.julia_depot_ode_positiveintegrators_master timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=.runic_tmp_env -e 'using Runic; exit(Runic.main(["--check", "lib/OrdinaryDiffEqSDIRK/src/generic_imex_perform_step.jl", "lib/OrdinaryDiffEqSDIRK/test/predictor_tests.jl"]))'` passed after the Runic formatting follow-up
- `JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/.julia_depot_ode_positiveintegrators_master timeout 3600 bash -lc 'git ls-files -z "*.jl" | xargs -0 -n 100 /home/crackauc/.juliaup/bin/julia +1.10 --project=.runic_tmp_env -e '\''using Runic; exit(Runic.main(vcat(["--check"], ARGS)))'\'''` passed after the Runic formatting follow-up
