### PR TITLE
docs: add DiffEqBase to the docs environment (fixes master Documentation build)

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ImplicitDiscreteSolve = "3263718b-31ed-49cf-8a0f-35a466e8af96"
@@ -35,6 +36,7 @@ OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 OrdinaryDiffEqVerner = "79d7bb75-1356-48c1-b8c0-6832512096c2"
 
 [sources]
+DiffEqBase = {path = "../lib/DiffEqBase"}
 DiffEqDevTools = {path = "../lib/DiffEqDevTools"}
 ImplicitDiscreteSolve = {path = "../lib/ImplicitDiscreteSolve"}
 OrdinaryDiffEqAMF = {path = "../lib/OrdinaryDiffEqAMF"}
@@ -69,6 +71,7 @@ OrdinaryDiffEqTsit5 = {path = "../lib/OrdinaryDiffEqTsit5"}
 OrdinaryDiffEqVerner = {path = "../lib/OrdinaryDiffEqVerner"}
 
 [compat]
+DiffEqBase = "7.6.1"
 DiffEqDevTools = "3, 4.0"
 Documenter = "0.27, 1"
 ImplicitDiscreteSolve = "2"


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Problem

Every master `Documentation` run since 2026-07-10 fails with:

```
ERROR: LoadError: ArgumentError: Package DiffEqBase not found in current path.
in expression starting at docs/make.jl:2
```

First failing master run: [29075697752](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/29075697752) on f416901a6; latest: [29116790122](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/29116790122). The last green master run was [29075638654](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/29075638654) on d57dc220a, immediately before.

## Root cause

f416901a6 (#3858) added `using DiffEqBase` to `docs/make.jl` (and `DiffEqBase` to the Documenter `modules` list) but never added DiffEqBase to `docs/Project.toml`.

## Fix

Add DiffEqBase to the docs environment, path-sourced from the vendored `lib/DiffEqBase` like every other in-repo package the docs load. The `[sources]` entry matters: registered DiffEqBase 7.6.1 (registry tree `3696ff4a`) predates the docstrings #3832 added to `lib/DiffEqBase` (tree `2e54d5ee`) that `docs/src/api/diffeqbase.md` now references, so the registry package is not equivalent to the vendored one. (Side observation: #3832 changed `lib/DiffEqBase` source without bumping its version, so vendored 7.6.1 != registered 7.6.1.)

## Verification

Ran the CI docs flow locally on this branch (Julia 1.12.4):

```
julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
julia --project=docs/ docs/make.jl
```

`makedocs` completed and rendered the full site (6.3 MB in `docs/build`), reaching `deploydocs` (deployment skipped locally, as expected). Only pre-existing `warnonly` warnings (missing docstrings / HTML size) remain.

Note: #3867 contains the same `[deps]`/`[compat]` addition bundled inside a large SciMLTesting 2.1 migration, but without the `[sources]` entry. This PR is the minimal fix to unblock master docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuzgQEbwBxi8AqwGnnE4wZ