### PR TITLE
Honor ImplicitEuler first-stage predictor (combines #3870 + #3873, fixes out-of-place MaxOrder)

### DIFF
--- a/lib/OrdinaryDiffEqSDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqSDIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSDIRK"
 uuid = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.8.0"
+version = "2.8.1"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/lib/OrdinaryDiffEqSDIRK/src/OrdinaryDiffEqSDIRK.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/OrdinaryDiffEqSDIRK.jl
@@ -16,7 +16,7 @@ using OrdinaryDiffEqCore: unwrap_alg,
     constvalue,
     trivial_limiter!,
     generic_solver_docstring,
-    _fixup_ad, current_extrapolant!, Predictor,
+    _fixup_ad, current_extrapolant!, current_extrapolant, Predictor,
     isnewton, get_W, set_new_W!, COEFFICIENT_MULTISTEP,
     find_algebraic_vars_eqs
 export Predictor

--- a/lib/OrdinaryDiffEqSDIRK/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/alg_utils.jl
@@ -91,8 +91,10 @@ isesdirk(alg::BHR553) = true
 # usually direct. The `hasproperty` fallback is for downstream algorithms that
 # reuse `ESDIRKIMEXCache` (e.g. OrdinaryDiffEqBDF's `ABDF2`, which uses the
 # Implicit Euler tableau as a starter step via `cache.eulercache`) without
-# carrying a `predictor` field of their own — `Predictor.Trivial` matches the
-# zero-seed branch they already take through the `alg isa Union{...}` gates.
+# carrying a `predictor` field of their own. Those callers report `Trivial`, but
+# the stage-1 seed in `generic_imex_perform_step.jl` re-checks `hasproperty` to
+# give them the linear bootstrap seed that preserves their convergence order,
+# rather than the zero seed a genuine `Trivial` request selects.
 _predictor(alg) = hasproperty(alg, :predictor) ? alg.predictor : Predictor.Trivial
 
 # The interpolant predictors use the Hermite power form; a method with a custom

--- a/lib/OrdinaryDiffEqSDIRK/src/generic_imex_perform_step.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/generic_imex_perform_step.jl
@@ -94,18 +94,27 @@ end
             @.. broadcast = false ks[1] = dt * integrator.fsalfirst - zs[1]
         end
     else
-        # Implicit first stage requires nlsolve. The IE tableau (E === :ie_dd2)
-        # is the only configuration that reaches this branch (Trapezoid and
-        # the other Newton-SDIRKs all have `explicit_first_stage = true` and
-        # take the `if` arm above), and for IE the linear extrapolant
-        # z = dt·f(uprev) is always the right nlsolve initial guess. Gating
-        # on the tableau (not the calling alg) also covers BDF callers that
-        # reuse the ImplicitEuler ESDIRKIMEXCache as a first-step bootstrap
-        # (e.g. ABDF2 via `cache.eulercache`) — which otherwise would have
-        # fallen through to `zs[1] = 0` and lost their second-order
-        # convergence under the loose NonlinearSolveAlg `iter==1 && ndz<1e-5`
-        # early-exit at small dt.
-        if E === :ie_dd2
+        # Implicit first stage requires nlsolve; seed it from the requested
+        # predictor. The IE tableau (E === :ie_dd2) is the only configuration
+        # that reaches this branch — Trapezoid and the other Newton-SDIRKs set
+        # `explicit_first_stage = true` and take the `if` arm above.
+        #
+        # `MaxOrder` extrapolates the previous step's interpolant, available only
+        # once a step has succeeded and outside an fsal reeval; `Linear` uses
+        # z = dt·f(uprev). BDF callers reuse this tableau as a first-step
+        # bootstrap (e.g. ABDF2 via `cache.eulercache`) without a `predictor`
+        # field of their own: `_predictor` reports `Trivial`, but
+        # `!hasproperty(alg, :predictor)` keeps them on the linear bootstrap seed
+        # from #3694 that preserves their convergence order under the loose
+        # NonlinearSolveAlg `iter==1 && ndz<1e-5` early-exit at small dt. A
+        # genuine `Trivial` request from a predictor-carrying alg falls through
+        # to the zero seed.
+        if E === :ie_dd2 && predictor == Predictor.MaxOrder &&
+                integrator.success_iter > 0 && !integrator.reeval_fsal
+            current_extrapolant!(u, t + dt, integrator)
+            @.. broadcast = false zs[1] = u - uprev
+        elseif E === :ie_dd2 && tab.stage1_extrapolation &&
+                (predictor == Predictor.Linear || !hasproperty(alg, :predictor))
             @.. broadcast = false zs[1] = dt * integrator.fsalfirst
         else
             zs[1] .= zero(eltype(zs[1]))
@@ -1380,8 +1389,14 @@ end
             z1 = dt * integrator.fsalfirst
         end
     else
-        # See matching branch in `_perform_step_iip!` above.
-        if E === :ie_dd2
+        # See the matching branch in `_perform_step_iip!` above. `u` is immutable
+        # here (scalar / SVector out-of-place), so the MaxOrder seed uses the
+        # allocating `current_extrapolant` rather than the in-place variant.
+        if E === :ie_dd2 && predictor == Predictor.MaxOrder &&
+                integrator.success_iter > 0 && !integrator.reeval_fsal
+            z1 = current_extrapolant(t + dt, integrator) - uprev
+        elseif E === :ie_dd2 && tab.stage1_extrapolation &&
+                (predictor == Predictor.Linear || !hasproperty(alg, :predictor))
             z1 = dt * integrator.fsalfirst
         else
             z1 = zero(u)

--- a/lib/OrdinaryDiffEqSDIRK/test/predictor_tests.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/predictor_tests.jl
@@ -29,6 +29,68 @@ predictors = [
     end
 end
 
+@testset "ImplicitEuler first-stage predictor seed" begin
+    # The direct ImplicitEuler solve reaches the implicit-first-stage branch of
+    # `generic_imex_perform_step.jl`. The predictor selects the nlsolver's stage-1
+    # initial guess, so recording the argument of every `f` call pins the seed:
+    # `Trivial` guesses z = 0 (first residual at uprev), `Linear` guesses
+    # z = dt*f(uprev) (first residual at uprev + z). The fsal evaluation at uprev
+    # is always the first recorded call.
+    for isinplace in (false, true)
+        calls = Float64[]
+        if isinplace
+            function f!(du, u, p, t)
+                eltype(u) === Float64 && push!(calls, u[1])
+                du[1] = 2u[1] - u[1]^2 + 2
+                return nothing
+            end
+            local_prob = ODEProblem(f!, [0.0], (0.0, 1.0))
+        else
+            function f(u, p, t)
+                u isa Float64 && push!(calls, u)
+                return 2u - u^2 + 2
+            end
+            local_prob = ODEProblem(f, 0.0, (0.0, 1.0))
+        end
+
+        solve(
+            local_prob, ImplicitEuler(predictor = Predictor.Trivial);
+            adaptive = false, dt = 1.0
+        )
+        @test calls[1:2] == [0.0, 0.0]
+
+        empty!(calls)
+        solve(
+            local_prob, ImplicitEuler(predictor = Predictor.Linear);
+            adaptive = false, dt = 1.0
+        )
+        @test calls[1:2] == [0.0, 2.0]
+    end
+end
+
+@testset "ImplicitEuler MaxOrder stage-1 seed" begin
+    # MaxOrder seeds stage 1 from the previous step's interpolant (from step 2 on).
+    # Out-of-place scalar `u` is immutable, so the seed must be built without the
+    # in-place `current_extrapolant!`. The predictor only changes the nlsolver's
+    # initial guess, so the converged trajectory must match `Trivial`.
+    for u0 in (1.0, [1.0])  # scalar out-of-place, then in-place
+        prob = u0 isa Number ?
+            ODEProblem((u, p, t) -> -u, u0, (0.0, 1.0)) :
+            ODEProblem((du, u, p, t) -> (du[1] = -u[1]; nothing), u0, (0.0, 1.0))
+        sol_max = solve(
+            prob, ImplicitEuler(predictor = Predictor.MaxOrder);
+            adaptive = false, dt = 0.01
+        )
+        sol_triv = solve(
+            prob, ImplicitEuler(predictor = Predictor.Trivial);
+            adaptive = false, dt = 0.01
+        )
+        @test all(isfinite, Array(sol_max))
+        @test Array(sol_max) ≈ Array(sol_triv) rtol = 1.0e-6
+        @test Array(sol_max)[end] ≈ exp(-1.0) rtol = 0.02
+    end
+end
+
 # deprecated `extrapolant` keyword still maps onto a predictor
 @testset "extrapolant deprecation" begin
     @test ImplicitEuler(extrapolant = :linear).predictor == Predictor.Linear


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary

Combines and supersedes #3870 and #3873, which were two independent attempts at the same fix. This PR takes the more complete pieces of each and fixes a latent bug present in **both** of them.

- Honor `Predictor.Trivial`, `Predictor.Linear`, and `Predictor.MaxOrder` when seeding the implicit first stage of direct `ImplicitEuler` solves (regressed by #3694, which always used the linear `dt * fsalfirst` seed and ignored the public predictor).
- Retain the linear bootstrap seed for BDF algorithms (e.g. `ABDF2`) that reuse the Implicit Euler tableau via `cache.eulercache` without carrying a `predictor` field — provably identical seed to the current `master`.
- **Fix an out-of-place crash that #3870 and #3873 both introduced:** their `MaxOrder` branch calls the in-place `current_extrapolant!(u, …)`, which throws `MethodError: no method matching fill!(::Float64, ::Float64)` for scalar out-of-place problems (`ImplicitEuler(predictor = Predictor.MaxOrder)` on a scalar `ODEProblem`). This PR uses the non-mutating `current_extrapolant` on the out-of-place path.
- Add regression coverage for all three predictors on both the in-place and out-of-place paths, including the previously-untested `MaxOrder` seed.
- Bump OrdinaryDiffEqSDIRK to v2.8.1.

## Relationship to #3870 and #3873

| | #3870 | #3873 | this PR |
|---|---|---|---|
| Version bump | ✅ 2.8.1 | ❌ | ✅ 2.8.1 |
| Linear-seed gating | `!hasproperty(alg, :predictor)` | `!(alg isa ImplicitEuler) && Trivial` | `!hasproperty(alg, :predictor)` |
| `_predictor` comment refreshed | ✅ | ❌ | ✅ |
| Out-of-place `MaxOrder` | ❌ crashes on scalars | ❌ crashes on scalars | ✅ fixed (non-mutating) |
| `MaxOrder` test coverage | ❌ | ❌ | ✅ |

The `!hasproperty(alg, :predictor)` gate (from #3870) is preferred over #3873's `!(alg isa ImplicitEuler) && predictor == Predictor.Trivial`: it mirrors `_predictor`'s own logic (the single source of truth for "does this alg participate in the predictor system") and does not hard-code `ImplicitEuler` as the only predictor-carrying algorithm, so a future predictor-aware SDIRK method routed through the IE tableau would still honor an explicit `Trivial` request. On the current codebase the two conditions are behaviorally identical, since the only `predictor`-carrying algorithm reaching this branch is `ImplicitEuler` itself.

## Why the out-of-place fix matters

The stage-2+ predictor ladder already computes the `MaxOrder` guess functionally (a non-mutating Hermite power form). Both prior PRs' stage-1 branch instead reused the in-place `current_extrapolant!`, writing into `u`. That is fine on the in-place path (where `u` is a mutable cache array) but fails on the out-of-place path when `u` is immutable (a scalar or `SVector`). Reproduced on this branch by temporarily restoring the in-place form:

```
ERROR: MethodError: no method matching fill!(::Float64, ::Float64)
```

The default `ImplicitEuler` predictor is `Trivial`, so no existing test exercised the `MaxOrder` stage-1 seed — which is why neither prior PR caught this.

## Local verification (Julia 1.10.11)

Full `Pkg.test()` for OrdinaryDiffEqSDIRK (non-QA groups) on Julia 1.10.11, exit 0 — `Testing OrdinaryDiffEqSDIRK tests passed`:

```
Tableau consistency |   57     57
Stage predictors    |  115    115      # +13 vs master: the new predictor-seed tests
Convergence         |  102  2 broken  104   # the 2 broken are pre-existing @test_broken
DAE tests           |    8      8
```

- `Stage predictors` breakdown: existing `Stage predictors` 102/102, new `ImplicitEuler first-stage predictor seed` 4/4 (Trivial/Linear call-trace, in-place + out-of-place), new `ImplicitEuler MaxOrder stage-1 seed` 6/6 (scalar out-of-place + in-place), `extrapolant deprecation` 3/3.
- Reproduced the out-of-place `MaxOrder` crash with the prior PRs' in-place form (`MethodError: no method matching fill!(::Float64, ::Float64)`) and confirmed this PR's non-mutating form resolves it.
- ABDF2 bootstrap seed is unchanged from `master` by construction: the bootstrap calls `perform_step!(integrator, cache.eulercache, …)` with `alg = ABDF2`, which has no `predictor` field, so `!hasproperty(alg, :predictor)` selects the same linear seed as before. (Confirmed the convergence group, which exercises the IE/ESDIRK path, still passes.)
- Runic v1.x `--check` passed on all changed Julia files.
