### PR TITLE
Fix RKMilGeneral DimensionMismatch for diagonal vector noise (#3863)

### DIFF
--- a/lib/StochasticDiffEqMilstein/src/perform_step/rkmilgeneral.jl
+++ b/lib/StochasticDiffEqMilstein/src/perform_step/rkmilgeneral.jl
@@ -44,9 +44,13 @@ Compute Stratonovich iterated integrals J. Strategy:
 
 4. **Fallback**: Return nothing → legacy path for diagonal/scalar noise.
 """
-function _compute_iterated_I(dt, dW, dZ, W_noise, alg)
-    # Only for non-diagonal vector noise (dW must be a Vector, not Matrix or Number)
+function _compute_iterated_I(dt, dW, dZ, W_noise, alg, is_diagonal)
+    # Only for non-diagonal vector noise (dW must be a Vector, not Matrix or Number).
+    # Diagonal noise also has a vector dW, but the diagonal perform_step! branch treats
+    # J as an element-wise m-vector (½ dW²), not the full m×m matrix returned here, so
+    # defer to the legacy diagonal path — which is exact for diagonal noise anyway.
     dW isa AbstractVector || return nothing
+    is_diagonal && return nothing
 
     m = length(dW)
 
@@ -257,7 +261,9 @@ end
     dW = W.dW
 
     # Try coefficient-based computation first (handles adaptivity + consistency)
-    J = _compute_iterated_I(dt, dW, W.dZ, W, integrator.alg)
+    J = _compute_iterated_I(
+        dt, dW, W.dZ, W, integrator.alg, is_diagonal_noise(integrator.sol.prob)
+    )
     if J === nothing
         # Fallback: legacy LevyArea path (scalar/diagonal/commutative noise)
         J = get_iterated_I(
@@ -332,7 +338,9 @@ end
     Jalg = cache.Jalg
 
     # Try coefficient-based computation first
-    J_coeffs = _compute_iterated_I(dt, dW, W.dZ, W, integrator.alg)
+    J_coeffs = _compute_iterated_I(
+        dt, dW, W.dZ, W, integrator.alg, is_diagonal_noise(integrator.sol.prob)
+    )
     if J_coeffs !== nothing
         Jalg.J .= J_coeffs
     else

--- a/lib/StochasticDiffEqMilstein/test/runtests.jl
+++ b/lib/StochasticDiffEqMilstein/test/runtests.jl
@@ -20,6 +20,59 @@ if TEST_GROUP == "ALL" || TEST_GROUP == "Core"
         @test WangLi3SMil_E() isa StochasticDiffEqAlgorithm
         @test WangLi3SMil_F() isa StochasticDiffEqAlgorithm
     end
+
+    @time @safetestset "RKMilGeneral diagonal vector noise (issue #3863)" begin
+        using StochasticDiffEqMilstein
+        using StochasticDiffEqMilstein.SciMLBase
+        using LinearAlgebra, Test
+
+        # Reproduction from the issue: diagonal-noise vector problem crashed with a
+        # DimensionMismatch because _compute_iterated_I returned a full m×m matrix
+        # while the diagonal perform_step! branch expects an element-wise m-vector.
+        f_lin(u, p, t) = 1.01 .* u
+        g_lin(u, p, t) = 0.87 .* u
+        prob = SDEProblem(f_lin, g_lin, [0.5, 0.25], (0.0, 1.0))
+        sol = solve(prob, RKMilGeneral(), seed = UInt64(7))
+        @test SciMLBase.successful_retcode(sol)
+
+        # In-place diagonal path must work too and match the out-of-place result
+        # at a fixed dt (identical noise realization).
+        f_iip(du, u, p, t) = (du .= 1.01 .* u)
+        g_iip(du, u, p, t) = (du .= 0.87 .* u)
+        prob_iip = SDEProblem(f_iip, g_iip, [0.5, 0.25], (0.0, 1.0))
+        for seed in (UInt64(7), UInt64(42))
+            s_oop = solve(prob, RKMilGeneral(); dt = 1 // 2^8, adaptive = false, seed = seed)
+            s_iip = solve(prob_iip, RKMilGeneral(); dt = 1 // 2^8, adaptive = false, seed = seed)
+            @test SciMLBase.successful_retcode(s_oop)
+            @test SciMLBase.successful_retcode(s_iip)
+            @test s_oop.u[end] ≈ s_iip.u[end] rtol = 1.0e-10
+        end
+
+        # Strong order ≈ 1.0 against the exact geometric-Brownian-motion solution,
+        # evaluated on the solver's own realized Brownian path.
+        mu = [1.01, -0.5]; sigma = [0.87, 0.3]; u0 = [0.5, 0.25]
+        fg(u, p, t) = mu .* u
+        gg(u, p, t) = sigma .* u
+        gbm = SDEProblem(fg, gg, u0, (0.0, 1.0))
+        function strong_error(dt; ntraj = 200)
+            total = 0.0
+            for k in 1:ntraj
+                sol = solve(
+                    gbm, RKMilGeneral(); dt = dt, adaptive = false,
+                    seed = UInt64(1000 + k), save_noise = true
+                )
+                WT = sol.W.W[end]
+                exact = u0 .* exp.((mu .- sigma .^ 2 ./ 2) .* 1.0 .+ sigma .* WT)
+                total += norm(sol.u[end] .- exact)
+            end
+            return total / ntraj
+        end
+        e_coarse = strong_error(1 // 2^4)
+        e_fine = strong_error(1 // 2^8)
+        @test e_fine < e_coarse
+        order = log2(e_coarse / e_fine) / log2((1 // 2^4) / (1 // 2^8))
+        @test order > 0.8
+    end
 end
 
 # Run QA tests (Aqua, JET) - skip on pre-release Julia


### PR DESCRIPTION
Fixes #3863.

> **Please ignore until reviewed by @ChrisRackauckas.**

## Problem

`RKMilGeneral` crashed with `DimensionMismatch` on diagonal-noise **vector** problems whenever the coefficient/S₂/grid iterated-integral path was taken (adaptive solves, `NoiseWrapper`/`NoiseGrid` sub-grids, or fresh steps with unpacked `dZ` coefficients). Minimal reproduction from the issue:

```julia
using StochasticDiffEq
f_lin(u, p, t) = 1.01 * u
g_lin(u, p, t) = 0.87 * u
prob = SDEProblem(f_lin, g_lin, [0.5, 0.25], (0.0, 1.0))
solve(prob, RKMilGeneral(), seed = UInt64(7))   # ERROR: DimensionMismatch
```

## Root cause

`_compute_iterated_I` gated on `dW isa AbstractVector`, which is *also* true for diagonal noise. It then returned the full `m×m` iterated-integral matrix `J`. But the diagonal branch of `perform_step!` treats `J` as an element-wise `m`-vector (`ggprime .* J` / `@.. u = K + L*dW + ggprime*J`), so an `m×m` matrix broadcasts to `m×m` and blows up downstream.

The function's own docstring already says it is "only for non-diagonal vector noise" — the `dW isa AbstractVector` check was simply insufficient to exclude diagonal noise.

## Fix

For diagonal noise the only iterated integral used is the exact `I_ii = ½ dW_i²`; the Lévy-area machinery contributes nothing (off-diagonal entries are unused, and the diagonal is exact regardless of sub-interval decomposition). So `_compute_iterated_I` now takes an `is_diagonal` flag and returns `nothing` for diagonal-noise problems, deferring to the exact legacy diagonal path. Non-diagonal noise is completely unaffected.

## Verification (run locally, Julia 1.10)

- The issue reproduction now solves successfully (`retcode = Success`).
- In-place and out-of-place diagonal solves agree to `rtol = 1e-10` at fixed `dt`.
- Strong error against the exact geometric-Brownian-motion solution (evaluated on the solver's realized Brownian path) converges at **order ≈ 1.06** — correct strong order 1.0 for diagonal Milstein — with errors `0.097 → 0.023 → 0.0051` as `dt` is quartered.
- Non-diagonal (matrix) noise still runs the coefficient path unchanged.

A regression test covering all of the above is added to the `Core` test group; `ODEDIFFEQ_TEST_GROUP=Core Pkg.test()` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)