### PR TITLE
Fix out-of-place PL1WM and RS weak SDE solvers (#3864)

### DIFF
--- a/lib/StochasticDiffEqWeak/src/perform_step/srk_weak.jl
+++ b/lib/StochasticDiffEqWeak/src/perform_step/srk_weak.jl
@@ -582,9 +582,9 @@ end
     if W.dW isa Number
         H12 = uprev + b121 * g1 * _dW
     elseif is_diagonal_noise(integrator.sol.prob)
-        H12 = Vector{typeof(uprev)}[uprev .+ b121 * g1[k] * _dW[k] for k in 1:m]
+        H12 = [uprev .+ b121 * g1[k] * _dW[k] for k in 1:m]
     else
-        H12 = Vector{typeof(uprev)}[uprev .+ b121 * g1[:, k] * _dW[k] for k in 1:m]
+        H12 = [uprev .+ b121 * g1[:, k] * _dW[k] for k in 1:m]
     end
 
     if W.dW isa Number
@@ -597,18 +597,18 @@ end
     if W.dW isa Number
         H13 = uprev + a131 * k1 * dt + b131 * g1 * _dW + b132 * g2 * _dW
     else
-        H13 = [zero(typeof(uprev)) for k in 1:m]
+        H13 = [zero(uprev) for k in 1:m]
         for k in 1:m
             H13[k] += uprev .+ a131 * k1 * dt
             if is_diagonal_noise(integrator.sol.prob)
                 H13[k] += b131 * g1[k] * _dW[k] .+ b132 * g2[k] * _dW[k]
                 for l in 1:m
                     if l != k
-                        H13[k] += b331 * g1[l] * _dW[l] .+ b332 * g2[l][l] * _dW[l]
+                        H13[k] += b331 * g1[l] * _dW[l] .+ b332 * g2[l] * _dW[l]
                     end
                 end
             else
-                H13 += b131 * g1[:, k] * _dW[k] .+ b132 * g2[k][:, k] * _dW[k]
+                H13[k] += b131 * g1[:, k] * _dW[k] .+ b132 * g2[k][:, k] * _dW[k]
                 for l in 1:m
                     if l != k
                         H13[k] += b331 * g1[:, l] * _dW[l] .+ b332 * g2[l][:, l] * _dW[l]
@@ -627,18 +627,18 @@ end
     if W.dW isa Number
         H14 = uprev + a141 * k1 * dt + b141 * g1 * _dW + b142 * g2 * _dW + b143 * g3 * _dW
     else
-        H14 = [zero(typeof(uprev)) for k in 1:m]
+        H14 = [zero(uprev) for k in 1:m]
         for k in 1:m
             H14[k] += uprev .+ a141 * k1 * dt
             if is_diagonal_noise(integrator.sol.prob)
                 H14[k] += b141 * g1[k] * _dW[k] .+ b142 * g2[k] * _dW[k] .+ b143 * g3[k] * _dW[k]
                 for l in 1:m
                     if l != k
-                        H14[k] += b341 * g1[l] * _dW[l] .+ b342 * g2[l][l] * _dW[l]
+                        H14[k] += b341 * g1[l] * _dW[l] .+ b342 * g2[l] * _dW[l]
                     end
                 end
             else
-                H14 += b141 * g1[:, k] * _dW[k] .+ b142 * g2[k][:, k] * _dW[k] .+
+                H14[k] += b141 * g1[:, k] * _dW[k] .+ b142 * g2[k][:, k] * _dW[k] .+
                     b143 * g3[k][:, k] * _dW[k]
                 for l in 1:m
                     if l != k
@@ -671,7 +671,7 @@ end
     else
         H03 += b031 * g1 .* _dW
         for k in 1:m
-            H03 += b032 * g2[k][k] * _dW[k]
+            H03 = H03 .+ b032 * g2[k][k] * _dW[k]
         end
     end
 
@@ -685,8 +685,8 @@ end
     # H^_2^(k) # H^_3^(k)
 
     if !(W.dW isa Number)
-        H22 = [uprev for k in 1:m]
-        H23 = [uprev for k in 1:m]
+        H22 = [copy(uprev) for k in 1:m]
+        H23 = [copy(uprev) for k in 1:m]
         # add inbounds for speed if working properly
         for k in 1:m
             for l in 1:m
@@ -887,8 +887,8 @@ end
 
     if (!(W.dW isa Number) || (m != 1))
         for k in 1:m
-            H22[k] = uprev
-            H23[k] = uprev
+            @.. H22[k] = uprev
+            @.. H23[k] = uprev
         end
         for k in 1:m
             for l in 1:m
@@ -969,11 +969,11 @@ end
             Yp = uprev + k1 * dt + g1 * integrator.sqdt
             Ym = uprev + k1 * dt - g1 * integrator.sqdt
         else
-            Yp = Vector{typeof(uprev)}[
+            Yp = [
                 uprev .+ k1 * dt .+ g1[:, k] * integrator.sqdt
                     for k in 1:m
             ]
-            Ym = Vector{typeof(uprev)}[
+            Ym = [
                 uprev .+ k1 * dt .- g1[:, k] * integrator.sqdt
                     for k in 1:m
             ]
@@ -1102,7 +1102,7 @@ end
     if W.dW isa Number
         integrator.f.g(tmpg1, Yp, p, t)
         integrator.f.g(tmpg2, Ym, p, t)
-        @.. u = u + 1 // 4 * (tmpg1 + tmpg2 + 2 * g1) * _dW + 1 // 4 * (tmpg1 - tmpg2) * chi1[k] / integrator.sqdt #(1.1)
+        @.. u = u + 1 // 4 * (tmpg1 + tmpg2 + 2 * g1) * _dW + (tmpg1 - tmpg2) * chi1 / integrator.sqdt #(1.1)
     else
         if !is_diagonal_noise(integrator.sol.prob) || W.dW isa Number
             # non-diag noise

--- a/lib/StochasticDiffEqWeak/test/runtests.jl
+++ b/lib/StochasticDiffEqWeak/test/runtests.jl
@@ -92,6 +92,12 @@ if TEST_GROUP == "ALL" || TEST_GROUP == "IRI1WeakConvergence"
     end
 end
 
+if TEST_GROUP == "ALL" || TEST_GROUP == "WeakOOPRegression"
+    @time @safetestset "Out-of-place weak SDE regression" begin
+        include("weak_convergence/oop_weak_regression.jl")
+    end
+end
+
 if TEST_GROUP == "ALL" || TEST_GROUP == "WeakAdaptiveCPU"
     @time @safetestset "CPU Weak adaptive" begin
         include("adaptive/sde_weak_adaptive.jl")

--- a/lib/StochasticDiffEqWeak/test/test_groups.toml
+++ b/lib/StochasticDiffEqWeak/test/test_groups.toml
@@ -53,6 +53,10 @@ local_only = true
 versions = ["1"]
 local_only = true
 
+[WeakOOPRegression]
+versions = ["1"]
+local_only = true
+
 [WeakAdaptiveCPU]
 versions = ["1"]
 local_only = true

--- a/lib/StochasticDiffEqWeak/test/weak_convergence/oop_weak_regression.jl
+++ b/lib/StochasticDiffEqWeak/test/weak_convergence/oop_weak_regression.jl
@@ -1,0 +1,88 @@
+"""
+Regression tests for previously-broken out-of-place weak SDE paths.
+
+These exercise the constant-cache (out-of-place) `perform_step!` code paths for
+PL1WM (Itô) and RS1/RS2 (Stratonovich) with multi-dimensional diagonal and
+non-diagonal noise. Every one of these used to error before the fixes:
+
+  * PL1WM / RS `H12`, `Yp`, `Ym` were built with `Vector{typeof(uprev)}[...]`,
+    which wraps the element type one level too deep -> `convert` `MethodError`.
+  * RS `H13`/`H14` non-diagonal updates dropped the per-channel `[k]` index and
+    seeded the stage vectors with `zero(typeof(uprev))` (undefined for arrays).
+  * RS diagonal cross-terms used `g2[l][l]` (scalar) instead of `g2[l]`.
+  * RS `H22`/`H23` aliased `uprev` (`[uprev for k in 1:m]`), so the in-place
+    accumulation corrupted `uprev` itself.
+
+The mean of a linear SDE with diagonal drift `du_i = a_i u_i dt + noise` is known
+in closed form, so we check weak accuracy against it:
+  * Itô (PL1WM):          E[u_i(T)] = u0_i * exp(a_i T)
+  * Stratonovich (RS):    E[u_i(T)] = u0_i * exp((a_i + 1/2 * sum_k b_{i,k}^2) T)
+"""
+
+using StochasticDiffEqWeak
+using Test
+using Random
+import Statistics
+
+const T_END = 1.0
+const U0 = [1.0, 2.0]
+const AVEC = [-0.5, -0.3]                 # diagonal drift coefficients
+# diffusion coefficients b[i, k] = d(noise channel k of component i)/du_i
+const BDIAG = [0.3 0.0; 0.0 0.25]         # diagonal noise (channel k drives only component k)
+const BND = [0.3 0.1; 0.15 0.25]          # non-diagonal noise matrix g(u)[i,k] = b[i,k]*u[i]
+
+ito_mean() = [U0[i] * exp(AVEC[i] * T_END) for i in 1:2]
+function strat_mean(b)
+    return [U0[i] * exp((AVEC[i] + 0.5 * sum(b[i, k]^2 for k in 1:2)) * T_END) for i in 1:2]
+end
+
+# out-of-place problem definitions
+fd(u, p, t) = [AVEC[1] * u[1], AVEC[2] * u[2]]
+gd(u, p, t) = [BDIAG[1, 1] * u[1], BDIAG[2, 2] * u[2]]
+gn(u, p, t) = [BND[1, 1] * u[1] BND[1, 2] * u[1]; BND[2, 1] * u[2] BND[2, 2] * u[2]]
+
+prob_diag = SDEProblem(fd, gd, copy(U0), (0.0, T_END))
+prob_nd = SDEProblem(fd, gn, copy(U0), (0.0, T_END), noise_rate_prototype = zeros(2, 2))
+
+function weak_mean(prob, alg, dt, N)
+    ep = EnsembleProblem(prob)
+    sol = solve(
+        ep, alg, EnsembleThreads(); trajectories = N, dt = dt,
+        save_everystep = false, save_start = false, adaptive = false
+    )
+    us = [sol.u[i].u[end] for i in 1:N]
+    return [Statistics.mean(u[j] for u in us) for j in 1:2]
+end
+
+const N = 60_000
+const DT = 1 // 50
+const TOL = 0.02
+
+@testset "out-of-place weak SDE regression" begin
+    @testset "PL1WM (Itô) out-of-place non-diagonal" begin
+        Random.seed!(20)
+        m = weak_mean(prob_nd, PL1WM(), DT, N)
+        @test all(isfinite, m)
+        @test maximum(abs, m .- ito_mean()) < TOL
+    end
+
+    for alg in (RS1(), RS2())
+        nm = string(nameof(typeof(alg)))
+        @testset "$nm (Stratonovich) out-of-place diagonal" begin
+            u0_before = copy(prob_diag.u0)
+            Random.seed!(20)
+            m = weak_mean(prob_diag, alg, DT, N)
+            @test all(isfinite, m)
+            @test maximum(abs, m .- strat_mean(BDIAG)) < TOL
+            @test prob_diag.u0 == u0_before   # an out-of-place solve must not mutate u0
+        end
+        @testset "$nm (Stratonovich) out-of-place non-diagonal" begin
+            u0_before = copy(prob_nd.u0)
+            Random.seed!(20)
+            m = weak_mean(prob_nd, alg, DT, N)
+            @test all(isfinite, m)
+            @test maximum(abs, m .- strat_mean(BND)) < TOL
+            @test prob_nd.u0 == u0_before
+        end
+    end
+end


### PR DESCRIPTION
> [!NOTE]
> **This PR should be ignored until reviewed by @ChrisRackauckas.**

Fixes the three latent StochasticDiffEqWeak bugs reported in #3864, plus the
cascade of related crashes that were blocking the same out-of-place code paths.

## Background

The out-of-place (constant-cache) `perform_step!` methods for **PL1WM** (Itô) and
**RS1/RS2** (Stratonovich) with *multi-dimensional* noise never ran: every one of
them threw before completing a step, so the bugs #3864 flagged by code-reading sat
behind earlier crashes. The scalar (`u0::Number`) and in-place multi-dimensional
paths were the only ones exercised by the existing (very expensive, `local_only`)
weak-convergence suites, which is why this went unnoticed.

I used the **in-place implementation as the ground-truth reference** (it is the
shipped/tested path) and **validated it against the analytical weak mean** of a
linear SDE with diagonal drift, then aligned the out-of-place path to it:

* Itô (PL1WM):        `E[u_i(T)] = u0_i · exp(a_i · T)`
* Stratonovich (RS):  `E[u_i(T)] = u0_i · exp((a_i + ½ Σ_k b_{i,k}²) · T)`

## Fixes (`lib/StochasticDiffEqWeak/src/perform_step/srk_weak.jl`)

### PL1WM

1. **#3864 bug 1 — oop non-diagonal `MethodError`.** `Yp`/`Ym` (and RS `H12`) were
   built with `Vector{typeof(uprev)}[ … ]`. For `uprev::Vector{Float64}` the element
   type is then `Vector{Vector{Float64}}`, one level too deep, so assigning the
   `Vector{Float64}` stage values threw `convert(Vector{Float64}, ::Float64)`.
   Changed to plain `[ … ]` (matching DRI1), which infers the correct element type.

2. **#3864 bug 2 — iip scalar `1//4` factor.** The scalar in-place update carried a
   spurious `1//4` on the `chi1` term and referenced an undefined `chi1[k]`:
   `… + 1//4 * (tmpg1 - tmpg2) * chi1[k] / sqdt` → `… + (tmpg1 - tmpg2) * chi1 / sqdt`.
   The corrected form is identical to the five sibling paths (oop scalar/diagonal/
   non-diagonal and iip diagonal/non-diagonal), and to the oop scalar path validated
   by weak convergence.
   **Note:** this branch is currently *unreachable* — it requires `W.dW isa Number`
   with an in-place (array) state, in which case `chi1` is allocated as a scalar and
   the branch crashes earlier at `@.. chi1 = W.dW / sqdt` (can't `@..`-assign a
   scalar). Scalar SDEs use the out-of-place path, so this fix is a latent-code
   correction; the scalar-iip allocation crash is a separate pre-existing issue left
   for a follow-up.

### RS1 / RS2 (shared `RSConstantCache` / `RSCache`)

3. **#3864 bug 3 — non-diagonal `H13`/`H14` indexing.** The per-channel updates wrote
   `H13 += …` / `H14 += …` instead of `H13[k] += …` / `H14[k] += …` (the neighbouring
   cross-terms and the in-place path both index by `k`).

4. **#3864 bug 3 — `H22`/`H23` aliasing.** `H22 = [uprev for k in 1:m]` made `m`
   references to the *same* `uprev`. The subsequent `@.. H22[k] = H22[k] + …`
   accumulation mutates its target **in place** (confirmed: `@.. A[k] = A[k] + v`
   with `A[k] === uprev` mutates `uprev`), so it corrupted `uprev` mid-step. Changed
   to `[copy(uprev) for k in 1:m]` (matching DRI1). The in-place cache had the same
   aliasing (`H22[k] = uprev` rebinds the pre-allocated buffer slot to `uprev`);
   changed to `@.. H22[k] = uprev` so the values are copied into the existing buffer
   and the buffers stay distinct from `uprev`.

   This is a genuine behavior bug: a deterministic single-trajectory RS1 step gives
   different results before vs after the fix (e.g. diagonal `[0.4563, 0.7075]` →
   `[0.4615, 0.7071]`). The existing weak-convergence suites passed on master anyway
   because the corruption happened to be ~mean-preserving for their specific test
   problems; the fix keeps the weak order at ≈ 2 (verified below) while removing the
   corruption in general.

5. **Cascade crashes that blocked the above (found while making the paths run):**
   * `H13`/`H14` seeded with `zero(typeof(uprev))` (undefined for array types) →
     `zero(uprev)`.
   * diagonal cross-terms used `g2[l][l]` (a scalar) where the in-place path uses the
     full `g2[l]` vector → aligned to `g2[l]`.
   * diagonal `H03` did `H03 += <scalar>` (a non-broadcast `Vector + Float64`) →
     `H03 = H03 .+ <scalar>` (matching the in-place broadcast).

## Verification (local, Julia 1.11)

Weak means of a 2-D linear SDE (diagonal drift), `N = 1.2e5` trajectories,
`dt = 1//100`, compared to the analytical Itô / Stratonovich means above:

```
                     mean               err
PL1WM diag  -iip     [0.60575, 1.4806]  0.0010   (Itô)
PL1WM diag  -oop     [0.60575, 1.4806]  0.0010
PL1WM ndiag -iip     [0.60589, 1.4809]  0.0007
PL1WM ndiag -oop     [0.60583, 1.4809]  0.0008   <- was MethodError
RS1   diag  -iip     matches Stratonovich mean
RS1   diag  -oop     matches Stratonovich mean   <- was MethodError
RS1   ndiag -iip     matches Stratonovich mean
RS1   ndiag -oop     matches Stratonovich mean    (== iip)  <- was MethodError
```

The existing in-place weak-order suites are unaffected. Re-running the exact
`test_convergence` blocks from `weak_strat.jl` (diagonal iip RS) on the fixed branch:

```
RS1 diagonal iip:  weak order = 1.60   (CI assert |order - 2| < 0.4)  ✓
RS2 diagonal iip:  weak order = 1.98   (CI assert |order - 2| < 0.3)  ✓
```

For the non-diagonal in-place RS case (`weak_strat_non_diagonal.jl`), the fixed and
master codes produce **statistically identical** weak errors at a feasible trajectory
count (`[0.00139, 0.00317, 0.0079]` for both RS1 and RS2, seed-matched) — i.e. the
aliasing fix changes the ensemble weak moments by < 1e-3 here, so it does not regress
that suite. (The order can only be resolved at the CI's 1e8 trajectories; below that
the estimate sits on the Monte-Carlo floor for both master and this branch.)

New regression test `test/weak_convergence/oop_weak_regression.jl` (group
`WeakOOPRegression`, `local_only`) exercises PL1WM oop non-diagonal and RS1/RS2 oop
diagonal + non-diagonal, asserting they run and stay finite, the weak mean matches
the analytical value, and the out-of-place solve leaves `prob.u0` intact. Every one
of these five paths errored on master, so the test fails loudly on the unfixed code.
Passes 14/14.

## Scope / not covered

* The out-of-place fixes for PL1WM and RS are the ones exercised by #3864. Other weak
  solvers were not in scope; a grep for the specific anti-patterns
  (`Vector{typeof(uprev)}[…]`, `zero(typeof(uprev))`, `[uprev for …]`) found no other
  occurrences.
* The PL1WM in-place *scalar* branch remains unreachable (see bug 2 note) — the
  separate `@.. chi1 = …` scalar-allocation crash is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
