### PR TITLE
NonlinearSolveAlg: reuse the ODE WOperator matrix-free for Krylov linsolves

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/src/operators.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/operators.jl
@@ -27,6 +27,11 @@ end
 
 SciMLBase.isinplace(::JVPCache) = true
 ArrayInterface.can_setindex(::JVPCache) = false
+# A JVPCache is genuinely matrix-free: it only implements `mul!` (the DI pushforward), with
+# no `convert(AbstractMatrix, ·)`. Report that honestly so a `WOperator` wrapping one is
+# itself matrix-free and consumers (e.g. NonlinearSolve) route it to a matrix-free linear
+# solver instead of trying to factorize it.
+SciMLOperators.isconvertible(::JVPCache) = false
 function ArrayInterface.restructure(y::JVPCache, x::JVPCache)
     @assert size(y) == size(x) "cannot restructure operators. ensure their sizes match."
     return x

--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -38,6 +38,7 @@ OrdinaryDiffEqFIRK = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
+SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
@@ -83,7 +84,7 @@ SciMLOperators = "1.24.3"
 ConstructionBase = "1.5.8"
 
 [targets]
-test = ["DiffEqDevTools", "LineSearches", "ODEProblemLibrary", "OrdinaryDiffEqBDF", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "Random", "SafeTestsets", "StaticArrays", "Statistics", "Test", "Pkg", "SciMLTesting"]
+test = ["DiffEqDevTools", "LineSearches", "ODEProblemLibrary", "OrdinaryDiffEqBDF", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "Random", "SafeTestsets", "SparseConnectivityTracer", "StaticArrays", "Statistics", "Test", "Pkg", "SciMLTesting"]
 
 [sources.OrdinaryDiffEqDifferentiation]
 path = "../OrdinaryDiffEqDifferentiation"

--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.2.0"
+version = "2.3.0"
 
 [deps]
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
@@ -79,7 +79,7 @@ ODEProblemLibrary = "1"
 PreallocationTools = "1.1.2"
 DiffEqBase = "7"
 SafeTestsets = "0.1.0"
-SciMLOperators = "1.23"
+SciMLOperators = "1.24.3"
 ConstructionBase = "1.5.8"
 
 [targets]

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
@@ -30,7 +30,7 @@ using ForwardDiff: Dual
 using RecursiveArrayTools: recursivecopy!
 import OrdinaryDiffEqCore
 
-import SciMLOperators: islinear, AbstractSciMLOperator
+import SciMLOperators: islinear, AbstractSciMLOperator, MatrixOperator
 import OrdinaryDiffEqCore: nlsolve_f, set_new_W!, set_W_γdt!
 
 import OrdinaryDiffEqCore: default_nlsolve

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -121,17 +121,12 @@ function initialize!(
             nlp_params = (tmp, ustep, γ, α, tstep, k, invγdt, method, p, dt, f)
         end
         if length(cache.cache.u) != length(z)
-            new_prob = if cache.W !== nothing && cache.prob.f.jac isa WReuseJac
-                # Concrete reuse: point the WReuseJac at the resized W and give the
-                # NonlinearFunction a matching jac_prototype. Both keep their types (only
-                # array sizes change), so cache.prob's concrete type is preserved.
-                cache.prob.f.jac.W[] = cache.W
-                new_f = SciMLBase.remake(cache.prob.f; jac_prototype = similar(cache.W))
-                SciMLBase.remake(cache.prob; f = new_f, u0 = copy(z), p = nlp_params)
-            elseif cache.W !== nothing
-                # Matrix-free reuse: the operator is resized by the integrator's resize!
-                # machinery; just re-point the jac_prototype at it.
-                new_f = SciMLBase.remake(cache.prob.f; jac_prototype = cache.W)
+            new_prob = if cache.W !== nothing
+                # W-reuse: re-point the operator `jac_prototype` at the resized W via the same
+                # mapping used at build time. Only array sizes change, so the operator's type
+                # — and hence `cache.prob`'s concrete type — is preserved and `init` stays
+                # type-stable.
+                new_f = SciMLBase.remake(cache.prob.f; jac_prototype = reuse_jac_prototype(cache.W))
                 SciMLBase.remake(cache.prob; f = new_f, u0 = copy(z), p = nlp_params)
             else
                 SciMLBase.remake(cache.prob; u0 = copy(z), p = nlp_params)

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -121,7 +121,16 @@ function initialize!(
             nlp_params = (tmp, ustep, γ, α, tstep, k, invγdt, method, p, dt, f)
         end
         if length(cache.cache.u) != length(z)
-            new_prob = SciMLBase.remake(cache.prob; u0 = copy(z), p = nlp_params)
+            new_prob = if cache.W !== nothing
+                # The problem was resized: point the WReuseJac at the resized W and give
+                # the NonlinearFunction a matching jac_prototype. Both keep their types
+                # (only array sizes change), so cache.prob's concrete type is preserved.
+                cache.prob.f.jac.W[] = cache.W
+                new_f = SciMLBase.remake(cache.prob.f; jac_prototype = similar(cache.W))
+                SciMLBase.remake(cache.prob; f = new_f, u0 = copy(z), p = nlp_params)
+            else
+                SciMLBase.remake(cache.prob; u0 = copy(z), p = nlp_params)
+            end
             cache.prob = new_prob
             cache.cache = init(new_prob, cache.cache.alg)
         else

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -121,12 +121,17 @@ function initialize!(
             nlp_params = (tmp, ustep, γ, α, tstep, k, invγdt, method, p, dt, f)
         end
         if length(cache.cache.u) != length(z)
-            new_prob = if cache.W !== nothing
-                # The problem was resized: point the WReuseJac at the resized W and give
-                # the NonlinearFunction a matching jac_prototype. Both keep their types
-                # (only array sizes change), so cache.prob's concrete type is preserved.
+            new_prob = if cache.W !== nothing && cache.prob.f.jac isa WReuseJac
+                # Concrete reuse: point the WReuseJac at the resized W and give the
+                # NonlinearFunction a matching jac_prototype. Both keep their types (only
+                # array sizes change), so cache.prob's concrete type is preserved.
                 cache.prob.f.jac.W[] = cache.W
                 new_f = SciMLBase.remake(cache.prob.f; jac_prototype = similar(cache.W))
+                SciMLBase.remake(cache.prob; f = new_f, u0 = copy(z), p = nlp_params)
+            elseif cache.W !== nothing
+                # Matrix-free reuse: the operator is resized by the integrator's resize!
+                # machinery; just re-point the jac_prototype at it.
+                new_f = SciMLBase.remake(cache.prob.f; jac_prototype = cache.W)
                 SciMLBase.remake(cache.prob; f = new_f, u0 = copy(z), p = nlp_params)
             else
                 SciMLBase.remake(cache.prob; u0 = copy(z), p = nlp_params)
@@ -144,19 +149,26 @@ function _update_nlsolvealg_W!(nlcache, integrator, dtgamma, tstep, new_jac = tr
     (; J, W, uf, jac_config, du1) = nlcache
     (; f, p, uprev, alg) = integrator
     mass_matrix = f.mass_matrix
-    if new_jac
-        if SciMLBase.has_jac(f)
-            f.jac(J, uprev, p, tstep)
-        elseif uf !== nothing
-            uf.f = nlsolve_f(f, alg)
-            uf.t = tstep
-            if !(p isa SciMLBase.NullParameters)
-                uf.p = p
+    if W isa AbstractSciMLOperator
+        # Matrix-free reused W: refresh its state and gamma in place; its own `mul!`
+        # supplies the Jacobian action to the inner (Krylov) solve, so there is no
+        # concrete J to reassemble.
+        update_coefficients!(W, uprev, p, tstep; gamma = dtgamma)
+    else
+        if new_jac
+            if SciMLBase.has_jac(f)
+                f.jac(J, uprev, p, tstep)
+            elseif uf !== nothing
+                uf.f = nlsolve_f(f, alg)
+                uf.t = tstep
+                if !(p isa SciMLBase.NullParameters)
+                    uf.p = p
+                end
+                jacobian!(J, uf, uprev, du1, integrator, jac_config)
             end
-            jacobian!(J, uf, uprev, du1, integrator, jac_config)
         end
+        jacobian2W!(W, mass_matrix, dtgamma, J)
     end
-    jacobian2W!(W, mass_matrix, dtgamma, J)
     nlcache.W_γdt = dtgamma
     integrator.stats.nw += 1
     return nothing

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
@@ -366,6 +366,16 @@ mutable struct HomotopyNonlinearSolveCache{uType, tType, rateType, tType2, F, R}
     nf::R
 end
 
+# Analytic-jac callback handing the ODE-side W to the inner NonlinearSolve under
+# W-reuse. Deliberately a struct holding a Ref rather than a closure: its type depends
+# only on W's type, not on a captured binding, so when `resize!` replaces the W array
+# the same NonlinearFunction/NonlinearProblem types remain valid and `initialize!` just
+# swaps the Ref target.
+struct WReuseJac{W} <: Function
+    W::Base.RefValue{W}
+end
+(j::WReuseJac)(J_out, z, p) = (copyto!(J_out, j.W[]); J_out)
+
 mutable struct NonlinearSolveCache{uType, tType, rateType, tType2, P, C, JType, WType, ufType, jcType, du1Type, weightType} <:
     AbstractNLSolverCache
     ustep::uType

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
@@ -366,16 +366,6 @@ mutable struct HomotopyNonlinearSolveCache{uType, tType, rateType, tType2, F, R}
     nf::R
 end
 
-# Analytic-jac callback handing the ODE-side W to the inner NonlinearSolve under
-# W-reuse. Deliberately a struct holding a Ref rather than a closure: its type depends
-# only on W's type, not on a captured binding, so when `resize!` replaces the W array
-# the same NonlinearFunction/NonlinearProblem types remain valid and `initialize!` just
-# swaps the Ref target.
-struct WReuseJac{W} <: Function
-    W::Base.RefValue{W}
-end
-(j::WReuseJac)(J_out, z, p) = (copyto!(J_out, j.W[]); J_out)
-
 mutable struct NonlinearSolveCache{uType, tType, rateType, tType2, P, C, JType, WType, ufType, jcType, du1Type, weightType} <:
     AbstractNLSolverCache
     ustep::uType

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -391,9 +391,7 @@ function build_nlsolver(
                     (tmp, ustep, γ, α, tstep, k, invγdt, DIRK, p, dt, f)
                 end
                 if use_w_reuse
-                    nlf_jac! = let W = W_for_reuse
-                        (J_out, z, p) -> (copyto!(J_out, W); J_out)
-                    end
+                    nlf_jac! = WReuseJac(Ref(W_for_reuse))
                     # Without a `jac_prototype`, NonlinearSolve allocates a dense J for an
                     # analytic-jac function, so a sparse/structured W degrades to dense LU
                     # and sparse-only linsolves (e.g. KLU) crash. Mirror W's structure.

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -394,10 +394,14 @@ function build_nlsolver(
                     nlf_jac! = let W = W_for_reuse
                         (J_out, z, p) -> (copyto!(J_out, W); J_out)
                     end
+                    # Without a `jac_prototype`, NonlinearSolve allocates a dense J for an
+                    # analytic-jac function, so a sparse/structured W degrades to dense LU
+                    # and sparse-only linsolves (e.g. KLU) crash. Mirror W's structure.
                     NonlinearProblem(
                         NonlinearFunction{true, SciMLBase.FullSpecialize}(
                             nlf;
-                            jac = nlf_jac!
+                            jac = nlf_jac!,
+                            jac_prototype = similar(W_for_reuse)
                         ),
                         ztmp, nlp_params
                     )

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -248,6 +248,18 @@ function _nlalg_with_linsolve(inner_alg, linsolve)
     return remake(inner_alg; descent = remake(descent; linsolve = linsolve))
 end
 
+# The reused ODE `W` as the operator handed to the inner NonlinearSolve as `jac_prototype`.
+# A matrix-free `WOperator` (its `J` an operator) is passed through and applied via `mul!`;
+# a concrete `WOperator`'s materialized form, or a raw matrix, is wrapped in a
+# `MatrixOperator` and materialized via `convert` for a factorization. Used identically at
+# build time and after a `resize!` so the inner `NonlinearFunction`'s concrete type is
+# preserved.
+function reuse_jac_prototype(W)
+    Wr = W isa WOperator && W.J !== nothing && !(W.J isa AbstractSciMLOperator) ?
+        W._concrete_form : W
+    return Wr isa AbstractSciMLOperator ? Wr : MatrixOperator(Wr)
+end
+
 """
     build_nlsolver(alg, [nlalg,] u, uprev, p, t, dt, f, rate_prototype,
                    uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits, γ, c, [α,]
@@ -398,26 +410,18 @@ function build_nlsolver(
                 else
                     (tmp, ustep, γ, α, tstep, k, invγdt, DIRK, p, dt, f)
                 end
-                if use_w_reuse && matrixfree_W
-                    # Hand the matrix-free WOperator over as the Jacobian operator; the
-                    # inner Krylov solve applies it via `mul!`.
+                if use_w_reuse
+                    # Hand the reused W to the inner NonlinearFunction as an operator
+                    # `jac_prototype`. A matrix-free `WOperator` is applied via `mul!`
+                    # (Krylov); a concrete W is materialized via `convert` for a
+                    # factorization (NonlinearSolve copies it before an in-place `lu!`, so the
+                    # ODE-owned W is never destroyed). `jac` is auto-wired to
+                    # `update_coefficients!`; the ODE owns W's updates, so NonlinearSolve holds
+                    # W fixed across its Newton steps.
                     NonlinearProblem(
                         NonlinearFunction{true, SciMLBase.FullSpecialize}(
                             nlf;
-                            jac_prototype = W
-                        ),
-                        ztmp, nlp_params
-                    )
-                elseif use_w_reuse
-                    nlf_jac! = WReuseJac(Ref(W_for_reuse))
-                    # Without a `jac_prototype`, NonlinearSolve allocates a dense J for an
-                    # analytic-jac function, so a sparse/structured W degrades to dense LU
-                    # and sparse-only linsolves (e.g. KLU) crash. Mirror W's structure.
-                    NonlinearProblem(
-                        NonlinearFunction{true, SciMLBase.FullSpecialize}(
-                            nlf;
-                            jac = nlf_jac!,
-                            jac_prototype = similar(W_for_reuse)
+                            jac_prototype = reuse_jac_prototype(W)
                         ),
                         ztmp, nlp_params
                     )

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -372,6 +372,10 @@ function build_nlsolver(
             γ = tTypeNoUnits(γ)
             α = tTypeNoUnits(α)
             dt = tTypeNoUnits(dt)
+            # A matrix-free W (a `WOperator` wrapping a `JVPCache`, built for a Krylov
+            # linear solver) is reused as an operator: NonlinearSolve applies it via
+            # `mul!` rather than rebuilding a residual-derived AD JVP.
+            matrixfree_W = W isa WOperator && W.J isa AbstractSciMLOperator
             W_for_reuse = if W isa WOperator && W.J !== nothing &&
                     !(W.J isa AbstractSciMLOperator)
                 W._concrete_form
@@ -379,8 +383,12 @@ function build_nlsolver(
                 W
             end
             use_w_reuse = !isdae && f.nlstep_data === nothing &&
-                W_for_reuse isa AbstractMatrix &&
-                !(W_for_reuse isa AbstractSciMLOperator)
+                (
+                (
+                    W_for_reuse isa AbstractMatrix &&
+                        !(W_for_reuse isa AbstractSciMLOperator)
+                ) || matrixfree_W
+            )
             prob = if f.nlstep_data !== nothing
                 f.nlstep_data.nlprob
             else
@@ -390,7 +398,17 @@ function build_nlsolver(
                 else
                     (tmp, ustep, γ, α, tstep, k, invγdt, DIRK, p, dt, f)
                 end
-                if use_w_reuse
+                if use_w_reuse && matrixfree_W
+                    # Hand the matrix-free WOperator over as the Jacobian operator; the
+                    # inner Krylov solve applies it via `mul!`.
+                    NonlinearProblem(
+                        NonlinearFunction{true, SciMLBase.FullSpecialize}(
+                            nlf;
+                            jac_prototype = W
+                        ),
+                        ztmp, nlp_params
+                    )
+                elseif use_w_reuse
                     nlf_jac! = WReuseJac(Ref(W_for_reuse))
                     # Without a `jac_prototype`, NonlinearSolve allocates a dense J for an
                     # analytic-jac function, so a sparse/structured W degrades to dense LU

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_matrixfree_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_matrixfree_tests.jl
@@ -1,0 +1,67 @@
+using OrdinaryDiffEqBDF, OrdinaryDiffEqNonlinearSolve, OrdinaryDiffEqRosenbrock
+using OrdinaryDiffEqNonlinearSolve: NonlinearSolveAlg
+using NonlinearSolve, LinearSolve, LinearAlgebra, SparseArrays, ADTypes
+using SparseConnectivityTracer, SciMLBase
+using SciMLOperators: AbstractSciMLOperator
+using Test
+
+# With a Krylov inner linear solver the ODE builds a matrix-free `WOperator`; NonlinearSolveAlg
+# now hands that operator to NonlinearSolve, which applies it via `mul!`. Previously the inner
+# solve rebuilt a residual-derived AD Jacobian-vector product, which crashed under ForwardDiff
+# (`No matching function wrapper`) because it differentiated the FunctionWrapped ODE residual.
+
+const N = 8
+const xyd = range(0, stop = 1, length = N)
+lim(a, n) = a == n + 1 ? 1 : a == 0 ? n : a
+function bruss!(du, u, p, t)
+    A, B, al, dx = p
+    al = al / dx^2
+    return @inbounds for I in CartesianIndices((N, N))
+        i, j = Tuple(I)
+        ip, im, jp, jm = lim(i + 1, N), lim(i - 1, N), lim(j + 1, N), lim(j - 1, N)
+        du[i, j, 1] = al * (
+            u[im, j, 1] + u[ip, j, 1] + u[i, jp, 1] + u[i, jm, 1] -
+                4u[i, j, 1]
+        ) + B + u[i, j, 1]^2 * u[i, j, 2] - (A + 1) * u[i, j, 1]
+        du[i, j, 2] = al * (
+            u[im, j, 2] + u[ip, j, 2] + u[i, jp, 2] + u[i, jm, 2] -
+                4u[i, j, 2]
+        ) + A * u[i, j, 1] - u[i, j, 1]^2 * u[i, j, 2]
+    end
+end
+u0 = ones(N, N, 2)
+p = (3.4, 1.0, 10.0, step(xyd))
+jsp = ADTypes.jacobian_sparsity(
+    (du, u) -> bruss!(du, u, p, 0.0), similar(u0), u0,
+    TracerSparsityDetector()
+)
+prob = ODEProblem(ODEFunction(bruss!; jac_prototype = float.(jsp)), u0, (0.0, 1.0), p)
+refsol = solve(prob, Rodas5P(); abstol = 1.0e-10, reltol = 1.0e-10)
+
+@testset "NSA + Krylov linsolve works for every inner autodiff (was a ForwardDiff crash)" begin
+    for ad in (AutoFiniteDiff(), AutoForwardDiff())
+        nsa = NonlinearSolveAlg(NewtonRaphson(; autodiff = ad))
+        for ls in (KrylovJL_GMRES(), KLUFactorization(), nothing)
+            alg = ls === nothing ? FBDF(nlsolve = nsa) : FBDF(linsolve = ls, nlsolve = nsa)
+            sol = solve(prob, alg; reltol = 1.0e-5, abstol = 1.0e-8)
+            @test SciMLBase.successful_retcode(sol)
+            @test norm(sol.u[end] .- refsol.u[end]) / norm(refsol.u[end]) < 1.0e-5
+        end
+    end
+end
+
+@testset "Krylov: the ODE WOperator is reused matrix-free" begin
+    integ = init(
+        prob,
+        FBDF(
+            linsolve = KrylovJL_GMRES(),
+            nlsolve = NonlinearSolveAlg(NewtonRaphson(; autodiff = AutoForwardDiff()))
+        );
+        reltol = 1.0e-5, abstol = 1.0e-8
+    )
+    c = integ.cache.nlsolver.cache
+    @test c.W !== nothing
+    # The inner NonlinearSolve holds the ODE's WOperator as its Jacobian (matrix-free),
+    # not a residual-derived JacobianOperator.
+    @test c.cache.jac_cache.J isa AbstractSciMLOperator
+end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_sparse_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_sparse_tests.jl
@@ -68,3 +68,43 @@ end
         @test sol.u[end] ≈ refsol.u[end] rtol = 1.0e-5
     end
 end
+
+# Resizing the integrator must rebuild the inner Jacobian at the new size: the jac
+# closure and jac_prototype are fixed at build time, so the length-mismatch path in
+# initialize! has to refresh both against the resized W (this crashed with
+# `DimensionMismatch: B has leading dimension 2, but needs 1` when jac_prototype
+# followed the W structure).
+@testset "resize with W-reuse rebuilds inner Jacobian" begin
+    fgrow = function (du, u, p, t)
+        for i in 1:length(u)
+            du[i] = (0.3 / length(u)) * u[i]
+        end
+        return nothing
+    end
+    condition = (u, t, integrator) -> 1 - maximum(u)
+    affect! = function (integrator)
+        u = integrator.u
+        maxidx = findmax(u)[2]
+        resize!(integrator, length(u) + 1)
+        Θ = 0.3
+        u[maxidx] = Θ
+        u[end] = 1 - Θ
+        return nothing
+    end
+    cb = ContinuousCallback(condition, affect!)
+    probg = ODEProblem(fgrow, [0.2], (0.0, 10.0))
+    # NOTE: assert the resize worked and nothing crashed (mirroring
+    # test/Integrators_II/ode_cache_tests.jl). Whether the marginally-stable
+    # grow-a-cell dynamics finishes with Success is method- and
+    # rounding-sensitive (ImplicitEuler+NLNewton is Unstable on it too), so
+    # retcode is only checked for TRBDF2.
+    for alg in (
+            TRBDF2(nlsolve = nsa), KenCarp4(nlsolve = nsa),
+            ImplicitEuler(nlsolve = nsa),
+        )
+        sol = solve(probg, alg; callback = cb, dt = 1 / 2)
+        @test length(sol.u[end]) > 1
+    end
+    sol = solve(probg, TRBDF2(nlsolve = nsa); callback = cb, dt = 1 / 2)
+    @test SciMLBase.successful_retcode(sol)
+end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_sparse_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_sparse_tests.jl
@@ -4,6 +4,7 @@ using OrdinaryDiffEqNonlinearSolve: NonlinearSolveAlg
 using NonlinearSolve: NewtonRaphson
 using LinearSolve, LinearAlgebra, SparseArrays, ADTypes
 using SciMLBase
+using SciMLOperators: MatrixOperator
 using Test
 
 # 1D Brusselator with a hand-assembled sparse Jacobian pattern (tridiagonal blocks).
@@ -54,8 +55,11 @@ nsa = NonlinearSolveAlg(NewtonRaphson(; autodiff = AutoForwardDiff()))
     integ = init(prob, FBDF(nlsolve = nsa); reltol = 1.0e-8, abstol = 1.0e-10)
     nsacache = integ.cache.nlsolver.cache
     @test nsacache.W isa SparseMatrixCSC
-    # The inner NonlinearSolve Jacobian must mirror W's structure, not densify.
-    @test integ.cache.nlsolver.cache.cache.jac_cache.J isa SparseMatrixCSC
+    # The inner NonlinearSolve Jacobian is the reused W as an operator; its underlying
+    # matrix must mirror W's structure (stay sparse), not densify.
+    J = integ.cache.nlsolver.cache.cache.jac_cache.J
+    @test J isa MatrixOperator
+    @test convert(AbstractMatrix, J) isa SparseMatrixCSC
 end
 
 @testset "NSA + sparse-only linsolve (KLU) solves" begin

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_sparse_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_sparse_tests.jl
@@ -1,0 +1,70 @@
+using OrdinaryDiffEqBDF, OrdinaryDiffEqSDIRK
+using OrdinaryDiffEqNonlinearSolve
+using OrdinaryDiffEqNonlinearSolve: NonlinearSolveAlg
+using NonlinearSolve: NewtonRaphson
+using LinearSolve, LinearAlgebra, SparseArrays, ADTypes
+using SciMLBase
+using Test
+
+# 1D Brusselator with a hand-assembled sparse Jacobian pattern (tridiagonal blocks).
+const N_b = 8
+function bruss1d!(du, u, p, t)
+    A, B, alpha, dx = p
+    a = alpha / dx^2
+    n = N_b
+    @inbounds for i in 1:n
+        im1 = i == 1 ? n : i - 1
+        ip1 = i == n ? 1 : i + 1
+        x = u[i]
+        y = u[n + i]
+        du[i] = a * (u[im1] + u[ip1] - 2x) + B + x^2 * y - (A + 1) * x
+        du[n + i] = a * (u[n + im1] + u[n + ip1] - 2y) + A * x - x^2 * y
+    end
+    return nothing
+end
+function bruss1d_jacproto(n)
+    Is = Int[]
+    Js = Int[]
+    for i in 1:n
+        im1 = i == 1 ? n : i - 1
+        ip1 = i == n ? 1 : i + 1
+        for (r, c) in (
+                (i, im1), (i, i), (i, ip1), (i, n + i),
+                (n + i, n + im1), (n + i, n + i), (n + i, n + ip1), (n + i, i),
+            )
+            push!(Is, r)
+            push!(Js, c)
+        end
+    end
+    return sparse(Is, Js, ones(length(Is)), 2n, 2n)
+end
+u0 = vcat(
+    [22 * (i / (N_b + 1) * (1 - i / (N_b + 1)))^(3 / 2) for i in 1:N_b],
+    [27 * (i / (N_b + 1) * (1 - i / (N_b + 1)))^(3 / 2) for i in 1:N_b]
+)
+p = (3.4, 1.0, 10.0, 1 / N_b)
+f_sparse = ODEFunction(bruss1d!; jac_prototype = bruss1d_jacproto(N_b))
+prob = ODEProblem(f_sparse, u0, (0.0, 2.0), p)
+
+refsol = solve(prob, FBDF(); reltol = 1.0e-10, abstol = 1.0e-12)
+
+nsa = NonlinearSolveAlg(NewtonRaphson(; autodiff = AutoForwardDiff()))
+
+@testset "NSA W-reuse keeps inner Jacobian sparse" begin
+    integ = init(prob, FBDF(nlsolve = nsa); reltol = 1.0e-8, abstol = 1.0e-10)
+    nsacache = integ.cache.nlsolver.cache
+    @test nsacache.W isa SparseMatrixCSC
+    # The inner NonlinearSolve Jacobian must mirror W's structure, not densify.
+    @test integ.cache.nlsolver.cache.cache.jac_cache.J isa SparseMatrixCSC
+end
+
+@testset "NSA + sparse-only linsolve (KLU) solves" begin
+    for alg in (
+            FBDF(linsolve = KLUFactorization(), nlsolve = nsa),
+            TRBDF2(linsolve = KLUFactorization(), nlsolve = nsa),
+        )
+        sol = solve(prob, alg; reltol = 1.0e-8, abstol = 1.0e-10)
+        @test SciMLBase.successful_retcode(sol)
+        @test sol.u[end] ≈ refsol.u[end] rtol = 1.0e-5
+    end
+end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
@@ -37,6 +37,7 @@ if TEST_GROUP ∉ ("QA", "ModelingToolkit")
     @time @safetestset "Nested AD over NonlinearSolveAlg" include("nested_ad_nlsolvealg_tests.jl")
     @time @safetestset "NonlinearSolveAlg Jacobian Reuse Tests" include("nsa_jacobian_reuse_tests.jl")
     @time @safetestset "Homotopy Nonlinear Solver Tests" include("homotopy_nlsolve_tests.jl")
+    @time @safetestset "NonlinearSolveAlg Sparse Jacobian Tests" include("nsa_sparse_tests.jl")
 end
 
 # Run QA tests (JET, Aqua)

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
@@ -38,6 +38,7 @@ if TEST_GROUP ∉ ("QA", "ModelingToolkit")
     @time @safetestset "NonlinearSolveAlg Jacobian Reuse Tests" include("nsa_jacobian_reuse_tests.jl")
     @time @safetestset "Homotopy Nonlinear Solver Tests" include("homotopy_nlsolve_tests.jl")
     @time @safetestset "NonlinearSolveAlg Sparse Jacobian Tests" include("nsa_sparse_tests.jl")
+    @time @safetestset "NonlinearSolveAlg Matrix-Free WOperator Tests" include("nsa_matrixfree_tests.jl")
 end
 
 # Run QA tests (JET, Aqua)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

**Stacked on #3819.** Opened against `master`, so it also shows #3819's commits until #3819 merges. This PR *supersedes* #3819's concrete `WReuseJac` mechanism — see the final commit, which unifies both W-reuse paths.

### What
Under `NonlinearSolveAlg`, reuse the ODE's `W` in the inner NonlinearSolve via a **single** operator `jac_prototype`, replacing two separate paths:

- the matrix-free `jac_prototype = W` branch (Krylov: `WOperator` applied via `mul!`), and
- the concrete `WReuseJac(Ref(W))` analytic-jac copy-closure (factorization).

`reuse_jac_prototype(W)` maps the reused W to the operator handed to the inner solve:
- a **matrix-free** `WOperator` (its `J` a `JVPCache`) → passed through, applied via `mul!`;
- a **concrete** W (a raw matrix, or a `WOperator`'s materialized form) → wrapped in a `MatrixOperator`, materialized via `convert` for a factorization.

The original ForwardDiff crash (`No matching function wrapper`, from rebuilding a residual-derived AD JVP) is gone because the operator is reused instead of re-differentiated. NonlinearSolve holds W fixed across its Newton steps (the ODE owns W's updates via `_update_nlsolvealg_W!`), and LinearSolve copies the materialized matrix before an in-place `lu!` (`_copy_A_for_safety`) — so the ODE-owned W is never destroyed, the guarantee `WReuseJac`'s explicit copy used to provide. The same helper reapplies to the resized W in `initialize!`, so `WReuseJac`/its `Ref` are removed entirely.

`SciMLOperators.isconvertible(::JVPCache) = false` is added so a `WOperator` wrapping a matrix-free J reports itself matrix-free (with SciML/SciMLOperators.jl#404).

### Dependencies / merge order
1. NonlinearSolveBase operator `jac_prototype` support — SciML/NonlinearSolve.jl#1047 + #1048 (**merged**; a NonlinearSolveBase fix release is in flight).
2. SciMLOperators `WOperator` `isconvertible` honesty — SciML/SciMLOperators.jl#404 (**merged**).
3. **SciMLOperators `copy(::MatrixOperator)` fix — SciML/SciMLOperators.jl#405**: the dense-LU factorization safety-copy calls `copy(::MatrixOperator)`, which before #405 dropped `update_func!` and produced a type-unstable copy → `MethodError`. Bumps `SciMLOperators` compat to `1.24.2`.
4. #3819 (base; superseded by the unify commit here).
5. This PR.

### Local verification (Julia 1.12, SciMLOperators 1.24.2, NonlinearSolveBase 2.34.1)
- `nsa_sparse_tests.jl`: **11/11** — inner J stays sparse (`MatrixOperator` over `SparseMatrixCSC`), KLU solves, and W-reuse survives a `resize!`.
- `nsa_matrixfree_tests.jl`: **14/14** — all `{AutoFiniteDiff,AutoForwardDiff}×{GMRES,KLU,default}` combos match `Rodas5P`; inner `jac_cache.J` is the ODE `WOperator`.
- Dense-LU concrete reuse also verified against a stiff dense system (matches `Rodas5P`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)