### PR TITLE
LinearExponential: adopt ExponentialUtilities 1.33 matrix-free tolerance

### DIFF
--- a/lib/OrdinaryDiffEqLinear/Project.toml
+++ b/lib/OrdinaryDiffEqLinear/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqLinear"
 uuid = "521117fe-8c41-49f8-b3b6-30780b3f0fb5"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.1"
+version = "2.1.2"
 
 [deps]
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
@@ -37,7 +37,7 @@ Test = "<0.0.1, 1"
 Random = "<0.0.1, 1"
 DiffEqDevTools = "3"
 OrdinaryDiffEqVerner = "2"
-ExponentialUtilities = "1.32"
+ExponentialUtilities = "1.33"
 LinearAlgebra = "1.10"
 SciMLBase = "3.35.1"
 OrdinaryDiffEqCore = "4"

--- a/lib/OrdinaryDiffEqLinear/src/OrdinaryDiffEqLinear.jl
+++ b/lib/OrdinaryDiffEqLinear/src/OrdinaryDiffEqLinear.jl
@@ -9,7 +9,7 @@ import OrdinaryDiffEqCore: alg_extrapolates, dt_required,
     get_fsalfirstlast,
     isdtchangeable, full_cache,
     generic_solver_docstring
-using LinearAlgebra: mul!, I, norm
+using LinearAlgebra: mul!, I
 using SciMLOperators: AbstractSciMLOperator, update_coefficients, update_coefficients!
 using ExponentialUtilities: ExponentialUtilities, ExpMethodGeneric, ExpvCache,
     KrylovSubspace, PhivCache, arnoldi!, exponential!,

--- a/lib/OrdinaryDiffEqLinear/src/linear_perform_step.jl
+++ b/lib/OrdinaryDiffEqLinear/src/linear_perform_step.jl
@@ -1,18 +1,3 @@
-# Scale-aware absolute tolerance for the adaptive Krylov time-stepper
-# (`expv_timestep`). Supplying this together with an explicit initial `tau` lets
-# ExponentialUtilities skip its default `opnorm(A, Inf)` scale estimate, which
-# is undefined for some operator types (e.g. sparse GPU matrices). Using the
-# solution scale `norm(u)` -- a vector norm, always defined -- honors both
-# `abstol` and `reltol` without needing an operator norm, and avoids the
-# over-solving of a bare fixed `abstol`. Component-wise tolerances are reduced
-# to a representative scalar.
-_tol_scalar(x::Number) = x
-_tol_scalar(x) = maximum(x)
-function _linear_krylov_abstol(integrator, u)
-    return _tol_scalar(integrator.opts.abstol) +
-        _tol_scalar(integrator.opts.reltol) * norm(u, Inf)
-end
-
 function initialize!(integrator, cache::MagnusMidpointCache)
     integrator.kshortsize = 2
 
@@ -823,7 +808,6 @@ function perform_step!(
     else
         u = expv_timestep(
             dt, A, integrator.u; m = min(alg.m, size(A, 1)), iop = alg.iop,
-            tau = dt, abstol = _linear_krylov_abstol(integrator, integrator.u),
             tol = integrator.opts.reltol
         )
     end
@@ -871,7 +855,6 @@ function perform_step!(integrator, cache::LinearExponentialCache, repeat_step = 
         expv_timestep!(
             tmp, dt, A, u; adaptive = true, caches = KsCache,
             m = min(alg.m, size(A, 1)), iop = alg.iop,
-            tau = dt, abstol = _linear_krylov_abstol(integrator, u),
             tol = integrator.opts.reltol
         )
     end


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Draft. **Time-sensitive — see below.**

## What

Updates `LinearExponential`'s adaptive Krylov tolerance to ExponentialUtilities 1.33's matrix-free default. Follow-up to #3884 (merged), required by the 1.33 release.

## Why (time-sensitive)

#3884 (merged, OrdinaryDiffEqLinear 2.1.1) drives the tolerance with `expv_timestep(...; abstol = _linear_krylov_abstol(...), tau = dt)` — using ExponentialUtilities 1.32's `abstol` keyword, with compat `"1.32"` (which allows 1.33).

ExponentialUtilities 1.33 (SciML/ExponentialUtilities.jl#250, now registering) **removes the `abstol` keyword** and estimates the tolerance scale matrix-free from the Arnoldi Hessenberg by default. So once 1.33 registers, resolving OrdinaryDiffEq master picks it up and the `abstol = ...` call throws `unsupported keyword argument "abstol"` at runtime in `LinearExponential(krylov = :adaptive)`.

**This PR is the fix.** It should be merged promptly after 1.33 registers to close the window where master's adaptive `LinearExponential` is broken.

## Change

Drop the `abstol`/`tau` arguments and the `_linear_krylov_abstol` helper at the two adaptive call sites; inherit the 1.33 matrix-free default (never evaluates `opnorm(A)`, so the sparse-GPU fix is retained). Bump `ExponentialUtilities` compat to `1.33`, version to 2.1.2. Net: +3 / −20 lines.

## Tests

`Core` group passes locally against ExponentialUtilities 1.33 (37 pass, 0 fail), including the `BrokenOpnormMatrix` regression test (operator whose `opnorm` throws).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPgZrXncWhnFNt6T8WQrNY
