### PR TITLE
Release prep: batched patch bumps for 28 packages (QA/docstring/compat-only)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEq"
 uuid = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "7.1.2"
+version = "7.1.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/DelayDiffEq/Project.toml
+++ b/lib/DelayDiffEq/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.0.6"
+version = "6.0.7"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.6.1"
+version = "7.6.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/ImplicitDiscreteSolve/Project.toml
+++ b/lib/ImplicitDiscreteSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "ImplicitDiscreteSolve"
 uuid = "3263718b-31ed-49cf-8a0f-35a466e8af96"
 authors = ["vyudu <vincent.duyuan@gmail.com>"]
-version = "2.1.2"
+version = "2.1.3"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/OrdinaryDiffEqAMF/Project.toml
+++ b/lib/OrdinaryDiffEqAMF/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqAMF"
 uuid = "08082164-f6a1-4363-b3df-3aa6fcf571ad"
 authors = ["Utkarsh <rajpututkarsh530@gmail.com>"]
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/lib/OrdinaryDiffEqAdamsBashforthMoulton/Project.toml
+++ b/lib/OrdinaryDiffEqAdamsBashforthMoulton/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqAdamsBashforthMoulton"
 uuid = "89bda076-bce5-4f1c-845f-551c83cdda9a"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFIRK"
 uuid = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.4.0"
+version = "2.4.1"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqImplicitTableaus/Project.toml
+++ b/lib/OrdinaryDiffEqImplicitTableaus/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqImplicitTableaus"
 uuid = "75f66a49-58fc-43e3-9173-2340726368f7"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/OrdinaryDiffEqLowOrderRK/Project.toml
+++ b/lib/OrdinaryDiffEqLowOrderRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqLowOrderRK"
 uuid = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqLowStorageRK/Project.toml
+++ b/lib/OrdinaryDiffEqLowStorageRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqLowStorageRK"
 uuid = "b0944070-b475-4768-8dec-fb6eb410534d"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "3.2.0"
+version = "3.2.1"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/OrdinaryDiffEqNewmark/Project.toml
+++ b/lib/OrdinaryDiffEqNewmark/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqNewmark"
 uuid = "d204908a-63b9-11ef-18f5-cfec7123a93b"
-version = "2.2.0"
+version = "2.2.1"
 authors = ["Dennis Ogiermann <termi-official@users.noreply.github.com>"]
 
 [deps]

--- a/lib/OrdinaryDiffEqNordsieck/Project.toml
+++ b/lib/OrdinaryDiffEqNordsieck/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNordsieck"
 uuid = "c9986a66-5c92-4813-8696-a7ec84c806c8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"

--- a/lib/OrdinaryDiffEqPDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqPDIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqPDIRK"
 uuid = "5dd0a6cf-3d4b-4314-aa06-06d4e299bc89"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqPRK/Project.toml
+++ b/lib/OrdinaryDiffEqPRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqPRK"
 uuid = "5b33eab2-c0f1-4480-b2c3-94bc1e80bda1"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqQPRK/Project.toml
+++ b/lib/OrdinaryDiffEqQPRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqQPRK"
 uuid = "04162be5-8125-4266-98ed-640baecc6514"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqRKIP/Project.toml
+++ b/lib/OrdinaryDiffEqRKIP/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqRKIP"
 uuid = "a4daff8c-1d43-4ff3-8eff-f78720aeecdc"
 authors = ["Azercoco <20425137+Azercoco@users.noreply.github.com>"]
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/lib/OrdinaryDiffEqRKN/Project.toml
+++ b/lib/OrdinaryDiffEqRKN/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqRKN"
 uuid = "af6ede74-add8-4cfd-b1df-9a4dbb109d7a"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqRosenbrockTableaus/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrockTableaus/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqRosenbrockTableaus"
 uuid = "b4bd8bb3-f80f-41d2-9b21-73a655b304b9"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.2.0"
+version = "2.2.1"
 
 [extras]
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"

--- a/lib/SimpleImplicitDiscreteSolve/Project.toml
+++ b/lib/SimpleImplicitDiscreteSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleImplicitDiscreteSolve"
 uuid = "8b67ef88-54bd-43ff-aca0-8be02588656a"
 authors = ["vyudu <vincent.duyuan@gmail.com>"]
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/StochasticDiffEq/Project.toml
+++ b/lib/StochasticDiffEq/Project.toml
@@ -1,6 +1,6 @@
 name = "StochasticDiffEq"
 uuid = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
-version = "7.1.1"
+version = "7.1.2"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]

--- a/lib/StochasticDiffEqHighOrder/Project.toml
+++ b/lib/StochasticDiffEqHighOrder/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqHighOrder"
 uuid = "0520c28c-50fd-4d16-9c96-902fc80b3bab"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.1.1"
+version = "2.1.2"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/StochasticDiffEqImplicit/Project.toml
+++ b/lib/StochasticDiffEqImplicit/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqImplicit"
 uuid = "5080b986-4c76-4669-b5dc-373a41579d5b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.1.1"
+version = "2.1.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/StochasticDiffEqLeaping/Project.toml
+++ b/lib/StochasticDiffEqLeaping/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqLeaping"
 uuid = "aefaaa88-39f2-4e89-b162-d61b7e8cc81b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/StochasticDiffEqLevyArea/Project.toml
+++ b/lib/StochasticDiffEqLevyArea/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqLevyArea"
 uuid = "90dbc90e-856a-4131-af2c-e8c5aa0f35b5"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/lib/StochasticDiffEqLowOrder/Project.toml
+++ b/lib/StochasticDiffEqLowOrder/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqLowOrder"
 uuid = "d15fe365-ce7f-450a-828a-7985bd5b681b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/StochasticDiffEqMilstein/Project.toml
+++ b/lib/StochasticDiffEqMilstein/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqMilstein"
 uuid = "8c95a807-c8e7-4581-8419-890d001af53e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/StochasticDiffEqRODE/Project.toml
+++ b/lib/StochasticDiffEqRODE/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqRODE"
 uuid = "49714585-0aa1-4f53-b1e6-a9b8c0d5e03f"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/StochasticDiffEqWeak/Project.toml
+++ b/lib/StochasticDiffEqWeak/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqWeak"
 uuid = "af2a2fcd-1c36-4cbe-a6d0-5afda784a085"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.1.1"
+version = "2.1.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Patch-releases 28 packages in this monorepo whose unreleased content (verified against General's git-tree-sha1 per package) is limited to docstrings, QA/CI scaffolding, ExplicitImports cleanup, DiffEqBase->SciMLBase renames, and compat-floor-only changes -- no new public API, no signature changes. No compat floor edits needed on any sibling.