### PR TITLE
Release prep: intermediate version 2.5.0 for OrdinaryDiffEqMultirate (registry gap fix)

### DIFF
--- a/lib/OrdinaryDiffEqMultirate/Project.toml
+++ b/lib/OrdinaryDiffEqMultirate/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqMultirate"
 uuid = "d4b830b4-ac80-426b-8507-16693d424963"
 authors = ["singhharsh1708 <hs1663531@gmail.com>"]
-version = "2.6.0"
+version = "2.5.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Registry gap-pullback: General has OrdinaryDiffEqMultirate registered through 2.4.0, but source is at 2.6.0. AutoMerge rejects sequential-version-skipping releases, so this registers the missing 2.5.0 intermediate first (content-identical bump, no source changes) before the final 2.6.0 can be registered.