### PR TITLE
Release prep: OrdinaryDiffEqMultirate 2.6.0 (final target after registry gap-pullback)

### DIFF
--- a/lib/OrdinaryDiffEqMultirate/Project.toml
+++ b/lib/OrdinaryDiffEqMultirate/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqMultirate"
 uuid = "d4b830b4-ac80-426b-8507-16693d424963"
 authors = ["singhharsh1708 <hs1663531@gmail.com>"]
-version = "2.5.0"
+version = "2.6.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Completes the registry gap pullback (General was at 2.4.0, gap-filled through 2.5.0 in #3890, now the real content target 2.6.0).