### PR TITLE
Move OrdinaryDiffEq controller docs to definition points

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/alg_utils.jl
@@ -355,15 +355,21 @@ stiffness auto-switching logic through its specialized default path.
 isdefaultalg(alg) = false
 
 """
-    qmin_default(alg)
-    qmax_default(alg)
+    qmin_default(alg) -> Real
 
-Algorithm-specific default for the lower / upper bound on the per-step
-shrink/grow factor. Used by `resolve_basic` to fill in
-[`CommonControllerOptions`](@ref) when the user didn't override.
-Override these for a new algorithm type to change its defaults.
-The generic fallbacks are `qmin = 1 // 5`, `qmax = 10` for adaptive
-algorithms (`qmin = 0` for non-adaptive).
+Return the algorithm-specific lower bound for the per-step shrink factor.
+
+`resolve_basic` uses this developer extension point to fill
+[`CommonControllerOptions`](@ref) when the user did not pass `qmin`.
+
+# Arguments
+
+- `alg`: The solver algorithm whose controller defaults are being resolved.
+
+# Returns
+
+- `Real`: The default lower bound. Adaptive algorithms use `1 // 5`; non-adaptive
+    algorithms use `0`.
 """
 function qmin_default(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm})
     return isadaptive(alg) ? 1 // 5 : 0
@@ -372,7 +378,22 @@ qmin_default(alg::CompositeAlgorithm) = maximum(qmin_default.(alg.algs))
 # Generic fallback for non-ODE algorithms (SDE, RODE) calling __init
 qmin_default(alg) = 1 // 5
 
-@doc (@doc qmin_default) qmax_default
+"""
+    qmax_default(alg) -> Real
+
+Return the algorithm-specific upper bound for the per-step growth factor.
+
+`resolve_basic` uses this developer extension point to fill
+[`CommonControllerOptions`](@ref) when the user did not pass `qmax`.
+
+# Arguments
+
+- `alg`: The solver algorithm whose controller defaults are being resolved.
+
+# Returns
+
+- `Real`: The default upper bound. The generic default is `10`.
+"""
 qmax_default(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm}) = 10
 qmax_default(alg::CompositeAlgorithm) = minimum(qmax_default.(alg.algs))
 # Generic fallback for non-ODE algorithms (SDE, RODE) calling __init
@@ -697,20 +718,40 @@ function _digest_beta1_beta2(alg, cache, ::Val{QT}, _beta1, _beta2) where {QT}
 end
 
 """
-    beta1_default(alg, beta2)
-    beta2_default(alg)
+    beta2_default(alg) -> Real
 
-Algorithm-specific defaults for the proportional / integral gains of the
-[`PIController`](@ref). Defaults are scaled by the algorithm's order
-(`beta2 = 2 // (5 alg_order(alg))`, `beta1 = 7 // (10 alg_order(alg))`)
-for adaptive algorithms and `0` otherwise. `beta1` is computed from
-`beta2`, so override `beta2_default` first if you want both to change.
+Return the algorithm-specific default integral gain for [`PIController`](@ref).
+
+# Arguments
+
+- `alg`: The solver algorithm whose PI-controller defaults are being resolved.
+
+# Returns
+
+- `Real`: For adaptive algorithms, `2 // (5 * alg_order(alg))`; otherwise `0`.
 """
 function beta2_default(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm})
     return isadaptive(alg) ? 2 // (5alg_order(alg)) : 0
 end
 
-@doc (@doc beta2_default) beta1_default
+"""
+    beta1_default(alg, beta2) -> Real
+
+Return the algorithm-specific default proportional gain for
+[`PIController`](@ref).
+
+`beta1` is allowed to depend on the resolved `beta2` value, so algorithms that
+override both should normally override `beta2_default` first.
+
+# Arguments
+
+- `alg`: The solver algorithm whose PI-controller defaults are being resolved.
+- `beta2`: The resolved integral gain.
+
+# Returns
+
+- `Real`: For adaptive algorithms, `7 // (10 * alg_order(alg))`; otherwise `0`.
+"""
 function beta1_default(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm}, beta2)
     return isadaptive(alg) ? 7 // (10alg_order(alg)) : 0
 end
@@ -741,17 +782,41 @@ default; `true` for FIRK methods).
 fac_default_gamma(alg) = false
 
 """
-    qsteady_min_default(alg)
-    qsteady_max_default(alg)
+    qsteady_min_default(alg) -> Real
 
-Algorithm-specific defaults for the deadband interval — if the proposed
-step-size factor lies inside `[qsteady_min, qsteady_max]`, the controller
-holds `dt` constant. Generic fallback is `1` for both (no deadband).
-Adaptive implicit algorithms widen `qsteady_max` to `6 // 5` to reduce
-Jacobian recomputation; BDF widens both (`9 // 10`, `12 // 10`).
+Return the lower edge of the algorithm-specific step-size deadband.
+
+If the proposed step-size factor lies inside
+`[qsteady_min, qsteady_max]`, the controller holds `dt` constant.
+
+# Arguments
+
+- `alg`: The solver algorithm whose controller deadband is being resolved.
+
+# Returns
+
+- `Real`: The lower deadband edge. The generic default is `1`.
 """
 qsteady_min_default(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm}) = 1
-@doc (@doc qsteady_min_default) qsteady_max_default
+
+"""
+    qsteady_max_default(alg) -> Real
+
+Return the upper edge of the algorithm-specific step-size deadband.
+
+If the proposed step-size factor lies inside
+`[qsteady_min, qsteady_max]`, the controller holds `dt` constant.
+Adaptive implicit algorithms widen this default to `6 // 5` to reduce
+Jacobian recomputation; BDF methods may specialize it further.
+
+# Arguments
+
+- `alg`: The solver algorithm whose controller deadband is being resolved.
+
+# Returns
+
+- `Real`: The upper deadband edge. The generic default is `1`.
+"""
 qsteady_max_default(alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm}) = 1
 # Generic fallbacks for non-ODE algorithms (SDE, RODE) calling __init
 qsteady_min_default(alg) = 1

--- a/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
@@ -286,40 +286,119 @@ See also: https://github.com/SciML/DifferentialEquations.jl/issues/299
 end
 
 """
-    get_qmin(integrator)
-    get_qmax(integrator)
-    get_qmax_first_step(integrator)
-    get_gamma(integrator)
-    get_qsteady_min(integrator)
-    get_qsteady_max(integrator)
-    get_failfactor(integrator)
+    get_qmin(integrator) -> Real
 
-Read a step-size knob from the integrator's controller. Default
-dispatch reads `integrator.controller_cache.controller.basic.X` —
-i.e. it goes through the `CommonControllerOptions` embedded on every concrete
-controller (`IController`/`PIController`/`PIDController`/
-`PredictiveController`/`BDFController`/`JVODEController`).
+Read the lower step-size shrink bound from the integrator's active controller.
 
-`CompositeControllerCache` overrides each accessor to delegate to the
-currently active sub-cache (mirroring how `stepsize_controller!` and
-friends dispatch). The transitional `DummyControllerCache` also
-provides overrides for the BDF/Nordsieck cases that haven't been
-migrated yet.
+The default dispatch reads `integrator.controller_cache.controller.basic.qmin`
+through [`CommonControllerOptions`](@ref). `CompositeControllerCache` delegates
+to the currently active sub-cache.
 
-These accessors are what the integrator-level paths (e.g. the
-`isoutofdomain` rejection path for `qmin`,
-[`post_newton_controller!`](@ref) for `failfactor`) call instead of
-reading `integrator.opts.X` — the v7 controller refactor moved these
-knobs off `DEOptions` and onto the controller object.
+# Arguments
+
+- `integrator`: The active `DEIntegrator`.
+
+# Returns
+
+- `Real`: The controller's lower step-size shrink bound.
 """
 function get_qmin end
 
-@doc (@doc get_qmin) function get_qmax end
-@doc (@doc get_qmin) function get_qmax_first_step end
-@doc (@doc get_qmin) function get_gamma end
-@doc (@doc get_qmin) function get_qsteady_min end
-@doc (@doc get_qmin) function get_qsteady_max end
-@doc (@doc get_qmin) function get_failfactor end
+"""
+    get_qmax(integrator) -> Real
+
+Read the upper step-size growth bound from the integrator's active controller.
+
+# Arguments
+
+- `integrator`: The active `DEIntegrator`.
+
+# Returns
+
+- `Real`: The controller's upper step-size growth bound.
+"""
+function get_qmax end
+
+"""
+    get_qmax_first_step(integrator) -> Real
+
+Read the first-step upper growth bound from the integrator's active controller.
+
+# Arguments
+
+- `integrator`: The active `DEIntegrator`.
+
+# Returns
+
+- `Real`: The controller's upper step-size growth bound for the first accepted
+    step attempt.
+"""
+function get_qmax_first_step end
+
+"""
+    get_gamma(integrator) -> Real
+
+Read the safety factor from the integrator's active controller.
+
+# Arguments
+
+- `integrator`: The active `DEIntegrator`.
+
+# Returns
+
+- `Real`: The controller's multiplicative safety factor.
+"""
+function get_gamma end
+
+"""
+    get_qsteady_min(integrator) -> Real
+
+Read the lower edge of the steady-step deadband from the active controller.
+
+# Arguments
+
+- `integrator`: The active `DEIntegrator`.
+
+# Returns
+
+- `Real`: The lower edge of the interval in which proposed `dt` changes are
+    suppressed.
+"""
+function get_qsteady_min end
+
+"""
+    get_qsteady_max(integrator) -> Real
+
+Read the upper edge of the steady-step deadband from the active controller.
+
+# Arguments
+
+- `integrator`: The active `DEIntegrator`.
+
+# Returns
+
+- `Real`: The upper edge of the interval in which proposed `dt` changes are
+    suppressed.
+"""
+function get_qsteady_max end
+
+"""
+    get_failfactor(integrator) -> Real
+
+Read the implicit-solver failure shrink factor from the active controller.
+
+[`post_newton_controller!`](@ref) uses this value to reduce `integrator.dt`
+after a nonlinear solver failure.
+
+# Arguments
+
+- `integrator`: The active `DEIntegrator`.
+
+# Returns
+
+- `Real`: The factor used to shrink `dt` after a nonlinear solve failure.
+"""
+function get_failfactor end
 
 @inline get_qmin(integrator::SciMLBase.DEIntegrator) =
     get_qmin(integrator, integrator.controller_cache)

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
@@ -161,7 +161,7 @@ step-size homotopy.
     `ArcLengthContinuation(inner = NewtonRaphson(autodiff = AutoFiniteDiff()))` to track
     the branch around folds. Note that the inner solver must not use ForwardDiff-based
     autodiff: the stage residual closes over preallocated `Float64` buffers (the same
-    restriction as [`NonlinearSolveAlg`](@ref)).
+    restriction as `NonlinearSolveAlg`).
 
 # Keyword arguments
 


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Moves copied `@doc (@doc ...)` documentation for controller/default accessor APIs onto the actual definition points.
- Expands the docstrings with signatures, argument descriptions, and return descriptions in the SciMLStyle shape.
- Keeps `NonlinearSolveAlg` internal by changing a broken public docs cross-reference to plain code text.

## Validation

- `timeout 3600 julia +release --startup-file=no --project=/home/crackauc/sandbox/tmp_20260708_051717_3275/.runic-env -e 'using Runic; exit(Runic.main(ARGS))' -- --check lib/OrdinaryDiffEqCore/src/alg_utils.jl lib/OrdinaryDiffEqCore/src/integrators/controllers.jl lib/OrdinaryDiffEqNonlinearSolve/src/type.jl`
- `timeout 3600 julia +release --startup-file=no --project=docs docs/make.jl`

The docs build completed successfully. It still emits pre-existing Documenter warnings for unrelated unresolved `@docs` entries and skipped doctests from the existing docs configuration.
