### PR TITLE
Flip now-passing NLStep convergence @test_broken to @test

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/nlstep_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/nlstep_tests.jl
@@ -46,7 +46,7 @@ sol2 = solve(testprob, TRBDF2(autodiff = AutoFiniteDiff(), nlsolve = nlalg), ada
 test_setup = Dict(:alg => FBDF(), :reltol => 1.0e-14, :abstol => 1.0e-14)
 dts = 2.0 .^ (-10:-1:-15)
 sim = analyticless_test_convergence(dts, testprob, TRBDF2(autodiff = AutoFiniteDiff(), nlsolve = nlalgrobust), test_setup);
-@test_broken abs(sim.𝒪est[:l∞] - 2) < 0.2
+@test abs(sim.𝒪est[:l∞] - 2) < 0.2
 
 dts = 2.0 .^ (-10:-1:-12)
 sim = analyticless_test_convergence(dts, testprob, KenCarp4(autodiff = AutoFiniteDiff(), nlsolve = nlalgrobust), test_setup);
@@ -58,7 +58,7 @@ sim = analyticless_test_convergence(dts, testprob, ABDF2(autodiff = AutoFiniteDi
 
 dts = 2.0 .^ (-13:-1:-16)
 sim = analyticless_test_convergence(dts, testprob, QNDF2(autodiff = AutoFiniteDiff(), nlsolve = nlalgrobust), test_setup);
-@test_broken abs(sim.𝒪est[:l∞] - 2.5) < 0.2 # Superconvergence
+@test abs(sim.𝒪est[:l∞] - 2.5) < 0.2 # Superconvergence
 
 dts = 2.0 .^ (-14:-1:-17)
 sim = analyticless_test_convergence(dts, testprob, FBDF(autodiff = AutoFiniteDiff(), nlsolve = nlalgrobust), test_setup);
@@ -102,7 +102,7 @@ sol2 = solve(testprob, TRBDF2(autodiff = AutoFiniteDiff(), nlsolve = nlalg), ada
 test_setup = Dict(:alg => FBDF(), :reltol => 1.0e-14, :abstol => 1.0e-14)
 dts = 2.0 .^ (-10:-1:-15)
 sim = analyticless_test_convergence(dts, testprob, TRBDF2(autodiff = AutoFiniteDiff(), nlsolve = nlalgrobust), test_setup);
-@test_broken abs(sim.𝒪est[:l∞] - 2) < 0.2
+@test abs(sim.𝒪est[:l∞] - 2) < 0.2
 
 dts = 2.0 .^ (-10:-1:-12)
 sim = analyticless_test_convergence(dts, testprob, KenCarp4(autodiff = AutoFiniteDiff(), nlsolve = nlalgrobust), test_setup);
@@ -114,7 +114,7 @@ sim = analyticless_test_convergence(dts, testprob, ABDF2(autodiff = AutoFiniteDi
 
 dts = 2.0 .^ (-13:-1:-16)
 sim = analyticless_test_convergence(dts, testprob, QNDF2(autodiff = AutoFiniteDiff(), nlsolve = nlalgrobust), test_setup);
-@test_broken abs(sim.𝒪est[:l∞] - 2.5) < 0.2 # Superconvergence
+@test abs(sim.𝒪est[:l∞] - 2.5) < 0.2 # Superconvergence
 
 dts = 2.0 .^ (-14:-1:-17)
 sim = analyticless_test_convergence(dts, testprob, FBDF(autodiff = AutoFiniteDiff(), nlsolve = nlalgrobust), test_setup);


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

The `sublibrary-ci / lib/OrdinaryDiffEqNonlinearSolve [ModelingToolkit]` job is red on `master` because four `@test_broken` convergence-order checks in `test/modelingtoolkit/nlstep_tests.jl` now **pass**, which the Test framework reports as an error ("Unexpected Pass ... please change to @test if no longer broken"):

- TRBDF2 order 2 (autonomous, line 49; non-autonomous, line 105)
- QNDF2 order 2.5 superconvergence (autonomous, line 61; non-autonomous, line 117)

Flip those four to `@test`. The KenCarp4 order-4 checks (lines 53, 109) are **left** `@test_broken` — they still don't reach order 4.

Verified locally (Julia 1.12): the full `nlstep_tests.jl` is **23 pass / 2 broken / 0 errored**.

This is orthogonal to #3885 (the NLStep path — `f.nlstep_data !== nothing` — is not touched by the W-reuse changes there); the failure reproduces on plain `master` (e.g. commit 9cb1737f's MTK job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)