### PR TITLE
nlstep tests: unbreak NSA(TrustRegion) order assertions that now pass

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/nlstep_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/nlstep_tests.jl
@@ -46,7 +46,7 @@ sol2 = solve(testprob, TRBDF2(autodiff = AutoFiniteDiff(), nlsolve = nlalg), ada
 test_setup = Dict(:alg => FBDF(), :reltol => 1.0e-14, :abstol => 1.0e-14)
 dts = 2.0 .^ (-10:-1:-15)
 sim = analyticless_test_convergence(dts, testprob, TRBDF2(autodiff = AutoFiniteDiff(), nlsolve = nlalgrobust), test_setup);
-@test_broken abs(sim.𝒪est[:l∞] - 2) < 0.2
+@test abs(sim.𝒪est[:l∞] - 2) < 0.2
 
 dts = 2.0 .^ (-10:-1:-12)
 sim = analyticless_test_convergence(dts, testprob, KenCarp4(autodiff = AutoFiniteDiff(), nlsolve = nlalgrobust), test_setup);
@@ -58,7 +58,7 @@ sim = analyticless_test_convergence(dts, testprob, ABDF2(autodiff = AutoFiniteDi
 
 dts = 2.0 .^ (-13:-1:-16)
 sim = analyticless_test_convergence(dts, testprob, QNDF2(autodiff = AutoFiniteDiff(), nlsolve = nlalgrobust), test_setup);
-@test_broken abs(sim.𝒪est[:l∞] - 2.5) < 0.2 # Superconvergence
+@test abs(sim.𝒪est[:l∞] - 2.5) < 0.2 # Superconvergence
 
 dts = 2.0 .^ (-14:-1:-17)
 sim = analyticless_test_convergence(dts, testprob, FBDF(autodiff = AutoFiniteDiff(), nlsolve = nlalgrobust), test_setup);
@@ -102,7 +102,7 @@ sol2 = solve(testprob, TRBDF2(autodiff = AutoFiniteDiff(), nlsolve = nlalg), ada
 test_setup = Dict(:alg => FBDF(), :reltol => 1.0e-14, :abstol => 1.0e-14)
 dts = 2.0 .^ (-10:-1:-15)
 sim = analyticless_test_convergence(dts, testprob, TRBDF2(autodiff = AutoFiniteDiff(), nlsolve = nlalgrobust), test_setup);
-@test_broken abs(sim.𝒪est[:l∞] - 2) < 0.2
+@test abs(sim.𝒪est[:l∞] - 2) < 0.2
 
 dts = 2.0 .^ (-10:-1:-12)
 sim = analyticless_test_convergence(dts, testprob, KenCarp4(autodiff = AutoFiniteDiff(), nlsolve = nlalgrobust), test_setup);
@@ -114,7 +114,7 @@ sim = analyticless_test_convergence(dts, testprob, ABDF2(autodiff = AutoFiniteDi
 
 dts = 2.0 .^ (-13:-1:-16)
 sim = analyticless_test_convergence(dts, testprob, QNDF2(autodiff = AutoFiniteDiff(), nlsolve = nlalgrobust), test_setup);
-@test_broken abs(sim.𝒪est[:l∞] - 2.5) < 0.2 # Superconvergence
+@test abs(sim.𝒪est[:l∞] - 2.5) < 0.2 # Superconvergence
 
 dts = 2.0 .^ (-14:-1:-17)
 sim = analyticless_test_convergence(dts, testprob, FBDF(autodiff = AutoFiniteDiff(), nlsolve = nlalgrobust), test_setup);


### PR DESCRIPTION
Four `@test_broken` order assertions in `modelingtoolkit/nlstep_tests.jl` now pass, so the MTK lane reports them as `Unexpected Pass` and errors out:

```
Unexpected Pass
Expression: abs(sim.𝒪est[:l∞] - 2) < 0.2
Got correct result, please change to @test if no longer broken.
```

All four are `NonlinearSolveAlg(TrustRegion())` convergence-order checks — TRBDF2 and QNDF2, in both the non-autonomous and autonomous Robertson blocks. They were the failures behind #3807 and #3818, and the recent NonlinearSolve releases (SciML/NonlinearSolve.jl#1010 recomputing the trust-region radius on `reinit!`, plus #1008) fixed them upstream.

This flips those four to `@test`. The two KenCarp4 order-4 assertions still fail and stay `@test_broken`.

Verified on a clean checkout of master (8ed2f7a5c1): before, `19 passed, 0 failed, 4 errored, 2 broken`; after, `23 passed, 2 broken, 0 errored`. The same 4 errors show up on the MTK lane of every open PR that touches this sublibrary, which is what makes that lane red.

## AI Disclosure

Claude assisted with this work.
