### PR TITLE
Test Enzyme on current stable Julia

### DIFF
--- a/test/AD/autodiff_events.jl
+++ b/test/AD/autodiff_events.jl
@@ -1,12 +1,13 @@
 # Version-dependent AD backend selection
-# Enzyme/Zygote: Julia <= 1.11 only (see https://github.com/EnzymeAD/Enzyme.jl/issues/2699)
+# Enzyme: all AD test lanes
+# Zygote: Julia <= 1.11 only
 # Mooncake: works on all Julia versions for the ForwardDiffSensitivity-based
 #   gradient tests below via SciMLSensitivityMooncakeExt. Mooncake does NOT
 #   support ReverseDiffAdjoint (TypeError on the ODESolution CoDual), so the
 #   ReverseDiffAdjoint-based gradient tests are not run with Mooncake.
 # ForwardDiff: all versions
 
-const JULIA_VERSION_ALLOWS_ENZYME_ZYGOTE = VERSION < v"1.12" && isempty(VERSION.prerelease)
+const JULIA_VERSION_ALLOWS_ZYGOTE = VERSION < v"1.12" && isempty(VERSION.prerelease)
 
 using SciMLSensitivity
 using OrdinaryDiffEq, OrdinaryDiffEqCore, FiniteDiff, Test
@@ -14,23 +15,22 @@ using OrdinaryDiffEqSDIRK
 using OrdinaryDiffEqCore: IController, PIController, PIDController
 using ADTypes
 import DifferentiationInterface as DI
+using Enzyme
 using Mooncake  # Load Mooncake after DI to ensure extension is loaded
 
 # Load version-dependent packages
-if JULIA_VERSION_ALLOWS_ENZYME_ZYGOTE
-    using Enzyme
+if JULIA_VERSION_ALLOWS_ZYGOTE
     using Zygote
     get_gradient_backends() = [AutoZygote()]
-    get_jacobian_backends() = [AutoForwardDiff()]
 else
-    # On Julia 1.12+, Zygote/Enzyme aren't available; the gradient_backends list
+    # On Julia 1.12+, Zygote isn't available; the gradient_backends list
     # is empty here because the existing gradient testset exercises sensealgs
     # (ReverseDiffAdjoint, PIDController, ...) that Mooncake does not support.
     # Mooncake-specific gradient tests for the sensealgs Mooncake DOES support
     # are added in a separate testset below.
     get_gradient_backends() = []
-    get_jacobian_backends() = [AutoForwardDiff()]
 end
+get_jacobian_backends() = [AutoForwardDiff()]
 
 function f(du, u, p, t)
     du[1] = u[2]
@@ -72,13 +72,11 @@ findiff
 end
 
 # Enzyme fails on ContinuousCallback with "mixed activity for jl_new_struct"
-if JULIA_VERSION_ALLOWS_ENZYME_ZYGOTE
-    @testset "Enzyme callback limitation (jacobian)" begin
-        @test_broken (
-            ad = DI.jacobian(test_f, AutoEnzyme(mode = Enzyme.set_runtime_activity(Enzyme.Forward)), p);
-            ad ≈ findiff
-        )
-    end
+@testset "Enzyme callback limitation (jacobian)" begin
+    @test_broken (
+        ad = DI.jacobian(test_f, AutoEnzyme(mode = Enzyme.set_runtime_activity(Enzyme.Forward)), p);
+        ad ≈ findiff
+    )
 end
 
 function test_f2(
@@ -141,13 +139,11 @@ end
 end
 
 # Enzyme fails on ContinuousCallback with "mixed activity for jl_new_struct"
-if JULIA_VERSION_ALLOWS_ENZYME_ZYGOTE
-    @testset "Enzyme callback limitation (gradient)" begin
-        @test (
-            g = DI.gradient(θ -> test_f2(θ, ForwardDiffSensitivity()), AutoEnzyme(mode = Enzyme.set_runtime_activity(Enzyme.Reverse)), p);
-            g ≈ findiff[2, 1:2]
-        )
-    end
+@testset "Enzyme callback limitation (gradient)" begin
+    @test (
+        g = DI.gradient(θ -> test_f2(θ, ForwardDiffSensitivity()), AutoEnzyme(mode = Enzyme.set_runtime_activity(Enzyme.Reverse)), p);
+        g ≈ findiff[2, 1:2]
+    )
 end
 
 # Mooncake gradient tests (all Julia versions). Only the sensealgs Mooncake

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -172,8 +172,7 @@ function downstream_group()
 end
 
 function ad_group()
-    # AD tests - Enzyme/Zygote only on Julia <= 1.11 (see https://github.com/EnzymeAD/Enzyme.jl/issues/2699)
-    # Mooncake works on all Julia versions
+    # Enzyme and Mooncake run on both AD lanes; Zygote runs on Julia <= 1.11.
     is_APPVEYOR && return
     activate_ad_env()
     @time @safetestset "AD Tests" include("AD/ad_tests.jl")

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -26,7 +26,7 @@ versions = ["lts", "1", "pre"]
 versions = ["lts", "1", "pre"]
 continue_on_error = true
 [AD]
-versions = ["lts"]
+versions = ["lts", "1"]
 [QA]
 versions = ["lts", "1"]
 [ODEInterfaceRegression]


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Closes #3889.

## Summary

- Add the current stable Julia release to the AD test matrix alongside LTS.
- Run the Enzyme callback-event tests on every supported AD lane.
- Preserve Zygote's existing Julia version restriction and keep prerelease Julia out of the AD matrix.

## Testing

- `GROUP=AD julia +1.10 --project -e 'using Pkg; Pkg.test()'` passed during development (28,301 AD assertions passed, 2 broken; 11 callback-event assertions passed, 3 broken; 1 discrete-callback assertion passed).
- `GROUP=AD julia +1 --project -e 'using Pkg; Pkg.test()'` is running against the exact committed tree; the PR will be updated with its final summary.
- Repository-wide Runic check passed.

## Process

I inspected #3889 and the callback-event test history, then separated the shared Enzyme/Zygote version gate so each backend follows its supported Julia versions. Prerelease Julia was considered and explicitly excluded from the AD matrix per maintainer direction.
