### PR TITLE
NSA W-reuse: give inner solver a concrete W, not an operator (#3899)

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -248,16 +248,18 @@ function _nlalg_with_linsolve(inner_alg, linsolve)
     return remake(inner_alg; descent = remake(descent; linsolve = linsolve))
 end
 
-# The reused ODE `W` as the operator handed to the inner NonlinearSolve as `jac_prototype`.
-# A matrix-free `WOperator` (its `J` an operator) is passed through and applied via `mul!`;
-# a concrete `WOperator`'s materialized form, or a raw matrix, is wrapped in a
-# `MatrixOperator` and materialized via `convert` for a factorization. Used identically at
-# build time and after a `resize!` so the inner `NonlinearFunction`'s concrete type is
-# preserved.
+# The reused ODE `W` handed to the inner NonlinearSolve as `jac_prototype`. A matrix-free
+# `WOperator` (its `J` an operator) is passed through and applied via `mul!`; a concrete
+# `WOperator`'s materialized form, or a raw matrix, is handed over as that matrix so the
+# inner Jacobian mirrors W's structure (a sparse W stays sparse) without densifying.
+# It is deliberately not wrapped in a `MatrixOperator`: a globalized inner solver
+# (e.g. `TrustRegion`) builds its step from a concrete J, and an operator-valued J leaves
+# it converging on a wrong model. Used identically at build time and after a `resize!` so
+# the inner `NonlinearFunction`'s concrete type is preserved.
 function reuse_jac_prototype(W)
     Wr = W isa WOperator && W.J !== nothing && !(W.J isa AbstractSciMLOperator) ?
         W._concrete_form : W
-    return Wr isa AbstractSciMLOperator ? Wr : MatrixOperator(Wr)
+    return Wr
 end
 
 """
@@ -411,16 +413,24 @@ function build_nlsolver(
                     (tmp, ustep, γ, α, tstep, k, invγdt, DIRK, p, dt, f)
                 end
                 if use_w_reuse
-                    # Hand the reused W to the inner NonlinearFunction as an operator
-                    # `jac_prototype`. A matrix-free `WOperator` is applied via `mul!`
-                    # (Krylov); a concrete W is materialized via `convert` for a
-                    # factorization (NonlinearSolve copies it before an in-place `lu!`, so the
-                    # ODE-owned W is never destroyed). `jac` is auto-wired to
-                    # `update_coefficients!`; the ODE owns W's updates, so NonlinearSolve holds
-                    # W fixed across its Newton steps.
+                    # Hand the reused W to the inner NonlinearFunction as `jac_prototype`,
+                    # so its Jacobian mirrors W's structure. A matrix-free `WOperator` is
+                    # applied via `mul!` (Krylov) and needs no `jac`. A concrete W is
+                    # copied in by an analytic `jac` instead of being re-derived by AD; the
+                    # ODE owns W's updates, so NonlinearSolve holds it fixed across its
+                    # Newton steps (NonlinearSolve copies J before an in-place `lu!`, so the
+                    # ODE-owned W is never destroyed).
+                    nlf_jac! = if matrixfree_W
+                        nothing
+                    else
+                        let W = W_for_reuse
+                            (J_out, z, p) -> (copyto!(J_out, W); J_out)
+                        end
+                    end
                     NonlinearProblem(
                         NonlinearFunction{true, SciMLBase.FullSpecialize}(
                             nlf;
+                            jac = nlf_jac!,
                             jac_prototype = reuse_jac_prototype(W)
                         ),
                         ztmp, nlp_params

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_jacobian_reuse_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_jacobian_reuse_tests.jl
@@ -1,7 +1,7 @@
 using OrdinaryDiffEqBDF, OrdinaryDiffEqSDIRK
 using OrdinaryDiffEqNonlinearSolve
 using OrdinaryDiffEqNonlinearSolve: NonlinearSolveAlg
-using NonlinearSolve: NewtonRaphson
+using NonlinearSolve: NewtonRaphson, TrustRegion
 using ADTypes, LinearAlgebra, SciMLBase
 using Test
 
@@ -46,5 +46,23 @@ refsol = solve(prob, FBDF(); reltol = 1.0e-12, abstol = 1.0e-14)
         # stats.nw one-to-one.
         @test JAC_CALLS[] < sol.stats.nw / 3
         @test JAC_CALLS[] >= 1
+    end
+end
+
+@testset "W-reuse keeps a globalized inner solver accurate" begin
+    # Handing the reused W to the inner solver as a `MatrixOperator` leaves it without a
+    # concrete J to build a trust-region model from: TrustRegion then converges to a
+    # wrong answer while still reporting Success. Newton-type inner solvers tolerate it,
+    # so this is only visible with a globalized one.
+    for inner in (
+            TrustRegion(; autodiff = AutoForwardDiff()),
+            NewtonRaphson(; autodiff = AutoForwardDiff()),
+        )
+        sol = solve(
+            prob, FBDF(nlsolve = NonlinearSolveAlg(inner));
+            reltol = 1.0e-8, abstol = 1.0e-10
+        )
+        @test SciMLBase.successful_retcode(sol)
+        @test norm(sol.u[end] .- refsol.u[end]) / norm(refsol.u[end]) < 1.0e-6
     end
 end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_sparse_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_sparse_tests.jl
@@ -55,11 +55,12 @@ nsa = NonlinearSolveAlg(NewtonRaphson(; autodiff = AutoForwardDiff()))
     integ = init(prob, FBDF(nlsolve = nsa); reltol = 1.0e-8, abstol = 1.0e-10)
     nsacache = integ.cache.nlsolver.cache
     @test nsacache.W isa SparseMatrixCSC
-    # The inner NonlinearSolve Jacobian is the reused W as an operator; its underlying
-    # matrix must mirror W's structure (stay sparse), not densify.
+    # The inner NonlinearSolve Jacobian mirrors W's structure (stays sparse), rather
+    # than densifying. It is handed over as a plain matrix, not wrapped in an operator:
+    # a globalized inner solver (TrustRegion) needs a concrete J to build its model.
     J = integ.cache.nlsolver.cache.cache.jac_cache.J
-    @test J isa MatrixOperator
-    @test convert(AbstractMatrix, J) isa SparseMatrixCSC
+    @test J isa SparseMatrixCSC
+    @test nnz(J) == nnz(nsacache.W)
 end
 
 @testset "NSA + sparse-only linsolve (KLU) solves" begin


### PR DESCRIPTION
Fixes #3899.

## Bug

Under W-reuse, #3885 hands the reused ODE `W` to the inner `NonlinearFunction` as `jac_prototype = MatrixOperator(W)` with no `jac`, so the inner Jacobian is an operator.

`NewtonRaphson` only needs `J \ f`, which the operator supplies, and is unaffected. `TrustRegion` builds its step from a concrete Jacobian; given an operator it works from a model that does not match the residual, mismanages the trust radius, and converges to the wrong answer while the outer solve still sees a small displacement and accepts the stage.

FBDF on Robertson with an analytic jac, `reltol = 1e-8` / `abstol = 1e-10`, against `FBDF()` at `1e-12`/`1e-14`:

| commit | inner solver | relative error | retcode |
|---|---|---|---|
| 3b799e583a (pre-#3885) | TrustRegion | 2.03e-8 | Success |
| 9a2f7e7b79 (#3885) | TrustRegion | **0.1006** | **Success** |
| either | NewtonRaphson | 7.56e-10 | Success |

## Fix

Pass a concrete W to the inner solver as the matrix itself rather than wrapping it in a `MatrixOperator`, and give that path back its analytic `jac` closure so the Jacobian is copied from W instead of being re-derived by AD. The matrix-free `WOperator` path (Krylov, applied via `mul!`) is untouched — that is what the operator prototype is for.

Isolating the pieces:

| variant | TrustRegion relerr | #3885's sparse/matrix-free tests |
|---|---|---|
| #3885 as merged | 0.101 | pass |
| restore `jac`, keep the `MatrixOperator` prototype | 0.101 | — |
| drop `jac_prototype` entirely | 2.03e-8 | **fail** (inner J densifies) |
| raw-matrix `jac_prototype` + `jac` closure | **2.03e-8** | **pass** |

Everything #3885 set out to do still holds: the inner Jacobian mirrors W's structure, so a sparse W yields a sparse inner `J` with `nnz` unchanged (no densification) and `KLUFactorization` still works. TrustRegion returns to matching NewtonRaphson.

## Tests

`nsa_jacobian_reuse_tests.jl` gains a check that a globalized inner solver stays accurate under W-reuse — it fails on master and passes here.

One assertion in `nsa_sparse_tests.jl` changed: it asserted `J isa MatrixOperator`, which pins the implementation rather than the requirement. It now asserts the inner `J` is a `SparseMatrixCSC` whose `nnz` matches W's, which is the property that actually needs to hold.

`OrdinaryDiffEqNonlinearSolve` suites pass, including #3885's own `nsa_sparse_tests.jl` and `nsa_matrixfree_tests.jl`.

## AI Disclosure

Claude assisted with this work.
