### PR TITLE
Fix set_all_nzval!/get_nzval for non-CSC sparse matrices

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/ext/OrdinaryDiffEqDifferentiationSparseArraysExt.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/ext/OrdinaryDiffEqDifferentiationSparseArraysExt.jl
@@ -13,7 +13,7 @@ OrdinaryDiffEqDifferentiation.nonzeros(A::AbstractSparseMatrix) = nonzeros(A)
 OrdinaryDiffEqDifferentiation.spzeros(T::Type, m::Integer, n::Integer) = spzeros(T, m, n)
 
 # Helper functions for accessing sparse matrix internals
-OrdinaryDiffEqDifferentiation.get_nzval(A::SparseMatrixCSC) = A.nzval
-OrdinaryDiffEqDifferentiation.set_all_nzval!(A::SparseMatrixCSC, val) = (A.nzval .= val; A)
+OrdinaryDiffEqDifferentiation.get_nzval(A::AbstractSparseMatrix) = nonzeros(A)
+OrdinaryDiffEqDifferentiation.set_all_nzval!(A::AbstractSparseMatrix, val) = (nonzeros(A) .= val; A)
 
 end

--- a/lib/OrdinaryDiffEqDifferentiation/test/nzval_helpers_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/nzval_helpers_tests.jl
@@ -1,0 +1,36 @@
+using OrdinaryDiffEqDifferentiation
+using SparseArrays
+using LinearAlgebra
+using Test
+
+# `is_sparse` is true for every AbstractSparseMatrix, so the nzval helpers guarded by
+# it must work for every AbstractSparseMatrix as well -- not just SparseMatrixCSC.
+# GPU sparse matrices (CuSparseMatrixCSC/CSR/...) are AbstractSparseMatrix with
+# non-CSC storage and used to fall through to the "SparseArrays extension not loaded"
+# error, even with SparseArrays loaded. The real cuSPARSE matrices are exercised on
+# GPU CI (test/gpu/sparse_default_linsolve_tests.jl); here we stand in for them with a
+# minimal non-CSC sparse matrix that only provides the AbstractSparseMatrix interface.
+struct COOMatrix{Tv, Ti} <: AbstractSparseMatrix{Tv, Ti}
+    m::Int
+    n::Int
+    rows::Vector{Ti}
+    cols::Vector{Ti}
+    vals::Vector{Tv}
+end
+Base.size(A::COOMatrix) = (A.m, A.n)
+SparseArrays.nonzeros(A::COOMatrix) = A.vals
+
+A_csc = sparse([1.0 0.0; 0.5 2.0])
+A_coo = COOMatrix(2, 2, [1, 2, 2], [1, 1, 2], [1.0, 0.5, 2.0])
+
+@test OrdinaryDiffEqDifferentiation.is_sparse(A_csc)
+@test OrdinaryDiffEqDifferentiation.is_sparse(A_coo)
+
+@test OrdinaryDiffEqDifferentiation.get_nzval(A_csc) == [1.0, 0.5, 2.0]
+@test OrdinaryDiffEqDifferentiation.get_nzval(A_coo) == [1.0, 0.5, 2.0]
+
+@test OrdinaryDiffEqDifferentiation.set_all_nzval!(A_csc, 7.0) === A_csc
+@test all(==(7.0), nonzeros(A_csc))
+
+@test OrdinaryDiffEqDifferentiation.set_all_nzval!(A_coo, 7.0) === A_coo
+@test all(==(7.0), nonzeros(A_coo))

--- a/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
@@ -30,6 +30,7 @@ end
 # Run functional tests
 if TEST_GROUP ∉ ("QA", "Sparse", "ModelingToolkit")
     @time @safetestset "DAE jacobian2W sparse" include("dae_jacobian2w_sparse_tests.jl")
+    @time @safetestset "nzval helpers" include("nzval_helpers_tests.jl")
     @time @safetestset "OOP J_t Tracking" include("oop_jt_tracking_test.jl")
     @time @safetestset "Differentiation Trait Tests" include("differentiation_traits_tests.jl")
     @time @safetestset "Autodiff Error Tests" include("autodiff_error_tests.jl")


### PR DESCRIPTION
is_sparse is true for every AbstractSparseMatrix, but get_nzval and set_all_nzval! were only defined for SparseMatrixCSC, so GPU sparse matrices (CuSparseMatrixCSC/CSR/...) hit the "SparseArrays extension not loaded" stub in build_J_W even though SparseArrays was loaded. This makes a mass-matrix DAE with a cuSPARSE jac_prototype unsolvable with the default (concrete-A) linsolve.

Both helpers now dispatch on AbstractSparseMatrix via nonzeros.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
