### PR TITLE
Add OrdinaryDiffEqNewmark Documentation

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -20,6 +20,7 @@ OrdinaryDiffEqIMEXMultistep = "9f002381-b378-40b7-97a6-27a27c83f129"
 OrdinaryDiffEqLinear = "521117fe-8c41-49f8-b3b6-30780b3f0fb5"
 OrdinaryDiffEqLowOrderRK = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
 OrdinaryDiffEqLowStorageRK = "b0944070-b475-4768-8dec-fb6eb410534d"
+OrdinaryDiffEqNewmark = "d204908a-63b9-11ef-18f5-cfec7123a93b"
 OrdinaryDiffEqNonlinearSolve = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 OrdinaryDiffEqNordsieck = "c9986a66-5c92-4813-8696-a7ec84c806c8"
 OrdinaryDiffEqPDIRK = "5dd0a6cf-3d4b-4314-aa06-06d4e299bc89"
@@ -55,6 +56,7 @@ OrdinaryDiffEqIMEXMultistep = {path = "../lib/OrdinaryDiffEqIMEXMultistep"}
 OrdinaryDiffEqLinear = {path = "../lib/OrdinaryDiffEqLinear"}
 OrdinaryDiffEqLowOrderRK = {path = "../lib/OrdinaryDiffEqLowOrderRK"}
 OrdinaryDiffEqLowStorageRK = {path = "../lib/OrdinaryDiffEqLowStorageRK"}
+OrdinaryDiffEqNewmark = {path = "../lib/OrdinaryDiffEqNewmark"}
 OrdinaryDiffEqNonlinearSolve = {path = "../lib/OrdinaryDiffEqNonlinearSolve"}
 OrdinaryDiffEqNordsieck = {path = "../lib/OrdinaryDiffEqNordsieck"}
 OrdinaryDiffEqPDIRK = {path = "../lib/OrdinaryDiffEqPDIRK"}
@@ -92,6 +94,7 @@ OrdinaryDiffEqIMEXMultistep = "2.0.0"
 OrdinaryDiffEqLinear = "2.0.0"
 OrdinaryDiffEqLowOrderRK = "2.0.0"
 OrdinaryDiffEqLowStorageRK = "3.0.0"
+OrdinaryDiffEqNewmark = "2.0.0"
 OrdinaryDiffEqNonlinearSolve = "2"
 OrdinaryDiffEqNordsieck = "2.0.0"
 OrdinaryDiffEqPDIRK = "2.0.0"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -26,6 +26,7 @@ using OrdinaryDiffEqNordsieck
 using OrdinaryDiffEqPDIRK
 using OrdinaryDiffEqPRK
 using OrdinaryDiffEqQPRK
+using OrdinaryDiffEqNewmark
 using OrdinaryDiffEqRKN
 using OrdinaryDiffEqRosenbrock
 using OrdinaryDiffEqSDIRK
@@ -69,6 +70,7 @@ makedocs(
         OrdinaryDiffEqPDIRK,
         OrdinaryDiffEqPRK,
         OrdinaryDiffEqQPRK,
+        OrdinaryDiffEqNewmark,
         OrdinaryDiffEqRKN,
         OrdinaryDiffEqRosenbrock,
         OrdinaryDiffEqSDIRK,

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -34,9 +34,10 @@ pages = [
         "imex/StabilizedIRK.md",
         "imex/IMEXBDF.md",
     ],
-    "Dynamical ODE Explicit Solvers" => [
+    "Dynamical ODE Solvers" => [
         "dynamicalodeexplicit/RKN.md",
         "dynamicalodeexplicit/SymplecticRK.md",
+        "dynamicalodeexplicit/Newmark.md",
     ],
     "Semilinear ODE Solvers" => [
         "semilinear/ExponentialRK.md",

--- a/docs/src/dynamicalodeexplicit/Newmark.md
+++ b/docs/src/dynamicalodeexplicit/Newmark.md
@@ -4,7 +4,7 @@ CollapsedDocStrings = true
 
 # OrdinaryDiffEqNewmark
 
-Newmark-β and generalized-α methods for second-order ODEs, typically in mass-matrix form. These are second order time integrators, advancing the displacement and velocity with Newmark updates and solve a nonlinear residual for the acceleration directly. They arose from time stepping in structural and computational mechanics and are designed for such systems.
+Newmark-β and generalized-α methods for second-order ODEs, typically in mass-matrix form. These are second-order time integrators, advancing the displacement and velocity with Newmark updates and solving a nonlinear residual for the acceleration directly. They arose from time stepping in structural and computational mechanics and are designed for such systems.
 
 ## Key Properties
 
@@ -44,9 +44,9 @@ and the standard Newmark updates for `uₙ₊₁` and `vₙ₊₁`. Setting `α�
 
   - **`NewmarkBeta`**: Classical Newmark-β. Default `β = 1/4`, `γ = 1/2` (average acceleration, second-order when `γ = 1/2`).
   - **`GeneralizedAlpha`**: Preferred when controllable high-frequency damping is needed.
-      - **`GeneralizedAlpha(; rho_inf)`**: Recommended parameterization. `ρ∞ = 1` gives no algorithmic damping (equivalent to undamped Newmark); `ρ∞ = 0` gives maximum damping. Always sets unconditionally stable in [0, 1].
+      - **`GeneralizedAlpha(; rho_inf)`**: Recommended parameterization. `ρ∞ = 1` gives no algorithmic damping (equivalent to undamped Newmark); `ρ∞ = 0` gives maximum damping. Always unconditionally stable in [0, 1].
       - **`GeneralizedAlpha(; alpha_hht)`**: HHT-α convenience (`α ∈ [-1/3, 0]`). Also unconditionally stable in that range.
-      - **`GeneralizedAlpha(αm, αf, β, γ)`**: Explicit four-parameter construction. Can break unconditionally stablity if parameters are chosen poorly.
+      - **`GeneralizedAlpha(αm, αf, β, γ)`**: Explicit four-parameter construction. Can break unconditional stability if parameters are chosen poorly.
 
 ### Unconditional stability
 
@@ -60,7 +60,7 @@ Second-order accuracy further requires `γ = 1/2 - αₘ + αf`. The `rho_inf` a
 
 ## Installation
 
-To be able to access the solvers in `OrdinaryDiffEqNewmark`, you must first install them use the Julia package manager:
+To be able to access the solvers in `OrdinaryDiffEqNewmark`, you must first install them using the Julia package manager:
 
 ```julia
 using Pkg

--- a/docs/src/dynamicalodeexplicit/Newmark.md
+++ b/docs/src/dynamicalodeexplicit/Newmark.md
@@ -1,0 +1,96 @@
+```@meta
+CollapsedDocStrings = true
+```
+
+# OrdinaryDiffEqNewmark
+
+Newmark-β and generalized-α methods for second-order ODEs, typically in mass-matrix form. These are second order time integrators, advancing the displacement and velocity with Newmark updates and solve a nonlinear residual for the acceleration directly. They arose from time stepping in structural and computational mechanics and are designed for such systems.
+
+## Key Properties
+
+These methods provide:
+
+  - **Direct integration** of second-order ODEs, including mass-matrix form
+  - **Unconditionally stable** parameter choices for structural dynamics
+  - **Controllable high-frequency damping** via generalized-α's (`ρ∞`)
+  - **Newmark-β and HHT-α** as special cases of generalized-α
+  - **Adaptive time stepping** with the Zienkiewicz–Xie local truncation error estimate (Newmark-β)
+
+## When to Use Newmark Methods
+
+These methods are recommended for:
+
+  - **Structural dynamics** and finite-element/Galerkin vibration problems
+  - **Second-order ODEs** of the form `M a = f(u, v, t)`
+  - **Problems needing algorithmic damping** of spurious high-frequency modes
+  - **Mass-matrix second-order systems** arising from spatial discretizations
+  - **Cases where RKN/symplectic methods are not the right fit** (implicit structural integrators with dissipation control)
+
+## Mathematical Background
+
+The generalized-α method evaluates the equations of motion at interpolated states:
+
+`M * aₙ₊αₘ = f(uₙ₊αf, vₙ₊αf, tₙ₊αf)`
+
+with
+
+  - `aₙ₊αₘ = (1 - αₘ) * aₙ₊₁ + αₘ * aₙ`
+  - `uₙ₊αf = (1 - αf) * uₙ₊₁ + αf * uₙ`
+  - `vₙ₊αf = (1 - αf) * vₙ₊₁ + αf * vₙ`
+
+and the standard Newmark updates for `uₙ₊₁` and `vₙ₊₁`. Setting `αₘ = αf = 0` recovers Newmark-β; setting `αₘ = 0` recovers HHT-α.
+
+## Solver Selection Guide
+
+  - **`NewmarkBeta`**: Classical Newmark-β. Default `β = 1/4`, `γ = 1/2` (average acceleration, second-order when `γ = 1/2`).
+  - **`GeneralizedAlpha`**: Preferred when controllable high-frequency damping is needed.
+      - **`GeneralizedAlpha(; rho_inf)`**: Recommended parameterization. `ρ∞ = 1` gives no algorithmic damping (equivalent to undamped Newmark); `ρ∞ = 0` gives maximum damping. Always sets unconditionally stable in [0, 1].
+      - **`GeneralizedAlpha(; alpha_hht)`**: HHT-α convenience (`α ∈ [-1/3, 0]`). Also unconditionally stable in that range.
+      - **`GeneralizedAlpha(αm, αf, β, γ)`**: Explicit four-parameter construction. Can break unconditionally stablity if parameters are chosen poorly.
+
+### Unconditional stability
+
+**Newmark-β** is unconditionally stable when `γ ≥ 1/2` and `β ≥ (1/4) * (γ + 1/2)^2`.
+
+The default `β = 1/4`, `γ = 1/2` (average acceleration) sits on this bound and is second-order. `γ = 1/2` with `β < 1/4` (e.g. central difference `β = 0`) is only conditionally stable. `γ > 1/2` adds numerical damping but drops the method to first order.
+
+**Generalized-α** is unconditionally stable when `αₘ ≤ αf ≤ 1/2` and `β ≥ (1/4) * (1/2 + αf - αₘ)^2`.
+
+Second-order accuracy further requires `γ = 1/2 - αₘ + αf`. The `rho_inf` and `alpha_hht` constructors enforce these choices; the four-parameter form asserts the stability inequalities above at construction, so values that violate them will error rather than silently run unstably.
+
+## Installation
+
+To be able to access the solvers in `OrdinaryDiffEqNewmark`, you must first install them use the Julia package manager:
+
+```julia
+using Pkg
+Pkg.add("OrdinaryDiffEqNewmark")
+```
+
+This will only install the solvers listed at the bottom of this page.
+If you want to explore other solvers for your problem,
+you will need to install some of the other libraries listed in the navigation bar on the left.
+
+## Example usage
+
+```julia
+using OrdinaryDiffEqNewmark
+function f1!(dv, v, u, p, t)
+    dv .= -u
+end
+function f2!(du, v, u, p, t)
+    du .= v
+end
+v0 = ones(2)
+u0 = zeros(2)
+prob = DynamicalODEProblem(f1!, f2!, v0, u0, (0.0, 5.0))
+sol = solve(prob, NewmarkBeta(), dt = 0.1)
+sol_ga = solve(prob, GeneralizedAlpha(; rho_inf = 0.8), dt = 0.1)
+```
+
+## Full list of solvers
+
+```@docs
+NewmarkBeta
+GeneralizedAlpha
+```


### PR DESCRIPTION
## Add OrdinaryDiffEqNewmark Documentation
Adds public documentation for the Newmark-β and generalized-α solvers in OrdinaryDiffEqNewmark, which previously had no docs page.

- Renamed the docs section from "Dynamical ODE Explicit Solvers" to "Dynamical ODE Solvers" so it covers both the existing explicit dynamical methods (RKN, SymplecticRK) and the Newmark family which can be and is often implicit
- Added docs/src/dynamicalodeexplicit/Newmark.md for OrdinaryDiffEqNewmark, matching the style of the RKN/Symplectic pages 
- Included guidance on unconditional stability/background for Newmark-β and generalized-α parameter choices
- Wired OrdinaryDiffEqNewmark into docs/make.jl and docs/Project.toml so Documenter can resolve the package and docstrings