### PR TITLE
Propagate downstream resolver failures

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -49,17 +49,10 @@ jobs:
         shell: julia --color=yes --project=downstream {0}
         run: |
           using Pkg
-          try
-            Pkg.develop(map(path ->Pkg.PackageSpec.(;path="lib/$(path)"), readdir("./lib")));
-            Pkg.test(coverage=true)  # resolver may fail with test time depsAdd commentMore actions
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
-          end
+          Pkg.develop(PackageSpec(path="."))
+          Pkg.develop(map(path -> Pkg.PackageSpec(; path = joinpath("lib", path)), readdir("lib")))
+          Pkg.update()
+          Pkg.test(coverage=true)
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7
         with:


### PR DESCRIPTION
## Summary

- remove the custom downstream workflow's `ResolverError` catch and successful `exit(0)` path
- develop the OrdinaryDiffEq root package as well as its sublibraries before testing
- update the resolved downstream environment before running its selected group

The prior workflow converted all 12 recently sampled resolver failures into green jobs without running tests. This change makes incompatible environments visible so they cannot masquerade as successful integration coverage.

## Local verification

- workflow-shaped Julia 1.10 run for `PositiveIntegrators/Downstream` — exited 1 at the dependency resolver, demonstrating that the incompatibility now propagates instead of being reported successful
- `actionlint` — passed
- `julia +1.12 -m Runic --check .` — passed
- `git diff --check` — passed

The resolver conflict itself is a legitimate downstream compatibility failure and is intentionally not hidden by this PR.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.