### PR TITLE
Document DiffEqDevTools public API

### DIFF
--- a/docs/src/devtools/alg_dev/benchmarks.md
+++ b/docs/src/devtools/alg_dev/benchmarks.md
@@ -77,3 +77,13 @@ wp_set = WorkPrecisionSet(prob, abstols, reltols, setups; dt = 1 / 2^4, numruns 
 
 Both of these types have a plot recipe to produce a work-precision diagram,
 and a print which will show some relevant information.
+
+## API
+
+```@docs
+DiffEqDevTools.Shootout
+DiffEqDevTools.ShootoutSet
+DiffEqDevTools.WorkPrecision
+DiffEqDevTools.WorkPrecisionSet
+DiffEqDevTools.get_sample_errors
+```

--- a/docs/src/devtools/alg_dev/convergence.md
+++ b/docs/src/devtools/alg_dev/convergence.md
@@ -91,3 +91,11 @@ halving/doubling stepsizes via
 log2(error[i+1]/error[i])
 
 Returns the mean of the convergence estimates.
+
+## API
+
+```@docs
+DiffEqDevTools.ConvergenceSimulation
+DiffEqDevTools.test_convergence
+DiffEqDevTools.analyticless_test_convergence
+```

--- a/docs/src/devtools/internals/tableaus.md
+++ b/docs/src/devtools/internals/tableaus.md
@@ -113,6 +113,7 @@
 ```@docs
 DiffEqDevTools.stability_region
 DiffEqDevTools.imaginary_stability_interval
+DiffEqDevTools.check_tableau
 OrdinaryDiffEq.ODE_DEFAULT_TABLEAU
 ```
 

--- a/lib/DiffEqDevTools/src/benchmark.jl
+++ b/lib/DiffEqDevTools/src/benchmark.jl
@@ -11,6 +11,18 @@ __default_name(alg) = string(nameof(typeof(alg)))
 
 ## Shootouts
 
+"""
+    Shootout(prob, setups; appxsol = nothing, names = nothing,
+        error_estimate = :final, numruns = 20, seconds = 2, kwargs...)
+
+Benchmark multiple solver configurations on one problem. Each entry of `setups` is a
+dictionary containing an `:alg` and any solver-specific keyword arguments. The result
+stores the solutions, errors, timings, efficiencies, and the configuration with the
+highest efficiency, where efficiency is `1 / (error * time)`.
+
+Use `appxsol` as a numerical reference when the problem has no analytic solution.
+Additional keyword arguments are forwarded to every solve.
+"""
 mutable struct Shootout
     setups::Vector{Dict{Symbol, Any}}
     times::Any #::Vector{Float64}
@@ -24,6 +36,14 @@ mutable struct Shootout
     winner::String
 end
 
+"""
+    ShootoutSet(probs, setups; probaux = nothing, names = nothing,
+        print_names = false, kwargs...)
+
+Run a [`Shootout`](@ref) for every problem in `probs`. `probaux` may contain one
+dictionary of per-problem keyword arguments for each problem; other keyword arguments
+are shared by every shootout.
+"""
 mutable struct ShootoutSet
     shootouts::Vector{Shootout}
     probs::Any #::Vector{AbstractDEProblem}
@@ -165,6 +185,19 @@ Base.lastindex(shoot::ShootoutSet) = lastindex(shoot.shootouts)
 
 ## WorkPrecisions
 
+"""
+    WorkPrecision(prob, alg, abstols, reltols, dts = nothing;
+        name = nothing, appxsol = nothing, error_estimate = :final,
+        numruns = 20, seconds = 2, kwargs...)
+
+Measure error and execution time for `alg` at corresponding absolute and relative
+tolerances. When `dts` is provided, its entries select a fixed time step for each
+tolerance pair. The result stores the measured errors, timings, solver statistics, and
+inputs for plotting a work-precision diagram.
+
+Use `appxsol` as a numerical reference when the problem has no analytic solution.
+Additional keyword arguments are forwarded to `solve`.
+"""
 mutable struct WorkPrecision
     prob::Any
     abstols::Any
@@ -178,6 +211,14 @@ mutable struct WorkPrecision
     N::Int
 end
 
+"""
+    WorkPrecisionSet(prob, abstols, reltols, setups; kwargs...)
+
+Build one [`WorkPrecision`](@ref) result for each solver configuration in `setups` so
+their work-precision curves can be compared. Each setup is a dictionary containing an
+`:alg` and may override the shared tolerances or fixed step sizes with `:abstols`,
+`:reltols`, or `:dts`.
+"""
 mutable struct WorkPrecisionSet
     wps::Vector{WorkPrecision}
     N::Int
@@ -889,6 +930,22 @@ function WorkPrecisionSet(
     )
 end
 
+"""
+    get_sample_errors(prob::AbstractRODEProblem, setup, test_dt = nothing;
+        numruns, solution_runs, appxsol_setup = nothing,
+        sample_error_runs = 10^7, parallel_type = :none, kwargs...)
+
+Estimate an approximate 95% confidence half-width for the sampling error of an RODE
+solver setup. `numruns` may be one sample count or a collection of counts; the return
+value is respectively a scalar or a collection of sampling-error estimates.
+`solution_runs` controls the number of independent estimates used to measure their
+variation.
+
+When an analytic solution is available, `sample_error_runs` controls the Monte Carlo
+estimate of its expected endpoint. Otherwise, repeated numerical solution means provide
+the endpoint reference. Set `parallel_type = :threads` to parallelize the solution
+samples.
+"""
 function get_sample_errors(
         prob::AbstractRODEProblem, setup, test_dt = nothing;
         appxsol_setup = nothing,

--- a/lib/DiffEqDevTools/src/convergence.jl
+++ b/lib/DiffEqDevTools/src/convergence.jl
@@ -1,3 +1,14 @@
+"""
+    ConvergenceSimulation(solutions, convergence_axis;
+        auxdata = nothing, additional_errors = nothing, expected_value = nothing)
+
+Collect solutions and error series from a convergence experiment. The constructor
+combines the error measurements from `solutions` with `additional_errors` and estimates
+the observed convergence order between adjacent points on `convergence_axis`.
+
+Set `expected_value` when the error series are supplied through `additional_errors`, as
+done by ensemble convergence tests.
+"""
 mutable struct ConvergenceSimulation{SolType}
     solutions::Array{SolType}
     errors::Any
@@ -43,6 +54,19 @@ function ConvergenceSimulation(
     return (ConvergenceSimulation(solutions, errors, N, auxdata, 𝒪est, convergence_axis))
 end
 
+"""
+    test_convergence(dts, prob, alg[, ensemblealg]; kwargs...)
+    test_convergence(probs, convergence_axis, alg; kwargs...)
+    test_convergence(setup::ConvergenceSetup, alg; kwargs...)
+
+Solve a problem at each point on a convergence axis and return a
+[`ConvergenceSimulation`](@ref). For time-step convergence tests, each value in `dts`
+is passed to the solver as `dt`. Remaining keyword arguments are forwarded to `solve`.
+
+The computed solutions must contain error measurements, usually obtained from an
+analytic solution. Use [`analyticless_test_convergence`](@ref) when only a numerical
+reference solution is available.
+"""
 function test_convergence(
         dts::AbstractArray,
         prob::Union{
@@ -120,6 +144,15 @@ function test_convergence(
     )
 end
 
+"""
+    analyticless_test_convergence(dts, prob, alg, reference; kwargs...)
+
+Estimate convergence against a numerical reference solution and return a
+[`ConvergenceSimulation`](@ref). For ODE problems, `reference` is a solver setup whose
+`:alg` entry selects the reference algorithm. For stochastic problems, `reference` is
+the finer reference step size, and each tested solution reuses the reference noise
+realization.
+"""
 function analyticless_test_convergence(
         dts::AbstractArray,
         prob::Union{

--- a/lib/DiffEqDevTools/src/tableau_info.jl
+++ b/lib/DiffEqDevTools/src/tableau_info.jl
@@ -134,6 +134,14 @@ end
 
 isfsal(tab::ExplicitRKTableau) = tab.fsal
 isfsal(::ImplicitRKTableau) = nothing
+
+"""
+    check_tableau(tab; tol = 10eps(1.0))
+
+Check that a Runge-Kutta tableau satisfies the order conditions for its declared
+primary and embedded orders within `tol`. Return `true` when all conditions hold and
+throw an error when an order condition fails.
+"""
 function check_tableau(tab; tol = 10eps(1.0))
     order = all(i -> residual_order_condition(tab, i, +, abs) < tol, 1:(tab.order))
     if !order


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- add docstrings for the nine exported DiffEqDevTools names exposed by the SciMLTesting public-API documentation check
- render those APIs in the existing convergence, benchmark, and tableau manual pages

## Root cause

A clean `master` QA run failed with the following undocumented names:

`ConvergenceSimulation`, `Shootout`, `ShootoutSet`, `WorkPrecision`,
`WorkPrecisionSet`, `analyticless_test_convergence`, `check_tableau`,
`get_sample_errors`, and `test_convergence`.

The adjacent source boundary is commit `12b6996e27ea4ea589a30cd4858cb8ecdd3ef446`
(#3867), which upgraded SciMLTesting and activated the public-API docstring check.
Its parent `d7a66c0fe` passes the same QA command with SciMLTesting 1.8; the first
bad commit exposes the pre-existing documentation gaps.

## Validation

- `JULIA_PKG_PRECOMPILE_AUTO=0 ODEDIFFEQ_TEST_GROUP=QA julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`
  - `Aqua | 11 passed / 11 total`
  - `DiffEqDevTools tests passed`
- `julia +1.12 -m Runic --check .`
- full OrdinaryDiffEq Documenter build on Julia 1.12 exited 0 and accepted all nine new `@docs` entries
- `git diff --check`

The full manual still emits unrelated pre-existing warn-only diagnostics; none refers
to these nine entries.