### PR TITLE
Restore isdiscretecache public API

### DIFF
--- a/docs/src/devtools/internals/public_api.md
+++ b/docs/src/devtools/internals/public_api.md
@@ -132,6 +132,7 @@ OrdinaryDiffEqCore.has_stiff_interpolation
 OrdinaryDiffEqCore.allows_null_u0
 OrdinaryDiffEqCore.isaposteriori
 OrdinaryDiffEqCore.isdiscretealg
+OrdinaryDiffEqCore.isdiscretecache
 OrdinaryDiffEqCore.isdp8
 OrdinaryDiffEqCore.isesdirk
 OrdinaryDiffEqCore.isfirk

--- a/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
+++ b/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
@@ -435,7 +435,7 @@ include("precompilation_setup.jl")
             :get_gamma, :get_new_W_γdt_cutoff, :get_qmax, :get_qmax_first_step, :get_qmin, :get_qsteady_max,
             :get_qsteady_min, :get_W, :GLM, :hermite_interpolant, :IController,
             :ImplicitSecondOrderAlgorithm, :increment_accept!, :increment_nf!, :increment_reject!, :InterpolationData, :isautoswitch,
-            :is_composite_algorithm, :isdefaultalg, :isdtchangeable, :isfirstcall,
+            :is_composite_algorithm, :isdefaultalg, :isdiscretecache, :isdtchangeable, :isfirstcall,
             :isfirststage, :isfsal, :isimplicit, :isJcurrent, :is_mass_matrix_alg, :ismultistep,
             :issplit, :isthreaded, :isWmethod, :MethodType, :NewtonAlgorithm, :nlsolve_f,
             :NLStatus, :NORDSIECK_MULTISTEP, :_ode_addsteps!, :ode_addsteps!, :ODEIntegrator, :_ode_interpolant,

--- a/lib/OrdinaryDiffEqCore/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqCore/test/qa/qa.jl
@@ -4,6 +4,10 @@ using SciMLTesting, OrdinaryDiffEqCore, Test
 # ExplicitImports cannot statically analyze; allow it to be unanalyzable.
 const UNANALYZABLE = (OrdinaryDiffEqCore.Predictor,)
 
+@static if VERSION >= v"1.11.0-DEV.469"
+    @test Base.ispublic(OrdinaryDiffEqCore, :isdiscretecache)
+end
+
 run_qa(
     OrdinaryDiffEqCore;
     aqua_kwargs = (; piracies = false, unbound_args = false),


### PR DESCRIPTION
> **Please ignore this draft until it has been reviewed by @ChrisRackauckas.**

## Summary

- Restore `OrdinaryDiffEqCore.isdiscretecache` to the public declaration.
- Restore its rendered developer-API documentation entry.
- Add a Julia 1.11+ `Base.ispublic` regression test.

## Root cause

PR #3832 split the public and developer API documentation and accidentally removed `isdiscretecache` from both the public declaration and the replacement rendered docs. `ImplicitDiscreteSolve` still imports the name from `OrdinaryDiffEqCore`, so current master fails ExplicitImports QA.

The latest released `OrdinaryDiffEqCore` version, v4.6.0, already exposes this name. Current v4.7.0 is unreleased, so this prevents a release regression and does not require another version bump.

## Validation

- Clean-master reproduction: ImplicitDiscreteSolve JET `1/1`; Aqua `17 pass / 1 error` with `isdiscretecache is not public`.
- Bisected first bad commit: `e1db9b088674f780b2ea055bafd3cfa700add29e` (#3832).
- ImplicitDiscreteSolve QA after the fix: JET `1/1`; Aqua `18/18`.
- OrdinaryDiffEqCore QA: AllocCheck `1/1`; JET `30 pass / 1 pre-existing broken`; Aqua `18/18`.
- ImplicitDiscreteSolve Core: all 30 assertions passed.
- OrdinaryDiffEqCore Core: all 107 assertions passed.
- Repository-wide Runic check: exit 0.
- `git diff --check`: exit 0.

## Process notes

The failure was reproduced in a clean worktree, bisected independently, repaired at the public API and rendered-doc layers together, and validated in both the importing package and the declaring package.
