### PR TITLE
Fix strict Kantorovich step acceptance

### DIFF
--- a/lib/ImplicitDiscreteSolve/Project.toml
+++ b/lib/ImplicitDiscreteSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "ImplicitDiscreteSolve"
 uuid = "3263718b-31ed-49cf-8a0f-35a466e8af96"
 authors = ["vyudu <vincent.duyuan@gmail.com>"]
-version = "2.1.3"
+version = "2.1.4"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/ImplicitDiscreteSolve/src/controller.jl
+++ b/lib/ImplicitDiscreteSolve/src/controller.jl
@@ -112,14 +112,14 @@ function OrdinaryDiffEqCore.step_reject_controller!(
     return
 end
 
+function _accept_kantorovich_step(controller, Θks)
+    return !controller.strict || all(Θk -> Θk <= controller.Θreject, Θks)
+end
+
 function OrdinaryDiffEqCore.accept_step_controller(integrator, cache::KantorovichTypeControllerCache, alg)
     (; controller) = cache
     (; Θks) = integrator.cache
-    if controller.strict
-        return all(controller.Θreject .< Θks)
-    else
-        return true
-    end
+    return _accept_kantorovich_step(controller, Θks)
 end
 
 function OrdinaryDiffEqCore.sync_controllers!(cache1::KantorovichTypeControllerCache, cache2::KantorovichTypeControllerCache)

--- a/lib/ImplicitDiscreteSolve/test/runtests.jl
+++ b/lib/ImplicitDiscreteSolve/test/runtests.jl
@@ -92,6 +92,20 @@ if TEST_GROUP != "QA"
         @test idsol.retcode == ReturnCode.Success
     end
 
+    @testset "Kantorovich strict acceptance" begin
+        strict = ImplicitDiscreteSolve.KantorovichTypeController(;
+            Θmin = 1 // 8, p = 1
+        )
+        @test ImplicitDiscreteSolve._accept_kantorovich_step(strict, Float64[])
+        @test ImplicitDiscreteSolve._accept_kantorovich_step(strict, [0.2, 0.95])
+        @test !ImplicitDiscreteSolve._accept_kantorovich_step(strict, [0.2, 0.951])
+
+        nonstrict = ImplicitDiscreteSolve.KantorovichTypeController(;
+            Θmin = 1 // 8, p = 1, strict = false
+        )
+        @test ImplicitDiscreteSolve._accept_kantorovich_step(nonstrict, [Inf])
+    end
+
     @testset "Handle nothing in u0" begin
         emptyiip(residual, u_next, u, p, t) = nothing
         emptyoop(u_next, u, p, t) = nothing


### PR DESCRIPTION
> **Please ignore this draft until it has been reviewed by @ChrisRackauckas.**

## Summary

- Fix strict `KantorovichTypeController` acceptance to accept a converged step only when every recorded contraction satisfies `Θk <= Θreject`.
- Keep non-strict mode accepting every converged nonlinear solve.
- Add boundary, rejection, empty-history, and non-strict regression coverage.
- Bump `ImplicitDiscreteSolve` from 2.1.3 to 2.1.4.

## Root cause

The controller documentation says strict mode rejects a step whenever any `Θk > Θreject`. The implementation used `all(Θreject .< Θks)`, which reversed the inequality: normal well-contracted steps were rejected, while a history in which every contraction exceeded the rejection threshold was accepted.

## Why this remains separate from homotopy solving

[NonlinearSolve #1071](https://github.com/SciML/NonlinearSolve.jl/pull/1071) now provides the controller as `KantorovichHomotopy` for a genuine `HomotopyProblem`, and OrdinaryDiffEq's existing `HomotopyNonlinearSolveAlg` adapter can use it for ODE stage equations. That does not make it a drop-in replacement for this controller:

- `HomotopyNonlinearSolveAlg` is an `OrdinaryDiffEqCore.AbstractNLSolverAlgorithm` consumed by the ODE stage-solver machinery, not a NonlinearSolve algorithm accepted by `init(::NonlinearProblem, ...)`. An exact attempted substitution in `IDSolve.nlsolve` exits with `SciMLBase.NonSolverError`.
- A general `ImplicitDiscreteProblem` solves `f(u_next, uprev, p, t) = 0` and replaces `uprev` after every accepted state. It is therefore a sequence of changing nonlinear problems, not one fixed homotopy in `t`.
- An artificial per-step affine homotopy can preserve the endpoint equation for square problems, but it changes the solve strategy, is not a generic construction for the existing rectangular least-squares cases, and does not match current performance.

## Performance check

The closest generic square-problem prototype used

```math
H(x, λ) = (1 - λ)(x - u_{prev}) + λ f(x, u_{prev}, p, t)
```

at every discrete step. The recurrence endpoint matched the current solver to about `1e-12`. Medians below are from 20 warmed Julia 1.12.6 samples:

| Recurrence implementation | Time | Residual calls | Memory | Allocations |
|---|---:|---:|---:|---:|
| current `IDSolve` | 0.592 ms | 360 | 65,904 B | 1,357 |
| affine `KantorovichHomotopy` per step | 10.292 ms | 1,358 | 3,288,096 B | 47,965 |
| affine `HomotopySweep` per step | 10.444 ms | 1,958 | 3,423,296 B | 51,215 |

The Kantorovich replacement was 17.4x slower and allocated 35x as many objects.

For a scalar path whose residual ignores `uprev`, a whole-span homotopy is valid and avoids the IDS integrator overhead. In that restricted case, `HomotopySweep` took 0.205 ms and `KantorovichHomotopy` took 0.347 ms (current IDS: 0.507 ms), with all endpoints agreeing at floating-point precision. This is consistent with [NonlinearSolve #1071](https://github.com/SciML/NonlinearSolve.jl/pull/1071)'s broader comparison: Kantorovich continuation can win on some paths, but it is not a general replacement for Sweep or for the recurrence controller here.

## Validation

Run on the rebased branch head `6a73faf817`:

- `ODEDIFFEQ_TEST_GROUP=Core` on Julia 1.10.11: exit 0, all 34 assertions passed; `Kantorovich strict acceptance` passed 4/4.
- Repository-wide Runic check: exit 0.
- `git diff --check`: exit 0.
- `ODEDIFFEQ_TEST_GROUP=QA` on rebased head: JET passed 1/1; Aqua passed 16/17 and failed only the rendered-public-API check on 185 SciMLBase re-exports plus `IDSolve` (186 names total). This clean-master failure was bisected to #3867 and remains isolated in [#3969](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3969); that focused fix passes Julia 1.10 JET 1/1 and Aqua 17/17 plus Runic and diff checks. The umbrella docs fix [#3970](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3970) is merged in this branch base. No test was skipped, silenced, loosened, or changed.

- Rebased-head GitHub CI completed with 119 successful, 3 skipped, and 7 failed checks. All ImplicitDiscreteSolve Core lanes, its downgrade lane, documentation, Runic, and both benchmark lanes passed. The non-passing checks are independent clean-master baselines or infrastructure:
  - IDS rendered-API QA: [#3969](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3969). The former root half is fixed by merged [#3970](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3970).
  - `MatrixOperator` downgrade failures in BDF, SDIRK, and OrdinaryDiffEqNonlinearSolve: [#3917](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3917), with shared-workflow prerequisite [SciML/.github #118](https://github.com/SciML/.github/pull/118). The exact locked #3917 Core suite was independently rerun on Julia 1.11 and exited 0, including the formerly failing 44/44 and 113/113 groups.
  - TaylorSeries resolver conflict: [#3965](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3965), independently verified at 81/81 locked Core tests.
  - DiffEqDevTools: the self-hosted runner lost communication again; the job-specific rerun endpoint returned HTTP 403.
  - GPU: exited 1 after 22m23s, but the self-hosted failed-step log is unavailable. Equivalence to the independently reproduced clean-master 137-case DAE failure is therefore an inference, tracked by [#3922](https://github.com/SciML/OrdinaryDiffEq.jl/issues/3922), [#3923](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3923), and [CUDA.jl #3199](https://github.com/JuliaGPU/CUDA.jl/pull/3199); no NVIDIA GPU is available locally.

## Process notes

The work mapped the exact residual-contraction sampling and Deuflhard step-size formula, extracted the reusable controller into NonlinearSolve, benchmarked it against `HomotopySweep` and `ArcLengthContinuation`, tested the proposed direct and affine adapters after [NonlinearSolve #1071](https://github.com/SciML/NonlinearSolve.jl/pull/1071) merged, and kept this independent predicate bug as a small OrdinaryDiffEq patch.
