### PR TITLE
Use GROUP consistently for sublibrary tests

### DIFF
--- a/.github/workflows/DowngradeSublibraries.yml
+++ b/.github/workflows/DowngradeSublibraries.yml
@@ -22,6 +22,6 @@ jobs:
     with:
       julia-version: "1.11"
       skip: "Pkg,TOML,Statistics,LinearAlgebra,SparseArrays,InteractiveUtils,OrdinaryDiffEqCore,OrdinaryDiffEqNonlinearSolve,OrdinaryDiffEqDifferentiation"
-      group-env-name: "ODEDIFFEQ_TEST_GROUP"
+      group-env-name: "GROUP"
       group-env-value: "Core"
       # Every lib/* sublibrary is downgrade-tested (projects auto-discovered, no exclusions).

--- a/.github/workflows/SublibraryCI.yml
+++ b/.github/workflows/SublibraryCI.yml
@@ -15,6 +15,6 @@ jobs:
   sublibrary-ci:
     uses: "SciML/.github/.github/workflows/sublibrary-project-tests.yml@v1"
     with:
-      group-env-name: ODEDIFFEQ_TEST_GROUP
+      group-env-name: GROUP
       check-bounds: auto
     secrets: "inherit"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ which relies on OrdinaryDiffEqCore.
 Each sublibrary declares its CI jobs through `test/test_groups.toml`. Groups listed there
 (e.g. `Core`, `QA`, `GPU`, `ModelingToolkit`) become matrix entries dispatched by
 `.github/scripts/compute_affected_sublibraries.jl`. The group name is passed to the
-sublibrary's `test/runtests.jl` via `ENV["ODEDIFFEQ_TEST_GROUP"]`.
+sublibrary's `test/runtests.jl` via `ENV["GROUP"]`.
 
 ### Skipping a group on dependency-graph triggers (`local_only`)
 

--- a/lib/DelayDiffEq/test/runtests.jl
+++ b/lib/DelayDiffEq/test/runtests.jl
@@ -1,6 +1,6 @@
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 if TEST_GROUP == "ALL" || TEST_GROUP == "Interface"
     @time @safetestset "AD Tests" begin

--- a/lib/DiffEqBase/test/runtests.jl
+++ b/lib/DiffEqBase/test/runtests.jl
@@ -2,7 +2,7 @@ using Pkg
 using SafeTestsets
 using Test
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "Core")
+const TEST_GROUP = get(ENV, "GROUP", "Core")
 
 function activate_downstream_env()
     Pkg.activate(joinpath(@__DIR__, "downstream"))

--- a/lib/DiffEqDevTools/test/runtests.jl
+++ b/lib/DiffEqDevTools/test/runtests.jl
@@ -2,7 +2,7 @@ using DiffEqDevTools
 using SciMLTesting
 using Test
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/GlobalDiffEq/test/runtests.jl
+++ b/lib/GlobalDiffEq/test/runtests.jl
@@ -3,7 +3,7 @@ using Test
 using SciMLTesting
 
 run_tests(;
-    env = "ODEDIFFEQ_TEST_GROUP",
+    env = "GROUP",
     core = function ()
         @safetestset "Basic functionality" begin
             include("basic_functionality_tests.jl")

--- a/lib/ImplicitDiscreteSolve/test/runtests.jl
+++ b/lib/ImplicitDiscreteSolve/test/runtests.jl
@@ -7,7 +7,7 @@ using SciMLBase
 using SafeTestsets
 using SciMLTesting
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqAMF/test/runtests.jl
+++ b/lib/OrdinaryDiffEqAMF/test/runtests.jl
@@ -2,7 +2,7 @@ using SciMLTesting
 using Test
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqAdamsBashforthMoulton/test/runtests.jl
+++ b/lib/OrdinaryDiffEqAdamsBashforthMoulton/test/runtests.jl
@@ -2,7 +2,7 @@ using Pkg
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])
@@ -20,7 +20,7 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
 end
 
 # Threaded tests require Polyester.jl (for FastBroadcast.Threaded() support).
-# Runs only on explicit `ODEDIFFEQ_TEST_GROUP=Threaded` — the SublibraryCI
+# Runs only on explicit `GROUP=Threaded` — the SublibraryCI
 # matrix (lib/OrdinaryDiffEqAdamsBashforthMoulton/test/test_groups.toml)
 # schedules this as its own Julia 1 / 2-thread job. Matches the GPU-group
 # convention in sibling sublibs (LowStorageRK, Rosenbrock, BDF).

--- a/lib/OrdinaryDiffEqBDF/test/runtests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/runtests.jl
@@ -2,7 +2,7 @@ using Pkg
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_gpu_env()
     Pkg.activate(joinpath(@__DIR__, "gpu"))

--- a/lib/OrdinaryDiffEqCore/test/runtests.jl
+++ b/lib/OrdinaryDiffEqCore/test/runtests.jl
@@ -2,7 +2,7 @@ using Pkg
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_gpu_env()
     Pkg.activate(joinpath(@__DIR__, "gpu"))

--- a/lib/OrdinaryDiffEqDefault/test/runtests.jl
+++ b/lib/OrdinaryDiffEqDefault/test/runtests.jl
@@ -2,7 +2,7 @@ using Pkg
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_gpu_env()
     Pkg.activate(joinpath(@__DIR__, "gpu"))

--- a/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
@@ -2,7 +2,7 @@ using SafeTestsets
 using Pkg
 using SciMLTesting
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_sparse_env()
     Pkg.activate(joinpath(@__DIR__, "sparse"))

--- a/lib/OrdinaryDiffEqExplicitRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqExplicitRK/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqExplicitTableaus/test/runtests.jl
+++ b/lib/OrdinaryDiffEqExplicitTableaus/test/runtests.jl
@@ -1,6 +1,6 @@
 using SciMLTesting
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqExponentialRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqExtrapolation/test/runtests.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqFIRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqFeagin/test/runtests.jl
+++ b/lib/OrdinaryDiffEqFeagin/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqFunctionMap/test/runtests.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqHighOrderRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqHighOrderRK/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqIMEXMultistep/test/runtests.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqImplicitTableaus/test/runtests.jl
+++ b/lib/OrdinaryDiffEqImplicitTableaus/test/runtests.jl
@@ -1,6 +1,6 @@
 using SciMLTesting
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqLinear/test/runtests.jl
+++ b/lib/OrdinaryDiffEqLinear/test/runtests.jl
@@ -2,7 +2,7 @@ using Pkg
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_gpu_env()
     Pkg.activate(joinpath(@__DIR__, "gpu"))

--- a/lib/OrdinaryDiffEqLowOrderRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqLowOrderRK/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqLowStorageRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/test/runtests.jl
@@ -2,7 +2,7 @@ using Pkg
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_gpu_env()
     Pkg.activate(joinpath(@__DIR__, "gpu"))

--- a/lib/OrdinaryDiffEqMultirate/test/runtests.jl
+++ b/lib/OrdinaryDiffEqMultirate/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqNewmark/test/runtests.jl
+++ b/lib/OrdinaryDiffEqNewmark/test/runtests.jl
@@ -3,7 +3,7 @@ using OrdinaryDiffEqNewmark, Test, RecursiveArrayTools, DiffEqDevTools
 using LinearAlgebra: norm
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
@@ -2,7 +2,7 @@ using SafeTestsets
 using Pkg
 using SciMLTesting
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_modelingtoolkit_env()
     Pkg.activate(joinpath(@__DIR__, "modelingtoolkit"))

--- a/lib/OrdinaryDiffEqNordsieck/test/runtests.jl
+++ b/lib/OrdinaryDiffEqNordsieck/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqPDIRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqPDIRK/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqPRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqPRK/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqQPRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqQPRK/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqRKIP/test/runtests.jl
+++ b/lib/OrdinaryDiffEqRKIP/test/runtests.jl
@@ -2,7 +2,7 @@ using Pkg
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_gpu_env()
     Pkg.activate(joinpath(@__DIR__, "gpu"))

--- a/lib/OrdinaryDiffEqRKN/test/runtests.jl
+++ b/lib/OrdinaryDiffEqRKN/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqRosenbrock/test/runtests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/runtests.jl
@@ -2,7 +2,7 @@ using Pkg
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_gpu_env()
     Pkg.activate(joinpath(@__DIR__, "gpu"))

--- a/lib/OrdinaryDiffEqRosenbrockTableaus/test/runtests.jl
+++ b/lib/OrdinaryDiffEqRosenbrockTableaus/test/runtests.jl
@@ -1,6 +1,6 @@
 using SciMLTesting
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqSDIRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqSIMDRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqSIMDRK/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqSSPRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqSSPRK/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqStabilizedIRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqStabilizedIRK/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqStabilizedRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/runtests.jl
@@ -2,7 +2,7 @@ using Pkg
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_gpu_env()
     Pkg.activate(joinpath(@__DIR__, "gpu"))

--- a/lib/OrdinaryDiffEqSymplecticRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqSymplecticRK/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl
@@ -4,7 +4,7 @@ using SciMLBase
 using Test
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqTsit5/test/runtests.jl
+++ b/lib/OrdinaryDiffEqTsit5/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/OrdinaryDiffEqVerner/test/runtests.jl
+++ b/lib/OrdinaryDiffEqVerner/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/SimpleImplicitDiscreteSolve/test/runtests.jl
+++ b/lib/SimpleImplicitDiscreteSolve/test/runtests.jl
@@ -4,7 +4,7 @@ using OrdinaryDiffEqSDIRK
 using SafeTestsets
 using SciMLTesting
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/StochasticDiffEq/test/runtests.jl
+++ b/lib/StochasticDiffEq/test/runtests.jl
@@ -15,7 +15,7 @@ end
 
 const LONGER_TESTS = false
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 const is_APPVEYOR = Sys.iswindows() && haskey(ENV, "APPVEYOR")
 

--- a/lib/StochasticDiffEqCore/test/runtests.jl
+++ b/lib/StochasticDiffEqCore/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/StochasticDiffEqHighOrder/test/runtests.jl
+++ b/lib/StochasticDiffEqHighOrder/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/StochasticDiffEqIIF/test/runtests.jl
+++ b/lib/StochasticDiffEqIIF/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/StochasticDiffEqImplicit/test/runtests.jl
+++ b/lib/StochasticDiffEqImplicit/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/StochasticDiffEqLeaping/test/runtests.jl
+++ b/lib/StochasticDiffEqLeaping/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/StochasticDiffEqLevyArea/test/runtests.jl
+++ b/lib/StochasticDiffEqLevyArea/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/StochasticDiffEqLowOrder/test/runtests.jl
+++ b/lib/StochasticDiffEqLowOrder/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/StochasticDiffEqMilstein/test/runtests.jl
+++ b/lib/StochasticDiffEqMilstein/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/StochasticDiffEqROCK/test/runtests.jl
+++ b/lib/StochasticDiffEqROCK/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/StochasticDiffEqRODE/test/runtests.jl
+++ b/lib/StochasticDiffEqRODE/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/lib/StochasticDiffEqWeak/test/runtests.jl
+++ b/lib/StochasticDiffEqWeak/test/runtests.jl
@@ -1,7 +1,7 @@
 using SciMLTesting
 using SafeTestsets
 
-const TEST_GROUP = get(ENV, "ODEDIFFEQ_TEST_GROUP", "ALL")
+const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -219,7 +219,7 @@ end
 @time begin
     # Monorepo sublibrary routing. The root reads GROUP to pick a `lib/<sub>`
     # sublibrary, transitively develops its `[sources]` on Julia < 1.11, then
-    # `Pkg.test`s it with the sub-group handed off via ODEDIFFEQ_TEST_GROUP.
+    # `Pkg.test`s it with the sub-group handed off via GROUP.
     # This is kept as an explicit pre-step (rather than delegated to
     # `run_tests`'s built-in `lib_dir` path) so the sublibrary `Pkg.test`
     # invocation — `julia_args`, `force_latest_compatible_version = false`,
@@ -274,7 +274,7 @@ end
             # fail to find unregistered siblings.
             isempty(specs) || Pkg.develop(specs)
         end
-        withenv("ODEDIFFEQ_TEST_GROUP" => test_group) do
+        withenv("GROUP" => test_group) do
             Pkg.test(base_group, julia_args = ["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version = false, allow_reresolve = true)
         end
     else
@@ -327,11 +327,10 @@ end
                 "Integrators" => ["Integrators_I", "Integrators_II"],
                 "Regression" => ["Regression_I", "Regression_II"],
             ),
-            # Monorepo sublibrary handoff var: the root reads GROUP, but each
-            # sublibrary reads ODEDIFFEQ_TEST_GROUP for its sub-group. The
+            # The root and each sublibrary use GROUP for monorepo routing.
             # sublibrary Pkg.test is done explicitly above; sublib_env/lib_dir
             # are passed for completeness so the routing config is self-describing.
-            sublib_env = "ODEDIFFEQ_TEST_GROUP",
+            sublib_env = "GROUP",
             lib_dir = LIB_DIR,
         )
     end


### PR DESCRIPTION
## Summary

- replace the package-specific sublibrary group variable with the SciML-standard GROUP variable throughout OrdinaryDiffEq
- use GROUP for the root-to-sublibrary handoff and both reusable sublibrary CI workflows
- update contributor documentation

## Why

SciML downstream workflows export GROUP. A separate OrdinaryDiffEq-specific group variable made direct sublibrary runs inconsistent and allowed downstream group requests to be ignored. There is now a single group-routing interface for all OrdinaryDiffEq sublibrary runners.

Ignore this PR until reviewed by @ChrisRackauckas.

## Local verification

- Julia 1.12: GROUP=DiffEqDevTools_Core Pkg.test(): passed through the root-to-sublibrary route
- Runic check for lib and test/runtests.jl
- actionlint .github/workflows/SublibraryCI.yml .github/workflows/DowngradeSublibraries.yml
- git diff --check