### PR TITLE
Allow private solver hooks in ExplicitImports QA

### DIFF
--- a/lib/OrdinaryDiffEqExtrapolation/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/qa/qa.jl
@@ -1,12 +1,5 @@
 using SciMLTesting, OrdinaryDiffEqExtrapolation, Test
 
-# After the solver-author extension API was declared `public` in OrdinaryDiffEqCore /
-# OrdinaryDiffEqDifferentiation / OrdinaryDiffEqNonlinearSolve / DiffEqBase, the only
-# remaining ExplicitImports public-API exceptions are the genuinely-internal names
-# below that have no public replacement: OrdinaryDiffEqCore's private `@threaded`
-# codegen macro and `_resolved_QT` controller helper, plus a handful of upstream
-# (SciMLBase / FastPower / Base.Threads) internals. Everything else is clean.
-# Tracked for a future make-public pass; see SciML/OrdinaryDiffEq.jl#3776.
 run_qa(
     OrdinaryDiffEqExtrapolation;
     explicit_imports = true,
@@ -15,6 +8,10 @@ run_qa(
             ignore = (
                 # OrdinaryDiffEqCore private codegen macro (deliberately kept non-public)
                 Symbol("@threaded"),
+                # OrdinaryDiffEqDifferentiation owner-internal cross-sublibrary hooks;
+                # no public wrapper exists.
+                :build_grad_config, :build_jac_config, :calc_J, :calc_J!,
+                :dolinsolve, :jacobian2W!,
                 # SciMLBase internals (reshaping / val-unwrap helpers, no public replacement)
                 :_reshape, :_unwrap_val, :_vec,
             ),

--- a/lib/OrdinaryDiffEqIMEXMultistep/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/test/qa/qa.jl
@@ -11,6 +11,14 @@ run_qa(
         # kept non-public there:
         #   OrdinaryDiffEqCore: `_fixup_ad` (autodiff-fixup private helper)
         #   SciMLBase:          `_unwrap_val`
-        all_explicit_imports_are_public = (; ignore = (:_fixup_ad, :_unwrap_val)),
+        # OrdinaryDiffEqNonlinearSolve owner-internal cross-sublibrary hooks;
+        # no public wrapper exists.
+        all_explicit_imports_are_public = (;
+            ignore = (
+                :_fixup_ad, :_unwrap_val,
+                :build_nlsolver, :du_alias_or_new, :markfirststage!, :nlsolve!,
+                :nlsolvefail,
+            ),
+        ),
     ),
 )

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/qa/qa.jl
@@ -26,6 +26,13 @@ run_qa(
                 :AbstractSciMLOperator,
                 # OrdinaryDiffEqDifferentiation W-operator types (attributed to SciMLOperators).
                 :WOperator, :StaticWOperator,
+                # Owner-internal cross-sublibrary hooks with no public wrapper.
+                # OrdinaryDiffEqCore:
+                :AbstractNLSolverCache,
+                # OrdinaryDiffEqDifferentiation:
+                :build_J_W, :build_jac_config, :build_uf, :dolinsolve,
+                :is_always_new, :jacobian!, :jacobian2W!, :resize_jac_config!,
+                :update_W!, :wrapprecs,
                 # ForwardDiff / StaticArraysCore internals.
                 :Dual, :StaticArray,
             ),

--- a/lib/OrdinaryDiffEqPDIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqPDIRK/test/qa/qa.jl
@@ -9,6 +9,9 @@ run_qa(
                 # OrdinaryDiffEqCore: `@threaded` is a private codegen/perf macro,
                 # deliberately kept non-public upstream (owner-internal).
                 Symbol("@threaded"),
+                # OrdinaryDiffEqNonlinearSolve owner-internal cross-sublibrary hooks;
+                # no public wrapper exists.
+                :build_nlsolver, :markfirststage!, :nlsolve!, :nlsolvefail,
                 # SciMLBase: not declared public on the registered release.
                 :_unwrap_val,
             ),

--- a/lib/OrdinaryDiffEqStabilizedIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqStabilizedIRK/test/qa/qa.jl
@@ -6,6 +6,11 @@ run_qa(
     ei_kwargs = (;
         all_explicit_imports_are_public = (;
             ignore = (
+                # Owner-internal cross-sublibrary hooks with no public wrapper.
+                # OrdinaryDiffEqDifferentiation:
+                :dolinsolve, :update_W!,
+                # OrdinaryDiffEqNonlinearSolve:
+                :build_nlsolver, :du_alias_or_new, :markfirststage!, :nlsolve!,
                 # SciMLBase internals, not public on registered releases.
                 :_unwrap_val, :_reshape, :_vec,
             ),


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Allow only the owner-internal OrdinaryDiffEqNonlinearSolve and OrdinaryDiffEqDifferentiation hooks used across IMEXMultistep, PDIRK, Extrapolation, StabilizedIRK, and OrdinaryDiffEqNonlinearSolve in their existing ExplicitImports QA configurations.
- Keep the hooks non-public and keep every other ExplicitImports check enabled.
- Replace Extrapolation's obsolete public-extension-API comment with the narrow per-owner rationale.

## Root cause

The solver sublibraries share a small implementation surface across package boundaries. Those names are intentionally private in their owning sublibraries and have no public wrapper, so restoring public declarations would undo the intended API boundary. The QA checks therefore need precise, documented exceptions rather than a broad disable.

## Local validation

Run on Julia 1.12.6 from a clean worktree based on upstream/master `5265a6c542`:

- `ODEDIFFEQ_TEST_GROUP=QA julia +1.12 --project=lib/OrdinaryDiffEqIMEXMultistep -e 'using Pkg; Pkg.test()'` — passed; Aqua 19/19.
- `ODEDIFFEQ_TEST_GROUP=QA julia +1.12 --project=lib/OrdinaryDiffEqPDIRK -e 'using Pkg; Pkg.test()'` — passed; Aqua 19/19 and convergence 4/4.
- `ODEDIFFEQ_TEST_GROUP=QA julia +1.12 --project=lib/OrdinaryDiffEqStabilizedIRK -e 'using Pkg; Pkg.test()'` — passed; Aqua 19/19.
- `ODEDIFFEQ_TEST_GROUP=QA julia +1.12 --project=lib/OrdinaryDiffEqExtrapolation -e 'using Pkg; Pkg.test()'` — the targeted `all_explicit_imports_are_public` check passed. The lane retains its unrelated master failure for stale `BaseThreads` and `Sequential` imports.
- `ODEDIFFEQ_TEST_GROUP=QA julia +1.12 --project=lib/OrdinaryDiffEqNonlinearSolve -e 'using Pkg; Pkg.test()'` — all six ExplicitImports checks passed. The lane retains its unrelated master failure for the missing `SparseConnectivityTracer` extras compat entry.
- Runic 1.7.0 whole-repository check passed.
- `git diff --check` passed.
