### PR TITLE
Fix structured Jacobian cache initialization

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -1152,6 +1152,14 @@ as-is.
 end
 @inline _dtgamma_prototype(t, dt, ::Type{T}) where {T} = promote(t, dt)[2]
 
+function _fill_structural_nonzeros!(A, value)
+    rows, cols = ArrayInterface.findstructralnz(A)
+    for k in 1:length(rows)
+        A[rows[k], cols[k]] = value
+    end
+    return A
+end
+
 """
     build_J_W(alg, u, uprev, p, t, dt, f, jac_config, ::Type{uEltypeNoUnits}, ::Val{iip}) -> (J, W)
 
@@ -1208,8 +1216,8 @@ function build_J_W(
             set_all_nzval!(W, one(eltype(W)))
         elseif ArrayInterface.has_sparsestruct(J)
             # A nonzero fill conflicts with the implicit zeros of structured matrices.
-            copyto!(J, one(J))
-            copyto!(W, one(W))
+            _fill_structural_nonzeros!(J, one(eltype(J)))
+            _fill_structural_nonzeros!(W, one(eltype(W)))
         else
             fill!(J, one(eltype(J)))
             fill!(W, one(eltype(W)))

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -1206,6 +1206,10 @@ function build_J_W(
         if is_sparse(J)
             set_all_nzval!(J, one(eltype(J)))
             set_all_nzval!(W, one(eltype(W)))
+        elseif ArrayInterface.has_sparsestruct(J)
+            # A nonzero fill conflicts with the implicit zeros of structured matrices.
+            copyto!(J, one(J))
+            copyto!(W, one(W))
         else
             fill!(J, one(eltype(J)))
             fill!(W, one(eltype(W)))

--- a/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
@@ -35,6 +35,7 @@ if TEST_GROUP ∉ ("QA", "Sparse", "ModelingToolkit")
     @time @safetestset "Differentiation Trait Tests" include("differentiation_traits_tests.jl")
     @time @safetestset "Autodiff Error Tests" include("autodiff_error_tests.jl")
     @time @safetestset "No Jac Tests" include("nojac_tests.jl")
+    @time @safetestset "Structured Jacobian Prototypes" include("structured_jacobian_prototype_tests.jl")
 end
 
 # Run sparse tests (separate environment due to ComponentArrays dep conflicts)

--- a/lib/OrdinaryDiffEqDifferentiation/test/structured_jacobian_prototype_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/structured_jacobian_prototype_tests.jl
@@ -1,0 +1,35 @@
+using LinearAlgebra: Bidiagonal, Diagonal, Tridiagonal
+using OrdinaryDiffEqRosenbrock: Rosenbrock23
+using SciMLBase: ODEFunction, ODEProblem, init, solve
+using Test
+
+function structured_f!(du, u, p, t)
+    return du .= u ./ t
+end
+
+function structured_jac!(J, u, p, t)
+    J[1, 1] = 1 / t
+    J[2, 2] = 1 / t
+    J[1, 2] = 0
+    J[2, 1] = 0
+    return J
+end
+
+prototypes = (
+    Diagonal(zeros(2)),
+    Bidiagonal(zeros(2), zeros(1), :U),
+    Tridiagonal(zeros(1), zeros(2), zeros(1)),
+)
+
+for jac_prototype in prototypes
+    f = ODEFunction(structured_f!; jac = structured_jac!, jac_prototype)
+    prob = ODEProblem(f, ones(2), (1.0, 10.0))
+    @test init(prob, Rosenbrock23()) !== nothing
+end
+
+f = ODEFunction(structured_f!; jac = structured_jac!, jac_prototype = first(prototypes))
+prob = ODEProblem(f, ones(2), (1.0, 10.0))
+sol = solve(prob, Rosenbrock23())
+
+@test sol.u[end] ≈ [10.0, 10.0]
+@test length(sol.t) < 60

--- a/lib/OrdinaryDiffEqDifferentiation/test/structured_jacobian_prototype_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/structured_jacobian_prototype_tests.jl
@@ -18,6 +18,7 @@ end
 prototypes = (
     Diagonal(zeros(2)),
     Bidiagonal(zeros(2), zeros(1), :U),
+    Bidiagonal(zeros(2), zeros(1), :L),
     Tridiagonal(zeros(1), zeros(2), zeros(1)),
 )
 


### PR DESCRIPTION
## Summary

- initialize only the stored entries of structured Jacobian and W caches
- preserve implicit structural zeros for `Diagonal`, `Bidiagonal`, and `Tridiagonal` prototypes
- add regressions for both bidiagonal orientations, diagonal/tridiagonal initialization, and a full diagonal Rosenbrock solve

## Investigation

A clean upstream-master checkout reproduced the structured-cache failure:

```
ArgumentError: array of type Diagonal{Float64, ...} ... cannot be filled with 1.0
```

The immediate parent `b797bac1bfd94b1615026d0601ede22d1aa4dd92` passes the targeted reproducer. An independent `git bisect` identified `d8cbb9e4446427305484e25eb4c81c9f85c09277` ("Initialize sparse Jacobian caches with stored values (#3833)") as the first bad commit.

That change used a nonzero `fill!` fallback for non-sparse prototypes. Structured matrices have implicit entries that cannot be assigned a nonzero value, so the fallback fails before the solver can use the cache. This patch uses the public `ArrayInterface.findstructralnz` API and initializes each stored structural position while leaving implicit zeros untouched.

## Local verification

- Julia 1.12, `ODEDIFFEQ_TEST_GROUP=Core`: exit 0; `Structured Jacobian Prototypes | 6/6`; package tests passed.
- Julia 1.10, `ODEDIFFEQ_TEST_GROUP=Core`: exit 0; `Structured Jacobian Prototypes | 6/6`; package tests passed.
- Julia 1.12 sparse test project: exit 0; `Non-Full Diagonal Sparsity Tests | 2/2`; package tests passed.
- `julia +1.12 --startup-file=no -m Runic --check .`: exit 0.
- `git diff --check upstream/master...HEAD`: exit 0.
- The branch is current with `upstream/master` (0 commits behind).

A broader DiffEqBase downstream run did execute the structured linear-solve tests, then failed later in the unrelated FlexUnits 0.5.7 regression tracked in #3925. I am not claiming that full downstream group is green.

Please ignore this PR until reviewed by @ChrisRackauckas.