### PR TITLE
Fix migrated vector callback regression test

### DIFF
--- a/lib/DiffEqBase/test/downstream/community_callback_tests.jl
+++ b/lib/DiffEqBase/test/downstream/community_callback_tests.jl
@@ -225,9 +225,9 @@ function cond!(out, u, t, i)
     return nothing
 end
 function terminate_affect!(int, events)
-    return any(!iszero, events) && terminate!(int)
+    return any(isone, events) && terminate!(int)
 end
-cb = VectorContinuousCallback(cond!, terminate_affect!, nothing, 1)
+cb = VectorContinuousCallback(cond!, terminate_affect!, 1)
 
 u0 = [0.0, 0.0, 1.0]
 prob = ODEProblem(f!, u0, (0.0, 10.0); callback = cb)


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.**

## Summary

- Update the remaining DiffEqBase community callback test to use the supported three-argument `VectorContinuousCallback` constructor.
- Preserve the test's original upcrossing-only behavior by terminating only when the signed event mask contains `+1`.

## Root cause

The v7 callback migration in `8199a5c187` updated this affect function to accept the signed event mask, but it left the old four-argument constructor in place and changed the behavior from upcrossing-only to either direction. SciML/SciMLBase.jl#1350 later removed that obsolete constructor, exposing the stale test as a `MethodError`.

A SciMLBase bisect with a direct constructor reproducer identified `ba118addc7d7fffa529428bdae2c75168429e98b` as the first bad commit for the old call (parent `80ff6a7464b0de0fb59c23fc0bc652029a4a8e72` accepts it). The SciMLBase change was intentional; the downstream test migration was incomplete.

## Local verification

- Focused callback solve on Julia 1.12: passed, terminating at `t = 4.712335206969428` against the existing `4.712347213360699 ± 1e-4` assertion.
- `ODEDIFFEQ_TEST_GROUP=Downstream2 julia +1.12 --project=lib/DiffEqBase -e 'using Pkg; Pkg.test()'`: passed (`Community Callback Tests` 16/16, `Distributed Ensemble Tests` 4/4).
- Repository-wide Runic check: passed.
