### PR TITLE
Fix jacobian2W! DimensionMismatch for ScalarOperator mass matrix (#3915)

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/src/OrdinaryDiffEqDifferentiation.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/OrdinaryDiffEqDifferentiation.jl
@@ -23,7 +23,7 @@ import StaticArraysCore: StaticArray, StaticMatrix
 using SciMLBase: UJacobianWrapper, UDerivativeWrapper, _vec, _unwrap_val
 import SciMLBase: SciMLBase, @set, DEIntegrator, ODEFunction, SplitFunction, DAEFunction, remake, solve!
 import SciMLOperators: SciMLOperators, update_coefficients, update_coefficients!, MatrixOperator, AbstractSciMLOperator,
-    islinear, isconstant
+    islinear, isconstant, ScalarOperator
 import SparseMatrixColorings: ConstantColoringAlgorithm, GreedyColoringAlgorithm, ColoringProblem,
     ncolors, column_colors, coloring, sparsity_pattern
 import OrdinaryDiffEqCore

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -578,6 +578,15 @@ function do_newJW(integrator, alg, nlsolver, repeat_step)::NTuple{2, Bool}
     end
 end
 
+# `ScalarOperator` (λ·I) reports `axes(mm) == ()` like `UniformScaling`, but unlike
+# `UniformScaling` it isn't matched by `isa UniformScaling` -- treat both as the same
+# scalar-times-identity case rather than requiring `axes(mm) == axes(W)`.
+_is_scalar_massmatrix(mm) = false
+_is_scalar_massmatrix(::UniformScaling) = true
+_is_scalar_massmatrix(::ScalarOperator) = true
+_scalar_massmatrix_λ(mm::UniformScaling) = mm.λ
+_scalar_massmatrix_λ(mm::ScalarOperator) = convert(Number, mm)
+
 @noinline _throwWJerror(W, J) = throw(DimensionMismatch("W: $(axes(W)), J: $(axes(J))"))
 @noinline function _throwWMerror(W, mass_matrix)
     throw(DimensionMismatch("W: $(axes(W)), mass matrix: $(axes(mass_matrix))"))
@@ -608,14 +617,14 @@ function jacobian2W!(
     # check size and dimension
     iijj = axes(W)
     @boundscheck (iijj == axes(J) && length(iijj) == 2) || _throwWJerror(W, J)
-    mass_matrix isa UniformScaling ||
+    _is_scalar_massmatrix(mass_matrix) ||
         @boundscheck axes(mass_matrix) == axes(W) || _throwWMerror(W, mass_matrix)
     @inbounds begin
         invdtgamma = inv(dtgamma)
-        if mass_matrix isa UniformScaling
+        if _is_scalar_massmatrix(mass_matrix)
             copyto!(W, J)
             idxs = diagind(W)
-            λ = -mass_matrix.λ
+            λ = -_scalar_massmatrix_λ(mass_matrix)
             if ArrayInterface.fast_scalar_indexing(J) &&
                     ArrayInterface.fast_scalar_indexing(W)
                 @inbounds for i in 1:size(J, 1)
@@ -639,14 +648,14 @@ function jacobian2W!(W::Matrix, mass_matrix, dtgamma::Number, J::Matrix)::Nothin
     # check size and dimension
     iijj = axes(W)
     @boundscheck (iijj == axes(J) && length(iijj) == 2) || _throwWJerror(W, J)
-    mass_matrix isa UniformScaling ||
+    _is_scalar_massmatrix(mass_matrix) ||
         @boundscheck axes(mass_matrix) == axes(W) || _throwWMerror(W, mass_matrix)
     @inbounds begin
         invdtgamma = inv(dtgamma)
-        if mass_matrix isa UniformScaling
+        if _is_scalar_massmatrix(mass_matrix)
             copyto!(W, J)
             idxs = diagind(W)
-            λ = -mass_matrix.λ
+            λ = -_scalar_massmatrix_λ(mass_matrix)
             @inbounds for i in 1:size(J, 1)
                 W[i, i] = muladd(λ, invdtgamma, J[i, i])
             end
@@ -661,12 +670,12 @@ end
 
 function jacobian2W(mass_matrix, dtgamma::Number, J::AbstractMatrix)
     # check size and dimension
-    mass_matrix isa UniformScaling ||
+    _is_scalar_massmatrix(mass_matrix) ||
         @boundscheck axes(mass_matrix) == axes(J) || _throwJMerror(J, mass_matrix)
     @inbounds begin
         invdtgamma = inv(dtgamma)
-        if mass_matrix isa UniformScaling
-            λ = -mass_matrix.λ
+        if _is_scalar_massmatrix(mass_matrix)
+            λ = -_scalar_massmatrix_λ(mass_matrix)
             W = J + (λ * invdtgamma) * I
         else
             W = muladd(-mass_matrix, invdtgamma, J)

--- a/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
@@ -31,6 +31,7 @@ end
 if TEST_GROUP ∉ ("QA", "Sparse", "ModelingToolkit")
     @time @safetestset "DAE jacobian2W sparse" include("dae_jacobian2w_sparse_tests.jl")
     @time @safetestset "prepare_user_sparsity mass matrix" include("prepare_user_sparsity_tests.jl")
+    @time @safetestset "ScalarOperator mass matrix" include("scalar_operator_massmatrix_tests.jl")
     @time @safetestset "nzval helpers" include("nzval_helpers_tests.jl")
     @time @safetestset "prepare_sparse_jac!" include("prepare_sparse_jac_tests.jl")
     @time @safetestset "OOP J_t Tracking" include("oop_jt_tracking_test.jl")

--- a/lib/OrdinaryDiffEqDifferentiation/test/scalar_operator_massmatrix_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/scalar_operator_massmatrix_tests.jl
@@ -1,0 +1,67 @@
+using OrdinaryDiffEqDifferentiation
+using OrdinaryDiffEqSDIRK
+using SciMLBase
+using SciMLOperators
+using SparseArrays
+using LinearAlgebra
+using Test
+
+# ScalarOperator (λ·I) reports axes(mm) == (), unlike UniformScaling, so it fell
+# through the `mass_matrix isa UniformScaling` special case and hit the
+# `axes(mass_matrix) == axes(W)` boundscheck meant for full mass matrices.
+J = [1.0 2.0; 3.0 4.0]
+λ = 2.0
+W_expected = J - λ * inv(0.5) * I
+
+# `Matrix` specialization
+W = similar(J)
+OrdinaryDiffEqDifferentiation.jacobian2W!(W, ScalarOperator(λ), 0.5, J)
+@test W ≈ W_expected
+
+W_uniform = similar(J)
+OrdinaryDiffEqDifferentiation.jacobian2W!(W_uniform, λ * I, 0.5, J)
+@test W ≈ W_uniform
+
+# generic `AbstractMatrix` method, reached through a sparse J
+Js = sparse(J)
+W_sparse = similar(Js)
+W_sparse_uniform = similar(Js)
+OrdinaryDiffEqDifferentiation.jacobian2W!(W_sparse, ScalarOperator(λ), 0.5, Js)
+OrdinaryDiffEqDifferentiation.jacobian2W!(W_sparse_uniform, λ * I, 0.5, Js)
+@test W_sparse == W_sparse_uniform
+@test W_sparse ≈ W_expected
+
+# out-of-place
+@test OrdinaryDiffEqDifferentiation.jacobian2W(ScalarOperator(λ), 0.5, J) ≈ W_expected
+
+# end-to-end: the `solve` reported in #3915
+function lorenz!(du, u, p, t)
+    du[1] = 10.0 * (u[2] - u[1])
+    du[2] = u[1] * (28.0 - u[3]) - u[2]
+    du[3] = u[1] * u[2] - (8 / 3) * u[3]
+    return nothing
+end
+u0 = [1.0, 0.0, 0.0]
+tspan = (0.0, 1.0)
+sol_op = solve(
+    ODEProblem(ODEFunction(lorenz!; mass_matrix = ScalarOperator(λ)), u0, tspan),
+    TRBDF2(), abstol = 1.0e-10, reltol = 1.0e-10
+)
+sol_uniform = solve(
+    ODEProblem(ODEFunction(lorenz!; mass_matrix = λ * I), u0, tspan),
+    TRBDF2(), abstol = 1.0e-10, reltol = 1.0e-10
+)
+@test SciMLBase.successful_retcode(sol_op)
+@test sol_op.u[end] ≈ sol_uniform.u[end]
+
+# The case `UniformScaling` cannot express: a time-varying scalar mass matrix.
+# M(t) u' = -u with M(t) = (1+t) I has the exact solution u(t) = u0 / (1+t), so
+# a stale or ignored `update_func` shows up directly in the answer.
+mm_t = ScalarOperator(1.0; update_func = (a, u, p, t) -> 1.0 + t)
+decay!(du, u, p, t) = (du .= -u; nothing)
+sol_t = solve(
+    ODEProblem(ODEFunction(decay!; mass_matrix = mm_t), [1.0], (0.0, 1.0)),
+    TRBDF2(), abstol = 1.0e-10, reltol = 1.0e-10
+)
+@test SciMLBase.successful_retcode(sol_t)
+@test sol_t.u[end][1] ≈ 0.5 atol = 1.0e-5


### PR DESCRIPTION
Fixes #3915.

## Bug

`jacobian2W!`/`jacobian2W` special-case `mass_matrix isa UniformScaling` to skip the `axes(mass_matrix) == axes(W)` boundscheck and use the scalar directly. `ScalarOperator` is the same thing (λ·I) but isn't a `UniformScaling`, and reports `axes(mm) == ()`, so it falls through to the boundscheck meant for full matrices and throws.

```julia
using OrdinaryDiffEqSDIRK, SciMLOperators
f = ODEFunction((du, u, p, t) -> (du .= -u); mass_matrix = ScalarOperator(1.0))
solve(ODEProblem(f, [1.0], (0.0, 1.0)), TRBDF2())
# DimensionMismatch: W: (Base.OneTo(1), Base.OneTo(1)), mass matrix: ()
```

`IdentityOperator` doesn't hit this since its `axes` happen to match `W`.

## Fix

Treat `ScalarOperator` the same as `UniformScaling` in both `jacobian2W!` methods and `jacobian2W`, via `_is_scalar_massmatrix`/`_scalar_massmatrix_λ`. Follows #3814 → SciMLOperators#400 → #3837, the same operator-mass-matrix chain, one step further (this is the first place a `ScalarOperator` mass matrix reaches once the entry crash and `get_differential_vars` are both already fixed).

## Tests

New `scalar_operator_massmatrix_tests.jl` covers `jacobian2W!` through both the `::Matrix` specialization and the generic `::AbstractMatrix` method (reached with a sparse `J`), the out-of-place `jacobian2W`, and an end-to-end `TRBDF2()` solve of the case from #3915 — Lorenz with `mass_matrix = ScalarOperator(2.0)` against `mass_matrix = 2.0*I`. 7 assertions; the file errors on master with the reported `DimensionMismatch`.

Those two solves are in fact bit-identical (max abs difference 0.0 over `saveat = 0:0.1:1` at `abstol = reltol = 1e-12`, identical accepted-step counts) for TRBDF2, KenCarp4, FBDF and Rodas5P, and Rodas5P agrees to 7e-12 with a 1e-14 reference solve of the equivalent `M = I`, `f/2` problem.

`OrdinaryDiffEqDifferentiation` Core suite: 65 passes across 10 testsets (master: 61 across 9). QA also passes (JET 1/1, Aqua/ExplicitImports 15/15).

## Scope

This fixes the in-place W assembly, which is what #3915 reports. Still failing and unchanged by this PR, with different errors: out-of-place and StaticArrays `ScalarOperator` mass matrices (`Out-of-place NLNewton does not support non-concrete W`, and an `AssertionError` in the `StaticWOperator` path), and a sparse `jac_prototype` combined with a `ScalarOperator` mass matrix, which fails earlier in `prepare_user_sparsity`.

## AI Disclosure

Claude assisted with this work.

