### PR TITLE
Raise NonlinearSolveBase floor for operator Jacobians

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.3.0"
+version = "2.3.1"
 
 [deps]
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"

--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,10 +1,11 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.3.1"
+version = "2.3.2"
 
 [deps]
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+NonlinearSolveBase = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
@@ -50,6 +51,7 @@ DiffEqDevTools = {path = "../DiffEqDevTools"}
 SciMLTesting = "2.1"
 Pkg = "1"
 NonlinearSolve = "4.20.3"
+NonlinearSolveBase = "2.34.1"
 ForwardDiff = "1.3.3"
 Test = "<0.0.1, 1"
 FastBroadcast = "1.3"

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
@@ -17,6 +17,8 @@ import PreallocationTools: DiffCache, get_tmp
 using SimpleNonlinearSolve: SimpleTrustRegion, SimpleGaussNewton
 using NonlinearSolve: FastShortcutNonlinearPolyalg, FastShortcutNLLSPolyalg, NewtonRaphson,
     HomotopySweep, step!
+# The operator Jacobian path is implemented in NonlinearSolveBase and needs its own floor.
+import NonlinearSolveBase
 using MuladdMacro: @muladd
 using FastBroadcast: @..
 import FastClosures: @closure

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -132,7 +132,10 @@ function initialize!(
                 SciMLBase.remake(cache.prob; u0 = copy(z), p = nlp_params)
             end
             cache.prob = new_prob
-            cache.cache = init(new_prob, cache.cache.alg)
+            cache.cache = init(
+                new_prob, cache.cache.alg;
+                verbose = integrator.opts.verbose.nonlinear_verbosity
+            )
         else
             SciMLBase.reinit!(cache.cache, z, p = nlp_params)
         end

--- a/test/InterfaceIII/verbosity.jl
+++ b/test/InterfaceIII/verbosity.jl
@@ -428,5 +428,21 @@ using NonlinearSolve: NonlinearVerbosity
             @test integrator.cache.nlsolver.cache.cache.verbose == NonlinearVerbosity(SciMLLogging.Detailed())
         end
 
+        @testset "Resize preserves Detailed NonlinearVerbosity" begin
+            resize_prob = ODEProblem((du, u, p, t) -> du .= u, [1.0], (0.0, 1.0))
+            verbose = DEVerbosity(nonlinear_verbosity = SciMLLogging.Detailed())
+            integrator = init(
+                resize_prob, ImplicitEuler(nlsolve = NonlinearSolveAlg());
+                verbose, dt = 0.1
+            )
+            expected = NonlinearVerbosity(SciMLLogging.Detailed())
+            @test integrator.cache.nlsolver.cache.cache.verbose == expected
+
+            resize!(integrator, 2)
+            step!(integrator)
+
+            @test integrator.cache.nlsolver.cache.cache.verbose == expected
+        end
+
     end
 end


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## Summary

- declare `NonlinearSolveBase` as a direct dependency of `OrdinaryDiffEqNonlinearSolve`
- require `NonlinearSolveBase` 2.34.1 or newer, the first tested floor with the operator-Jacobian support this sublibrary uses
- bump the sublibrary patch version to 2.3.2

## Root cause

PR #3885 began passing `SciMLOperators` Jacobian prototypes into NonlinearSolve. Its implementation requires newer `NonlinearSolveBase`, but the package metadata raised only the umbrella `NonlinearSolve` floor. Registry compatibility for that umbrella release still permits `NonlinearSolveBase 2.33.0`.

The deployed downgrade action therefore selects 2.33.0 and fails in `safe_similar` while constructing a cache for a `SciMLOperators.MatrixOperator`. A frozen-environment bisect identified `9a2f7e7b79141951df24a0f2191a8aa20e94f49a` (the commit for #3885) as the first bad commit; `3b799e583` was the adjacent passing control.

## Source prerequisite and temporary stack

#3971 fixes the independent resize path that dropped configured nonlinear verbosity. It takes version 2.3.1 and must land before this compatibility-floor patch.

GitHub cannot use a fork-only branch as this PR's upstream base, so the currently published branch temporarily contains #3971 followed by this PR's focused commit. The focused top commit changes only the direct dependency, its 2.34.1 compatibility floor, the corresponding import, and this package's 2.3.2 version. After #3971 merges, this branch must be rebased onto updated `master` so the final #3917 diff contains only that focused commit.

#3927 is intentionally outside this stack. Its unique `SparseConnectivityTracer = "1"` compatibility metadata can follow independently as 2.3.3 after these two patches.

## Shared-workflow prerequisite

This package patch deliberately does not duplicate `SciMLOperators`, `NonlinearSolveBase`, or downstream `MuladdMacro` floors across unrelated sublibraries.

The currently deployed downgrade action removes path-source packages before minimum resolution, so their transitive constraints are invisible until the action appends those sources afterward. SciML/.github [#118](https://github.com/SciML/.github/pull/118) fixes that shared workflow by exposing source constraints before resolution and restoring the original project for the final locked test. Its `v1` release is required for every path-source downgrade lane to consume this floor correctly.

## Validation

- The exact #118-reconciled downgrade graph selected `NonlinearSolveBase 2.34.1`, `SciMLOperators 1.24.3`, `LinearSolve 4.3.0`, `MuladdMacro 0.2.4`, and `SciMLLogging 1.10.1`; its manifest SHA-256 was `dcb935a041618f14baa966fc95f7348071b145bf5bbc31d3c2882bc8b0a34880`.
- The official locked `ODEDIFFEQ_TEST_GROUP=Core` package suite exited 0: Newton 6/6, sparse DAE initialization 27/27, linear nonlinear solver 44/44, linear solver 113/113, split solver 10/10, mass matrix 225 passed with 42 pre-existing broken, W-operator 18/18, DAE initialization 19/19, CheckInit 4/4, nested AD 5/5, Jacobian reuse 8/8, homotopy 25/25, sparse Jacobian 11/11, and matrix-free W-operator 14/14. The manifest hash was unchanged after the run.
- The deterministic resize/verbosity regression passed 2/2 and the three focused sparse/resize testsets passed 3/3, 4/4, and 4/4 under the constrained graph.
- Whole-repository Runic 1.7.0, `git diff --check`, and parsing every tracked `Project.toml` passed with the final 2.3.2 bump.
- On #3971 without this floor, the current NonlinearSolve, BDF, and SDIRK downgrade lanes all reproduce the same `NonlinearSolveBase 2.33.0` `safe_similar(::MatrixOperator)` failure. The earlier #3917 NonlinearSolve downgrade lane passed after selecting 2.34.1.

## Process

The incompatibility was reproduced under the deployed downgrade workflow, bisected with a frozen graph, reduced to the missing direct dependency floor, validated under the reconciled exact graph, then rebased as a focused commit on top of the independently tested #3971 prerequisite.
