### PR TITLE
Stabilize the out-of-place tau-leaping mean test

### DIFF
--- a/lib/StochasticDiffEq/test/tau_leaping.jl
+++ b/lib/StochasticDiffEq/test/tau_leaping.jl
@@ -85,8 +85,8 @@ jumpdiff_prob = JumpProblem(oop_sdeprob, Direct(), rj)
 @time sol = solve(jumpdiff_prob, EM(); dt = 1.0)
 @time sol = solve(jumpdiff_prob, ImplicitEM(); dt = 1.0)
 
-sol = solve(EnsembleProblem(jumpdiff_prob), EM(); dt = 1.0, trajectories = 10_000)
-meanX = mean([sol.u[i][end, end] for i in 1:10_000])
+sol = solve(EnsembleProblem(jumpdiff_prob), EM(); dt = 1.0, trajectories = N)
+meanX = mean([sol.u[i][end, end] for i in 1:N])
 @test mean1 ≈ meanX rtol = 1.0e-2
 
 sol = solve(EnsembleProblem(jumpdiff_prob), ImplicitEM(); dt = 1.0, trajectories = 1_000)


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

Use the existing N = 40,000 trajectory count for the out-of-place EM ensemble comparison, matching the SimpleTauLeaping reference ensemble in the same test. The 1% relative-tolerance assertion is unchanged.

## Why

The current test compares a 40,000-trajectory reference mean with only 10,000 out-of-place EM trajectories. On the exact RNG state from the failing Interface2 job, clean master reproduces the failure with mean1 = 727.4012 and meanX = 719.9237. This is a 1.028% sample-mean difference against a 1% assertion.

This test has previously needed trajectory-count increases for the same sampling issue:

- https://github.com/SciML/StochasticDiffEq.jl/commit/df26673cfb850e6f6da9c630b7641eaf1aeec7ae
- https://github.com/SciML/StochasticDiffEq.jl/commit/3df94801251ba56474111c5a368a335fbd597aa3

Failing job: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/29408885667/job/87339835182

## Sampling-variance check

I ran both estimators at 40,000 trajectories for five fixed seeds and evaluated the out-of-place mean using both its first 10,000 samples and all 40,000 samples. The clean and candidate worktrees produced identical measurements, as expected because this patch changes only the test sample count.

- Empirical standard deviation of reference-minus-EM differences: 3.0426 at 10,000, 1.7622 at 40,000.
- Mean estimated standard error of the difference: 2.6696 at 10,000, 1.6780 at 40,000.
- Mean 40,000-trajectory difference across seeds: -0.1843, about 0.11 mean estimated standard errors from zero.
- Worst relative difference across the five seeds: 0.8471% at 10,000 and 0.3878% at 40,000.
- All five seeds passed the unchanged 1% assertion at both counts; the larger count materially increases margin without changing the expected value or tolerance.

## Local verification

- Exact CI RNG on clean master: reproduced the failure, 14/15 Basic Tau Leaping assertions passed.
- Exact CI RNG with this patch: 15/15 passed.
- Clean master, ODEDIFFEQ_TEST_GROUP=Interface2 on Julia 1.12.6: StochasticDiffEq tests passed.
- This patch, ODEDIFFEQ_TEST_GROUP=Interface2 on Julia 1.12.6: StochasticDiffEq tests passed; Basic Tau Leaping 15/15; complete group finished in 1,014 seconds.
- Runic 1.7 repository-wide check passed.
- git diff --check passed.