### PR TITLE
Fix reinit! crash on null-u0 integrators (uType Nothing)

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.7.0"
+version = "4.7.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
@@ -511,6 +511,14 @@ function SciMLBase.reinit!(
             integrator.sol = sol
         end
     end
+    # Null u0 (e.g., MTK systems with only observed/algebraic variables and no state).
+    # `init` coerces such a `nothing` to the working state (`Float64[]`), but `prob.u0`
+    # (the default here) and `late_binding_update_u0_p` can still hand back `nothing`.
+    # There is no state to reinitialize, so fall back to the integrator's current `u`,
+    # which downstream copying/saving can handle uniformly.
+    if u0 === nothing
+        u0 = integrator.u
+    end
     if isinplace(integrator.sol.prob)
         recursivecopy!(integrator.u, u0)
         recursivecopy!(integrator.uprev, integrator.u)

--- a/test/Integrators_I/reinit_test.jl
+++ b/test/Integrators_I/reinit_test.jl
@@ -147,3 +147,23 @@ end
     # The solver should handle the discontinuities correctly
     @test integrator.sol.retcode == ReturnCode.Success
 end
+
+@testset "reinit with null u0 (no state variables)" begin
+    # Systems with only observed/algebraic variables (e.g. MTK models that
+    # structurally simplify to zero dynamical states) have `prob.u0 === nothing`.
+    # `init` coerces that to an empty working state, but `reinit!` used to feed the
+    # raw `nothing` into `recursivecopy!`/`copyat_or_push!`. A callback forces the
+    # real ODEIntegrator path rather than the NullODEIntegrator shortcut.
+    prob = ODEProblem((du, u, p, t) -> nothing, nothing, (0.0, 1.0))
+    cb = DiscreteCallback((u, t, integrator) -> false, integrator -> nothing)
+
+    integrator = init(prob, Tsit5(); callback = cb)
+    @test integrator.u == Float64[]
+    solve!(integrator)
+    @test integrator.sol.retcode == ReturnCode.Success
+
+    reinit!(integrator)
+    @test integrator.u == Float64[]
+    solve!(integrator)
+    @test integrator.sol.retcode == ReturnCode.Success
+end


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

## Problem

Reported from STK CI (Slack). Systems with only observed/algebraic variables — e.g. MTK models that structurally simplify to zero dynamical states — build `ODEProblem`s with `uType Nothing` (`prob.u0 === nothing`). Calling `reinit!` on such an integrator throws:

```
MethodError: no method matching recursivecopy!(::Vector{Float64}, ::Nothing)
```

## Root cause

`init` coerces a `nothing` `u0` to an empty working state (`Float64[]`) so solver caches can be built (`solve.jl`, guarded by `allows_null_u0`), but `prob.u0` itself stays `nothing`. `reinit!` defaults `u0 = integrator.sol.prob.u0` (== `nothing`) and, for MTK problems, `late_binding_update_u0_p` also passes the `nothing` straight through. That `nothing` then reaches:

- `recursivecopy!(integrator.u, u0)` → the reported `MethodError`, and
- `copyat_or_push!(integrator.sol.u, 1, u0)` in the save-reinit block → `length(::Nothing)`.

A callback (MTK event) is what selects the real `ODEIntegrator` path rather than the `NullODEIntegrator` shortcut, which is why it surfaces on MTK systems with events.

## Fix

When the reinit `u0` resolves to `nothing` there is no state to reinitialize, so fall back to the integrator's current `u` (the empty state `init` already established). Every downstream copy/save path then handles it uniformly. One-line coercion, no behavior change for stateful systems.

## Reproduction (MTK-free)

```julia
using OrdinaryDiffEq
prob = ODEProblem((du, u, p, t) -> nothing, nothing, (0.0, 1.0))
cb = DiscreteCallback((u, t, integ) -> false, integ -> nothing)
integ = init(prob, Tsit5(); callback = cb)
solve!(integ)
reinit!(integ)   # threw before this PR; ok now
```

## Testing

- Added a regression testset ("reinit with null u0 (no state variables)") to `test/Integrators_I/reinit_test.jl`. Verified it **fails** on unpatched `master` with the exact `recursivecopy!(::Vector{Float64}, ::Nothing)` error and **passes** with the fix.
- Full `reinit_test.jl` passes locally (all pre-existing testsets + the new one).
- Confirmed the original MTK scenario (`mtkcompile`d system with all-observed unknowns + event callback) now reinits cleanly.
- `Runic` clean on both changed files.

Patch bump: OrdinaryDiffEqCore `4.7.0 → 4.7.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)