### PR TITLE
get_differential_vars: check Diagonal.diag, not the full matrix

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/misc_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/misc_utils.jl
@@ -213,6 +213,12 @@ function get_differential_vars(f, u)
         elseif mm isa SciMLOperators.ScalarOperator
             # λ·I: every variable is algebraic when λ is zero.
             return iszero(mm.val) ? falses(size(u)) : nothing
+        elseif mm isa Diagonal
+            # Check only `mm.diag`: the generic paths below visit every (i, j)
+            # pair via scalar `getindex`, which is disallowed when `mm.diag` is
+            # GPU-backed (e.g. `Diagonal{Float64, <:CuVector}`), while a
+            # broadcast over `mm.diag` dispatches to a proper GPU kernel.
+            return reshape(mm.diag .!= 0, size(u))
         elseif all(!iszero, mm)
             return trues(size(mm, 1))
         elseif !(mm isa SciMLOperators.AbstractSciMLOperator) && _isdiag(mm)

--- a/lib/OrdinaryDiffEqCore/test/algebraic_vars_detection_tests.jl
+++ b/lib/OrdinaryDiffEqCore/test/algebraic_vars_detection_tests.jl
@@ -113,3 +113,37 @@ end
     ff_singular = ODEFunction(f!, mass_matrix = ScalarOperator(0.0))
     @test get_differential_vars(ff_singular, u) == falses(3)
 end
+
+@testset "get_differential_vars: Diagonal mass matrix" begin
+    f!(du, u, p, t) = (du .= -u; nothing)
+    u = zeros(4)
+    ff_mixed = ODEFunction(f!, mass_matrix = Diagonal([1.0, 1.0, 0.0, 0.0]))
+    @test get_differential_vars(ff_mixed, u) == Bool[1, 1, 0, 0]
+    ff_alldiff = ODEFunction(f!, mass_matrix = Diagonal([1.0, 2.0, 3.0, 4.0]))
+    @test get_differential_vars(ff_alldiff, u) == Bool[1, 1, 1, 1]
+    ff_allalg = ODEFunction(f!, mass_matrix = Diagonal(zeros(4)))
+    @test get_differential_vars(ff_allalg, u) == Bool[0, 0, 0, 0]
+end
+
+# Mimics GPU device-array semantics on the CPU: elementwise scalar `getindex`
+# is forbidden (like CUDA's default `allowscalar(false)`), while whole-array
+# broadcast still works. Any code path that walks a `Diagonal` of this via
+# `getindex` -- `all(!iszero, mm)` or a `diag(mm)` copy -- errors, so the test
+# below catches a regression back to the whole-matrix check without needing a
+# GPU. Must be top-level: structs cannot be defined inside a `@testset`.
+struct NoScalarIndexVector{T} <: AbstractVector{T}
+    data::Vector{T}
+end
+Base.size(v::NoScalarIndexVector) = size(v.data)
+function Base.getindex(::NoScalarIndexVector, ::Int)
+    error("scalar getindex disallowed on NoScalarIndexVector")
+end
+Base.Broadcast.broadcastable(v::NoScalarIndexVector) = v.data
+
+@testset "get_differential_vars: no scalar indexing of Diagonal mass matrix" begin
+    f!(du, u, p, t) = (du .= -u; nothing)
+    u = zeros(4)
+    mm = Diagonal(NoScalarIndexVector([1.0, 1.0, 0.0, 0.0]))
+    ff = ODEFunction(f!, mass_matrix = mm)
+    @test get_differential_vars(ff, u) == Bool[1, 1, 0, 0]
+end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/mass_matrix_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/mass_matrix_tests.jl
@@ -383,9 +383,12 @@ prob = ODEProblem(f, x0, tspan)
 foop = ODEFunction{false, SciMLBase.AutoSpecialize}(dynamics, mass_matrix = M)
 proboop = ODEProblem(f, x0, tspan)
 @test_broken sol = @inferred solve(prob, Rosenbrock23(autodiff = adalg))
-@test_broken sol = @inferred solve(prob, Rodas4(autodiff = adalg), initializealg = ShampineCollocationInit())
+# The Rodas4 + ShampineCollocationInit cases infer since get_differential_vars
+# got a statically resolvable Diagonal branch; keep @inferred so an inference
+# regression errors, but @test_broken would error ("non-Boolean") on success.
+@test (@inferred solve(prob, Rodas4(autodiff = adalg), initializealg = ShampineCollocationInit()); true)
 @test_broken sol = @inferred solve(proboop, Rodas5())
-@test_broken sol = @inferred solve(proboop, Rodas4(), initializealg = ShampineCollocationInit())
+@test (@inferred solve(proboop, Rodas4(), initializealg = ShampineCollocationInit()); true)
 
 # InitialFailure with chunksize matching ODE size (> alg vars), #3157
 @testset "Mass Matrix: less alg vars than ODE AD chunksize" begin

--- a/test/gpu/dae_tests.jl
+++ b/test/gpu/dae_tests.jl
@@ -458,6 +458,11 @@ end
 @testset "GPU DAE solver compatibility" begin
     global results = run_all()
     show_results(results)
+    # Print the actual caught exceptions on failure -- `show_results` only prints
+    # a per-case status glyph, which is not enough on its own to diagnose what
+    # broke from a CI log.
+    any(r -> r.status ∈ (:gpu_error, :gpu_mismatch, :gpu_failed), results) &&
+        show_errors(results)
     @testset "$(r.case)" for r in results
         # :cpu_skip = the CPU couldn't solve this case, so there is no reference
         # to compare against — record as skipped, not pass/fail.


### PR DESCRIPTION
Rework of the original patch, rebased onto current master (dc7f91af).

The GPU DAE lane has recovered on master without this change. After the CUDA environment rework on the self-hosted runner, `GPU: dae_tests.jl` stands at 136 passed / 1 failed / 7 broken as of master run [30340807357](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/30340807357) (Jul 28); the one remaining failure is `Hairer4 [jac=CSC, mass=diag_cu]`, a different problem. So the earlier "fixes 100% GPU DAE failure" framing no longer applies, and #3922 should be closed or retitled to track the remaining Hairer4 case. What this PR still fixes is the access pattern.

`get_differential_vars` (`lib/OrdinaryDiffEqCore/src/misc_utils.jl`) checks the mass matrix with `all(!iszero, mm)` before its `_isdiag` branch. For a `Diagonal` that walks all n^2 positions, and every diagonal hit is a scalar `getindex` on the underlying vector, which is disallowed by default when that vector is a `CuVector`, and O(n^2) for a question the type answers in O(n). The fix adds a `Diagonal` dispatch that broadcasts over `mm.diag`, so the reduction is O(n) and stays on device. This is the same diagonal-only reduction `find_algebraic_vars_eqs(::Diagonal)` in the same file performs, though that one goes through `diag(M)` rather than the field.

CPU results are unchanged for every case that previously reached the `_isdiag` branch. Mixed, all-nonzero and all-zero diagonals return exactly what the old `_isdiag` path returned, including the `reshape` to `size(u)` for matrix-valued `u`, and all three are covered by new tests.

The access pattern itself is now tested on CPU: a `Diagonal` wrapping a vector type that errors on scalar `getindex` but supports whole-array broadcast, i.e. device-array semantics without a GPU. On master's code path that construction throws inside `all(!iszero, mm)`; with this patch it returns the correct differential-vars mask.

One test adjustment was required. The `Diagonal` branch is statically resolvable, which fixes inference of `solve` for the two Rodas4 + `ShampineCollocationInit` cases at `lib/OrdinaryDiffEqNonlinearSolve/test/mass_matrix_tests.jl:385/387`. Those lines were `@test_broken sol = @inferred solve(...)`, a form that errors with "Expression evaluated to non-Boolean" once `@inferred` succeeds, because the successful `@inferred` returns the solution object. Both lines now read `@test (@inferred solve(...); true)`: green while inference holds, an error if it regresses. I checked the replacement form against master's code and it does error there, so it is not a rubber stamp. The `Rosenbrock23` and `Rodas5` lines are untouched and stay `@test_broken`; those two fail because `solve` itself throws `CheckInitFailureError`, which this change does not affect.

Also wires up `show_errors(results)` in the GPU DAE test entry point; it was defined but never called, so a failing case only ever logged a status glyph with no exception text. That file runs only on the self-hosted GPU lane.

Local verification on Julia 1.12.6, rebased on master:

- `lib/OrdinaryDiffEqCore/test/algebraic_vars_detection_tests.jl`: 22 passed / 0 failed (18 on master, so 4 new assertions).
- `lib/OrdinaryDiffEqNonlinearSolve/test/mass_matrix_tests.jl`: 227 passed / 0 failed / 0 errored / 40 broken. Master baseline on the same file is 225 passed / 42 broken; the two that flip are the Rodas4 lines above.
- `lib/OrdinaryDiffEqBDF`: `dae_convergence_tests.jl` 50/50, `dae_initialization_tests.jl` 38 passed / 2 broken (pre-existing).
- Runic 1.5.1 clean on all four changed files.

No GPU hardware here, so the CUDA path is covered by the CPU device-semantics guard test rather than on-device.

## AI Disclosure

Claude assisted with this work.
