### PR TITLE
Fuse RosenbrockCache stage accumulation loops into single-sweep SIMD kernels

### DIFF
--- a/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_perform_step.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_perform_step.jl
@@ -575,26 +575,63 @@ end
 
 # Fused single-sweep accumulation kernels for the stage loops below. Each
 # replaces a sequence of per-coefficient broadcasts — one full memory sweep per
-# tableau entry — with a single sweep using muladd, which is where the
-# pre-consolidation hand-unrolled kernels got their speed. `Array` states (incl.
-# N-d arrays; linear indexing) take these; anything without fast scalar indexing
-# (GPU etc.) keeps the broadcast fallback.
+# tableau entry — with a single sweep, which is where the pre-consolidation
+# hand-unrolled kernels got their speed. The tableau coefficients are hoisted
+# into an NTuple through a bounded `@nif` ladder (single function, not
+# per-`Val{num_stages}` specializations, so no compile-time blowup) and the
+# inner term expansion unrolls statically so the sweep SIMD-vectorizes.
+# `Array` states take these; anything without fast scalar indexing (GPU etc.)
+# keeps the per-coefficient broadcast fallback. Beyond 8 fused terms (only
+# Rodas6P's late stages) the fallback path is used as well.
+
+@inline function _madd_terms(acc, idx, cs::Tuple, karrs::Tuple)
+    return _madd_terms(
+        muladd(first(cs), (@inbounds first(karrs)[idx]), acc),
+        idx, Base.tail(cs), Base.tail(karrs)
+    )
+end
+@inline _madd_terms(acc, idx, ::Tuple{}, ::Tuple{}) = acc
+
+@inline function _fused_lincomb!(
+        out::Array, base::Array, cs::NTuple{N, Any}, karrs::NTuple{N, Any}
+    ) where {N}
+    @inbounds @simd ivdep for idx in eachindex(out)
+        out[idx] = _madd_terms(base[idx], idx, cs, karrs)
+    end
+    return nothing
+end
+
+@inline function _fused_lincomb!(
+        out::Array, ::Nothing, cs::NTuple{N, Any}, karrs::NTuple{N, Any}
+    ) where {N}
+    z = zero(eltype(out))
+    @inbounds @simd ivdep for idx in eachindex(out)
+        out[idx] = _madd_terms(z, idx, cs, karrs)
+    end
+    return nothing
+end
 
 # out .= base .+ sum(A[stage, i] .* ks[i] for i in 1:(stage-1))
 @inline function _stage_accum!(
         out::Array, base::Array, A::AbstractMatrix, ks::Vector{<:Array}, stage::Int
     )
-    @inbounds for idx in eachindex(out)
-        acc = base[idx]
-        for i in 1:(stage - 1)
-            acc = muladd(A[stage, i], ks[i][idx], acc)
+    nks = stage - 1
+    if nks <= 8
+        Base.Cartesian.@nif 8 n -> (nks == n) n -> begin
+            cs = Base.Cartesian.@ntuple n i -> A[stage, i]
+            ka = Base.Cartesian.@ntuple n i -> ks[i]
+            _fused_lincomb!(out, base, cs, ka)
         end
-        out[idx] = acc
+    else
+        _stage_accum_fallback!(out, base, A, ks, stage)
     end
     return nothing
 end
 
-@inline function _stage_accum!(out, base, A, ks, stage::Int)
+_stage_accum!(out, base, A, ks, stage::Int) =
+    _stage_accum_fallback!(out, base, A, ks, stage)
+
+@inline function _stage_accum_fallback!(out, base, A, ks, stage::Int)
     out === base || copyto!(out, base)
     @inbounds for i in 1:(stage - 1)
         @.. out += A[stage, i] * ks[i]
@@ -607,17 +644,27 @@ end
         linsolve_tmp::Array, du::Array, dtd_s, dT::Array, dtC::AbstractMatrix,
         ks::Vector{<:Array}, stage::Int
     )
-    @inbounds for idx in eachindex(linsolve_tmp)
-        acc = muladd(dtd_s, dT[idx], du[idx])
-        for i in 1:(stage - 1)
-            acc = muladd(dtC[stage, i], ks[i][idx], acc)
+    nks = stage - 1
+    if nks <= 8
+        Base.Cartesian.@nif 8 n -> (nks == n) n -> begin
+            cs = Base.Cartesian.@ntuple n i -> dtC[stage, i]
+            ka = Base.Cartesian.@ntuple n i -> ks[i]
+            @inbounds @simd ivdep for idx in eachindex(linsolve_tmp)
+                linsolve_tmp[idx] = _madd_terms(
+                    muladd(dtd_s, dT[idx], du[idx]), idx, cs, ka
+                )
+            end
         end
-        linsolve_tmp[idx] = acc
+    else
+        _stage_rhs_fallback!(linsolve_tmp, du, dtd_s, dT, dtC, ks, stage)
     end
     return nothing
 end
 
-@inline function _stage_rhs!(linsolve_tmp, du, dtd_s, dT, dtC, ks, stage::Int)
+_stage_rhs!(linsolve_tmp, du, dtd_s, dT, dtC, ks, stage::Int) =
+    _stage_rhs_fallback!(linsolve_tmp, du, dtd_s, dT, dtC, ks, stage)
+
+@inline function _stage_rhs_fallback!(linsolve_tmp, du, dtd_s, dT, dtC, ks, stage::Int)
     @.. linsolve_tmp = du + dtd_s * dT
     @inbounds for i in 1:(stage - 1)
         @.. linsolve_tmp += dtC[stage, i] * ks[i]
@@ -625,22 +672,28 @@ end
     return nothing
 end
 
-# out .= (base or zero) .+ sum(w[i] .* ks[i] for nonzero w[i])
+# out .= (base or zero) .+ sum(w[i] .* ks[i]); zero weights are multiplied
+# through on the fused path (exact zeros, ks are always finite solver output)
+# and skipped on the fallback path.
 @inline function _weighted_sum!(
         out::Array, base::Union{Array, Nothing}, w::AbstractVector, ks::Vector{<:Array}
     )
-    @inbounds for idx in eachindex(out)
-        acc = base === nothing ? zero(eltype(out)) : base[idx]
-        for i in eachindex(ks)
-            wi = w[i]
-            iszero(wi) || (acc = muladd(wi, ks[i][idx], acc))
+    nks = length(ks)
+    if nks <= 8
+        Base.Cartesian.@nif 8 n -> (nks == n) n -> begin
+            cs = Base.Cartesian.@ntuple n i -> w[i]
+            ka = Base.Cartesian.@ntuple n i -> ks[i]
+            _fused_lincomb!(out, base, cs, ka)
         end
-        out[idx] = acc
+    else
+        _weighted_sum_fallback!(out, base, w, ks)
     end
     return nothing
 end
 
-@inline function _weighted_sum!(out, base, w, ks)
+_weighted_sum!(out, base, w, ks) = _weighted_sum_fallback!(out, base, w, ks)
+
+@inline function _weighted_sum_fallback!(out, base, w, ks)
     if base === nothing
         fill!(out, zero(eltype(out)))
     else
@@ -656,17 +709,22 @@ end
 
 # kj .= sum(H[j, i] .* ks[i] for i in eachindex(ks))
 @inline function _dense_row!(kj::Array, H::AbstractMatrix, j::Int, ks::Vector{<:Array})
-    @inbounds for idx in eachindex(kj)
-        acc = zero(eltype(kj))
-        for i in eachindex(ks)
-            acc = muladd(H[j, i], ks[i][idx], acc)
+    nks = length(ks)
+    if nks <= 8
+        Base.Cartesian.@nif 8 n -> (nks == n) n -> begin
+            cs = Base.Cartesian.@ntuple n i -> H[j, i]
+            ka = Base.Cartesian.@ntuple n i -> ks[i]
+            _fused_lincomb!(kj, nothing, cs, ka)
         end
-        kj[idx] = acc
+    else
+        _dense_row_fallback!(kj, H, j, ks)
     end
     return nothing
 end
 
-@inline function _dense_row!(kj, H, j::Int, ks)
+_dense_row!(kj, H, j::Int, ks) = _dense_row_fallback!(kj, H, j, ks)
+
+@inline function _dense_row_fallback!(kj, H, j::Int, ks)
     fill!(kj, zero(eltype(kj)))
     @inbounds for i in eachindex(ks)
         @.. kj += H[j, i] * ks[i]

--- a/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_perform_step.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_perform_step.jl
@@ -573,6 +573,107 @@ function initialize!(integrator, cache::RosenbrockCache)
     return
 end
 
+# Fused single-sweep accumulation kernels for the stage loops below. Each
+# replaces a sequence of per-coefficient broadcasts — one full memory sweep per
+# tableau entry — with a single sweep using muladd, which is where the
+# pre-consolidation hand-unrolled kernels got their speed. `Array` states (incl.
+# N-d arrays; linear indexing) take these; anything without fast scalar indexing
+# (GPU etc.) keeps the broadcast fallback.
+
+# out .= base .+ sum(A[stage, i] .* ks[i] for i in 1:(stage-1))
+@inline function _stage_accum!(
+        out::Array, base::Array, A::AbstractMatrix, ks::Vector{<:Array}, stage::Int
+    )
+    @inbounds for idx in eachindex(out)
+        acc = base[idx]
+        for i in 1:(stage - 1)
+            acc = muladd(A[stage, i], ks[i][idx], acc)
+        end
+        out[idx] = acc
+    end
+    return nothing
+end
+
+@inline function _stage_accum!(out, base, A, ks, stage::Int)
+    out === base || copyto!(out, base)
+    @inbounds for i in 1:(stage - 1)
+        @.. out += A[stage, i] * ks[i]
+    end
+    return nothing
+end
+
+# linsolve_tmp .= du .+ dtd_s .* dT .+ sum(dtC[stage, i] .* ks[i] for i in 1:(stage-1))
+@inline function _stage_rhs!(
+        linsolve_tmp::Array, du::Array, dtd_s, dT::Array, dtC::AbstractMatrix,
+        ks::Vector{<:Array}, stage::Int
+    )
+    @inbounds for idx in eachindex(linsolve_tmp)
+        acc = muladd(dtd_s, dT[idx], du[idx])
+        for i in 1:(stage - 1)
+            acc = muladd(dtC[stage, i], ks[i][idx], acc)
+        end
+        linsolve_tmp[idx] = acc
+    end
+    return nothing
+end
+
+@inline function _stage_rhs!(linsolve_tmp, du, dtd_s, dT, dtC, ks, stage::Int)
+    @.. linsolve_tmp = du + dtd_s * dT
+    @inbounds for i in 1:(stage - 1)
+        @.. linsolve_tmp += dtC[stage, i] * ks[i]
+    end
+    return nothing
+end
+
+# out .= (base or zero) .+ sum(w[i] .* ks[i] for nonzero w[i])
+@inline function _weighted_sum!(
+        out::Array, base::Union{Array, Nothing}, w::AbstractVector, ks::Vector{<:Array}
+    )
+    @inbounds for idx in eachindex(out)
+        acc = base === nothing ? zero(eltype(out)) : base[idx]
+        for i in eachindex(ks)
+            wi = w[i]
+            iszero(wi) || (acc = muladd(wi, ks[i][idx], acc))
+        end
+        out[idx] = acc
+    end
+    return nothing
+end
+
+@inline function _weighted_sum!(out, base, w, ks)
+    if base === nothing
+        fill!(out, zero(eltype(out)))
+    else
+        out === base || copyto!(out, base)
+    end
+    @inbounds for i in eachindex(ks)
+        if !iszero(w[i])
+            @.. out += w[i] * ks[i]
+        end
+    end
+    return nothing
+end
+
+# kj .= sum(H[j, i] .* ks[i] for i in eachindex(ks))
+@inline function _dense_row!(kj::Array, H::AbstractMatrix, j::Int, ks::Vector{<:Array})
+    @inbounds for idx in eachindex(kj)
+        acc = zero(eltype(kj))
+        for i in eachindex(ks)
+            acc = muladd(H[j, i], ks[i][idx], acc)
+        end
+        kj[idx] = acc
+    end
+    return nothing
+end
+
+@inline function _dense_row!(kj, H, j::Int, ks)
+    fill!(kj, zero(eltype(kj)))
+    @inbounds for i in eachindex(ks)
+        @.. kj += H[j, i] * ks[i]
+    end
+    return nothing
+end
+
 @muladd function perform_step!(integrator, cache::RosenbrockCache, repeat_step = false)
     (; t, dt, uprev, u, f, p) = integrator
     (;
@@ -591,8 +692,11 @@ end
     @. dtd = dt * d
     dtgamma = dt * gamma
 
-    f(cache.fsalfirst, uprev, p, t)
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    if !repeat_step
+        # On a repeated step uprev and t are unchanged, so fsalfirst is still valid.
+        f(cache.fsalfirst, uprev, p, t)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    end
 
     new_W = calc_rosenbrock_differentiation!(integrator, cache, dtd[1], dtgamma, repeat_step)
 
@@ -612,10 +716,7 @@ end
     integrator.stats.nsolve += 1
 
     for stage in 2:length(ks)
-        u .= uprev
-        for i in 1:(stage - 1)
-            @.. u += A[stage, i] * ks[i]
-        end
+        _stage_accum!(u, uprev, A, ks, stage)
 
         stage_limiter!(u, integrator, p, t + c[stage] * dt)
         # Skip redundant f evaluation when a[stage,:]=a[stage-1,:] and c[stage]=c[stage-1]
@@ -628,19 +729,14 @@ end
             OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
         end
 
-        du1 .= 0
         if mass_matrix === I
-            for i in 1:(stage - 1)
-                @.. du1 += dtC[stage, i] * ks[i]
-            end
+            _stage_rhs!(linsolve_tmp, du, dtd[stage], dT, dtC, ks, stage)
         else
-            for i in 1:(stage - 1)
-                @.. du1 += dtC[stage, i] * ks[i]
-            end
+            fill!(du1, zero(eltype(du1)))
+            _stage_accum!(du1, du1, dtC, ks, stage)
             mul!(_vec(du2), mass_matrix, _vec(du1))
-            du1 .= du2
+            @.. linsolve_tmp = du + dtd[stage] * dT + du2
         end
-        @.. linsolve_tmp = du + dtd[stage] * dT + du1
 
         linres = dolinsolve(integrator, cache.linsolve; b = _vec(linsolve_tmp))
         @.. $(_vec(ks[stage])) = -linres.u
@@ -649,23 +745,13 @@ end
 
     # Solution update using explicit b weights
     tab = cache.tab
-    u .= uprev
-    for i in eachindex(ks)
-        if !iszero(tab.b[i])
-            @.. u += tab.b[i] * ks[i]
-        end
-    end
+    _weighted_sum!(u, uprev, tab.b, ks)
 
     step_limiter!(u, integrator, p, t + dt)
 
     if integrator.opts.adaptive && tab.btilde !== nothing
         # Error estimate using explicit btilde weights
-        du .= 0
-        for i in eachindex(ks)
-            if !iszero(tab.btilde[i])
-                @.. du += tab.btilde[i] * ks[i]
-            end
-        end
+        _weighted_sum!(du, nothing, tab.btilde, ks)
         calculate_residuals!(
             atmp, du, uprev, u, integrator.opts.abstol,
             integrator.opts.reltol, integrator.opts.internalnorm, t
@@ -676,12 +762,7 @@ end
     if integrator.opts.calck
         if size(H, 1) > 0
             for j in eachindex(integrator.k)
-                integrator.k[j] .= 0
-            end
-            for i in eachindex(ks)
-                for j in eachindex(integrator.k)
-                    @.. integrator.k[j] += H[j, i] * ks[i]
-                end
+                _dense_row!(integrator.k[j], H, j, ks)
             end
             if (integrator.alg isa Rodas5Pr) && integrator.opts.adaptive &&
                     (OrdinaryDiffEqCore.get_EEst(integrator) < 1.0)


### PR DESCRIPTION
> [!IMPORTANT]
> This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

The 2026-03 consolidation of the Rosenbrock `perform_step!` into a single tableau-driven loop replaced the old hand-fused stage kernels with per-coefficient broadcast accumulations. For an s-stage method every stage does `u .= uprev` followed by `stage-1` separate `@.. u += A[stage,i]*ks[i]` sweeps, and likewise for the `C`-coefficient RHS accumulation, the final `b`-weight sum, the `btilde` error sum, and the dense-output `H`-row sums. For Rodas5P that is ~116 full-vector sweeps per step where the pre-consolidation kernels did ~21.

This PR fuses each of those accumulations back into a single sweep without giving up the unified tableau-driven architecture:

- Tableau coefficients for a stage are hoisted into an `NTuple` through a bounded `Base.Cartesian.@nif` ladder (max 8 fused terms), and the linear combination is expanded statically via tuple recursion so the single sweep SIMD-vectorizes. This is the "single function for max N, not per-`Val{N}` specializations" approach suggested in the message of the earlier revert commit 27f2f3a — there is no per-stage-count compile-time blowup.
- `Array` states take the fused path; anything else (GPU arrays etc.) and >8-term accumulations (Rodas6P's late stages) keep the existing per-coefficient broadcast loop as a fallback.
- `f(fsalfirst, uprev, p, t)` is now skipped on `repeat_step` — `uprev` and `t` are unchanged on a repeated step, and stage 1's RHS (`linsolve_tmp = fsalfirst + dtd1*dT` in `calc_tderivative!`) is rebuilt from the stored `fsalfirst` each call, so the value is still valid. Saves one f-eval per repeated step.

An intermediate version of this patch used a scalar-indexed loop with a runtime-length inner loop over stages; that defeated SIMD and coefficient hoisting and was ~12% *slower* at n=2000. The `@nif`+`NTuple` version is what survived benchmarking.

## Benchmarks

3 interleaved rounds, `BenchmarkTools` minima, Julia 1.10.11, default solver options unless noted. Step counts/stats identical between master and this PR in every case.

| problem | master | this PR | Δ |
|---|---|---|---|
| ROBER n=3, tol=1e-8, dense output | 0.929–0.933 ms | 0.859–0.868 ms | **−7.3%** |
| Van der Pol μ=1e6 n=2, tol=1e-8 | 32.06–32.46 ms | 29.71–30.26 ms | **−7.7%** |
| Brusselator 8×8 (n=128), FullSpecialize, RFLU | 39.3 ms | 39.2 ms | parity (LU-dominated) |
| 1-D reaction-diffusion n=2000, sparse J | 123.6 ms avg | 122.1 ms avg | −1% |

Correctness: final states and interpolants agree with master to ~13 significant digits (the fused accumulation changes float summation association — same association as the pre-consolidation kernels); identical accept/reject/step counts on ROBER, Brusselator, and a Rodas5P mass-matrix DAE.

The interesting context from the same investigation (filed separately as issues): the dominant Rodas5P performance regressions vs OrdinaryDiffEq v6.87 are not in this loop at all but in linear-solve defaults (RecursiveFactorization no longer loaded by anything → LAPACK `getrf!` for dense W, and LAPACK `getrs!` ccall overhead dominating tiny systems).

## Process notes

Investigation and benchmarks were run locally on the shared benchmark box; benchmark scripts compared this branch against master and against OrdinaryDiffEq v6.87.0 (last release with the hand-unrolled Rodas5 kernels). `Pkg.test()` for OrdinaryDiffEqRosenbrock run locally (result posted in comments). Runic applied (no changes needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
