### PR TITLE
Document public HybridExplicitImplicitRK (fixes Rosenbrock QA docstring failure on master)

### DIFF
--- a/docs/src/massmatrixdae/Rosenbrock.md
+++ b/docs/src/massmatrixdae/Rosenbrock.md
@@ -160,4 +160,6 @@ Velds4
 GRK4T
 GRK4A
 Ros4LStab
+HybridExplicitImplicitRK
+Tsit5DA
 ```

--- a/lib/OrdinaryDiffEqRosenbrock/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/algorithms.jl
@@ -337,6 +337,50 @@ end
 # HybridExplicitImplicitRK — generic tableau-based hybrid explicit/linear-implicit method
 ################################################################################
 
+"""
+    HybridExplicitImplicitRK(tab; order, kwargs...)
+    HybridExplicitImplicitRK(; tab, order, kwargs...)
+
+Generic tableau-driven hybrid explicit/linear-implicit Runge-Kutta method for
+semi-explicit index-1 DAEs in mass matrix form. Differential variables are
+advanced with explicit Runge-Kutta stages while algebraic variables are treated
+with Rosenbrock-type linear-implicit stages, so only the (typically small)
+algebraic block of the Jacobian needs to be factorized. For pure ODEs (no
+algebraic constraints), the method reduces to the underlying explicit
+Runge-Kutta method.
+
+The concrete method is determined by the tableau `tab` (e.g. `Tsit5DATableau`)
+together with its adaptive `order`; `Tsit5DA` is the provided instance of this
+algorithm.
+
+# Arguments
+
+  - `tab`: tableau constructor `(T, T2) -> tableau` holding the explicit
+    coefficients, the linear-implicit (Gamma) coefficients, the embedded-error
+    weights, and the dense output coefficients.
+  - `order`: the order of accuracy of the method described by `tab`, used for
+    adaptive time stepping.
+
+# Keyword Arguments
+
+  - `autodiff`: AD backend used for the Jacobian of the algebraic block, an
+    `ADTypes.AbstractADType` (defaults to `AutoForwardDiff()`).
+  - `concrete_jac`: whether a concrete Jacobian is materialized for the linear
+    solver (defaults to `nothing`, letting the linear solver decide).
+  - `linsolve`: LinearSolve.jl algorithm for the linear-implicit stages
+    (defaults to `nothing`, i.e. the default linear solver).
+  - `step_limiter!`, `stage_limiter!`: limiter functions applied after each step
+    / explicit stage (default `trivial_limiter!`).
+  - `max_jac_age`, `jac_reuse_gamma_tol`: Jacobian-reuse tuning knobs shared
+    with the other Rosenbrock algorithm constructors. Jacobian reuse currently
+    activates only for W-methods on non-mass-matrix problems, so for this
+    method the Jacobian is recomputed every step regardless of these values.
+
+References:
+
+  - Steinebach G., Rodas6P and Tsit5DA - two new Rosenbrock-type methods for
+    DAEs. arXiv:2511.21252, 2025.
+"""
 struct HybridExplicitImplicitRK{TabType, AD, F, StepLimiter, StageLimiter, CJ} <:
     OrdinaryDiffEqRosenbrockAdaptiveAlgorithm
     tab::TabType


### PR DESCRIPTION
> [!IMPORTANT]
> This PR should be ignored until reviewed by @ChrisRackauckas.

## Problem

The OrdinaryDiffEqRosenbrock QA group fails on unmodified `master` (aa895b5):

```
public API has docstrings: Test Failed at .../SciMLTesting/NNINT/src/SciMLTesting.jl:1038
  Expression: isempty(undocumented)
   Evaluated: isempty([:HybridExplicitImplicitRK])
┌ Info: run_api_docs: public API names missing a docstring
│   pkg = OrdinaryDiffEqRosenbrock
│   undocumented =
│    1-element Vector{Symbol}:
└     :HybridExplicitImplicitRK
Test Summary:               | Fail  Total  Time
Public API documentation    |    1      1  6.6s
  public API has docstrings |    1      1  2.5s
```

`HybridExplicitImplicitRK` is exported from OrdinaryDiffEqRosenbrock but has no
docstring, so the SciMLTesting `run_api_docs` "public API has docstrings" check
(run inside `run_qa` in `test/qa/qa.jl`) fails.

## Provenance

- The name was made public without a docstring by 1c68eff1c4b2d751349a1a61377bade20a1d994b
  ("Refactor Tsit5DA to generic HybridExplicitImplicitRK", part of #3070, merged
  2026-02-24 as 6f57229a).
- The failure became observable when #3867 (12b6996e, merged 2026-07-11) upgraded
  the QA infrastructure to SciMLTesting v2.1, whose `run_qa` includes the
  `run_api_docs` public-API-docstring check. #3858 (f416901a) documented public
  API repo-wide the day before but missed this name.

## Fix

- Add a docstring to `HybridExplicitImplicitRK`
  (`lib/OrdinaryDiffEqRosenbrock/src/algorithms.jl`), describing the generic
  tableau-driven hybrid explicit/linear-implicit RK algorithm behind `Tsit5DA`
  (Steinebach 2025, arXiv:2511.21252), its arguments, and keyword arguments.
  Content is based on the surrounding code (`alg_order(alg) = alg.order`, the
  `Tsit5DA` constructor, the `Tsit5DATableau` docstring, and the
  `_rosenbrock_jac_reuse_decision` reuse semantics).
- Public and documented move together: render `HybridExplicitImplicitRK` and its
  instance `Tsit5DA` in the docs by adding them to the `@docs` block in
  `docs/src/massmatrixdae/Rosenbrock.md` (neither was previously rendered).

## Verification

Reproduced the failure on unmodified master (output above), then re-ran the QA
`qa.jl` testset (SciMLTesting `run_qa`: Aqua + ExplicitImports + api docs) with
the fix applied on Julia 1.10:

```
Precompiling packages...
  18704.2 ms  ✓ OrdinaryDiffEqRosenbrock
  26184.8 ms  ✓ OrdinaryDiffEqDefault
   4744.4 ms  ✓ OrdinaryDiffEq
  3 dependencies successfully precompiled in 53 seconds. 160 already precompiled.
Test Summary:     | Pass  Total   Time
Quality Assurance |   16     16  49.7s
```

Runic formatting checked on the modified source file (no diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
