### PR TITLE
DiffEqDevTools: floor RootedTrees compat at 2.8 to fix LTS CI precompile failure

### DIFF
--- a/lib/DiffEqDevTools/Project.toml
+++ b/lib/DiffEqDevTools/Project.toml
@@ -75,8 +75,6 @@ OrdinaryDiffEqVerner = "2"
 ParameterizedFunctions = "5.24"
 RecipesBase = "1.3.4"
 RecursiveArrayTools = "4.2.0"
-# 2.8 is the first version with `RungeKuttaMethod`; without this floor the resolver
-# can downgrade RootedTrees below it to escape Latexify's OrderedCollections 1 bound.
 RootedTrees = "2.8"
 SDEProblemLibrary = "1"
 SciMLBase = "3.35.1"

--- a/lib/DiffEqDevTools/Project.toml
+++ b/lib/DiffEqDevTools/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqDevTools"
 uuid = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "3.1.2"
+version = "3.1.3"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
@@ -75,7 +75,9 @@ OrdinaryDiffEqVerner = "2"
 ParameterizedFunctions = "5.24"
 RecipesBase = "1.3.4"
 RecursiveArrayTools = "4.2.0"
-RootedTrees = "2"
+# 2.8 is the first version with `RungeKuttaMethod`; without this floor the resolver
+# can downgrade RootedTrees below it to escape Latexify's OrderedCollections 1 bound.
+RootedTrees = "2.8"
 SDEProblemLibrary = "1"
 SciMLBase = "3.35.1"
 SciMLLogging = "2"


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

## Problem

All PRs currently fail the Julia LTS (1.10) lanes (`Regression_I/II`, `AlgConvergence_I/III`, `Integrators_I`, `InterfaceI`, ...) with:

```
ERROR: LoadError: UndefVarError: `RungeKuttaMethod` not defined
in expression starting at .../lib/DiffEqDevTools/src/DiffEqDevTools.jl:1
```

`DiffEqDevTools` fails to precompile in the test environment because RootedTrees resolves to **v2.6.2** (LTS test sandbox) — a version that predates `RungeKuttaMethod` (introduced in RootedTrees v2.8.0), while `lib/DiffEqDevTools/src/DiffEqDevTools.jl` does `using RootedTrees: RootedTreeIterator, RungeKuttaMethod, residual_order_condition`.

## Root cause

A dependency-resolution chain triggered by a new **DataStructures v0.19.6** release (registered 2026-07-15/16, General registry commit `43ef749b58d`):

1. DataStructures v0.19.6 widened its OrderedCollections compat from `1.1.0 - 1` to `1.1.0 - 2`. Until then, DataStructures was the constraint keeping OrderedCollections at 1.x in this dependency graph.
2. With that cap gone, the resolver upgrades **OrderedCollections to v2.0.1** (released 2026-06-26).
3. Every Latexify version since v0.15.17 requires `OrderedCollections = "1"`, so Latexify gets downgraded to **v0.15.16** (the last version with no OrderedCollections dep) or dropped entirely.
4. RootedTrees ≥ 2.6.3 depends on Latexify (v2.24+ pins `Latexify = "0.16.8 - 0.16"`), so with `RootedTrees = "2"` compat the resolver is free to slide RootedTrees down to a Latexify-free version: **v2.23.1** in the main env, **v2.6.2** in the test sandbox — and v2.6.2 has no `RungeKuttaMethod`.

The failure is LTS-specific in CI, but the mechanism is registry-driven; the LTS lanes are simply where the sandbox resolution lands on 2.6.2. Verified against the failing CI log of PR #3931 (job 87872986603): test env resolved `OrderedCollections v2.0.1`, `RootedTrees v2.6.2`.

## Fix

Raise the RootedTrees compat floor in `lib/DiffEqDevTools/Project.toml` from `"2"` to `"2.8"` — the first version providing `RungeKuttaMethod`. The resolver then lands on RootedTrees v2.23.1 (with Latexify v0.15.16 + OrderedCollections v2.0.1), which has the full API DiffEqDevTools uses. Bumped DiffEqDevTools to v3.1.3.

Both API forms used by DiffEqDevTools (`residual_order_condition(t, A, b, c)` and `residual_order_condition(t, RungeKuttaMethod(A, b, c))`) were functionally verified to give identical results on RootedTrees 2.8.0 and 2.25.3, so the new floor is also safe for the Downgrade lanes (where the old floor of 2.0.0 could not even load).

No change is needed on Julia 1.12: there the env resolves RootedTrees v2.25.3 as before (`"2.8"` does not exclude it).

## Verification (local)

- Reproduced the failure on unmodified master with Julia 1.10.11: `GROUP=Regression_I Pkg.test()` sandbox resolved RootedTrees v2.6.2 → identical `UndefVarError: RungeKuttaMethod` precompile failure as CI.
- With the fix on Julia **1.10.11** (after running SciML/.github `develop_sources.jl` to replicate CI's path-dep handling on <1.11): test sandbox resolves RootedTrees v2.25.3 + Latexify v0.16.11 with OrderedCollections held at v1.8.2; DiffEqDevTools v3.1.3 precompiles cleanly; `GROUP=Regression_I Pkg.test()` completed with **exit 0, "Testing OrdinaryDiffEq tests passed"**, zero Fail/Error lines.
- With the fix on Julia **1.12.6** (pristine root project, native `[sources]`): test sandbox resolves RootedTrees v2.25.3; DiffEqDevTools precompiles; `GROUP=Regression_I Pkg.test()` completed with **exit 0, "Testing OrdinaryDiffEq tests passed"**, zero Fail/Error lines.
- `lib/DiffEqDevTools`'s own environment also instantiates, precompiles, and loads on both 1.10.11 and 1.12.6 (RootedTrees v2.25.3).

## Upstream note

The underlying ecosystem wart is that Latexify does not yet support OrderedCollections 2, so any package depending on Latexify (transitively: RootedTrees ≥ 2.6.3) can be silently sacrificed by the resolver once OrderedCollections 2 enters an environment. Neither Latexify nor RootedTrees is a SciML package, so no upstream PRs/issues were opened; once Latexify ships OrderedCollections 2 support and RootedTrees follows, this floor remains correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNigabD3sZaUKvDZ1NVQgv
