### PR TITLE
Floor DiffEqDevTools RootedTrees compat at 2.8 to fix UndefVarError(RungeKuttaMethod) CI failures

### DIFF
--- a/lib/DiffEqDevTools/Project.toml
+++ b/lib/DiffEqDevTools/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqDevTools"
 uuid = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "3.1.2"
+version = "3.1.3"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
@@ -75,7 +75,7 @@ OrdinaryDiffEqVerner = "2"
 ParameterizedFunctions = "5.24"
 RecipesBase = "1.3.4"
 RecursiveArrayTools = "4.2.0"
-RootedTrees = "2"
+RootedTrees = "2.8"
 SDEProblemLibrary = "1"
 SciMLBase = "3.35.1"
 SciMLLogging = "2"


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

## Problem

Since 2026-07-17, CI on `master`/PRs fails for every top-level group that uses DiffEqDevTools (`InterfaceI`, `Integrators_I`, `Regression_I`, `Regression_II`, `AlgConvergence_I`, `AlgConvergence_III`):

```
Failed to precompile DiffEqDevTools ...
ERROR: LoadError: UndefVarError: `RungeKuttaMethod` not defined
in expression starting at .../DiffEqDevTools/src/DiffEqDevTools.jl
```

`DiffEqDevTools.jl` does `using RootedTrees: RootedTreeIterator, RungeKuttaMethod, residual_order_condition`, but the test environment resolves **RootedTrees v2.6.2** (from 2021) instead of the current v2.25.3. `RungeKuttaMethod` was introduced in RootedTrees v2.8.0 (absent in 2.7.0 and earlier), while the DiffEqDevTools compat was `RootedTrees = "2"`, so the ancient version was admissible.

## Root cause: DataStructures v0.19.6 (registered 2026-07-17)

The dependency chain:

1. **DataStructures v0.19.6** (released 2026-07-17) widened its compat to `OrderedCollections = "1.1, 2"`. All prior versions capped OrderedCollections at `1`.
2. With that cap gone, the resolver now prefers **OrderedCollections v2.0.1**.
3. **Latexify** (all versions, incl. 0.16.11) requires `OrderedCollections = "1"`, so Latexify becomes unresolvable alongside OrderedCollections v2.
4. **RootedTrees >= 2.6.3** depends on Latexify; v2.6.2 is the last version with no Latexify dependency.
5. With `RootedTrees = "2"` in DiffEqDevTools' compat, the resolver silently falls back to RootedTrees v2.6.2 + OrderedCollections v2.0.1 instead of RootedTrees v2.25.3 + Latexify + OrderedCollections v1.8.2 — and RootedTrees 2.6.2 predates `RungeKuttaMethod`, so DiffEqDevTools fails to precompile.

Reproduction (Julia 1.10 LTS, also reproduces on 1.12): build the merged test env for the root package (e.g. `TestEnv.activate()` or `GROUP=InterfaceI Pkg.test()`) and observe the manifest contains `RootedTrees v2.6.2`, `OrderedCollections v2.0.1`, and no Latexify.

## Fix

Set the DiffEqDevTools compat floor to `RootedTrees = "2.8"` — the first version providing `RungeKuttaMethod` (v2.8.0 also already has the `residual_order_condition(t, A, b, c)` method DiffEqDevTools calls, as a deprecation). This makes the broken combination unresolvable instead of silently loadable: the resolver is then forced to pick RootedTrees >= 2.8 + Latexify + OrderedCollections 1.x, which resolves fine (DataStructures 0.19.6 still allows OrderedCollections 1.1+).

DiffEqDevTools is bumped to v3.1.3.

**Note for LTS CI:** on Julia < 1.11 the root-package test env ignores `[sources]` and pulls DiffEqDevTools from the registry, so the `lts` lanes for the root groups will stay red until DiffEqDevTools v3.1.3 is registered. Julia 1.11+ lanes pick up the fix from this branch directly. (Longer term, Latexify gaining OrderedCollections v2 compat upstream would dissolve the conflict entirely.)

## Verification

- Julia 1.12, this branch: `GROUP=InterfaceI julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` — previously the merged env resolved the broken combo on unmodified master (verified: RootedTrees v2.6.2, OrderedCollections v2.0.1, no Latexify); with this change the env resolves RootedTrees v2.25.3 + Latexify v0.16.11 + OrderedCollections v1.8.2, DiffEqDevTools precompiles, and the group passes.
- Julia 1.10 LTS (emulating the post-release registry state): built the merged root test env and `Pkg.develop`ed this branch's `lib/DiffEqDevTools`; resolution moved `RootedTrees v2.6.2 -> v2.25.3`, added `Latexify v0.16.11`, downgraded `OrderedCollections v2.0.1 -> v1.8.2`, and DiffEqDevTools precompiled and loaded successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
