### PR TITLE
Fix build_J_W cache init for structured jac_prototypes

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/src/OrdinaryDiffEqDifferentiation.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/OrdinaryDiffEqDifferentiation.jl
@@ -11,7 +11,8 @@ import FunctionWrappersWrappers
 import DiffEqBase
 
 import LinearAlgebra
-import LinearAlgebra: Diagonal, I, UniformScaling, diagind, opnorm
+import LinearAlgebra: Bidiagonal, Diagonal, I, SymTridiagonal, Tridiagonal,
+    UniformScaling, diagind, opnorm
 import LinearAlgebra: LowerTriangular
 import ArrayInterface
 
@@ -69,6 +70,15 @@ nonzeros(A) = error("SparseArrays extension not loaded. Please load SparseArrays
 spzeros(args...) = error("SparseArrays extension not loaded. Please load SparseArrays to use sparse matrix functionality.")
 get_nzval(A) = error("SparseArrays extension not loaded. Please load SparseArrays to use sparse matrix functionality.")
 set_all_nzval!(A, val) = error("SparseArrays extension not loaded. Please load SparseArrays to use sparse matrix functionality.")
+
+# `fill!` on LinearAlgebra's banded structured matrices throws for nonzero
+# values since the off-band entries are constrained to zero, so write the
+# stored bands directly instead.
+fill_stored!(A, v) = fill!(A, v)
+fill_stored!(A::Diagonal, v) = (fill!(A.diag, v); A)
+fill_stored!(A::Bidiagonal, v) = (fill!(A.dv, v); fill!(A.ev, v); A)
+fill_stored!(A::Tridiagonal, v) = (fill!(A.dl, v); fill!(A.d, v); fill!(A.du, v); A)
+fill_stored!(A::SymTridiagonal, v) = (fill!(A.dv, v); fill!(A.ev, v); A)
 
 include("alg_utils.jl")
 include("linsolve_utils.jl")

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -1207,8 +1207,8 @@ function build_J_W(
             set_all_nzval!(J, one(eltype(J)))
             set_all_nzval!(W, one(eltype(W)))
         else
-            fill!(J, one(eltype(J)))
-            fill!(W, one(eltype(W)))
+            fill_stored!(J, one(eltype(J)))
+            fill_stored!(W, one(eltype(W)))
         end
     elseif (
             IIP && (concrete_jac(alg) === nothing || !concrete_jac(alg)) &&

--- a/lib/OrdinaryDiffEqDifferentiation/test/nzval_helpers_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/nzval_helpers_tests.jl
@@ -1,4 +1,5 @@
 using OrdinaryDiffEqDifferentiation
+using OrdinaryDiffEqRosenbrock
 using SparseArrays
 using LinearAlgebra
 using Test
@@ -34,3 +35,48 @@ A_coo = COOMatrix(2, 2, [1, 2, 2], [1, 1, 2], [1.0, 0.5, 2.0])
 
 @test OrdinaryDiffEqDifferentiation.set_all_nzval!(A_coo, 7.0) === A_coo
 @test all(==(7.0), nonzeros(A_coo))
+
+using OrdinaryDiffEqDifferentiation: fill_stored!
+
+@testset "fill_stored!" begin
+    A = zeros(2, 2)
+    @test fill_stored!(A, 3.0) === A
+    @test all(==(3.0), A)
+
+    D = Diagonal(zeros(2))
+    @test fill_stored!(D, 3.0) === D
+    @test D == Diagonal([3.0, 3.0])
+
+    B = Bidiagonal(zeros(3), zeros(2), :U)
+    @test fill_stored!(B, 3.0) === B
+    @test B == Bidiagonal([3.0, 3.0, 3.0], [3.0, 3.0], :U)
+
+    T = Tridiagonal(zeros(2), zeros(3), zeros(2))
+    @test fill_stored!(T, 3.0) === T
+    @test T == Tridiagonal([3.0, 3.0], [3.0, 3.0, 3.0], [3.0, 3.0])
+
+    S = SymTridiagonal(zeros(3), zeros(2))
+    @test fill_stored!(S, 3.0) === S
+    @test S == SymTridiagonal([3.0, 3.0, 3.0], [3.0, 3.0])
+end
+
+# build_J_W used to `fill!` non-sparse jac_prototype caches with one, which
+# throws for banded structured matrices whose off-band entries are constrained.
+@testset "structured jac_prototype J/W caches initialize with stored ones" begin
+    f! = (du, u, p, t) -> du .= u ./ t
+    # Zero the off-diagonal stored entries too: they are initialized to one, so
+    # a jac! that skips them would leave a wrong Jacobian behind.
+    jac! = (J, u, p, t) -> (J[1, 1] = 1 / t; J[2, 2] = 1 / t; J[1, 2] = 0; J[2, 1] = 0; nothing)
+
+    for jac_prototype in (Diagonal(zeros(2)), Tridiagonal(zeros(1), zeros(2), zeros(1)))
+        fun = ODEFunction(f!; jac = jac!, jac_prototype = jac_prototype)
+        prob = ODEProblem(fun, ones(2), (1.0, 10.0))
+        integ = init(prob, Rosenbrock23())
+        ones_prototype = fill_stored!(copy(jac_prototype), 1.0)
+        @test integ.cache.J isa typeof(jac_prototype)
+        @test integ.cache.J == ones_prototype
+        @test integ.cache.W == ones_prototype
+        sol = solve!(integ)
+        @test sol.u[end] ≈ [10.0, 10.0]
+    end
+end


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

## Problem

`lib/DiffEqBase`'s `[Downstream]` test group fails on master in `test/downstream/default_linsolve_structure.jl`:

```
ArgumentError: array of type Diagonal{Float64, Vector{Float64}} and size (2, 2) can
not be filled with 1.0, since some of its entries are constrained.
```

thrown from `build_J_W` at `lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl` when solving an `ODEProblem` whose `jac_prototype` is a structured matrix (`Diagonal`, `Tridiagonal`, ...) with a default (factorization) linsolve, e.g.

```julia
fun = ODEFunction(f; jac = jac, jac_prototype = Diagonal(zeros(2)))
solve(ODEProblem(fun, ones(2), (1.0, 10.0)), Rosenbrock23())
```

## Root cause

Bisected to d8cbb9e4446427305484e25eb4c81c9f85c09277 ("Initialize sparse Jacobian caches with stored values", #3833). That commit initializes the `J`/`W` caches allocated in `build_J_W` with ones so factorizations never see undef garbage:

```julia
if is_sparse(J)
    set_all_nzval!(J, one(eltype(J)))
    set_all_nzval!(W, one(eltype(W)))
else
    fill!(J, one(eltype(J)))
    fill!(W, one(eltype(W)))
end
```

But LinearAlgebra's `fill!` on banded structured matrices (`Diagonal`, `Bidiagonal`, `Tridiagonal`, `SymTridiagonal`) throws for any nonzero value because the off-band entries are constrained to zero. So every structured (non-sparse, non-dense) `jac_prototype` on the default-linsolve path now errors at cache construction. Verified by running the reproducer on d8cbb9e44~1 with the same current dependency versions: it passes there and fails on master, so this is a code regression from #3833, not registry drift (the failure only surfaced later because the monorepo's own CI lanes for #3833 did not run the DiffEqBase Downstream group).

## Fix

Add a `fill_stored!` helper that writes only the stored bands of the LinearAlgebra structured matrix types and falls back to `fill!` otherwise, and use it in `build_J_W`'s non-sparse initialization. Semantics for dense and sparse prototypes are unchanged.

## Tests

- New `fill_stored!` unit tests and a structured-`jac_prototype` init/solve regression test in `lib/OrdinaryDiffEqDifferentiation/test/nzval_helpers_tests.jl` (asserts the `J`/`W` caches are initialized with stored ones, mirroring the #3833 testset, and that the solve completes).
- The previously failing downstream file `lib/DiffEqBase/test/downstream/default_linsolve_structure.jl` passes locally with this change (output in the PR conversation).

This resolves the red `lib/DiffEqBase [Downstream]` lane seen on #3692 (which merely surfaced the pre-existing master failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
