### PR TITLE
Migrate community callback test off removed VectorContinuousCallback 4-arg form

### DIFF
--- a/lib/DiffEqBase/test/downstream/community_callback_tests.jl
+++ b/lib/DiffEqBase/test/downstream/community_callback_tests.jl
@@ -227,12 +227,19 @@ end
 function terminate_affect!(int, events)
     return any(!iszero, events) && terminate!(int)
 end
-cb = VectorContinuousCallback(cond!, terminate_affect!, nothing, 1)
+# SciMLBase v3.10 removed the 4-arg `VectorContinuousCallback(cond, affect!,
+# affect_neg!, len)` form: `affect!` now fires on every crossing, and
+# `affect_neg! = nothing` no longer suppresses downcrossings. The condition is
+# u[3] = cos(t), so the solve now terminates at the first crossing pi/2 rather
+# than at the old expectation 3pi/2 (an upcrossing). The point of this #1528
+# regression test is that callback handling doesn't error on the constant-zero
+# condition element out[1].
+cb = VectorContinuousCallback(cond!, terminate_affect!, 1)
 
 u0 = [0.0, 0.0, 1.0]
 prob = ODEProblem(f!, u0, (0.0, 10.0); callback = cb)
 soln = solve(prob, Tsit5())
-@test soln.t[end] ≈ 4.712347213360699 atol = 1.0e-4
+@test soln.t[end] ≈ pi / 2 atol = 1.0e-4
 
 odefun = ODEFunction((u, p, t) -> [u[2], u[2] - p]; mass_matrix = [1 0; 0 0])
 callback = PresetTimeCallback(0.5, integ -> (integ.p = -integ.p))

--- a/lib/DiffEqBase/test/downstream/community_callback_tests.jl
+++ b/lib/DiffEqBase/test/downstream/community_callback_tests.jl
@@ -227,13 +227,6 @@ end
 function terminate_affect!(int, events)
     return any(!iszero, events) && terminate!(int)
 end
-# SciMLBase v3.10 removed the 4-arg `VectorContinuousCallback(cond, affect!,
-# affect_neg!, len)` form: `affect!` now fires on every crossing, and
-# `affect_neg! = nothing` no longer suppresses downcrossings. The condition is
-# u[3] = cos(t), so the solve now terminates at the first crossing pi/2 rather
-# than at the old expectation 3pi/2 (an upcrossing). The point of this #1528
-# regression test is that callback handling doesn't error on the constant-zero
-# condition element out[1].
 cb = VectorContinuousCallback(cond!, terminate_affect!, 1)
 
 u0 = [0.0, 0.0, 1.0]


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

## Problem

`lib/DiffEqBase`'s `[Downstream2]` test group fails on master in `test/downstream/community_callback_tests.jl`:

```
MethodError: no method matching VectorContinuousCallback(::typeof(cond!), ::typeof(terminate_affect!), ::Nothing, ::Int64)
```

## Root cause

The test still used the SciMLBase v2 4-positional-arg form `VectorContinuousCallback(condition, affect!, affect_neg!, len)`. SciMLBase intentionally removed that form (and the `affect_neg!` keyword) in v3.10.0 — commit SciML/SciMLBase.jl@ba118addc7d7fffa529428bdae2c75168429e98b ("Remove `affect_neg!` from `VectorContinuousCallback` constructor") — because `VectorContinuousCallback` never honored `affect_neg!`: its `apply_callback!` dispatch always invokes `affect!(integrator, event_idx)` and ignored the field, so accepting it was a silent footgun (see SciML/OrdinaryDiffEq.jl#3613). The current SciMLBase docstring states "`VectorContinuousCallback` intentionally does not have an `affect_neg!` callback."

The downstream env only recently started resolving a SciMLBase new enough to drop the method (3.36.0 today), which is why this surfaced now (registry drift, first seen on #3692's CI, reproduces on unmodified master).

## Fix

Update the test to the supported 3-arg form `VectorContinuousCallback(cond!, terminate_affect!, 1)`, and update the expected termination time from `3pi/2` to `pi/2`:

- Under the removed v2 API, `affect_neg! = nothing` made event *detection* skip downcrossings, so the condition `u[3] = cos(t)` first triggered at the upcrossing `3pi/2`.
- Under the current intentional semantics, `affect!` fires on every crossing (the struct's `affect_neg!` field is always `affect!` and DiffEqBase v7's `apply_callback!` for `VectorContinuousCallback` never calls `affect_neg!`), so the solve terminates at the first zero of `cos(t)`, i.e. `pi/2`. Observed locally: `soln.t[end] = 1.5707927986` with the same `atol = 1e-4` as before.

The point of this #1528 regression test — callback handling must not error when one condition element is constantly zero — is preserved; only the API form and the crossing-direction expectation change, matching the documented upstream behavior.

Verified locally: `lib/DiffEqBase/test/downstream/community_callback_tests.jl` passes with SciMLBase 3.36.0 (output in the PR conversation).

This resolves the red `lib/DiffEqBase [Downstream2]` lane seen on #3692 (which merely surfaced the pre-existing master failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
