### PR TITLE
Unwrap operator mass matrices before findall in Differentiation

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/src/OrdinaryDiffEqDifferentiation.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/OrdinaryDiffEqDifferentiation.jl
@@ -58,6 +58,13 @@ import DiffEqBase: OrdinaryDiffEqTag
 is_sparse(::Any) = false
 is_sparse_csc(::Any) = false
 
+# Seeding a sparsity pattern from the mass matrix uses `findall`/`getindex`, which a
+# SciMLOperator does not support. `convert` reads the operator's currently-cached array
+# rather than re-evaluating it, which is what is wanted here: only the structural
+# pattern matters, and this runs before `init`.
+concrete_mass_matrix(mm) = mm
+concrete_mass_matrix(mm::AbstractSciMLOperator) = convert(AbstractMatrix, mm)
+
 # These will error if called without the extension, but should never be called
 # on non-sparse types due to the is_sparse checks
 function nonzeros end

--- a/lib/OrdinaryDiffEqDifferentiation/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/alg_utils.jl
@@ -123,21 +123,22 @@ function prepare_user_sparsity(ad_alg, prob)
                     @. @view(jac_prototype[idxs]) = 1
                 end
             else
-                idxs = findall(!iszero, prob.f.mass_matrix)
+                mm = concrete_mass_matrix(prob.f.mass_matrix)
+                idxs = findall(!iszero, mm)
                 for idx in idxs
-                    sparsity[idx] = prob.f.mass_matrix[idx]
+                    sparsity[idx] = mm[idx]
                 end
 
                 if !isnothing(jac_prototype)
                     for idx in idxs
-                        jac_prototype[idx] = prob.f.mass_matrix[idx]
+                        jac_prototype[idx] = mm[idx]
                     end
                 end
             end
         end
 
         # KnownJacobianSparsityDetector needs an AbstractMatrix
-        sparsity = sparsity isa MatrixOperator ? sparsity.A : sparsity
+        sparsity = concrete_mass_matrix(sparsity)
 
         color_alg = SciMLBase.has_colorvec(prob.f) ?
             ConstantColoringAlgorithm(

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_wrappers.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_wrappers.jl
@@ -295,8 +295,9 @@ function build_jac_config(
                 idxs = diagind(jac_prototype)
                 @. @view(jac_prototype[idxs]) = 1
             else
-                idxs = findall(!iszero, f.mass_matrix)
-                @. @view(jac_prototype[idxs]) = @view(f.mass_matrix[idxs])
+                mm = concrete_mass_matrix(f.mass_matrix)
+                idxs = findall(!iszero, mm)
+                @. @view(jac_prototype[idxs]) = @view(mm[idxs])
             end
         end
 
@@ -480,8 +481,9 @@ function sparsity_colorvec(f::F, x) where {F}
             idxs = diagind(sparsity)
             @. @view(sparsity[idxs]) = 1
         else
-            idxs = findall(!iszero, f.mass_matrix)
-            @. @view(sparsity[idxs]) = @view(f.mass_matrix[idxs])
+            mm = concrete_mass_matrix(f.mass_matrix)
+            idxs = findall(!iszero, mm)
+            @. @view(sparsity[idxs]) = @view(mm[idxs])
         end
     end
 

--- a/lib/OrdinaryDiffEqDifferentiation/test/prepare_user_sparsity_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/prepare_user_sparsity_tests.jl
@@ -1,0 +1,72 @@
+using OrdinaryDiffEqDifferentiation
+using SparseArrays
+using SciMLOperators
+using SciMLBase
+using ADTypes
+using Test
+
+f!(du, u, p, t) = (du .= u; nothing)
+ad_alg = AutoForwardDiff()
+
+# `findall`/`getindex` on the mass matrix need a concrete matrix; a SciMLOperator
+# (e.g. `MatrixOperator`) supports neither directly, so it must be unwrapped first.
+@testset "MatrixOperator mass matrix" begin
+    M = sparse([1.0 2.0; 0.0 1.0])
+    mass_matrix = MatrixOperator(M; update_func = (A, u, p, t) -> M)
+    jac_prototype = sparse([1.0 0.0; 0.0 1.0])
+    sparsity = copy(jac_prototype)
+    odef = ODEFunction(f!; mass_matrix, jac_prototype, sparsity)
+    prob = ODEProblem(odef, ones(2), (0.0, 1.0))
+
+    OrdinaryDiffEqDifferentiation.prepare_user_sparsity(ad_alg, prob)
+    @test Matrix(prob.f.sparsity) == Matrix(M)
+    @test Matrix(prob.f.jac_prototype) == Matrix(M)
+end
+
+@testset "UniformScaling mass matrix (unchanged path)" begin
+    jac_prototype = sparse([1.0 0.0; 0.0 1.0])
+    sparsity = copy(jac_prototype)
+    odef = ODEFunction(f!; jac_prototype, sparsity)
+    prob = ODEProblem(odef, ones(2), (0.0, 1.0))
+
+    OrdinaryDiffEqDifferentiation.prepare_user_sparsity(ad_alg, prob)
+    @test Matrix(prob.f.sparsity) == Matrix(jac_prototype)
+    @test Matrix(prob.f.jac_prototype) == Matrix(jac_prototype)
+end
+
+@testset "Plain sparse mass matrix (unchanged path)" begin
+    M = sparse([1.0 2.0; 0.0 1.0])
+    jac_prototype = sparse([1.0 0.0; 0.0 1.0])
+    sparsity = copy(jac_prototype)
+    odef = ODEFunction(f!; mass_matrix = M, jac_prototype, sparsity)
+    prob = ODEProblem(odef, ones(2), (0.0, 1.0))
+
+    OrdinaryDiffEqDifferentiation.prepare_user_sparsity(ad_alg, prob)
+    @test Matrix(prob.f.sparsity) == Matrix(M)
+    @test Matrix(prob.f.jac_prototype) == Matrix(M)
+end
+
+@testset "DiagonalOperator mass matrix" begin
+    mass_matrix = DiagonalOperator([1.0, 2.0])
+    jac_prototype = sparse([1.0 0.0; 0.0 1.0])
+    sparsity = copy(jac_prototype)
+    odef = ODEFunction(f!; mass_matrix, jac_prototype, sparsity)
+    prob = ODEProblem(odef, ones(2), (0.0, 1.0))
+
+    OrdinaryDiffEqDifferentiation.prepare_user_sparsity(ad_alg, prob)
+    @test Matrix(prob.f.sparsity) == [1.0 0.0; 0.0 2.0]
+    @test Matrix(prob.f.jac_prototype) == [1.0 0.0; 0.0 2.0]
+end
+
+# `sparsity` defaults to (and aliases) `jac_prototype`, which is how #2929's report
+# constructs the problem.
+@testset "MatrixOperator mass matrix, sparsity defaulted" begin
+    M = sparse([1.0 2.0; 0.0 1.0])
+    mass_matrix = MatrixOperator(M; update_func = (A, u, p, t) -> M)
+    jac_prototype = sparse([1.0 0.0; 0.0 1.0])
+    odef = ODEFunction(f!; mass_matrix, jac_prototype)
+    prob = ODEProblem(odef, ones(2), (0.0, 1.0))
+
+    OrdinaryDiffEqDifferentiation.prepare_user_sparsity(ad_alg, prob)
+    @test Matrix(prob.f.jac_prototype) == Matrix(M)
+end

--- a/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
@@ -30,6 +30,7 @@ end
 # Run functional tests
 if TEST_GROUP ∉ ("QA", "Sparse", "ModelingToolkit")
     @time @safetestset "DAE jacobian2W sparse" include("dae_jacobian2w_sparse_tests.jl")
+    @time @safetestset "prepare_user_sparsity mass matrix" include("prepare_user_sparsity_tests.jl")
     @time @safetestset "nzval helpers" include("nzval_helpers_tests.jl")
     @time @safetestset "prepare_sparse_jac!" include("prepare_sparse_jac_tests.jl")
     @time @safetestset "OOP J_t Tracking" include("oop_jt_tracking_test.jl")


### PR DESCRIPTION
Removes the `MethodError` crash sites on the path reported in #2929. #2929 itself stays open — see below.

## Bug

Several places in `OrdinaryDiffEqDifferentiation` seed a sparsity pattern from the mass matrix with

```julia
idxs = findall(!iszero, f.mass_matrix)
@. @view(sparsity[idxs]) = @view(f.mass_matrix[idxs])
```

Both `findall` and `getindex` need a concrete matrix. A SciMLOperator mass matrix supports neither, so combining one with a `jac_prototype` throws `MethodError: no method matching keys(::MatrixOperator{...})`:

```julia
using OrdinaryDiffEqDifferentiation, SparseArrays, SciMLOperators, SciMLBase, ADTypes
M = sparse([1.0 2.0; 0.0 1.0])
mass_matrix = MatrixOperator(M; update_func = (A, u, p, t) -> M)
jac_prototype = sparse([1.0 0.0; 0.0 1.0])
f!(du, u, p, t) = (du .= u; nothing)
odef = ODEFunction(f!; mass_matrix, jac_prototype, sparsity = copy(jac_prototype))
prob = ODEProblem(odef, ones(2), (0.0, 1.0))
OrdinaryDiffEqDifferentiation.prepare_user_sparsity(AutoForwardDiff(), prob)
# MethodError: no method matching keys(::MatrixOperator{...})
```

## Fix

One helper, used at all four sites that had the pattern — `prepare_user_sparsity` and its `sparsity` unwrap in `alg_utils.jl`, and `build_jac_config` and `sparsity_colorvec` in `derivative_wrappers.jl`:

```julia
concrete_mass_matrix(mm) = mm
concrete_mass_matrix(mm::AbstractSciMLOperator) = convert(AbstractMatrix, mm)
```

`convert` reads the operator's currently-cached array rather than re-evaluating it, so no `update_coefficients!` is involved. That is what is wanted here: only the structural pattern matters, and `prepare_alg` runs before `init`, so the cached array is the one the operator was constructed with. Non-operator mass matrices dispatch to the identity method, so plain-matrix behaviour is unchanged.

Besides `MatrixOperator` this also covers `DiagonalOperator`, `IdentityOperator`, `ScaledOperator`, `AddedOperator`, `ComposedOperator` and `TensorProductOperator`, which all define `convert(AbstractMatrix, ·)`. `ScalarOperator`, `FunctionOperator` and `AffineOperator` have no such method and still error, but they were already failing earlier on `keys` and none is a plausible mass matrix here.

## What this does not fix

#2929's reproducer calls `solve`, and that still fails — but for a different reason and further along. With these four sites fixed it gets past every `keys` error and reaches the sparse-`W` branch of `jacobian2W!` (`derivative_utils.jl`), which broadcasts the operator directly into a `SparseMatrixCSC` and stack-overflows. So #2929 needs at least one more change and should stay open; this PR is a strict improvement rather than a resolution.

Measured, same MWE: master fails with `MethodError: keys(::MatrixOperator)`; this branch fails with `StackOverflowError` from `jacobian2W!`.

An earlier version of this description blamed a SciMLOperators `setfield!` bug for the remaining failure. That was SciML/SciMLOperators.jl#409, fixed by #416 and released in SciMLOperators v1.25.2, and is no longer relevant.

## Tests

New `prepare_user_sparsity_tests.jl`: `MatrixOperator` and `DiagonalOperator` mass matrices, plus a case where `sparsity` is left to default to `jac_prototype` (how #2929 constructs the problem). Three of those error on master with the `keys` `MethodError` and pass here. Two further testsets pin the `UniformScaling` and plain-sparse paths as unchanged, and pass on both sides.

Branch: 9/9. `OrdinaryDiffEqDifferentiation` Core suite goes from 61 passes on master to 67 here.

## AI Disclosure

Claude assisted with this work.
