### PR TITLE
Restore OrdinaryDiffEqNonlinearSolve solver-author public API

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.3.0"
+version = "2.4.0"
 
 [deps]
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
@@ -69,15 +69,25 @@ include("initialize_dae.jl")
 
 export BrownFullBasicInit, ShampineCollocationInit
 
-# Nonlinear-solver algorithms accepted by OrdinaryDiffEq implicit methods. The
-# lower-level build/step/Anderson helpers are implementation details, not public API.
-# The `public` keyword is only parseable on Julia >= 1.11.0-DEV.469, so it is
-# gated to keep the 1.10 floor parsing.
+# Declare the documented solver-author extension API `public` so downstream solver
+# packages (the OrdinaryDiffEq solver sublibs, DelayDiffEq's fixed-point solver, etc.)
+# can drop their `OrdinaryDiffEqNonlinearSolve.X` non-public ExplicitImports ignores.
+# These are the nonlinear-solver algorithm types and the stepping/build hooks that
+# downstream packages legitimately construct and extend. The `public` keyword is only
+# parseable on Julia >= 1.11.0-DEV.469, so it is gated to keep the 1.10 floor parsing.
 @static if VERSION >= v"1.11.0-DEV.469"
     eval(
         Expr(
             :public,
-            :NLNewton, :NLFunctional, :NLAnderson, :HomotopyNonlinearSolveAlg
+            # Nonlinear-solver algorithm types
+            :NLNewton, :NLFunctional, :NLAnderson, :HomotopyNonlinearSolveAlg,
+            # Solver construction
+            :build_nlsolver,
+            # Stepping / status hooks extended and called by downstream solvers
+            :nlsolve!, :nlsolvefail, :compute_step!, :initial_η,
+            :markfirststage!, :du_alias_or_new,
+            # Anderson-acceleration kernels (DelayDiffEq fixed-point solver reuses these)
+            :anderson, :anderson!
         )
     )
 end

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
@@ -28,7 +28,8 @@ end
 
 Anderson-accelerated fixed-point iteration for the implicit stage equations. Like
 [`NLFunctional`](@ref) but mixes in `max_history` previous residuals via a
-least-squares update to accelerate convergence.
+least-squares update to accelerate convergence (see [`anderson`](@ref) /
+[`anderson!`](@ref)).
 
 # Keyword arguments
 


### PR DESCRIPTION
## Bug

`#3832` ("Split public and developer API docs") removed most of `OrdinaryDiffEqNonlinearSolve`'s public block, keeping only the three algorithm types (`NLNewton`, `NLFunctional`, `NLAnderson`, plus `HomotopyNonlinearSolveAlg` added later). But the solver-author extension API it dropped — `build_nlsolver`, `nlsolve!`, `nlsolvefail`, `compute_step!`, `initial_η`, `markfirststage!`, `du_alias_or_new`, `anderson`, `anderson!` — is still directly imported by every downstream solver sublibrary that implements an implicit method: `OrdinaryDiffEqPDIRK`, `OrdinaryDiffEqStabilizedIRK`, `OrdinaryDiffEqIMEXMultistep`, `OrdinaryDiffEqFIRK`, `DelayDiffEq`, `StochasticDiffEqImplicit`, `StochasticDiffEqLeaping`. Their `all_explicit_imports_are_public` QA check fails on every one of them as a result.

## Fix

Restore exactly the set `#3832` removed (confirmed via `git blame` on `e1db9b0`), plus the `type.jl` docstring cross-reference to `anderson`/`anderson!` it also stripped. `HomotopyNonlinearSolveAlg`, added after `#3832` in #3876, is untouched.

## Scope note

This is a different owning package from #3940 (which restores `OrdinaryDiffEqDifferentiation`'s block) — not a duplicate. No open PR currently covers this piece; the two prior attempts at the full set (#3872, #3874) were closed without merging.

## Verification

- `ExplicitImports.check_all_explicit_imports_are_public(OrdinaryDiffEqPDIRK)` on Julia 1.12.6 (matching CI): all names from this restoration (`build_nlsolver`, `markfirststage!`, `nlsolve!`, `nlsolvefail`, `du_alias_or_new`) no longer flagged. The one remaining flag (`_unwrap_val`, owned by SciMLBase) is unrelated to this change.
- Checked every downstream consumer's `qa.jl` for these 9 names in an `ignore`/`ei_broken` list — none has one, so restoring them can't flip anything to an unexpected-pass failure.
- Package loads and a basic `TRBDF2()` solve succeeds (`Success` retcode) against a full local dev-path checkout.
- A `public` declaration cannot change runtime dispatch or behavior — it is visibility/tooling-only — so this carries no runtime regression risk by construction.
- Runic clean.

## AI Disclosure

Claude assisted with this work.
