### PR TITLE
Fix SERK2 in-place inner stage loop evaluating f at the wrong stage vector

### DIFF
--- a/lib/OrdinaryDiffEqStabilizedRK/src/rkc_perform_step.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/rkc_perform_step.jl
@@ -1048,11 +1048,11 @@ end
         @.. broadcast = false tmp = uᵢ₋₁
         @.. broadcast = false uᵢ₋₁ = u
         for j in 2:internal_deg
-            f(k, tmp, p, t + (j^2 + (i - 1) * internal_deg^2) * α * dt)
+            f(k, uᵢ₋₁, p, t + (j^2 + (i - 1) * internal_deg^2) * α * dt)
             OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
             @.. broadcast = false u = 2 * uᵢ₋₁ - tmp + 2 * α * dt * k
             @.. broadcast = false Sᵢ = Sᵢ + Bᵢ[start + j + (i - 1) * internal_deg] * u
-            if j < mdeg
+            if j * i < mdeg
                 @.. broadcast = false tmp = uᵢ₋₁
                 @.. broadcast = false uᵢ₋₁ = u
             end

--- a/lib/OrdinaryDiffEqStabilizedRK/test/rkc_tests.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/rkc_tests.jl
@@ -197,6 +197,46 @@ end
     end
 end
 
+@testset "In-place and out-of-place agree in the stiff high-stage regime" begin
+    # Stiff forced heat equation stepped at fixed dt with dt*λ ≈ 217 so that the
+    # stage counts are high enough to exercise the deep recurrences (e.g. SERK2's
+    # inner stage loop only runs once mdeg >= 20).
+    N = 32
+    dx = 1.0 / (N + 1)
+    xs = collect(range(dx, 1 - dx; length = N))
+    A = Tridiagonal(fill(1 / dx^2, N - 1), fill(-2 / dx^2, N), fill(1 / dx^2, N - 1))
+    lam = 4 / dx^2
+    g(t) = cos(10t)
+    f_oop(u, p, t) = A * u .+ g(t)
+    f_iip(du, u, p, t) = (mul!(du, A, u); du .+= g(t); nothing)
+    u0 = sin.(pi .* xs)
+    tspan = (0.0, 0.5)
+    prob_oop = ODEProblem{false}(f_oop, u0, tspan)
+    prob_iip = ODEProblem{true}(f_iip, u0, tspan)
+    eigen_est = (integrator) -> integrator.eigen_est = lam
+
+    algs = [
+        ROCK2(eigen_est = eigen_est), ROCK4(eigen_est = eigen_est),
+        RKC(eigen_est = eigen_est), RKMC2(eigen_est = eigen_est),
+        TSRKC2(eigen_est = eigen_est), TSRKC3(eigen_est = eigen_est),
+        SERK2(eigen_est = eigen_est), ESERK4(eigen_est = eigen_est),
+        ESERK5(eigen_est = eigen_est), RKL1(eigen_est = eigen_est),
+        RKL2(eigen_est = eigen_est), RKG1(eigen_est = eigen_est),
+        RKG2(eigen_est = eigen_est),
+    ]
+    @testset "$alg" for alg in algs
+        sol_oop = solve(
+            prob_oop, alg, adaptive = false, dt = 0.05,
+            save_everystep = false
+        )
+        sol_iip = solve(
+            prob_iip, alg, adaptive = false, dt = 0.05,
+            save_everystep = false
+        )
+        @test norm(sol_oop.u[end] .- sol_iip.u[end], Inf) < 1.0e-6
+    end
+end
+
 @testset "Number of function evaluations" begin
     x = Ref(0)
     u0 = [1.0, 1.0]


### PR DESCRIPTION
> [!IMPORTANT]
> This PR should be ignored until reviewed by @ChrisRackauckas.

## What

The in-place `SERK2` `perform_step!` evaluated `f` at `tmp` (which holds uᵢ₋₂) instead of `uᵢ₋₁` in its inner stage loop, and used a different buffer-shift guard (`j < mdeg`) than the out-of-place implementation (`j * i < mdeg`).

## Why it went undetected

The divergent code path only executes when `mdeg >= 20` (`internal_deg = mdeg ÷ 10 >= 2`), i.e. for genuinely stiff steps with dt·λ ≳ 300. The existing convergence tests use `prob_ode_linear`/`prob_ode_2Dlinear` with mild step sizes, which never reach that regime.

## Impact

In the stiff regime the in-place solver is unstable. On a forced heat equation (N = 32, dt·λ ≈ 217, fixed dt = 0.05):

| | ‖u − ref‖∞ |
|---|---|
| out-of-place | 2.5e-3 |
| in-place (before) | **3.8e83** |
| in-place (after) | 2.5e-3 (agrees with oop to 1.7e-13) |

## Tests

Adds a stiff fixed-dt in-place/out-of-place agreement regression testset covering all 13 stabilized RK methods (ROCK2/4, RKC, RKMC2, TSRKC2/3, SERK2, ESERK4/5, RKL1/2, RKG1/2). It fails on the previous code for SERK2 and passes with this fix.

Ran locally: `ODEDIFFEQ_TEST_GROUP=Core Pkg.test()` on the sublibrary — 210/210 pass. Runic applied to changed files.

## Process notes

Found during a correctness/performance audit of the stabilized RK family: code inspection flagged the oop/iip asymmetry, then a fixed-dt stiff comparison confirmed the blow-up, and the one-line fix restores roundoff-level agreement. Related (separate PRs): RKL/RKG non-autonomous stage-time fixes; SERK2 also has a separate non-autonomous order-reduction issue that needs the original paper's coefficients and is intentionally NOT addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015WU5V4PXt8SZ3BpjxdtM7d