### PR TITLE
Fix RKL1/RKL2 stage times for non-autonomous problems

### DIFF
--- a/lib/OrdinaryDiffEqStabilizedRK/src/rkc_perform_step.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/rkc_perform_step.jl
@@ -1562,17 +1562,24 @@ end
     # stage 1
     uᵢ₋₂ = uprev
     uᵢ₋₁ = uprev + (dt * w1) * fsalfirst
+    # stage times follow the same recurrence as the stage values so that each
+    # stage is internally consistent: cⱼ = (j² + j)/(s² + s)
+    cⱼ₋₂ = zero(T)
+    cⱼ₋₁ = w1
 
     # stages 2 to s
     for j in 2:s
         μⱼ = T(2j - 1) / j
         νⱼ = -T(j - 1) / j
         μ̃ⱼ = μⱼ * w1
-        fYm1 = f(uᵢ₋₁, p, t)
+        fYm1 = f(uᵢ₋₁, p, t + dt * cⱼ₋₁)
         OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
         u = μⱼ * uᵢ₋₁ + νⱼ * uᵢ₋₂ + μ̃ⱼ * dt * fYm1
+        cⱼ = μⱼ * cⱼ₋₁ + νⱼ * cⱼ₋₂ + μ̃ⱼ
         uᵢ₋₂ = uᵢ₋₁
         uᵢ₋₁ = u
+        cⱼ₋₂ = cⱼ₋₁
+        cⱼ₋₁ = cⱼ
     end
 
     # error estimate from a single forward-Euler step
@@ -1611,17 +1618,24 @@ end
     # stage 1
     @.. broadcast = false tmp = uprev
     @.. broadcast = false uᵢ₋₁ = uprev + (dt * w1) * fsalfirst
+    # stage times follow the same recurrence as the stage values so that each
+    # stage is internally consistent: cⱼ = (j² + j)/(s² + s)
+    cⱼ₋₂ = zero(T)
+    cⱼ₋₁ = w1
 
     # stages 2 to s
     for j in 2:s
         μⱼ = T(2j - 1) / j
         νⱼ = -T(j - 1) / j
         μ̃ⱼ = μⱼ * w1
-        f(k, uᵢ₋₁, p, t)
+        f(k, uᵢ₋₁, p, t + dt * cⱼ₋₁)
         OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
         @.. broadcast = false u = μⱼ * uᵢ₋₁ + νⱼ * tmp + (dt * μ̃ⱼ) * k
+        cⱼ = μⱼ * cⱼ₋₁ + νⱼ * cⱼ₋₂ + μ̃ⱼ
         @.. broadcast = false tmp = uᵢ₋₁
         @.. broadcast = false uᵢ₋₁ = u
+        cⱼ₋₂ = cⱼ₋₁
+        cⱼ₋₁ = cⱼ
     end
 
     if integrator.opts.adaptive
@@ -1682,6 +1696,10 @@ end
     μ̃₁ = (T(1) / 3) * w1
     uᵢ₋₂ = uprev
     uᵢ₋₁ = uprev + (dt * μ̃₁) * fsalfirst
+    # stage times follow the same recurrence as the stage values so that each
+    # stage is internally consistent: cⱼ = (j² + j - 2)/(s² + s - 2) for j >= 2
+    cⱼ₋₂ = zero(T)
+    cⱼ₋₁ = μ̃₁
 
     # stages 2 to s
     for j in 2:s
@@ -1699,14 +1717,17 @@ end
         ajm1 = 1 - bjm1
         γ̃ⱼ = -ajm1 * μ̃ⱼ
 
-        fYm1 = f(uᵢ₋₁, p, t)
+        fYm1 = f(uᵢ₋₁, p, t + dt * cⱼ₋₁)
         OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 
         u = μⱼ * uᵢ₋₁ + νⱼ * uᵢ₋₂ + (1 - μⱼ - νⱼ) * uprev +
             dt * μ̃ⱼ * fYm1 + dt * γ̃ⱼ * fsalfirst
 
+        cⱼ = μⱼ * cⱼ₋₁ + νⱼ * cⱼ₋₂ + μ̃ⱼ + γ̃ⱼ
         uᵢ₋₂ = uᵢ₋₁
         uᵢ₋₁ = u
+        cⱼ₋₂ = cⱼ₋₁
+        cⱼ₋₁ = cⱼ
     end
 
     # error estimate based on a one step prediction
@@ -1748,6 +1769,10 @@ end
     μ̃₁ = (T(1) / 3) * w1
     @.. broadcast = false tmp = uprev
     @.. broadcast = false uᵢ₋₁ = uprev + (dt * μ̃₁) * fsalfirst
+    # stage times follow the same recurrence as the stage values so that each
+    # stage is internally consistent: cⱼ = (j² + j - 2)/(s² + s - 2) for j >= 2
+    cⱼ₋₂ = zero(T)
+    cⱼ₋₁ = μ̃₁
 
     # stages 2 to s
     for j in 2:s
@@ -1763,14 +1788,17 @@ end
         μ̃ⱼ = μⱼ * w1
         γ̃ⱼ = -ajm1 * μ̃ⱼ
 
-        f(k, uᵢ₋₁, p, t)
+        f(k, uᵢ₋₁, p, t + dt * cⱼ₋₁)
         OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
         @.. broadcast = false u = μⱼ * uᵢ₋₁ + νⱼ * tmp +
             (1 - μⱼ - νⱼ) * uprev +
             (dt * μ̃ⱼ) * k +
             (dt * γ̃ⱼ) * fsalfirst
+        cⱼ = μⱼ * cⱼ₋₁ + νⱼ * cⱼ₋₂ + μ̃ⱼ + γ̃ⱼ
         @.. broadcast = false tmp = uᵢ₋₁
         @.. broadcast = false uᵢ₋₁ = u
+        cⱼ₋₂ = cⱼ₋₁
+        cⱼ₋₁ = cⱼ
     end
 
     if integrator.opts.adaptive

--- a/lib/OrdinaryDiffEqStabilizedRK/test/rkc_tests.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/rkc_tests.jl
@@ -237,6 +237,46 @@ end
     end
 end
 
+@testset "RKL non-autonomous convergence" begin
+    # Prothero-Robinson-type problem: uᵢ' = -λᵢ*(uᵢ - cos(t)) - sin(t), exact uᵢ = cos(t).
+    # Catches wrong or missing stage times, which autonomous problems cannot see.
+    lams = [1.0, 5.0, 20.0, 50.0]
+    f_na_oop(u, p, t) = @. -p * (u - cos(t)) - sin(t)
+    f_na_iip(du, u, p, t) = (@. du = -p * (u - cos(t)) - sin(t); nothing)
+    na_analytic(u0, p, t) = cos(t) .* ones(length(p))
+    prob_na_oop = ODEProblem(
+        ODEFunction{false}(f_na_oop, analytic = na_analytic), ones(4), (0.0, 1.0), lams
+    )
+    prob_na_iip = ODEProblem(
+        ODEFunction{true}(f_na_iip, analytic = na_analytic), ones(4), (0.0, 1.0), lams
+    )
+    # pure quadrature: u' = cos(t), any correct second-order method gets order 2
+    fq_oop(u, p, t) = fill(cos(t), 2)
+    fq_iip(du, u, p, t) = (du .= cos(t); nothing)
+    q_analytic(u0, p, t) = u0 .+ sin(t)
+    prob_q_oop = ODEProblem(
+        ODEFunction{false}(fq_oop, analytic = q_analytic), zeros(2), (0.0, 1.0)
+    )
+    prob_q_iip = ODEProblem(
+        ODEFunction{true}(fq_iip, analytic = q_analytic), zeros(2), (0.0, 1.0)
+    )
+
+    dts = 1 .// 2 .^ (10:-1:5)
+    testTol = 0.25
+    # fixed estimate exercises the classical dt -> 0 regime; the 1/dt-scaled
+    # estimate keeps the stage count constant (stiff regime)
+    fixed_eig = (integrator) -> integrator.eigen_est = 55.0
+    scaled_eig = (integrator) -> integrator.eigen_est = 500 / abs(integrator.dt)
+    for prob in [prob_na_oop, prob_na_iip, prob_q_oop, prob_q_iip],
+            eig in [fixed_eig, scaled_eig]
+
+        sim = test_convergence(dts, prob, RKL1(eigen_est = eig))
+        @test sim.𝒪est[:l∞] ≈ 1 atol = testTol
+        sim = test_convergence(dts, prob, RKL2(eigen_est = eig))
+        @test sim.𝒪est[:l∞] ≈ 2 atol = testTol
+    end
+end
+
 @testset "Number of function evaluations" begin
     x = Ref(0)
     u0 = [1.0, 1.0]


### PR DESCRIPTION
> [!IMPORTANT]
> This PR should be ignored until reviewed by @ChrisRackauckas.

## What

`RKL1`/`RKL2` evaluated every interior stage at time `t` — no stage-time offsets at all. On any time-dependent problem RKL2 loses an order: measured order ~1.1–1.2 on a Prothero–Robinson problem and exactly 1.0 on pure quadrature `u' = cos(t)` (it degenerates to forward Euler in `t`). Autonomous problems — the only thing the existing convergence tests use — cannot see this.

## Fix

Track stage times cⱼ through the same three-term recurrence the stage values satisfy (initialized with c₁ = μ̃₁, updated cⱼ = μⱼcⱼ₋₁ + νⱼcⱼ₋₂ + μ̃ⱼ (+ γ̃ⱼ for RKL2)), and evaluate stage j at `t + dt*cⱼ₋₁`. This makes each stage internally consistent and reproduces the closed forms from Meyer, Balsara & Aslam (JCP 2014): cⱼ = (j²+j)/(s²+s) for RKL1, cⱼ = (j²+j−2)/(s²+s−2) for RKL2. Internal consistency + the already-verified autonomous order conditions give the non-autonomous order via the t-augmented autonomous system.

## Measured convergence orders (before → after)

RKL2, ℓ∞ order over dts = 2⁻¹⁰..2⁻⁵, forced eigenvalue estimates:

| problem | fixed λ | λ ∝ 1/dt (stiff regime) |
|---|---|---|
| Prothero–Robinson oop | 1.20 → **2.00** | 1.13 → **2.00** |
| Prothero–Robinson iip | 1.20 → **2.00** | 1.13 → **2.00** |
| quadrature oop | 1.00 → **2.00** | 1.00 → **2.00** |
| quadrature iip | 1.00 → **2.00** | 1.00 → **2.00** |

RKL1 remains order 1.00 everywhere (it is first order by design; correct stage times still improve the constant). Autonomous convergence unchanged (2.00 / 1.00).

## Tests

Adds an `RKL non-autonomous convergence` testset (Prothero–Robinson + quadrature, oop + iip, both eigenvalue regimes). Ran locally: `ODEDIFFEQ_TEST_GROUP=Core Pkg.test()` — 213/213 pass. Runic applied.

Part of a stabilized-RK audit; sibling PRs: SERK2 in-place fix, RKG1/RKG2 stage times (same construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015WU5V4PXt8SZ3BpjxdtM7d