### PR TITLE
Fix RKG1/RKG2 stage times for non-autonomous problems

### DIFF
--- a/lib/OrdinaryDiffEqStabilizedRK/src/rkc_perform_step.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/rkc_perform_step.jl
@@ -1872,6 +1872,10 @@ end
     μ̃₁ = (3 * b1 / b0) * w1
     uᵢ₋₂ = uprev
     uᵢ₋₁ = uprev + (dt * μ̃₁) * fsalfirst
+    # stage times follow the same recurrence as the stage values so that each
+    # stage is internally consistent
+    cⱼ₋₂ = zero(T)
+    cⱼ₋₁ = μ̃₁
 
     # stages 2 to s
     for j in 2:s
@@ -1885,11 +1889,14 @@ end
         νⱼ = -T(j + 1) / j * bj / bjm2
         μ̃ⱼ = μⱼ * w1
 
-        fYm1 = f(uᵢ₋₁, p, t)
+        fYm1 = f(uᵢ₋₁, p, t + dt * cⱼ₋₁)
         OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
         u = μⱼ * uᵢ₋₁ + νⱼ * uᵢ₋₂ + μ̃ⱼ * dt * fYm1
+        cⱼ = μⱼ * cⱼ₋₁ + νⱼ * cⱼ₋₂ + μ̃ⱼ
         uᵢ₋₂ = uᵢ₋₁
         uᵢ₋₁ = u
+        cⱼ₋₂ = cⱼ₋₁
+        cⱼ₋₁ = cⱼ
     end
 
     if integrator.opts.adaptive
@@ -1933,6 +1940,10 @@ end
 
     @.. broadcast = false tmp = uprev
     @.. broadcast = false uᵢ₋₁ = uprev + (dt * μ̃₁) * fsalfirst
+    # stage times follow the same recurrence as the stage values so that each
+    # stage is internally consistent
+    cⱼ₋₂ = zero(T)
+    cⱼ₋₁ = μ̃₁
 
     # stages 2 to s
     for j in 2:s
@@ -1943,11 +1954,14 @@ end
         νⱼ = -T(j + 1) / j * bj / bjm2
         μ̃ⱼ = μⱼ * w1
 
-        f(k, uᵢ₋₁, p, t)
+        f(k, uᵢ₋₁, p, t + dt * cⱼ₋₁)
         OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
         @.. broadcast = false u = μⱼ * uᵢ₋₁ + νⱼ * tmp + (dt * μ̃ⱼ) * k
+        cⱼ = μⱼ * cⱼ₋₁ + νⱼ * cⱼ₋₂ + μ̃ⱼ
         @.. broadcast = false tmp = uᵢ₋₁
         @.. broadcast = false uᵢ₋₁ = u
+        cⱼ₋₂ = cⱼ₋₁
+        cⱼ₋₁ = cⱼ
     end
 
     if integrator.opts.adaptive
@@ -2006,6 +2020,10 @@ end
     μ̃₁ = w1
     uᵢ₋₂ = uprev
     uᵢ₋₁ = uprev + (dt * μ̃₁) * fsalfirst
+    # stage times follow the same recurrence as the stage values so that each
+    # stage is internally consistent
+    cⱼ₋₂ = zero(T)
+    cⱼ₋₁ = μ̃₁
 
     # stages 2 to s: b_0=1, b_1=1/3, b_j=4(j-1)(j+4)/(3j(j+1)(j+2)(j+3)) for j>=2
     # a_{j-1} = 1 - j(j+1)/2 * b_{j-1}
@@ -2023,14 +2041,17 @@ end
         μ̃ⱼ = μⱼ * w1
         γ̃ⱼ = -μ̃ⱼ * ajm1
 
-        fYm1 = f(uᵢ₋₁, p, t)
+        fYm1 = f(uᵢ₋₁, p, t + dt * cⱼ₋₁)
         OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 
         u = μⱼ * uᵢ₋₁ + νⱼ * uᵢ₋₂ + (1 - μⱼ - νⱼ) * uprev +
             dt * μ̃ⱼ * fYm1 + dt * γ̃ⱼ * fsalfirst
 
+        cⱼ = μⱼ * cⱼ₋₁ + νⱼ * cⱼ₋₂ + μ̃ⱼ + γ̃ⱼ
         uᵢ₋₂ = uᵢ₋₁
         uᵢ₋₁ = u
+        cⱼ₋₂ = cⱼ₋₁
+        cⱼ₋₁ = cⱼ
     end
 
     if integrator.opts.adaptive
@@ -2070,6 +2091,10 @@ end
 
     @.. broadcast = false tmp = uprev
     @.. broadcast = false uᵢ₋₁ = uprev + (dt * μ̃₁) * fsalfirst
+    # stage times follow the same recurrence as the stage values so that each
+    # stage is internally consistent
+    cⱼ₋₂ = zero(T)
+    cⱼ₋₁ = μ̃₁
 
     # stages 2 to s
     for j in 2:s
@@ -2086,15 +2111,18 @@ end
         μ̃ⱼ = μⱼ * w1
         γ̃ⱼ = -μ̃ⱼ * ajm1
 
-        f(k, uᵢ₋₁, p, t)
+        f(k, uᵢ₋₁, p, t + dt * cⱼ₋₁)
         OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 
         @.. broadcast = false u = μⱼ * uᵢ₋₁ + νⱼ * tmp +
             (1 - μⱼ - νⱼ) * uprev +
             (dt * μ̃ⱼ) * k +
             (dt * γ̃ⱼ) * fsalfirst
+        cⱼ = μⱼ * cⱼ₋₁ + νⱼ * cⱼ₋₂ + μ̃ⱼ + γ̃ⱼ
         @.. broadcast = false tmp = uᵢ₋₁
         @.. broadcast = false uᵢ₋₁ = u
+        cⱼ₋₂ = cⱼ₋₁
+        cⱼ₋₁ = cⱼ
     end
 
     if integrator.opts.adaptive

--- a/lib/OrdinaryDiffEqStabilizedRK/test/rkc_tests.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/rkc_tests.jl
@@ -277,6 +277,46 @@ end
     end
 end
 
+@testset "RKG non-autonomous convergence" begin
+    # Prothero-Robinson-type problem: uᵢ' = -λᵢ*(uᵢ - cos(t)) - sin(t), exact uᵢ = cos(t).
+    # Catches wrong or missing stage times, which autonomous problems cannot see.
+    lams = [1.0, 5.0, 20.0, 50.0]
+    f_na_oop(u, p, t) = @. -p * (u - cos(t)) - sin(t)
+    f_na_iip(du, u, p, t) = (@. du = -p * (u - cos(t)) - sin(t); nothing)
+    na_analytic(u0, p, t) = cos(t) .* ones(length(p))
+    prob_na_oop = ODEProblem(
+        ODEFunction{false}(f_na_oop, analytic = na_analytic), ones(4), (0.0, 1.0), lams
+    )
+    prob_na_iip = ODEProblem(
+        ODEFunction{true}(f_na_iip, analytic = na_analytic), ones(4), (0.0, 1.0), lams
+    )
+    # pure quadrature: u' = cos(t), any correct second-order method gets order 2
+    fq_oop(u, p, t) = fill(cos(t), 2)
+    fq_iip(du, u, p, t) = (du .= cos(t); nothing)
+    q_analytic(u0, p, t) = u0 .+ sin(t)
+    prob_q_oop = ODEProblem(
+        ODEFunction{false}(fq_oop, analytic = q_analytic), zeros(2), (0.0, 1.0)
+    )
+    prob_q_iip = ODEProblem(
+        ODEFunction{true}(fq_iip, analytic = q_analytic), zeros(2), (0.0, 1.0)
+    )
+
+    dts = 1 .// 2 .^ (10:-1:5)
+    testTol = 0.25
+    # fixed estimate exercises the classical dt -> 0 regime; the 1/dt-scaled
+    # estimate keeps the stage count constant (stiff regime)
+    fixed_eig = (integrator) -> integrator.eigen_est = 55.0
+    scaled_eig = (integrator) -> integrator.eigen_est = 500 / abs(integrator.dt)
+    for prob in [prob_na_oop, prob_na_iip, prob_q_oop, prob_q_iip],
+            eig in [fixed_eig, scaled_eig]
+
+        sim = test_convergence(dts, prob, RKG1(eigen_est = eig))
+        @test sim.𝒪est[:l∞] ≈ 1 atol = testTol
+        sim = test_convergence(dts, prob, RKG2(eigen_est = eig))
+        @test sim.𝒪est[:l∞] ≈ 2 atol = testTol
+    end
+end
+
 @testset "Number of function evaluations" begin
     x = Ref(0)
     u0 = [1.0, 1.0]


### PR DESCRIPTION
> [!IMPORTANT]
> This PR should be ignored until reviewed by @ChrisRackauckas.

## What

Same defect and same construction as the RKL PR (#3948), for the Runge–Kutta–Gegenbauer methods: `RKG1`/`RKG2` evaluated every interior stage at time `t`, so RKG2 loses an order on any time-dependent problem (order 1.0 on quadrature `u' = cos(t)`, ~1.1–1.2 on Prothero–Robinson). Autonomous problems cannot detect this, which is all the existing tests used.

## Fix

Track stage times cⱼ through the same three-term recurrence the stage values satisfy (c₁ = μ̃₁, cⱼ = μⱼcⱼ₋₁ + νⱼcⱼ₋₂ + μ̃ⱼ (+ γ̃ⱼ for RKG2)) and evaluate stage j at `t + dt*cⱼ₋₁`. Each stage becomes internally consistent, and internal consistency + the verified autonomous order conditions imply the non-autonomous order via the t-augmented autonomous system. The recurrence is a few scalar ops per stage — no measurable cost.

## Measured convergence orders (before → after)

RKG2, ℓ∞ order over dts = 2⁻¹⁰..2⁻⁵, forced eigenvalue estimates: order 1.0–1.2 → **2.00** in all eight configurations (Prothero–Robinson + quadrature, oop + iip, fixed-λ + λ∝1/dt). RKG1 remains order 1.00 everywhere. Autonomous convergence unchanged.

## Tests

Adds an `RKG non-autonomous convergence` testset mirroring the RKL one. Ran locally: `ODEDIFFEQ_TEST_GROUP=Core Pkg.test()` — 213/213 pass. Runic applied.

Part of a stabilized-RK audit; sibling PRs: #3947 (SERK2 in-place fix), #3948 (RKL stage times).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015WU5V4PXt8SZ3BpjxdtM7d