### PR TITLE
GlobalDiffEq: add GLEE23/GLEE24/GLEE35 and MM5GEE global-error-estimating solvers

### DIFF
--- a/docs/src/globalerrorcontrol/GlobalDiffEq.md
+++ b/docs/src/globalerrorcontrol/GlobalDiffEq.md
@@ -14,9 +14,42 @@ To use these methods:
 using GlobalDiffEq
 ```
 
+The global-error-estimating solvers [`GLEE24`](@ref), [`GLEE35`](@ref)
+(Constantinescu 2016), and the Dormand-Prince-based [`MM5GEE`](@ref) (Makazaga
+and Murua 2003) carry a running, asymptotically correct estimate of the
+solution's global error at every time point, at the cost of a few extra stages
+per step. Solving with them produces a solution whose states are
+`ArrayPartition`s (`sol.u[i].x[1]` the solution, `sol.u[i].x[2]` the global
+error estimate); [`global_error_estimate`](@ref) extracts the estimates.
+
 [`GlobalRichardson`](@ref) wraps any fixed-step method in global Richardson
 extrapolation over whole solves, interpreting `abstol` and `reltol` as global
 tolerances. It is the most robust and most expensive option.
+
+For example, solving while tracking the global error along the trajectory:
+
+```julia
+using GlobalDiffEq
+
+function lorenz!(du, u, p, t)
+    du[1] = 10.0(u[2] - u[1])
+    du[2] = u[1] * (28.0 - u[3]) - u[2]
+    du[3] = u[1] * u[2] - (8 / 3) * u[3]
+end
+prob = ODEProblem(lorenz!, [1.0; 0.0; 0.0], (0.0, 10.0))
+sol = solve(prob, GLEE35(); abstol = 1.0e-8, reltol = 1.0e-8)
+errs = global_error_estimate(sol)  # global error estimate at every sol.t
+```
+
+## Global-error-estimating solvers
+
+```@docs
+GLEE23
+GLEE24
+GLEE35
+MM5GEE
+global_error_estimate
+```
 
 ## Global error controlling wrappers
 

--- a/lib/GlobalDiffEq/Project.toml
+++ b/lib/GlobalDiffEq/Project.toml
@@ -1,31 +1,41 @@
 name = "GlobalDiffEq"
 uuid = "1d72d19b-84cc-4cb7-a099-7cbdb9ccc67c"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.2.1"
+version = "1.3.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
+FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
+OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Richardson = "708f8203-808e-40c0-ba2d-98a6953ed40d"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
+OrdinaryDiffEqCore = {path = "../OrdinaryDiffEqCore"}
 OrdinaryDiffEqTsit5 = {path = "../OrdinaryDiffEqTsit5"}
 
 [compat]
 DiffEqBase = "7"
+FastBroadcast = "1.3"
 LinearAlgebra = "1"
+MuladdMacro = "0.2.1"
+OrdinaryDiffEqCore = "4"
 OrdinaryDiffEqSSPRK = "2"
 OrdinaryDiffEqTsit5 = "2"
 PrecompileTools = "1.1"
-Reexport = "1.0"
+RecursiveArrayTools = "4.2.0"
+Reexport = "0.2, 1.0"
 Richardson = "1.2"
-SafeTestsets = "0.1"
+SafeTestsets = "0.0.1, 0.1"
 SciMLBase = "3"
-SciMLTesting = "2.8"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"
 
@@ -33,9 +43,10 @@ julia = "1.10"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrdinaryDiffEqSSPRK = "669c94d9-1f4b-4b64-b377-1aa079aa2388"
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
+RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["LinearAlgebra", "OrdinaryDiffEqSSPRK", "OrdinaryDiffEqTsit5", "SafeTestsets", "SciMLTesting", "Test"]
+test = ["LinearAlgebra", "OrdinaryDiffEqSSPRK", "OrdinaryDiffEqTsit5", "RecursiveArrayTools", "SafeTestsets", "SciMLTesting", "Test"]

--- a/lib/GlobalDiffEq/src/GlobalDiffEq.jl
+++ b/lib/GlobalDiffEq/src/GlobalDiffEq.jl
@@ -3,14 +3,25 @@ module GlobalDiffEq
 using Reexport: @reexport
 @reexport using DiffEqBase
 
-import OrdinaryDiffEqTsit5, Richardson, SciMLBase
+import LinearAlgebra, OrdinaryDiffEqCore, OrdinaryDiffEqTsit5,
+    RecursiveArrayTools, Richardson, SciMLBase
+import DiffEqBase: initialize!, calculate_residuals, calculate_residuals!
+import OrdinaryDiffEqCore: perform_step!, @cache
+using FastBroadcast: FastBroadcast, @..
+using MuladdMacro: MuladdMacro, @muladd
 using PrecompileTools: @setup_workload, @compile_workload
 
 abstract type GlobalDiffEqAlgorithm <: SciMLBase.AbstractODEAlgorithm end
 
 include("richardson.jl")
+include("glee/tableaus.jl")
+include("glee/algorithms.jl")
+include("glee/solve.jl")
+include("glee/caches.jl")
+include("glee/perform_step.jl")
 
 export GlobalRichardson
+export GLEE23, GLEE24, GLEE35, MM5GEE, global_error_estimate
 
 @setup_workload begin
     # Simple test ODE: exponential decay du/dt = -u

--- a/lib/GlobalDiffEq/src/glee/algorithms.jl
+++ b/lib/GlobalDiffEq/src/glee/algorithms.jl
@@ -1,0 +1,90 @@
+# Explicit general linear methods with built-in global error estimation
+# (GLEE methods) from Constantinescu (2016), doi:10.1137/15M1014633.
+abstract type AbstractGLEEAlgorithm <:
+OrdinaryDiffEqCore.OrdinaryDiffEqAdaptiveAlgorithm end
+
+const _GLEE_DOCS_SHARED = """
+GLEE methods propagate the solution `y` together with an asymptotically
+correct estimate `ε` of its global (accumulated) error, at the cost of a few
+extra stages per step. Solving any `ODEProblem` with a GLEE method produces a
+solution whose states are `ArrayPartition`s: `sol.u[i].x[1]` is the solution
+and `sol.u[i].x[2]` is the global error estimate at `sol.t[i]` (see
+[`global_error_estimate`](@ref)). The per-step increment of `ε` is an
+asymptotically correct local error estimate, which drives standard step-size
+adaptivity, so local tolerances behave exactly as for ordinary adaptive
+Runge-Kutta methods while the global error is estimated for free.
+
+Only explicit, mass-matrix-free ODEs are supported. The reference for the
+methods and their theory is:
+
+Emil M. Constantinescu, *Estimating Global Errors in Time Stepping*, SIAM
+Journal on Numerical Analysis 54(6), 2016. [arXiv:1503.05166](https://arxiv.org/abs/1503.05166)
+"""
+
+"""
+    GLEE23()
+
+3-stage, second-order explicit general linear method with global error
+estimation (Constantinescu 2016, eq. (4.6); PETSc's `TSGLEE23`). The cheapest
+GLEE method: only the first decoupling condition holds, so prefer
+[`GLEE24`](@ref) for long-time integration or mildly stiff problems.
+
+$(_GLEE_DOCS_SHARED)
+"""
+struct GLEE23 <: AbstractGLEEAlgorithm end
+
+"""
+    GLEE24()
+
+4-stage, second-order explicit general linear method with global error
+estimation (Constantinescu 2016, eq. (A.3); PETSc's `TSGLEE24`). Satisfies
+both decoupling conditions (`B·U` and `B·A·U` diagonal), which keeps the error
+estimate faithful in long-time integration; this is the recommended
+second-order GLEE method.
+
+$(_GLEE_DOCS_SHARED)
+"""
+struct GLEE24 <: AbstractGLEEAlgorithm end
+
+"""
+    GLEE35()
+
+5-stage, third-order explicit general linear method with global error
+estimation (Constantinescu 2016, eq. (4.9); PETSc's `TSGLEE35`). Satisfies
+both decoupling conditions and has a large negative-real-axis stability
+region; this is the recommended third-order GLEE method.
+
+$(_GLEE_DOCS_SHARED)
+"""
+struct GLEE35 <: AbstractGLEEAlgorithm end
+
+"""
+    MM5GEE()
+
+Fifth-order Dormand-Prince-based scheme with cheap global error estimation
+(Makazaga and Murua, BIT Numerical Mathematics 43, 2003). Propagates the
+standard DOPRI5 solution together with an order-6 companion solution through
+three extra stages (9 function evaluations per step in total), whose
+difference is an asymptotically correct global error estimate. This is the
+recommended method of the Runge-Kutta triple family of Dormand, Duckers and
+Prince, as it is the coefficient-complete published scheme of that type.
+
+$(_GLEE_DOCS_SHARED)
+
+  - J. Makazaga and A. Murua, New Runge-Kutta based schemes for ODEs with
+    cheap global error estimation, BIT Numerical Mathematics 43 (2003).
+"""
+struct MM5GEE <: AbstractGLEEAlgorithm end
+
+SciMLBase.alg_order(::GLEE23) = 2
+SciMLBase.alg_order(::GLEE24) = 2
+SciMLBase.alg_order(::GLEE35) = 3
+SciMLBase.alg_order(::MM5GEE) = 5
+
+OrdinaryDiffEqCore.alg_adaptive_order(alg::AbstractGLEEAlgorithm) =
+    SciMLBase.alg_order(alg)
+
+_glee_tableau_for(::GLEE23, ::Type{T}, ::Type{T2}) where {T, T2} = GLEE23Tableau(T, T2)
+_glee_tableau_for(::GLEE24, ::Type{T}, ::Type{T2}) where {T, T2} = GLEE24Tableau(T, T2)
+_glee_tableau_for(::GLEE35, ::Type{T}, ::Type{T2}) where {T, T2} = GLEE35Tableau(T, T2)
+_glee_tableau_for(::MM5GEE, ::Type{T}, ::Type{T2}) where {T, T2} = MM5GEETableau(T, T2)

--- a/lib/GlobalDiffEq/src/glee/caches.jl
+++ b/lib/GlobalDiffEq/src/glee/caches.jl
@@ -1,0 +1,52 @@
+@cache struct GLEECache{uType, yType, rateType, yRateType, uNoUnitsType, TabType} <:
+    OrdinaryDiffEqCore.OrdinaryDiffEqMutableCache
+    u::uType
+    uprev::uType
+    tmp::uType
+    fsalfirst::rateType
+    fsallast::rateType
+    ks::Vector{yRateType}
+    ytmp::yType
+    εloc::yType
+    atmp::uNoUnitsType
+    tab::TabType
+end
+
+OrdinaryDiffEqCore.get_fsalfirstlast(cache::GLEECache, u) =
+    (cache.fsalfirst, cache.fsallast)
+
+struct GLEEConstantCache{TabType} <: OrdinaryDiffEqCore.OrdinaryDiffEqConstantCache
+    tab::TabType
+end
+
+function OrdinaryDiffEqCore.alg_cache(
+        alg::AbstractGLEEAlgorithm, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{true}, verbose
+    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    tab = _glee_tableau_for(
+        alg, OrdinaryDiffEqCore.constvalue(uBottomEltypeNoUnits),
+        OrdinaryDiffEqCore.constvalue(tTypeNoUnits)
+    )
+    y = u.x[1]
+    yrate = rate_prototype.x[1]
+    ks = [zero(yrate) for _ in 1:nstages(tab)]
+    return GLEECache(
+        u, uprev, zero(u), zero(rate_prototype), zero(rate_prototype), ks,
+        zero(y), zero(y), fill!(similar(y, uEltypeNoUnits), 0), tab
+    )
+end
+
+function OrdinaryDiffEqCore.alg_cache(
+        alg::AbstractGLEEAlgorithm, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{false}, verbose
+    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    tab = _glee_tableau_for(
+        alg, OrdinaryDiffEqCore.constvalue(uBottomEltypeNoUnits),
+        OrdinaryDiffEqCore.constvalue(tTypeNoUnits)
+    )
+    return GLEEConstantCache(tab)
+end

--- a/lib/GlobalDiffEq/src/glee/perform_step.jl
+++ b/lib/GlobalDiffEq/src/glee/perform_step.jl
@@ -1,0 +1,131 @@
+function initialize!(integrator, cache::GLEECache)
+    integrator.kshortsize = 2
+    resize!(integrator.k, integrator.kshortsize)
+    integrator.k[1] = cache.fsalfirst
+    integrator.k[2] = cache.fsallast
+    integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    return nothing
+end
+
+@muladd function perform_step!(integrator, cache::GLEECache, repeat_step = false)
+    (; t, dt, uprev, u, f, p) = integrator
+    (; ks, ytmp, εloc, atmp, tab) = cache
+    inner = _glee_inner(f)
+    yprev = uprev.x[1]
+    εprev = uprev.x[2]
+    s = nstages(tab)
+
+    for i in 1:s
+        if i == 1 && tab.stage1_fsal
+            copyto!(ks[1], integrator.fsalfirst.x[1])
+            continue
+        end
+        @.. ytmp = tab.U[i, 1] * yprev + tab.U[i, 2] * εprev
+        for j in 1:(i - 1)
+            iszero(tab.A[i, j]) && continue
+            @.. ytmp = ytmp + dt * tab.A[i, j] * ks[j]
+        end
+        inner(ks[i], ytmp, p, t + tab.c[i] * dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    end
+
+    ynew = u.x[1]
+    εnew = u.x[2]
+    fill!(εloc, zero(eltype(εloc)))
+    for j in 1:s
+        iszero(tab.B[2, j]) && continue
+        @.. εloc = εloc + dt * tab.B[2, j] * ks[j]
+    end
+    copyto!(ynew, yprev)
+    for j in 1:s
+        iszero(tab.B[1, j]) && continue
+        @.. ynew = ynew + dt * tab.B[1, j] * ks[j]
+    end
+    @.. εnew = εprev + εloc
+
+    if tab.solution_stage == 0
+        f(integrator.fsallast, u, p, t + dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    else
+        copyto!(integrator.fsallast.x[1], ks[tab.solution_stage])
+    end
+    εslope = integrator.fsallast.x[2]
+    @.. εslope = εloc / dt
+
+    if integrator.opts.adaptive
+        calculate_residuals!(
+            atmp, εloc, yprev, ynew, integrator.opts.abstol,
+            integrator.opts.reltol, integrator.opts.internalnorm, t
+        )
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+    return nothing
+end
+
+function initialize!(integrator, cache::GLEEConstantCache)
+    integrator.kshortsize = 2
+    integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
+    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.fsallast = zero(integrator.fsalfirst)
+    integrator.k[1] = integrator.fsalfirst
+    integrator.k[2] = integrator.fsallast
+    return nothing
+end
+
+@muladd function perform_step!(integrator, cache::GLEEConstantCache, repeat_step = false)
+    (; t, dt, uprev, u, f, p) = integrator
+    tab = cache.tab
+    inner = _glee_inner(f)
+    yprev = uprev.x[1]
+    εprev = uprev.x[2]
+    s = nstages(tab)
+
+    k1 = if tab.stage1_fsal
+        integrator.fsalfirst.x[1]
+    else
+        Y1 = tab.U[1, 1] * yprev + tab.U[1, 2] * εprev
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+        inner(Y1, p, t + tab.c[1] * dt)
+    end
+    ks = Vector{typeof(k1)}(undef, s)
+    ks[1] = k1
+    for i in 2:s
+        Y = tab.U[i, 1] * yprev + tab.U[i, 2] * εprev
+        for j in 1:(i - 1)
+            iszero(tab.A[i, j]) && continue
+            Y = Y + dt * tab.A[i, j] * ks[j]
+        end
+        ks[i] = inner(Y, p, t + tab.c[i] * dt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    end
+
+    ynew = yprev
+    εloc = zero(yprev)
+    for j in 1:s
+        ynew = ynew + dt * tab.B[1, j] * ks[j]
+        εloc = εloc + dt * tab.B[2, j] * ks[j]
+    end
+    εnew = εprev + εloc
+    integrator.u = RecursiveArrayTools.ArrayPartition(ynew, εnew)
+
+    fy = if tab.solution_stage == 0
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+        inner(ynew, p, t + dt)
+    else
+        ks[tab.solution_stage]
+    end
+    integrator.fsallast = RecursiveArrayTools.ArrayPartition(fy, εloc / dt)
+    integrator.k[1] = integrator.fsalfirst
+    integrator.k[2] = integrator.fsallast
+
+    if integrator.opts.adaptive
+        atmp = calculate_residuals(
+            εloc, yprev, ynew, integrator.opts.abstol,
+            integrator.opts.reltol, integrator.opts.internalnorm, t
+        )
+        OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
+    end
+    return nothing
+end

--- a/lib/GlobalDiffEq/src/glee/solve.jl
+++ b/lib/GlobalDiffEq/src/glee/solve.jl
@@ -1,0 +1,106 @@
+# The GLEE methods integrate a partitioned state (y, ε). Users pass a plain
+# ODEProblem; __solve extends it to ArrayPartition form with this RHS wrapper,
+# which applies the user's f to the solution partition. The ε partition has no
+# ODE of its own (the GL method updates it directly), so its rate is zero
+# wherever the wrapper is evaluated (initialization, dense output derivatives).
+struct GLEEExtendedRHS{iip, F}
+    f::F
+end
+
+function (rhs::GLEEExtendedRHS{true})(du, u, p, t)
+    rhs.f(du.x[1], u.x[1], p, t)
+    fill!(du.x[2], zero(eltype(du.x[2])))
+    return nothing
+end
+
+function (rhs::GLEEExtendedRHS{false})(u, p, t)
+    return RecursiveArrayTools.ArrayPartition(rhs.f(u.x[1], p, t), zero(u.x[1]))
+end
+
+function _glee_inner(f)
+    rhs = f isa SciMLBase.AbstractODEFunction ? f.f : f
+    rhs isa GLEEExtendedRHS || throw(
+        ArgumentError(
+            "GLEE methods integrate plain ODEProblems through their own " *
+                "partitioned-state extension; do not pass a manually partitioned problem"
+        )
+    )
+    return rhs.f
+end
+
+function _glee_extended_problem(prob)
+    prob.u0 isa RecursiveArrayTools.ArrayPartition && throw(
+        ArgumentError(
+            "GLEE methods construct their own partitioned (y, ε) state; " *
+                "pass the plain ODEProblem instead of an ArrayPartition state"
+        )
+    )
+    prob.u0 isa AbstractArray ||
+        throw(ArgumentError("GLEE methods require an array state"))
+    prob.f.mass_matrix == LinearAlgebra.I ||
+        throw(ArgumentError("GLEE methods require the standard mass matrix"))
+    iip = SciMLBase.isinplace(prob)
+    rhs = GLEEExtendedRHS{iip, typeof(prob.f)}(prob.f)
+    extended_f = SciMLBase.ODEFunction{iip, SciMLBase.FullSpecialize}(rhs)
+    u0 = RecursiveArrayTools.ArrayPartition(copy(prob.u0), zero(prob.u0))
+    return SciMLBase.remake(prob; f = extended_f, u0 = u0)
+end
+
+_is_glee_extended(prob) = prob.f.f isa GLEEExtendedRHS
+
+# init/solve on a plain ODEProblem transparently extend it to the partitioned
+# (y, ε) state; the invoke dispatches into OrdinaryDiffEqCore's generic __init
+# (its exact five-argument form, so the DiffEqBase default-algorithm catch-all
+# cannot be selected).
+function SciMLBase.__init(
+        prob::SciMLBase.AbstractODEProblem, alg::AbstractGLEEAlgorithm,
+        timeseries_init = (), ts_init = (), ks_init = ();
+        kwargs...
+    )
+    extended_prob = _is_glee_extended(prob) ? prob : _glee_extended_problem(prob)
+    return invoke(
+        SciMLBase.__init,
+        Tuple{
+            SciMLBase.AbstractODEProblem,
+            OrdinaryDiffEqCore.OrdinaryDiffEqAlgorithm,
+            Any, Any, Any,
+        },
+        extended_prob, alg, timeseries_init, ts_init, ks_init; kwargs...
+    )
+end
+
+function SciMLBase.__solve(
+        prob::SciMLBase.AbstractODEProblem, alg::AbstractGLEEAlgorithm, args...;
+        kwargs...
+    )
+    integrator = SciMLBase.__init(prob, alg, args...; kwargs...)
+    SciMLBase.solve!(integrator)
+    return integrator.sol
+end
+
+"""
+    global_error_estimate(sol)
+    global_error_estimate(sol, i)
+
+Extract the global error estimate from a solution computed with a GLEE method
+([`GLEE23`](@ref), [`GLEE24`](@ref), [`GLEE35`](@ref)).
+
+GLEE solutions carry the partitioned state `(y, ε)`: `sol.u[i].x[1]` is the
+solution value and `sol.u[i].x[2]` the estimate of its global error at
+`sol.t[i]`. `global_error_estimate(sol, i)` returns the error estimate at the
+`i`-th saved time point and `global_error_estimate(sol)` returns the vector of
+estimates at every saved time point.
+"""
+function global_error_estimate(sol::SciMLBase.AbstractODESolution)
+    return [global_error_estimate(sol, i) for i in eachindex(sol.u)]
+end
+
+function global_error_estimate(sol::SciMLBase.AbstractODESolution, i::Integer)
+    u = sol.u[i]
+    u isa RecursiveArrayTools.ArrayPartition && length(u.x) == 2 || throw(
+        ArgumentError(
+            "global_error_estimate expects a solution produced by a GLEE method"
+        )
+    )
+    return u.x[2]
+end

--- a/lib/GlobalDiffEq/src/glee/tableaus.jl
+++ b/lib/GlobalDiffEq/src/glee/tableaus.jl
@@ -1,0 +1,189 @@
+# GLEE (global-error-estimating general linear method) tableaus in the y-ε form
+# of Constantinescu (2016), doi:10.1137/15M1014633 (arXiv:1503.05166):
+#
+#   Y_i    = U[i,1] y⁽ⁿ⁻¹⁾ + U[i,2] ε⁽ⁿ⁻¹⁾ + Δt Σ_j A[i,j] f(Y_j)
+#   y⁽ⁿ⁾   = y⁽ⁿ⁻¹⁾ + Δt Σ_j B[1,j] f(Y_j)
+#   ε⁽ⁿ⁾   = ε⁽ⁿ⁻¹⁾ + Δt Σ_j B[2,j] f(Y_j)
+#
+# ε⁽ⁿ⁾ is an asymptotically correct estimate of the global error at t_n, and the
+# per-step increment ε⁽ⁿ⁾ − ε⁽ⁿ⁻¹⁾ is an asymptotically correct local error
+# estimate for the order-p solution y⁽ⁿ⁾.
+struct GLEETableau{MType, M2Type, BType, cType, T}
+    A::MType
+    U::M2Type
+    B::BType
+    c::cType
+    γ::T
+    order::Int
+    # Stage 1 equals the propagated solution register (U row [1, 0], zero A row),
+    # so its f evaluation can reuse fsalfirst.
+    stage1_fsal::Bool
+    # Index of a stage that equals the step's end solution y⁽ⁿ⁾ (FSAL-style), so
+    # its f evaluation doubles as fsallast; 0 when no such stage exists.
+    solution_stage::Int
+end
+
+nstages(tab::GLEETableau) = length(tab.c)
+
+function _detect_solution_stage(A, U, B, c)
+    for i in 2:length(c)
+        isone(U[i, 1]) && iszero(U[i, 2]) || continue
+        isone(c[i]) || continue
+        all(j -> A[i, j] == B[1, j], 1:(i - 1)) || continue
+        all(iszero, @view B[1, i:end]) || continue
+        return i
+    end
+    return 0
+end
+
+# Convert a tableau from the paper's y-ỹ form to the y-ε form via Lemma 4.1 with
+# T = [1 0; 1 1-γ]: U_yε[:,1] = U_yỹ*1, U_yε[:,2] = (1-γ) U_yỹ[:,2],
+# B_yε = T⁻¹ B_yỹ.
+function _yytilde_to_yeps(U::AbstractMatrix, B::AbstractMatrix, γ)
+    Uyε = hcat(U[:, 1] .+ U[:, 2], (1 - γ) .* U[:, 2])
+    Byε = vcat(B[1:1, :], (B[2:2, :] .- B[1:1, :]) ./ (1 - γ))
+    return Uyε, Byε
+end
+
+function _glee_tableau(::Type{T}, ::Type{T2}, A, U, B, γ, order) where {T, T2}
+    c_exact = vec(sum(A, dims = 2))
+    stage1_fsal = all(iszero, A[1, :]) && isone(U[1, 1]) && iszero(U[1, 2])
+    solution_stage = _detect_solution_stage(A, U, B, c_exact)
+    return GLEETableau(
+        map(T, A), map(T, U), map(T, B), map(T2, c_exact), T(γ), order,
+        stage1_fsal, solution_stage
+    )
+end
+
+"""
+    GLEE23Tableau(T, T2)
+
+Tableau of the 3-stage, order-2 explicit GLEE method of Constantinescu (2016),
+eq. (4.6) (PETSc's `TSGLEE23`). `γ = 0`, `B·U` diagonal.
+"""
+function GLEE23Tableau(::Type{T}, ::Type{T2}) where {T, T2}
+    A = [
+        0 0 0
+        1 0 0
+        1 // 4 1 // 4 0
+    ]
+    U = [
+        1 0
+        1 10
+        1 -1
+    ]
+    B = [
+        1 // 12 1 // 12 5 // 6
+        1 // 12 1 // 12 -1 // 6
+    ]
+    return _glee_tableau(T, T2, A, U, B, 0, 2)
+end
+
+"""
+    GLEE24Tableau(T, T2)
+
+Tableau of the 4-stage, order-2 explicit GLEE method of Constantinescu (2016),
+eq. (A.3) (PETSc's `TSGLEE24`). `γ = 0`; both decoupling conditions (`B·U` and
+`B·A·U` diagonal) hold, making it the robust second-order choice for long-time
+integration.
+"""
+function GLEE24Tableau(::Type{T}, ::Type{T2}) where {T, T2}
+    A = [
+        0 0 0 0
+        3 // 4 0 0 0
+        1 // 4 29 // 60 0 0
+        -21 // 44 145 // 44 -20 // 11 0
+    ]
+    # y-ỹ form as printed in the paper
+    U = [
+        0 1
+        75 // 58 -17 // 58
+        0 1
+        0 1
+    ]
+    B = [
+        109 // 275 58 // 75 -37 // 110 1 // 6
+        3 // 11 0 75 // 88 -1 // 8
+    ]
+    Uyε, Byε = _yytilde_to_yeps(U, B, 0 // 1)
+    return _glee_tableau(T, T2, A, Uyε, Byε, 0, 2)
+end
+
+"""
+    GLEE35Tableau(T, T2)
+
+Tableau of the 5-stage, order-3 explicit GLEE method of Constantinescu (2016),
+eq. (4.9) (PETSc's `TSGLEE35`). `γ = 0`; both decoupling conditions hold. The
+coefficients are exact rationals whose numerators exceed `Int64`, so the
+tableau is constructed with `BigInt` rationals before conversion.
+"""
+function GLEE35Tableau(::Type{T}, ::Type{T2}) where {T, T2}
+    R(num, den) = big(num) // big(den)
+    Z = R(0, 1)
+    A = [
+        Z Z Z Z Z;
+        R(-2169604947363702313, 24313474998937147335) Z Z Z Z;
+        R(46526746497697123895, 94116917485856474137) R(-10297879244026594958, 49199457603717988219) Z Z Z;
+        R(23364788935845982499, 87425311444725389446) R(-79205144337496116638, 148994349441340815519) R(40051189859317443782, 36487615018004984309) Z Z;
+        R(42089522664062539205, 124911313006412840286) R(-15074384760342762939, 137927286865289746282) R(-62274678522253371016, 125918573676298591413) R(13755475729852471739, 79257927066651693390) Z
+    ]
+    # y-ỹ form as printed in the paper
+    U = [
+        R(70820309139834661559, 80863923579509469826) R(10043614439674808267, 80863923579509469826);
+        R(161694774978034105510, 106187653640211060371) R(-55507121337823045139, 106187653640211060371);
+        R(78486094644566264568, 88171030896733822981) R(9684936252167558413, 88171030896733822981);
+        R(65394922146334854435, 84570853840405479554) R(19175931694070625119, 84570853840405479554);
+        R(8607282770183754108, 108658046436496925911) R(100050763666313171803, 108658046436496925911)
+    ]
+    B = [
+        R(61546696837458703723, 56982519523786160813) R(-55810892792806293355, 206957624151308356511) R(24061048952676379087, 158739347956038723465) R(3577972206874351339, 7599733370677197135) R(-59449832954780563947, 137360038685338563670);
+        R(-9738262186984159168, 99299082461487742983) R(-32797097931948613195, 61521565616362163366) R(42895514606418420631, 71714201188501437336) R(22608567633166065068, 55371917805607957003) R(94655809487476459565, 151517167160302729021)
+    ]
+    Uyε, Byε = _yytilde_to_yeps(U, B, Z)
+    return _glee_tableau(T, T2, A, Uyε, Byε, 0, 3)
+end
+
+"""
+    MM5GEETableau(T, T2)
+
+Tableau of the Makazaga-Murua global-error-estimating scheme built on the
+Dormand-Prince 5(4) method (Makazaga and Murua, BIT Numerical Mathematics 43,
+2003, Table 4.1), rewritten in the y-ε general linear form: stages 1-7 are the
+standard DOPRI5 stages (stage 7 the FSAL stage), stages 8-10 propagate the
+order-6 companion solution `ȳ = y + ε` through the mixing coefficients
+`U[i,2] = 1 - μ_i`, and the second output row is `b̄ - b`.
+"""
+function MM5GEETableau(::Type{T}, ::Type{T2}) where {T, T2}
+    R(num, den) = big(num) // big(den)
+    Z = R(0, 1)
+    b = [
+        R(35, 384), Z, R(500, 1113), R(125, 192), R(-2187, 6784), R(11, 84), Z,
+        Z, Z, Z,
+    ]
+    A = [
+        Z Z Z Z Z Z Z Z Z Z;
+        R(1, 5) Z Z Z Z Z Z Z Z Z;
+        R(3, 40) R(9, 40) Z Z Z Z Z Z Z Z;
+        R(44, 45) R(-56, 15) R(32, 9) Z Z Z Z Z Z Z;
+        R(19372, 6561) R(-25360, 2187) R(64448, 6561) R(-212, 729) Z Z Z Z Z Z;
+        R(9017, 3168) R(-355, 33) R(46732, 5247) R(49, 176) R(-5103, 18656) Z Z Z Z Z;
+        R(35, 384) Z R(500, 1113) R(125, 192) R(-2187, 6784) R(11, 84) Z Z Z Z;
+        R(26251126, 75292183) R(-30511879, 68834945) R(11490887, 155205387) R(700737845, 174891007) R(-5336, 941) R(5735, 1214) R(-2507, 898) Z Z Z;
+        R(-126276029, 115017392) R(153409379, 49308629) R(-107711621, 48274693) R(-675136779, 64711289) R(559269939, 36928210) R(-669687859, 52442748) R(193952703, 25738526) R(169021117, 130072535) Z Z;
+        R(89178409, 82486612) R(-275044175, 99029299) R(115406143, 68971088) R(140298385, 24130572) R(-344040692, 42025591) R(121333564, 17575013) R(-190380249, 47005513) R(-12078143, 165601005) R(56747365, 92317949) Z
+    ]
+    # U[:, 2] = 1 - μ_i: the weight of the companion register ȳ = y + ε in each
+    # stage; μ_i = 1 for the DOPRI5 stages 1-7.
+    one_minus_μ = [
+        Z, Z, Z, Z, Z, Z, Z,
+        R(140719960, 143529893), R(941, 896), R(92493035, 95359057),
+    ]
+    U = hcat(fill(R(1, 1), 10), one_minus_μ)
+    b̄ = [
+        R(56696811, 789712427), Z, R(-47431484, 279691831), R(72791025, 357831874),
+        R(17490085, 349505178), R(-66245097, 563676842), R(-24, 611),
+        R(40757463, 82884629), R(33159666, 111811519), R(42422453, 199331202),
+    ]
+    B = permutedims(hcat(b, b̄ .- b))
+    return _glee_tableau(T, T2, A, U, B, 0, 5)
+end

--- a/lib/GlobalDiffEq/test/glee_tests.jl
+++ b/lib/GlobalDiffEq/test/glee_tests.jl
@@ -1,0 +1,111 @@
+using GlobalDiffEq, OrdinaryDiffEqTsit5, LinearAlgebra
+using RecursiveArrayTools: ArrayPartition
+using Test
+import SciMLBase
+
+# Unstable Prince42 problem: y' = y - sin(t) + cos(t), y(0) = 0, exact y = sin(t).
+# Perturbations grow like e^t, making it the classic global-error-estimation test.
+f_prince!(du, u, p, t) = (du[1] = u[1] - sin(t) + cos(t); nothing)
+f_prince(u, p, t) = [u[1] - sin(t) + cos(t)]
+const prince_tspan = (0.0, 2.0)
+prince_exact(t) = sin(t)
+
+function glee_convergence(prob, alg, dts)
+    errs = Float64[]
+    est_errs = Float64[]
+    for dt in dts
+        sol = solve(prob, alg; dt = dt, adaptive = false)
+        err = prince_exact(prince_tspan[2]) - sol.u[end].x[1][1]
+        est = global_error_estimate(sol, length(sol.u))[1]
+        push!(errs, abs(err))
+        push!(est_errs, abs(est - err))
+    end
+    sol_order = log2(errs[end - 1] / errs[end])
+    est_order = log2(est_errs[end - 1] / est_errs[end])
+    return sol_order, est_order
+end
+
+@testset "GLEE convergence and estimate accuracy" begin
+    dts = 2.0 .^ -(5:8)
+    for iip in (true, false)
+        prob = if iip
+            ODEProblem(f_prince!, [0.0], prince_tspan)
+        else
+            ODEProblem(f_prince, [0.0], prince_tspan)
+        end
+        for (alg, p) in (
+                (GLEE23(), 2), (GLEE24(), 2), (GLEE35(), 3),
+            )
+            sol_order, est_order = glee_convergence(prob, alg, dts)
+            @test sol_order ≈ p atol = 0.15
+            # ε is an asymptotically correct global error estimate: it converges
+            # to the true error one order faster than the solution converges
+            @test est_order ≈ p + 1 atol = 0.2
+        end
+        sol_order, est_order = glee_convergence(prob, MM5GEE(), 2.0 .^ -(2:5))
+        @test sol_order ≈ 5 atol = 0.35
+        @test est_order > 5.5
+    end
+end
+
+@testset "GLEE estimate tracks the true error" begin
+    prob = ODEProblem(f_prince!, [0.0], prince_tspan)
+    for alg in (GLEE23(), GLEE24(), GLEE35(), MM5GEE())
+        sol = solve(prob, alg; dt = 1 / 128, adaptive = false)
+        err = prince_exact(prince_tspan[2]) - sol.u[end].x[1][1]
+        est = global_error_estimate(sol)[end][1]
+        @test est / err ≈ 1 rtol = 0.1
+    end
+end
+
+@testset "GLEE adaptive stepping" begin
+    prob = ODEProblem(f_prince!, [0.0], prince_tspan)
+    for alg in (GLEE24(), MM5GEE())
+        sol = solve(prob, alg; abstol = 1.0e-8, reltol = 1.0e-8)
+        @test SciMLBase.successful_retcode(sol)
+        err = prince_exact(prince_tspan[2]) - sol.u[end].x[1][1]
+        est = global_error_estimate(sol)[end][1]
+        @test isfinite(est)
+        @test est / err ≈ 1 rtol = 0.6
+    end
+end
+
+@testset "GLEE integrator interface" begin
+    prob = ODEProblem(f_prince!, [0.0], prince_tspan)
+    integrator = init(prob, GLEE24(); dt = 1 / 64, adaptive = false)
+    @test integrator.u isa ArrayPartition
+    solve!(integrator)
+    sol = integrator.sol
+    @test SciMLBase.successful_retcode(sol)
+    err = prince_exact(prince_tspan[2]) - sol.u[end].x[1][1]
+    @test global_error_estimate(sol)[end][1] / err ≈ 1 rtol = 0.1
+end
+
+@testset "MM5GEE function evaluation count" begin
+    prob = ODEProblem(f_prince!, [0.0], prince_tspan)
+    sol = solve(prob, MM5GEE(); dt = 1 / 32, adaptive = false)
+    # 9 f-evals per step (FSAL first stage + solution stage reuse) plus the
+    # initialization evaluation
+    @test sol.stats.nf == 9 * (length(sol.t) - 1) + 1
+end
+
+@testset "GLEE argument validation" begin
+    prob = ODEProblem(f_prince!, [0.0], prince_tspan)
+    partitioned_prob = ODEProblem(
+        (du, u, p, t) -> nothing, ArrayPartition([0.0], [0.0]), prince_tspan
+    )
+    @test_throws ArgumentError solve(partitioned_prob, GLEE24(); dt = 0.1)
+
+    mm_prob = ODEProblem(
+        ODEFunction(f_prince!; mass_matrix = [2.0;;]), [0.0], prince_tspan
+    )
+    @test_throws ArgumentError solve(mm_prob, GLEE24(); dt = 0.1)
+
+    sol = solve(prob, Tsit5())
+    @test_throws ArgumentError global_error_estimate(sol, 1)
+
+    @test SciMLBase.alg_order(GLEE23()) == 2
+    @test SciMLBase.alg_order(GLEE24()) == 2
+    @test SciMLBase.alg_order(GLEE35()) == 3
+    @test SciMLBase.alg_order(MM5GEE()) == 5
+end

--- a/lib/GlobalDiffEq/test/runtests.jl
+++ b/lib/GlobalDiffEq/test/runtests.jl
@@ -3,13 +3,16 @@ using Test
 using SciMLTesting
 
 run_tests(;
-    env = "GROUP",
+    env = "ODEDIFFEQ_TEST_GROUP",
     core = function ()
         @safetestset "Basic functionality" begin
             include("basic_functionality_tests.jl")
         end
         @safetestset "Algorithm traits forwarding" begin
             include("algorithm_traits_tests.jl")
+        end
+        @safetestset "GLEE solvers" begin
+            include("glee_tests.jl")
         end
         return @safetestset "BigFloat support" begin
             include("bigfloat_tests.jl")


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

**Unstacked and independent**: this PR now applies directly to `master` and contains only the RK global-error-estimating solvers (no dependency on the other GlobalDiffEq PRs).

## Summary

Adds explicit general linear methods with built-in global error estimation to the `lib/GlobalDiffEq` sublibrary as proper `OrdinaryDiffEqCore` solver algorithms:

- **`GLEE23`, `GLEE24`, `GLEE35`** — Constantinescu, *Estimating Global Errors in Time Stepping*, SIAM J. Numer. Anal. 54(6), 2016 ([arXiv:1503.05166](https://arxiv.org/abs/1503.05166); PETSc's `TSGLEE23/24/35`). Addresses SciML/GlobalDiffEq.jl#6 and SciML/GlobalDiffEq.jl#22.
- **`MM5GEE`** — Makazaga & Murua, BIT 43 (2003), the DOPRI5-based order-5 scheme with cheap global error estimation. **Folded in from the former PR #3955 per review** ("just merge this into the other PR of the RK global error estimating methods").

The methods propagate the partitioned state `(y, ε)` where `ε` is an asymptotically correct estimate of the global error; `solve`/`init` on a plain `ODEProblem` transparently extend it to `ArrayPartition` state, and `global_error_estimate(sol)` extracts the estimate trajectory. The per-step `ε` increment is an asymptotically correct local error estimate that drives the standard step-size controllers. Tableaus transcribed from the papers (GLEE from the LaTeX source, cross-checked against PETSc `glee.c`; MM5GEE's Table 4.1 verified with exact rational arithmetic against the order + independency conditions). The paper's defective method A4 is deliberately not implemented.

> Note on the review direction: @ChrisRackauckas noted these "should be a solver library" and that global error should become a SciMLBase interface (a `has_global_error` trait, a `sol.global_error` array-of-arrays populated by splitting the `ArrayPartition` in `savevalues!`). That is planned as follow-up (see the thread on #3956); this PR lands the methods in the current sublibrary form and will be migrated onto that interface once it exists.

## Validation (run locally, current master)

- `ODEDIFFEQ_TEST_GROUP=Core`: **pass** — Basic 1/1, Algorithm traits 3/3, GLEE solvers 37/37 (incl. MM5GEE), BigFloat 2/2.
- `ODEDIFFEQ_TEST_GROUP=QA`: **pass** — 23 passed, 1 pre-existing declared broken (`no_implicit_imports` from the deliberate `@reexport`).
- Convergence on the unstable Prince42 problem, in-place and out-of-place: solution orders 2/2/3/5, estimate-accuracy orders 3/3/4/6, est/true-error ratio ≈ 1.0; MM5GEE at 9 f-evals/step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)