### PR TITLE
Fix NonlinearSolveAlg crashing/stalling with polyalgorithm inner solvers

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -51,7 +51,7 @@ DiffEqDevTools = {path = "../DiffEqDevTools"}
 SciMLTesting = "2.1"
 Pkg = "1"
 NonlinearSolve = "4.20.3"
-NonlinearSolveBase = "2.35"
+NonlinearSolveBase = "2.39"
 ForwardDiff = "1.3.3"
 Test = "<0.0.1, 1"
 FastBroadcast = "1.3"

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
@@ -20,7 +20,9 @@ using NonlinearSolve: FastShortcutNonlinearPolyalg, FastShortcutNLLSPolyalg, New
     HomotopySweep, HomotopyPolyAlgorithm, ArcLengthContinuation, step!
 # The operator Jacobian path is implemented in NonlinearSolveBase and needs its own floor.
 import NonlinearSolveBase
-using NonlinearSolveBase: get_linear_cache
+# `get_u`/`get_fu` are the only inner-state reads that hold for every inner cache type:
+# polyalgorithm caches keep `u`/`fu` on the active branch, not as top-level fields.
+using NonlinearSolveBase: get_linear_cache, get_u, get_fu
 using MuladdMacro: @muladd
 using FastBroadcast: @..
 import FastClosures: @closure

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -140,7 +140,7 @@ function initialize!(
         else
             nlp_params = (tmp, ustep, γ, α, tstep, k, invγdt, method, p, dt, f)
         end
-        if length(cache.cache.u) != length(z)
+        if length(get_u(cache.cache)) != length(z)
             new_prob = if cache.W !== nothing
                 # W-reuse: re-point the inner jacobian at the resized W via the same mapping
                 # used at build time. Only array sizes change, so the jac's concrete type —
@@ -229,7 +229,7 @@ function rescale_stale_W_rhs!(nlcache, nlsolver, integrator, nlstep_data)
     isdae = nlsolve_f(integrator) isa DAEFunction
     γdt = isdae ? nlsolver.α * cache.invγdt : nlsolver.γ * integrator.dt
     W_γdt ≈ γdt && return nothing
-    rmul!(nlcache.fu, 2 / (1 + γdt / W_γdt))
+    rmul!(get_fu(nlcache), 2 / (1 + γdt / W_γdt))
     return nothing
 end
 
@@ -252,11 +252,12 @@ end
         return convert(eltype(z), Inf)
     end
     step!(nlcache; recompute_jacobian)
-    nlsolver.ztmp = nlcache.u
+    active_u = get_u(nlcache)
+    nlsolver.ztmp = active_u
 
     ustep = compute_ustep(tmp, γ, z, method)
     atmp = calculate_residuals(
-        z .- nlcache.u, uprev, ustep, opts.abstol, opts.reltol,
+        z .- active_u, uprev, ustep, opts.abstol, opts.reltol,
         opts.internalnorm, t
     )
     ndz = opts.internalnorm(atmp, t)
@@ -289,15 +290,18 @@ end
     step!(nlcache; recompute_jacobian)
 
     if nlstep_data !== nothing
+        active_fu = get_fu(nlcache)
+        # No `trace` is attached: this solution only feeds `nlprobmap` right below, and
+        # polyalgorithm caches keep the trace on the active branch with no accessor for it.
         nlstepsol = SciMLBase.build_solution(
-            nlcache.prob, nlcache.alg, nlcache.u, nlcache.fu;
-            nlcache.retcode, nlcache.stats, nlcache.trace
+            nlcache.prob, nlcache.alg, get_u(nlcache), active_fu;
+            nlcache.retcode, nlcache.stats
         )
         nlstep_data.nlprobmap(ztmp, nlstepsol)
         ustep = compute_ustep!(ustep, tmp, γ, z, method)
         atmp_sub = @view(atmp[nlstep_data.u0perm])
         calculate_residuals!(
-            atmp_sub, nlcache.fu,
+            atmp_sub, active_fu,
             @view(uprev[nlstep_data.u0perm]),
             @view(ustep[nlstep_data.u0perm]), opts.abstol,
             opts.reltol, opts.internalnorm, t
@@ -309,7 +313,8 @@ end
         # convergence check to declare success ~sqrt(n_full/n_sub) early.
         ndz = opts.internalnorm(atmp_sub, t)
     else
-        @.. broadcast = false ztmp = nlcache.u
+        active_u = get_u(nlcache)
+        @.. broadcast = false ztmp = active_u
         ustep = compute_ustep!(ustep, tmp, γ, z, method)
         @.. broadcast = false atmp = z - ztmp
         calculate_residuals!(

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_polyalg_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_polyalg_tests.jl
@@ -1,0 +1,43 @@
+using OrdinaryDiffEqBDF, OrdinaryDiffEqSDIRK
+using OrdinaryDiffEqNonlinearSolve
+using OrdinaryDiffEqNonlinearSolve: NonlinearSolveAlg
+using NonlinearSolve: RobustMultiNewton, NewtonRaphson
+using ADTypes, LinearAlgebra, SciMLBase
+using Test
+
+# Regression test for #3859: a NonlinearSolve polyalgorithm (e.g. RobustMultiNewton)
+# used as the NonlinearSolveAlg inner solver used to crash in `initialize!` with
+# `type NonlinearSolvePolyAlgorithmCache has no field u`, because a polyalg cache keeps
+# `u`/`fu` on its active branch rather than at top level; newton.jl now reads them
+# through `NonlinearSolveBase.get_u`/`get_fu`. A second bug lived upstream: the polyalg
+# cache's `reinit!` did not clear `force_stop`/`retcode`, so once any branch converged,
+# every later `step!` short-circuited on `not_terminated`, silently reusing a stale `u`
+# and diverging (fixed in NonlinearSolveBase 2.39). This test exercises both: it would
+# throw without the accessors and return wrong values without the `reinit!` reset.
+
+const A = [-1000.0 1.0; 1.0 -2.0]
+function lin!(du, u, p, t)
+    mul!(du, A, u)
+    return nothing
+end
+prob = ODEProblem(lin!, [1.0, 1.0], (0.0, 0.5))
+uexact = exp(A * 0.5) * prob.u0
+
+poly = NonlinearSolveAlg(RobustMultiNewton(; autodiff = AutoForwardDiff()))
+single = NonlinearSolveAlg(NewtonRaphson(; autodiff = AutoForwardDiff()))
+
+# Each run is checked against the analytic solution rather than the polyalg run against
+# the NewtonRaphson one: the outer iteration takes exactly one inner `step!` per
+# iteration, and RobustMultiNewton's active trust-region branch damps that step, so the
+# two inner solvers legitimately produce different step sequences (and step counts).
+# The stale-iterate bug produced O(1) errors, far above this bound.
+@testset "polyalg inner solver solves as accurately as single-algorithm" begin
+    for ODEAlg in (TRBDF2, FBDF)
+        ref = solve(prob, ODEAlg(nlsolve = single); reltol = 1.0e-8, abstol = 1.0e-10)
+        sol = solve(prob, ODEAlg(nlsolve = poly); reltol = 1.0e-8, abstol = 1.0e-10)
+        @test SciMLBase.successful_retcode(ref)
+        @test SciMLBase.successful_retcode(sol)
+        @test norm(ref.u[end] .- uexact) / norm(uexact) < 1.0e-4
+        @test norm(sol.u[end] .- uexact) / norm(uexact) < 1.0e-4
+    end
+end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/qa/qa.jl
@@ -40,7 +40,7 @@ run_qa(
                 # Base — owner-internal, no public alternative
                 :RefValue,
                 # NonlinearSolveBase — owner-internal, no public alternative
-                :not_terminated,
+                :not_terminated, :get_u, :get_fu,
                 # OrdinaryDiffEqDifferentiation — owner-internal, no public alternative
                 :default_krylov_warm_start,
                 # `@SciMLMessage` reached through OrdinaryDiffEqCore (owner SciMLLogging).

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
@@ -42,6 +42,7 @@ if TEST_GROUP ∉ ("QA", "ModelingToolkit")
     @time @safetestset "NonlinearSolveAlg Matrix-Free WOperator Tests" include("nsa_matrixfree_tests.jl")
     @time @safetestset "NonlinearSolveAlg Smoothed Error Estimate Tests" include("nsa_smooth_est_tests.jl")
     @time @safetestset "NonlinearSolveAlg Stats Tests" include("nsa_stats_tests.jl")
+    @time @safetestset "NonlinearSolveAlg Polyalgorithm Inner Solver Tests" include("nsa_polyalg_tests.jl")
 end
 
 # Run QA tests (JET, Aqua)


### PR DESCRIPTION
Fixes the `FieldError` crash in #3859.

`NonlinearSolvePolyAlgorithmCache` (RobustMultiNewton, FastShortcutNonlinearPolyalg) keeps `u`/`fu` on its active subcache, not at top level, so every raw `cache.cache.u`-style read in newton.jl threw `FieldError` the moment a polyalgorithm was used as the `NonlinearSolveAlg` inner solver. Its `reinit!` also left `force_stop`/`retcode` set after a branch converged once, so a `step!`-driven loop silently no-oped forever after and reused a stale iterate.

Per review, both problems are fixed at the interface level in NonlinearSolve.jl#1115 (polyalg `get_u`/`get_fu` accessors plus the `force_stop`/`retcode` reset in `reinit!`), merged and released as NonlinearSolveBase 2.39.0. This PR is just the consumer side: every polyalg-unsafe inner-cache read in newton.jl — the resize length check, the stale-`W` rhs rescale from #4028, both `compute_step!` paths, and the nlstep `build_solution` — goes through `NonlinearSolveBase.get_u`/`get_fu`. No local workaround remains. Top-level fields the polyalg cache genuinely has (`retcode`, `stats`, `prob`, `alg`) are read as before, and `not_terminated` only touches `force_stop`/`nsteps`/`maxiters`, which are also top-level. The nlstep `build_solution` no longer attaches the inner trace (no polyalg accessor exists; the transient solution only feeds `nlprobmap`). The compat floor is raised to `"2.39"`, and `get_u`/`get_fu` are added to the QA non-public-import allowlist alongside `not_terminated`.

Regression test `nsa_polyalg_tests.jl` runs TRBDF2 and FBDF with a `RobustMultiNewton` inner solver and checks both against the analytic solution of a stiff linear system to 1e-4, plus retcodes. Against the registered NonlinearSolveBase (pinned to the 2.39.0 floor): 8/8 new, and unchanged elsewhere — newton_tests 6/6, nsa_jacobian_reuse 17/17, nsa_matrixfree 14/14, nsa_smooth_est 10/10, nsa_sparse 10/10, nsa_stats 24/24, QA 16/16, all identical to master.

The #3859 MWE (Robertson, `TRBDF2(nlsolve = NonlinearSolveAlg(RobustMultiNewton(autodiff = AutoForwardDiff())))`, `reltol=1e-6`, `abstol=1e-9`) throws `FieldError` on master and returns `Success` here, with `u(1e5) = [0.0178650, 7.2744e-8, 0.9821349]` against a default-`FBDF` reference of `[0.0178659, 7.2748e-8, 0.9821340]` (5e-5 relative). The active branch is TrustRegion, and the run is step-for-step identical to `NonlinearSolveAlg(TrustRegion())`.

Scope: this fixes the crash, not every polyalgorithm. `FastShortcutNonlinearPolyalg` no longer throws, but its leading branches are Jacobian-free quasi-Newton methods, which do not produce a usable stage step under the one-`step!`-per-outer-iteration driving mode; the integrator reports `Unstable`/`MaxIters` rather than a wrong answer. Polyalgorithms combined with a matrix-free `W` (`linsolve = KrylovJL_GMRES()`) are still refused at `init` by NonlinearSolveBase, identically on master, because `_nlalg_with_linsolve` cannot push a linsolve into a polyalgorithm; the related SciML/NonlinearSolve.jl#1132 is still open. Both are better addressed by the #3817 redesign (drive inner solvers by `solve!` per stage) than by more glue here.

## AI Disclosure

Claude assisted with this work.
