### PR TITLE
Recompute non-lazy interpolation stages after a callback-truncated step

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
@@ -67,11 +67,11 @@ function SciMLBase.reeval_internals_due_to_modification!(
     if continuous_modification && integrator.opts.calck
         resize!(integrator.k, integrator.kshortsize) # Reset k for next step!
         alg = unwrap_alg(integrator, false)
-        if SciMLBase.has_lazy_interpolation(alg)
-            ode_addsteps!(integrator, integrator.f, true, false, !_unwrap_val(alg.lazy))
-        else
-            ode_addsteps!(integrator, integrator.f, true, false)
-        end
+        # A non-lazy interpolant keeps its extra stages inside kshortsize, so the
+        # resize! above cannot drop them and they stay stale for the shortened dt.
+        # Force them to be recomputed; lazy interpolants build them on demand.
+        force_calc_end = !SciMLBase.has_lazy_interpolation(alg)
+        ode_addsteps!(integrator, integrator.f, true, false, force_calc_end)
     end
 
     integrator.derivative_discontinuity = false

--- a/lib/OrdinaryDiffEqLowOrderRK/test/bs5_truncated_step_interpolation.jl
+++ b/lib/OrdinaryDiffEqLowOrderRK/test/bs5_truncated_step_interpolation.jl
@@ -1,0 +1,23 @@
+using OrdinaryDiffEqLowOrderRK, DiffEqBase, Test
+
+# The extra interpolation stages of the non-lazy BS5 interpolant live inside
+# kshortsize, so a step shortened by a ContinuousCallback must explicitly force
+# them to be recomputed rather than reuse the ones built for the original dt.
+
+exp_prob = ODEProblem((du, u, p, t) -> (du[1] = u[1]; nothing), [1.0], (0.0, 5.0))
+root_cb = ContinuousCallback((u, t, integ) -> u[1] - 50.0, integ -> nothing)
+
+function worst_interior_error(sol, lo, hi)
+    return maximum(
+        abs(sol(t)[1] - exp(t)) / exp(t)
+            for t in range(lo, hi, length = 21)[2:(end - 1)]
+    )
+end
+
+for alg in (BS5(lazy = false), BS5())
+    sol = solve(
+        exp_prob, alg; abstol = 1.0e-10, reltol = 1.0e-10, callback = root_cb
+    )
+    i = findfirst(≈(log(50.0)), sol.t)
+    @test worst_interior_error(sol, sol.t[i - 1], sol.t[i]) < 1.0e-8
+end

--- a/lib/OrdinaryDiffEqLowOrderRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqLowOrderRK/test/runtests.jl
@@ -12,6 +12,7 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "Low Order ERK Convergence Tests" include("low_order_erk_convergence_tests.jl")
     @time @safetestset "OwrenZen Tests" include("owrenzen_tests.jl")
     @time @safetestset "Euler SSP Tests" include("euler_ssp.jl")
+    @time @safetestset "BS5 Truncated Step Interpolation" include("bs5_truncated_step_interpolation.jl")
 end
 
 # Run QA tests (AllocCheck, JET, Aqua)

--- a/lib/OrdinaryDiffEqVerner/test/ode_verner_tests.jl
+++ b/lib/OrdinaryDiffEqVerner/test/ode_verner_tests.jl
@@ -182,3 +182,31 @@ solve(
 
 @test length(interp_lazy) == length(interp_nolazy)
 @test maximum(abs.(interp_lazy .- interp_nolazy)) < 1.0e-10
+
+### Interpolation inside a step truncated by a ContinuousCallback
+# The extra interpolation stages of the non-lazy interpolants live inside
+# kshortsize, so a shortened step must explicitly force them to be recomputed
+# rather than reuse the ones built for the original dt.
+println("Interpolation in a callback-truncated step")
+
+exp_prob = ODEProblem((du, u, p, t) -> (du[1] = u[1]; nothing), [1.0], (0.0, 5.0))
+root_cb = ContinuousCallback((u, t, integ) -> u[1] - 50.0, integ -> nothing)
+
+function worst_interior_error(sol, lo, hi)
+    return maximum(
+        abs(sol(t)[1] - exp(t)) / exp(t)
+            for t in range(lo, hi, length = 21)[2:(end - 1)]
+    )
+end
+
+for alg in (
+        Vern6(lazy = false), Vern7(lazy = false),
+        Vern8(lazy = false), Vern9(lazy = false),
+        Vern6(), Vern7(), Vern8(), Vern9(),
+    )
+    sol = solve(
+        exp_prob, alg; abstol = 1.0e-10, reltol = 1.0e-10, callback = root_cb
+    )
+    i = findfirst(≈(log(50.0)), sol.t)
+    @test worst_interior_error(sol, sol.t[i - 1], sol.t[i]) < 1.0e-8
+end


### PR DESCRIPTION
Fixes #3963.

**Please ignore until reviewed by @ChrisRackauckas.**

## Root cause

`reeval_internals_due_to_modification!` rebuilds the interpolation stages after a `ContinuousCallback` truncates a step. The `force_calc_end` argument it passed to `ode_addsteps!` **could never be `true`**:

```julia
if SciMLBase.has_lazy_interpolation(alg)
    ode_addsteps!(integrator, integrator.f, true, false, !_unwrap_val(alg.lazy))
else
    ode_addsteps!(integrator, integrator.f, true, false)
end
```

`has_lazy_interpolation(alg)` is *defined as* `_unwrap_val(alg.lazy)` (`OrdinaryDiffEqVerner/src/alg_utils.jl:18`), so inside the true branch `!_unwrap_val(alg.lazy)` is always `false`, and the else branch takes the `false` default. Dead logic on both paths.

Why that only breaks `lazy=false`:

- **`lazy=true`** — `kshortsize` *excludes* the extra stages (13 for Vern8), so the preceding `resize!` drops them and lazy interpolation rebuilds them against the new `dt`. Correct.
- **`lazy=false`** — `kshortsize` *includes* them (21 for Vern8), so `resize!` is a no-op and stages 14–21 survive holding values computed for the **original, longer `dt`**. `_ode_addsteps!` then skips them, because its guard `(allow_calc_end && length(k) < 21) || force_calc_end` is false on every term.

Step endpoints stay correct since they derive from stages 1–13 — only the interior interpolant of the truncated step is wrong, exactly as reported.

## Scope beyond the issue

`BS5(lazy=false)` has the identical defect (`kshortsize` 11 vs 8, guard at `low_order_rk_addsteps.jl:175`). Not mentioned in the issue; verified below.

## Verification

MRE from the issue, before → after:

| algorithm | truncated (before) | truncated (after) | prev. clean |
|---|---|---|---|
| `Vern8()` lazy | 4.94e-11 | 4.94e-11 | 6.52e-11 |
| `Vern8(lazy=false)` | **1.64e-02** | **4.94e-11** | 6.52e-11 |
| `Vern9(lazy=false)` | **4.44e-03** | **1.56e-13** | 2.04e-13 |
| `Vern7(lazy=false)` | **7.24e-04** | **6.10e-13** | 6.18e-13 |
| `Vern6(lazy=false)` | **5.44e-04** | **2.43e-12** | 2.81e-12 |
| `Tsit5()` | 6.63e-12 | 6.63e-12 | 1.18e-11 |

`Vern8(lazy=false)` now reads 4.94e-11, **identical to `Vern8()` lazy** — that equality is what the bug was breaking. The `prev. clean` column is unchanged and the lazy/`Tsit5` rows are bit-identical, so untruncated steps and non-Verner algorithms are unaffected.

Negative controls (tests run against the unfixed tree, to confirm they actually catch the bug):

```
Verner suite, no fix:   35 pass, 4 fail  <- exactly the four lazy=false variants
Verner suite, with fix: 39 pass
BS5 test,     no fix:   FAILS, 9.25e-5
BS5 test,     with fix: 2/2 pass
LowOrderRK suite:       70 pass
```

The Verner failures partition exactly along the `lazy` boundary the analysis predicts, and the other 35 tests pass on the unfixed base — so there are no pre-existing failures on this commit.

## Caveats

- Verified locally on Julia 1.12.6: `ODEDIFFEQ_TEST_GROUP=Core` for OrdinaryDiffEqVerner and OrdinaryDiffEqLowOrderRK only. Not the full monorepo suite, not QA.
- The change makes `force_calc_end` `true` for *every* non-lazy algorithm, not just Verner/BS5. Only those two families have a `force_calc_end` branch in `_ode_addsteps!` at all, and all methods share the 5-arg signature via the generic `ode_addsteps!` (`generic_dense.jl:109`), so it should be inert elsewhere — but that part rests on inspection rather than execution, and is what CI should confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sc5xC1E4H646cPhLSccGCP
