### PR TITLE
Constrain TaylorSeries test OrderedCollections compat

### DIFF
--- a/lib/OrdinaryDiffEqTaylorSeries/Project.toml
+++ b/lib/OrdinaryDiffEqTaylorSeries/Project.toml
@@ -23,6 +23,8 @@ TruncatedStacktraces = "781d530d-4396-4725-bb49-402e4bee1e77"
 [extras]
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
+# DiffEqDevTools brings Latexify; releases compatible with Symbolics 7 require OrderedCollections 1.
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
@@ -43,6 +45,7 @@ LinearAlgebra = "1.10"
 MuladdMacro = "0.2.1"
 ODEProblemLibrary = "1"
 OrdinaryDiffEqCore = "4"
+OrderedCollections = "1"
 Pkg = "1"
 PrecompileTools = "1.2.1, 1.3"
 Preferences = "1.5.0"
@@ -62,4 +65,4 @@ julia = "1.10"
 path = "../OrdinaryDiffEqCore"
 
 [targets]
-test = ["DiffEqDevTools", "Random", "SafeTestsets", "Test", "ODEProblemLibrary", "Pkg", "SciMLTesting"]
+test = ["DiffEqDevTools", "Random", "SafeTestsets", "Test", "ODEProblemLibrary", "OrderedCollections", "Pkg", "SciMLTesting"]


### PR DESCRIPTION
**Ignore this PR until reviewed by @ChrisRackauckas.**

## Summary

Constrain the TaylorSeries test target to `OrderedCollections = "1"`.

This is test-only: production dependencies and public API behavior are unchanged.

## Root cause

The exact sublibrary downgrade graph selects Symbolics 7.6.0 and
DataStructures 0.19.6. DataStructures 0.19.6 widened its
OrderedCollections compatibility to include 2.x, so the downgrade resolver
selects OrderedCollections 2.0.1. The test-only DiffEqDevTools dependency
brings Latexify 0.16.11, whose released compatibility remains
`OrderedCollections = "1"`; the resulting graph is unsatisfiable.

The direct test constraint keeps DataStructures 0.19.6 while selecting
OrderedCollections 1.1.0, encoding the actual Latexify requirement without
capping an otherwise compatible transitive dependency.

## Verification

- Clean `master`, exact deployed downgrade action, Julia 1.11.9: reproduced
  the Latexify/OrderedCollections resolver failure.
- This branch, exact deployed downgrade action, Julia 1.11.9: resolved
  Symbolics 7.6.0, DataStructures 0.19.6, Latexify 0.16.11, and
  OrderedCollections 1.1.0.
- Locked exact-floor Core test with `allow_reresolve=false`, Julia 1.11.9:
  **81 passed**.
- Current-resolution Core, Julia 1.12.6: **81 passed**.
- Current-resolution QA, Julia 1.12.6: allocation checks **1 passed / 2
  pre-existing broken**, JET **1 passed**, Aqua **15 passed**.
- Runic 1.7 check: **1000 passed**.
- `git diff --check`: passed.
