### PR TITLE
Precompile a mass matrix DAE in the OrdinaryDiffEqBDF workload

### DIFF
--- a/lib/OrdinaryDiffEqBDF/src/OrdinaryDiffEqBDF.jl
+++ b/lib/OrdinaryDiffEqBDF/src/OrdinaryDiffEqBDF.jl
@@ -37,7 +37,7 @@ using TruncatedStacktraces: @truncate_stacktrace
 using MuladdMacro: @muladd
 using FastBroadcast: @..
 using RecursiveArrayTools: recursivefill!
-using LinearAlgebra: mul!, I
+using LinearAlgebra: mul!, I, Diagonal
 import ArrayInterface
 import OrdinaryDiffEqCore
 import OrdinaryDiffEqCore: default_controller
@@ -59,7 +59,7 @@ import ADTypes: AutoForwardDiff
 
 using Reexport: Reexport, @reexport
 import SciMLBase
-using SciMLBase: ODEProblem, derivative_discontinuity!, solve
+using SciMLBase: ODEProblem, ODEFunction, derivative_discontinuity!, solve
 @reexport using SciMLBase
 
 include("algorithms.jl")
@@ -77,6 +77,16 @@ include("stiff_addsteps.jl")
 
 import PrecompileTools
 import Preferences
+
+# Index-1 mass matrix DAE (Robertson). The pure-ODE problems in the workload below
+# never reach the algebraic variable detection or the DAE initialization solve, so
+# without this every mass matrix FBDF user pays that inference at first solve.
+function precompile_mm_dae(du, u, p, t)
+    du[1] = -0.04u[1] + 1.0e4 * u[2] * u[3]
+    du[2] = 0.04u[1] - 3.0e7 * u[2]^2 - 1.0e4 * u[2] * u[3]
+    return du[3] = u[1] + u[2] + u[3] - 1.0
+end
+
 PrecompileTools.@compile_workload begin
     lorenz = OrdinaryDiffEqCore.lorenz
     lorenz_oop = OrdinaryDiffEqCore.lorenz_oop
@@ -86,6 +96,14 @@ PrecompileTools.@compile_workload begin
     if Preferences.@load_preference("PrecompileDefaultSpecialize", true)
         push!(prob_list, ODEProblem(lorenz, [1.0; 0.0; 0.0], (0.0, 1.0)))
         push!(prob_list, ODEProblem(lorenz, [1.0; 0.0; 0.0], (0.0, 1.0), Float64[]))
+    end
+
+    if Preferences.@load_preference("PrecompileMassMatrixDAE", true)
+        mm_dae = ODEFunction(
+            precompile_mm_dae, mass_matrix = Diagonal([1.0, 1.0, 0.0])
+        )
+        push!(prob_list, ODEProblem(mm_dae, [1.0, 0.0, 0.0], (0.0, 1.0)))
+        push!(prob_list, ODEProblem(mm_dae, [1.0, 0.0, 0.0], (0.0, 1.0), Float64[]))
     end
 
     if Preferences.@load_preference("PrecompileAutoSpecialize", false)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Problem

`OrdinaryDiffEqBDF`'s `@compile_workload` only precompiles pure-ODE problems (`lorenz`). Nothing in it reaches the algebraic variable detection or the DAE initialization solve, so every mass matrix FBDF user pays that inference on their first solve — even though DAEs are one of the main reasons to reach for BDF.

This came out of a broader TTFX investigation into stiff ODE solves. The interesting part of that investigation was a negative result: `using OrdinaryDiffEq` invalidates ~3300 MethodInstances, but the FBDF solve path's pkgimage survives them intact (`staleinstances` = 0 on the ODE path). First-solve cost is almost entirely *precompile coverage misses*, not invalidation. This PR closes one such gap.

## Change

Adds an index-1 Robertson mass matrix problem to the workload, gated behind a new `PrecompileMassMatrixDAE` preference (default `true`) so it can be disabled alongside the existing specialization toggles.

## Measurements

Julia 1.12.6, first solve of a Robertson mass matrix DAE *distinct* from the one in the workload (so this measures genuine cache reuse, not an exact-signature hit):

| | first solve |
|---|---|
| before | 4.21s, 3.94s |
| after | 0.32s, 0.34s, 0.34s |

Cost: `OrdinaryDiffEqBDF` precompile time goes from ~12s to ~17.5s.

Non-DAE path is unaffected (lorenz FBDF first solve stays at 0.0016s).

Solution correctness cross-checked against `Rodas5P` at `abstol=reltol=1e-10`: max component difference 1.8e-10, algebraic constraint residual exactly 0.

## Tests

`ODEDIFFEQ_TEST_GROUP=Core` on this branch vs. clean master — identical results:

| testset | master | this branch |
|---|---|---|
| DAE Convergence | 26/26 | 26/26 |
| DAE AD | 16/16 | 16/16 |
| DAE Event | 4/4 | 4/4 |
| DAE derivative_discontinuity! | 5/5 | 5/5 |
| DAE Initialization | 35 pass, 2 broken | 35 pass, 2 broken |
| BDF Inference | **1 error** | **1 error** |

The `BDF Inference Tests` error is **pre-existing on master** (`248c2fd6f`), not introduced here — it reproduces on a clean checkout with this change stashed. It is an `@inferred` failure on `build_nlsolver` with `NonlinearSolveAlg(TrustRegion(...))` at `lib/OrdinaryDiffEqBDF/test/inference_tests.jl:19`, and is being investigated separately.

Runic-formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)