### PR TITLE
Fix ImplicitDiscreteSolve API docs QA

### DIFF
--- a/lib/ImplicitDiscreteSolve/test/qa/qa.jl
+++ b/lib/ImplicitDiscreteSolve/test/qa/qa.jl
@@ -18,4 +18,9 @@ run_qa(
             ),
         ),
     ),
+    api_docs_kwargs = (;
+        docs_src = joinpath(pkgdir(ImplicitDiscreteSolve), "..", "..", "docs", "src"),
+        # SciMLBase owns its reexported API; this monorepo's manual renders IDSolve.
+        rendered_ignore = names(SciMLBase),
+    ),
 )


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- Point ImplicitDiscreteSolve's public-API rendering check at the OrdinaryDiffEq monorepo manual, where `IDSolve` is documented.
- Exclude SciMLBase-owned reexports from ImplicitDiscreteSolve's local rendering obligation while retaining the docstring check for the full public API.

## Root cause

`git bisect` identified `12b6996e27` (`Update SciMLTesting QA docs coverage (#3867)`) as the first bad commit. That change moved the QA environment to SciMLTesting 2.x, whose `run_qa` checks rendered public API by default.

ImplicitDiscreteSolve has no package-local `docs/src`; its documentation lives in the monorepo's root `docs/src`. On Julia 1.10, the failed check therefore compared an empty documentation tree against 186 exported names: 185 SciMLBase reexports plus the package-owned `IDSolve`. The root manual already renders `IDSolve` in `docs/src/misc.md`.

The fix keeps the rendering assertion active for package-owned API. It only delegates SciMLBase reexports to their owner.

## Validation

- `ODEDIFFEQ_TEST_GROUP=QA julia +1.10 --project=lib/ImplicitDiscreteSolve -e 'using Pkg; Pkg.test()'`
  - JET: 1/1 passed
  - Aqua/QA: 17/17 passed
  - `Pkg.test()` exited successfully
- `julia +1.12 --project=<local Runic environment> -m Runic --check lib/ImplicitDiscreteSolve/test/qa/qa.jl` passed with Runic 1.7.0.
- `git diff --check` passed.

For the bisect's good side, `d7a66c0fe4` resolved SciMLTesting 1.8 and passed JET 1/1 plus Aqua 15/15. The first-bad commit reproduced the rendered-docs failure with 16 passes and 1 failure.

An additional Julia 1.12 run was blocked before this QA file loaded by a separate package-source resolution error for `OrdinaryDiffEqCore`'s relative `DiffEqBase` source. That baseline is being investigated separately.
