### PR TITLE
Preserve nonlinear verbosity when resizing caches

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.5.1"
+version = "2.5.2"
 
 [deps]
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## Summary

- preserve the configured nonlinear verbosity when resize-driven initialization rebuilds an inner NonlinearSolve cache
- add a regression test that resizes and steps an `ImplicitEuler` integrator configured with detailed nonlinear verbosity
- bump `OrdinaryDiffEqNonlinearSolve` from 2.3.0 to 2.3.1

## Root cause

The first inner NonlinearSolve cache is initialized with `integrator.opts.verbose.nonlinear_verbosity`. When an integrator resize changes the nonlinear problem size, `initialize!` rebuilt that cache without passing the verbosity setting, so NonlinearSolve fell back to its default.

Besides silently changing the requested logging behavior, the rebuilt cache can have a different concrete verbosity type from the cache field created during the original initialization. With `SciMLLogging.Detailed()`, the resize path then fails while assigning the rebuilt cache.

This patch passes the integrator's configured nonlinear verbosity through the rebuild, matching the original initialization path.

The source-introduction boundary is `32dec6cafeb4104bb69438f578a9043c4f7bd11f` (#3799), which introduced both `Base.resize!(::NonlinearSolveCache, ...)` and its keyword-less cache rebuild. Its parent, `4259e46ca875a7c9f297271aebbd5590ec648d46`, has no specialized resize method, so this is not a conventional passing-parent/first-failing behavioral bisect: the resize capability and omitted propagation entered together. Commit `030f9eb84` later moved the already-defective rebuild into `initialize!`; it did not introduce the omission.

## Validation

- Red/green regression on the pre-rebase source base: with the new test present and the source fix reverted, the official `GROUP=InterfaceIII` `Pkg.test()` run reported 141 passes and one error in `DEVerbosity Tests`, at the post-resize `step!`. Restoring the fix produced 142/142 passing DEVerbosity assertions; the full InterfaceIII group also passed (12/12 derivative utilities, 14/14 stats, 24/24 no-index, 5/5 events/DAE, and 52 passed plus four pre-existing broken unit tests).
- A sequential isolated-depot boundary probe used identical external versions (`LinearSolve 3.87.0`, `NonlinearSolve 4.21.0`, `NonlinearSolveBase 2.33.0`, `SciMLLogging 2.0.3`) and confirmed exact in-tree source paths. At `32dec6caf`, Detailed verbosity was present before resize and the rebuilt default-verbosity cache caused the expected typed-field conversion error. At its parent, the same probe stopped at the expected missing `resize!(::NonlinearSolveCache, ...)` method.
- On the rebased commit, the deterministic resize/verbosity regression passed.
- Under the exact constrained downgrade graph produced with [SciML/.github#118](https://github.com/SciML/.github/pull/118) (`NonlinearSolveBase 2.34.1`, `SciMLLogging 1.10.1`), all 11 focused sparse/resize assertions passed (3/3, 4/4, and 4/4).
- Full-repository Runic 1.7.0, `git diff --check`, and TOML parsing passed after the rebase.

## Scope and coordination

The natural downgrade graph on unmodified master independently selects `NonlinearSolveBase 2.33.0` and fails the existing sparse operator-Jacobian test in `safe_similar`. That compatibility-floor issue is addressed by #3917 and is intentionally not folded into this source fix.

This PR takes the `OrdinaryDiffEqNonlinearSolve` 2.3.1 patch version. #3917 and #3927 currently touch the same version line and will need to rebase and use the next available patch version.

## Process

The failure was reproduced against clean source, reduced to the resize rebuild, traced to its source-introduction boundary, verified red/green with a deterministic regression, checked against the exact reconciled downgrade graph, then rebased onto current `master` and revalidated before publication.
