### PR TITLE
Bump 4 OrdinaryDiffEq sublibraries for release

### DIFF
--- a/lib/OrdinaryDiffEqBDF/Project.toml
+++ b/lib/OrdinaryDiffEqBDF/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqBDF"
 uuid = "6ad6398a-0878-4a85-9266-38940aa047c8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.3.1"
+version = "2.3.2"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.7.1"
+version = "4.8.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqExtrapolation/Project.toml
+++ b/lib/OrdinaryDiffEqExtrapolation/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExtrapolation"
 uuid = "becaefa8-8ca2-5cf9-886d-c06f3d2bd2c4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.3.0"
+version = "2.3.1"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqRosenbrock/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrock/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqRosenbrock"
 uuid = "43230ef6-c299-4910-a778-202eb28ce4ce"
-version = "2.4.1"
+version = "2.4.2"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
Releases unreleased changes on master across four sublibraries:
- **OrdinaryDiffEqCore** 4.7.1 → 4.8.0 (minor: restores `isdiscretecache` public API (#3907); recompute non-lazy interpolation stages after a truncated step (#3964))
- **OrdinaryDiffEqBDF** 2.3.1 → 2.3.2 (precompile a mass matrix DAE in the workload (#3966))
- **OrdinaryDiffEqExtrapolation** 2.3.0 → 2.3.1 (drop stale BaseThreads/Sequential imports (#3945))
- **OrdinaryDiffEqRosenbrock** 2.4.1 → 2.4.2 (SIMD-fuse RosenbrockCache stage loops; docstring for public HybridExplicitImplicitRK (#3938))

Detected by comparing the `git-tree-sha1` of the latest live registered version in General against the `src` subtree on the default branch. Only the `version` field in `Project.toml` is changed. **No local test run** — CI on this PR is the check. Please ignore until reviewed by @ChrisRackauckas.