### PR TITLE
Fix ExplicitTaylor fsallast aliasing to state buffer

### DIFF
--- a/lib/OrdinaryDiffEqTaylorSeries/src/OrdinaryDiffEqTaylorSeries.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/src/OrdinaryDiffEqTaylorSeries.jl
@@ -8,7 +8,7 @@ import OrdinaryDiffEqCore: alg_stability_size, explicit_rk_docstring,
     _ode_interpolant, _ode_interpolant!,
     OrdinaryDiffEqAlgorithm,
     _ode_addsteps!,
-    get_fsalfirstlast,
+    get_fsalfirstlast, isfsal,
     DerivativeOrderNotPossibleError, unwrap_alg, step_accept_controller!,
     stepsize_controller!, get_current_adaptive_order, get_current_alg_order
 using FastBroadcast: Serial

--- a/lib/OrdinaryDiffEqTaylorSeries/src/TaylorSeries_caches.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/src/TaylorSeries_caches.jl
@@ -81,7 +81,7 @@ function alg_cache(
     )
 end
 
-get_fsalfirstlast(cache::ExplicitTaylorCache, u) = (cache.u, cache.u)
+get_fsalfirstlast(cache::ExplicitTaylorCache, u) = (nothing, nothing)
 
 struct ExplicitTaylorConstantCache{P, taylorType, uType, tType} <:
     OrdinaryDiffEqConstantCache
@@ -151,7 +151,7 @@ function alg_cache(
     )
 end
 
-get_fsalfirstlast(cache::ExplicitTaylorAdaptiveOrderCache, u) = (cache.u, cache.u)
+get_fsalfirstlast(cache::ExplicitTaylorAdaptiveOrderCache, u) = (nothing, nothing)
 
 struct ExplicitTaylorAdaptiveOrderConstantCache{P, Q, taylorType, uType, tType} <:
     OrdinaryDiffEqConstantCache

--- a/lib/OrdinaryDiffEqTaylorSeries/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/src/alg_utils.jl
@@ -6,6 +6,12 @@ alg_stability_size(alg::ExplicitTaylor2) = 1
 alg_order(::ExplicitTaylor{P}) where {P} = P
 alg_stability_size(alg::ExplicitTaylor) = 1
 
+# These build each step from the Taylor jet rather than reusing the previous step's
+# last derivative, so they are not FSAL. Without this they inherit the `true` default,
+# which makes `ode_determine_initdt` write an extra `f` evaluation into `fsallast`.
+isfsal(::ExplicitTaylor) = false
+isfsal(::ExplicitTaylorAdaptiveOrder) = false
+
 alg_order(alg::ExplicitTaylorAdaptiveOrder) = get_value(alg.min_order)
 get_current_adaptive_order(::ExplicitTaylorAdaptiveOrder, cache) = cache.current_order[]
 get_current_alg_order(::ExplicitTaylorAdaptiveOrder, cache) = cache.current_order[]

--- a/lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl
@@ -41,6 +41,43 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
         @test SciMLBase.successful_retcode(sol)
     end
 
+    # `get_fsalfirstlast` used to alias the FSAL buffer to `cache.u`, which is
+    # `integrator.u`. The auto-dt heuristic writes an extra `f` evaluation into
+    # `fsallast`, so the aliasing made that call `f(u, u, p, t)` and corrupted the
+    # state before the first step, for any RHS that reads `u` after writing `du`.
+    @testset "auto-dt must not write through the state buffer" begin
+        function f_alias!(du, u, p, t)
+            du[1] = 7.0
+            du[2] = 9.0
+            s = u[1] + u[2]
+            du[1] = -s
+            du[2] = s
+            return nothing
+        end
+        u0 = [1.0, 2.0]
+        for alg in (ExplicitTaylor(order = Val(4)), ExplicitTaylorAdaptiveOrder())
+            integ = init(
+                ODEProblem(f_alias!, copy(u0), (0.0, 1.0)), alg,
+                abstol = 1.0e-8, reltol = 1.0e-8
+            )
+            @test !OrdinaryDiffEqTaylorSeries.isfsal(alg)
+            @test integ.u == u0
+        end
+    end
+
+    # End-to-end: with the state corrupted, the auto-dt heuristic saw a NaN and
+    # collapsed `dt0` to `dtmin`, so the controller burned hundreds of steps
+    # climbing back out (905 before the fix, 587 after, at this tolerance).
+    @testset "Auto-dt on Pleiades does not collapse to dtmin" begin
+        sol = solve(
+            prob_ode_pleiades, ExplicitTaylor(order = Val(6)),
+            abstol = 1.0e-10, reltol = 1.0e-10
+        )
+        @test SciMLBase.successful_retcode(sol)
+        @test all(isfinite, sol.u[end])
+        @test length(sol.t) < 700
+    end
+
     # Test AutoSpecialize (default ODEProblem wraps in FunctionWrappers)
     # and FullSpecialize paths for IIP problems
     @testset "AutoSpecialize / FullSpecialize IIP" begin


### PR DESCRIPTION
## Summary

`ExplicitTaylor` and `ExplicitTaylorAdaptiveOrder` build each step from the Taylor jet and never reuse the previous step's last derivative, so they are not FSAL methods. Neither declared `isfsal`, though, so both inherited the `true` default.

That made `ode_determine_initdt` take its FSAL branch, which writes an extra `f` evaluation into `integrator.fsallast`. The mutable caches returned `(cache.u, cache.u)` from `get_fsalfirstlast`, and `cache.u === integrator.u`, so that call was literally `f(u, u, p, t)` — corrupting `u` mid-evaluation for any in-place RHS that reads from `u` after writing to `du`, which is a normal pattern.

Effects on master, before a single step is taken:

- With `u0 = [1.0, 2.0]` and an RHS that writes `du` then reads `u`, `integrator.u` comes back from `init` as `[-16.0, 16.0]`.
- The initial-step estimate sees a `NaN`, warns, and falls back to `tdir * dtmin`. On `prob_ode_pleiades` at `abstol = reltol = 1e-10` that is a first step of `1.0e-323`, and the controller spends hundreds of steps climbing out.

## Fix

Declare the two methods non-FSAL. The heuristic then takes its other branch and uses its own `zero(u0)`, so nothing writes through the state buffer and no cache-owned FSAL storage is needed at all — the caches return `(nothing, nothing)`, as `FunctionMapCache` already does.

Measured on `prob_ode_pleiades` with `ExplicitTaylor(order = Val(6))`:

| setting | before | after |
| --- | --- | --- |
| default tolerances | Success, 386 steps + NaN warning | Success, 59 steps |
| `abstol = reltol = 1e-10` | Success, 905 steps | Success, 587 steps |

Solutions agree to about six significant figures on this chaotic problem.

## Known follow-up, not fixed here

`ExplicitTaylorAdaptiveOrder` had the same problem. Before this fix its auto-dt collapsed to `dtmin` and the solve died loudly with `retcode = MaxIters` after 1,000,001 steps. Afterwards that failure is gone, but a separate pre-existing bug in its per-step order/error controller becomes visible: on Pleiades it returns `Success` after 3 steps with `sol.u[end]` bit-identical to `u0`. That is a silent wrong answer where there used to be a loud failure, filed as #3976 rather than fixed here, and worth weighing when reviewing.

## Tests

`auto-dt must not write through the state buffer` asserts both methods report `isfsal == false` and that `init` leaves `u` unmodified, using a two-line RHS that reads `u` after writing `du`. It fails four times on master and passes here, in about two seconds.

`Auto-dt on Pleiades does not collapse to dtmin` keeps an end-to-end check with a bound that discriminates (`length(sol.t) < 700`; master takes 905, this branch 587).

Existing `OrdinaryDiffEqTaylorSeries` Core group passes unchanged. Runic clean.

## AI Disclosure

Claude assisted with this work.
