### PR TITLE
Align root test dependency floors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -54,8 +54,10 @@ OrdinaryDiffEqSymplecticRK = {path = "lib/OrdinaryDiffEqSymplecticRK"}
 [compat]
 ADTypes = "1.22.0"
 CommonSolve = "0.2.6"
+DifferentiationInterface = "0.7.18"
 DocStringExtensions = "0.9.5"
 ForwardDiff = "1.3.3"
+NonlinearSolve = "4.20.3"
 OrdinaryDiffEqBDF = "2"
 OrdinaryDiffEqCore = "4, 5.0"
 OrdinaryDiffEqDefault = "2"


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- add the root test-extra floor `NonlinearSolve = "4.20.3"` to match `OrdinaryDiffEqNonlinearSolve`
- add the root test-extra floor `DifferentiationInterface = "0.7.18"` to match the source-tree Rosenbrock packages

The root project had no compat entries for either test extra. The downgrade resolver therefore selected `NonlinearSolve 4.20.2`, which became unsatisfiable after the monorepo packages were promoted as path dependencies because `OrdinaryDiffEqNonlinearSolve` requires `4.20.3` or newer. Adding that floor exposed the same masked problem for `DifferentiationInterface 0.7.12` versus the source-tree requirement of `0.7.18`.

These are test-environment constraints only; the package's runtime dependency surface and public API are unchanged. The existing downgrade workflow provides regression coverage by resolving the old-style test extras before promoting the source packages.

## Validation

- clean-base pinned downgrade reproduction: failed before tests with `NonlinearSolve 4.20.2` versus source requirement `4.20.3 - 4`
- one-floor diagnostic: selected `NonlinearSolve 4.20.3`, then failed before tests with `DifferentiationInterface 0.7.12` versus source requirement `0.7.18`
- final pinned downgrade graph, Julia 1.10.11, `GROUP=InterfaceI`, `allow_reresolve=false`: passed (455 pass, 7 pre-existing broken); selected `NonlinearSolve 4.20.3` and `DifferentiationInterface 0.7.18`
- promoted manifest stayed byte-identical through build and test: `a72d68117bd460d0ef97c50b4800215fa504625df82eb789a1237d6422b48f31`
- current graph, Julia 1.12.6, `GROUP=InterfaceI`, `Pkg.test()`: passed (497 pass, 7 pre-existing broken); selected `NonlinearSolve 4.21.1` and `DifferentiationInterface 0.7.20`
- Runic 1.7.0 full-tree check: passed
- `Project.toml` parse/floor assertions and `git diff --check`: passed
