### PR TITLE
Allow LinearSolve 5 across implicit solver packages

### DIFF
--- a/lib/DelayDiffEq/Project.toml
+++ b/lib/DelayDiffEq/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.0.7"
+version = "6.0.8"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -70,7 +70,7 @@ FastBroadcast = "1.3"
 FiniteDiff = "2.27"
 ForwardDiff = "1.3.3"
 LinearAlgebra = "1"
-LinearSolve = "3.75.0, 4"
+LinearSolve = "3.75.0, 4, 5"
 Logging = "1"
 OrdinaryDiffEqBDF = "2"
 OrdinaryDiffEqCore = "4"

--- a/lib/OrdinaryDiffEqAMF/Project.toml
+++ b/lib/OrdinaryDiffEqAMF/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqAMF"
 uuid = "08082164-f6a1-4363-b3df-3aa6fcf571ad"
 authors = ["Utkarsh <rajpututkarsh530@gmail.com>"]
-version = "2.1.1"
+version = "2.1.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -15,7 +15,7 @@ SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 SciMLTesting = "2.1"
 LinearAlgebra = "1.10"
 SafeTestsets = "0.1.0"
-LinearSolve = "3.75.0, 4"
+LinearSolve = "3.75.0, 4, 5"
 OrdinaryDiffEqCore = "4"
 Reexport = "1.2.2"
 SciMLBase = "3.35.1"

--- a/lib/OrdinaryDiffEqBDF/Project.toml
+++ b/lib/OrdinaryDiffEqBDF/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqBDF"
 uuid = "6ad6398a-0878-4a85-9266-38940aa047c8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.3.2"
+version = "2.3.3"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -56,7 +56,7 @@ Random = "<0.0.1, 1"
 DiffEqDevTools = "3"
 DifferentiationInterface = "0.7.18"
 MuladdMacro = "0.2.1"
-LinearSolve = "3.75.0, 4"
+LinearSolve = "3.75.0, 4, 5"
 PrecompileTools = "1.2.1, 1.3"
 LinearAlgebra = "1.10"
 OrdinaryDiffEqDifferentiation = "3"

--- a/lib/OrdinaryDiffEqDefault/Project.toml
+++ b/lib/OrdinaryDiffEqDefault/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqDefault"
 uuid = "50262376-6c5a-4cf5-baba-aaf4f84d72d7"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.3.0"
+version = "2.3.1"
 
 [deps]
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
@@ -50,7 +50,7 @@ Random = "<0.0.1, 1"
 DiffEqDevTools = "3"
 OrdinaryDiffEqBDF = "2"
 OrdinaryDiffEqVerner = "2"
-LinearSolve = "3.75.0, 4"
+LinearSolve = "3.75.0, 4, 5"
 PrecompileTools = "1.2.1, 1.3"
 EnumX = "1.0.4"
 LinearAlgebra = "1.10"

--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "3.4.0"
+version = "3.4.1"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 
@@ -21,7 +21,7 @@ DiffEqDevTools = "3"
 Test = "<0.0.1, 1"
 FiniteDiff = "2.27"
 DifferentiationInterface = "0.7.18"
-LinearSolve = "3.75.0, 4"
+LinearSolve = "3.75.0, 4, 5"
 ConstructionBase = "1.5.8"
 LinearAlgebra = "1.10"
 SciMLBase = "3.35.1"

--- a/lib/OrdinaryDiffEqDifferentiation/test/sparse/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/test/sparse/Project.toml
@@ -13,5 +13,5 @@ OrdinaryDiffEqSDIRK = {path = "../../../OrdinaryDiffEqSDIRK"}
 
 [compat]
 ComponentArrays = "0.15, 1"
-LinearSolve = "3, 4"
+LinearSolve = "3, 4, 5"
 OrdinaryDiffEq = "7"

--- a/lib/OrdinaryDiffEqExponentialRK/Project.toml
+++ b/lib/OrdinaryDiffEqExponentialRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExponentialRK"
 uuid = "e0540318-69ee-4070-8777-9e2de6de23de"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -48,7 +48,7 @@ Random = "<0.0.1, 1"
 DiffEqDevTools = "3"
 MuladdMacro = "0.2.1"
 OrdinaryDiffEqVerner = "2"
-LinearSolve = "3.75.0, 4"
+LinearSolve = "3.75.0, 4, 5"
 ExponentialUtilities = "1.27"
 LinearAlgebra = "1.10"
 OrdinaryDiffEqDifferentiation = "3"

--- a/lib/OrdinaryDiffEqExtrapolation/Project.toml
+++ b/lib/OrdinaryDiffEqExtrapolation/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExtrapolation"
 uuid = "becaefa8-8ca2-5cf9-886d-c06f3d2bd2c4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.3.1"
+version = "2.3.2"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -40,7 +40,7 @@ FastBroadcast = "1.3"
 Random = "<0.0.1, 1"
 DiffEqDevTools = "3"
 MuladdMacro = "0.2.1"
-LinearSolve = "3.75.0, 4"
+LinearSolve = "3.75.0, 4, 5"
 OrdinaryDiffEqDifferentiation = "3"
 SciMLBase = "3.35.1"
 OrdinaryDiffEqCore = "4.4"

--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFIRK"
 uuid = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.4.1"
+version = "2.4.2"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -44,7 +44,7 @@ Random = "<0.0.1, 1"
 DiffEqDevTools = "3"
 FastGaussQuadrature = "1.2"
 MuladdMacro = "0.2.1"
-LinearSolve = "3.75.0, 4"
+LinearSolve = "3.75.0, 4, 5"
 LinearAlgebra = "1.10"
 OrdinaryDiffEqDifferentiation = "3"
 SciMLBase = "3.35.1"

--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.4.0"
+version = "2.4.1"
 
 [deps]
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
@@ -58,7 +58,7 @@ FastBroadcast = "1.3"
 Random = "<0.0.1, 1"
 DiffEqDevTools = "3"
 MuladdMacro = "0.2.1"
-LinearSolve = "3.75.0, 4"
+LinearSolve = "3.75.0, 4, 5"
 LineSearches = "7.5.1"
 LinearAlgebra = "1.10"
 OrdinaryDiffEqDifferentiation = "3"

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/Project.toml
@@ -24,7 +24,7 @@ OrdinaryDiffEqSDIRK = {path = "../../../OrdinaryDiffEqSDIRK"}
 DiffEqDevTools = "3"
 ImplicitDiscreteSolve = "2"
 IncompleteLU = "0.2"
-LinearSolve = "3, 4"
+LinearSolve = "3, 4, 5"
 ModelingToolkit = "10.10, 11"
 NonlinearSolve = "4.10"
 OrdinaryDiffEq = "7"

--- a/lib/OrdinaryDiffEqRosenbrock/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrock/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqRosenbrock"
 uuid = "43230ef6-c299-4910-a778-202eb28ce4ce"
-version = "2.4.2"
+version = "2.4.3"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 
 [deps]
@@ -42,7 +42,7 @@ FastBroadcast = "1.3"
 FiniteDiff = "2.27"
 ForwardDiff = "1.3.3"
 LinearAlgebra = "1.10"
-LinearSolve = "3.75.0, 4"
+LinearSolve = "3.75.0, 4, 5"
 MacroTools = "0.5.6"
 MuladdMacro = "0.2.1"
 ODEProblemLibrary = "1"

--- a/lib/OrdinaryDiffEqRosenbrockTableaus/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrockTableaus/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqRosenbrockTableaus"
 uuid = "b4bd8bb3-f80f-41d2-9b21-73a655b304b9"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.2.2"
+version = "2.2.3"
 
 [extras]
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
@@ -21,7 +21,7 @@ ADTypes = "1.22.0"
 DiffEqDevTools = "3"
 Enzyme = "0.13"
 LinearAlgebra = "1.10"
-LinearSolve = "3.46, 4"
+LinearSolve = "3.46, 4, 5"
 ODEProblemLibrary = "1"
 OrdinaryDiffEqRosenbrock = "2"
 Pkg = "1"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- Allow LinearSolve 5 across the OrdinaryDiffEq implicit-solver subpackages that currently accept LinearSolve 3/4.
- Bump each affected subpackage patch version.
- Exercise LinearSolve 5 in the sparse-differentiation and ModelingToolkit test environments.

This is the OrdinaryDiffEq companion to SciML/ExponentialUtilities.jl#257 and is required by NonlinearSolve 4.23, whose current dependency graph resolves LinearSolve 5.

## Local verification

- On the dependent #3985 stack, `ODEDIFFEQ_TEST_GROUP=Core julia +1.12 --startup-file=no --project=lib/OrdinaryDiffEqNonlinearSolve -e 'using Pkg; Pkg.test()'` resolved LinearSolve 5.0.1 and exited 0.
- The complete Core run passed all functional sections, including Linear Solver Tests 113/113, Split ODE Tests 10/10, Mass Matrix Tests 225 passed with 42 existing broken, Sparse Jacobian Tests 11/11, and Matrix-Free WOperator Tests 14/14.
- Whole-repository Runic `--check` and `git diff --check` exited 0.

The homotopy cache work tested in the same local stack is kept in the separate follow-up #3985.
