### PR TITLE
Reuse homotopy caches across implicit ODE stages

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,9 +1,10 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.6.0"
+version = "2.6.1"
 
 [deps]
+CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 NonlinearSolveBase = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -49,8 +50,9 @@ DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 SciMLTesting = "2.1"
+CommonSolve = "0.2.6"
 Pkg = "1"
-NonlinearSolve = "4.20.3"
+NonlinearSolve = "4.24"
 NonlinearSolveBase = "2.39"
 ForwardDiff = "1.3.3"
 Test = "<0.0.1, 1"

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
@@ -1,9 +1,10 @@
 module OrdinaryDiffEqNonlinearSolve
 
 using ADTypes: ADTypes, AutoForwardDiff, AutoFiniteDiff
+using CommonSolve: init, solve, solve!, step!
 
 import SciMLBase
-import SciMLBase: init, solve, remake
+import SciMLBase: remake
 using SciMLOperators: update_coefficients!
 using SciMLBase: DAEFunction, DEIntegrator, NonlinearFunction, NonlinearProblem,
     NonlinearLeastSquaresProblem, LinearProblem, ODEProblem, DAEProblem,
@@ -16,13 +17,14 @@ import DiffEqBase: OrdinaryDiffEqTag, calculate_residuals, calculate_residuals!,
 import ConstructionBase
 import PreallocationTools: DiffCache, get_tmp
 using SimpleNonlinearSolve: SimpleTrustRegion, SimpleGaussNewton
-using NonlinearSolve: FastShortcutNonlinearPolyalg, FastShortcutNLLSPolyalg, NewtonRaphson,
-    HomotopySweep, HomotopyPolyAlgorithm, ArcLengthContinuation, step!
+using NonlinearSolve: FastShortcutNonlinearPolyalg, FastShortcutNLLSPolyalg, NewtonRaphson
 # The operator Jacobian path is implemented in NonlinearSolveBase and needs its own floor.
 import NonlinearSolveBase
 # `get_u`/`get_fu` are the only inner-state reads that hold for every inner cache type:
 # polyalgorithm caches keep `u`/`fu` on the active branch, not as top-level fields.
-using NonlinearSolveBase: get_linear_cache, get_u, get_fu
+using NonlinearSolveBase:
+    ArcLengthContinuation, HomotopyPolyAlgorithm, HomotopySweep, KantorovichHomotopy,
+    get_linear_cache, get_u, get_fu
 using MuladdMacro: @muladd
 using FastBroadcast: @..
 import FastClosures: @closure

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/homotopy.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/homotopy.jl
@@ -1,7 +1,7 @@
 # Step-size homotopy for the implicit stage equations.
 #
 # The stage residual of `nlsolve!` (see nlsolve.jl) is embedded into the one-parameter
-# family obtained by scaling the `f` evaluation with `λ ∈ (0, 1)`:
+# family obtained by scaling the `f` evaluation with `λ ∈ [0, 1]`:
 #
 #   DIRK form:                H(z, λ) = λ⋅dt⋅f(tmp + γ⋅z, p, tstep) - M z
 #   COEFFICIENT_MULTISTEP:    H(z, λ) = (γ dt / α)⋅(tmp + λ⋅f(z, p, tstep)) - M z
@@ -18,6 +18,14 @@
 
 _scalar_tol(x::Number) = x
 _scalar_tol(x) = minimum(x)
+
+function _init_homotopy_nonlinear_cache(prob, alg, abstol, verbose)
+    alg.alg isa Union{HomotopySweep, KantorovichHomotopy} || return nothing
+    if alg.reltol === nothing
+        return init(prob, alg.alg; abstol, verbose)
+    end
+    return init(prob, alg.alg; abstol, reltol = alg.reltol, verbose)
+end
 
 function homotopy_odenlf(ztmp, z, p, λ)
     tmp, ustep, γ, α, tstep, k, invγdt, method, _p, dt, f, nf = p
@@ -127,15 +135,26 @@ function nlsolve!(
         u0 = method === COEFFICIENT_MULTISTEP ? z : zero(z)
         nlp_params = (tmp, γ, α, tstep, invγdt, method, p, dt, f, nlcache.nf)
     end
-    prob = SciMLBase.HomotopyProblem{iip}(nlfunc, u0, nlp_params; λspan = λspan)
-
     # The residual is in `u` units, so the integrator's absolute tolerance sets its
     # natural convergence scale; κ tightens it like the Newton κ⋅tol criterion.
     abstol = alg.abstol === nothing ?
         nlsolver.κ * _scalar_tol(integrator.opts.abstol) : alg.abstol
     kwargs = (; abstol = abstol)
     alg.reltol === nothing || (kwargs = merge(kwargs, (; reltol = alg.reltol)))
-    sol = solve(prob, alg.alg; kwargs...)
+    if nlcache.needs_rebuild
+        prob = SciMLBase.HomotopyProblem{iip}(nlfunc, u0, nlp_params; λspan = λspan)
+        nlcache.continuation_cache = _init_homotopy_nonlinear_cache(
+            prob, alg, abstol, nlcache.verbose
+        )
+        nlcache.needs_rebuild = false
+    end
+    sol = if nlcache.continuation_cache === nothing
+        prob = SciMLBase.HomotopyProblem{iip}(nlfunc, u0, nlp_params; λspan = λspan)
+        solve(prob, alg.alg; kwargs...)
+    else
+        SciMLBase.reinit!(nlcache.continuation_cache, u0; p = nlp_params, kwargs...)
+        solve!(nlcache.continuation_cache)
+    end
 
     if iip
         copyto!(z, sol.u)
@@ -173,5 +192,6 @@ function Base.resize!(
     )
     nlcache.ustep === nothing || resize!(nlcache.ustep, i)
     nlcache.k === nothing || resize!(nlcache.k, i)
+    nlcache.needs_rebuild = nlcache.continuation_cache !== nothing
     return nothing
 end

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
@@ -133,7 +133,7 @@ a plain Newton iteration. The stage equation
 is embedded into the one-parameter family
 
 ```math
-H(z, λ) = λ⋅dt⋅f(\\mathrm{tmp} + γ⋅z, p, t + c⋅dt) - M z, \\quad λ ∈ (0, 1)
+H(z, λ) = λ⋅dt⋅f(\\mathrm{tmp} + γ⋅z, p, t + c⋅dt) - M z, \\quad λ ∈ [0, 1]
 ```
 
 (with the analogous embedding `tmp + λ⋅f(z) - α/(γ dt)⋅M z` for multistep-form
@@ -146,6 +146,11 @@ timesteps of implicit ODE methods*, AIMS Mathematics 4(6), 2019). This is much m
 expensive than [`NLNewton`](@ref) per stage, but it converges from the exact anchor at
 `λ = 0` regardless of predictor quality, which makes it useful on problems where the
 Newton iteration fails even after step-size reduction.
+
+For continuation algorithms that implement `init`/`reinit!`/`solve!` (currently
+`HomotopySweep` and `KantorovichHomotopy`), the homotopy problem and solver cache are
+initialized with the ODE cache and reused across implicit stages. Other homotopy
+algorithms retain the one-shot `solve` path.
 
 When the continuation cannot reach `λ = 1` (for example at a fold, where the connected
 solution branch of the stage equation turns back and no consistent solution at the full
@@ -354,7 +359,7 @@ mutable struct NLAndersonConstantCache{uType, tType, uEltypeNoUnits} <:
     droptol::Union{Nothing, tType}
 end
 
-mutable struct HomotopyNonlinearSolveCache{uType, tType, rateType, tType2, F, R} <:
+mutable struct HomotopyNonlinearSolveCache{uType, tType, rateType, tType2, F, R, V, C} <:
     AbstractNLSolverCache
     ustep::uType
     tstep::tType
@@ -364,6 +369,9 @@ mutable struct HomotopyNonlinearSolveCache{uType, tType, rateType, tType2, F, R}
     # residual-evaluation counter (a `Ref(0)`): the continuation solutions do not carry
     # stats, so the residual itself counts its `f` calls for the integrator statistics
     nf::R
+    verbose::V
+    continuation_cache::C
+    needs_rebuild::Bool
 end
 
 mutable struct NonlinearSolveCache{uType, tType, rateType, tType2, P, C, JType, WType, ufType, jcType, du1Type, weightType, dzType, lsType} <:

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -396,9 +396,23 @@ function build_nlsolver(
                     "embedding degenerates the algebraic equations at λ = 0."
             )
         )
+        γ = tTypeNoUnits(γ)
+        α = tTypeNoUnits(α)
         invγdt = inv(oneunit(t) * one(uTolType))
         nlfunc = NonlinearFunction{true, SciMLBase.FullSpecialize}(homotopy_odenlf)
-        nlcache = HomotopyNonlinearSolveCache(ustep, tstep, k, invγdt, nlfunc, Ref(0))
+        nf = Ref(0)
+        nlp_params = (tmp, ustep, γ, α, tstep, k, invγdt, DIRK, p, dt, f, nf)
+        prob = SciMLBase.HomotopyProblem{true}(
+            nlfunc, ztmp, nlp_params; λspan = (zero(γ), one(γ))
+        )
+        cache_abstol = nlalg.abstol === nothing ? zero(nlalg.κ * one(uTolType)) :
+            nlalg.abstol
+        cache = _init_homotopy_nonlinear_cache(
+            prob, nlalg, cache_abstol, verbose.nonlinear_verbosity
+        )
+        nlcache = HomotopyNonlinearSolveCache(
+            ustep, tstep, k, invγdt, nlfunc, nf, verbose.nonlinear_verbosity, cache, false
+        )
     elseif nlalg isa Union{NLNewton, NonlinearSolveAlg}
         nf = nlsolve_f(f, alg)
 
@@ -624,9 +638,24 @@ function build_nlsolver(
                     "embedding degenerates the algebraic equations at λ = 0."
             )
         )
+        γ = tTypeNoUnits(γ)
+        α = tTypeNoUnits(α)
         invγdt = inv(oneunit(t) * one(uTolType))
         nlfunc = NonlinearFunction{false, SciMLBase.FullSpecialize}(homotopy_oopodenlf)
-        nlcache = HomotopyNonlinearSolveCache(nothing, tstep, nothing, invγdt, nlfunc, Ref(0))
+        nf = Ref(0)
+        nlp_params = (tmp, γ, α, tstep, invγdt, DIRK, p, dt, f, nf)
+        prob = SciMLBase.HomotopyProblem{false}(
+            nlfunc, zero(z), nlp_params; λspan = (zero(γ), one(γ))
+        )
+        cache_abstol = nlalg.abstol === nothing ? zero(nlalg.κ * one(uTolType)) :
+            nlalg.abstol
+        cache = _init_homotopy_nonlinear_cache(
+            prob, nlalg, cache_abstol, verbose.nonlinear_verbosity
+        )
+        nlcache = HomotopyNonlinearSolveCache(
+            nothing, tstep, nothing, invγdt, nlfunc, nf,
+            verbose.nonlinear_verbosity, cache, false
+        )
     elseif nlalg isa Union{NLNewton, NonlinearSolveAlg}
         nf = nlsolve_f(f, alg)
         if isdae

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/homotopy_nlsolve_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/homotopy_nlsolve_tests.jl
@@ -3,7 +3,8 @@ using OrdinaryDiffEqCore
 using OrdinaryDiffEqSDIRK
 using OrdinaryDiffEqBDF
 using SciMLBase
-using NonlinearSolve
+using NonlinearSolve: NewtonRaphson
+using NonlinearSolveBase: ArcLengthContinuation, KantorovichHomotopy
 using ADTypes: AutoFiniteDiff
 using StaticArrays
 using LinearAlgebra
@@ -15,6 +16,13 @@ function vdp!(du, u, p, t)
     return nothing
 end
 vdp(u, p, t) = SA[u[2], p[1] * ((1 - u[1]^2) * u[2] - u[1])]
+
+function cached_homotopy_step_allocations!(integrator)
+    step!(integrator)
+    step!(integrator)
+    GC.gc()
+    return @allocated step!(integrator)
+end
 
 @testset "stiff van der Pol, DIRK and multistep forms" begin
     prob = ODEProblem(vdp!, [2.0, 0.0], (0.0, 0.3), [1.0e3])
@@ -29,6 +37,58 @@ vdp(u, p, t) = SA[u[2], p[1] * ((1 - u[1]^2) * u[2] - u[1])]
         @test sol.retcode == SciMLBase.ReturnCode.Success
         @test maximum(abs.(sol.u[end] .- ref.u[end])) < 1.0e-2
     end
+end
+
+@testset "continuation cache is reused across stages" begin
+    prob = ODEProblem((du, u, p, t) -> (du[1] = t - u[1]; nothing), [1.0], (0.0, 1.0))
+    nlsolve_algs = (
+        HomotopyNonlinearSolveAlg(),
+        HomotopyNonlinearSolveAlg(
+            KantorovichHomotopy(
+                inner = NewtonRaphson(autodiff = AutoFiniteDiff()), strict = false
+            )
+        ),
+    )
+    for nlsolve_alg in nlsolve_algs
+        integrator = init(
+            prob, ImplicitEuler(nlsolve = nlsolve_alg);
+            adaptive = false, dt = 0.1, save_everystep = false
+        )
+        continuation_cache = integrator.cache.nlsolver.cache.continuation_cache
+        @test continuation_cache !== nothing
+
+        step!(integrator)
+        @test integrator.cache.nlsolver.cache.continuation_cache === continuation_cache
+        step!(integrator)
+        @test integrator.cache.nlsolver.cache.continuation_cache === continuation_cache
+        first_step = (1.0 + 0.1 * 0.1) / 1.1
+        @test integrator.u[1] ≈ (first_step + 0.1 * 0.2) / 1.1
+        VERSION >= v"1.11" && @test cached_homotopy_step_allocations!(integrator) == 0
+    end
+end
+
+@testset "continuation cache is rebuilt after integrator resize" begin
+    fresize! = function (du, u, p, t)
+        for i in eachindex(u)
+            du[i] = -u[i]
+        end
+        return nothing
+    end
+    prob = ODEProblem(fresize!, [1.0], (0.0, 0.3))
+    integrator = init(
+        prob, ImplicitEuler(nlsolve = HomotopyNonlinearSolveAlg());
+        adaptive = false, dt = 0.1
+    )
+    step!(integrator)
+    old_cache = integrator.cache.nlsolver.cache.continuation_cache
+
+    resize!(integrator, 2)
+    integrator.u .= 1.0
+    step!(integrator)
+
+    @test length(integrator.u) == 2
+    @test integrator.cache.nlsolver.cache.continuation_cache !== old_cache
+    @test !integrator.cache.nlsolver.cache.needs_rebuild
 end
 
 @testset "out-of-place with StaticArrays" begin


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Dependencies and scope

SciML/NonlinearSolve.jl#1100 is merged and released in NonlinearSolve 4.24 / NonlinearSolveBase 2.38. It provides reusable `HomotopySweep` and `KantorovichHomotopy` `init`/`reinit!`/`solve!` caches through public APIs.

The related ImplicitDiscreteSolve cache work, SciML/OrdinaryDiffEq.jl#4042, and its registered NonlinearSolveBase 2.38 compatibility correction, SciML/OrdinaryDiffEq.jl#4055, are merged.

This PR only changes implicit ODE stage solves through `OrdinaryDiffEqNonlinearSolve.HomotopyNonlinearSolveAlg`.

## What this changes

`HomotopyNonlinearSolveAlg` previously rebuilt a `HomotopyProblem` and used one-shot `solve` for every implicit stage. This PR:

- initializes one continuation cache for `HomotopySweep` and `KantorovichHomotopy`;
- refreshes the stage initial guess, parameter tuple (including stage time), and tolerances with public `reinit!`, then calls public `solve!`;
- rebuilds the continuation cache after integrator resizing;
- retains one-shot `solve` for homotopy algorithms without this reusable cache path, including arc-length continuation;
- imports the continuation algorithms from their declaring public module, `NonlinearSolveBase`;
- documents the cached and fallback behavior.

`IDSolve` should not be replaced by this wrapper. Its controller is a timestep/path-continuation policy that uses the previous accepted state and every Newton contraction ratio, whereas `HomotopyNonlinearSolveAlg` solves an individual implicit ODE stage equation. The merged IDS path now has its own reusable `init`/`reinit!`/`solve!` implementation.

## Solver comparison

On the exact 51-solve IDS recurrence benchmark, using a fresh environment pinned to registered SciMLBase 3.39.1, NonlinearSolve 4.24, and NonlinearSolveBase 2.38, two independent 20-sample runs measured:

- cached IDS: 0.09914-0.10570 ms, 192 bytes, 561 residual calls;
- cached Kantorovich: 0.27951-0.29414 ms, 32 bytes, 2,040 residual calls;
- cached Sweep: 0.30429-0.30484 ms, 32 bytes, 2,346 residual calls.

IDS was 2.64x-2.97x faster than Kantorovich and 2.88x-3.08x faster than Sweep on its native problem. To reduce sequential-load bias, a separate 31-trial paired benchmark with 200 recurrences per timing measured 250.94 microseconds for Kantorovich versus 268.39 microseconds for Sweep, a 6.55% median paired time reduction. Kantorovich also used 13.04% fewer residual calls.

A rotated 31-trial variant benchmark also measured 250.27 microseconds / 2,040 residual calls for strict Kantorovich's constant predictor, 243.56 microseconds / 1,989 calls with its trust-monitored secant predictor, and 242.25 microseconds / 1,989 calls for secant plus non-strict acceptance. The useful Sweep predictor machinery is therefore already available in Kantorovich; this single smooth recurrence is not evidence to change its defaults.

That does not make strict Kantorovich the safer default. In a controlled slow-corrector check with a 0.99 residual-contraction ratio, strict Kantorovich rejected the converged corrector from `u0 = 0`, while non-strict Kantorovich and Sweep both reached `u = 0.1`. At a fold, Kantorovich failed and the Sweep-to-arc-length polyalgorithm succeeded. Strict Kantorovich is therefore more conservative/less robust on these checks, not numerically “unstable”; Sweep remains the default, with arc length needed to round folds.

## Local verification

Final rebased head `967902f1b3` on current `upstream/master` (`fd3f95bb99`):

- The official `homotopy_nlsolve_tests.jl` file passed 38/38. This includes cache identity across stages, time-dependent parameter refresh, resize rebuild, exact warmed `@allocated == 0` for both cached algorithms, out-of-place/static arrays, arc-length fallback, fold rejection, and DAE rejection.
- `GROUP=QA julia --project=lib/OrdinaryDiffEqNonlinearSolve -e 'using Pkg; Pkg.test()'` exited 0: JET 13/13 with 33 pre-existing broken cases; Aqua 19/19; package tests passed.
- Runic 1.7 `--check` on every changed Julia file and `git diff --check upstream/master` exited 0. Whole-tree Runic on current master is tracked independently by SciML/OrdinaryDiffEq.jl#4064; the homotopy diff is not involved.
- A 20-sample, 1,000-stage ImplicitEuler comparison measured 7.4617735 microseconds/stage and 0 bytes/stage with the reused cache versus 9.316223 microseconds/stage and 5,520 bytes/stage when forcing a rebuild before every stage: 1.2485x faster / 19.91% lower median time, with identical endpoints.
- The current full Core run did not complete: after 1h50 and successful groups through CheckInit, the nested-AD test raised `UndefVarError: issquare not defined in LinearSolveForwardDiffExt` with registered LinearSolve 5.3, before reaching the homotopy file. This dependency regression is being handled separately; it was not skipped or silenced here.
