### PR TITLE
reexport `NoAutoDiff`

### DIFF
--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -57,7 +57,7 @@ export ReturnCode, derivative_discontinuity!, add_tstop!, ODEAliasSpecifier
 export SciMLBase, SciMLLogging, remake, successful_retcode, reinit!, set_proposed_dt!
 
 # ADTypes
-export AutoForwardDiff, AutoFiniteDiff, AutoSparse
+export AutoForwardDiff, AutoFiniteDiff, NoAutoDiff, AutoSparse
 
 # Default algorithm
 export DefaultODEAlgorithm

--- a/src/OrdinaryDiffEq.jl
+++ b/src/OrdinaryDiffEq.jl
@@ -28,7 +28,7 @@ using SciMLBase: SciMLBase,
 using SciMLLogging: SciMLLogging
 
 # Import ADTypes for autodiff specification
-using ADTypes: ADTypes, AutoForwardDiff, AutoFiniteDiff, AutoSparse
+using ADTypes: ADTypes, AutoForwardDiff, AutoFiniteDiff, NoAutoDiff, AutoSparse
 
 # Import from OrdinaryDiffEqCore
 using OrdinaryDiffEqCore: OrdinaryDiffEqCore


### PR DESCRIPTION
For circumstances where the user is providing derivatives manually and doesn't want any autodiff to be used (even `FiniteDiff`).
