### PR TITLE
Audit intentional OrdinaryDiffEq facade reexports

### DIFF
--- a/test/qa/qa_tests.jl
+++ b/test/qa/qa_tests.jl
@@ -1,4 +1,7 @@
-using SciMLTesting, OrdinaryDiffEq, SciMLBase
+using SciMLTesting, OrdinaryDiffEq
+using ADTypes, CommonSolve, OrdinaryDiffEqBDF, OrdinaryDiffEqDefault,
+    OrdinaryDiffEqRosenbrock, OrdinaryDiffEqTsit5, OrdinaryDiffEqVerner,
+    SciMLBase, SciMLLogging
 using Test
 
 @testset "PureKLU-compatible MuladdMacro floors" begin
@@ -25,12 +28,30 @@ using Test
     end
 end
 
+const ORDINARYDIFFEQ_REEXPORTS = intersect(
+    public_api_names(OrdinaryDiffEq),
+    union(
+        public_api_names(ADTypes),
+        public_api_names(CommonSolve),
+        public_api_names(OrdinaryDiffEqBDF),
+        public_api_names(OrdinaryDiffEqDefault),
+        public_api_names(OrdinaryDiffEqRosenbrock),
+        public_api_names(OrdinaryDiffEqTsit5),
+        public_api_names(OrdinaryDiffEqVerner),
+        public_api_names(SciMLBase),
+        public_api_names(SciMLLogging),
+        (:SciMLBase, :SciMLLogging),
+    ),
+)
+
 # The umbrella package's QA lane historically ran only the ExplicitImports checks
 # (no Aqua/JET), so keep `aqua = false` to preserve that scope.
 run_qa(
     OrdinaryDiffEq;
     aqua = false,
     explicit_imports = true,
+    check_reexports = true,
+    reexports_allow = ORDINARYDIFFEQ_REEXPORTS,
     ei_kwargs = (;
         no_implicit_imports = (; skip = (Base, Core, SciMLBase)),
     ),


### PR DESCRIPTION
## Summary

- keep the root public-reexport audit explicitly enabled
- derive the allowlist from the public APIs of the nine owner modules explicitly reexported by the OrdinaryDiffEq facade
- intersect that owner-derived set with the facade public API, so the allowlist contains exactly the 46 detected facade bindings and no extra entries

## Derivation check

On Julia 1.12.6, the owner-derived allowlist contained 46 symbols and the reexport audit detected 46 external bindings. Both set differences were empty:

    allowed=46 actual=46
    unapproved=Symbol[]
    extra=Symbol[]

The owner modules are ADTypes, CommonSolve, OrdinaryDiffEqBDF, OrdinaryDiffEqDefault, OrdinaryDiffEqRosenbrock, OrdinaryDiffEqTsit5, OrdinaryDiffEqVerner, SciMLBase, and SciMLLogging. OrdinaryDiffEqCore is deliberately excluded because the root does not publicly reexport any Core-owned binding.

## Local verification

Julia 1.12.6:

    GROUP=QA JULIA_PKG_PRECOMPILE_AUTO=0 julia +1.12 --startup-file=no --project=. -e using Pkg; Pkg.test()
    Quality Assurance Tests | 9 passed / 9 total
    Testing OrdinaryDiffEq tests passed

Also passed:

    julia +1.12 --startup-file=no -m Runic --check .
    git diff --check

## Review

Ignore this PR until reviewed by @ChrisRackauckas.