### PR TITLE
Add missing SciMLOperators [compat] to root project (fixes Downgrade CI)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -67,6 +67,7 @@ OrdinaryDiffEqVerner = "2"
 RecursiveArrayTools = "4.2.0"
 SciMLBase = "3.35.1"
 SciMLLogging = "2.0.0"
+SciMLOperators = "1.24.4"
 SciMLTesting = "2.1"
 julia = "1.10"
 


### PR DESCRIPTION
> [!IMPORTANT]
> Draft — please ignore until reviewed by @ChrisRackauckas.

Fixes the umbrella **Downgrade** workflow, which has been red on master since #3983 (first-failing commit `8e20cb18`; last green `8fc48e69`).

#3983 added `SciMLOperators` to root `[extras]` and the `test` target but did not add a `[compat]` entry. The Downgrade action then floors the uncapped test dependency to its lowest registered version (`SciMLOperators` 1.15.0), which is unsatisfiable against the in-repo path sublibraries — `OrdinaryDiffEqDifferentiation` requires `SciMLOperators ≥ 1.24.4` (and `OrdinaryDiffEqExtrapolation ≥ 1.24.3`) — giving `Unsatisfiable requirements detected for package SciMLOperators … no versions left`.

One-line fix: add `SciMLOperators = "1.24.4"` to root `[compat]`, matching the sublibrary floor.

Scope: this addresses only the umbrella `Downgrade` regression. The separate, chronic `Downgrade Sublibraries` failures (stale `LinearSolve = "3.75.0"` floors inconsistent with the `NonlinearSolveBase 2.34.1` floor) are tracked under #2972/#2977 and are not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)