### PR TITLE
ExponentialRK: @views residual column-slice updates to remove per-step allocations

### DIFF
--- a/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_perform_step.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_perform_step.jl
@@ -768,7 +768,7 @@ function perform_step!(integrator, cache::Exp4ConstantCache, repeat_step = false
     B1 = [zero(f0) f0]
     K1 = phiv_timestep(ts, J, B1; kwargs...) # tϕ(tA)f0
     @inbounds for i in 1:3
-        K1[:, i] ./= ts[i]
+        @views K1[:, i] ./= ts[i]
     end
     w4 = K1 * [-7 / 300, 97 / 150, -37 / 300]
     u4 = uprev + dt * w4
@@ -778,7 +778,7 @@ function perform_step!(integrator, cache::Exp4ConstantCache, repeat_step = false
     B2 = [zero(d4) d4]
     K2 = phiv_timestep(ts, J, B2; kwargs...)
     @inbounds for i in 1:3
-        K2[:, i] ./= ts[i]
+        @views K2[:, i] ./= ts[i]
     end
     w7 = K1 * [59 / 300, -7 / 75, 269 / 300] + K2 * [2 / 3, 2 / 3, 2 / 3]
     u7 = uprev + dt * w7
@@ -819,7 +819,7 @@ function perform_step!(integrator, cache::Exp4Cache, repeat_step = false)
     B[:, 2] .= f0
     phiv_timestep!(K, ts, J, B; kwargs...)
     @inbounds for i in 1:3
-        K[:, i] ./= ts[i]
+        @views K[:, i] ./= ts[i]
     end
     @views @.. broadcast = false rtmp = (-7 / 300) * K[:, 1] + (97 / 150) * K[:, 2] +
         (-37 / 300) * K[:, 3] # rtmp is now w4
@@ -835,7 +835,7 @@ function perform_step!(integrator, cache::Exp4Cache, repeat_step = false)
     # Krylov for the first remainder d4
     phiv_timestep!(K, ts, J, B; kwargs...)
     @inbounds for i in 1:3
-        K[:, i] ./= ts[i]
+        @views K[:, i] ./= ts[i]
     end
     @views @.. broadcast = false rtmp2 = (2 / 3) * (K[:, 1] + K[:, 2] + K[:, 3])
     rtmp .+= rtmp2 # w7 fully updated
@@ -924,8 +924,8 @@ function perform_step!(integrator, cache::EPIRK4s3ACache, repeat_step = false)
     f(rtmp, tmp, p, t + 2dt / 3)
     mul!(rtmp2, J, @view(K[:, 2]))
     @.. broadcast = false rtmp = rtmp - f0 - rtmp2 # rtmp is now R3
-    B[:, 4] .-= (13.5 / dt^2) .* rtmp
-    B[:, 5] .+= (81 / dt^3) .* rtmp
+    @views B[:, 4] .-= (13.5 / dt^2) .* rtmp
+    @views B[:, 5] .+= (81 / dt^3) .* rtmp
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
 
     # Update u
@@ -953,8 +953,8 @@ function perform_step!(integrator, cache::EPIRK4s3BConstantCache, repeat_step = 
 
     # Compute U2 and U3 vertically
     K = phiv_timestep([dt / 2, 3dt / 4], J, [zero(f0) zero(f0) f0]; kwargs...)
-    K[:, 1] .*= 8 / (3 * dt)
-    K[:, 2] .*= 16 / (9 * dt)
+    @views K[:, 1] .*= 8 / (3 * dt)
+    @views K[:, 2] .*= 16 / (9 * dt)
     U2 = uprev + K[:, 1]
     U3 = uprev + K[:, 2]
     R2 = f(U2, p, t + dt / 2) - f0 - J * K[:, 1] # remainder of U2
@@ -995,8 +995,8 @@ function perform_step!(integrator, cache::EPIRK4s3BCache, repeat_step = false)
     ts[1] = dt / 2
     ts[2] = 3dt / 4
     phiv_timestep!(K, ts, J, @view(B[:, 1:3]); kwargs...)
-    K[:, 1] .*= 8 / (3 * dt)
-    K[:, 2] .*= 16 / (9 * dt)
+    @views K[:, 1] .*= 8 / (3 * dt)
+    @views K[:, 2] .*= 16 / (9 * dt)
     ## U2 and R2
     @.. broadcast = false tmp = uprev + @view(K[:, 1]) # tmp is now U2
     f(rtmp, tmp, p, t + dt / 2)
@@ -1009,8 +1009,8 @@ function perform_step!(integrator, cache::EPIRK4s3BCache, repeat_step = false)
     f(rtmp, tmp, p, t + 3dt / 4)
     mul!(rtmp2, J, @view(K[:, 2]))
     @.. broadcast = false rtmp = rtmp - f0 - rtmp2 # rtmp is now R3
-    B[:, 4] .-= (16 / dt^2) .* rtmp
-    B[:, 5] .+= (144 / dt^3) .* rtmp
+    @views B[:, 4] .-= (16 / dt^2) .* rtmp
+    @views B[:, 5] .+= (144 / dt^3) .* rtmp
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)
 
     # Update u
@@ -1112,8 +1112,8 @@ function perform_step!(integrator, cache::EPIRK5s3Cache, repeat_step = false)
     mul!(rtmp2, J, k)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     @.. broadcast = false rtmp = rtmp - f0 - rtmp2 # rtmp is now R3
-    B[:, 4] .+= (2187 / (106 * dt^2)) .* rtmp
-    B[:, 5] .-= (2187 / (106 * dt^3)) .* rtmp
+    @views B[:, 4] .+= (2187 / (106 * dt^2)) .* rtmp
+    @views B[:, 5] .-= (2187 / (106 * dt^3)) .* rtmp
 
     # Update u
     phiv_timestep!(k, dt, J, B; kwargs...)
@@ -1209,8 +1209,8 @@ function perform_step!(integrator, cache::EXPRB53s3Cache, repeat_step = false)
     mul!(rtmp2, J, tmp)
     @.. broadcast = false rtmp = rtmp - f0 - rtmp2 # rtmp is now R3
     ## Update B using R3
-    B[:, 4] .-= (250 / (81 * dt^2)) .* rtmp
-    B[:, 5] .+= (500 / (27 * dt^3)) .* rtmp
+    @views B[:, 4] .-= (250 / (81 * dt^2)) .* rtmp
+    @views B[:, 5] .+= (500 / (27 * dt^3)) .* rtmp
 
     # Update u
     du = @view(K[:, 1])
@@ -1327,7 +1327,7 @@ function perform_step!(integrator, cache::EPIRK5P1Cache, repeat_step = false)
     mul!(rtmp2, J, tmp)
     @.. broadcast = false rtmp = rtmp - f0 - rtmp2 # rtmp is now R2
     axpy!(b2, k, u) # partially update u
-    B[:, 4] .+= rtmp # is now dR
+    @views B[:, 4] .+= rtmp # is now dR
 
     # Compute the third column (dR = R2 - 2R1)
     fill!(@view(B[:, 2]), zero(eltype(B)))

--- a/lib/OrdinaryDiffEqExponentialRK/test/qa/allocation_tests.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/test/qa/allocation_tests.jl
@@ -124,3 +124,59 @@ using Test
         end
     end
 end
+
+# Runtime allocation guard for the Krylov steppers. Before the column-slice
+# updates in perform_step! were `@views`-wrapped, each `X[:, i] .op= ...` read
+# materialized a fresh length-`n` column copy, so per-step allocations grew
+# linearly with the state size `n`. A view-based (or copy-based) regression can
+# only be told apart from the constant-overhead baseline by how it scales with
+# `n`, which is version- and platform-robust, unlike an absolute byte ceiling.
+# Exp4 uses the symmetric-Jacobian Lanczos path, which keeps a stable Krylov
+# subspace, so its per-step allocation is `n`-independent once the slices are
+# views; a reintroduced slice copy makes it scale with `n` and trips this test.
+@testset "Krylov perform_step! runtime allocations do not scale with state size" begin
+    function reaction_diffusion(n)
+        dx = 1.0 / (n + 1)
+        A = zeros(n, n)
+        for i in 1:n
+            A[i, i] = -2.0 / dx^2
+            i > 1 && (A[i, i - 1] = 1.0 / dx^2)
+            i < n && (A[i, i + 1] = 1.0 / dx^2)
+        end
+        u0 = [sinpi(i * dx) for i in 1:n]
+        f! = (du, u, p, t) -> (mul!(du, A, u); @inbounds @. du += u - u^3; nothing)
+        function jac!(J, u, p, t)
+            copyto!(J, A)
+            @inbounds for i in 1:n
+                J[i, i] += 1 - 3u[i]^2
+            end
+            nothing
+        end
+        ODEProblem(
+            ODEFunction{true, FullSpecialize}(f!; jac = jac!, jac_prototype = zeros(n, n)),
+            u0, (0.0, 1.0)
+        )
+    end
+
+    function per_step_allocs(n; nsteps = 40)
+        integrator = init(
+            reaction_diffusion(n), Exp4(m = 30);
+            dt = 1.0e-3, adaptive = false, save_everystep = false, save_start = false
+        )
+        for _ in 1:5
+            step!(integrator)  # warm up compilation and the workspace caches
+        end
+        return @allocated(
+            for _ in 1:nsteps
+                step!(integrator)
+            end
+        ) / nsteps
+    end
+
+    small = per_step_allocs(32)
+    large = per_step_allocs(256)
+    # An unviewed slice copy scales ~8n bytes/step: at n=256 that is several KB
+    # over the n=32 baseline, i.e. a large multiple. The view-based code stays
+    # essentially flat, so a generous 3x bound cleanly separates the two.
+    @test large < 3 * small
+end


### PR DESCRIPTION
## Summary

Follow-up to #3928. The EPIRK/Exp4/Exprb steppers still allocated per step
through bare column-slice compound assignments of the form `X[:, i] .op= ...`
(e.g. `K[:, i] ./= ts[i]`, `B[:, 4] .-= c .* rtmp`). Without `@views`, the
right-hand-side read of the slice materializes a fresh length-`n` column copy
each time (Base `_unsafe_getindex -> similar`), so each such line allocates one
working vector per step and the cost grows linearly with the state size.

#3928 converted the large fused updates to `@views @.. broadcast=false` but
left these smaller normalization/update slices unviewed. This wraps the
remaining 17 of them in `@views`. Each is an in-place elementwise write back to
the same slice with a scalar or separate-array RHS (no column aliasing), so the
result is unchanged — only the transient copy is removed.

## Measured effect

Per-step allocations via the `step!` interface after warmup, on a 1D semilinear
reaction–diffusion problem (`N=128`, `adaptive_krylov`, `m=30`), master vs this
branch:

| method    | master     | this PR   | reduction |
|-----------|-----------:|----------:|----------:|
| Exp4      | 7647 B     | 927 B     | 8.2×      |
| EPIRK4s3B | 5132 B     | 652 B     | 7.9×      |
| EPIRK4s3A | 2879 B     | 639 B     | 4.5×      |
| EXPRB53s3 | 3180 B     | 940 B     | 3.4×      |
| EPIRK5P1  | 2047 B     | 927 B     | 2.2×      |

The final solution is **bit-identical** before/after for every method
(`max|Δu| = 0` across Exp4/EPIRK4s3A/EPIRK4s3B/EXPRB53s3/EPIRK5P1/EPIRK5P2/
Exprb32/Exprb43).

## Test

Adds a runtime size-independence regression test: `Exp4`'s per-step allocation
must not scale with the state size `n` (measured at `n=32` vs `n=256`). Exp4
uses the symmetric-Jacobian Lanczos path with a stable Krylov subspace, so once
the slices are views its per-step allocation is `n`-independent; a reintroduced
slice copy makes it scale with `n` and trips the test. This is version- and
platform-robust, unlike an absolute byte ceiling.

Verified locally: the `Core` group (Linear-Nonlinear Krylov + Convergence
tests) passes; the new regression test passes (ratio ≈ 1.0 on this branch, ≈
4.8 on master). The 3 pre-existing `Aqua`/QA failures (missing EPIRK docstrings
+ reexport hygiene) are unrelated to this change and already fail on master.

## Remaining work (separate PR)

At large `n`, the EPIRK family still allocates in the **ExponentialUtilities**
adaptive `phiv_timestep!` path — the matrix-exponential Padé workspace is
reallocated (`alloc_mem`) when the adaptive subspace size varies (cache keyed by
size → misses), and the Krylov subspace is `resize!`d. That is a separate
ExponentialUtilities change and is not addressed here.

---

Draft — please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
