### PR TITLE
Error on velocity-dependent RHS in velocity-independent RKN/Nyström methods (#3961)

### DIFF
--- a/lib/OrdinaryDiffEqRKN/src/rkn_perform_step.jl
+++ b/lib/OrdinaryDiffEqRKN/src/rkn_perform_step.jl
@@ -4,6 +4,68 @@
 ## y₁ = y₀ + hy'₀ + h²∑b̄ᵢk'ᵢ
 ## y'₁ = y'₀ + h∑bᵢk'ᵢ
 
+"""
+    RKNFirstDerivativeSentinel
+
+Singleton placed in the velocity (`u'`) slot during a one-time probe of `f.f1` performed
+when a *velocity-independent* RKN/Nyström method (DPRKN, ERKN, Nyström*VelocityIndependent,
+IRKN, …) is initialized.
+
+These methods require a second-order ODE of the form `u'' = f(u, p, t)` that does not depend
+on the first derivative `u'`; internally they hold the velocity constant across all stages.
+If handed a velocity-dependent right-hand side they used to *silently* integrate it at order
+one instead of erroring (SciML/OrdinaryDiffEq.jl#3961). Any arithmetic, indexing, or
+broadcast that touches this sentinel throws [`RKNVelocityDependenceError`](@ref), turning
+that silent inaccuracy into a clear error. A correct (velocity-independent) `f.f1` never
+touches its velocity argument, so the probe is a no-op.
+"""
+struct RKNFirstDerivativeSentinel end
+
+struct RKNVelocityDependenceError <: Exception end
+
+function Base.showerror(io::IO, ::RKNVelocityDependenceError)
+    return print(
+        io,
+        "This RKN/Nyström method requires a second-order ODE of the form u'' = f(u, p, t) " *
+            "that does not depend on the first derivative u' (the velocity). The provided " *
+            "acceleration function `f.f1` accesses u', so this method would silently " *
+            "integrate the problem at order 1. Use a method that supports velocity " *
+            "dependence instead — e.g. Nystrom4, FineRKN4, FineRKN5, or RKN4 — or reformulate " *
+            "the problem as a first-order ODE."
+    )
+end
+
+@inline _rkn_velocity_dependence_error() = throw(RKNVelocityDependenceError())
+
+Base.getindex(::RKNFirstDerivativeSentinel, ::Any...) = _rkn_velocity_dependence_error()
+Base.broadcastable(s::RKNFirstDerivativeSentinel) = Ref(s)
+Base.:-(::RKNFirstDerivativeSentinel) = _rkn_velocity_dependence_error()
+Base.:+(::RKNFirstDerivativeSentinel) = _rkn_velocity_dependence_error()
+for op in (:+, :-, :*, :/, :\, :^)
+    for T in (:Number, :AbstractArray)
+        @eval Base.$op(::RKNFirstDerivativeSentinel, ::$T) = _rkn_velocity_dependence_error()
+        @eval Base.$op(::$T, ::RKNFirstDerivativeSentinel) = _rkn_velocity_dependence_error()
+    end
+    @eval Base.$op(::RKNFirstDerivativeSentinel, ::RKNFirstDerivativeSentinel) = _rkn_velocity_dependence_error()
+end
+
+# One-time check (out-of-place `f.f1`) that the acceleration does not depend on u'.
+# Velocity-independent RKN/Nyström methods hold u' constant across stages; a velocity-
+# dependent f.f1 is otherwise silently integrated at order 1 (SciML/OrdinaryDiffEq.jl#3961).
+function _probe_rkn_velocity_independence(integrator)
+    _, uprev = integrator.uprev.x
+    integrator.f.f1(RKNFirstDerivativeSentinel(), uprev, integrator.p, integrator.t)
+    return nothing
+end
+
+# One-time check (in-place `f.f1`). Only the velocity input is the sentinel; the output is
+# written into a throwaway scratch of the real derivative type.
+function _probe_rkn_velocity_independence!(integrator, scratch)
+    _, uprev = integrator.uprev.x
+    integrator.f.f1(scratch, RKNFirstDerivativeSentinel(), uprev, integrator.p, integrator.t)
+    return nothing
+end
+
 const NystromCCDefaultInitialization = Union{
     Nystrom4VelocityIndependentConstantCache,
     IRKN3ConstantCache, IRKN4ConstantCache,
@@ -14,6 +76,7 @@ function initialize!(integrator, cache::NystromCCDefaultInitialization)
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
 
     duprev, uprev = integrator.uprev.x
+    _probe_rkn_velocity_independence(integrator)
     kdu = integrator.f.f1(duprev, uprev, integrator.p, integrator.t)
     ku = integrator.f.f2(duprev, uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
@@ -33,6 +96,7 @@ function initialize!(integrator, cache::NystromDefaultInitialization)
     resize!(integrator.k, integrator.kshortsize)
     integrator.k[1] = integrator.fsalfirst
     integrator.k[2] = integrator.fsallast
+    _probe_rkn_velocity_independence!(integrator, zero(integrator.k[1].x[1]))
     integrator.f.f1(integrator.k[1].x[1], duprev, uprev, integrator.p, integrator.t)
     integrator.f.f2(integrator.k[1].x[2], duprev, uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
@@ -291,6 +355,7 @@ function initialize!(integrator, cache::NystromVIConstantCache)
     integrator.kshortsize = cache.tab.kshortsize
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
     duprev, uprev = integrator.uprev.x
+    _probe_rkn_velocity_independence(integrator)
     kdu = integrator.f.f1(duprev, uprev, integrator.p, integrator.t)
     ku = integrator.f.f2(duprev, uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
@@ -307,6 +372,7 @@ end
 
 function initialize!(integrator, cache::NystromVICache)
     duprev, uprev = integrator.uprev.x
+    _probe_rkn_velocity_independence!(integrator, zero(integrator.fsalfirst.x[1]))
     integrator.f.f1(integrator.fsalfirst.x[1], duprev, uprev, integrator.p, integrator.t)
     integrator.f.f2(integrator.fsalfirst.x[2], duprev, uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)

--- a/lib/OrdinaryDiffEqRKN/test/nystrom_convergence_tests.jl
+++ b/lib/OrdinaryDiffEqRKN/test/nystrom_convergence_tests.jl
@@ -443,123 +443,119 @@ end
         @test_skip sol_i.u ≈ sol_o.u
     end
 
-    @testset "DPRKN4" begin
-        alg = DPRKN4()
-        dt = 0.5
-        # fixed time step
-        sol_i = solve(ode_i, alg, adaptive = false, dt = dt)
-        sol_o = solve(ode_o, alg, adaptive = false, dt = dt)
-        @test sol_i.t ≈ sol_o.t
-        @test sol_i.u ≈ sol_o.u
-        @test sol_i.stats.nf == sol_o.stats.nf
-        @test sol_i.stats.nf2 == sol_o.stats.nf2
-        @test sol_i.stats.naccept == sol_o.stats.naccept
-        @test 19 <= sol_i.stats.naccept <= 21
-        @test abs(sol_i.stats.nf - 4 * sol_i.stats.naccept) < 4
-        # adaptive time step — see FineRKN4 comment (generic-loop IIP/OOP divergence)
-        sol_i = solve(ode_i, alg)
-        sol_o = solve(ode_o, alg)
-        @test_broken sol_i.t ≈ sol_o.t
-        @test_broken sol_i.u ≈ sol_o.u
+    # The velocity-independent DPRKN methods no longer silently integrate this
+    # velocity-dependent (`-0.5*du`) problem at order 1; they reject it at init.
+    # See "velocity dependence is rejected" testset below and issue #3961.
+    @testset "$(nameof(typeof(alg))) rejects velocity dependence" for alg in
+        (DPRKN4(), DPRKN5(), DPRKN6(), DPRKN6FM(), DPRKN8(), DPRKN12())
+        @test_throws OrdinaryDiffEqRKN.RKNVelocityDependenceError solve(
+            ode_i, alg, adaptive = false, dt = 0.5
+        )
+        @test_throws OrdinaryDiffEqRKN.RKNVelocityDependenceError solve(
+            ode_o, alg, adaptive = false, dt = 0.5
+        )
+    end
+end
+
+# Regression test for https://github.com/SciML/OrdinaryDiffEq.jl/issues/3961:
+# velocity-independent RKN/Nyström methods used to silently integrate a velocity-dependent
+# (u''=f(u,u',t)) right-hand side at order 1. They now reject it at initialization with a
+# descriptive RKNVelocityDependenceError, while velocity-dependent methods keep working.
+const VDErr = OrdinaryDiffEqRKN.RKNVelocityDependenceError
+
+@testset "velocity dependence is rejected (#3961)" begin
+    velocity_independent_algs = (
+        DPRKN4(), DPRKN5(), DPRKN6(), DPRKN6FM(), DPRKN8(), DPRKN12(),
+        ERKN4(), ERKN5(), ERKN7(),
+        Nystrom4VelocityIndependent(), Nystrom5VelocityIndependent(),
+        IRKN3(), IRKN4(),
+    )
+    velocity_dependent_algs = (Nystrom4(), FineRKN4(), FineRKN5(), RKN4())
+
+    # The probe must be a no-op for a valid (velocity-independent) u'' = -u problem:
+    # every velocity-independent method still integrates the in-place vector form to Success.
+    @testset "velocity-independent problem still solves (in-place): $(nameof(typeof(alg)))" for alg in
+        velocity_independent_algs
+        prob_iip = SecondOrderODEProblem(
+            (ddu, du, u, p, t) -> (@. ddu = -u),
+            [0.0, 0.0], [1.0, 0.5], (0.0, 5.0)
+        )
+        @test SciMLBase.successful_retcode(solve(prob_iip, alg, dt = 0.05, adaptive = false))
     end
 
-    @testset "DPRKN5" begin
-        alg = DPRKN5()
-        dt = 0.5
-        # fixed time step
-        sol_i = solve(ode_i, alg, adaptive = false, dt = dt)
-        sol_o = solve(ode_o, alg, adaptive = false, dt = dt)
-        @test sol_i.t ≈ sol_o.t
-        @test sol_i.u ≈ sol_o.u
-        @test sol_i.stats.nf == sol_o.stats.nf
-        @test sol_i.stats.nf2 == sol_o.stats.nf2
-        @test sol_i.stats.naccept == sol_o.stats.naccept
-        @test 19 <= sol_i.stats.naccept <= 21
-        @test abs(sol_i.stats.nf - 6 * sol_i.stats.naccept) < 4
-        # adaptive time step — see FineRKN4 comment (generic-loop IIP/OOP divergence)
-        sol_i = solve(ode_i, alg)
-        sol_o = solve(ode_o, alg)
-        @test_broken sol_i.t ≈ sol_o.t
-        @test_broken sol_i.u ≈ sol_o.u
+    # Out-of-place scalar form. IRKN3/IRKN4 have a pre-existing out-of-place perform_step!
+    # bug (they are @test_broken out-of-place above), unrelated to the velocity probe.
+    @testset "velocity-independent problem still solves (out-of-place): $(nameof(typeof(alg)))" for alg in
+        filter(a -> !(a isa IRKN3 || a isa IRKN4), collect(velocity_independent_algs))
+        prob_oop = DynamicalODEProblem(
+            (v, u, p, t) -> -u, (v, u, p, t) -> v,
+            1.0, 0.0, (0.0, 5.0)
+        )
+        @test SciMLBase.successful_retcode(solve(prob_oop, alg, dt = 0.05, adaptive = false))
     end
 
-    @testset "DPRKN6" begin
-        alg = DPRKN6()
-        dt = 0.5
-        # fixed time step
-        sol_i = solve(ode_i, alg, adaptive = false, dt = dt)
-        sol_o = solve(ode_o, alg, adaptive = false, dt = dt)
-        @test sol_i.t ≈ sol_o.t
-        @test sol_i.u ≈ sol_o.u
-        @test sol_i.stats.nf == sol_o.stats.nf
-        @test sol_i.stats.nf2 == sol_o.stats.nf2
-        @test sol_i.stats.naccept == sol_o.stats.naccept
-        @test 19 <= sol_i.stats.naccept <= 21
-        @test abs(sol_i.stats.nf - 6 * sol_i.stats.naccept) < 4
-        # adaptive time step — see FineRKN4 comment (generic-loop IIP/OOP divergence)
-        sol_i = solve(ode_i, alg)
-        sol_o = solve(ode_o, alg)
-        @test_broken sol_i.t ≈ sol_o.t
-        @test_broken sol_i.u ≈ sol_o.u
+    # Accuracy sanity check on u(0)=0, u'(0)=1 (exact u = sin t): high-order methods must
+    # stay accurate — an order-1 collapse (the #3961 symptom) would blow past this atol.
+    @testset "velocity-independent accuracy: $(nameof(typeof(alg)))" for alg in
+        (DPRKN6(), DPRKN8(), DPRKN12())
+        prob = DynamicalODEProblem(
+            (v, u, p, t) -> -u, (v, u, p, t) -> v,
+            1.0, 0.0, (0.0, 5.0)
+        )
+        sol = solve(prob, alg, dt = 0.05, adaptive = false)
+        @test SciMLBase.successful_retcode(sol)
+        @test sol.u[end].x[2] ≈ sin(5.0) atol = 1.0e-6
     end
 
-    @testset "DPRKN6FM" begin
-        alg = DPRKN6FM()
-        dt = 0.5
-        # fixed time step
-        sol_i = solve(ode_i, alg, adaptive = false, dt = dt)
-        sol_o = solve(ode_o, alg, adaptive = false, dt = dt)
-        @test sol_i.t ≈ sol_o.t
-        @test sol_i.u ≈ sol_o.u
-        @test sol_i.stats.nf == sol_o.stats.nf
-        @test sol_i.stats.nf2 == sol_o.stats.nf2
-        @test sol_i.stats.naccept == sol_o.stats.naccept
-        @test 19 <= sol_i.stats.naccept <= 21
-        @test abs(sol_i.stats.nf - 6 * sol_i.stats.naccept) < 4
-        # adaptive time step — see FineRKN4 comment (generic-loop IIP/OOP divergence)
-        sol_i = solve(ode_i, alg)
-        sol_o = solve(ode_o, alg)
-        @test_broken sol_i.t ≈ sol_o.t
-        @test_broken sol_i.u ≈ sol_o.u
+    @testset "velocity-dependent problem errors: $(nameof(typeof(alg)))" for alg in
+        velocity_independent_algs
+        # out-of-place, scalar: u'' = -u - 0.2u'
+        prob_oop_scalar = DynamicalODEProblem(
+            (v, u, p, t) -> -u - 0.2v,
+            (v, u, p, t) -> v, 1.0, 0.0, (0.0, 5.0)
+        )
+        @test_throws VDErr solve(prob_oop_scalar, alg, dt = 0.1, adaptive = false)
+
+        # out-of-place, vector broadcast
+        prob_oop_vec = DynamicalODEProblem(
+            (v, u, p, t) -> -u .- 0.2 .* v,
+            (v, u, p, t) -> v, [1.0, 0.0], [0.0, 1.0], (0.0, 5.0)
+        )
+        @test_throws VDErr solve(prob_oop_vec, alg, dt = 0.1, adaptive = false)
+
+        # in-place, vector broadcast
+        prob_iip_vec = SecondOrderODEProblem(
+            (ddu, du, u, p, t) -> (@. ddu = -u - 0.2 * du),
+            [0.0, 0.0], [1.0, 1.0], (0.0, 5.0)
+        )
+        @test_throws VDErr solve(prob_iip_vec, alg, dt = 0.1, adaptive = false)
+
+        # in-place, indexed access (Coriolis terms, cf. Arenstorf #1030 / Hill #1372)
+        function coriolis!(ddu, du, u, p, t)
+            ddu[1] = 2 * du[2] + u[1]
+            ddu[2] = -2 * du[1] + u[2]
+            return nothing
+        end
+        prob_iip_idx = SecondOrderODEProblem(coriolis!, [0.0, 0.0], [1.0, 0.5], (0.0, 3.0))
+        @test_throws VDErr solve(prob_iip_idx, alg, dt = 0.05, adaptive = false)
     end
 
-    @testset "DPRKN8" begin
-        alg = DPRKN8()
-        dt = 0.5
-        # fixed time step
-        sol_i = solve(ode_i, alg, adaptive = false, dt = dt)
-        sol_o = solve(ode_o, alg, adaptive = false, dt = dt)
-        @test sol_i.t ≈ sol_o.t
-        @test sol_i.u ≈ sol_o.u
-        @test sol_i.stats.nf == sol_o.stats.nf
-        @test sol_i.stats.nf2 == sol_o.stats.nf2
-        @test sol_i.stats.naccept == sol_o.stats.naccept
-        @test 19 <= sol_i.stats.naccept <= 21
-        @test abs(sol_i.stats.nf - 9 * sol_i.stats.naccept) < 4
-        # adaptive time step — see FineRKN4 comment (generic-loop IIP/OOP divergence)
-        sol_i = solve(ode_i, alg)
-        sol_o = solve(ode_o, alg)
-        @test_broken sol_i.t ≈ sol_o.t
-        @test_broken sol_i.u ≈ sol_o.u
-    end
-
-    @testset "DPRKN12" begin
-        alg = DPRKN12()
-        dt = 0.5
-        # fixed time step
-        sol_i = solve(ode_i, alg, adaptive = false, dt = dt)
-        sol_o = solve(ode_o, alg, adaptive = false, dt = dt)
-        @test sol_i.t ≈ sol_o.t
-        @test sol_i.u ≈ sol_o.u
-        @test sol_i.stats.nf == sol_o.stats.nf
-        @test sol_i.stats.nf2 == sol_o.stats.nf2
-        @test sol_i.stats.naccept == sol_o.stats.naccept
-        @test 19 <= sol_i.stats.naccept <= 21
-        @test abs(sol_i.stats.nf - 17 * sol_i.stats.naccept) < 4
-        # adaptive time step
-        sol_i = solve(ode_i, alg)
-        sol_o = solve(ode_o, alg)
-        @test_broken sol_i.t ≈ sol_o.t
-        @test_broken sol_i.u ≈ sol_o.u
+    @testset "velocity-dependent methods still accept u': $(nameof(typeof(alg)))" for alg in
+        velocity_dependent_algs
+        prob_iip = SecondOrderODEProblem(
+            (ddu, du, u, p, t) -> (@. ddu = -u - 0.5 * du),
+            [0.0], [1.0], (0.0, 5.0)
+        )
+        prob_oop = SecondOrderODEProblem(
+            (du, u, p, t) -> -u - 0.5 * du, [0.0], [1.0], (0.0, 5.0)
+        )
+        sol_iip = solve(prob_iip, alg, dt = 0.05, adaptive = false)
+        sol_oop = solve(prob_oop, alg, dt = 0.05, adaptive = false)
+        @test SciMLBase.successful_retcode(sol_iip)
+        @test SciMLBase.successful_retcode(sol_oop)
+        # exact solution of u'' + 0.5u' + u = 0, u(0)=1, u'(0)=0
+        w = sqrt(15) / 4
+        u_exact = exp(-5.0 / 4) * (cos(w * 5.0) + (0.25 / w) * sin(w * 5.0))
+        @test sol_iip.u[end].x[2][1] ≈ u_exact atol = 1.0e-2
     end
 end


### PR DESCRIPTION
## Summary

Fixes #3961. Velocity-independent RKN/Nyström methods (DPRKN4/5/6/6FM/8/12, ERKN4/5/7, `Nystrom4VelocityIndependent`, `Nystrom5VelocityIndependent`, IRKN3/4) require a second-order ODE `u'' = f(u, p, t)` that does **not** depend on the first derivative `u'`. Internally they hold the velocity (`duprev`) constant across all stages, so when handed a velocity-dependent right-hand side they **silently integrated it at order 1** instead of erroring.

This is the root cause behind two long-standing reports:
- #1030 (Arenstorf orbit) — Coriolis terms `+2y'`, `-2x'`
- #1372 (Hill problem) — Coriolis terms `2du[2]`, `-2du[1]`

The tell from #3961: DPRKN6/DPRKN8/DPRKN12 (orders 6, 8, 12) returned **bit-identical** order-1 results on `u'' = -u - 0.2u'`.

## Fix

A one-time probe at solver initialization (modeled on SciMLBase's `NullParameters` sentinel behavior): a `RKNFirstDerivativeSentinel` is placed in the velocity slot of a trial `f.f1` call. Any arithmetic, indexing, or broadcast that touches it throws a descriptive `RKNVelocityDependenceError`. A correct (velocity-independent) `f.f1` never touches its velocity argument, so the probe is a no-op and stepping proceeds with the real `duprev` exactly as before.

The probe is applied **only** to the velocity-independent initializers (`NystromVIConstantCache`/`NystromVICache` and the `Nystrom*Default` initializers used by IRKN and `Nystrom4VelocityIndependent`). The velocity-dependent methods (`Nystrom4`, `FineRKN4`, `FineRKN5`, `RKN4`) go through the separate VD cache path (which propagates `u'` through the stages) and are left untouched.

Error message:
> This RKN/Nyström method requires a second-order ODE of the form u'' = f(u, p, t) that does not depend on the first derivative u' (the velocity). The provided acceleration function `f.f1` accesses u', so this method would silently integrate the problem at order 1. Use a method that supports velocity dependence instead — e.g. Nystrom4, FineRKN4, FineRKN5, or RKN4 — or reformulate the problem as a first-order ODE.

## Tests

- Reworked the "in-place vs. out-of-place" testset: the DPRKN entries were comparing order-1 garbage IIP-vs-OOP on a velocity-dependent damped oscillator; they now assert the new `RKNVelocityDependenceError` is thrown.
- Added a `velocity dependence is rejected (#3961)` regression testset covering: velocity-independent problems still solve (all VI methods, in-place and out-of-place) and stay accurate (DPRKN6/8/12 vs `sin`); velocity-dependent RHS now errors across scalar/vector, in-place/out-of-place, broadcast, and indexed Coriolis forms; and velocity-dependent methods (`Nystrom4`, `FineRKN4`, `FineRKN5`, `RKN4`) still accept `u'`.

## Local test results (Julia 1.10.11)

`ODEDIFFEQ_TEST_GROUP=Core`:
```
Nystrom Convergence Tests |  267       8    275   (0 fail, 0 error; 8 broken = pre-existing)
Testing OrdinaryDiffEqRKN tests passed
```

`ODEDIFFEQ_TEST_GROUP=QA`: Method ambiguity ✅, Unbound type parameters ✅, JET ✅, allocations (all pre-existing `broken=true`). Two Aqua failures (`public API is rendered in docs`, `No unapproved public reexports`) are **pre-existing and unrelated** — they flag ~185–196 `@reexport using SciMLBase` names (e.g. `:BVProblem`, `:step!`); none are the two internal types added here, and the module's export/reexport list is unchanged from `master`.

---

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzPcEgSqYDBg11sEcTvpVW