### PR TITLE
Fix DABDF2 adaptive error estimate on DAEs (Unstable regression, #3960)

### DIFF
--- a/lib/OrdinaryDiffEqBDF/src/dae_perform_step.jl
+++ b/lib/OrdinaryDiffEqBDF/src/dae_perform_step.jl
@@ -120,6 +120,10 @@ end
         cache.dtₙ₋₁ = dtₙ
         perform_step!(integrator, cache.eulercache, repeat_step)
         integrator.fsalfirst = @.. broadcast = false (integrator.u - integrator.uprev) / dtₙ
+        # DImplicitEuler is not FSAL and leaves integrator.fsallast stale, but DABDF2 is
+        # FSAL: the next step copies fsallast into fsalfirst. Seed fsallast with the
+        # startup derivative so the first BDF2 error estimate sees a valid duₙ₋₁.
+        integrator.fsallast = integrator.fsalfirst
         cache.fsalfirstprev = integrator.fsalfirst
         return
     end
@@ -138,7 +142,10 @@ end
     nlsolvefail(nlsolver) && return
 
     uₙ = uₙ₋₁ + z
-    integrator.fsallast = @.. broadcast = false z / dtₙ
+    integrator.du = du = (nlsolver.α * z + nlsolver.tmp) * inv(nlsolver.γ * dtₙ)
+    # fsallast is the BDF2 derivative duₙ (matching fsalfirst = duₙ₋₁), not the chord
+    # slope z/dtₙ; the latter makes the LTE second-difference estimate inconsistent.
+    integrator.fsallast = du
 
     if integrator.opts.adaptive
         tmp = integrator.fsallast - (1 + dtₙ / dtₙ₋₁) * integrator.fsalfirst +
@@ -159,7 +166,6 @@ end
     end
 
     integrator.u = uₙ
-    integrator.du = du = (nlsolver.α * z + nlsolver.tmp) * inv(nlsolver.γ * dtₙ)
 
     if integrator.opts.calck
         integrator.k[2] = integrator.k[1]
@@ -187,6 +193,10 @@ end
         cache.dtₙ₋₁ = dtₙ
         perform_step!(integrator, cache.eulercache, repeat_step)
         @.. broadcast = false integrator.fsalfirst = (uₙ - uₙ₋₁) / dt
+        # DImplicitEuler is not FSAL and leaves integrator.fsallast stale, but DABDF2 is
+        # FSAL: the next step copies fsallast into fsalfirst. Seed fsallast with the
+        # startup derivative so the first BDF2 error estimate sees a valid duₙ₋₁.
+        @.. broadcast = false integrator.fsallast = integrator.fsalfirst
         cache.fsalfirstprev .= integrator.fsalfirst
         return
     end

--- a/lib/OrdinaryDiffEqBDF/test/dae_convergence_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/dae_convergence_tests.jl
@@ -1,4 +1,6 @@
 using OrdinaryDiffEqBDF, DiffEqDevTools, ADTypes
+using SciMLBase: successful_retcode
+import SciMLBase
 using Test, Random
 Random.seed!(100)
 
@@ -182,4 +184,45 @@ prob_dae_linear_oop_sep = DAEProblem(
     @test sim23.𝒪est[:final] ≈ 2 atol = testTol
 
     @test_nowarn solve(prob, DFBDF())
+end
+
+# Regression test for issue #3960: DABDF2 adaptive error estimate blew up on the
+# first BDF2 step (the FSAL startup left integrator.fsallast stale, so fsalfirst
+# was ~0 at the first estimate), forcing dt below eps and returning Unstable on a
+# trivial index-1 DAE that DImplicitEuler/DFBDF solve. The fixed-dt convergence
+# tests above do not exercise the adaptive controller, so this uses adaptive solves.
+@testset "DABDF2 adaptive index-1 DAE (issue #3960)" begin
+    # u1' = -u1 ;  0 = u2 - u1     exact: u1 = u2 = exp(-t)
+    f_index1_iip = (res, du, u, p, t) -> begin
+        res[1] = du[1] + u[1]
+        res[2] = u[2] - u[1]
+        return nothing
+    end
+    prob_iip = DAEProblem(
+        f_index1_iip, [-1.0, -1.0], [1.0, 1.0], (0.0, 1.0);
+        differential_vars = [true, false]
+    )
+    # scalar out-of-place hits the DABDF2ConstantCache path
+    f_scalar_oop = (du, u, p, t) -> du + u
+    prob_oop = DAEProblem(f_scalar_oop, -1.0, 1.0, (0.0, 1.0))
+
+    exact = exp(-1.0)
+    prev_err = Inf
+    for tol in (1.0e-4, 1.0e-6, 1.0e-8, 1.0e-10)
+        # atol 2e-3 cleanly separates a correct solve (worst observed err ~8e-4)
+        # from the pre-fix Unstable behavior (u stuck near the u0 = 1.0, err ~0.6)
+        sol_iip = solve(prob_iip, DABDF2(), abstol = tol, reltol = tol)
+        @test SciMLBase.successful_retcode(sol_iip)
+        @test sol_iip.u[end][1] ≈ exact atol = 2.0e-3
+        @test sol_iip.u[end][2] ≈ exact atol = 2.0e-3
+
+        sol_oop = solve(prob_oop, DABDF2(), abstol = tol, reltol = tol)
+        @test SciMLBase.successful_retcode(sol_oop)
+        @test sol_oop.u[end] ≈ exact atol = 2.0e-3
+
+        # tightening the tolerance must improve accuracy (estimator is meaningful)
+        err = abs(sol_iip.u[end][1] - exact)
+        @test err <= prev_err
+        prev_err = err
+    end
 end


### PR DESCRIPTION
Fixes #3960.

## Problem

`DABDF2` returned `retcode=Unstable` on a trivial linear index-1 DAE that
`DFBDF` and `DImplicitEuler` solve correctly, forcing `dt` below floating-point
epsilon after only a couple of steps:

```julia
# u1' = -u1 ;  0 = u2 - u1     exact: u1 = u2 = exp(-t)
f = (res, du, u, p, t) -> (res[1] = du[1] + u[1]; res[2] = u[2] - u[1])
prob = DAEProblem(f, [-1.0, -1.0], [1.0, 1.0], (0.0, 1.0); differential_vars = [true, false])
solve(prob, DABDF2(), abstol = 1e-8, reltol = 1e-8)   # -> Unstable, u ≈ [1.0, 1.0]
```

## Root cause

`DABDF2` is a FSAL method, so at the start of each step the integrator copies
`integrator.fsallast` into `integrator.fsalfirst`. The second-order startup step
runs a `DImplicitEuler` step, which is **not** FSAL and therefore never writes
`integrator.fsallast`. The startup code set `integrator.fsalfirst` to the startup
derivative but left `integrator.fsallast` at its stale (≈0) initial value. On the
first true BDF2 step the FSAL copy then overwrote `fsalfirst` with that stale ≈0
value.

The BDF2 error estimate is a scaled second difference of the step derivatives,
`(dtₙ₋₁+dtₙ)/6 · (duₙ − (1+ρ)·duₙ₋₁ + ρ·duₙ₋₂)`. With `duₙ₋₁ ≈ 0` instead of
`≈ -1`, the middle term vanished and the estimate became `O(1)` instead of
`O(dt²)`, so `EEst ≈ 8–30` on a step that should have been accepted. The
controller then shrank `dt` repeatedly until it fell below `eps`, aborting with
`Unstable`.

A related, second defect affected the scalar / out-of-place path
(`DABDF2ConstantCache`), which additionally used the chord slope `z/dtₙ` for
`fsallast` instead of the actual BDF2 derivative `duₙ`. That made `fsallast`
inconsistent with `fsalfirst` (which holds a real derivative) and caused
`Unstable` at every tolerance, not just tight ones.

## Fix

- In both the in-place (`DABDF2Cache`) and out-of-place (`DABDF2ConstantCache`)
  second-order startup, seed `integrator.fsallast` with the startup derivative so
  the FSAL copy carries a valid `duₙ₋₁` into the first BDF2 error estimate.
- In `DABDF2ConstantCache`, set `fsallast = duₙ` (the BDF2 derivative) rather than
  the chord slope `z/dtₙ`, matching the in-place cache and the ODE `ABDF2` method.

## Verification (run locally, Julia 1.11.9)

Before the fix the problem above returns `Unstable` at `abstol=reltol` of `1e-8`
and `1e-10` (in-place) and at every tolerance (scalar); after the fix all cases
return `Success` and converge to `exp(-1) = 0.36787944…`, with accuracy
improving monotonically as the tolerance tightens.

The existing fixed-`dt` `DABDF2` order-2 convergence tests still pass (they did
not exercise the adaptive controller, which is why this slipped through), and a
new adaptive regression test on the index-1 DAE is added to
`dae_convergence_tests.jl`.

---
This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
