### PR TITLE
Preserve ArrayPartition wrapper in out-of-place stiff steps (#3962)

### DIFF
--- a/lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl
@@ -1,7 +1,8 @@
-using OrdinaryDiffEqBDF, OrdinaryDiffEqCore, ForwardDiff, Test
+using OrdinaryDiffEqBDF, OrdinaryDiffEqCore, ForwardDiff, Test, LinearAlgebra
 using OrdinaryDiffEqCore: DEVerbosity
 import OrdinaryDiffEqCore.SciMLLogging as SciMLLogging
 using OrdinaryDiffEqNonlinearSolve: BrownFullBasicInit, NLNewton
+using RecursiveArrayTools: ArrayPartition
 
 foop = (u, p, t) -> u * p
 proboop = ODEProblem(foop, ones(2), (0.0, 1000.0), 1.0)
@@ -195,4 +196,26 @@ end
     # the solver gives up cleanly (Unstable) instead of overflowing the stack.
     @test sol.retcode != ReturnCode.Success
     @test sol.retcode != ReturnCode.Default
+end
+
+# Regression test for issue #3962: the out-of-place Newton step used
+# `_reshape(W \ _vec(ztmp), axes(ztmp))`, which collapses the ArrayPartition state
+# behind SecondOrderODEProblem/DynamicalODEFunction down to a bare Vector. Storing
+# `z .- dz` back into the ArrayPartition-typed nlsolver fields then failed with
+# `Cannot convert Vector to ArrayPartition`.
+@testset "OOP SecondOrderODEProblem with FBDF preserves ArrayPartition (#3962)" begin
+    # u'' = -u  ⇒  position = [cos t, sin t], velocity = [-sin t, cos t]
+    ho_iip(ddu, du, u, p, t) = (@. ddu = -u)
+    ho_oop(du, u, p, t) = -u
+    u0 = [1.0, 0.0]
+    du0 = [0.0, 1.0]
+    tspan = (0.0, 1.0)
+    prob_iip = SecondOrderODEProblem(ho_iip, du0, u0, tspan)
+    prob_oop = SecondOrderODEProblem(ho_oop, du0, u0, tspan)
+
+    ref = solve(prob_iip, FBDF(), abstol = 1.0e-10, reltol = 1.0e-10)
+    sol = solve(prob_oop, FBDF(), abstol = 1.0e-10, reltol = 1.0e-10)
+    @test sol.retcode == ReturnCode.Success
+    @test sol.u[end] isa ArrayPartition
+    @test norm(sol.u[end] - ref.u[end]) < 1.0e-6
 end

--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.5.0"
+version = "2.5.1"
 
 [deps]
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
@@ -29,7 +29,7 @@ import ArrayInterface: ArrayInterface
 import LinearSolve
 import ForwardDiff: ForwardDiff
 using ForwardDiff: Dual
-using RecursiveArrayTools: recursivecopy!
+using RecursiveArrayTools: recursivecopy!, ArrayPartition
 import OrdinaryDiffEqCore
 
 import SciMLOperators: islinear, AbstractSciMLOperator, MatrixOperator

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
@@ -29,7 +29,7 @@ import ArrayInterface: ArrayInterface
 import LinearSolve
 import ForwardDiff: ForwardDiff
 using ForwardDiff: Dual
-using RecursiveArrayTools: recursivecopy!, ArrayPartition
+using RecursiveArrayTools: recursivecopy!
 import OrdinaryDiffEqCore
 
 import SciMLOperators: islinear, AbstractSciMLOperator, MatrixOperator

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/functional.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/functional.jl
@@ -126,7 +126,7 @@ end
                 ztmp = (tmp .+ f(z, p, tstep)) * (γdt / α)
                 dz = ztmp .- z
             else
-                ztmp = _reshape_state(mass_matrix * _vec(z), z)
+                ztmp = _restructure_state(z, mass_matrix * _vec(z))
                 dz = (tmp .+ f(z, p, tstep)) * γdt - α .* ztmp
                 ztmp = dz .+ z
             end
@@ -136,7 +136,7 @@ end
                 ztmp = dt .* f(ustep, p, tstep)
                 dz = ztmp .- z
             else
-                ztmp = _reshape_state(mass_matrix * _vec(z), z)
+                ztmp = _restructure_state(z, mass_matrix * _vec(z))
                 dz = dt .* f(ustep, p, tstep) .- ztmp
                 ztmp = z .+ dz
             end

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/functional.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/functional.jl
@@ -126,7 +126,7 @@ end
                 ztmp = (tmp .+ f(z, p, tstep)) * (γdt / α)
                 dz = ztmp .- z
             else
-                ztmp = _reshape(mass_matrix * _vec(z), axes(z))
+                ztmp = _reshape_state(mass_matrix * _vec(z), z)
                 dz = (tmp .+ f(z, p, tstep)) * γdt - α .* ztmp
                 ztmp = dz .+ z
             end
@@ -136,7 +136,7 @@ end
                 ztmp = dt .* f(ustep, p, tstep)
                 dz = ztmp .- z
             else
-                ztmp = _reshape(mass_matrix * _vec(z), axes(z))
+                ztmp = _reshape_state(mass_matrix * _vec(z), z)
                 dz = dt .* f(ustep, p, tstep) .- ztmp
                 ztmp = z .+ dz
             end

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -294,7 +294,7 @@ Equations II, Springer Series in Computational Mathematics. ISBN
                 "Use the in-place form (define f!(du, u, p, t)) or supply a concrete jac_prototype."
         )
     end
-    dz = _reshape_state(W \ _vec(ztmp), ztmp)
+    dz = _restructure_state(ztmp, W \ _vec(ztmp))
     dz = relax(dz, nlsolver, integrator, f)
     if SciMLBase.has_stats(integrator)
         integrator.stats.nsolve += 1

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -294,7 +294,7 @@ Equations II, Springer Series in Computational Mathematics. ISBN
                 "Use the in-place form (define f!(du, u, p, t)) or supply a concrete jac_prototype."
         )
     end
-    dz = _reshape(W \ _vec(ztmp), axes(ztmp))
+    dz = _reshape_state(W \ _vec(ztmp), ztmp)
     dz = relax(dz, nlsolver, integrator, f)
     if SciMLBase.has_stats(integrator)
         integrator.stats.nsolve += 1

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -2,14 +2,12 @@
 # This allows nlsolver to work with DiscreteFunction which lacks mass_matrix
 get_mass_matrix(f) = hasproperty(f, :mass_matrix) ? f.mass_matrix : I
 
-# Reshape a flat linear-solve result back into the shape/container of the state.
-# Plain `reshape` collapses structured AbstractVector wrappers such as ArrayPartition
-# (the state type behind SecondOrderODEProblem / DynamicalODEFunction) down to a bare
-# Vector. That bare Vector then poisons the out-of-place Newton update `z .- dz`, whose
-# result can no longer be stored back into the ArrayPartition-typed nlsolver fields.
-# For those states, copy into a matching container so the wrapper is preserved.
-@inline _reshape_state(x, template) = _reshape(x, axes(template))
-@inline _reshape_state(x, template::ArrayPartition) = copyto!(similar(template, eltype(x)), x)
+# Map a flat linear-solve result back onto the state container. Delegates to
+# ArrayInterface.restructure (which preserves ArrayPartition / other wrappers that
+# plain reshape collapses); Number states need a convert because restructure
+# relies on `similar`.
+@inline _restructure_state(template, x) = ArrayInterface.restructure(template, x)
+@inline _restructure_state(template::Number, x) = oftype(template, x)
 
 get_status(nlsolver::AbstractNLSolver) = nlsolver.status
 get_new_W_γdt_cutoff(nlsolver::AbstractNLSolver) = nlsolver.cache.new_W_γdt_cutoff

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -2,6 +2,15 @@
 # This allows nlsolver to work with DiscreteFunction which lacks mass_matrix
 get_mass_matrix(f) = hasproperty(f, :mass_matrix) ? f.mass_matrix : I
 
+# Reshape a flat linear-solve result back into the shape/container of the state.
+# Plain `reshape` collapses structured AbstractVector wrappers such as ArrayPartition
+# (the state type behind SecondOrderODEProblem / DynamicalODEFunction) down to a bare
+# Vector. That bare Vector then poisons the out-of-place Newton update `z .- dz`, whose
+# result can no longer be stored back into the ArrayPartition-typed nlsolver fields.
+# For those states, copy into a matching container so the wrapper is preserved.
+@inline _reshape_state(x, template) = _reshape(x, axes(template))
+@inline _reshape_state(x, template::ArrayPartition) = copyto!(similar(template, eltype(x)), x)
+
 get_status(nlsolver::AbstractNLSolver) = nlsolver.status
 get_new_W_γdt_cutoff(nlsolver::AbstractNLSolver) = nlsolver.cache.new_W_γdt_cutoff
 # handle FIRK

--- a/lib/OrdinaryDiffEqRosenbrock/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrock/Project.toml
@@ -5,6 +5,7 @@ authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
+ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -34,6 +35,7 @@ OrdinaryDiffEqRosenbrockTableaus = {path = "../OrdinaryDiffEqRosenbrockTableaus"
 [compat]
 SciMLTesting = "2.1"
 ADTypes = "1.22.0"
+ArrayInterface = "7.19"
 DiffEqBase = "7"
 DiffEqDevTools = "3"
 DifferentiationInterface = "0.7.18"

--- a/lib/OrdinaryDiffEqRosenbrock/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrock/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqRosenbrock"
 uuid = "43230ef6-c299-4910-a778-202eb28ce4ce"
-version = "2.6.0"
+version = "2.6.1"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 
 [deps]

--- a/lib/OrdinaryDiffEqRosenbrock/src/OrdinaryDiffEqRosenbrock.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/OrdinaryDiffEqRosenbrock.jl
@@ -17,7 +17,7 @@ import OrdinaryDiffEqCore: alg_adaptive_order, isWmethod, isfsal, _unwrap_val,
     find_algebraic_vars_eqs
 using MuladdMacro: MuladdMacro, @muladd
 using FastBroadcast: FastBroadcast, @..
-using RecursiveArrayTools: RecursiveArrayTools, recursivefill!
+using RecursiveArrayTools: RecursiveArrayTools, recursivefill!, ArrayPartition
 using DiffEqBase: @def
 import DifferentiationInterface as DI
 import LinearSolve

--- a/lib/OrdinaryDiffEqRosenbrock/src/OrdinaryDiffEqRosenbrock.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/OrdinaryDiffEqRosenbrock.jl
@@ -17,7 +17,12 @@ import OrdinaryDiffEqCore: alg_adaptive_order, isWmethod, isfsal, _unwrap_val,
     find_algebraic_vars_eqs
 using MuladdMacro: MuladdMacro, @muladd
 using FastBroadcast: FastBroadcast, @..
-using RecursiveArrayTools: RecursiveArrayTools, recursivefill!, ArrayPartition
+using RecursiveArrayTools: RecursiveArrayTools, recursivefill!
+using ArrayInterface: ArrayInterface
+
+# Map flat linear-solve results onto the state container (ArrayPartition-safe).
+@inline _restructure_state(template, x) = ArrayInterface.restructure(template, x)
+@inline _restructure_state(template::Number, x) = oftype(template, x)
 using DiffEqBase: @def
 import DifferentiationInterface as DI
 import LinearSolve

--- a/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_perform_step.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_perform_step.jl
@@ -1,12 +1,3 @@
-# Reshape a flat linear-solve result back into the shape/container of the state.
-# Plain `reshape` (used for matrix-valued states) collapses structured AbstractVector
-# wrappers such as ArrayPartition — the state type behind SecondOrderODEProblem /
-# DynamicalODEFunction — down to a bare Vector. That bare Vector then survives the
-# out-of-place stage broadcasts and breaks the user's `f(u,p,t)` which expects `u.x`.
-# For those states, copy into a matching container so the wrapper is preserved.
-@inline _reshape_state(x, uprev) = _reshape(x, axes(uprev))
-@inline _reshape_state(x, uprev::ArrayPartition) = copyto!(similar(uprev, eltype(x)), x)
-
 function initialize!(
         integrator, cache::Union{
             Rosenbrock23Cache,
@@ -288,16 +279,16 @@ end
         return nothing
     end
 
-    k₁ = _reshape_state(W \ _vec((integrator.fsalfirst + dtγ * dT)), uprev) * neginvdtγ
+    k₁ = _restructure_state(uprev, W \ _vec((integrator.fsalfirst + dtγ * dT))) * neginvdtγ
     integrator.stats.nsolve += 1
     tmp = @.. uprev + dto2 * k₁
     f₁ = f(tmp, p, t + dto2)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 
     if mass_matrix === I
-        k₂ = _reshape_state(W \ _vec(f₁ - k₁), uprev)
+        k₂ = _restructure_state(uprev, W \ _vec(f₁ - k₁))
     else
-        k₂ = _reshape_state(W \ _vec(f₁ - mass_matrix * k₁), uprev)
+        k₂ = _restructure_state(uprev, W \ _vec(f₁ - mass_matrix * k₁))
     end
     k₂ = @.. k₂ * neginvdtγ + k₁
     integrator.stats.nsolve += 1
@@ -319,7 +310,7 @@ end
                     c₃₂ * f₁ + 2 * integrator.fsalfirst + dt * dT
             )
         end
-        k₃ = _reshape_state(W \ _vec(linsolve_tmp), uprev) * neginvdtγ
+        k₃ = _restructure_state(uprev, W \ _vec(linsolve_tmp)) * neginvdtγ
         integrator.stats.nsolve += 1
 
         if u isa Number
@@ -373,17 +364,17 @@ end
         return nothing
     end
 
-    k₁ = _reshape_state(W \ -_vec((integrator.fsalfirst + dtγ * dT)), uprev) / dtγ
+    k₁ = _restructure_state(uprev, W \ -_vec((integrator.fsalfirst + dtγ * dT))) / dtγ
     integrator.stats.nsolve += 1
     tmp = @.. uprev + dto2 * k₁
     f₁ = f(tmp, p, t + dto2)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 
     if mass_matrix === I
-        k₂ = _reshape_state(W \ _vec(f₁ - k₁), uprev)
+        k₂ = _restructure_state(uprev, W \ _vec(f₁ - k₁))
     else
         linsolve_tmp = f₁ - mass_matrix * k₁
-        k₂ = _reshape_state(W \ _vec(linsolve_tmp), uprev)
+        k₂ = _restructure_state(uprev, W \ _vec(linsolve_tmp))
     end
     k₂ = @.. k₂ * neginvdtγ + k₁
 
@@ -404,7 +395,7 @@ end
                 c₃₂ * f₁ + 2 * integrator.fsalfirst + dt * dT
         )
     end
-    k₃ = _reshape_state(W \ _vec(linsolve_tmp), uprev) * neginvdtγ
+    k₃ = _restructure_state(uprev, W \ _vec(linsolve_tmp)) * neginvdtγ
     integrator.stats.nsolve += 1
     u = @.. uprev + dto6 * (k₁ + 4k₂ + k₃)
 
@@ -470,7 +461,7 @@ end
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     fsalfirst_cache = du  # save for interpolation (du gets overwritten in stage loop)
     linsolve_tmp = @.. du + dtd[1] * dT
-    k1 = _reshape_state(W \ -_vec(linsolve_tmp), uprev)
+    k1 = _restructure_state(uprev, W \ -_vec(linsolve_tmp))
     # constant number for type stability make sure this is greater than num_stages
     ks = ntuple(Returns(k1), Val(20))
 
@@ -505,7 +496,7 @@ end
         end
         linsolve_tmp = @.. du + dtd[stage] * dT + linsolve_tmp
 
-        ks = Base.setindex(ks, _reshape_state(W \ -_vec(linsolve_tmp), uprev), stage)
+        ks = Base.setindex(ks, _restructure_state(uprev, W \ -_vec(linsolve_tmp)), stage)
         integrator.stats.nsolve += 1
     end
     # Solution update using explicit b weights

--- a/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_perform_step.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_perform_step.jl
@@ -1,3 +1,12 @@
+# Reshape a flat linear-solve result back into the shape/container of the state.
+# Plain `reshape` (used for matrix-valued states) collapses structured AbstractVector
+# wrappers such as ArrayPartition — the state type behind SecondOrderODEProblem /
+# DynamicalODEFunction — down to a bare Vector. That bare Vector then survives the
+# out-of-place stage broadcasts and breaks the user's `f(u,p,t)` which expects `u.x`.
+# For those states, copy into a matching container so the wrapper is preserved.
+@inline _reshape_state(x, uprev) = _reshape(x, axes(uprev))
+@inline _reshape_state(x, uprev::ArrayPartition) = copyto!(similar(uprev, eltype(x)), x)
+
 function initialize!(
         integrator, cache::Union{
             Rosenbrock23Cache,
@@ -279,16 +288,16 @@ end
         return nothing
     end
 
-    k₁ = _reshape(W \ _vec((integrator.fsalfirst + dtγ * dT)), axes(uprev)) * neginvdtγ
+    k₁ = _reshape_state(W \ _vec((integrator.fsalfirst + dtγ * dT)), uprev) * neginvdtγ
     integrator.stats.nsolve += 1
     tmp = @.. uprev + dto2 * k₁
     f₁ = f(tmp, p, t + dto2)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 
     if mass_matrix === I
-        k₂ = _reshape(W \ _vec(f₁ - k₁), axes(uprev))
+        k₂ = _reshape_state(W \ _vec(f₁ - k₁), uprev)
     else
-        k₂ = _reshape(W \ _vec(f₁ - mass_matrix * k₁), axes(uprev))
+        k₂ = _reshape_state(W \ _vec(f₁ - mass_matrix * k₁), uprev)
     end
     k₂ = @.. k₂ * neginvdtγ + k₁
     integrator.stats.nsolve += 1
@@ -310,7 +319,7 @@ end
                     c₃₂ * f₁ + 2 * integrator.fsalfirst + dt * dT
             )
         end
-        k₃ = _reshape(W \ _vec(linsolve_tmp), axes(uprev)) * neginvdtγ
+        k₃ = _reshape_state(W \ _vec(linsolve_tmp), uprev) * neginvdtγ
         integrator.stats.nsolve += 1
 
         if u isa Number
@@ -364,17 +373,17 @@ end
         return nothing
     end
 
-    k₁ = _reshape(W \ -_vec((integrator.fsalfirst + dtγ * dT)), axes(uprev)) / dtγ
+    k₁ = _reshape_state(W \ -_vec((integrator.fsalfirst + dtγ * dT)), uprev) / dtγ
     integrator.stats.nsolve += 1
     tmp = @.. uprev + dto2 * k₁
     f₁ = f(tmp, p, t + dto2)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 
     if mass_matrix === I
-        k₂ = _reshape(W \ _vec(f₁ - k₁), axes(uprev))
+        k₂ = _reshape_state(W \ _vec(f₁ - k₁), uprev)
     else
         linsolve_tmp = f₁ - mass_matrix * k₁
-        k₂ = _reshape(W \ _vec(linsolve_tmp), axes(uprev))
+        k₂ = _reshape_state(W \ _vec(linsolve_tmp), uprev)
     end
     k₂ = @.. k₂ * neginvdtγ + k₁
 
@@ -395,7 +404,7 @@ end
                 c₃₂ * f₁ + 2 * integrator.fsalfirst + dt * dT
         )
     end
-    k₃ = _reshape(W \ _vec(linsolve_tmp), axes(uprev)) * neginvdtγ
+    k₃ = _reshape_state(W \ _vec(linsolve_tmp), uprev) * neginvdtγ
     integrator.stats.nsolve += 1
     u = @.. uprev + dto6 * (k₁ + 4k₂ + k₃)
 
@@ -461,7 +470,7 @@ end
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     fsalfirst_cache = du  # save for interpolation (du gets overwritten in stage loop)
     linsolve_tmp = @.. du + dtd[1] * dT
-    k1 = _reshape(W \ -_vec(linsolve_tmp), axes(uprev))
+    k1 = _reshape_state(W \ -_vec(linsolve_tmp), uprev)
     # constant number for type stability make sure this is greater than num_stages
     ks = ntuple(Returns(k1), Val(20))
 
@@ -496,7 +505,7 @@ end
         end
         linsolve_tmp = @.. du + dtd[stage] * dT + linsolve_tmp
 
-        ks = Base.setindex(ks, _reshape(W \ -_vec(linsolve_tmp), axes(uprev)), stage)
+        ks = Base.setindex(ks, _reshape_state(W \ -_vec(linsolve_tmp), uprev), stage)
         integrator.stats.nsolve += 1
     end
     # Solution update using explicit b weights

--- a/lib/OrdinaryDiffEqRosenbrock/src/stiff_addsteps.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/stiff_addsteps.jl
@@ -35,13 +35,13 @@ function _ode_addsteps!(
             end
         end
         f₀ = f(uprev, p, t)
-        k₁ = _reshape(W \ _vec((f₀ + dtγ * dT)), axes(uprev)) * neginvdtγ
+        k₁ = _restructure_state(uprev, W \ _vec((f₀ + dtγ * dT))) * neginvdtγ
         tmp = @.. uprev + dto2 * k₁
         f₁ = f(tmp, p, t + dto2)
         if mass_matrix === I
-            k₂ = _reshape(W \ _vec(f₁ - k₁), axes(uprev))
+            k₂ = _restructure_state(uprev, W \ _vec(f₁ - k₁))
         else
-            k₂ = _reshape(W \ _vec(f₁ - mass_matrix * k₁), axes(uprev))
+            k₂ = _restructure_state(uprev, W \ _vec(f₁ - mass_matrix * k₁))
         end
         k₂ = @.. k₂ * neginvdtγ + k₁
         copyat_or_push!(k, 1, k₁)
@@ -89,7 +89,7 @@ function _ode_addsteps!(
         num_stages = size(A, 1)
         du = f(u, p, t)
         linsolve_tmp = @.. du + dtd[1] * dT
-        k1 = _reshape(W \ _vec(linsolve_tmp), axes(uprev))
+        k1 = _restructure_state(uprev, W \ _vec(linsolve_tmp))
         # constant number for type stability make sure this is greater than num_stages
         ks = ntuple(Returns(k1), Val(20))
         # Last stage affect's ks for Rodas5,5P,6P
@@ -114,7 +114,7 @@ function _ode_addsteps!(
                 linsolve_tmp = mass_matrix * linsolve_tmp
             end
             linsolve_tmp = @.. du + dtd[stage] * dT + linsolve_tmp
-            ks = Base.setindex(ks, _reshape(W \ _vec(linsolve_tmp), axes(uprev)), stage)
+            ks = Base.setindex(ks, _restructure_state(uprev, W \ _vec(linsolve_tmp)), stage)
         end
 
         if size(H, 1) > 0

--- a/lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl
@@ -1,4 +1,5 @@
 using OrdinaryDiffEqRosenbrock, DiffEqDevTools, Test, LinearAlgebra, LinearSolve, ADTypes
+using RecursiveArrayTools: ArrayPartition
 import ODEProblemLibrary: prob_ode_linear,
     prob_ode_2Dlinear,
     prob_ode_bigfloatlinear, prob_ode_bigfloat2Dlinear
@@ -529,5 +530,31 @@ using OrdinaryDiffEqNonlinearSolve: BrownFullBasicInit
         )
         @test SciMLBase.successful_retcode(sol_rodas)
         @test norm(sol_rodas.u[end] - ref.u[end]) < 1.0e-4
+    end
+end
+
+# Regression test for issue #3962 (and #1263): out-of-place Rosenbrock/Rodas steps
+# used `_reshape(W \ _vec(...), axes(uprev))`, which collapses the ArrayPartition
+# state behind SecondOrderODEProblem/DynamicalODEFunction down to a bare Vector. The
+# next `f(u,p,t)` then failed with `type Array has no field x`. The out-of-place
+# stages must keep the state an ArrayPartition.
+@testset "OOP SecondOrderODEProblem preserves ArrayPartition (#3962)" begin
+    # u'' = -u  ⇒  position = [cos t, sin t], velocity = [-sin t, cos t]
+    ho_iip(ddu, du, u, p, t) = (@. ddu = -u)
+    ho_oop(du, u, p, t) = -u
+    u0 = [1.0, 0.0]
+    du0 = [0.0, 1.0]
+    tspan = (0.0, 1.0)
+    prob_iip = SecondOrderODEProblem(ho_iip, du0, u0, tspan)
+    prob_oop = SecondOrderODEProblem(ho_oop, du0, u0, tspan)
+
+    for alg in (Rosenbrock23(), Rodas5P(), Rodas4(), Rodas5())
+        ref = solve(prob_iip, alg, abstol = 1.0e-10, reltol = 1.0e-10)
+        sol = solve(prob_oop, alg, abstol = 1.0e-10, reltol = 1.0e-10)
+        @test SciMLBase.successful_retcode(sol)
+        # Wrapper must survive the out-of-place stages.
+        @test sol.u[end] isa ArrayPartition
+        # And the answer must match the in-place reference, not merely not-error.
+        @test norm(sol.u[end] - ref.u[end]) < 1.0e-6
     end
 end

--- a/lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl
@@ -534,10 +534,10 @@ using OrdinaryDiffEqNonlinearSolve: BrownFullBasicInit
 end
 
 # Regression test for issue #3962 (and #1263): out-of-place Rosenbrock/Rodas steps
-# used `_reshape(W \ _vec(...), axes(uprev))`, which collapses the ArrayPartition
-# state behind SecondOrderODEProblem/DynamicalODEFunction down to a bare Vector. The
-# next `f(u,p,t)` then failed with `type Array has no field x`. The out-of-place
-# stages must keep the state an ArrayPartition.
+# previously used `_reshape(W \ _vec(...), axes(uprev))`, which collapses the
+# ArrayPartition state behind SecondOrderODEProblem/DynamicalODEFunction down to a
+# bare Vector. The next `f(u,p,t)` then failed with `type Array has no field x`.
+# Stages now use `ArrayInterface.restructure(uprev, ...)` so the wrapper is kept.
 @testset "OOP SecondOrderODEProblem preserves ArrayPartition (#3962)" begin
     # u'' = -u  ⇒  position = [cos t, sin t], velocity = [-sin t, cos t]
     ho_iip(ddu, du, u, p, t) = (@. ddu = -u)


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

Fixes #3962. Also fixes #1263 (and unblocks the OOP-stiff path noted in SciML/DifferentialEquations.jl#301).

## Problem

Out-of-place stiff solvers failed on `SecondOrderODEProblem` / `DynamicalODEFunction` states backed by `ArrayPartition`:

```
oop (vector components):
  Rodas5P / Rosenbrock23  ->  ERROR: type Array has no field x
  FBDF                    ->  MethodError: Cannot convert Vector{Float64} to ArrayPartition{...}
iip (same problem):
  all -> retcode = Success
```

## Root cause

The out-of-place stages rebuild the state from a flat linear-solve result with

```julia
_reshape(W \ _vec(...), axes(uprev))
```

`reshape` to the (linear) axes of an `ArrayPartition` collapses it to a bare `Vector`. That bare `Vector` then survives the stage broadcasts, and:

- in Rosenbrock/Rodas the next `f(u, p, t)` hits `u.x` → `type Array has no field x`;
- in the shared out-of-place Newton path (FBDF and the other BDF/DIRK methods) the update `z .- dz` produces a `Vector` that can no longer be stored back into the `ArrayPartition`-typed nlsolver fields → `Cannot convert Vector to ArrayPartition`.

## Fix

Use the public API `ArrayInterface.restructure(template, flat)` (documented for ArrayPartition; RAT uses it internally) at every out-of-place reshape site in the Rosenbrock constant caches, stiff dense-output addsteps, and the out-of-place Newton / functional-iteration nlsolver paths.

A thin local wrapper handles `Number` states (`restructure` relies on `similar`, which is not defined for scalars):

```julia
@inline _restructure_state(template, x) = ArrayInterface.restructure(template, x)
@inline _restructure_state(template::Number, x) = oftype(template, x)
```

This mirrors how the in-place paths already keep the wrapper (they fill `_vec(ks[i])` of a preallocated `ArrayPartition` in place). Plain `Vector`, `StaticArray`, matrix-valued, and scalar states go through restructure/`oftype` cleanly.

## Verification (run locally, Julia 1.11.9)

`u'' = -u`, `u(0) = [1,0]`, `u'(0) = [0,1]` as an OOP `SecondOrderODEProblem`; compared against the in-place reference:

| solver | before | after |
|---|---|---|
| Rosenbrock23 | `type Array has no field x` | Success, matches ref |
| Rodas5P | `type Array has no field x` | Success, matches ref |
| FBDF | `Cannot convert Vector to ArrayPartition` | Success, matches ref |

Also verified: #1263 MWE succeeds and stays `ArrayPartition`; scalar and StaticArray OOP stiff paths still succeed after the Number branch.

## Tests

- `lib/OrdinaryDiffEqRosenbrock/test/ode_rosenbrock_tests.jl`: OOP `SecondOrderODEProblem` with Rosenbrock23/Rodas5P/Rodas4/Rodas5 stays an `ArrayPartition` and matches the in-place reference.
- `lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl`: same for FBDF.

Patch-version bumps for `OrdinaryDiffEqRosenbrock` (2.6.1) and `OrdinaryDiffEqNonlinearSolve` (2.5.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)