### PR TITLE
Coerce initdt equality checks to scalar Bool (ODE#1402 / PyCall#900)

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -145,3 +145,4 @@ Comput = "Comput"  # J. Comput. Phys. (Journal of Computational Physics)
 
 # Julia spelling convention
 inferrable = "inferrable"  # Julia uses "inferrable" not "inferable"
+hom = "hom"  # scc_hom homotopy abbreviation in NonlinearSolve tests (#3989)

--- a/lib/OrdinaryDiffEqCore/src/initdt.jl
+++ b/lib/OrdinaryDiffEqCore/src/initdt.jl
@@ -6,6 +6,14 @@
 #   d₂ uses max(|Δf±ΔgMax|)/sk instead of Δf/sk
 # =============================================================================
 
+# Coerce `a == b` to a scalar `Bool`. Some array wrappers (notably PyCall
+# `PyObject` of arrays — JuliaPy/PyCall.jl#900) return `Vector{Bool}` from `==`,
+# which is not valid in a boolean context. See OrdinaryDiffEq.jl#1402.
+@inline function _bool_equal(a, b)
+    r = a == b
+    return r isa Bool ? r : all(r)
+end
+
 @muladd function _ode_initdt_iip(
         u0, t, tdir, dtmax, abstol, reltol, internalnorm,
         prob, g, noise_prototype, order, integrator
@@ -242,8 +250,11 @@
 
     # Constant zone before callback
     # Just return first guess
-    # Avoids AD issues
-    length(u0) > 0 && f₀ == f₁ && return tdir * max(dtmin, 100dt₀)
+    # Avoids AD issues.
+    # `==` is not guaranteed to return `Bool` (e.g. PyCall `PyObject` arrays
+    # return `Vector{Bool}` — JuliaPy/PyCall.jl#900 / OrdinaryDiffEq.jl#1402).
+    # Coerce array-valued equality so the boolean context always receives a Bool.
+    length(u0) > 0 && _bool_equal(f₀, f₁) && return tdir * max(dtmin, 100dt₀)
 
     # d₂: fold in diffusion terms when g !== nothing
     if g !== nothing
@@ -403,8 +414,9 @@ end
 
     # Constant zone before callback
     # Just return first guess
-    # Avoids AD issues
-    f₀ == f₁ && return tdir * max(dtmin, 100dt₀)
+    # Avoids AD issues.
+    # See iip path: coerce array-valued `==` (OrdinaryDiffEq.jl#1402).
+    _bool_equal(f₀, f₁) && return tdir * max(dtmin, 100dt₀)
 
     # d₂: fold in diffusion terms when g !== nothing
     if g !== nothing

--- a/lib/OrdinaryDiffEqCore/test/bool_equal_tests.jl
+++ b/lib/OrdinaryDiffEqCore/test/bool_equal_tests.jl
@@ -1,0 +1,25 @@
+using OrdinaryDiffEqCore
+using Test
+
+# OrdinaryDiffEq.jl#1402 / JuliaPy/PyCall.jl#900:
+# some wrappers return Vector{Bool} from `==`, which is invalid in boolean context.
+struct ArrayValuedEq
+    x::Vector{Float64}
+end
+Base.:(==)(a::ArrayValuedEq, b::ArrayValuedEq) = a.x .== b.x
+
+@testset "_bool_equal coerces array-valued ==" begin
+    @test OrdinaryDiffEqCore._bool_equal(1.0, 1.0)
+    @test !OrdinaryDiffEqCore._bool_equal(1.0, 2.0)
+    @test OrdinaryDiffEqCore._bool_equal([1.0, 2.0], [1.0, 2.0])
+    @test !OrdinaryDiffEqCore._bool_equal([1.0, 2.0], [1.0, 3.0])
+
+    a = ArrayValuedEq([1.0, 2.0, 3.0])
+    b = ArrayValuedEq([1.0, 2.0, 3.0])
+    c = ArrayValuedEq([1.0, 2.0, 4.0])
+    @test (a == b) isa AbstractArray
+    @test OrdinaryDiffEqCore._bool_equal(a, b)
+    @test !OrdinaryDiffEqCore._bool_equal(a, c)
+    # boolean context must work
+    @test OrdinaryDiffEqCore._bool_equal(a, b) && true
+end

--- a/lib/OrdinaryDiffEqCore/test/runtests.jl
+++ b/lib/OrdinaryDiffEqCore/test/runtests.jl
@@ -36,4 +36,5 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "Algebraic Vars Detection" include("algebraic_vars_detection_tests.jl")
     @time @safetestset "Discontinuity Detection" include("disco_tests.jl")
     @time @safetestset "Interpolation Search Hint" include("interpolation_hint_tests.jl")
+    @time @safetestset "Bool Equal Coercion" include("bool_equal_tests.jl")
 end


### PR DESCRIPTION
## Summary

Initial timestep estimation uses `f₀ == f₁` to detect a constant zone before callbacks. That expression is not guaranteed to return a scalar `Bool`: PyCall `PyObject` of arrays returns `Vector{Bool}` ([JuliaPy/PyCall.jl#900](https://github.com/JuliaPy/PyCall.jl/issues/900)), which throws `TypeError: non-boolean (Vector{Bool}) used in boolean context` ([OrdinaryDiffEq.jl#1402](https://github.com/SciML/OrdinaryDiffEq.jl/issues/1402)).

Add a small `_bool_equal` helper that returns `r` when `r isa Bool`, else `all(r)`, and use it in both iip and oop initdt paths. This is a SciML-side robustness fix; the upstream PyCall bug remains open.

## Test plan

- [x] Unit tests for `_bool_equal` with scalar Bool, array `==`, and a mock type that returns `Vector{Bool}` from `==`
- [x] Local test PASS (8/8)
- [ ] CI OrdinaryDiffEqCore Core group

This PR should be ignored until reviewed by @ChrisRackauckas.