### PR TITLE
Route OOP initdt NaN checks through DiffEqBase.NAN_CHECK (#1404)

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -145,3 +145,4 @@ Comput = "Comput"  # J. Comput. Phys. (Journal of Computational Physics)
 
 # Julia spelling convention
 inferrable = "inferrable"  # Julia uses "inferrable" not "inferable"
+hom = "hom"  # scc_hom homotopy abbreviation in NonlinearSolve tests (#3989)

--- a/lib/OrdinaryDiffEqCore/src/initdt.jl
+++ b/lib/OrdinaryDiffEqCore/src/initdt.jl
@@ -360,11 +360,15 @@ end
 
     f₀ = f(u0, p, t)
 
-    if any(x -> any(isnan, x), f₀)
+    # Use the overloadable DiffEqBase.NAN_CHECK hook (same intent as the IIP
+    # isnan(d₁) path) rather than nested any(isnan, ·), which custom array /
+    # field types cannot sensibly overload (OrdinaryDiffEq #1404).
+    if DiffEqBase.NAN_CHECK(f₀)
         @SciMLMessage(
             "First function call produced NaNs. Exiting. Double check that none of the initial conditions, parameters, or timespan values are NaN.",
             integrator.opts.verbose, :init_NaN
         )
+        return tdir * dtmin
     end
 
     inferredtype = Base.promote_op(/, typeof(u0), typeof(oneunit(t)))
@@ -377,17 +381,27 @@ end
     g₀ = nothing
     if g !== nothing
         g₀ = 3g(u0, p, t)
-        if any(x -> any(isnan, x), g₀)
+        if DiffEqBase.NAN_CHECK(g₀)
             @SciMLMessage(
                 "First function call for g produced NaNs. Exiting.",
                 integrator.opts.verbose, :init_NaN
             )
+            return tdir * dtmin
         end
         d₁ = internalnorm(
             max.(internalnorm.(f₀ .+ g₀, t), internalnorm.(f₀ .- g₀, t)) ./ sk, t
         )
     else
         d₁ = internalnorm(f₀ ./ sk .* oneunit_tType, t)
+    end
+
+    # Also catch NaN AD partials that NAN_CHECK on values may miss (matches IIP).
+    if isnan(d₁)
+        @SciMLMessage(
+            "First function call produced NaNs. Exiting. Double check that none of the initial conditions, parameters, or timespan values are NaN.",
+            integrator.opts.verbose, :init_NaN
+        )
+        return tdir * dtmin
     end
 
     if d₀ < 1 // 10^(5) || d₁ < 1 // 10^(5)

--- a/test/InterfaceI/ode_initdt_tests.jl
+++ b/test/InterfaceI/ode_initdt_tests.jl
@@ -88,3 +88,19 @@ let
         @test SciMLBase.successful_retcode(solve(prob, DefaultODEAlgorithm()))
     end
 end
+
+# https://github.com/SciML/OrdinaryDiffEq.jl/issues/1404
+# OOP initdt must route through DiffEqBase.NAN_CHECK (not nested any(isnan, ·))
+# so custom array types can overload it, matching the IIP intent.
+@testset "OOP initdt NaN handling (#1404)" begin
+    f_nan(u, p, t) = [NaN]
+    prob = ODEProblem(f_nan, [1.0], (0.0, 1.0))
+    sol = solve(prob, Tsit5())
+    # NAN_CHECK triggers early exit with dtmin; subsequent stepping aborts as
+    # Unstable (tiny dt). Must not MethodError on any(isnan, ·).
+    @test sol.retcode in (ReturnCode.DtNaN, ReturnCode.Unstable)
+
+    f_ok(u, p, t) = -u
+    sol_ok = solve(ODEProblem(f_ok, [1.0], (0.0, 1.0)), Tsit5())
+    @test SciMLBase.successful_retcode(sol_ok)
+end


### PR DESCRIPTION
## Summary

- OOP `initdt` used `any(x -> any(isnan, x), f₀)`, which custom array/field types cannot overload.
- Replace with `DiffEqBase.NAN_CHECK` (and `isnan(d₁)` for AD partials), aligning with the IIP intent.
- Also early-returns `tdir * dtmin` on NaN (previously only warned and continued).

Fixes #1404

This PR should be ignored until reviewed by @ChrisRackauckas.

## Test plan

- [x] Local: OOP `f -> [NaN]` exits without MethodError
- [x] Local: finite OOP still succeeds
- [ ] CI: InterfaceI initdt tests