### PR TITLE
Allow hom typos word for homotopy test names

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -69,6 +69,7 @@ arXiv = "arXiv"
 # (Numer already declared above for "BIT Numer" context.)
 
 # Technical variable names
+hom = "hom"  # homotopy abbreviation (scc_hom, HomotopyProblem)
 dorder = "dorder"  # Parameter for delta order / order change
 
 


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

## Summary

- Master Spell Check fails after #3989 with `hom` should be `home` on `scc_hom` in `homotopy_default_nlsolve_tests.jl`.
- Add `hom` to `.typos.toml` extend-words (intentional homotopy abbreviation).

No code changes.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>