### PR TITLE
AutoDePSpecialize: de-specialize non-isbits parameters via OpaqueRef

### DIFF
--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.8.0"
+version = "7.9.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/DiffEqBase/ext/DiffEqBaseForwardDiffExt.jl
+++ b/lib/DiffEqBase/ext/DiffEqBaseForwardDiffExt.jl
@@ -133,9 +133,10 @@ function wrapfun_iip(
 end
 
 # Opaque-p variant of the 3-arg wrapfun_iip: same matrix of (du, u, p, t)
-# variants as the regular FD wrapper, but with `OpaqueParams` substituted in
-# place of `T3` (the parameter slot). The user's `ff` is wrapped in
-# `OpaqueVoid(P, ff)` so the unpack-to-`P` happens before `ff` is invoked.
+# variants as the regular FD wrapper, but with the opaque container substituted
+# in place of `T3` (the parameter slot) — `OpaqueParams` for an `isbits` `P`,
+# `OpaqueRef` otherwise. The user's `ff` is wrapped in `OpaqueVoid(P, ff)` so
+# the unpack-to-`P` happens before `ff` is invoked.
 function wrapfun_iip_opaque(
         ff,
         ::Type{P},
@@ -152,7 +153,7 @@ function wrapfun_iip_opaque(
     dualT1_time = ArrayInterface.promote_eltype(T1, dualT_time)
     dualT4_time = dualgen(promote_type(T, T4))
 
-    O = RespecializeParams.OpaqueParams
+    O = RespecializeParams.opaque_container_type(P)
     return _make_fww(
         OpaqueVoid(P, ff),
         Tuple{T1, T2, O, T4},

--- a/lib/DiffEqBase/src/opaque_void.jl
+++ b/lib/DiffEqBase/src/opaque_void.jl
@@ -28,7 +28,10 @@ the wrapper signature carries it in the `p` slot.
 
 Excluded (kept as-is): `SciMLBase.NullParameters` (already a uniform singleton)
 and already-packed containers (idempotency, so a sensitivity adjoint that
-re-concretizes an opaque problem does not nest wrappers).
+re-concretizes an opaque problem does not nest wrappers). Problems carrying a
+symbolic system (`SciMLBase.has_sys(f)`, e.g. ModelingToolkit) are declined at
+the `promote_f` call site rather than here, since that policy needs `f`, not
+just `p`: their `p` must stay concrete for initialization and symbolic indexing.
 
 De-specializing makes `sol.prob.p` an opaque container, so **`AutoDePSpecialize`
 is a forward-solve latency tool, not for parameter-estimation workflows**:

--- a/lib/DiffEqBase/src/opaque_void.jl
+++ b/lib/DiffEqBase/src/opaque_void.jl
@@ -20,12 +20,25 @@
 """
     should_opaque_p(p) :: Bool
 
-Policy for whether the [`AutoDePSpecialize`](@ref) path de-specializes `p`: true
-for an `isbits` non-`NullParameters` payload, false otherwise. `NullParameters`
-is already a uniform singleton, and non-`isbits` payloads fall back to the plain
-`AutoSpecialize` wrapping.
+Policy for whether the [`AutoDePSpecialize`](@ref) path de-specializes `p`.
+`isbits` structs are packed into a `RespecializeParams.OpaqueParams` (byte copy)
+and non-`isbits` structs into a `RespecializeParams.OpaqueRef` (by reference);
+`RespecializeParams.pack_auto` / `opaque_container_type` pick the container and
+the wrapper signature carries it in the `p` slot.
+
+Excluded (kept as-is): `SciMLBase.NullParameters` (already a uniform singleton)
+and already-packed containers (idempotency, so a sensitivity adjoint that
+re-concretizes an opaque problem does not nest wrappers).
+
+De-specializing makes `sol.prob.p` an opaque container, so **`AutoDePSpecialize`
+is a forward-solve latency tool, not for parameter-estimation workflows**:
+reverse-mode AD of `p` (SciMLSensitivity) and symbolic parameter indexing
+(`getp`/`setp`/observed) both read the concrete parameter object and are not
+supported under it (reverse-mode support is a planned follow-up). Recover the
+payload explicitly with `RespecializeParams.unpack(sol.prob.p, typeof(p))`.
 """
-@inline should_opaque_p(p) = isbits(p) && !(p isa SciMLBase.NullParameters)
+@inline should_opaque_p(p) = !(p isa SciMLBase.NullParameters) &&
+    !(p isa RespecializeParams.OpaqueParams) && !(p isa RespecializeParams.OpaqueRef)
 
 """
     wrapfun_iip_opaque(ff, ::Type{P}, inputs, ::Val{CS}) -> FunctionWrappersWrapper

--- a/lib/DiffEqBase/src/solve.jl
+++ b/lib/DiffEqBase/src/solve.jl
@@ -852,7 +852,14 @@ function promote_f(
     # Idempotency: never re-wrap an already function-wrapped `f` (e.g. when a
     # sensitivity adjoint re-concretizes a problem whose `f.f` is already an
     # opaque wrapper) — doing so would nest `OpaqueVoid` around the wrapper.
+    # Symbolic systems (`has_sys`, e.g. ModelingToolkit): decline. Their `p`
+    # (MTKParameters) must stay concrete for the initialization pipeline and
+    # symbolic parameter indexing; an opaque container makes `solve` error in
+    # `promote_u0_p` and breaks `getp`/observed. They also gain nothing here
+    # (MTKParameters is non-isbits and already type-uniform), so falling back to
+    # the normal specialization is the correct no-op.
     opaque = specialize === AutoDePSpecialize && should_opaque_p(p) &&
+        !SciMLBase.has_sys(f) &&
         !(f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper)
     P = typeof(p)
     sig_p = opaque ? RespecializeParams.opaque_container_type(P) : P
@@ -953,6 +960,7 @@ function promote_f(
     end
 
     if specialize === AutoDePSpecialize && should_opaque_p(p) &&
+            !SciMLBase.has_sys(f) &&
             !(f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper)
         P = typeof(p)
         sig = Tuple{typeof(u0), typeof(u0), P, typeof(t)}

--- a/lib/DiffEqBase/src/solve.jl
+++ b/lib/DiffEqBase/src/solve.jl
@@ -849,9 +849,13 @@ function promote_f(
     # non-NullParameters payload, route the wrapped Void through OpaqueVoid so
     # the wrapper's signature has `OpaqueParams` in the p slot. The packed p is
     # returned alongside f and is plumbed into prob.p by `get_concrete_problem`.
-    opaque = specialize === AutoDePSpecialize && should_opaque_p(p)
+    # Idempotency: never re-wrap an already function-wrapped `f` (e.g. when a
+    # sensitivity adjoint re-concretizes a problem whose `f.f` is already an
+    # opaque wrapper) — doing so would nest `OpaqueVoid` around the wrapper.
+    opaque = specialize === AutoDePSpecialize && should_opaque_p(p) &&
+        !(f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper)
     P = typeof(p)
-    sig_p = opaque ? RespecializeParams.OpaqueParams : P
+    sig_p = opaque ? RespecializeParams.opaque_container_type(P) : P
 
     # tgrad: same (dT, u, p, t) shape as the RHS.
     if f.tgrad !== nothing && !(f.tgrad isa FunctionWrappersWrappers.FunctionWrappersWrapper)
@@ -948,7 +952,8 @@ function promote_f(
         return (f, p)
     end
 
-    if specialize === AutoDePSpecialize && should_opaque_p(p)
+    if specialize === AutoDePSpecialize && should_opaque_p(p) &&
+            !(f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper)
         P = typeof(p)
         sig = Tuple{typeof(u0), typeof(u0), P, typeof(t)}
         wrapped = RespecializeParams.wrap_void_opaque(f.f, P, (sig,))

--- a/lib/DiffEqBase/test/opaque_p_test.jl
+++ b/lib/DiffEqBase/test/opaque_p_test.jl
@@ -3,6 +3,7 @@ using SciMLBase
 using RespecializeParams
 using Test
 using ForwardDiff
+using SymbolicIndexingInterface: SymbolCache
 
 # An `isbits` parameter struct. `get_concrete_problem` on an AutoDePSpecialize
 # in-place ODEFunction with such a `p` should route through the opaque path:
@@ -84,6 +85,27 @@ concretize(prob, alg = nothing) = DiffEqBase.get_concrete_problem(prob, true; al
         f_vec!(du, u, p::Vector{Float64}, t) = (@inbounds du[1] = -p[1] * u[1]; nothing)
         cpv = concretize(ODEProblem{true, DiffEqBase.AutoDePSpecialize}(f_vec!, [1.0], (0.0, 1.0), [0.5]))
         @test cpv.p isa RespecializeParams.OpaqueRef
+    end
+
+    @testset "symbolic-system problems are declined (MTK safety)" begin
+        # A problem whose `f` carries a symbolic system (`has_sys`, as every
+        # ModelingToolkit problem does) must NOT be opaque-ified: its `p` has to
+        # stay concrete for the initialization pipeline and symbolic parameter
+        # indexing. `SymbolCache` stands in for an MTK `System` here without the
+        # ModelingToolkit dependency. The opaque path declines and falls back.
+        f_sym!(du, u, p, t) = (@inbounds du[1] = -u[1]; nothing)
+        ff = ODEFunction(f_sym!; sys = SymbolCache([:x], [:k], :t))
+        @test SciMLBase.has_sys(ff)
+
+        # non-isbits p that would otherwise pack into an OpaqueRef:
+        cp = concretize(ODEProblem{true, DiffEqBase.AutoDePSpecialize}(ff, [1.0], (0.0, 1.0), VecP([0.5])))
+        @test cp.p isa VecP
+        @test !(cp.p isa RespecializeParams.OpaqueRef)
+
+        # isbits p that would otherwise pack into an OpaqueParams:
+        cpi = concretize(ODEProblem{true, DiffEqBase.AutoDePSpecialize}(ff, [1.0], (0.0, 1.0), LinearP(0.5)))
+        @test cpi.p isa LinearP
+        @test !(cpi.p isa RespecializeParams.OpaqueParams)
     end
 
     @testset "already-packed p is not re-wrapped (idempotent)" begin

--- a/lib/DiffEqBase/test/opaque_p_test.jl
+++ b/lib/DiffEqBase/test/opaque_p_test.jl
@@ -14,6 +14,10 @@ struct LinearP
     k::Float64
 end
 
+struct VecP
+    ks::Vector{Float64}
+end
+
 function linear_rhs!(du, u, p::LinearP, t)
     @inbounds du[1] = -p.k * u[1]
     return nothing
@@ -64,14 +68,29 @@ concretize(prob, alg = nothing) = DiffEqBase.get_concrete_problem(prob, true; al
         @test cp.p isa SciMLBase.NullParameters
     end
 
-    @testset "Non-isbits p falls back to AutoSpecialize-style wrapping" begin
-        f_vec!(du, u, p::Vector{Float64}, t) = (@inbounds du[1] = -p[1] * u[1]; nothing)
-        prob = ODEProblem{true, DiffEqBase.AutoDePSpecialize}(
-            f_vec!, [1.0], (0.0, 1.0), [0.5],
-        )
+    @testset "non-isbits p is de-specialized via OpaqueRef" begin
+        # A non-isbits struct (Vector field). It packs by reference into an
+        # OpaqueRef, and the wrapper signature carries OpaqueRef in the p slot.
+        f_vecp!(du, u, p::VecP, t) = (@inbounds du[1] = -p.ks[1] * u[1]; nothing)
+        prob = ODEProblem{true, DiffEqBase.AutoDePSpecialize}(f_vecp!, [1.0], (0.0, 1.0), VecP([0.5]))
         cp = concretize(prob)
-        @test cp.p isa Vector{Float64}
-        @test cp.f.f isa DiffEqBase.FunctionWrappersWrappers.FunctionWrappersWrapper
+        @test cp.p isa RespecializeParams.OpaqueRef
+        du = [0.0]
+        cp.f(du, [1.0], cp.p, 0.0)
+        @test du[1] ≈ -0.5
+        @test RespecializeParams.unpack(cp.p, VecP).ks == [0.5]
+
+        # a bare Vector parameter is likewise de-specialized into an OpaqueRef
+        f_vec!(du, u, p::Vector{Float64}, t) = (@inbounds du[1] = -p[1] * u[1]; nothing)
+        cpv = concretize(ODEProblem{true, DiffEqBase.AutoDePSpecialize}(f_vec!, [1.0], (0.0, 1.0), [0.5]))
+        @test cpv.p isa RespecializeParams.OpaqueRef
+    end
+
+    @testset "already-packed p is not re-wrapped (idempotent)" begin
+        cp = concretize(deprob([1.0], LinearP(0.5)))
+        cp2 = concretize(cp)   # re-concretize the opaque problem
+        @test cp2.p isa RespecializeParams.OpaqueParams
+        @test typeof(cp2.f) === typeof(cp.f)   # no nested OpaqueVoid wrapping
     end
 
     @testset "two LinearP problems share the wrapped-f type" begin

--- a/lib/OrdinaryDiffEqBDF/Project.toml
+++ b/lib/OrdinaryDiffEqBDF/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqBDF"
 uuid = "6ad6398a-0878-4a85-9266-38940aa047c8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.4.0"
+version = "2.4.1"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqBDF/src/OrdinaryDiffEqBDF.jl
+++ b/lib/OrdinaryDiffEqBDF/src/OrdinaryDiffEqBDF.jl
@@ -131,6 +131,13 @@ PrecompileTools.@compile_workload begin
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_p_params
             )
         )
+        push!(
+            prob_list,
+            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
+                OrdinaryDiffEqCore.lorenz_pref, [1.0; 0.0; 0.0],
+                (0.0, 1.0), OrdinaryDiffEqCore.lorenz_pref_params
+            )
+        )
     end
 
     if Preferences.@load_preference("PrecompileFunctionWrapperSpecialize", false)

--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.10.0"
+version = "4.10.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqCore/src/precompilation_setup.jl
+++ b/lib/OrdinaryDiffEqCore/src/precompilation_setup.jl
@@ -20,6 +20,20 @@ end
 
 const lorenz_p_params = (σ = 10.0, ρ = 28.0, β = 8 / 3)
 
+# Non-isbits variant for the AutoDePSpecialize workloads: a non-`isbits` `p`
+# (here a `Vector`) is packed by reference into an `OpaqueRef`, and — like the
+# isbits `OpaqueParams` case — the precompiled solve is shared across *all*
+# non-isbits parameter types since the wrapped signature carries `OpaqueRef`
+# instead of `typeof(p)`. Without this the `OpaqueRef` path compiles on first
+# use and non-isbits `p` sees no TTFX benefit.
+function lorenz_pref(du, u, p, t)
+    du[1] = p[1] * (u[2] - u[1])
+    du[2] = u[1] * (p[2] - u[3]) - u[2]
+    return du[3] = u[1] * u[2] - p[3] * u[3]
+end
+
+const lorenz_pref_params = [10.0, 28.0, 8 / 3]
+
 PrecompileTools.@compile_workload begin
     ODEProblem(lorenz, [1.0; 0.0; 0.0], (0.0, 1.0))
     ODEProblem(lorenz, [1.0; 0.0; 0.0], (0.0, 1.0), Float64[])
@@ -48,10 +62,15 @@ PrecompileTools.@compile_workload begin
         lorenz_p, [1.0; 0.0; 0.0],
         (0.0, 1.0), lorenz_p_params
     )
+    ODEProblem{true, AutoDePSpecialize}(
+        lorenz_pref, [1.0; 0.0; 0.0],
+        (0.0, 1.0), lorenz_pref_params
+    )
 
     lorenz([1.0; 0.0; 0.0], [1.0; 0.0; 0.0], SciMLBase.NullParameters(), 0.0)
     lorenz([1.0; 0.0; 0.0], [1.0; 0.0; 0.0], Float64[], 0.0)
     lorenz_p([1.0; 0.0; 0.0], [1.0; 0.0; 0.0], lorenz_p_params, 0.0)
+    lorenz_pref([1.0; 0.0; 0.0], [1.0; 0.0; 0.0], lorenz_pref_params, 0.0)
     lorenz_oop([1.0; 0.0; 0.0], SciMLBase.NullParameters(), 0.0)
     lorenz_oop([1.0; 0.0; 0.0], Float64[], 0.0)
 end

--- a/lib/OrdinaryDiffEqDefault/Project.toml
+++ b/lib/OrdinaryDiffEqDefault/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqDefault"
 uuid = "50262376-6c5a-4cf5-baba-aaf4f84d72d7"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.4.0"
+version = "2.4.1"
 
 [deps]
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"

--- a/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
+++ b/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
@@ -74,6 +74,13 @@ PrecompileTools.@compile_workload begin
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_p_params
             )
         )
+        push!(
+            prob_list,
+            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
+                OrdinaryDiffEqCore.lorenz_pref, [1.0; 0.0; 0.0],
+                (0.0, 1.0), OrdinaryDiffEqCore.lorenz_pref_params
+            )
+        )
     end
 
     if Preferences.@load_preference("PrecompileFunctionWrapperSpecialize", false)

--- a/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
+++ b/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
@@ -66,21 +66,27 @@ PrecompileTools.@compile_workload begin
         )
     end
 
+    # Kept in their own list as well as `prob_list`: besides the usual
+    # `solve(prob, solver)` sweep, these also drive the no-algorithm
+    # `solve(prob)` entry below.
+    depspecialize_prob_list = []
+
     if Preferences.@load_preference("PrecompileAutoDePSpecialize", true)
         push!(
-            prob_list,
+            depspecialize_prob_list,
             ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
                 OrdinaryDiffEqCore.lorenz_p, [1.0; 0.0; 0.0],
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_p_params
             )
         )
         push!(
-            prob_list,
+            depspecialize_prob_list,
             ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
                 OrdinaryDiffEqCore.lorenz_pref, [1.0; 0.0; 0.0],
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_pref_params
             )
         )
+        append!(prob_list, depspecialize_prob_list)
     end
 
     if Preferences.@load_preference("PrecompileFunctionWrapperSpecialize", false)
@@ -119,8 +125,19 @@ PrecompileTools.@compile_workload begin
         solve(prob, solver)(5.0)
     end
 
+    # `solve(prob)` (no algorithm) runs default algorithm *selection*, a
+    # separate entry point from `solve(prob, DefaultODEAlgorithm())` above and
+    # the one most user code and MTK tutorials actually write. Without this the
+    # opaque-p wins never reach it: measured 11.2s vs 0.42s for the explicit
+    # form on an AutoDePSpecialize problem.
+    for prob in depspecialize_prob_list
+
+        solve(prob)(5.0)
+    end
+
     prob_list = nothing
     solver_list = nothing
+    depspecialize_prob_list = nothing
 end
 
 export DefaultODEAlgorithm, DefaultImplicitODEAlgorithm

--- a/lib/OrdinaryDiffEqLowStorageRK/Project.toml
+++ b/lib/OrdinaryDiffEqLowStorageRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqLowStorageRK"
 uuid = "b0944070-b475-4768-8dec-fb6eb410534d"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "3.2.3"
+version = "3.2.4"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/OrdinaryDiffEqLowStorageRK/src/OrdinaryDiffEqLowStorageRK.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/OrdinaryDiffEqLowStorageRK.jl
@@ -83,6 +83,13 @@ PrecompileTools.@compile_workload begin
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_p_params
             )
         )
+        push!(
+            prob_list,
+            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
+                OrdinaryDiffEqCore.lorenz_pref, [1.0; 0.0; 0.0],
+                (0.0, 1.0), OrdinaryDiffEqCore.lorenz_pref_params
+            )
+        )
     end
 
     if Preferences.@load_preference("PrecompileFunctionWrapperSpecialize", false)

--- a/lib/OrdinaryDiffEqRosenbrock/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrock/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqRosenbrock"
 uuid = "43230ef6-c299-4910-a778-202eb28ce4ce"
-version = "2.6.1"
+version = "2.6.2"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 
 [deps]

--- a/lib/OrdinaryDiffEqRosenbrock/src/OrdinaryDiffEqRosenbrock.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/OrdinaryDiffEqRosenbrock.jl
@@ -181,6 +181,13 @@ PrecompileTools.@compile_workload begin
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_p_params
             )
         )
+        push!(
+            prob_list,
+            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
+                OrdinaryDiffEqCore.lorenz_pref, [1.0; 0.0; 0.0],
+                (0.0, 1.0), OrdinaryDiffEqCore.lorenz_pref_params
+            )
+        )
     end
 
     if Preferences.@load_preference("PrecompileFunctionWrapperSpecialize", false)

--- a/lib/OrdinaryDiffEqSDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqSDIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSDIRK"
 uuid = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.8.2"
+version = "2.8.3"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/lib/OrdinaryDiffEqSDIRK/src/OrdinaryDiffEqSDIRK.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/OrdinaryDiffEqSDIRK.jl
@@ -104,6 +104,13 @@ PrecompileTools.@compile_workload begin
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_p_params
             )
         )
+        push!(
+            prob_list,
+            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
+                OrdinaryDiffEqCore.lorenz_pref, [1.0; 0.0; 0.0],
+                (0.0, 1.0), OrdinaryDiffEqCore.lorenz_pref_params
+            )
+        )
     end
 
     if Preferences.@load_preference("PrecompileFunctionWrapperSpecialize", false)

--- a/lib/OrdinaryDiffEqSSPRK/Project.toml
+++ b/lib/OrdinaryDiffEqSSPRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSSPRK"
 uuid = "669c94d9-1f4b-4b64-b377-1aa079aa2388"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.2"
+version = "2.2.3"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqSSPRK/src/OrdinaryDiffEqSSPRK.jl
+++ b/lib/OrdinaryDiffEqSSPRK/src/OrdinaryDiffEqSSPRK.jl
@@ -80,6 +80,13 @@ PrecompileTools.@compile_workload begin
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_p_params
             )
         )
+        push!(
+            prob_list,
+            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
+                OrdinaryDiffEqCore.lorenz_pref, [1.0; 0.0; 0.0],
+                (0.0, 1.0), OrdinaryDiffEqCore.lorenz_pref_params
+            )
+        )
     end
 
     if Preferences.@load_preference("PrecompileFunctionWrapperSpecialize", false)

--- a/lib/OrdinaryDiffEqTsit5/Project.toml
+++ b/lib/OrdinaryDiffEqTsit5/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqTsit5"
 uuid = "b1df2697-797e-41e3-8120-5422d3b24e4a"
-version = "2.1.2"
+version = "2.1.3"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 
 [deps]

--- a/lib/OrdinaryDiffEqTsit5/src/OrdinaryDiffEqTsit5.jl
+++ b/lib/OrdinaryDiffEqTsit5/src/OrdinaryDiffEqTsit5.jl
@@ -74,6 +74,13 @@ PrecompileTools.@compile_workload begin
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_p_params
             )
         )
+        push!(
+            prob_list,
+            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
+                OrdinaryDiffEqCore.lorenz_pref, [1.0; 0.0; 0.0],
+                (0.0, 1.0), OrdinaryDiffEqCore.lorenz_pref_params
+            )
+        )
     end
 
     if Preferences.@load_preference("PrecompileFunctionWrapperSpecialize", false)

--- a/lib/OrdinaryDiffEqVerner/Project.toml
+++ b/lib/OrdinaryDiffEqVerner/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqVerner"
 uuid = "79d7bb75-1356-48c1-b8c0-6832512096c2"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.2"
+version = "2.2.3"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqVerner/src/OrdinaryDiffEqVerner.jl
+++ b/lib/OrdinaryDiffEqVerner/src/OrdinaryDiffEqVerner.jl
@@ -72,6 +72,13 @@ PrecompileTools.@compile_workload begin
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_p_params
             )
         )
+        push!(
+            prob_list,
+            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
+                OrdinaryDiffEqCore.lorenz_pref, [1.0; 0.0; 0.0],
+                (0.0, 1.0), OrdinaryDiffEqCore.lorenz_pref_params
+            )
+        )
     end
 
     if Preferences.@load_preference("PrecompileFunctionWrapperSpecialize", false)


### PR DESCRIPTION
> [!NOTE]
> Draft PR — please ignore until reviewed by @ChrisRackauckas.

Follow-up to #3692 (which shipped `AutoDePSpecialize` for **isbits** parameters, now on master). This extends the opaque-`p` path to **non-isbits** parameters.

## What changed

`should_opaque_p` now de-specializes any `p` except `NullParameters` and already-packed containers (previously isbits-only). `RespecializeParams.pack_auto`/`opaque_container_type` route the payload: **isbits → `OpaqueParams`** (byte copy, as before), **everything else → `OpaqueRef`** (by reference). The ForwardDiff extension substitutes `opaque_container_type(P)` instead of hardcoding `OpaqueParams`, and an **idempotency guard** stops a re-concretized opaque problem from being re-wrapped (no nested `OpaqueVoid`).

The RespecializeParams machinery (`OpaqueRef`, `OpaqueVoid`'s `OpaqueRef` methods, `pack_auto`) already existed — this just stops gating it out. `DiffEqBase 7.8.0 → 7.9.0`.

## Value + scope

Extends the shared-compilation TTFX benefit to problems whose parameter type is a **non-isbits struct** (e.g. a parameter struct holding arrays — different model types then share one precompiled solve).

It remains a **forward-solve latency tool**. De-specializing makes `sol.prob.p` an opaque container, so:
- **Reverse-mode AD of `p`** (SciMLSensitivity) and **symbolic parameter indexing** (`getp`/`setp`/observed) — which read the concrete parameter — are **not supported**. Recover the payload explicitly with `RespecializeParams.unpack(sol.prob.p, typeof(p))`.
- **Reverse-mode support is a planned follow-up**: the adjoint would unwrap the RHS (via `unwrapped_f`, extended to see through `OpaqueVoid`) and unpack `p`, the same way it already unwraps the plain `AutoSpecialize` function wrapper. (Prototyped; it's a multi-path SciMLSensitivity change, so it's separated out.)
- Forward-mode AD of `p` is unaffected — the existing `isdualtype(u0)` guard skips the opaque path whenever `p` carries duals.

## Verified

- `GROUP=Core` green: **Opaque-p Hook 25/25** (adds OpaqueRef + idempotency + inference cases), ForwardDiff Dual Detection unchanged.
- Full-stack non-isbits solves match `FullSpecialize` across `Tsit5`/`Rodas5P`/`FBDF` (`sol.prob.p isa OpaqueRef`, unpack roundtrips, different non-isbits types share `typeof(prob.f)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UuAbA8hSnrirMrJjFqxwn5