### PR TITLE
Fix DiffEqDevTools QA: package-local docs + residual_order_condition reexport

### DIFF
--- a/lib/DiffEqDevTools/Project.toml
+++ b/lib/DiffEqDevTools/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqDevTools"
 uuid = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "3.1.4"
+version = "3.1.5"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/DiffEqDevTools/docs/src/index.md
+++ b/lib/DiffEqDevTools/docs/src/index.md
@@ -1,0 +1,34 @@
+# DiffEqDevTools
+
+Public API for convergence testing, work-precision benchmarks, and Runge–Kutta
+tableau utilities.
+
+## Convergence
+
+```@docs
+DiffEqDevTools.ConvergenceSimulation
+DiffEqDevTools.test_convergence
+DiffEqDevTools.analyticless_test_convergence
+DiffEqDevTools.appxtrue
+DiffEqDevTools.TestSolution
+```
+
+## Benchmarks
+
+```@docs
+DiffEqDevTools.Shootout
+DiffEqDevTools.ShootoutSet
+DiffEqDevTools.WorkPrecision
+DiffEqDevTools.WorkPrecisionSet
+DiffEqDevTools.get_sample_errors
+```
+
+## Tableaus
+
+```@docs
+DiffEqDevTools.stability_region
+DiffEqDevTools.imaginary_stability_interval
+DiffEqDevTools.check_tableau
+DiffEqDevTools.deduce_Butcher_tableau
+DiffEqDevTools.residual_order_condition
+```

--- a/lib/DiffEqDevTools/test/qa/qa.jl
+++ b/lib/DiffEqDevTools/test/qa/qa.jl
@@ -7,6 +7,9 @@ run_qa(
         deps_compat = (; check_extras = false),
     ),
     explicit_imports = true,
+    # residual_order_condition is owned by RootedTrees; DiffEqDevTools reexports it
+    # after extending it for ODERKTableau (tableau_info.jl).
+    reexports_allow = (:residual_order_condition,),
     ei_kwargs = (;
         # SciMLBase-owned solver-interface predicates accessed via SciMLBase (their
         # owner) but not declared `public` in the registered SciMLBase release.


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## Summary

- add `lib/DiffEqDevTools/docs/src/index.md` with `@docs` for the public exported API so SciMLTesting's package-local docs check passes
- allowlist intentional `residual_order_condition` reexport from RootedTrees (extended here for `ODERKTableau`)
- bump DiffEqDevTools `3.1.4` → `3.1.5`

## Root cause

SciMLBase IntegrationTest clones the OrdinaryDiffEq monorepo and runs DiffEqDevTools Core/QA. SciMLTesting looks for docs under `lib/DiffEqDevTools/docs/src`, not the monorepo `docs/src/devtools/` pages added in #3906. That leaves every exported name "unrendered" for the package QA job. Separately, `residual_order_condition` is owned by RootedTrees and reexported after a local method extension; that reexport was not allowlisted.

## Local verification

```
Quality Assurance | 15 passed / 15 total
```

## Unblocks

SciMLBase IntegrationTest `OrdinaryDiffEq.jl/Core` DiffEqDevTools QA residual (partial — other Core lanes may still need registry packages).

This PR should be ignored until reviewed by @ChrisRackauckas.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>