### PR TITLE
Portable absolute URL for developer extension API links (DiffEqDocs #879)

### DIFF
--- a/docs/src/api/diffeqbase.md
+++ b/docs/src/api/diffeqbase.md
@@ -2,7 +2,7 @@
 
 This page lists the user-facing DiffEqBase API documented with OrdinaryDiffEq.
 Solver-author hooks, callback machinery, and cache types are documented separately
-in the [developer extension API](@ref Developer-Extension-API).
+in the [developer extension API](https://docs.sciml.ai/OrdinaryDiffEq/stable/devtools/internals/public_api/).
 
 ## Specialization levels
 

--- a/docs/src/api/ordinarydiffeqcore.md
+++ b/docs/src/api/ordinarydiffeqcore.md
@@ -2,7 +2,7 @@
 
 This page lists user-facing OrdinaryDiffEqCore API. The controller API has its
 own page, and solver-author hooks are documented separately in the
-[developer extension API](@ref Developer-Extension-API).
+[developer extension API](https://docs.sciml.ai/OrdinaryDiffEq/stable/devtools/internals/public_api/).
 
 ## Integrator objects
 
@@ -50,7 +50,7 @@ OrdinaryDiffEqCore.Predictor
 These OrdinaryDiffEqNonlinearSolve algorithms are public user API because they
 are passed directly through implicit solver constructors as `nlsolve = ...`.
 Lower-level nonlinear-solve hooks intended for solver authors are listed on the
-[developer extension API](@ref Developer-Extension-API) page.
+[developer extension API](https://docs.sciml.ai/OrdinaryDiffEq/stable/devtools/internals/public_api/) page.
 
 ```@docs
 OrdinaryDiffEqNonlinearSolve.NLAnderson

--- a/docs/src/devtools/internals/public_api.md
+++ b/docs/src/devtools/internals/public_api.md
@@ -1,4 +1,4 @@
-# Developer Extension API
+# [Developer Extension API](@id Developer-Extension-API)
 
 This page documents the version-controlled API intended for solver authors and
 OrdinaryDiffEq monorepo subpackages. These names are not application-facing


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

## Summary

Source fix for [DiffEqDocs.jl#879](https://github.com/SciML/DiffEqDocs.jl/issues/879) (ODE side).

`docs/src/api/*.md` pages are copied into DiffEqDocs, which then deletes `devtools/`. Bare `[...](@ref Developer-Extension-API)` links in those pages therefore fail DiffEqDocs Documenter with `[:cross_references]`.

Replace the three user-facing API links with absolute URLs to the published OrdinaryDiffEq developer page, and mark that page with `@id Developer-Extension-API` for in-repo stability.

Companion SciMLBase source fix: https://github.com/SciML/SciMLBase.jl/pull/1468

This supersedes rewriting links inside DiffEqDocs (`make.jl` hacks in DiffEqDocs#881).

## Test plan

- [ ] OrdinaryDiffEq docs still build
- [ ] DiffEqDocs green once this + SciMLBase#1468 are available (no DiffEqDocs-side ref rewrite needed)

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>