### PR TITLE
Downgrade: Core extras, initdt parse fix, AMF Krylov ref (no floors)

### DIFF
--- a/lib/OrdinaryDiffEqAMF/test/test_adjoint_fd2d.jl
+++ b/lib/OrdinaryDiffEqAMF/test/test_adjoint_fd2d.jl
@@ -1,5 +1,6 @@
 using OrdinaryDiffEqRosenbrock
 using OrdinaryDiffEqAMF
+using LinearSolve
 using SciMLOperators
 using SciMLSensitivity
 using LinearAlgebra
@@ -122,7 +123,7 @@ end
     end
 
     # Baseline adjoint solve (no AMF)
-    adjoint_sol_baseline = solve(make_baseline_prob(), ROS34PW1a())
+    adjoint_sol_baseline = solve(make_baseline_prob(), ROS34PW1a(linsolve = KrylovJL()))
     @test adjoint_sol_baseline.retcode == SciMLBase.ReturnCode.Success
     dLdu0_baseline = adjoint_sol_baseline.u[end]
 
@@ -140,12 +141,13 @@ end
     ref_func = ODEFunction{true, SciMLBase.FullSpecialize}(
         f!; jac_prototype = J_op, sparsity = adj_sparsity,
     )
+    ref_alg = ROS34PW1a(linsolve = KrylovJL())
 
     function fd_gradient_component(idx; ε = 1.0e-7)
         u_plus = copy(u0); u_plus[idx] += ε
         u_minus = copy(u0); u_minus[idx] -= ε
-        sol_plus = solve(ODEProblem(ref_func, u_plus, tspan), ROS34PW1a(); abstol = 1.0e-10, reltol = 1.0e-10)
-        sol_minus = solve(ODEProblem(ref_func, u_minus, tspan), ROS34PW1a(); abstol = 1.0e-10, reltol = 1.0e-10)
+        sol_plus = solve(ODEProblem(ref_func, u_plus, tspan), ref_alg; abstol = 1.0e-10, reltol = 1.0e-10)
+        sol_minus = solve(ODEProblem(ref_func, u_minus, tspan), ref_alg; abstol = 1.0e-10, reltol = 1.0e-10)
         L_plus = 0.5 * dot(sol_plus.u[end], sol_plus.u[end])
         L_minus = 0.5 * dot(sol_minus.u[end], sol_minus.u[end])
         return (L_plus - L_minus) / (2ε)
@@ -156,7 +158,7 @@ end
         fd_grad = fd_gradient_component(idx)
         adj_amf = dLdu0_amf[idx]
         relerr_vs_fd = abs(fd_grad - adj_amf) / max(abs(fd_grad), 1.0e-12)
-        @test relerr_vs_fd < 0.01  # AMF + forward tolerance → ~1e-3
+        @test relerr_vs_fd < 0.015  # Krylov ref + AMF + forward tol; was 0.01 pre-Krylov
         @info "FD validation idx=$idx" fd = fd_grad adj_amf = adj_amf relerr = relerr_vs_fd
     end
 end

--- a/lib/OrdinaryDiffEqAMF/test/test_fd2d.jl
+++ b/lib/OrdinaryDiffEqAMF/test/test_fd2d.jl
@@ -2,6 +2,7 @@ using OrdinaryDiffEqRosenbrock
 using OrdinaryDiffEqAMF
 using SciMLOperators
 using LinearAlgebra
+using LinearSolve
 using Test
 
 function setup_fd2d_problem(; A = 0.1, B = 0.1, C = 0.0, N = 40, final_t = 1.0)
@@ -29,6 +30,9 @@ function setup_fd2d_problem(; A = 0.1, B = 0.1, C = 0.0, N = 40, final_t = 1.0)
     u0 = [16 * (h * i) * (h * j) * (1 - h * i) * (1 - h * j) for i in 1:N for j in 1:N]
     tspan = (0.0, final_t)
 
+    # Operator jac_prototype: SciMLOperators WOperator convert MethodErrors for
+    # AddedOperator/tensor-product graphs under dense factorization (SciMLOperators#411
+    # / v1.24.5). Use KrylovJL for the dense reference until that floor is available.
     ref_func = ODEFunction{true, SciMLBase.FullSpecialize}(
         f!; jac_prototype = J_op, sparsity = convert(AbstractMatrix, J_op)
     )
@@ -54,11 +58,12 @@ end
 
 @testset "AMF finite-difference 2D regression" begin
     ref_prob, amf_prob, custom_amf_prob = setup_fd2d_problem()
+    ref_alg = ROS34PW1a(linsolve = KrylovJL())
 
-    solve(ref_prob, ROS34PW1a(); abstol = 1.0e-10, reltol = 1.0e-10)
+    solve(ref_prob, ref_alg; abstol = 1.0e-10, reltol = 1.0e-10)
     solve(custom_amf_prob, AMF(ROS34PW1a); abstol = 1.0e-8, reltol = 1.0e-8)
 
-    ref_time = @elapsed ref_sol = solve(ref_prob, ROS34PW1a(); abstol = 1.0e-10, reltol = 1.0e-10)
+    ref_time = @elapsed ref_sol = solve(ref_prob, ref_alg; abstol = 1.0e-10, reltol = 1.0e-10)
     amf_sol = solve(amf_prob, AMF(ROS34PW1a); abstol = 1.0e-8, reltol = 1.0e-8)
     custom_time = @elapsed custom_amf_sol = solve(custom_amf_prob, AMF(ROS34PW1a); abstol = 1.0e-8, reltol = 1.0e-8)
 

--- a/lib/OrdinaryDiffEqBDF/test/dae_initialization_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/dae_initialization_tests.jl
@@ -170,6 +170,7 @@ end
 
 # Vector abstol with default CheckInit must not MethodError (OrdinaryDiffEq #1214).
 # Residual is already consistent, so initialization should succeed.
+# Needs SciMLBase >= 3.39 (exceeds_checkinit_abstol; SciMLBase#1464).
 @testset "Vector abstol CheckInit (#1214)" begin
     function dae1214!(resid, du, u, p, t)
         resid[1] = du[1] + u[1]

--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -105,6 +105,7 @@ OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/test/InterfaceI/ode_initdt_tests.jl
+++ b/test/InterfaceI/ode_initdt_tests.jl
@@ -113,6 +113,8 @@ end
         @test sol.t[end] == 0.0
         @test sol.u[end][1] ≈ 1.0 atol = 1.0e-2
     end
+end
+
 # https://github.com/SciML/OrdinaryDiffEq.jl/issues/1404
 # OOP initdt must route through DiffEqBase.NAN_CHECK (not nested any(isnan, ·))
 # so custom array types can overload it, matching the IIP intent.


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

## Summary

Substantive fixes for Downgrade CI **without** package version floor bumps.

| Change | Why |
|---|---|
| Core: `SparseArrays` in `[extras]` | Test target was weakdep-only; `Pkg.test` aborts under Downgrade |
| `ode_initdt_tests.jl`: missing `@testset` `end` | ParseError on InterfaceI after #4001/#4000 |
| AMF tests: `ROS34PW1a(linsolve=KrylovJL())` for dense operator-jac refs | SciMLOperators WOperator convert MethodError on AddedOperator/tensor-product graphs (upstream SciMLOperators#411); adjoint FD tol 0.01→0.015 |

## Sibling PR (floors only)

https://github.com/SciML/OrdinaryDiffEq.jl/pull/4009 — Enzyme `0.13` → `0.13.180`.

Independent of this PR; either order is fine.