### PR TITLE
Close the unterminated @testset in ode_initdt_tests.jl

### DIFF
--- a/test/InterfaceI/ode_initdt_tests.jl
+++ b/test/InterfaceI/ode_initdt_tests.jl
@@ -113,6 +113,8 @@ end
         @test sol.t[end] == 0.0
         @test sol.u[end][1] ≈ 1.0 atol = 1.0e-2
     end
+end
+
 # https://github.com/SciML/OrdinaryDiffEq.jl/issues/1404
 # OOP initdt must route through DiffEqBase.NAN_CHECK (not nested any(isnan, ·))
 # so custom array types can overload it, matching the IIP intent.


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

## The failure

`test/InterfaceI/ode_initdt_tests.jl` does not parse on master:

```
LoadError: ParseError:
# Error @ test/InterfaceI/ode_initdt_tests.jl:130:5
    @test SciMLBase.successful_retcode(sol_ok)
end
└ ── Expected `end`
```

The `@testset "DAE reversed tspan automatic initdt (#908)"` block added in #4001
was never closed. The file's last `end` closes the `for` loop inside it, so the
parser reaches EOF still expecting the testset's `end`.

## Blast radius

One missing `end`, five red jobs on master:

| Job | Symptom |
|---|---|
| `tests / InterfaceI (julia lts)` | `Initdt Tests` errored, group failed |
| `tests / InterfaceI (julia 1)` | same |
| `tests / InterfaceI (julia pre)` | same |
| `Downgrade / Downgrade Tests - InterfaceI` | same |
| `format-check / Runic` | `[954/1017] test/InterfaceI/ode_initdt_tests.jl ✖` (Runic cannot format a file that will not parse) |

Because the file never parsed, **every assertion in the #908 testset has been
dead since #4001 merged** — the `integ.dt < 0` regression check that PR was
written to add has never actually executed.

## The fix

Add the missing `end`.

## Verification

Ran locally on Julia 1.10 (lts), from a clean checkout of this branch:

```
$ GROUP=InterfaceI julia --project=. -e 'using Pkg; Pkg.test()'
...
Test Summary: | Pass  Total     Time
Initdt Tests  |   29     29  1m14.6s
...
     Testing OrdinaryDiffEq tests passed
```

29 passing assertions where master got 15 passed + 1 error — the 14 newly-live
assertions in the #908 testset all pass, so #4001's fix is sound; only its test
was unreachable.

Runic is clean on the file:

```
$ julia --project=@runic -e 'using Runic; exit(Runic.main(["--check","--diff","test/InterfaceI/ode_initdt_tests.jl"]))'
$ echo $?
0
```

## Relation to other PRs

#4012 bundles this fix together with two unrelated changes. This PR is the
parse fix on its own so it can land and unblock InterfaceI/Downgrade/format-check
independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPHRh64BLfoXSzQ3AxKNwC