### PR TITLE
Core: declare SparseArrays in [extras] so the test target survives weakdep promotion

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -105,6 +105,7 @@ OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

## The failure

`Downgrade Sublibraries / test (lib/OrdinaryDiffEqCore)` aborts before a single
test runs:

```
`SparseArrays` declared as a `test` dependency, but no such entry in `extras` or `weakdeps`
```

## Why

`SparseArrays` is in `lib/OrdinaryDiffEqCore`'s `test` target but was listed
only under `[weakdeps]`. That resolves fine normally — `Pkg` looks the test
target up in `[extras]` *and* `[weakdeps]`. But julia-downgrade-compat promotes
a weak dependency to a real one when another package in the merged project
needs it, and in this job it does exactly that:

```
[ Info: Promoting root weak dependency required by OrdinaryDiffEqNonlinearSolve: SparseArrays
```

Promotion moves the entry **out of** `[weakdeps]` and **into** `[deps]`. The
`test` target is then pointing at a name that is in neither `[extras]` nor
`[weakdeps]`, so `Pkg.test` errors out during test-environment generation.

This is the only Project.toml in the repo with a test-target name that lives in
`[weakdeps]` but not `[extras]`:

```julia
julia> for f in vcat(["Project.toml"], [joinpath("lib",d,"Project.toml") for d in readdir("lib")])
           d = TOML.parsefile(f)
           tgt = Set(get(get(d,"targets",Dict()),"test",String[]))
           extras = Set(keys(get(d,"extras",Dict()))); weak = Set(keys(get(d,"weakdeps",Dict())))
           w = setdiff(intersect(tgt, weak), extras)
           isempty(w) || println(f, ": ", sort(collect(w)))
       end
lib/OrdinaryDiffEqCore/Project.toml: ["SparseArrays"]
```

## The fix

Also list `SparseArrays` in `[extras]`. `[weakdeps]` and `[extensions]` are
untouched, so `OrdinaryDiffEqCoreSparseArraysExt` still loads conditionally —
the entry only gives the test target a UUID that survives promotion.

## Verification

**1. Reproduced the CI failure locally** by replaying the promotion step
(`SparseArrays`: `[weakdeps]` → `[deps]`) on unmodified master:

```
$ julia +1.11 --project=lib/OrdinaryDiffEqCore -e 'using Pkg; Pkg.test()'
ERROR: `SparseArrays` declared as a `test` dependency, but no such entry in `extras` or `weakdeps`
```

**2. Same promotion, with this patch** — the abort is gone and the test env builds:

```
      Status `~/claude_tmp/jl_Zb5Z9v/Project.toml`
Precompiling project for configuration --code-coverage=none ...
     Testing Running tests...
```

**3. Normal (un-promoted) path still green** — full Core group on Julia 1.11,
matching the CI job's `ODEDIFFEQ_TEST_GROUP=Core`:

```
$ ODEDIFFEQ_TEST_GROUP=Core julia +1.11 --project=lib/OrdinaryDiffEqCore -e 'using Pkg; Pkg.test()'
...
   2044.3 ms  ✓ OrdinaryDiffEqCore → OrdinaryDiffEqCoreSparseArraysExt
...
     Testing OrdinaryDiffEqCore tests passed
```

The extension still precompiles, confirming the `[weakdeps]` role is intact.

**4. Both spellings resolve on every supported Julia** — a minimal package with
`SparseArrays` in `[weakdeps]`+`[extras]` (normal) and in `[deps]`+`[extras]`
(post-promotion) passes `Pkg.test` on 1.10, 1.11 and 1.12.

## Relation to other PRs

#4012 includes this same one-line change bundled with two unrelated fixes; this
PR isolates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPHRh64BLfoXSzQ3AxKNwC