### PR TITLE
Render AutoDePSpecialize in a @docs block

### DIFF
--- a/docs/src/api/diffeqbase.md
+++ b/docs/src/api/diffeqbase.md
@@ -16,6 +16,10 @@ It is re-exported from OrdinaryDiffEq, so
 across all parameter struct types; recover the original payload from
 `sol.prob.p` with `RespecializeParams.unpack(sol.prob.p, typeof(p))`.
 
+```@docs
+OrdinaryDiffEq.AutoDePSpecialize
+```
+
 ## Default callback behavior
 
 ```@docs


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

✅ **Unblocked** — https://github.com/SciML/SciMLBase.jl/pull/1469 is merged and SciMLBase **3.39.1 is registered**.

## The failure

`tests / QA (julia 1)` on master:

```
public API is rendered in docs: Test Failed
  Evaluated: isempty([:AutoDePSpecialize])

┌ Info: run_api_docs: public API names not rendered in a @docs block
│   pkg = OrdinaryDiffEq
│   unrendered = [:AutoDePSpecialize]
```

`run_api_docs` requires every public name of OrdinaryDiffEq to appear in a
```@docs``` block under `docs/src`. `AutoDePSpecialize` appeared only in prose
on the DiffEqBase API page.

## Why this needed a SciMLBase fix first

Adding the ```@docs``` block on its own used to break the docs build.
`AutoDePSpecialize` is SciMLBase-owned, so the block renders SciMLBase's
docstring, which opened with ``[`AutoSpecialize`](@ref)``. `@ref` resolves
against the current build, and this manual does not render `AutoSpecialize`:

```
┌ Error: Cannot resolve @ref for md"[`AutoSpecialize`](@ref)" in docs/src/api/diffeqbase.md.
ERROR: LoadError: `makedocs` encountered an error [:cross_references] -- terminating build before rendering.
```

Rendering `AutoSpecialize` here instead does not help — its docstring @refs
`FullSpecialize` and `unwrapped_f`, and `unwrapped_f` is a solver-author hook
this manual deliberately documents in the developer-extension API.

https://github.com/SciML/SciMLBase.jl/pull/1469 fixed it at the source: the
docstring now links to SciMLBase's rendered specialization-levels section
instead of using `@ref`, following the absolute-link convention already used in
those docstrings. That resolves from any build.

## Verification

Full `docs/make.jl` with this branch's ```@docs``` block:

| SciMLBase | Result |
|---|---|
| 3.39.0 | `ERROR: makedocs encountered an error [:cross_references]` |
| **3.39.1 (released, from the registry)** | **exit 0** |

The 3.39.1 run uses the registered package, not a `Pkg.develop`ed checkout.

The docstring renders on the page with a working link:

```html
<a href="https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels">
  <code>AutoSpecialize</code></a> by additionally <em>de-speci…
```

QA locally (Julia 1.10): `Public API documentation | 2 passed` — both the
docstring and rendered halves. CI on an earlier revision of this branch
confirmed `tests / QA (julia 1)` **pass**.

## History

An earlier revision used `rendered_ignore = (:AutoDePSpecialize,)` to sidestep
the cross-reference problem. Fixing the `@ref` upstream is the better fix, so
this renders the name properly instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPHRh64BLfoXSzQ3AxKNwC
