### PR TITLE
Drop the duplicate hom key from .typos.toml

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -146,4 +146,6 @@ Comput = "Comput"  # J. Comput. Phys. (Journal of Computational Physics)
 
 # Julia spelling convention
 inferrable = "inferrable"  # Julia uses "inferrable" not "inferable"
-hom = "hom"  # scc_hom homotopy abbreviation in NonlinearSolve tests (#3989)
+
+# (hom already declared above under "Technical variable names"; it covers the
+# scc_hom NonlinearSolve test variables too.)


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

## The failure

`Spell Check with Typos` fails on master in 6 seconds, exit code 78:

```
$ /home/runner/work/_temp/typos .
TOML parse error at line 149, column 1
    | ^^^
##[error]Process completed with exit code 78.
```

## Why

`.typos.toml` declares `hom` twice, and TOML forbids duplicate keys:

```
$ grep -n '^hom = ' .typos.toml
72:hom = "hom"  # homotopy abbreviation (scc_hom, HomotopyProblem)
149:hom = "hom"  # scc_hom homotopy abbreviation in NonlinearSolve tests (#3989)
```

Line 72 came from #4004, line 149 from #4000 — two PRs allowlisting the same
abbreviation, merged close together. typos cannot parse its own config, so it
exits before checking a single file: the spell check has not actually run on
master since.

## The fix

Remove the later duplicate. The line 72 declaration already covers the
`scc_hom` variables the second entry was added for. A pointer comment goes in
its place, matching how the file already handles this for `Numer`
(`# (Numer already declared above for "BIT Numer" context.)`).

## Verification

Reproduced and fixed locally with the same command the workflow runs:

```
$ typos .            # on master
TOML parse error at line 149, column 1
    |
149 | hom = "hom"  # scc_hom homotopy abbreviation in NonlinearSolve tests (#3989)
    | ^^^
duplicate key
exit=78

$ typos .            # on this branch
exit=0
```

Clean exit with no findings, so the spell check now actually runs and passes —
and dropping the entry loses no coverage (`hom` is still allowlisted by line 72).

Local typos is 1.47.0 vs the workflow's 1.48.0; the TOML duplicate-key rejection
is version-independent, but CI on this PR is the authoritative check for 1.48's
dictionary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPHRh64BLfoXSzQ3AxKNwC