### PR TITLE
Configure the sublibrary QA lanes for monorepo docs and facade reexports

### DIFF
--- a/lib/DelayDiffEq/test/qa/qa_tests.jl
+++ b/lib/DelayDiffEq/test/qa/qa_tests.jl
@@ -45,6 +45,9 @@ const EXPLICIT_INTERNAL = (
 
 run_qa(
     DelayDiffEq;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     aqua_kwargs = (;
         ambiguities = (; recursive = false),
         # piracy is allowed for the default solver methods and SDE integration

--- a/lib/DiffEqDevTools/test/qa/qa.jl
+++ b/lib/DiffEqDevTools/test/qa/qa.jl
@@ -2,6 +2,8 @@ using SciMLTesting, DiffEqDevTools, Test
 
 run_qa(
     DiffEqDevTools;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
     aqua_kwargs = (;
         ambiguities = false, piracies = false, unbound_args = false, stale_deps = false,
         deps_compat = (; check_extras = false),

--- a/lib/GlobalDiffEq/test/qa/qa.jl
+++ b/lib/GlobalDiffEq/test/qa/qa.jl
@@ -16,6 +16,7 @@ reexported_names = Tuple(
 
 run_qa(
     GlobalDiffEq;
+    reexports_allow = union(public_api_names(DiffEqBase), (:DiffEqBase,)),
     explicit_imports = true,
     # GlobalDiffEq's rendered documentation lives in the monorepo docs, two
     # directories up from the sublibrary root.

--- a/lib/ImplicitDiscreteSolve/test/qa/qa.jl
+++ b/lib/ImplicitDiscreteSolve/test/qa/qa.jl
@@ -2,6 +2,7 @@ using SciMLTesting, ImplicitDiscreteSolve, Test
 
 run_qa(
     ImplicitDiscreteSolve;
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     aqua_kwargs = (; piracies = false),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqAdamsBashforthMoulton/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqAdamsBashforthMoulton/test/qa/qa.jl
@@ -2,6 +2,9 @@ using SciMLTesting, OrdinaryDiffEqAdamsBashforthMoulton, Test
 
 run_qa(
     OrdinaryDiffEqAdamsBashforthMoulton;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (
         all_explicit_imports_are_public = (;

--- a/lib/OrdinaryDiffEqBDF/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqBDF/test/qa/qa.jl
@@ -2,6 +2,9 @@ using SciMLTesting, OrdinaryDiffEqBDF, Test
 
 run_qa(
     OrdinaryDiffEqBDF;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (
         all_qualified_accesses_are_public = (;

--- a/lib/OrdinaryDiffEqCore/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqCore/test/qa/qa.jl
@@ -10,6 +10,7 @@ end
 
 run_qa(
     OrdinaryDiffEqCore;
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     aqua_kwargs = (; piracies = false, unbound_args = false),
     explicit_imports = true,
     ei_kwargs = (;
@@ -68,6 +69,7 @@ run_qa(
         ),
     ),
     api_docs_kwargs = (;
+        rendered = false,
         # Reexported upstream SciMLOperators names are documented at their owner.
         ignore = (:StaticWOperator, :has_concretization),
     ),

--- a/lib/OrdinaryDiffEqDefault/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqDefault/test/qa/qa.jl
@@ -39,6 +39,7 @@ end
 without_local_project_sources(OrdinaryDiffEqDefault) do
     run_qa(
         OrdinaryDiffEqDefault;
+        reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
         aqua_kwargs = (; piracies = false),
         explicit_imports = true,
         ei_kwargs = (;
@@ -61,6 +62,7 @@ without_local_project_sources(OrdinaryDiffEqDefault) do
             ),
         ),
         api_docs_kwargs = (;
+            rendered = false,
             # Reexported upstream SciMLOperators names are documented at their owner.
             ignore = (:StaticWOperator, :has_concretization),
         ),

--- a/lib/OrdinaryDiffEqDifferentiation/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/qa/qa.jl
@@ -8,6 +8,8 @@ using SciMLTesting, OrdinaryDiffEqDifferentiation, Test
 # tracked in SciML/OrdinaryDiffEq.jl#3776).
 run_qa(
     OrdinaryDiffEqDifferentiation;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
     aqua_kwargs = (; piracies = false, ambiguities = false),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqExplicitRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqExplicitRK/test/qa/qa.jl
@@ -2,6 +2,7 @@ using SciMLTesting, OrdinaryDiffEqExplicitRK, Test
 
 run_qa(
     OrdinaryDiffEqExplicitRK;
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;
         all_explicit_imports_are_public = (;
@@ -20,6 +21,7 @@ run_qa(
         ),
     ),
     api_docs_kwargs = (;
+        rendered = false,
         # Reexported upstream SciMLOperators names are documented at their owner.
         ignore = (:StaticWOperator, :has_concretization),
     ),

--- a/lib/OrdinaryDiffEqExplicitTableaus/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqExplicitTableaus/test/qa/qa.jl
@@ -3,6 +3,8 @@ using JET
 
 run_qa(
     OrdinaryDiffEqExplicitTableaus;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
 )

--- a/lib/OrdinaryDiffEqExponentialRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/test/qa/qa.jl
@@ -2,6 +2,9 @@ using SciMLTesting, OrdinaryDiffEqExponentialRK, Test
 
 run_qa(
     OrdinaryDiffEqExponentialRK;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (
         all_explicit_imports_are_public = (;

--- a/lib/OrdinaryDiffEqExtrapolation/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/qa/qa.jl
@@ -2,6 +2,9 @@ using SciMLTesting, OrdinaryDiffEqExtrapolation, Test
 
 run_qa(
     OrdinaryDiffEqExtrapolation;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;
         all_explicit_imports_are_public = (;

--- a/lib/OrdinaryDiffEqFIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/qa/qa.jl
@@ -8,6 +8,9 @@ using SciMLTesting, OrdinaryDiffEqFIRK, Test
 # See SciML/OrdinaryDiffEq.jl#3776.
 run_qa(
     OrdinaryDiffEqFIRK;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (
         all_explicit_imports_are_public = (;

--- a/lib/OrdinaryDiffEqFeagin/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFeagin/test/qa/qa.jl
@@ -2,6 +2,9 @@ using SciMLTesting, OrdinaryDiffEqFeagin, Test
 
 run_qa(
     OrdinaryDiffEqFeagin;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;
         # `@reexport using SciMLBase` deliberately re-exports SciMLBase's API

--- a/lib/OrdinaryDiffEqFunctionMap/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/test/qa/qa.jl
@@ -2,6 +2,9 @@ using SciMLTesting, OrdinaryDiffEqFunctionMap, Test
 
 run_qa(
     OrdinaryDiffEqFunctionMap;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     aqua_kwargs = (; piracies = false),  # piracy is needed for default-algorithm dispatch
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqHighOrderRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqHighOrderRK/test/qa/qa.jl
@@ -2,6 +2,9 @@ using SciMLTesting, OrdinaryDiffEqHighOrderRK, Test
 
 run_qa(
     OrdinaryDiffEqHighOrderRK;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (
         # `@reexport using SciMLBase` is the intended public-API reexport; it

--- a/lib/OrdinaryDiffEqIMEXMultistep/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/test/qa/qa.jl
@@ -2,6 +2,9 @@ using SciMLTesting, OrdinaryDiffEqIMEXMultistep, Test
 
 run_qa(
     OrdinaryDiffEqIMEXMultistep;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;
         # `@reexport using SciMLBase` brings the `SciMLBase` module name into scope

--- a/lib/OrdinaryDiffEqImplicitTableaus/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqImplicitTableaus/test/qa/qa.jl
@@ -3,6 +3,8 @@ using JET
 
 run_qa(
     OrdinaryDiffEqImplicitTableaus;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
 )

--- a/lib/OrdinaryDiffEqLinear/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqLinear/test/qa/qa.jl
@@ -2,6 +2,9 @@ using SciMLTesting, OrdinaryDiffEqLinear, Test
 
 run_qa(
     OrdinaryDiffEqLinear;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;
         # Residual non-public names below have no public-API replacement yet.

--- a/lib/OrdinaryDiffEqLowOrderRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqLowOrderRK/test/qa/qa.jl
@@ -2,6 +2,9 @@ using SciMLTesting, OrdinaryDiffEqLowOrderRK, Test
 
 run_qa(
     OrdinaryDiffEqLowOrderRK;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;
         # SciMLBase's has_lazy_interpolation interpolation trait, accessed via its

--- a/lib/OrdinaryDiffEqLowStorageRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/test/qa/qa.jl
@@ -2,6 +2,9 @@ using SciMLTesting, OrdinaryDiffEqLowStorageRK, Test
 
 run_qa(
     OrdinaryDiffEqLowStorageRK;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (
         # Every remaining name is a genuine non-public internal of its owner. The

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/qa/qa.jl
@@ -2,6 +2,8 @@ using SciMLTesting, OrdinaryDiffEqNonlinearSolve, Test
 
 run_qa(
     OrdinaryDiffEqNonlinearSolve;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
     aqua_kwargs = (; piracies = false),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqNordsieck/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqNordsieck/test/qa/qa.jl
@@ -2,6 +2,9 @@ using SciMLTesting, OrdinaryDiffEqNordsieck, Test
 
 run_qa(
     OrdinaryDiffEqNordsieck;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;
         # `@reexport using SciMLBase` is the package's public-API surface; the

--- a/lib/OrdinaryDiffEqPDIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqPDIRK/test/qa/qa.jl
@@ -2,6 +2,9 @@ using SciMLTesting, OrdinaryDiffEqPDIRK, Test
 
 run_qa(
     OrdinaryDiffEqPDIRK;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;
         all_explicit_imports_are_public = (;

--- a/lib/OrdinaryDiffEqPRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqPRK/test/qa/qa.jl
@@ -2,6 +2,9 @@ using SciMLTesting, OrdinaryDiffEqPRK, Test
 
 run_qa(
     OrdinaryDiffEqPRK;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;
         all_explicit_imports_are_public = (;

--- a/lib/OrdinaryDiffEqQPRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqQPRK/test/qa/qa.jl
@@ -2,6 +2,9 @@ using SciMLTesting, OrdinaryDiffEqQPRK, Test
 
 run_qa(
     OrdinaryDiffEqQPRK;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (
         all_explicit_imports_are_public = (

--- a/lib/OrdinaryDiffEqRKN/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqRKN/test/qa/qa.jl
@@ -2,6 +2,9 @@ using SciMLTesting, OrdinaryDiffEqRKN, Test
 
 run_qa(
     OrdinaryDiffEqRKN;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;
         all_explicit_imports_are_public = (;

--- a/lib/OrdinaryDiffEqRosenbrock/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/qa/qa.jl
@@ -29,6 +29,9 @@ const ROSENBROCK_INTERNAL_QUALIFIED_ACCESSES = (
 
 run_qa(
     OrdinaryDiffEqRosenbrock;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (
         all_explicit_imports_via_owners = (; ignore = ROSENBROCK_INTERNAL_EXPLICIT_IMPORTS),

--- a/lib/OrdinaryDiffEqRosenbrockTableaus/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqRosenbrockTableaus/test/qa/qa.jl
@@ -3,6 +3,8 @@ using JET
 
 run_qa(
     OrdinaryDiffEqRosenbrockTableaus;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
 )

--- a/lib/OrdinaryDiffEqSDIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/qa/qa.jl
@@ -12,6 +12,9 @@ using SciMLTesting, OrdinaryDiffEqSDIRK, Test
 #     `@truncate_stacktrace`).
 run_qa(
     OrdinaryDiffEqSDIRK;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (
         all_qualified_accesses_are_public = (;

--- a/lib/OrdinaryDiffEqSSPRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqSSPRK/test/qa/qa.jl
@@ -2,6 +2,9 @@ using SciMLTesting, OrdinaryDiffEqSSPRK, Test
 
 run_qa(
     OrdinaryDiffEqSSPRK;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (
         # Residual non-public names after the solver-author API was made public

--- a/lib/OrdinaryDiffEqStabilizedIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqStabilizedIRK/test/qa/qa.jl
@@ -2,6 +2,9 @@ using SciMLTesting, OrdinaryDiffEqStabilizedIRK, Test
 
 run_qa(
     OrdinaryDiffEqStabilizedIRK;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;
         all_explicit_imports_are_public = (;

--- a/lib/OrdinaryDiffEqStabilizedRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/qa/qa.jl
@@ -2,6 +2,9 @@ using SciMLTesting, OrdinaryDiffEqStabilizedRK, Test
 
 run_qa(
     OrdinaryDiffEqStabilizedRK;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (
         all_explicit_imports_are_public = (

--- a/lib/OrdinaryDiffEqSymplecticRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqSymplecticRK/test/qa/qa.jl
@@ -2,5 +2,8 @@ using SciMLTesting, OrdinaryDiffEqSymplecticRK, Test
 
 run_qa(
     OrdinaryDiffEqSymplecticRK;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
 )

--- a/lib/OrdinaryDiffEqTaylorSeries/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/test/qa/qa.jl
@@ -7,6 +7,9 @@ using SciMLTesting, OrdinaryDiffEqTaylorSeries, Test
 # been dropped; only the genuine residual remains (see SciML/OrdinaryDiffEq.jl#3776).
 run_qa(
     OrdinaryDiffEqTaylorSeries;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     aqua_kwargs = (;
         unbound_args = false, undefined_exports = false, stale_deps = false,
         ambiguities = false,

--- a/lib/OrdinaryDiffEqTsit5/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqTsit5/test/qa/qa.jl
@@ -2,6 +2,9 @@ using SciMLTesting, OrdinaryDiffEqTsit5, Test
 
 run_qa(
     OrdinaryDiffEqTsit5;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;
         # Residual after the PHASE-A make-public sweep: the solver-author API

--- a/lib/OrdinaryDiffEqVerner/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqVerner/test/qa/qa.jl
@@ -2,6 +2,9 @@ using SciMLTesting, OrdinaryDiffEqVerner, Test
 
 run_qa(
     OrdinaryDiffEqVerner;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (
         # `SciMLBase` module name is brought into scope by `@reexport using SciMLBase`

--- a/lib/StochasticDiffEqCore/test/qa/qa.jl
+++ b/lib/StochasticDiffEqCore/test/qa/qa.jl
@@ -75,6 +75,9 @@ const ODEC_STOCHASTIC_SURFACE = (
 
 run_qa(
     StochasticDiffEqCore;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(DiffEqBase), (:DiffEqBase,)),
     aqua_kwargs = (; piracies = (; treat_as_own = ODEC_STOCHASTIC_SURFACE)),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,

--- a/lib/StochasticDiffEqHighOrder/test/qa/qa.jl
+++ b/lib/StochasticDiffEqHighOrder/test/qa/qa.jl
@@ -3,6 +3,9 @@ using JET
 
 run_qa(
     StochasticDiffEqHighOrder;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/StochasticDiffEqIIF/test/qa/qa.jl
+++ b/lib/StochasticDiffEqIIF/test/qa/qa.jl
@@ -3,6 +3,9 @@ using JET
 
 run_qa(
     StochasticDiffEqIIF;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
 )

--- a/lib/StochasticDiffEqImplicit/test/qa/qa.jl
+++ b/lib/StochasticDiffEqImplicit/test/qa/qa.jl
@@ -3,6 +3,9 @@ using JET
 
 run_qa(
     StochasticDiffEqImplicit;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
     # Scope JET to this package in `:typo` mode, matching the OrdinaryDiffEq* solver
     # sublibraries. The deprecated `target_defined_modules = true` also reported
     # `nlsolve!`/`get_W`/`set_new_W!` "no matching method" cross-package false

--- a/lib/StochasticDiffEqLeaping/test/qa/qa.jl
+++ b/lib/StochasticDiffEqLeaping/test/qa/qa.jl
@@ -3,6 +3,9 @@ using JET
 
 run_qa(
     StochasticDiffEqLeaping;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
     # Scope JET to this package in `:typo` mode (the OrdinaryDiffEq* solver-sublibrary
     # convention); `target_defined_modules = true` is deprecated in JET.
     jet_kwargs = (; target_modules = (StochasticDiffEqLeaping,), mode = :typo),

--- a/lib/StochasticDiffEqLevyArea/test/qa/qa.jl
+++ b/lib/StochasticDiffEqLevyArea/test/qa/qa.jl
@@ -3,6 +3,8 @@ using JET
 
 run_qa(
     StochasticDiffEqLevyArea;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
 )

--- a/lib/StochasticDiffEqLowOrder/test/qa/qa.jl
+++ b/lib/StochasticDiffEqLowOrder/test/qa/qa.jl
@@ -3,6 +3,9 @@ using JET
 
 run_qa(
     StochasticDiffEqLowOrder;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
     ei_broken = (:no_implicit_imports, :all_explicit_imports_via_owners, :all_qualified_accesses_are_public, :all_explicit_imports_are_public),  # known-broken; see SciML/OrdinaryDiffEq.jl#3776

--- a/lib/StochasticDiffEqMilstein/test/qa/qa.jl
+++ b/lib/StochasticDiffEqMilstein/test/qa/qa.jl
@@ -3,6 +3,9 @@ using JET
 
 run_qa(
     StochasticDiffEqMilstein;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
     ei_broken = (:no_implicit_imports, :all_explicit_imports_via_owners, :all_qualified_accesses_are_public, :all_explicit_imports_are_public),  # known-broken; see SciML/OrdinaryDiffEq.jl#3776

--- a/lib/StochasticDiffEqROCK/test/qa/qa.jl
+++ b/lib/StochasticDiffEqROCK/test/qa/qa.jl
@@ -3,6 +3,9 @@ using JET
 
 run_qa(
     StochasticDiffEqROCK;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
     ei_broken = (:no_implicit_imports, :no_stale_explicit_imports, :all_explicit_imports_via_owners, :all_qualified_accesses_are_public, :all_explicit_imports_are_public),  # known-broken; see SciML/OrdinaryDiffEq.jl#3776

--- a/lib/StochasticDiffEqRODE/test/qa/qa.jl
+++ b/lib/StochasticDiffEqRODE/test/qa/qa.jl
@@ -3,6 +3,9 @@ using JET
 
 run_qa(
     StochasticDiffEqRODE;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
     ei_broken = (:no_implicit_imports, :all_explicit_imports_via_owners, :all_qualified_accesses_via_owners, :all_explicit_imports_are_public),  # known-broken; see SciML/OrdinaryDiffEq.jl#3776

--- a/lib/StochasticDiffEqWeak/test/qa/qa.jl
+++ b/lib/StochasticDiffEqWeak/test/qa/qa.jl
@@ -3,6 +3,9 @@ using JET
 
 run_qa(
     StochasticDiffEqWeak;
+    # No docs/ tree here; the umbrella manual renders this package's API.
+    api_docs_kwargs = (; rendered = false),
+    reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
     ei_broken = (:no_implicit_imports, :no_stale_explicit_imports, :all_explicit_imports_via_owners, :all_qualified_accesses_are_public, :all_explicit_imports_are_public),  # known-broken; see SciML/OrdinaryDiffEq.jl#3776


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

## The failure

Every `lib/*` QA lane is red — ~45 `sublibrary-ci / lib/… [QA]` jobs. This is
easy to miss because the sublibrary matrix is path-filtered: a PR that does not
touch `lib/` spawns **zero** sublibrary QA jobs, so its Sublibrary CI goes green
vacuously. #4014 touched `lib/OrdinaryDiffEqCore/Project.toml`, which triggered
the full matrix and surfaced it.

To be clear about causation: this **pre-dates** #4014. I checked out
`eb3888cf7` (before that merge) and ran the Feagin QA lane directly:

```
$ ODEDIFFEQ_TEST_GROUP=QA julia +1.12 --project=lib/OrdinaryDiffEqFeagin -e 'using Pkg; Pkg.test()'
public API is rendered in docs: Test Failed
No unapproved public reexports: Test Failed
ERROR: LoadError: Some tests did not pass: 19 passed, 2 failed, 0 errored, 0 broken.
```

## Why

SciMLTesting 2.x defaults `api_docs` and `check_reexports` to `true`. Both
assumptions are wrong for solver sublibraries:

**1. Rendered docs.** `run_api_docs` resolves `docs_src` to `<pkgroot>/docs/src`,
which no sublibrary has — `lib/OrdinaryDiffEqFeagin/` contains only
`src/ test/ Project.toml README.md LICENSE.md`. A missing directory yields an
empty rendered set, so *every* public name is reported unrendered:

```
┌ Info: run_api_docs: public API names not rendered in a @docs block
│   pkg = OrdinaryDiffEqFeagin
│   docs_src = ".../lib/OrdinaryDiffEqFeagin/docs/src"
│   unrendered = 182-element Vector{Symbol}
```

These packages are documented in the umbrella manual, where the root QA lane
already checks rendering.

**2. Facade reexports.** The solver packages `@reexport using SciMLBase` (or
`StochasticDiffEqCore` / `DiffEqBase`) by design — several qa.jl files already
say so in a comment. With no `reexports_allow`, that deliberate surface is
reported wholesale (185 names for Feagin).

## The fix

Per package, mirroring what #3988 did for the umbrella:

```julia
api_docs_kwargs = (; rendered = false),
reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
```

Neither check is switched off:

* the **docstring** half of the api-docs check stays on, so a public name with
  no docstring is still caught;
* reexports from any package *other* than the deliberately-reexported one are
  still reported.

Mapping is mechanical, from each package's own `@reexport using`:
`SciMLBase` (30), `StochasticDiffEqCore` (9), `DiffEqBase` (2), no reexport (7 —
`rendered = false` only). The module name is already in scope via the package's
own reexport, so **no test-environment or Project.toml changes are needed**.
GlobalDiffEq and ImplicitDiscreteSolve already point `docs_src` at the monorepo
manual; their api-docs configuration is left alone.

## Verification

Ran `ODEDIFFEQ_TEST_GROUP=QA` on Julia 1.12 (the version the QA lanes use),
covering every shape in the change:

| Package | Group | Result |
|---|---|---|
| OrdinaryDiffEqFeagin | SciMLBase | **tests passed** |
| OrdinaryDiffEqExplicitRK | SciMLBase, pre-existing `api_docs_kwargs` merged into | **tests passed** |
| OrdinaryDiffEqDifferentiation | no reexport | **tests passed** |
| GlobalDiffEq | DiffEqBase, bespoke `docs_src` preserved | **tests passed** |
| ImplicitDiscreteSolve | SciMLBase, bespoke `docs_src` preserved | **tests passed** |

## What this does *not* fix

Some sublibraries stay red on a **separate, pre-existing seam** unrelated to
these two checks. In each case the two checks this PR targets do now pass:

* `OrdinaryDiffEqTsit5` — `Public API documentation` 1 pass, `No unapproved
  public reexports` 1 pass; still errors on ExplicitImports
  (`all_qualified_accesses_are_public`).
* `StochasticDiffEqMilstein` — reexports check passes; `Public API
  documentation` still errors inside the *docstring* half with
  `Constant binding was imported from multiple modules` (a Julia 1.12
  `binding_module` interaction, not the rendered check).
* `OrdinaryDiffEqCore` — rendered check passes; still has a stale explicit
  import (`_unwrap_val`) and a non-public qualified access.
* `StochasticDiffEqCore` — still reports 22 reexported names (`SDEIntegrator`,
  `SDEOptions`, `issplit`, …). These are DiffEqBase-owned names the sublibrary
  `export`s even though DiffEqBase never declared them `public`. That is a real
  API-hygiene finding, so I deliberately did **not** allowlist it away — it
  wants either `public` declarations in `lib/DiffEqBase` or removal from the
  sublibrary export lists, as its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPHRh64BLfoXSzQ3AxKNwC