### PR TITLE
NonlinearSolveAlg: let the integrator decide convergence, and surface inner failures

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.5.1"
+version = "2.5.2"
 
 [deps]
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -185,6 +185,15 @@ end
 
     nlcache = nlsolver.cache.cache
     recompute_jacobian = nlsolver.iter == 1 && (cache.W === nothing || cache.new_W)
+    # A terminated inner cache makes `step!` a no-op, which would leave `ndz == 0` and read to
+    # the outer convergence test as a perfect solve. Terminating *successfully* is the normal
+    # path (the inner solve converged before the integrator's own test was satisfied); any
+    # other terminal state is a genuine failure and must reach the step controller, so report
+    # it the way `NLNewton` reports a failed linear solve.
+    if !NonlinearSolveBase.not_terminated(nlcache) &&
+            !SciMLBase.successful_retcode(nlcache.retcode)
+        return convert(eltype(z), Inf)
+    end
     step!(nlcache; recompute_jacobian)
     nlsolver.ztmp = nlcache.u
 
@@ -210,6 +219,15 @@ end
     nlstep_data = integrator.f.nlstep_data
     nlcache = nlsolver.cache.cache
     recompute_jacobian = nlsolver.iter == 1 && (cache.W === nothing || cache.new_W)
+    # A terminated inner cache makes `step!` a no-op, which would leave `ndz == 0` and read to
+    # the outer convergence test as a perfect solve. Terminating *successfully* is the normal
+    # path (the inner solve converged before the integrator's own test was satisfied); any
+    # other terminal state is a genuine failure and must reach the step controller, so report
+    # it the way `NLNewton` reports a failed linear solve.
+    if !NonlinearSolveBase.not_terminated(nlcache) &&
+            !SciMLBase.successful_retcode(nlcache.retcode)
+        return convert(eltype(atmp), Inf)
+    end
     step!(nlcache; recompute_jacobian)
 
     if nlstep_data !== nothing

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -275,6 +275,20 @@ end
 # passed through as an operator `jac_prototype` (applied via `mul!`, Krylov); a concrete W
 # reused via an analytic `WReuseJac`. Used at build time and after `resize!` so the inner
 # `NonlinearFunction`'s concrete type is preserved.
+# Tolerances for the inner NonlinearSolve. `nlsolve!` drives that cache one `step!` at a time
+# and decides convergence itself with the integrator's weighted `κ`/`η` test, exactly as it does
+# for `NLNewton`, so the inner solver must never terminate on its own first: its default is an
+# absolute residual bound unrelated to the integrator's tolerances, and the residual carries a
+# `1/(γ·dt)` factor, so once `dt` grows it is met immediately — after which `step!` becomes a
+# no-op, every later outer iteration sees a zero increment, and the outer test reads that as a
+# perfect solve and accepts an unconverged stage.
+#
+# Zeroing `abstol`/`reltol` disables that criterion, but those same values are forwarded to the
+# descent's linear solver, where zero is an unreachable target that costs an iterative (Krylov)
+# solve its Newton-direction accuracy. `linsolve_kwargs` is splatted after them, so it restores
+# a usable tolerance for the linear solve alone.
+_inner_lintol(::Type{T}) where {T} = eps(real(one(T)))^(4 // 5)
+
 function reuse_jac_kwargs(W)
     Wr = W isa WOperator && W.J !== nothing && !(W.J isa AbstractSciMLOperator) ?
         W._concrete_form : W
@@ -450,7 +464,21 @@ function build_nlsolver(
                 nlalg.alg,
                 wrapprecs(default_krylov_warm_start(alg.linsolve), W, weight)
             )
-            cache = init(prob, inner_alg, verbose = verbose.nonlinear_verbosity)
+            # The integrator owns the convergence decision, exactly as it does for `NLNewton`:
+            # `nlsolve!` drives this cache one `step!` at a time and stops on its own weighted
+            # `κ`/`η` test. Zero tolerances keep the inner solver's own criterion from ever
+            # firing first — otherwise it terminates on an absolute residual bound unrelated to
+            # the integrator's tolerances (and scaled by `1/(γ·dt)`, so it is trivially met once
+            # `dt` grows), after which `step!` becomes a no-op, every later outer iteration sees
+            # `ndz == 0`, and the outer test reads that as perfect convergence and accepts the
+            # step with an unconverged stage.
+            cache = init(
+                prob, inner_alg; verbose = verbose.nonlinear_verbosity,
+                abstol = zero(uTolType), reltol = zero(uTolType),
+                linsolve_kwargs = (;
+                    abstol = _inner_lintol(uTolType), reltol = _inner_lintol(uTolType),
+                )
+            )
             # Smoothed estimate `W \ tmp` reuses the inner solver's own W factorization (see
             # NonlinearSolveCache); `nothing` when it exposes none (native scalar/StaticArray
             # solve) falls back to the raw estimate.
@@ -617,7 +645,14 @@ function build_nlsolver(
                 copy(ztmp), nlp_params
             )
             inner_alg = _nlalg_with_linsolve(nlalg.alg, alg.linsolve)
-            cache = init(prob, inner_alg, verbose = verbose.nonlinear_verbosity)
+            # Zero tolerances: the integrator owns convergence (see the in-place branch above).
+            cache = init(
+                prob, inner_alg; verbose = verbose.nonlinear_verbosity,
+                abstol = zero(uTolType), reltol = zero(uTolType),
+                linsolve_kwargs = (;
+                    abstol = _inner_lintol(uTolType), reltol = _inner_lintol(uTolType),
+                )
+            )
             nlcache = NonlinearSolveCache(
                 nothing, tstep, nothing, nothing, invγdt, prob, cache,
                 nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing,


### PR DESCRIPTION
Fixes #4019.

`NonlinearSolveAlg` could return a physically impossible solution with `ReturnCode.Success`: on ROBER (`TRBDF2`, `reltol=1e-9`, `κ=1e-6`) it produced `[-9.44e6, -4.0e-6, +9.44e6]` — negative concentrations, mass 1.05 instead of 1, no `NaN`/`Inf` — where `NLNewton` is exact. At default settings the same mechanism cost **25–92% componentwise relative error** on ROBER's small components across `TRBDF2`/`KenCarp4`/`FBDF`.

## Mechanism

1. The inner `NonlinearSolve` cache is built with **no tolerances**, so it terminates on its own default absolute residual bound — unrelated to the integrator's tolerances, and applied to a residual carrying a `1/(γ·dt)` factor, so once `dt` grows it is met immediately.
2. `CommonSolve.step!` on an already-terminated cache is a **silent no-op** (`not_terminated(cache) || return`), leaving `u` unchanged.
3. `compute_step!` never inspected the inner cache, so every later outer iteration measured a **zero increment**. `ndz == 0` reads to the outer `κ`/`η` test as a *perfect* solve → `nlsolvefail` false → step accepted with an unconverged stage.

Measured on the baseline ROBER run: **415,726 of 1,123,453** `compute_step!` calls entered with a terminated cache, and every one produced `ndz == 0`. With the inner solver made structurally unable to converge (`maxiters=1`), the solve still reported **`nnonlinconvfail = 0`** over 200k steps — genuine failures were being laundered into successes.

This also explains why tightening `κ` made things *worse* rather than better: the outer `κ` test was inert.

## Fix

- **Zero the inner nonlinear tolerances** so the inner criterion can never fire first — the integrator owns convergence via its weighted `κ`/`η` test, exactly as for `NLNewton`.
- **Guard `compute_step!`**: a cache that terminated *unsuccessfully* returns `Inf` → `Divergence` → rejected step. The `successful_retcode` qualifier is load-bearing — terminating successfully is the normal path (the inner solve converges before the integrator's test is satisfied), so an unqualified check rejects nearly every step.
- **Restore the linear-solve tolerance via `linsolve_kwargs`**: those same `abstol`/`reltol` are forwarded to the descent's linear solver, where zero is unreachable and costs an iterative solve its Newton direction (`KrylovJL_GMRES` on the matrix-free Brusselator regressed 5.3e-7 → 4.1e-5 before this part was added). `linsolve_kwargs` is splatted after them, so it applies to the linear solve alone.

## Results

ROBER now matches `NLNewton` to 7 digits with mass conserved, using **a third of the work** it previously spent getting the wrong answer:

| ROBER, TRBDF2, reltol=1e-9 | u_end | mass | naccept |
|---|---|---|---|
| before | `[-9.44e6, -4.0e-6, 9.44e6]` | 1.052 | 166593 |
| **after** | `[2.083e-8, 8.33e-14, 1.0]` | 1.000 | **56949** |
| NLNewton | `[2.083e-8, 8.33e-14, 1.0]` | 1.000 | 167629 |

Matrix-free Brusselator, 12 configs (both autodiffs × {Krylov, KLU, default}): all pass, and `NonlinearSolveAlg` is now **more accurate than `NLNewton` on every one** (2.14e-7 vs 5.3e-7–7.1e-7) at matching step counts.

## Testing

Full `OrdinaryDiffEqNonlinearSolve` suite passes, 0 failures (Newton 6, Sparse DAE Init 27, Linear Nonlinear Solver 44, Linear Solver 113, Split ODE 10, Mass Matrix 225 +42 pre-existing broken, W-Operator Prototype 18, DAE Init 19, CheckInit 4, Nested AD 5, NSA Jacobian Reuse 8, Homotopy 25+12, NSA Sparse 10, NSA Matrix-Free 14, NSA Smoothed Error Estimate 10). That run also had #4011 applied; ROBER and the matrix-free comparison above were additionally re-verified on this branch alone, with byte-identical results.

## Not addressed here

`isnewton(nlsolver)` is false for `NonlinearSolveCache`, so `NonlinearSolveAlg` never reaches the stale-Jacobian retry that `NLNewton` uses on divergence — a `Divergence` always costs a full step rejection instead of a cheap retry with a fresh `W`. Worth a separate change.

Draft — please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
