### PR TITLE
NonlinearSolveAlg: stop paying for an inner termination check that cannot fire

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.5.2"
+version = "2.5.3"
 
 [deps]
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -106,8 +106,10 @@ function initialize!(
             # reassembling W = J - M/γdt from the stored J (jacobian2W! is O(nnz), a
             # Jacobian evaluation is not).
             new_jac = first_call || alg.always_new || nlsolver.status === Divergence
+            # `oftype`: `new_W_dt_cutoff` defaults to a `Rational`, and comparing a `Float64`
+            # against one goes through the slow mixed-type path on every stage.
             new_w = new_jac ||
-                abs(inv(dtgamma) / inv(W_γdt) - 1) > alg.new_W_dt_cutoff
+                abs(inv(dtgamma) / inv(W_γdt) - 1) > oftype(dtgamma, alg.new_W_dt_cutoff)
             if new_w
                 _update_nlsolvealg_W!(cache, integrator, dtgamma, tstep, new_jac)
                 cache.new_W = true
@@ -132,9 +134,16 @@ function initialize!(
                 SciMLBase.remake(cache.prob; u0 = copy(z), p = nlp_params)
             end
             cache.prob = new_prob
+            # Same tolerances and termination mode as `build_nlsolver`: the integrator owns
+            # convergence, so the inner criterion must stay inert here too (otherwise a resized
+            # cache could terminate on its own again), and the mode is part of the cache's type,
+            # so rebuilding with a different one would not even be assignable.
+            uT = real(eltype(z))
             cache.cache = init(
                 new_prob, cache.cache.alg;
-                verbose = integrator.opts.verbose.nonlinear_verbosity
+                verbose = integrator.opts.verbose.nonlinear_verbosity,
+                abstol = zero(uT), reltol = zero(uT),
+                termination_condition = _inner_termination()
             )
             # re-point the estimator linsolve alias at the rebuilt inner cache
             cache.linsolve = cache.W !== nothing ? get_linear_cache(cache.cache) : nothing

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -275,6 +275,14 @@ end
 # passed through as an operator `jac_prototype` (applied via `mul!`, Krylov); a concrete W
 # reused via an analytic `WReuseJac`. Used at build time and after `resize!` so the inner
 # `NonlinearFunction`'s concrete type is preserved.
+# Termination mode for the inner solve. The tolerances above are zero, so no criterion can
+# ever fire — the integrator decides convergence. NonlinearSolve's default
+# (`AbsNormSafeBestTerminationMode`) would nonetheless run its full per-iteration bookkeeping:
+# best-objective tracking with a state copy, a circular objective trace, and — because it
+# defaults to `max_stalled_steps = 32` — a state-difference buffer and a second norm. All of it
+# is dead weight here, so ask for the plain absolute-norm mode instead.
+_inner_termination() = NonlinearSolveBase.AbsNormTerminationMode(Base.Fix1(maximum, abs))
+
 # Tolerances for the inner NonlinearSolve. `nlsolve!` drives that cache one `step!` at a time
 # and decides convergence itself with the integrator's weighted `κ`/`η` test, exactly as it does
 # for `NLNewton`, so the inner solver must never terminate on its own first: its default is an
@@ -475,6 +483,7 @@ function build_nlsolver(
             cache = init(
                 prob, inner_alg; verbose = verbose.nonlinear_verbosity,
                 abstol = zero(uTolType), reltol = zero(uTolType),
+                termination_condition = _inner_termination(),
                 linsolve_kwargs = (;
                     abstol = _inner_lintol(uTolType), reltol = _inner_lintol(uTolType),
                 )
@@ -649,6 +658,7 @@ function build_nlsolver(
             cache = init(
                 prob, inner_alg; verbose = verbose.nonlinear_verbosity,
                 abstol = zero(uTolType), reltol = zero(uTolType),
+                termination_condition = _inner_termination(),
                 linsolve_kwargs = (;
                     abstol = _inner_lintol(uTolType), reltol = _inner_lintol(uTolType),
                 )


### PR DESCRIPTION
## What

Pass an explicit `AbsNormTerminationMode` to the inner `NonlinearSolve` cache, plus two related fixes in the same area.

## Why

`build_nlsolver` inits the inner cache with `abstol = reltol = 0`, because the integrator owns convergence via its own weighted `κ`/`η` test (that is the contract `NLNewton` follows, and what #4020 established). But no `termination_condition` was passed, so the cache still got NonlinearSolve's default `AbsNormSafeBestTerminationMode(maximum∘abs; max_stalled_steps = 32)` — and ran that mode's full body on **every inner iteration**:

- an `Linf` norm over the residual
- best-objective tracking, including a state copy via `update_u!!`
- a circular objective trace write
- and, because stall detection defaults on, a state-difference buffer plus a **second** norm

With a zero tolerance, none of it can ever terminate anything. It is pure per-iteration overhead.

## Effect

OREGO / TRBDF2 / `reltol=1e-6`, where both solvers take **identical steps** (239 accepted, 64 rejected) so this is a pure per-step comparison:

| | µs/step | vs NLNewton |
|---|---|---|
| before | 8.65 | 1.34× |
| **after** | **8.12** | **1.27×** |

Statistics are byte-identical (239 steps, `nf` 3985, `nnonliniter` 3609) — this changes cost, not behavior. Across the stiff benchmark set (ROBER/HIRES/OREGO/POLLU/VdP-stiff/Brusselator1D × TRBDF2/KenCarp4/FBDF × 1e-6,1e-9) the total goes **1.63× → 1.53×**.

A CPU profile diff (equal step counts, so the real work is identical — LAPACK, f-evals and Jacobians match within ±0.17 µs/step, and allocations per step are equal at 425.9 vs 425.5 B) attributes **40% of the entire per-step gap** to this one check. The remainder is NonlinearSolve-side and not addressed here: `update_A!` re-plumbing `A` on every inner iteration (9%), `@bb axpy!` routing a 3-element update through BLAS where the call overhead exceeds the arithmetic (part of 24%), and generic-cache `getproperty` forwarding.

Note the overhead is **fixed per iteration**, so it amortizes with problem size: the same benchmark shows 1.35× at 3 states but 1.11× at 32.

## Two further fixes

**1. The `resize!` path did not match the build sites (correctness).** It re-`init`ed the inner cache without the zero tolerances, so after a resize the inner solver silently regained its default tolerances and could terminate on its own again — the exact failure mode fixed in #4019/#4020, reachable through a callback that resizes the integrator. It now mirrors the build call. Because the termination mode is part of the cache's *type*, this mismatch also became a `MethodError` rather than a silent behavioral difference, which is how the existing `resize with W-reuse rebuilds inner Jacobian` test caught it.

**2. `Float64` vs `Rational` on a hot path.** `new_W_dt_cutoff` defaults to `1//5`, so the `W`-reuse test compared a `Float64` against a `Rational` through the slow mixed-type path (`ndigits0z`) on every stage. `NLNewton` avoids this by storing the converted value in its cache; this does the same with `oftype`.

## Testing

Full `OrdinaryDiffEqNonlinearSolve` suite passes. The NSA suites specifically: smooth_est 10/10, sparse 10/10 (including the resize test above), matrix-free 14/14, Jacobian-reuse 8/8. ROBER remains exact with mass conserved. Runic clean.

Draft — please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
