### PR TITLE
AMF: raise the SciMLOperators floor to 1.24.5

### DIFF
--- a/lib/OrdinaryDiffEqAMF/Project.toml
+++ b/lib/OrdinaryDiffEqAMF/Project.toml
@@ -19,7 +19,7 @@ LinearSolve = "5.1"
 OrdinaryDiffEqCore = "4"
 Reexport = "1.2.2"
 SciMLBase = "3.39"
-SciMLOperators = "1.24.3"
+SciMLOperators = "1.24.5"
 julia = "1.10"
 
 [sources.OrdinaryDiffEqCore]


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

⏳ **Blocked on SciMLOperators 1.24.5 being registered.** SciMLOperators master
is at `version = "1.24.5"` but General still tops out at 1.24.4, so CI here will
fail resolution (`Unsatisfiable requirements`) until the release lands. Holding
as a draft until then.

## The failure

`downgrade-sublibraries (lib/OrdinaryDiffEqAMF)` — the **only** failure in that
lane, 1 of 58 jobs:

```
MethodError: Cannot `convert` an object of type Matrix{Float64}
             to an object of type SciMLOperators.AddedOperator{Float64, ...}
  [1] setproperty!(x::WOperator{...})
  [2] convert(::Type{AbstractMatrix}, W::WOperator{...})
      @ SciMLOperators .../src/woperator.jl:202
```

Hit from `test_fd2d.jl` and `test_adjoint_fd2d.jl`, whose problems build an
operator-valued Jacobian out of `kron` graphs.

## Why a floor bump is the fix

SciML/SciMLOperators.jl#410 fixed the underlying bug and shipped in 1.24.5. But
the Downgrade lane resolves every dependency at its **compat floor**, and AMF
pinned `SciMLOperators = "1.24.3"`. Without raising the floor the lane keeps
installing 1.24.3 and keeps failing, no matter what is released.

## Verification

Same tree, same test group, varying only the SciMLOperators version:

| SciMLOperators | `ODEDIFFEQ_TEST_GROUP=Core` on `lib/OrdinaryDiffEqAMF` |
|---|---|
| 1.24.4 | **2 errored** — the `MethodError` above, in `AMF finite-difference 2D regression` and `Adjoint AMF fd2d (symmetric Jacobian)` |
| 1.24.5 | **`Testing OrdinaryDiffEqAMF tests passed`** |

The 1.24.5 run used SciMLOperators master `Pkg.develop`ed, since the release is
not registered yet; the source is identical to what 1.24.5 will ship.

A useful side check: with this floor in place, `Pkg.add(SciMLOperators@1.24.4)`
is now correctly rejected —

```
ERROR: Unsatisfiable requirements detected for package SciMLOperators:
 ├─restricted to versions 1.24.3 - 1 by OrdinaryDiffEqCore, leaving only versions: 1.24.3 - 1.24.4
 └─restricted to versions 1.24.5 - 1 by OrdinaryDiffEqAMF — no versions left
```

so the compat genuinely keeps the broken versions out of the Downgrade lane.

## Note on OrdinaryDiffEqCore

`OrdinaryDiffEqCore` still pins `SciMLOperators = "1.24.3"`. I left it alone —
its own Downgrade job passes, so there is no evidence it needs 1.24.5, and
raising floors without a failure to justify them just tightens resolution for
downstream users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPHRh64BLfoXSzQ3AxKNwC