### PR TITLE
Reinitialize DAEs on mid-integration derivative_discontinuity (#3932)

### DIFF
--- a/lib/OrdinaryDiffEqBDF/test/dae_derivative_discontinuity_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/dae_derivative_discontinuity_tests.jl
@@ -70,3 +70,40 @@ step!(int4)
 # Callback fires once → reeval_internals_due_to_modification! → initialize_dae! once
 # If double-init existed, this would be 2
 @test counter2.count[] == init_count_before + 1
+
+# Regression for #3932: after a successful step (iter > 0), manual
+# derivative_discontinuity! must still trigger DAE reinitialization. Previously
+# loopheader! only handled the flag when iter == 0, so a later modification was
+# silently accepted with broken algebraic constraints.
+@testset "derivative_discontinuity after first step (#3932)" begin
+    int5 = init(prob, DFBDF(), initializealg = DiffEqBase.CheckInit())
+    step!(int5)
+    @test int5.iter > 0
+    int5.u[1] = 2.0
+    derivative_discontinuity!(int5, true)
+    @test_throws SciMLBase.CheckInitFailureError step!(int5)
+
+    int6 = init(prob, DFBDF(), initializealg = BrownFullBasicInit())
+    step!(int6)
+    @test int6.iter > 0
+    int6.u[1] = 2.0
+    derivative_discontinuity!(int6, true)
+    step!(int6)
+    @test int6.u[1] + int6.u[2] + int6.u[3] ≈ 1.0 atol = 1.0e-10
+
+    # Callback path after the first step still reinitializes (and must not
+    # double-count in the following loopheader!).
+    counter3 = CountingInit(DiffEqBase.CheckInit(), Ref(0))
+    fired = Ref(false)
+    condition3(u, t, integrator) = fired[]  # arm after first step
+    affect3!(integrator) = (integrator.u .= integrator.u)
+    cb3 = DiscreteCallback(condition3, affect3!)
+    int7 = init(prob2, DFBDF(), initializealg = counter3, callback = cb3)
+    step!(int7)  # no callback fire yet
+    count_before_fire = counter3.count[]
+    fired[] = true
+    step!(int7)  # callback fires → exactly one initialize_dae!
+    @test counter3.count[] == count_before_fire + 1
+    step!(int7)  # fires again on next accept → +1 more, not +2 from loopheader
+    @test counter3.count[] == count_before_fire + 2
+end

--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
@@ -65,6 +65,15 @@ end
 function loopheader!(integrator)
     # Apply right after iterators / callbacks
 
+    # Manual derivative_discontinuity! (any iter, including after the first step)
+    # must reinit DAEs *before* accept/update_uprev, otherwise a broken u is
+    # committed into uprev (#3932). Callbacks already call initialize_dae! via
+    # reeval_internals_due_to_modification! and leave reeval_fsal=true; skip
+    # those so we do not double-init.
+    if integrator.derivative_discontinuity && !integrator.reeval_fsal
+        on_derivative_discontinuity_at_init!(integrator)
+    end
+
     # Accept or reject the step
     if integrator.iter > 0
         if (!integrator.force_stepfail) &&
@@ -87,8 +96,6 @@ function loopheader!(integrator)
             # REJECT
             handle_step_rejection!(integrator)
         end
-    elseif integrator.derivative_discontinuity # && integrator.iter == 0
-        on_derivative_discontinuity_at_init!(integrator)
     end
 
     integrator.iter += 1
@@ -125,8 +132,10 @@ end
 # Called after step rejection handling. Override for DDE discontinuity handling.
 post_step_reject!(integrator) = nothing
 
-# Called at iter==0 when u was modified by callbacks during init.
-# For SDE: isdae=false skips DAE re-init; isfsal=false makes update_fsal! a no-op.
+# Called when derivative_discontinuity! was set manually (not via a callback that
+# already ran reeval_internals_due_to_modification!). Runs for any iter, including
+# after the first step (#3932). For SDE: isdae=false skips DAE re-init;
+# isfsal=false makes update_fsal! a no-op.
 function on_derivative_discontinuity_at_init!(integrator)
     if integrator.isdae
         SciMLBase.initialize_dae!(integrator)


### PR DESCRIPTION
## Summary
- `loopheader!` only ran `on_derivative_discontinuity_at_init!` (`initialize_dae!`) when `iter == 0`, so a manual `derivative_discontinuity!` after the first step never reinitialized the DAE while callback-driven modifications still did via `reeval_internals_due_to_modification!`.
- Reinitialize whenever `derivative_discontinuity && !reeval_fsal`, before accept/`update_uprev!`. Callbacks already reinitalize and leave `reeval_fsal == true`, so they are not double-initialized.
- Adds a regression test covering CheckInit failure, BrownFullBasicInit repair after the first step, and no double-init on DiscreteCallback paths.

Fixes #3932

## Test plan
- [ ] `OrdinaryDiffEqBDF` tests including `dae_derivative_discontinuity_tests.jl`
- [ ] Manual `derivative_discontinuity!` after first step with `initializealg = CheckInit()` throws on inconsistent `u`
- [ ] Same with `BrownFullBasicInit()` repairs and continues
- [ ] DiscreteCallback that modifies the DAE still initializes once per fire (no extra init in the following `loopheader!`)