### PR TITLE
Make SplitODEProblem resize! regression test deterministic (#3972)

### DIFF
--- a/test/Integrators_II/resize_tests.jl
+++ b/test/Integrators_II/resize_tests.jl
@@ -231,11 +231,23 @@ runSim(Rosenbrock23())
 runSim(Rosenbrock23(autodiff = AutoFiniteDiff()))
 
 # https://github.com/SciML/OrdinaryDiffEq.jl/issues/1990
+# https://github.com/SciML/OrdinaryDiffEq.jl/issues/3972
 @testset "resize! with SplitODEProblem" begin
     f!(du, u, p, t) = du .= u
     ode = SplitODEProblem(f!, f!, [1.0], (0.0, 1.0))
     integrator = init(ode, Tsit5())
     @test_nowarn step!(integrator)
     @test_nowarn resize!(integrator, 2)
+    # #1990: SplitFunction scratch buffer must grow with the state
+    @test length(integrator.u) == 2
+    @test length(integrator.f._func_cache) == 2
+    # Julia's resize! leaves new entries undefined. Tsit5's next step reads
+    # uprev (and fsalfirst), so undef/NaN garbage can collapse dt and make the
+    # following @test_nowarn flake. Initialize the new component (same pattern
+    # as splitMod! above) and mark u modified so FSAL is recomputed.
+    integrator.u[2] = 0.0
+    integrator.uprev[2] = 0.0
+    u_modified!(integrator, true)
     @test_nowarn step!(integrator)
+    @test length(integrator.u) == 2
 end


### PR DESCRIPTION
## Summary
- The `#1990` regression at `test/Integrators_II/resize_tests.jl` called `step!` immediately after `resize!(integrator, 2)` without defining the new state entries.
- Julia `resize!` leaves new `Vector` slots undefined. Tsit5's next step builds from `uprev` and `fsalfirst`, so NaN/Inf-adjacent garbage can collapse `dt` and fail `@test_nowarn` intermittently (CI-only flake).
- Initialize `u[2]` / `uprev[2]`, call `u_modified!` so FSAL is recomputed (same pattern as `splitMod!` in this file), and assert `integrator.f._func_cache` grows so the `#1990` SplitFunction resize path stays covered.

Fixes #3972

## Test plan
- [ ] `Integrators_II` / `resize_tests.jl` passes locally
- [ ] Repeated runs of the SplitODEProblem resize `@testset` stay green (no undef-memory flake)
- [ ] `#1990` still asserted via `length(integrator.f._func_cache) == 2` after resize