### PR TITLE
NonlinearSolveAlg: apply the stale-W rescaling NLNewton already does

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -185,6 +185,33 @@ function _update_nlsolvealg_W!(nlcache, integrator, dtgamma, tstep, new_jac = tr
     return nothing
 end
 
+"""
+    rescale_stale_W_rhs!(nlcache, nlsolver, integrator, nlstep_data)
+
+Apply the stale-`W` correction of `compute_step!(::NLSolver{<:NLNewton, true}, ...)` to a
+`NonlinearSolveAlg` step: when the reused `W` was assembled at a different `γΔt` than the
+current step needs, the Newton direction it produces is off by that ratio.
+
+`NLNewton` scales the increment it just computed. `NonlinearSolveAlg` cannot: the inner
+solver computes *and* applies the increment inside `step!`. Scaling the right-hand side
+beforehand is equivalent for the Newton descent `δu = -W \\ fu`, and unlike rewriting
+`nlcache.u` afterwards it leaves the inner cache's `u`/`fu` pair mutually consistent — the
+inner solver re-evaluates `fu` at the end of `step!`, so the scaling does not persist.
+"""
+function rescale_stale_W_rhs!(nlcache, nlsolver, integrator, nlstep_data)
+    cache = nlsolver.cache
+    # `W` is only reused on the plain path; otherwise the inner solver refreshes its own
+    # Jacobian at every stage and there is nothing stale to correct.
+    (cache.W === nothing || nlstep_data !== nothing) && return nothing
+    W_γdt = cache.W_γdt
+    iszero(W_γdt) && return nothing
+    isdae = nlsolve_f(integrator) isa DAEFunction
+    γdt = isdae ? nlsolver.α * cache.invγdt : nlsolver.γ * integrator.dt
+    W_γdt ≈ γdt && return nothing
+    rmul!(nlcache.fu, 2 / (1 + γdt / W_γdt))
+    return nothing
+end
+
 ## compute_step!
 
 @muladd function compute_step!(nlsolver::NLSolver{<:NonlinearSolveAlg, false}, integrator)
@@ -237,6 +264,7 @@ end
             !SciMLBase.successful_retcode(nlcache.retcode)
         return convert(eltype(atmp), Inf)
     end
+    rescale_stale_W_rhs!(nlcache, nlsolver, integrator, nlstep_data)
     step!(nlcache; recompute_jacobian)
 
     if nlstep_data !== nothing

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_jacobian_reuse_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_jacobian_reuse_tests.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEqBDF, OrdinaryDiffEqSDIRK
+using OrdinaryDiffEqBDF, OrdinaryDiffEqSDIRK, OrdinaryDiffEqRosenbrock
 using OrdinaryDiffEqNonlinearSolve
 using OrdinaryDiffEqNonlinearSolve: NonlinearSolveAlg
 using NonlinearSolve: NewtonRaphson
@@ -47,4 +47,21 @@ refsol = solve(prob, FBDF(); reltol = 1.0e-12, abstol = 1.0e-14)
         @test JAC_CALLS[] < sol.stats.nw / 3
         @test JAC_CALLS[] >= 1
     end
+end
+
+@testset "stale-W Newton directions are rescaled" begin
+    # `W` is reused while `γΔt` drifts within `new_W_dt_cutoff`, which leaves the Newton
+    # direction it produces scaled wrong; `NLNewton` corrects for that. Reproducing it
+    # needs `dt` to range over many orders of magnitude, hence the long tspan, and an
+    # AD Jacobian rather than the analytic one used above.
+    staleprob = ODEProblem(rober!, [1.0, 0.0, 0.0], (0.0, 1.0e11), [0.04, 3.0e7, 1.0e4])
+    tight = solve(staleprob, Rodas5P(); reltol = 1.0e-13, abstol = 1.0e-15)
+    err(sol) = maximum(abs.(sol.u[end] .- tight.u[end]))
+
+    ref = solve(staleprob, KenCarp4(); reltol = 1.0e-9, abstol = 1.0e-12)
+    sol = solve(staleprob, KenCarp4(nlsolve = nsa); reltol = 1.0e-9, abstol = 1.0e-12)
+    @test SciMLBase.successful_retcode(sol)
+    # Uncorrected directions cost ~1.5x NLNewton's steps for ~9x its error here.
+    @test err(sol) < 3 * err(ref)
+    @test sol.stats.naccept < 1.25 * ref.stats.naccept
 end


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

`NLNewton` corrects the Newton direction when the reused `W` was assembled at a different `γΔt` than the current step needs ([`newton.jl`](https://github.com/SciML/OrdinaryDiffEq.jl/blob/master/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl) `compute_step!`, `rmul!(dz, 2/(1 + γdt/W_γdt))`). `NonlinearSolveAlg` reuses `W` under exactly the same `new_W_dt_cutoff` policy but never applied the correction, so it took uncorrected directions anywhere inside that 20% window.

### Implementation note

`NLNewton` scales the increment after computing it. NSA can't: the inner solver computes *and* applies the increment inside `step!`. Instead this scales the right-hand side `nlcache.fu` beforehand, which is equivalent for the Newton descent `δu = -W \ fu`, costs the same single `rmul!`, and needs no extra buffer.

It also keeps the inner cache consistent, which the write-back alternative does not: `NonlinearSolveFirstOrder`'s `step!` ends with `evaluate_f!(cache, cache.u, cache.p)`, so overwriting `nlcache.u` afterwards would leave `fu` evaluated at the un-rescaled point and the next `step!` would build its descent from that stale residual. Because `fu` is re-evaluated at the end of `step!`, the scaling does not persist.

Gated off when `cache.W === nothing` and on the `nlstep_data` path — neither reuses `W`. Out-of-place NSA is untouched, matching `NLNewton`.

### Effect

ROBER, `rtol=1e-9`, error vs a tight `Rodas5P` reference:

| | NLNewton | NSA before | NSA after |
|---|---|---|---|
| KenCarp4 | 32451 steps, 3.55e-13 | 48301, 3.14e-12 (8.85x) | **28208, 2.85e-13 (0.80x)** |
| QNDF | 6.27e-13 | 7.67e-13 | **6.65e-14** |
| QNDF `rtol=1e-6` | 4.25e-10 | 4.12e-09 | **4.92e-12** |

Across ROBER/HIRES/POLLU/VdPstiff x TRBDF2/KenCarp4/FBDF/QNDF x {1e-6, 1e-9}, NSA is more accurate than `NLNewton` in 21 of 31 configurations. VdPstiff/FBDF at `rtol=1e-9` now succeeds where `NLNewton` reports `Unstable`.

### Tradeoff, disclosed

Timing was measured on a loaded machine using interleaved min-of-N with both solvers in the same process, corroborated by deterministic `nf`/`nw` counters; ratios are meaningful, absolute ms are not. Aggregate over 15 configs:

| rtol | before | after |
|---|---|---|
| 1e-6 | 1.04x, 1.06x | **1.22x, 1.17x** |
| 1e-9 | 1.59x | **1.51x** |

Loose tolerance regresses. ROBER/TRBDF2 at `rtol=1e-6` goes from 0.92x to 1.12x with 22% more `f` evaluations — deterministic, not noise, and reproduced across reruns. What is happening is that master's uncorrected NSA beat `NLNewton` on ROBER at loose tolerance on both steps and accuracy, and the correction brings it back to `NLNewton`'s trajectory. Both still meet the requested tolerance.

In absolute time the aggregate improves (1.49x -> 1.45x), because the `1e-9` gain outweighs the `1e-6` cost. The argument for merging is consistency with `NLNewton` and the literature's stale-`W` correction rather than a throughput win; the loose-tolerance cost is real and worth weighing.

### Test

`nsa_jacobian_reuse_tests.jl` gains a case that fails without the fix (verified on master: `48301 < 40563.75` false, plus the error bound). Reproducing it needs a long tspan so `dt` spans many orders of magnitude and an AD Jacobian — the file's existing `t=1e5` analytic-Jacobian problem passes either way. Full NSA suite 45/45 locally, Runic clean.

### Out of scope, found while testing

Two pre-existing issues on master, neither caused or fixed here:
- NSA with a `TrustRegion` inner algorithm returns `Success` with an error of `3.4e+28` on ROBER/FBDF, and `2.2e+04` on ROBER/TRBDF2 at `rtol=1e-9`. Silent wrong answers, same class as #4019. This change slightly improves some of those cases (VdPstiff/FBDF `Unstable` -> `Success`) but does not address the root cause.
- ROBER/TRBDF2 at `rtol=1e-9` stays ~12x less accurate than `NLNewton` with ~36% more steps, before and after. Not stale-`W`; needs its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
