### PR TITLE
Allow-list the residual owner-internal names in the sublibrary QA lanes

### DIFF
--- a/lib/OrdinaryDiffEqBDF/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqBDF/test/qa/qa.jl
@@ -9,6 +9,10 @@ run_qa(
     ei_kwargs = (
         all_qualified_accesses_are_public = (;
             ignore = (
+                # OrdinaryDiffEqCore — owner-internal, no public alternative
+                :CompositeControllerCache, :lorenz_pref, :lorenz_pref_params,
+                # OrdinaryDiffEqNonlinearSolve — owner-internal, no public alternative
+                :build_nlsolver, :du_alias_or_new, :markfirststage!, :nlsolve!, :nlsolvefail,
                 # Precompile-workload test problems in OrdinaryDiffEqCore, kept
                 # non-public on purpose (test fixtures, not solver-author API).
                 :lorenz, :lorenz_oop, :lorenz_p, :lorenz_p_params,
@@ -16,6 +20,10 @@ run_qa(
         ),
         all_explicit_imports_are_public = (;
             ignore = (
+                # OrdinaryDiffEqCore — owner-internal, no public alternative
+                :CompositeControllerCache, :lorenz_pref, :lorenz_pref_params,
+                # OrdinaryDiffEqNonlinearSolve — owner-internal, no public alternative
+                :build_nlsolver, :du_alias_or_new, :markfirststage!, :nlsolve!, :nlsolvefail,
                 # OrdinaryDiffEqCore owner-internal helpers (deliberately excluded
                 # from the public solver-author extension surface).
                 :_resolved_QT, :trivial_limiter!,

--- a/lib/OrdinaryDiffEqCore/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqCore/test/qa/qa.jl
@@ -24,7 +24,7 @@ run_qa(
             allow_unanalyzable = UNANALYZABLE,
             ignore = (
                 :BrownFullBasicInit, :ShampineCollocationInit, :DEVerbosity,
-                :Minimal, :_vec, :_reshape, :unwrap_cache,
+                :Minimal, :_vec, :_reshape, :unwrap_cache, :_unwrap_val,
                 :calculate_residuals, :calculate_residuals!,
             ),
         ),
@@ -32,6 +32,8 @@ run_qa(
         # genuinely needs and that have no public replacement yet.
         all_qualified_accesses_are_public = (;
             ignore = (
+                # DiffEqBase — owner-internal, no public alternative
+                :NAN_CHECK,
                 # Base / Core internals
                 Symbol("@max_methods"), :Experimental, :Typeof, :promote_op,
                 # SciMLOperators internal
@@ -51,6 +53,8 @@ run_qa(
         # Internal (non-`public`) names imported from upstream packages.
         all_explicit_imports_are_public = (;
             ignore = (
+                # DiffEqBase — owner-internal, no public alternative
+                :NAN_CHECK,
                 # TruncatedStacktraces internals
                 Symbol("@truncate_stacktrace"), :VERBOSE_MSG,
                 # FunctionWrappers internal

--- a/lib/OrdinaryDiffEqExponentialRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/test/qa/qa.jl
@@ -7,8 +7,14 @@ run_qa(
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (
+        all_qualified_accesses_are_public = (;
+            # Base — owner-internal, no public alternative
+            ignore = (:structdiff,),
+        ),
         all_explicit_imports_are_public = (;
             ignore = (
+                # Base — owner-internal, no public alternative
+                :structdiff,
                 # OrdinaryDiffEqCore owner-internal helpers (deliberately not in the
                 # solver-author public API surface declared upstream).
                 :_fixup_ad, :fsal_typeof, :trivial_limiter!,

--- a/lib/OrdinaryDiffEqFIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/qa/qa.jl
@@ -15,6 +15,8 @@ run_qa(
     ei_kwargs = (
         all_explicit_imports_are_public = (;
             ignore = (
+                # OrdinaryDiffEqCore — owner-internal, no public alternative
+                :PredictiveControllerCache,
                 # OrdinaryDiffEqCore — private codegen macro / default no-op limiter,
                 # kept owner-internal (no public alternative).
                 Symbol("@threaded"), :trivial_limiter!,

--- a/lib/OrdinaryDiffEqLowStorageRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/test/qa/qa.jl
@@ -12,6 +12,8 @@ run_qa(
         # `public`, so those ignores were dropped.
         all_qualified_accesses_are_public = (;
             ignore = (
+                # OrdinaryDiffEqCore — owner-internal, no public alternative
+                :lorenz_pref, :lorenz_pref_params,
                 # OrdinaryDiffEqCore precompile-workload probes (owner-internal)
                 :lorenz, :lorenz_oop, :lorenz_p, :lorenz_p_params,
                 # Base.Broadcast internals used in ArrayFuse copyto!/materialize!
@@ -20,6 +22,8 @@ run_qa(
         ),
         all_explicit_imports_are_public = (;
             ignore = (
+                # OrdinaryDiffEqCore — owner-internal, no public alternative
+                :lorenz_pref, :lorenz_pref_params,
                 # OrdinaryDiffEqCore default no-op limiter (owner-internal)
                 :trivial_limiter!,
             ),

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/qa/qa.jl
@@ -7,6 +7,9 @@ run_qa(
     aqua_kwargs = (; piracies = false),
     explicit_imports = true,
     ei_kwargs = (;
+        # Imported into this namespace for dependent sublibraries; ExplicitImports
+        # cannot see that cross-package use and reports them as stale.
+        no_stale_explicit_imports = (; ignore = (:MatrixOperator, :_reshape)),
         # Names imported from a re-exporter rather than their defining package.
         # `@SciMLMessage` is owned by SciMLLogging but reached through OrdinaryDiffEqCore
         # (SciMLLogging is not a direct dependency); `WOperator`/`StaticWOperator` are the
@@ -20,6 +23,12 @@ run_qa(
         # name `public`/exports it. Tracked in SciML/OrdinaryDiffEq.jl#3776.
         all_explicit_imports_are_public = (;
             ignore = (
+                # Base — owner-internal, no public alternative
+                :RefValue,
+                # NonlinearSolveBase — owner-internal, no public alternative
+                :not_terminated,
+                # OrdinaryDiffEqDifferentiation — owner-internal, no public alternative
+                :default_krylov_warm_start,
                 # `@SciMLMessage` reached through OrdinaryDiffEqCore (owner SciMLLogging).
                 Symbol("@SciMLMessage"),
                 # SciMLBase internals (owner of these names but not public).
@@ -42,6 +51,12 @@ run_qa(
         # Qualified `Module.name` accesses to non-public names with no public alternative.
         all_qualified_accesses_are_public = (;
             ignore = (
+                # Base — owner-internal, no public alternative
+                :RefValue,
+                # NonlinearSolveBase — owner-internal, no public alternative
+                :not_terminated,
+                # OrdinaryDiffEqDifferentiation — owner-internal, no public alternative
+                :default_krylov_warm_start,
                 # SciMLBase internals.
                 :value, :anyeltypedual, :forwarddiff_chunksize,
                 :has_Wfact, :has_Wfact_t, :has_jac_u, :has_jac_du, :postamble!,

--- a/lib/OrdinaryDiffEqRKN/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqRKN/test/qa/qa.jl
@@ -7,8 +7,14 @@ run_qa(
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;
+        all_qualified_accesses_are_public = (;
+            # Base — owner-internal, no public alternative
+            ignore = (:broadcastable,),
+        ),
         all_explicit_imports_are_public = (;
             ignore = (
+                # Base — owner-internal, no public alternative
+                :broadcastable,
                 # SciMLBase codegen macro, deliberately kept non-public by its owner.
                 Symbol("@def"),
                 # DiffEqBase perf macro, deliberately kept non-public by its owner.

--- a/lib/OrdinaryDiffEqSSPRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqSSPRK/test/qa/qa.jl
@@ -13,6 +13,8 @@ run_qa(
         # surface.
         all_explicit_imports_are_public = (;
             ignore = (
+                # OrdinaryDiffEqCore — owner-internal, no public alternative
+                :lorenz_pref, :lorenz_pref_params,
                 # SciMLBase private codegen macro (no public counterpart).
                 Symbol("@def"),
                 # OrdinaryDiffEqCore codegen/perf internals kept non-public on
@@ -24,7 +26,10 @@ run_qa(
         ),
         # OrdinaryDiffEqCore precompile-workload test problems (not public API).
         all_qualified_accesses_are_public = (;
-            ignore = (:lorenz, :lorenz_oop, :lorenz_p, :lorenz_p_params),
+            ignore = (
+                :lorenz, :lorenz_oop, :lorenz_p, :lorenz_p_params,
+                :lorenz_pref, :lorenz_pref_params,
+            ),
         ),
     ),
 )

--- a/lib/OrdinaryDiffEqTsit5/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqTsit5/test/qa/qa.jl
@@ -14,12 +14,16 @@ run_qa(
         # remains are owner-internal names with no public alternative.
         all_qualified_accesses_are_public = (;
             ignore = (
+                # OrdinaryDiffEqCore — owner-internal, no public alternative
+                :lorenz_pref, :lorenz_pref_params,
                 # OrdinaryDiffEqCore — precompile-workload test functions (internal)
                 :lorenz, :lorenz_oop, :lorenz_p, :lorenz_p_params,
             ),
         ),
         all_explicit_imports_are_public = (;
             ignore = (
+                # OrdinaryDiffEqCore — owner-internal, no public alternative
+                :lorenz_pref, :lorenz_pref_params,
                 # OrdinaryDiffEqCore — private codegen macros / limiter kept
                 # non-public in PHASE A (owner-internal, no public alternative)
                 Symbol("@fold"), Symbol("@OnDemandTableauExtract"),

--- a/lib/OrdinaryDiffEqVerner/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqVerner/test/qa/qa.jl
@@ -14,6 +14,8 @@ run_qa(
         # Qualified accesses to names that are not (yet) declared public by their owners.
         all_qualified_accesses_are_public = (;
             ignore = (
+                # OrdinaryDiffEqCore — owner-internal, no public alternative
+                :lorenz_pref, :lorenz_pref_params,
                 # SciMLBase internals (not public on registered SciMLBase 3.30.x)
                 :has_lazy_interpolation,
                 # OrdinaryDiffEqCore test-only helpers (deliberately kept non-public)
@@ -23,6 +25,8 @@ run_qa(
         # Explicit imports of names not (yet) declared public by their owners.
         all_explicit_imports_are_public = (;
             ignore = (
+                # OrdinaryDiffEqCore — owner-internal, no public alternative
+                :lorenz_pref, :lorenz_pref_params,
                 # OrdinaryDiffEqCore owner-internal names (private codegen macros +
                 # cache/interpolation internals deliberately not part of the public
                 # solver-author API declared in PHASE A)

--- a/lib/StochasticDiffEqImplicit/test/qa/qa.jl
+++ b/lib/StochasticDiffEqImplicit/test/qa/qa.jl
@@ -20,6 +20,8 @@ run_qa(
         all_explicit_imports_via_owners = (; ignore = (Symbol("@.."),)),
         all_explicit_imports_are_public = (;
             ignore = (
+                # OrdinaryDiffEqNonlinearSolve — owner-internal, no public alternative
+                :build_nlsolver, :markfirststage!, :nlsolve!, :nlsolvefail,
                 # `@..` (FastBroadcast macro re-exported via DiffEqBase) is not `public` there.
                 Symbol("@.."),
                 # StochasticDiffEqCore internal codegen macro (owner-internal).

--- a/lib/StochasticDiffEqLeaping/test/qa/qa.jl
+++ b/lib/StochasticDiffEqLeaping/test/qa/qa.jl
@@ -19,6 +19,8 @@ run_qa(
         all_qualified_accesses_via_owners = (; ignore = (:pois_rand,)),
         all_explicit_imports_are_public = (;
             ignore = (
+                # OrdinaryDiffEqNonlinearSolve — owner-internal, no public alternative
+                :build_nlsolver, :markfirststage!, :nlsolve!, :nlsolvefail,
                 # FastBroadcast fused-broadcast macro, re-exported via DiffEqBase.
                 Symbol("@.."),
                 # StochasticDiffEqCore internal cache-alloc macro (non-public).
@@ -27,6 +29,8 @@ run_qa(
         ),
         all_qualified_accesses_are_public = (;
             ignore = (
+                # OrdinaryDiffEqNonlinearSolve — owner-internal, no public alternative
+                :build_nlsolver, :markfirststage!, :nlsolve!, :nlsolvefail,
                 # OrdinaryDiffEqCore internal a-posteriori error-estimate predicate
                 # (non-public).
                 :isaposteriori,


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

Follow-up to #4018, which fixed the two systemic QA checks but left 27
sublibrary lanes red. This clears the largest remaining group.

## Inventory first

I ran `ODEDIFFEQ_TEST_GROUP=QA` on Julia 1.12 (the version the QA lanes use)
across all 49 sublibraries locally. Result: **21 pass / 27 fail**, matching CI
exactly. The 27 break down as:

| Category | Packages | This PR |
|---|---|---|
| ExplicitImports on owner-internal names | ~18 | **fixed** |
| `public API has docstrings` | 7 | not addressed |
| `Public API documentation` errors on 1.12 | 5 | not addressed |
| `No unapproved public reexports` | 3 | not addressed |
| Aqua (`Method ambiguity`, `Persistent tasks`, AllocCheck) | 3 | not addressed |

## What this fixes

The Developer Extension API page already states the policy:

> Cache types and low-level nonlinear solve helper functions are **not** public API.

So these names are *deliberately* non-public and want an allow-list, not a
`public` declaration. Most of the group is a single omission: OrdinaryDiffEqCore's
precompile workload grew `lorenz_pref`/`lorenz_pref_params`, but the ignore lists
that already carry `lorenz`/`lorenz_oop`/`lorenz_p`/`lorenz_p_params` were never
extended. The remainder:

- Base internals with no public equivalent — `structdiff`, `broadcastable`
- names kept in a namespace for dependent sublibraries, whose cross-package use
  ExplicitImports cannot see — `_unwrap_val`, `MatrixOperator`, `_reshape`
  (the same rationale OrdinaryDiffEqCore already documents for `_vec`,
  `_reshape`, `unwrap_cache`)

No check is disabled; the existing per-package `ignore` lists are extended,
matching the pattern already in these files.

## Verification

Every ExplicitImports error across the 27 is gone. **7 lanes now pass fully**:

```
OrdinaryDiffEqBDF            PASS      OrdinaryDiffEqSSPRK          PASS
OrdinaryDiffEqFIRK           PASS      OrdinaryDiffEqTsit5          PASS
OrdinaryDiffEqLowStorageRK   PASS      OrdinaryDiffEqVerner         PASS
OrdinaryDiffEqRKN            PASS
```

**Correction:** an earlier revision of this description claimed 9 green lanes and
listed StochasticDiffEqImplicit and StochasticDiffEqLeaping among them. That was
a misread of my own results — both still fail `public API has docstrings`, which
this PR does not address. Their ExplicitImports errors *are* fixed (1 → 0 each);
the lanes are not green. CI on this PR caught the discrepancy. The correct count
is **7**.

The three that still fail do so only on categories this PR does not target:

```
OrdinaryDiffEqCore            1 failed  — No unapproved public reexports
OrdinaryDiffEqExponentialRK   1 failed  — public API has docstrings
OrdinaryDiffEqNonlinearSolve  2 failed  — Method ambiguity (Aqua), reexports
```

Their ExplicitImports errors went 2 → 0, 1 → 0 and 1 → 0 respectively.

## Remaining work, for whoever picks it up

- **`public API has docstrings`** (ExponentialRK, LowOrderRK, and the SDE family):
  public names with no docstring. Real documentation work.
- **`Public API documentation` errors** (5 SDE packages): `_has_docstring` throws
  `Constant binding was imported from multiple modules` on Julia 1.12 — a
  `binding_module` interaction, likely wants an upstream SciMLTesting fix.
- **`No unapproved public reexports`** (Core, NonlinearSolve, StochasticDiffEqCore):
  StochasticDiffEqCore exports 22 DiffEqBase-owned names (`SDEIntegrator`,
  `SDEOptions`, `issplit`, …) that DiffEqBase never declared `public`. That is a
  genuine API-hygiene question — either `public` declarations in `lib/DiffEqBase`
  or removal from the export lists — and deliberately not papered over here.
- **Aqua**: `Method ambiguity` in NonlinearSolve, `Persistent tasks` in Default,
  and an AllocCheck failure in AdamsBashforthMoulton (`AB3` `perform_step!`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPHRh64BLfoXSzQ3AxKNwC
