### PR TITLE
Route CI jobs to runner pools that exist and can hold them

### DIFF
--- a/lib/DiffEqDevTools/test/test_groups.toml
+++ b/lib/DiffEqDevTools/test/test_groups.toml
@@ -1,5 +1,11 @@
 [Core]
 versions = ["lts", "1", "pre"]
+# Peaks at ~7.6 GiB RSS (the 1e5-trajectory ensemble WorkPrecisionSets in
+# analyticless_stochastic_wp.jl), which does not fit the 4 vCPU / 8 GB pool that
+# answers the default `ubuntu-latest`; the runner agent gets reclaimed mid-run
+# and the job reports "the self-hosted runner lost communication with the
+# server". Pin the 8 vCPU / 16 GB pool instead.
+runner = ["self-hosted", "Linux", "X64"]
 
 [QA]
 versions = ["lts", "1"]

--- a/lib/StochasticDiffEq/test/test_groups.toml
+++ b/lib/StochasticDiffEq/test/test_groups.toml
@@ -10,9 +10,14 @@ versions = ["lts", "1", "pre"]
 [AlgConvergence]
 versions = ["1"]
 
+# `["self-hosted", "Linux", "X64"]` is the largest pool the SciML fleet actually
+# answers (8 vCPU / 16 GB). No runner carries a `high-memory` label, so asking
+# for one parks the job in the queue until GitHub expires it at 24h -- and this
+# group is not local_only, so it is in nearly every Sublibrary CI matrix and
+# hangs the whole workflow run with it.
 [NoncommutativeConvergence]
 versions = ["1"]
-runner = ["self-hosted", "Linux", "X64", "high-memory"]
+runner = ["self-hosted", "Linux", "X64"]
 timeout = 240
 
 [AlgConvergence2]
@@ -33,13 +38,13 @@ local_only = true
 
 [OOPWeakConvergence]
 versions = ["1"]
-runner = ["self-hosted", "Linux", "X64", "high-memory"]
+runner = ["self-hosted", "Linux", "X64"]
 timeout = 300
 local_only = true
 
 [IIPWeakConvergence]
 versions = ["1"]
-runner = ["self-hosted", "Linux", "X64", "high-memory"]
+runner = ["self-hosted", "Linux", "X64"]
 timeout = 300
 local_only = true
 

--- a/lib/StochasticDiffEqROCK/test/test_groups.toml
+++ b/lib/StochasticDiffEqROCK/test/test_groups.toml
@@ -6,7 +6,7 @@ versions = ["lts", "1", "pre"]
 # compute_affected_sublibraries.jl.
 [SROCKC2WeakConvergence]
 versions = ["1"]
-runner = ["self-hosted", "Linux", "X64", "high-memory"]
+runner = ["self-hosted", "Linux", "X64"]
 timeout = 240
 local_only = true
 

--- a/lib/StochasticDiffEqWeak/test/test_groups.toml
+++ b/lib/StochasticDiffEqWeak/test/test_groups.toml
@@ -13,7 +13,7 @@ local_only = true
 
 [WeakConvergence2]
 versions = ["1"]
-runner = ["self-hosted", "Linux", "X64", "high-memory"]
+runner = ["self-hosted", "Linux", "X64"]
 timeout = 300
 local_only = true
 
@@ -23,7 +23,7 @@ local_only = true
 
 [WeakConvergence3]
 versions = ["1"]
-runner = ["self-hosted", "Linux", "X64", "high-memory"]
+runner = ["self-hosted", "Linux", "X64"]
 timeout = 300
 local_only = true
 
@@ -33,19 +33,19 @@ local_only = true
 
 [WeakConvergence4]
 versions = ["1"]
-runner = ["self-hosted", "Linux", "X64", "high-memory"]
+runner = ["self-hosted", "Linux", "X64"]
 timeout = 420
 local_only = true
 
 [WeakConvergence5]
 versions = ["1"]
-runner = ["self-hosted", "Linux", "X64", "high-memory"]
+runner = ["self-hosted", "Linux", "X64"]
 timeout = 300
 local_only = true
 
 [WeakConvergence6]
 versions = ["1"]
-runner = ["self-hosted", "Linux", "X64", "high-memory"]
+runner = ["self-hosted", "Linux", "X64"]
 timeout = 300
 local_only = true
 

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -34,4 +34,8 @@ versions = ["lts"]
 [GPU]
 versions = ["1"]
 runner = ["self-hosted", "Linux", "X64", "gpu"]
-timeout = 60
+# The `gpu` label is answered by both a V100 and a T4 pool, and the T4 is ~1.76x
+# slower on this suite (measured on identical warmup blocks). The V100 finishes
+# in ~48 min, so the T4 needs ~85 min: a 60 min cap cancelled every T4-scheduled
+# run and hid whatever the tests actually reported.
+timeout = 120


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

Infrastructure-only. No test or source code changes — only `test_groups.toml` runner/timeout selection. Three CI lanes have been failing for runner-capacity reasons, and the failures are not code regressions.

## Evidence

Surveyed the last 150 `Sublibrary CI` runs plus the recent `CI` / `Downgrade Sublibraries` runs via the Actions API, tabulating requested `runs-on` labels against the `runner_name` that actually picked the job up:

| requested labels | runner it lands on | count |
|---|---|---|
| `ubuntu-latest` | `self-hosted-4vcpu-8gb-dqgwf-*` | 1275 |
| `ubuntu-latest` | GitHub-hosted (4 vCPU / 16 GB) | 256 |
| `self-hosted,Linux,X64` | `self-hosted-8vcpu-16gb-hh54d-*` | 35 |
| `self-hosted,Linux,X64,gpu` | `…gpu-v100-8vcpu-16gb-*` | 68 |
| `self-hosted,Linux,X64,gpu` | `…gpu-t4-8vcpu-16gb-*` | 7 |
| **`self-hosted,Linux,X64,high-memory`** | **never assigned** | **31** |

### 1. `high-memory` is a label no runner carries

Every job requesting it queues until GitHub expires it — the scan shows 24 h (1440 min) queue times before cancellation. `lib/StochasticDiffEq [NoncommutativeConvergence]` is **not** `local_only`, so it is in nearly every affected-sublibrary matrix, and it hangs the whole `Sublibrary CI` run behind it. Because `SublibraryCI.yml` uses `cancel-in-progress: false` on master, each push then queues behind the hung run and the next push evicts it: **104 of the last 140 master `Sublibrary CI` runs are `cancelled`, only 9 `success`.** The master run created at `2026-07-27T07:29:25Z` had exactly one incomplete job at the time of writing — the `high-memory` one, queued 3.5 h.

Fix: point those groups at `["self-hosted", "Linux", "X64"]` — the 8 vCPU / 16 GB pool, the largest label set the fleet answers (35/35 clean assignments, never lands on the 8 GB or GPU pools). If a `high-memory` scale set is provisioned later, revert.

### 2. `lib/DiffEqDevTools [Core]` OOMs the 8 GB pool

Measured locally: 55:47 wall, **7.62 GiB peak RSS**. `ubuntu-latest` lands on a 4 vCPU / 8 GB self-hosted runner 83 % of the time. Perfect correlation over the last ~15 runs of `downgrade-sublibraries / test (lib/DiffEqDevTools)`:

- 12/12 runs on `self-hosted-4vcpu-8gb-*` → *"The self-hosted runner lost communication with the server"* (and no log is uploaded — the agent died).
- 4/4 runs on a GitHub-hosted runner (16 GB) → **pass**, 44–60 min.

Same story in `Sublibrary CI` on one run: `Julia lts` passed in 47 min while `Julia 1` and `Julia pre` died at 36 / 32 min — i.e. it is marginal at 8 GB and 1.12 uses slightly more than 1.10.

Fix: pin `[Core]` to the 16 GB pool. The peak is driven by the two `1e5`-trajectory ensemble `WorkPrecisionSet`s at the end of `analyticless_stochastic_wp.jl` (that testset alone: 1019 s, 249 GiB allocated). Deliberately **not** reducing `numtraj` — the test asserts `isapprox(err1, err2, atol = 1e-3)` on a Monte-Carlo weak error, so shrinking the sample would mean loosening that tolerance to hide the change.

### 3. The root `GPU` group's 60 min cap is below its runtime

The `gpu` label is answered by both a V100 and a T4 pool. Measuring identical warm-up blocks in both logs, the **T4 is 1.76× slower** (119.3 s vs 67.6 s; 40.9 s vs 23.3 s). The V100 finishes the whole job in 46–48 min, so the T4 needs ≈ 85 min — every T4-scheduled run was cancelled at exactly 60 min with *"The job has exceeded the maximum execution time of 1h0m0s"*.

Fix: `timeout = 120`.

Note for the record: on the V100 the GPU suite **does** complete and reports a genuine failure, so this is not purely infrastructure noise —

```
GPU: dae_tests.jl | 136 pass 1 fail 7 broken | 25m54.3s
Hairer4 [jac=CSC, mass=diag_cu]: Test Failed at test/gpu/dae_tests.jl:467
  Expression: r.status === :pass
   Evaluated: gpu_mismatch === pass
```

That numerics bug is out of scope here; raising the timeout just makes it reportable instead of being masked by cancellations.

## Still broken after this PR — needs a change in `SciML/.github`

`downgrade-sublibraries / test (lib/DiffEqDevTools)` is **not** fixed by this PR. `sublibrary-downgrade.yml` does not read `test_groups.toml`; it hardcodes the runner at [`.github/workflows/sublibrary-downgrade.yml:98`](https://github.com/SciML/.github/blob/v1/.github/workflows/sublibrary-downgrade.yml#L98):

```yaml
runs-on: ${{ (inputs.apt-packages != '' || inputs.container != '') && fromJSON('["ubuntu-24.04"]') || 'ubuntu-latest' }}
```

so every sublibrary's downgrade job goes to the 8 GB pool and `lib/DiffEqDevTools` keeps killing its runner. The minimal change there would be a `runner` input (JSON-encoded label list, defaulting to `'"ubuntu-latest"'`) threaded into `runs-on`, plus an optional per-project override map so this repo could send only `lib/DiffEqDevTools` to the 16 GB pool. Not touching that repo without sign-off since it is shared across all of SciML.

## Verification

Ran the shared matrix generator against this branch:

```
$ julia compute_affected_sublibraries.jl . --root-matrix     # GPU cell -> "timeout":120
$ git ls-files 'lib/*' | julia compute_affected_sublibraries.jl . --projects-matrix
total cells: 283
high-memory cells: 0
```

`lib/DiffEqDevTools [Core]` now emits `runner: ["self-hosted","Linux","X64"], timeout: 120` on all three Julia versions.
