### PR TITLE
Resolve the unapproved-public-reexport QA failures per name

### DIFF
--- a/docs/src/devtools/internals/public_api.md
+++ b/docs/src/devtools/internals/public_api.md
@@ -10,8 +10,9 @@ documented under the API section.
     Do not build application code against these hooks. They exist so solver
     packages can extend common traits, controllers, interpolation hooks, and
     initialization protocols without depending on undocumented implementation
-    details. Cache types and low-level nonlinear solve helper functions are not
-    public API.
+    details. Concrete per-algorithm cache types and low-level nonlinear solve
+    helper functions are not public API; only the abstract cache supertypes a
+    solver package subtypes are.
 
 ## DiffEqBase solver hooks
 
@@ -238,10 +239,16 @@ The cache hierarchy and `@cache` macro are developer API for solver packages
 that implement new algorithms. They define internal solver storage, not
 application-facing cache objects.
 
+The `StochasticDiffEq*Cache` trio is the SDE/RODE analogue, subtyped by the
+StochasticDiffEq.jl solver sublibraries.
+
 ```@docs
 OrdinaryDiffEqCore.OrdinaryDiffEqCache
 OrdinaryDiffEqCore.OrdinaryDiffEqConstantCache
 OrdinaryDiffEqCore.OrdinaryDiffEqMutableCache
+OrdinaryDiffEqCore.StochasticDiffEqCache
+OrdinaryDiffEqCore.StochasticDiffEqConstantCache
+OrdinaryDiffEqCore.StochasticDiffEqMutableCache
 OrdinaryDiffEqCore.@cache
 OrdinaryDiffEqCore.alg_cache
 OrdinaryDiffEqCore.get_fsalfirstlast

--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.10.1"
+version = "4.11.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
+++ b/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
@@ -482,6 +482,11 @@ include("precompilation_setup.jl")
             :is_noise_saveable,
             # Docstring builder used by solver sublibs.
             :differentiation_rk_docstring,
+            # SDE/RODE abstract cache hierarchy. The SDE analogue of the already-public
+            # OrdinaryDiffEqCache trio: every StochasticDiffEq solver cache subtypes one
+            # of these, so they are a required solver-author extension point.
+            :StochasticDiffEqCache, :StochasticDiffEqConstantCache,
+            :StochasticDiffEqMutableCache,
         )
     )
 end

--- a/lib/OrdinaryDiffEqCore/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqCore/test/qa/qa.jl
@@ -10,7 +10,15 @@ end
 
 run_qa(
     OrdinaryDiffEqCore;
-    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
+    reexports_allow = union(
+        public_api_names(SciMLBase), (:SciMLBase,),
+        # `last_step_failed`/`postamble!` are SciMLBase-owned generic functions that
+        # OrdinaryDiffEqCore imports, extends, and re-declares `public` as part of the
+        # documented solver-author surface (docs/src/devtools/internals/public_api.md).
+        # SciMLBase has not declared them `public` yet, so `public_reexports` sees them
+        # as owned outside this package; drop these once SciMLBase marks them public.
+        (:last_step_failed, :postamble!),
+    ),
     aqua_kwargs = (; piracies = false, unbound_args = false),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/qa/qa.jl
@@ -7,6 +7,11 @@ run_qa(
     OrdinaryDiffEqNonlinearSolve;
     # No docs/ tree here; the umbrella manual renders this package's API.
     api_docs_kwargs = (; rendered = false),
+    # `BrownFullBasicInit`/`ShampineCollocationInit` are the user-facing DAE
+    # initialization algorithms. DiffEqBase owns, exports, and documents them; this
+    # package implements their solver-side methods and re-exports the names so
+    # `using OrdinaryDiffEq` keeps surfacing them unqualified.
+    reexports_allow = (:BrownFullBasicInit, :ShampineCollocationInit),
     aqua_kwargs = (; piracies = false, ambiguities = false),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/StochasticDiffEqCore/test/qa/qa.jl
+++ b/lib/StochasticDiffEqCore/test/qa/qa.jl
@@ -73,11 +73,39 @@ const ODEC_STOCHASTIC_SURFACE = (
     OrdinaryDiffEqCore.save_noise!,
 )
 
+# Solver-author API owned and declared `public` by OrdinaryDiffEqCore (all documented in
+# docs/src/devtools/internals/public_api.md) that StochasticDiffEqCore re-exports so the
+# StochasticDiffEq solver sublibraries get the SDE extension surface from one package.
+const ODEC_PUBLIC_REEXPORTS = (
+    :StochasticDiffEqAlgorithm, :StochasticDiffEqAdaptiveAlgorithm,
+    :StochasticDiffEqCompositeAlgorithm,
+    :StochasticDiffEqRODEAlgorithm, :StochasticDiffEqRODEAdaptiveAlgorithm,
+    :StochasticDiffEqRODECompositeAlgorithm,
+    :StochasticDiffEqNewtonAlgorithm, :StochasticDiffEqNewtonAdaptiveAlgorithm,
+    :StochasticDiffEqJumpAlgorithm, :StochasticDiffEqJumpAdaptiveAlgorithm,
+    :StochasticDiffEqJumpNewtonAdaptiveAlgorithm,
+    :StochasticDiffEqJumpDiffusionAlgorithm, :StochasticDiffEqJumpDiffusionAdaptiveAlgorithm,
+    :StochasticDiffEqJumpNewtonDiffusionAdaptiveAlgorithm,
+    :StochasticDiffEqCache, :StochasticDiffEqConstantCache, :StochasticDiffEqMutableCache,
+    :issplit,
+)
+
+# `SDEIntegrator` and `SDEOptions` are StochasticDiffEqCore's own public API, but they are
+# `const` aliases of OrdinaryDiffEqCore types (`ODEIntegrator{<:SDEAlgTypes}` and
+# `DEOptions`), and `public_reexports` attributes an alias to the aliased type's module.
+const SDEC_TYPE_ALIASES = (:SDEIntegrator, :SDEOptions)
+
 run_qa(
     StochasticDiffEqCore;
     # No docs/ tree here; the umbrella manual renders this package's API.
     api_docs_kwargs = (; rendered = false),
-    reexports_allow = union(public_api_names(DiffEqBase), (:DiffEqBase,)),
+    # `@reexport using DiffEqBase` pulls in DiffEqBase's own API plus its SciMLBase
+    # re-export. `names(DiffEqBase)` only propagates SciMLBase's *exports*, so SciMLBase's
+    # `public`-but-unexported API (`alg_order`, `isadaptive`) needs its own union entry.
+    reexports_allow = union(
+        public_api_names(DiffEqBase), public_api_names(SciMLBase),
+        (:DiffEqBase,), ODEC_PUBLIC_REEXPORTS, SDEC_TYPE_ALIASES,
+    ),
     aqua_kwargs = (; piracies = (; treat_as_own = ODEC_STOCHASTIC_SURFACE)),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

`SciMLTesting.public_reexports` flags any name in `public_api_names(pkg)` whose owner module lives outside the package's own module hierarchy. Three sublibrary QA lanes fail the resulting `No unapproved public reexports` assertion. Every flagged name is dispositioned individually below; nothing is blanket-allowed.

## Per-name dispositions

### `OrdinaryDiffEqCore` (2 flagged)

| Name | Owner | Disposition | Why |
| --- | --- | --- | --- |
| `last_step_failed` | SciMLBase (not public there) | allow-list, pending upstream make-public | Generic function OrdinaryDiffEqCore imports, extends, and re-declares `public` as part of its documented solver-author surface (`docs/src/devtools/internals/public_api.md`). Downstream sublibraries import it from OrdinaryDiffEqCore. The correct end state is SciMLBase declaring it `public`; the entry drops then. |
| `postamble!` | SciMLBase (not public there) | allow-list, pending upstream make-public | Same as above — every integrator sublibrary defines a `postamble!` method, and the name is in the rendered developer-API page. |

### `OrdinaryDiffEqNonlinearSolve` (2 flagged)

| Name | Owner | Disposition | Why |
| --- | --- | --- | --- |
| `BrownFullBasicInit` | DiffEqBase (**public + documented** there) | allow-list as deliberate reexport | User-facing DAE initialization algorithm. DiffEqBase owns/exports/documents it; this package implements its solver-side methods and re-exports the name so `using OrdinaryDiffEq` keeps surfacing it unqualified. Legitimate facade reexport of already-public API. |
| `ShampineCollocationInit` | DiffEqBase (**public + documented** there) | allow-list as deliberate reexport | Same. |

This lane had no `reexports_allow` at all (it was missed by #4018, which only touched lanes that `@reexport` a whole module).

### `StochasticDiffEqCore` (22 flagged)

The task description guessed these were DiffEqBase-owned; they are not. 20 of 22 are owned by `OrdinaryDiffEqCore`, 2 by `SciMLBase`.

**Make public + document (3)** — `OrdinaryDiffEqCore`:

| Name | Owner | Disposition | Why |
| --- | --- | --- | --- |
| `StochasticDiffEqCache` | OrdinaryDiffEqCore | **make public + document** | Abstract SDE/RODE cache supertype. Exact analogue of `OrdinaryDiffEqCache`, which is already `public` and rendered in the Developer Extension API page. |
| `StochasticDiffEqConstantCache` | OrdinaryDiffEqCore | **make public + document** | Same; 76 concrete caches across `lib/StochasticDiffEq*` subtype this trio, so it is a required extension point. |
| `StochasticDiffEqMutableCache` | OrdinaryDiffEqCore | **make public + document** | Same. |

All three already carried docstrings (which even cross-reference `` [`OrdinaryDiffEqCache`](@ref) ``); they are now rendered in the same `@docs` block as the ODE cache hierarchy, so public and documented move together.

*Re: the policy line "Cache types and low-level nonlinear solve helper functions are not public API"* — that same page already documents the abstract `OrdinaryDiffEqCache`/`ConstantCache`/`MutableCache` trio, with prose explaining they "define internal solver storage, not application-facing cache objects." The warning was about **concrete per-algorithm caches**, and is reworded to say so. If you disagree and want the abstract SDE trio kept internal, the alternative is an allow-list entry instead — say the word and I will flip those three.

**Allow-list as reexports of API public at its owner (17):**

| Name | Owner | Disposition | Why |
| --- | --- | --- | --- |
| `StochasticDiffEqAlgorithm` | OrdinaryDiffEqCore (public + documented) | allow-list | The 14 SDE/RODE/Jump algorithm supertypes are all `public` in OrdinaryDiffEqCore and rendered under "SDE / RODE algorithm hierarchy". StochasticDiffEqCore re-exports them so solver sublibraries get the whole SDE extension surface from one package. |
| `StochasticDiffEqAdaptiveAlgorithm` | " | allow-list | " |
| `StochasticDiffEqCompositeAlgorithm` | " | allow-list | " |
| `StochasticDiffEqRODEAlgorithm` | " | allow-list | " |
| `StochasticDiffEqRODEAdaptiveAlgorithm` | " | allow-list | " |
| `StochasticDiffEqRODECompositeAlgorithm` | " | allow-list | " |
| `StochasticDiffEqNewtonAlgorithm` | " | allow-list | " |
| `StochasticDiffEqNewtonAdaptiveAlgorithm` | " | allow-list | " |
| `StochasticDiffEqJumpAlgorithm` | " | allow-list | " |
| `StochasticDiffEqJumpAdaptiveAlgorithm` | " | allow-list | " |
| `StochasticDiffEqJumpNewtonAdaptiveAlgorithm` | " | allow-list | " |
| `StochasticDiffEqJumpDiffusionAlgorithm` | " | allow-list | " |
| `StochasticDiffEqJumpDiffusionAdaptiveAlgorithm` | " | allow-list | " |
| `StochasticDiffEqJumpNewtonDiffusionAdaptiveAlgorithm` | " | allow-list | " |
| `issplit` | OrdinaryDiffEqCore (public + documented) | allow-list | Algorithm trait, `public` in OrdinaryDiffEqCore and rendered under "Algorithm trait functions". |
| `alg_order` | SciMLBase (`public`, not exported) | allow-list | Reached through `@reexport using DiffEqBase` → `@reexport using SciMLBase`. `names(DiffEqBase)` only forwards SciMLBase's *exports*, so SciMLBase's `public`-but-unexported API needs its own `union` entry. |
| `isadaptive` | SciMLBase (`public`, not exported) | allow-list | Same. |

**Allow-list as local aliases the audit cannot attribute (2):**

| Name | Owner | Disposition | Why |
| --- | --- | --- | --- |
| `SDEIntegrator` | attributed to OrdinaryDiffEqCore | allow-list | `const SDEIntegrator = ODEIntegrator{<:SDEAlgTypes}` — StochasticDiffEqCore's own public name (users and sublibraries dispatch `f(::SDEIntegrator)`). `public_reexports` documents that it attributes a `const` alias to the aliased type's defining module. |
| `SDEOptions` | attributed to OrdinaryDiffEqCore | allow-list | `const SDEOptions = OrdinaryDiffEqCore.DEOptions` — legacy compatibility name from standalone StochasticDiffEq.jl; `DEOptions` is itself `public` in OrdinaryDiffEqCore. |

## Nothing here needs a maintainer decision to *land*

The only judgment call I would flag for you is the cache trio (make-public vs. allow-list), argued above. Everything else follows mechanically from "is the name public at its owner."

Two items are worth tracking but are out of this repo's reach:

- `last_step_failed` / `postamble!` want a SciMLBase make-public (SciMLBase#1412 rounds). Until then the allow-list entry is the honest description of the situation, and it is scoped to exactly two names.

## Verification (Julia 1.12.6, `ODEDIFFEQ_TEST_GROUP=QA`)

Before:

```
OrdinaryDiffEqCore          No unapproved public reexports | 1 Fail   [:last_step_failed, :postamble!]
OrdinaryDiffEqNonlinearSolve No unapproved public reexports | 1 Fail   [:BrownFullBasicInit, :ShampineCollocationInit]
StochasticDiffEqCore        No unapproved public reexports | 1 Fail   22 names
```

After:

```
OrdinaryDiffEqCore           Aqua | 19 Pass  19 Total   ->  Testing OrdinaryDiffEqCore tests passed
OrdinaryDiffEqNonlinearSolve   No unapproved public reexports | 1 Pass
StochasticDiffEqCore           No unapproved public reexports | 1 Pass
```

`OrdinaryDiffEqCore`'s QA lane is now **fully green**. The other two lanes still fail on pre-existing, unrelated checks that reproduce on `upstream/master` and are out of scope here:

- `OrdinaryDiffEqNonlinearSolve`: Aqua `Method ambiguity`.
- `StochasticDiffEqCore`: `all_qualified_accesses_are_public` (`is_composite_cache`, `is_constant_cache`), `all_explicit_imports_are_public` (`CompositeCache`), and `public API has docstrings`.

Side benefit: making the cache trio public removed 3 of the 6 `all_explicit_imports_are_public` reports in the StochasticDiffEqCore lane (`StochasticDiffEqCache`, `StochasticDiffEqConstantCache`, `StochasticDiffEqMutableCache` no longer appear).

`OrdinaryDiffEqCore` is bumped `4.10.1` → `4.11.0` for the added public API. Runic clean. `test/qa/Project.toml` mutations from `Pkg.test()` were reverted; the diff is only intentional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPHRh64BLfoXSzQ3AxKNwC
