### PR TITLE
Resolve the OrdinaryDiffEqNonlinearSolve method ambiguities

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.5.3"
+version = "2.5.4"
 
 [deps]
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/initialize_dae.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/initialize_dae.jl
@@ -111,6 +111,22 @@ function default_nlsolve(
     )
     return _homotopy_init_alg(u, autodiff, chunksize)
 end
+# A stateless `initializeprob` (`state_values(...) === nothing`) needs no solver at all;
+# OrdinaryDiffEqCore answers `nothing` for every `AbstractNonlinearProblem` with `u::Nothing`.
+# That method is more specific in `u` while the ones above are more specific in the problem
+# type, so the pair is ambiguous unless the intersection is spelled out here.
+function default_nlsolve(
+        ::Nothing, ::Val{true}, u::Nothing, ::SciMLBase.HomotopyProblem,
+        autodiff = false, chunksize = Val(1)
+    )
+    return nothing
+end
+function default_nlsolve(
+        ::Nothing, ::Val{false}, u::Nothing, ::SciMLBase.HomotopyProblem,
+        autodiff = false, chunksize = Val(1)
+    )
+    return nothing
+end
 
 # An `SCCNonlinearProblem` that contains `HomotopyProblem` blocks must be solved with
 # `nothing` so each block picks its own default: its `HomotopyProblem` blocks continue (via
@@ -156,6 +172,20 @@ function default_nlsolve(
     return SimpleTrustRegion(
         autodiff = autodiff ? _tagged_autodiff(u, chunksize) : AutoFiniteDiff()
     )
+end
+# Disambiguates against OrdinaryDiffEqCore's `u::Nothing` methods, as for `HomotopyProblem`
+# above.
+function default_nlsolve(
+        ::Nothing, isinplace::Val{true}, u::Nothing, ::SciMLBase.SCCNonlinearProblem,
+        autodiff = false, chunksize = Val(1)
+    )
+    return nothing
+end
+function default_nlsolve(
+        ::Nothing, isinplace::Val{false}, u::Nothing, ::SciMLBase.SCCNonlinearProblem,
+        autodiff = false, chunksize = Val(1)
+    )
+    return nothing
 end
 
 ## ShampineCollocationInit

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/homotopy_default_nlsolve_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/homotopy_default_nlsolve_tests.jl
@@ -53,3 +53,15 @@ end
     @test default_nlsolve(nothing, Val(false), u, scc_plain) !== nothing
     @test default_nlsolve(nothing, Val(true), u, scc_plain) !== nothing
 end
+
+@testset "stateless init problem selects no solver" begin
+    # `u === nothing` (an `initializeprob` with `state_values(...) === nothing`): the
+    # OrdinaryDiffEqCore method covering it is more specific in `u` while these are more
+    # specific in the problem type, so without an explicit intersection method the call is
+    # an ambiguity error rather than the `nothing` Core answers everywhere else.
+    scc = SCCNonlinearProblem((np, hp), (Returns(nothing), Returns(nothing)), nothing, Val(true))
+    for iip in (Val(true), Val(false))
+        @test default_nlsolve(nothing, iip, nothing, hp) === nothing
+        @test default_nlsolve(nothing, iip, nothing, scc) === nothing
+    end
+end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/qa/qa.jl
@@ -1,10 +1,13 @@
 using SciMLTesting, OrdinaryDiffEqNonlinearSolve, Test
+using Aqua
 
+# Ambiguities are checked below over this package's own methods instead of Aqua's default
+# `[pkg, Base, Core]` module set; see the `Aqua.test_ambiguities` call.
 run_qa(
     OrdinaryDiffEqNonlinearSolve;
     # No docs/ tree here; the umbrella manual renders this package's API.
     api_docs_kwargs = (; rendered = false),
-    aqua_kwargs = (; piracies = false),
+    aqua_kwargs = (; piracies = false, ambiguities = false),
     explicit_imports = true,
     ei_kwargs = (;
         # Imported into this namespace for dependent sublibraries; ExplicitImports
@@ -66,3 +69,14 @@ run_qa(
         ),
     ),
 )
+
+# `Aqua.test_all` scans `[pkg, Base, Core]`, which reports every ambiguity between a Base
+# method and any loaded package — for this dependency tree, ForwardDiff's `Dual`
+# constructors, `convert`, `==`, `^` and `log` against Base, none of which involve a method
+# defined here or can be resolved from here. `detect_ambiguities` keeps only pairs with a
+# method defined in the listed modules, so scanning this package alone still catches every
+# ambiguity this package is responsible for — including ones against Base or a dependency —
+# while dropping the ForwardDiff/Base noise.
+@testset "Method ambiguity (own methods)" begin
+    Aqua.test_ambiguities(OrdinaryDiffEqNonlinearSolve)
+end


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

`ODEDIFFEQ_TEST_GROUP=QA` on `lib/OrdinaryDiffEqNonlinearSolve` fails Aqua's
`Method ambiguity` check with 32 ambiguous pairs. They split cleanly into two groups.

## 1. Twelve genuine ambiguities in this package (fixed in source)

`OrdinaryDiffEqCore` defines the stateless-init-problem fallbacks

```julia
default_nlsolve(::Nothing, ::Val{true},  u::Nothing, ::AbstractNonlinearProblem, autodiff = false, chunksize = Val(0)) = nothing
default_nlsolve(::Nothing, ::Val{false}, u::Nothing, ::AbstractNonlinearProblem, autodiff = false, chunksize = Val(0)) = nothing
```

while this package adds problem-type-specific methods for `SciMLBase.HomotopyProblem` and
`SciMLBase.SCCNonlinearProblem` (both `<: AbstractNonlinearProblem`) that leave `u`
untyped. Core's are more specific in `u`, this package's are more specific in the problem,
so every `(Nothing, Val{iip}, Nothing, HomotopyProblem/SCCNonlinearProblem)` call is an
ambiguity error. Two problem types x two `iip` values x three arities (the two trailing
arguments are defaulted) = the 12 reported pairs:

| # | OrdinaryDiffEqCore method | OrdinaryDiffEqNonlinearSolve method | disposition |
|---|---|---|---|
| 1-3 | `(::Nothing, ::Val{true}, ::Nothing, ::AbstractNonlinearProblem)`, 3 arities | `(::Nothing, ::Val{true}, u, ::HomotopyProblem)` | (a) fixed in source |
| 4-6 | `(::Nothing, ::Val{false}, ::Nothing, ::AbstractNonlinearProblem)`, 3 arities | `(::Nothing, ::Val{false}, u, ::HomotopyProblem)` | (a) fixed in source |
| 7-9 | `(::Nothing, ::Val{true}, ::Nothing, ::AbstractNonlinearProblem)`, 3 arities | `(::Nothing, ::Val{true}, u, ::SCCNonlinearProblem)` | (a) fixed in source |
| 10-12 | `(::Nothing, ::Val{false}, ::Nothing, ::AbstractNonlinearProblem)`, 3 arities | `(::Nothing, ::Val{false}, u, ::SCCNonlinearProblem)` | (a) fixed in source |

Fix: four disambiguating methods pinning the intersection (`u::Nothing` plus the specific
problem type), returning `nothing` — the same answer `OrdinaryDiffEqCore` already gives for
a stateless `initializeprob` everywhere else, which `OverrideInit` then forwards to
`SciMLBase.get_initial_values` as `nlsolve_alg = nothing`. Before the fix that call path
was a `MethodError`, so there is no behavior to preserve, only a hole to fill consistently.
A regression test is added to `test/homotopy_default_nlsolve_tests.jl`.

## 2. Twenty ForwardDiff-vs-Base ambiguities (not this package's; check narrowed)

The remaining 20 are all between ForwardDiff and Base/Core:

* `ForwardDiff.Dual` constructors vs `(::Type{T})(::TwicePrecision)`, `(::Type{T})(::AbstractChar)`, `(::Type{T})(::Complex)`, `(::Type{T})(x::T)` — 13 pairs
* `convert(::Type{Dual{T,V,N}}, x)` vs Base `convert(::Type{T}, ::AbstractChar)` / `(::CartesianIndex{1})` / `(::TwicePrecision)` — 3 pairs
* `==(::Dual, ::Real)` and `==(::Real, ::Dual)` vs Base `==(::Real, ::AbstractIrrational)` / `(::AbstractIrrational, ::Real)` — 2 pairs
* `^(::Irrational, ::Dual)` and `log(::Irrational, ::Dual)` vs `Base.MathConstants` — 2 pairs

Disposition (b)/(c): no method in either half of any of those pairs is defined in this
package, and none can be resolved from here — they are reported only because
`Aqua.test_all` scans `[pkg, Base, Core]` and ForwardDiff is in the dependency tree.

Rather than `ambiguities = false` (which would drop the check entirely), the QA lane now
runs `Aqua.test_ambiguities(OrdinaryDiffEqNonlinearSolve)`, scanning this package's own
modules. `Test.detect_ambiguities` filters candidate methods by defining module
(`is_in_mods(parentmodule(m), ...)`), so a package-scoped scan still reports **every**
ambiguity in which a method defined in this package participates, including ones against
Base or a dependency; it only drops pairs where neither method is ours. Coverage of this
package's own responsibility is unchanged.

## Verification (local, Julia 1.12.6)

Before, running exactly what `Aqua.test_all` runs, on unmodified `upstream/master`:

```
$ julia --project=lib/OrdinaryDiffEqNonlinearSolve/test/qa -e '
    using Aqua, OrdinaryDiffEqNonlinearSolve, Test
    Aqua.test_ambiguities([OrdinaryDiffEqNonlinearSolve, Base, Core])'
32 ambiguities found
...
Ambiguity #31
default_nlsolve(::Nothing, isinplace::Val{true}, u::Nothing, ::SciMLBase.AbstractNonlinearProblem) @ OrdinaryDiffEqCore .../lib/OrdinaryDiffEqCore/src/initialize_dae.jl:78
default_nlsolve(::Nothing, isinplace::Val{true}, u, prob::SciMLBase.SCCNonlinearProblem) @ OrdinaryDiffEqNonlinearSolve .../lib/OrdinaryDiffEqNonlinearSolve/src/initialize_dae.jl:133

Possible fix, define
  default_nlsolve(::Nothing, ::Val{true}, ::Nothing, ::SciMLBase.SCCNonlinearProblem)
...
Test Failed at ~/.julia/packages/Aqua/h1qD0/src/ambiguities.jl:80
  Expression: iszero(num_ambiguities)
```

After:

```
Test Summary:                                  | Pass  Fail  Total   Time
after fix                                      |    1     1      2  20.0s
  package-scoped (what qa.jl now runs)         |    1            1   7.7s
  pkg+Base+Core (Aqua default, for the record) |          1      1  12.4s
```

The package-scoped check (what the QA lane runs) passes with zero ambiguities. All 20 that
remain under Aqua's default module set mention `ForwardDiff`; none mentions
`OrdinaryDiffEq*`.

Runic clean. `test/qa/Project.toml` mutations from `Pkg.test()` were reverted; the diff is
only intentional changes.

Note: the `No unapproved public reexports` failure in this same lane is a separate issue and
is deliberately untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPHRh64BLfoXSzQ3AxKNwC
