### PR TITLE
Write the missing docstrings for the SDE/exponential-RK public API

### DIFF
--- a/lib/OrdinaryDiffEqExponentialRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/algorithms.jl
@@ -78,6 +78,35 @@ for (Alg, Description, Ref) in [
     end
 end
 
+"""
+    ETD1(; krylov = false, m = 30, iop = 0, autodiff = AutoForwardDiff(),
+           concrete_jac = nothing, step_limiter = trivial_limiter!)
+
+**ETD1: First Order Exponential Time Differencing (Semilinear ODE Solver)**
+
+Alias for [`NorsettEuler`](@ref): `ETD1 === NorsettEuler`. `ETD1` is the name this
+method carries in the exponential time differencing literature, `NorsettEuler` the
+name from the exponential-Runge-Kutta literature.
+
+The linear part of a semilinear problem `u' = Au + f(u,t)` is integrated exactly with
+the matrix exponential, and the nonlinear part with a first order quadrature.
+
+## Method Properties
+
+  - **Order**: 1
+  - **Time stepping**: Fixed
+  - **Problem type**: Semilinear ODEs (`SplitODEProblem`, or a supplied Jacobian)
+
+## Keyword Arguments
+
+Identical to [`NorsettEuler`](@ref); `krylov`, `m`, and `iop` control whether and how
+the matrix exponential actions are approximated in a Krylov subspace.
+
+## References
+
+  - Hochbruck, Marlis, and Alexander Ostermann. "Exponential Integrators." Acta
+    Numerica 19 (2010): 209–286. doi:10.1017/S0962492910000048.
+"""
 const ETD1 = NorsettEuler # alias
 
 REF2 = """
@@ -147,14 +176,20 @@ Tokman, M., Loffeld, J., & Tranquilli, P. (2012). New Adaptive Exponential Propa
 """
 
 for (Alg, Description, Ref) in [
-        (:Exp4, "4th order EPIRK scheme.", REF3)
+        (
+            :Exp4,
+            "4th order EPIRK scheme. Integrates the linear part of the semilinear problem `u' = Au + f(u,t)` exactly via the matrix exponential.",
+            REF3,
+        )
         (
             :EPIRK4s3A,
-            "4th order EPIRK scheme with stiff order 4.", REF4,
+            "4th order EPIRK scheme with stiff order 4, i.e. its order is retained uniformly in the stiffness of the linear part.",
+            REF4,
         )
         (
             :EPIRK4s3B,
-            "4th order EPIRK scheme with stiff order 4.", REF4,
+            "4th order EPIRK scheme with stiff order 4. A companion of `EPIRK4s3A` from the same family, differing in the choice of free coefficients.",
+            REF4,
         )
         (
             :EPIRK5s3,
@@ -163,11 +198,22 @@ for (Alg, Description, Ref) in [
         )
         (
             :EXPRB53s3,
-            "5th order EPIRK scheme with stiff order 5.", REF4,
+            "5th order EPIRK scheme with stiff order 5, built in the exponential Rosenbrock (EXPRB) form with three stages.",
+            REF4,
         )
-        (:EPIRK5P1, "5th order EPIRK scheme", REF5)
-        (:EPIRK5P2, "5th order EPIRK scheme", REF5)
+        (
+            :EPIRK5P1,
+            "5th order EPIRK scheme from the adaptive-Krylov EPIRK family of Tokman, Loffeld and Tranquilli.",
+            REF5,
+        )
+        (
+            :EPIRK5P2,
+            "5th order EPIRK scheme, a companion of `EPIRK5P1` from the same family using a different set of coefficients.",
+            REF5,
+        )
     ]
+    # NOTE: `@doc <expr>` must be immediately followed by the documented expression;
+    # a blank line in between silently detaches the docstring.
     @eval begin
         @doc generic_solver_docstring(
             $Description,
@@ -177,8 +223,8 @@ for (Alg, Description, Ref) in [
             """
             - `adaptive_krylov`: Determines if the adaptive Krylov algorithm with timestepping of Neisen & Wright is used.
             - `m`: Controls the size of Krylov subspace.
-                    - `iop`: If not zero, determines the length of the incomplete orthogonalization procedure (IOP).
-                        Note that if the linear operator/Jacobian is hermitian, then the Lanczos algorithm will always be used and the IOP setting is ignored.
+            - `iop`: If not zero, determines the length of the incomplete orthogonalization procedure (IOP).
+                Note that if the linear operator/Jacobian is hermitian, then the Lanczos algorithm will always be used and the IOP setting is ignored.
             """,
             """
             adaptive_krylov = true,
@@ -186,7 +232,6 @@ for (Alg, Description, Ref) in [
             iop = 0,
             """
         )
-
         struct $Alg{StepLimiter, AD, CJ} <:
             OrdinaryDiffEqExponentialAlgorithm
             step_limiter!::StepLimiter

--- a/lib/StochasticDiffEq/docs/src/stiff/implicit_methods.md
+++ b/lib/StochasticDiffEq/docs/src/stiff/implicit_methods.md
@@ -44,6 +44,23 @@ ISSEM
 ISSEulerHeun
 ```
 
+## Theta-Method Variants
+
+`STrapezoid` and `SImplicitMidpoint` are convenience constructors for particular
+members of the `ImplicitEM` family.
+
+### STrapezoid - Stochastic Trapezoidal Rule
+
+```@docs
+STrapezoid
+```
+
+### SImplicitMidpoint - Stochastic Implicit Midpoint Rule
+
+```@docs
+SImplicitMidpoint
+```
+
 ## Method Selection Guide
 
 ### Problem Classification:

--- a/lib/StochasticDiffEqCore/src/alg_utils.jl
+++ b/lib/StochasticDiffEqCore/src/alg_utils.jl
@@ -121,6 +121,19 @@ function qmin_default(alg::Union{StochasticDiffEqAlgorithm, StochasticDiffEqRODE
     return isadaptive(alg) ? 1 // 5 : 0
 end
 
+"""
+    delta_default(alg) -> Real
+
+Default value of the `delta` option for `alg`.
+
+`delta` is the SDE-specific mixing parameter of the adaptive error estimate: it
+weighs the drift (deterministic) error contribution against the diffusion
+(stochastic) one when the two are combined into a single `EEst`. A value of `1`
+uses the drift estimate at full strength.
+
+Solver subpackages override this for algorithms whose published adaptivity scheme
+prescribes a different weighting.
+"""
 delta_default(alg) = 1 // 1
 
 function OrdinaryDiffEqCore.gamma_default(
@@ -161,6 +174,16 @@ function alg_order(
     )
     return maximum(alg_order.(alg.algs))
 end
+"""
+    get_current_alg_order(alg, cache) -> Real
+
+Strong order of the algorithm that is currently being stepped with.
+
+For a plain algorithm this is just `alg_order(alg)`. For a
+`StochasticCompositeAlgorithm` it is the order of the member algorithm selected by
+`cache.current`, so that adaptivity uses the order of the method that actually took
+the step rather than the order of the composite as a whole.
+"""
 get_current_alg_order(alg::StochasticDiffEqAlgorithm, cache) = alg_order(alg)
 get_current_alg_order(alg::StochasticDiffEqRODEAlgorithm, cache) = alg_order(alg)
 function get_current_alg_order(
@@ -187,7 +210,24 @@ function SciMLBase.alg_interpretation(alg::StochasticDiffEqAlgorithm)
     return SciMLBase.AlgorithmInterpretation.Ito
 end
 
-# Default alg_compatible — false for abstract SDE type, true for RODE
+"""
+    alg_compatible(prob, alg) -> Bool
+
+Whether `alg` can solve `prob`.
+
+`solve` consults this trait before setting up an integrator and errors with a
+descriptive message when it returns `false`. Solver subpackages add methods for the
+problem classes their algorithm supports, for example a Milstein-type method that
+requires diagonal noise:
+
+```julia
+alg_compatible(prob::SciMLBase.AbstractSDEProblem, alg::RKMil) = is_diagonal_noise(prob)
+```
+
+For a `StochasticCompositeAlgorithm` the result is the maximum over its members, and
+for a `JumpProblem` compatibility additionally requires that the algorithm
+[`supports_regular_jumps`](@ref) whenever the problem carries a `RegularJump`.
+"""
 function alg_compatible(
         prob, alg::Union{
             StochasticDiffEqAlgorithm, StochasticDiffEqRODEAlgorithm,
@@ -206,8 +246,17 @@ function alg_compatible(
     return max((alg_compatible(prob, a) for a in alg.algs)...)
 end
 
-# Trait: whether an algorithm supports regular jumps in a JumpProblem.
-# Default is false; EM and ImplicitEM override to true in their subpackages.
+"""
+    supports_regular_jumps(alg) -> Bool
+
+Whether `alg` can integrate a `JumpProblem` that carries a `RegularJump`.
+
+Regular jumps are leaped over with a Poisson count per step rather than simulated
+one event at a time, which only some SDE integrators implement. The default is
+`false`; `EM` and `ImplicitEM` override it to `true` in their subpackages.
+[`alg_compatible`](@ref) uses this trait to reject a `RegularJump` problem paired
+with an algorithm that cannot handle it.
+"""
 supports_regular_jumps(alg) = false
 
 # JumpProblem compatibility defaults
@@ -224,6 +273,20 @@ function alg_compatible(
     return prob.prob isa DiscreteProblem
 end
 
+"""
+    alg_needs_extra_process(alg) -> Bool
+
+Whether `alg` needs a second noise process `ΔZ` alongside the Brownian increment `ΔW`.
+
+Higher order schemes (for example the Rößler SRA/SRI families) require an auxiliary
+independent process to approximate the extra stochastic integrals appearing in their
+order conditions. When this trait is `true` the integrator allocates and resizes the
+`Z` process in addition to `W`, so solver subpackages must set it for any algorithm
+that reads `integrator.W.dZ`.
+
+For a `StochasticCompositeAlgorithm` the result is the maximum over its members, so
+the extra process is present if any member needs it.
+"""
 function alg_needs_extra_process(
         alg::Union{
             StochasticDiffEqAlgorithm, StochasticDiffEqRODEAlgorithm,
@@ -275,8 +338,28 @@ OrdinaryDiffEqCore.concrete_jac(
     }
 ) = alg.concrete_jac
 
+"""
+    alg_mass_matrix_compatible(alg) -> Bool
+
+Whether `alg` can solve a problem with a non-identity mass matrix.
+
+`solve` errors when a mass matrix is supplied to an algorithm for which this is
+`false`. The implicit theta-method solvers accept a mass matrix only in the
+configurations for which the discretization stays consistent (symplectic, or
+`theta == 1`) and throw a descriptive error otherwise.
+"""
 alg_mass_matrix_compatible(alg::StochasticDiffEqAlgorithm) = false
 alg_mass_matrix_compatible(alg::StochasticDiffEqRODEAlgorithm) = false
+
+"""
+    alg_can_repeat_jac(alg) -> Bool
+
+Whether `alg` may reuse a Jacobian across a rejected-and-repeated step.
+
+When `true` the integrator keeps the factorized `W` matrix after a step rejection
+instead of recomputing it, which is the common case. Algorithms whose stage
+structure changes between attempts must override this to `false`.
+"""
 alg_can_repeat_jac(alg::StochasticDiffEqAlgorithm) = true
 
 function alg_mass_matrix_compatible(
@@ -293,12 +376,46 @@ function alg_mass_matrix_compatible(
     end
 end
 
+"""
+    is_split_step(alg) -> Bool
+
+Whether `alg` is a split-step method, i.e. one that advances the drift to an
+intermediate state before applying the diffusion rather than adding both
+contributions to the same base point.
+
+The split-step solvers (`ISSEM`, `ISSEulerHeun`) override this to `true`; the
+integrator uses it to select the matching residual and error-estimate paths.
+"""
 is_split_step(::StochasticDiffEqAlgorithm) = false
 
+"""
+    alg_stability_size(alg) -> Real
+
+Radius of the (deterministic) stability region of `alg` along the negative real axis.
+
+This is the scale used by the automatic stiffness detection of
+[`AutoSwitch`](@ref): the stiffness ratio is `abs(eigen_est * dt / alg_stability_size(alg))`,
+so an algorithm participating in a stiffness-switching composite must report a
+nonzero value. The default of `0` means "not characterized", and is overridden per
+algorithm in the solver subpackages.
+"""
 alg_stability_size(alg::StochasticDiffEqAlgorithm) = 0 # default, overridden per-alg
 
 # is_composite_algorithm trait is defined in OrdinaryDiffEqCore and extended in
 # integrator_utils.jl for SDE composite algorithm types.
+"""
+    unwrap_alg(integrator, is_nlsolve) -> alg
+
+The concrete algorithm that `integrator` should use for the current step.
+
+For a plain algorithm this is `integrator.alg` itself. For a
+`StochasticCompositeAlgorithm` it is the currently selected member: the stiff member
+when `is_nlsolve` is `true` under [`AutoSwitch`](@ref)-style stiffness switching, and
+the member indicated by `integrator.cache.current` otherwise.
+
+`perform_step!` implementations call this instead of reading `integrator.alg`
+directly so that they work unchanged inside a composite algorithm.
+"""
 function unwrap_alg(integrator, is_nlsolve)
     alg = integrator.alg
     if !is_composite_algorithm(alg)
@@ -323,5 +440,15 @@ function unwrap_alg(integrator, is_nlsolve)
     end
 end
 
+"""
+    alg_control_rate(alg) -> Bool
+
+Whether the adaptive step-size controller of `alg` acts on the jump/leap rate rather
+than on the usual solution error estimate.
+
+Tau-leaping methods choose `dt` from how much the propensities are allowed to change
+over a step, so they override this to `true` and the integrator routes step-size
+control through the leap-specific controller instead of the standard `EEst` path.
+"""
 alg_control_rate(::StochasticDiffEqAlgorithm) = false
 alg_control_rate(::StochasticDiffEqRODEAlgorithm) = false

--- a/lib/StochasticDiffEqCore/src/algorithms.jl
+++ b/lib/StochasticDiffEqCore/src/algorithms.jl
@@ -1,8 +1,55 @@
+"""
+    IteratedIntegralApprox
+
+Supertype for the strategies used to approximate the iterated stochastic integrals
+(Lévy areas) that higher order SDE solvers need for non-diagonal noise.
+
+An algorithm carries its choice in the `ii_approx` field, and
+[`get_Jalg`](@ref) turns that choice plus the problem's noise structure into the
+concrete `AbstractJ` object that computes the integrals.
+
+Subtypes: [`IICommutative`](@ref), [`IILevyArea`](@ref).
+"""
 abstract type IteratedIntegralApprox end
 
+"""
+    IICommutative()
+
+Iterated-integral strategy that assumes the noise is commutative.
+
+Under commutative noise the Lévy area terms cancel and the iterated integrals reduce
+to `1/2 ΔW ΔWᵀ`, which is cheap and exact for that problem class. Selecting this for
+a genuinely non-commutative problem silently loses the method's strong order, so use
+[`IILevyArea`](@ref) unless commutativity is known to hold.
+"""
 struct IICommutative <: IteratedIntegralApprox end
+
+"""
+    IILevyArea()
+
+Iterated-integral strategy that approximates the Lévy area numerically.
+
+This is the general-purpose choice: the number of terms is selected automatically
+from the step size and the requested accuracy, and an appropriate simulation
+algorithm is picked by `StochasticDiffEqLevyArea.optimal_algorithm`. It is more
+expensive than [`IICommutative`](@ref) but does not assume anything about the noise
+structure.
+"""
 struct IILevyArea <: IteratedIntegralApprox end
 
+"""
+    StochasticCompositeAlgorithm(algs, choice_function)
+
+Algorithm that switches between the members of `algs` from step to step.
+
+`choice_function(integrator)` returns the index into `algs` of the member to use for
+the next step; the matching cache is held in a
+[`StochasticCompositeCache`](@ref) and selected through its `current` field.
+
+This is the mechanism behind the automatic stiffness-switching solvers — see
+[`AutoAlgSwitch`](@ref), which pairs a nonstiff and a stiff algorithm with an
+[`AutoSwitch`](@ref) choice function.
+"""
 struct StochasticCompositeAlgorithm{T, F} <: StochasticDiffEqCompositeAlgorithm
     algs::T
     choice_function::F

--- a/lib/StochasticDiffEqCore/src/caches/cache_types.jl
+++ b/lib/StochasticDiffEqCore/src/caches/cache_types.jl
@@ -1,9 +1,36 @@
+"""
+    StochasticCompositeCache(caches, choice_function, current)
+
+Cache of a [`StochasticCompositeAlgorithm`](@ref).
+
+Holds one member cache per member algorithm in `caches`, the `choice_function` that
+selects among them, and `current`, the index chosen for the step being taken.
+[`unwrap_alg`](@ref) and [`get_current_alg_order`](@ref) read `current` so that
+`perform_step!` and the adaptivity see the member that is actually running.
+"""
 mutable struct StochasticCompositeCache{T, F} <: StochasticDiffEqCache
     caches::T
     choice_function::F
     current::Int
 end
 
+"""
+    alg_cache(alg, prob, u, ΔW, ΔZ, p, rate_prototype, noise_rate_prototype,
+              jump_rate_prototype, ::Type{uEltypeNoUnits}, ::Type{uBottomEltypeNoUnits},
+              ::Type{tTypeNoUnits}, uprev, f, t, dt, ::Type{Val{iip}}, verbose)
+
+Construct the per-algorithm cache used by `perform_step!`.
+
+This is the main extension point for SDE solver subpackages: each algorithm defines a
+cache type (usually with the `@cache` macro, which also generates the `full_cache`,
+`rand_cache`, and `ratenoise_cache` accessors used for `resize!`) and one
+`alg_cache` method that allocates it. The `Val{iip}` argument selects the in-place or
+out-of-place variant, and the `*NoUnits` type arguments give the element types the
+error estimates should be computed in.
+
+The fallback method defined here errors, pointing at the solver subpackage that needs
+to be loaded for `alg`.
+"""
 function alg_cache(alg::Union{StochasticDiffEqAlgorithm, StochasticDiffEqRODEAlgorithm}, args...)
     error("No cache constructor was loaded for $(typeof(alg)). Load the solver subpackage that defines this algorithm.")
 end

--- a/lib/StochasticDiffEqCore/src/composite_algs.jl
+++ b/lib/StochasticDiffEqCore/src/composite_algs.jl
@@ -13,6 +13,35 @@ mutable struct AutoSwitchCache{nAlg, sAlg, tolType, T}
     switch_max::Int
 end
 
+"""
+    AutoSwitch(nonstiffalg, stiffalg; maxstiffstep = 10, maxnonstiffstep = 3,
+               nonstifftol = 9//10, stifftol = 9//10, dtfac = 2,
+               stiffalgfirst = false, switch_max = 5)
+
+Choice function that switches a [`StochasticCompositeAlgorithm`](@ref) between a
+nonstiff and a stiff method based on an online stiffness estimate.
+
+Each step the estimate `abs(eigen_est * dt / alg_stability_size(alg))` is compared
+against a tolerance. Consecutive verdicts are counted, and the algorithm is only
+switched once the count exceeds the corresponding threshold, which prevents
+thrashing on a borderline problem.
+
+## Keyword Arguments
+
+  - `maxstiffstep`: Number of consecutive stiff verdicts required before switching to
+    `stiffalg` (default: `10`).
+  - `maxnonstiffstep`: Number of consecutive nonstiff verdicts required before
+    switching back to `nonstiffalg` (default: `3`).
+  - `nonstifftol`, `stifftol`: Stiffness-ratio tolerances used while the nonstiff and
+    the stiff algorithm is active, respectively (default: `9//10` for both).
+  - `dtfac`: Factor applied to `dt` at a switch — `dt` is multiplied by it when moving
+    to the stiff method and divided by it when moving back (default: `2`).
+  - `stiffalgfirst`: Start with `stiffalg` instead of `nonstiffalg` (default: `false`).
+  - `switch_max`: Number of successive nonstiff verdicts after which the error check
+    is re-enabled (default: `5`).
+
+Use [`AutoAlgSwitch`](@ref) to build the composite algorithm directly.
+"""
 struct AutoSwitch{nAlg, sAlg, tolType, T}
     nonstiffalg::nAlg
     stiffalg::sAlg
@@ -73,6 +102,20 @@ function (AS::AutoSwitchCache)(integrator)
     return Int(AS.is_stiffalg) + 1
 end
 
+"""
+    AutoAlgSwitch(nonstiffalg, stiffalg; kwargs...) -> StochasticCompositeAlgorithm
+
+Build a stiffness-switching composite of `nonstiffalg` and `stiffalg`.
+
+This is the constructor behind the `Auto*` SDE solvers (for example `AutoSOSRI2`):
+it wraps the two algorithms in a [`StochasticCompositeAlgorithm`](@ref) whose choice
+function is an [`AutoSwitch`](@ref). All keyword arguments are forwarded to
+`AutoSwitch`.
+
+```julia
+alg = AutoAlgSwitch(SOSRI(), ImplicitEM(); maxstiffstep = 5)
+```
+"""
 function AutoAlgSwitch(nonstiffalg, stiffalg; kwargs...)
     AS = AutoSwitch(nonstiffalg, stiffalg; kwargs...)
     return StochasticCompositeAlgorithm((nonstiffalg, stiffalg), AS)

--- a/lib/StochasticDiffEqCore/src/integrators/integrator_interface.jl
+++ b/lib/StochasticDiffEqCore/src/integrators/integrator_interface.jl
@@ -27,6 +27,21 @@ function jac_iter(integrator::StochasticCompositeCache)
     return Iterators.flatten(jac_iter(c) for c in integrator.caches)
 end
 
+"""
+    resize_noise!(integrator, cache, bot_idx, i) -> nothing
+
+Resize the noise process of `integrator` to length `i` after the state was resized.
+
+All of the noise process's buffers (`dW`, `dWtilde`, `dWtmp`, `curW`, the `dZ` family
+when [`alg_needs_extra_process`](@ref) holds, and the cached increments in the
+interpolation stacks `S₁`/`S₂`) are grown or shrunk together. New entries from
+`bot_idx` up to `i` are filled with freshly sampled increments via
+[`fill_new_noise_caches!`](@ref) so the process stays consistent with the already
+generated path.
+
+This is called from the `resize!` integrator interface; see
+[`deleteat_noise!`](@ref) and [`addat_noise!`](@ref) for the index-wise variants.
+"""
 function resize_noise!(integrator, cache, bot_idx, i)
     for c in integrator.W.S₁
         resize!(c[2], i)
@@ -74,6 +89,19 @@ function resize_noise!(integrator, cache, bot_idx, i)
     end
 end
 
+"""
+    fill_new_noise_caches!(integrator, c, scaling_factor, idxs) -> nothing
+
+Sample fresh noise increments into positions `idxs` of a cached noise entry `c`.
+
+`c` is one entry of the noise process's interpolation stacks (`W.S₁`/`W.S₂`), a tuple
+whose first element is the step's scaling factor and whose remaining elements hold the
+cached `ΔW` and, when [`alg_needs_extra_process`](@ref) holds, `ΔZ` values. The new
+values are drawn from the process's own distribution so that the extended path has
+the correct law.
+
+Used by [`resize_noise!`](@ref) and [`addat_noise!`](@ref) whenever the state grows.
+"""
 @inline function fill_new_noise_caches!(integrator, c, scaling_factor, idxs)
     return if isinplace(integrator.W)
         integrator.W.dist(
@@ -155,6 +183,16 @@ function addat_non_user_cache!(integrator::SDEIntegrator, cache::CompositeCache,
     return
 end
 
+"""
+    deleteat_noise!(integrator, cache, idxs) -> nothing
+
+Delete the components `idxs` from the noise process of `integrator`.
+
+The counterpart of [`addat_noise!`](@ref), called from `deleteat!` on the integrator:
+the same components are removed from every noise buffer and from the cached
+increments in the interpolation stacks, keeping the process dimension in step with
+the shrunken state.
+"""
 function deleteat_noise!(integrator, cache, idxs)
     for c in integrator.W.S₁
         deleteat!(c[2], idxs)
@@ -182,6 +220,16 @@ function deleteat_noise!(integrator, cache, idxs)
     end
 end
 
+"""
+    addat_noise!(integrator, cache, idxs) -> nothing
+
+Insert new components at positions `idxs` in the noise process of `integrator`.
+
+The counterpart of [`deleteat_noise!`](@ref), called from `addat!` on the integrator.
+Space is made in every noise buffer and in the cached increments of the interpolation
+stacks, and the new slots are filled with freshly sampled increments through
+[`fill_new_noise_caches!`](@ref).
+"""
 function addat_noise!(integrator, cache, idxs)
     for c in integrator.W.S₁
         addat!(c[2], idxs)

--- a/lib/StochasticDiffEqCore/src/integrators/integrator_utils.jl
+++ b/lib/StochasticDiffEqCore/src/integrators/integrator_utils.jl
@@ -19,9 +19,21 @@ end
 
 @inline initialize!(integrator, cache::StochasticDiffEqCache, f = integrator.f) = nothing
 
-# TauLeapingDrift: wrapper for tau-leaping drift function used by nlsolver
-# Computes drift(u, p, t) = c(u, p, t, rate(u, p, t), nothing)
-# where c is the stoichiometry function and rate is the propensity function
+"""
+    TauLeapingDrift{C, R, RateCache, IIP}(c, rate, rate_cache)
+
+Callable that presents the drift of a tau-leaping jump problem as an ordinary ODE
+right-hand side.
+
+The drift is `ν ⋅ a(u)` written in terms of the `RegularJump` pieces: `rate` is the
+propensity function `a` and `c` is the stoichiometry function that applies the jump
+counts. The wrapper evaluates `c(u, p, t, rate(u, p, t), nothing)`, which is exactly
+the function the implicit tau-leaping methods hand to their nonlinear solver.
+
+The `IIP` type parameter selects the calling convention: out-of-place instances are
+called as `drift(u, p, t)`, in-place ones as `drift(du, u, p, t)` and use
+`rate_cache` as scratch space for the propensities.
+"""
 struct TauLeapingDrift{C, R, RateCache, IIP}
     c::C              # Stoichiometry function (from integrator.c)
     rate::R           # Rate function (from integrator.P.cache.rate)

--- a/lib/StochasticDiffEqCore/src/integrators/type.jl
+++ b/lib/StochasticDiffEqCore/src/integrators/type.jl
@@ -1,4 +1,34 @@
+"""
+    SDEAlgTypes
+
+Union of the algorithm supertypes that the SDE integrator loop handles, i.e.
+`StochasticDiffEqAlgorithm` and `StochasticDiffEqRODEAlgorithm`.
+
+Used to constrain [`SDEIntegrator`](@ref) and to write methods that apply to both SDE
+and RODE algorithms at once.
+"""
 const SDEAlgTypes = Union{StochasticDiffEqAlgorithm, StochasticDiffEqRODEAlgorithm}
+
+"""
+    SDEIntegrator
+
+The integrator type for SDE and RODE problems: an `ODEIntegrator` specialized to an
+algorithm in [`SDEAlgTypes`](@ref).
+
+SDE integration reuses OrdinaryDiffEqCore's integrator machinery and adds the noise
+process in the `W` field (and `P` for jump problems), so this alias is what
+SDE-specific methods — resizing, noise cache handling, the interpolation and step
+interface — dispatch on.
+"""
 const SDEIntegrator = ODEIntegrator{<:SDEAlgTypes}
-# Backwards-compatibility alias for downstream packages (e.g. StochasticDelayDiffEq)
+
+"""
+    SDEOptions
+
+Alias for `OrdinaryDiffEqCore.DEOptions`, the container holding the solver options
+(tolerances, callbacks, save settings) of a running integrator.
+
+Kept as its own name for downstream packages such as StochasticDelayDiffEq that were
+written against the pre-migration `StochasticDiffEq.SDEOptions`.
+"""
 const SDEOptions = OrdinaryDiffEqCore.DEOptions

--- a/lib/StochasticDiffEqCore/src/iterated_integrals.jl
+++ b/lib/StochasticDiffEqCore/src/iterated_integrals.jl
@@ -1,23 +1,79 @@
 """
-All stochastic iterated integrals are written in Stratonovich sense as indicated
-by the J.
-"""
+    AbstractJ
 
+Supertype for the objects that evaluate the iterated stochastic integrals `J` needed
+by higher order SDE solvers.
+
+All stochastic iterated integrals are written in the Stratonovich sense, as indicated
+by the `J`. An `AbstractJ` is produced from a problem and an algorithm by
+[`get_Jalg`](@ref) and is then evaluated with [`get_iterated_I`](@ref) (out-of-place)
+or [`get_iterated_I!`](@ref) (in-place, storing the result in the object's `J` field).
+
+Subtypes: [`AbstractJDiagonal`](@ref), [`AbstractJCommute`](@ref), and the Lévy area
+algorithms of StochasticDiffEqLevyArea together with
+[`IteratedIntegralAlgorithm_iip`](@ref).
+"""
 abstract type AbstractJ end
 
-# Iterated stochastic integral (for diagonal and commutative noise processes where the Levy area approximation is not required.)
+"""
+    AbstractJDiagonal <: AbstractJ
+
+Iterated-integral evaluators for diagonal (or scalar) noise, where the integrals
+reduce to `1/2 ΔWᵢ²` componentwise and no Lévy area approximation is required.
+
+Subtypes: [`JDiagonal_oop`](@ref), [`JDiagonal_iip`](@ref).
+"""
 abstract type AbstractJDiagonal <: AbstractJ end
+
+"""
+    AbstractJCommute <: AbstractJ
+
+Iterated-integral evaluators for commutative noise, where the Lévy area terms cancel
+and the integrals reduce to the outer product `1/2 ΔW ΔWᵀ`.
+
+Subtypes: [`JCommute_oop`](@ref), [`JCommute_iip`](@ref).
+"""
 abstract type AbstractJCommute <: AbstractJ end
 
+"""
+    JDiagonal_oop()
+
+Out-of-place iterated-integral evaluator for diagonal noise.
+
+[`get_iterated_I`](@ref) returns a freshly allocated `1/2 .* ΔW .* ΔW`.
+"""
 struct JDiagonal_oop <: AbstractJDiagonal end
 
+"""
+    JDiagonal_iip(ΔW)
+
+In-place iterated-integral evaluator for diagonal noise, preallocated to the shape of
+the Brownian increment `ΔW`.
+
+[`get_iterated_I!`](@ref) writes `1/2 * ΔW^2` into the `J` field.
+"""
 mutable struct JDiagonal_iip{JType} <: AbstractJDiagonal
     J::JType
     JDiagonal_iip(ΔW) = new{typeof(ΔW)}(false .* ΔW .* ΔW)
 end
 
+"""
+    JCommute_oop()
+
+Out-of-place iterated-integral evaluator for commutative noise.
+
+[`get_iterated_I`](@ref) returns a freshly allocated `1/2 .* vec(ΔW) .* vec(ΔW)'`.
+"""
 struct JCommute_oop <: AbstractJCommute end
 
+"""
+    JCommute_iip(ΔW)
+
+In-place iterated-integral evaluator for commutative noise, preallocated to a
+`length(ΔW) × length(ΔW)` matrix.
+
+[`get_iterated_I!`](@ref) writes `1/2 * vec(ΔW) * vec(ΔW)'` into the `J` field.
+"""
 mutable struct JCommute_iip{JType} <: AbstractJCommute
     J::JType
     function JCommute_iip(ΔW)
@@ -26,10 +82,35 @@ mutable struct JCommute_iip{JType} <: AbstractJCommute
     end
 end
 
+"""
+    get_iterated_I(dt, dW, dZ, alg, p = nothing, c = 1, γ = 1//1)
+
+Evaluate and return the Stratonovich iterated stochastic integrals for the step, out
+of place.
+
+## Arguments
+
+  - `dt`: The step size.
+  - `dW`, `dZ`: The Brownian increment and, where the method needs one, the auxiliary
+    increment for the step.
+  - `alg`: The [`AbstractJ`](@ref) evaluator, as produced by [`get_Jalg`](@ref).
+  - `p`: Number of terms in the Lévy area series. `nothing` (the default) selects it
+    automatically from the requested accuracy `ε = c * dt^(γ + 1/2)`.
+  - `c`, `γ`: Constant and exponent of that accuracy target, normally the constant and
+    strong order of the calling solver.
+
+See [`get_iterated_I!`](@ref) for the in-place form.
+"""
 function get_iterated_I(dt, dW, dZ, alg::JDiagonal_oop, p = nothing, c = 1, γ = 1 // 1)
     return 1 // 2 .* dW .* dW
 end
 
+"""
+    get_iterated_I!(dt, dW, dZ, alg, p = nothing, c = 1, γ = 1//1)
+
+In-place form of [`get_iterated_I`](@ref): compute the Stratonovich iterated
+stochastic integrals for the step and store them in `alg.J`, returning `nothing`.
+"""
 function get_iterated_I!(dt, dW, dZ, alg::JDiagonal_iip, p = nothing, c = 1, γ = 1 // 1)
     (; J) = alg
     if dW isa Number
@@ -66,6 +147,16 @@ function get_iterated_I(
     return I .= 1 // 2 * dW .* dW' .+ dt .* I
 end
 
+"""
+    IteratedIntegralAlgorithm_iip(ΔW, levyalg)
+
+In-place wrapper around a StochasticDiffEqLevyArea iterated-integral algorithm.
+
+StochasticDiffEqLevyArea's algorithms are allocating; this wrapper pairs one of them
+(`levyalg`) with a preallocated `length(ΔW) × length(ΔW)` buffer `J`, so that
+[`get_iterated_I!`](@ref) can serve in-place solvers with general non-commutative
+noise.
+"""
 mutable struct IteratedIntegralAlgorithm_iip{JType, levyalgType} <:
     StochasticDiffEqLevyArea.AbstractIteratedIntegralAlgorithm
     J::JType
@@ -89,7 +180,27 @@ function get_iterated_I!(
     return nothing
 end
 
-# Default algorithms, keep KPWJ_oop() to have a non-mutating version
+"""
+    get_Jalg(ΔW, dt, prob, alg) -> AbstractJ
+
+Select the iterated-integral evaluator to use for `prob` with `alg`.
+
+The choice combines the algorithm's `ii_approx` field — an
+[`IteratedIntegralApprox`](@ref) — with the problem's noise structure and whether it
+is in-place:
+
+  - [`IILevyArea`](@ref) uses a diagonal evaluator when the noise is diagonal or
+    scalar, and otherwise the StochasticDiffEqLevyArea algorithm chosen by
+    `optimal_algorithm(length(ΔW), dt)` (wrapped in
+    [`IteratedIntegralAlgorithm_iip`](@ref) for in-place problems).
+  - [`IICommutative`](@ref) uses a diagonal evaluator for diagonal/scalar noise and a
+    commutative evaluator otherwise.
+  - Any other `ii_approx` is taken to be a concrete Lévy area algorithm and is used
+    directly.
+
+A solver subpackage can override the choice for a specific algorithm by adding a
+method, e.g. `get_Jalg(ΔW, dt, prob, alg::MySolver) = MronRoe()`.
+"""
 function get_Jalg(ΔW, dt, prob, alg)
     return if alg.ii_approx isa IILevyArea
         if isinplace(prob)

--- a/lib/StochasticDiffEqCore/src/misc_utils.jl
+++ b/lib/StochasticDiffEqCore/src/misc_utils.jl
@@ -1,5 +1,32 @@
+"""
+    DiffEqNLSolveTag
+
+ForwardDiff tag type used for the Jacobians of the nonlinear solves inside the SDE
+integrators.
+
+Tagging the duals keeps derivatives taken by the integrator distinguishable from
+derivatives a user takes through `solve`, which is what allows nested
+differentiation to work (see the ForwardDiff.jl documentation on tags).
+"""
 struct DiffEqNLSolveTag end
 
+"""
+    DiffCache(u)
+    DiffCache(u, nlsolve)
+    DiffCache(u, ::Type{Val{chunk_size}})
+    DiffCache(T, size, ::Type{Val{chunk_size}})
+
+Dual-buffered cache holding both a plain array and a `ForwardDiff.Dual` array of the
+same shape.
+
+An in-place function that must work both on ordinary numbers and on duals cannot use
+a single preallocated buffer, because the element types differ. `DiffCache` stores
+one buffer of each and [`get_du`](@ref) picks the right one from the element type at
+the call site.
+
+The chunk size defaults to `ForwardDiff.pickchunksize(length(u))`, or is taken from
+the nonlinear solver via [`get_chunksize`](@ref) when one is supplied.
+"""
 struct DiffCache{T <: AbstractArray, S <: AbstractArray}
     du::T
     dual_du::S
@@ -23,6 +50,16 @@ get_du(dc::DiffCache, T) = dc.du
 
 # Default nlsolve behavior, should be removed
 
+"""
+    determine_chunksize(u, alg) -> Int
+    determine_chunksize(u, CS) -> Int
+
+ForwardDiff chunk size to use when differentiating with respect to a state like `u`.
+
+A nonzero explicitly configured chunk size `CS` (or the one reported by
+[`get_chunksize`](@ref) for `alg`) is used as-is; `0` means "not configured" and
+falls back to `ForwardDiff.pickchunksize(length(u))`.
+"""
 Base.@pure determine_chunksize(u, alg::AbstractDEAlgorithm) = determine_chunksize(u, get_chunksize(alg))
 Base.@pure function determine_chunksize(u, CS)
     if CS != 0
@@ -32,12 +69,36 @@ Base.@pure function determine_chunksize(u, CS)
     end
 end
 
+"""
+    NLSOLVEJL_SETUP(; autodiff = AutoForwardDiff())
+
+Nonlinear-solver setup used by the IIF (implicit integrating factor) methods.
+
+The name is historical — the solve is no longer performed by NLsolve.jl but by
+`SimpleTrustRegion` from SimpleNonlinearSolve.jl. A setup object is callable in two
+ways: `setup(Val{:init}, f, u0_prototype)` wraps `f` in an
+[`IIFNLSolveFunc`](@ref), and `setup(wrapped_f, u0)` solves `f(resid, u) = 0`
+starting from `u0` and returns the root.
+
+## Keyword Arguments
+
+  - `autodiff`: ADTypes.jl backend used for the Jacobian of the inner solve
+    (default: `AutoForwardDiff()`).
+"""
 struct NLSOLVEJL_SETUP{AD}
     autodiff::AD
 end
 NLSOLVEJL_SETUP(; autodiff = ADTypes.AutoForwardDiff()) = NLSOLVEJL_SETUP(autodiff)
 
-# Wrapper to store the function for use with SimpleNonlinearSolve
+"""
+    IIFNLSolveFunc(f)
+
+Wrapper holding the residual function `f` of an IIF nonlinear solve.
+
+[`NLSOLVEJL_SETUP`](@ref) returns one of these from its `Val{:init}` call so that the
+in-place residual `f(resid, u)` can later be turned into a `NonlinearProblem` without
+recapturing the surrounding cache.
+"""
 struct IIFNLSolveFunc{F}
     f::F
 end
@@ -58,9 +119,39 @@ function (p::NLSOLVEJL_SETUP)(::Type{Val{:init}}, f, u0_prototype)
     return IIFNLSolveFunc(f)
 end
 
+"""
+    get_chunksize(x) -> Int
+
+ForwardDiff chunk size configured on `x`, or `0` when `x` does not configure one.
+
+`0` is the "unset" sentinel that makes [`determine_chunksize`](@ref) fall back to
+`ForwardDiff.pickchunksize`.
+"""
 get_chunksize(x) = 0
 get_chunksize(x::NLSOLVEJL_SETUP) = OrdinaryDiffEqCore._get_fwd_chunksize_int(x.autodiff)
 
+"""
+    @cache struct MyAlgCache{...} <: StochasticDiffEqMutableCache
+        ...
+    end
+
+Define an SDE solver cache and generate its buffer accessors.
+
+`resize!` on an integrator has to grow or shrink every buffer a cache holds, and the
+noise machinery has to know which of them are noise-shaped rather than state-shaped.
+Rather than writing those accessors by hand for each cache, `@cache` emits them from
+the declared field types:
+
+  - `full_cache` — fields typed `uType`, `rateType`, `kType`, or `uNoUnitsType`, plus
+    the `du`/`dual_du` pair of a `DiffCacheType` field and the duals of `JCType` and
+    `GCType` fields.
+  - `rand_cache` — fields typed `randType`.
+  - `ratenoise_cache` — fields typed `rateNoiseType` or `rateNoiseCollectionType`.
+  - `jac_iter` — fields typed `JType` or `WType`.
+
+Fields whose type parameter is none of the above are left out of all four accessors,
+which is the correct behavior for scalars, tableaus, and nonlinear solver objects.
+"""
 macro cache(expr)
     name = expr.args[2].args[1].args[1]
     fields = expr.args[3].args[2:2:end]

--- a/lib/StochasticDiffEqCore/src/solve.jl
+++ b/lib/StochasticDiffEqCore/src/solve.jl
@@ -40,7 +40,16 @@ function SciMLBase.__solve(
     return integrator.sol
 end
 
-# Make it easy to grab the RODEProblem/SDEProblem/DiscreteProblem from the keyword arguments
+"""
+    concrete_prob(prob) -> prob
+
+The underlying differential equation problem carried by `prob`.
+
+For an `SDEProblem`, `RODEProblem`, or `DiscreteProblem` this is `prob` itself; for a
+`JumpProblem` it is the wrapped `prob.prob`. Setup code that needs to inspect the
+problem's `f`, `u0`, or `tspan` goes through this so it works uniformly with and
+without a jump wrapper.
+"""
 concrete_prob(prob) = prob
 concrete_prob(prob::JumpProblem) = prob.prob
 
@@ -107,6 +116,21 @@ function SciMLBase.__init(
     return _sde_init(_prob, alg; kwargs...)
 end
 
+"""
+    _sde_init(prob, alg; kwargs...) -> SDEIntegrator
+
+Build the [`SDEIntegrator`](@ref) for `prob` and `alg`.
+
+This is the body of `SciMLBase.__init` for SDE, RODE, and jump problems: it resolves
+the options and the RNG, allocates the solution object, the algorithm cache
+([`alg_cache`](@ref)) and the noise process, and returns the integrator positioned at
+the initial condition. `solve` is `init` followed by `solve!`, so every documented
+`solve` keyword is accepted here.
+
+It is exposed separately from `__init` so that downstream packages which build on the
+SDE integrator (for example StochasticDelayDiffEq) can construct one without going
+through `SciMLBase.__init` dispatch.
+"""
 function _sde_init(
         _prob::Union{SciMLBase.AbstractRODEProblem, JumpProblem},
         alg::Union{StochasticDiffEqAlgorithm, StochasticDiffEqRODEAlgorithm};

--- a/lib/StochasticDiffEqCore/src/weak_utils.jl
+++ b/lib/StochasticDiffEqCore/src/weak_utils.jl
@@ -1,20 +1,69 @@
+"""
+    calc_twopoint_random!(_dW, sqdt, dW) -> nothing
+
+In-place form of [`calc_twopoint_random`](@ref), writing the discrete increments into
+`_dW`.
+"""
 @muladd function calc_twopoint_random!(_dW, sqdt, dW)
     @.. _dW = ifelse(sign(dW) > false, sqdt, -sqdt)
     return nothing
 end
 
+"""
+    calc_twopoint_random(sqdt, dW)
+
+Two-point discrete random variable replacing the Brownian increment in a weak
+(moment-matching) scheme.
+
+Returns `±sqdt`, taking the sign of `dW`, so the result has the same mean and
+variance as the Brownian increment while taking only two values. Weak-order methods
+may substitute such a variable because they only need the moments of the noise to
+match, and sampling two points is cheaper than sampling a Gaussian.
+
+`sqdt` is `sqrt(dt)`. See [`calc_threepoint_random`](@ref) for the variant that also
+matches the fourth moment.
+"""
 @muladd function calc_twopoint_random(sqdt, dW)
     return ifelse(sign(dW) > false, sqdt, -sqdt)
 end
 
+"""
+    calc_threepoint_random!(_dW, sq3dt, quantile, dW_scaled) -> nothing
+
+In-place form of [`calc_threepoint_random`](@ref), writing the discrete increments
+into `_dW`.
+"""
 function calc_threepoint_random!(_dW, sq3dt, quantile, dW_scaled)
     @. _dW = ifelse(abs(dW_scaled) > -quantile, ifelse(dW_scaled < quantile, -sq3dt, sq3dt), zero(sq3dt))
     return nothing
 end
 
+"""
+    calc_threepoint_random(sq3dt, quantile, dW_scaled)
+
+Three-point discrete random variable replacing the Brownian increment in a weak
+(moment-matching) scheme.
+
+Returns `-sq3dt`, `0`, or `+sq3dt` depending on where the standardized increment
+`dW_scaled` falls relative to `quantile`. Unlike the two-point variable of
+[`calc_twopoint_random`](@ref) this matches the fourth moment of the Gaussian as
+well, which weak order 2 schemes require.
+
+`sq3dt` is `sqrt(3dt)`, and `quantile` is the (negative) standard-normal quantile
+that gives the zero outcome its correct probability.
+"""
 @muladd function calc_threepoint_random(sq3dt, quantile, dW_scaled)
     return ifelse(abs(dW_scaled) > -quantile, ifelse(dW_scaled < quantile, -sq3dt, sq3dt), zero(sq3dt))
 end
 
-# Ihat2 function stub: methods are defined in StochasticDiffEqWeak alongside their cache types.
+"""
+    Ihat2(...)
+
+Approximation of the second-order multiple stochastic integral used by the weak
+order 2 schemes.
+
+Only the generic function lives here; the methods are defined in
+StochasticDiffEqWeak alongside the cache types they dispatch on, because their
+argument lists differ between the DRI/RI (Rößler) and RDI families.
+"""
 function Ihat2 end

--- a/lib/StochasticDiffEqImplicit/src/StochasticDiffEqImplicit.jl
+++ b/lib/StochasticDiffEqImplicit/src/StochasticDiffEqImplicit.jl
@@ -20,6 +20,10 @@ import StochasticDiffEqCore: alg_cache, alg_order, alg_compatible,
 import DiffEqBase: @.., SplitSDEFunction, initialize!
 import DiffEqBase: calculate_residuals, calculate_residuals!
 import DiffEqBase: full_cache, rand_cache, ratenoise_cache
+# Without these imports the cache accessors below would define a *new* local
+# `u_cache`/`du_cache` that shadows the SciMLBase interface function rather than
+# extending it, so `resize!` would never see them.
+import DiffEqBase: u_cache, du_cache
 
 import MuladdMacro: @muladd
 import SciMLBase

--- a/lib/StochasticDiffEqImplicit/src/algorithms.jl
+++ b/lib/StochasticDiffEqImplicit/src/algorithms.jl
@@ -1,6 +1,64 @@
 using ADTypes: AutoForwardDiff
 using OrdinaryDiffEqCore: _fixup_ad
 
+"""
+    ImplicitEM(; theta = 1, symplectic = false, linsolve = nothing,
+                 nlsolve = NLNewton(), extrapolant = :constant,
+                 new_jac_conv_bound = 1e-3,
+                 autodiff = AutoForwardDiff(), concrete_jac = nothing)
+
+**ImplicitEM: Drift-Implicit Euler-Maruyama (Stiff)**
+
+Drift-implicit theta-method version of Euler-Maruyama for Itô SDEs. The drift is
+integrated with the theta method while the diffusion is kept explicit, which gives
+stability for problems with a stiff drift term.
+
+## Method Properties
+
+  - **Strong Order**: 0.5
+  - **Weak Order**: 1.0
+  - **Time stepping**: Adaptive
+  - **Noise types**: All (diagonal, non-diagonal, scalar)
+  - **SDE interpretation**: Itô
+
+## Mathematical Formulation
+
+```math
+u_{n+1} = u_n + dt (θ f(u_{n+1}, t_{n+1}) + (1 - θ) f(u_n, t_n)) + g(u_n, t_n) ΔW_n
+```
+
+## When to Use
+
+  - SDEs with a stiff drift term and non-stiff diffusion
+  - As a robust fallback when explicit methods require impractically small steps
+  - Problems where only a low-order method is needed but stability is essential
+
+If the diffusion term is also stiff, prefer the split-step method [`ISSEM`](@ref).
+For Stratonovich problems, use [`ImplicitEulerHeun`](@ref).
+
+## Keyword Arguments
+
+  - `theta`: Implicitness parameter of the drift discretization (default: `1`, i.e.
+    drift-implicit Euler). `theta = 1/2` gives the trapezoidal rule ([`STrapezoid`](@ref)).
+  - `symplectic`: If `true`, uses the symplectic midpoint discretization
+    (forces `theta = 1/2`). See [`SImplicitMidpoint`](@ref).
+  - `linsolve`: LinearSolve.jl algorithm used for the Newton linear systems
+    (default: `nothing`, i.e. the LinearSolve.jl default).
+  - `nlsolve`: Nonlinear solver used for the implicit stage (default: `NLNewton()`).
+  - `extrapolant`: Initial guess method for the nonlinear solve (default: `:constant`).
+  - `new_jac_conv_bound`: Convergence bound below which the Jacobian is reused
+    instead of recomputed (default: `1e-3`).
+  - `autodiff`: ADTypes.jl backend used for the Jacobian (default: `AutoForwardDiff()`).
+  - `concrete_jac`: Whether to build a concrete Jacobian matrix even when a
+    matrix-free linear solver is used (default: `nothing`, i.e. decided automatically).
+
+## References
+
+  - Kloeden, P.E., Platen, E., "Numerical Solution of Stochastic Differential
+    Equations", Springer (1992).
+  - Milstein, G.N., "Numerical Integration of Stochastic Differential Equations",
+    Kluwer (1995).
+"""
 struct ImplicitEM{AD, F, F2, T2, T3, CJ} <:
     StochasticDiffEqNewtonAdaptiveAlgorithm
     linsolve::F
@@ -29,9 +87,128 @@ function ImplicitEM(;
     )
 end
 
+"""
+    STrapezoid(; kwargs...)
+
+**STrapezoid: Stochastic Trapezoidal Rule (Stiff)**
+
+Convenience constructor for the trapezoidal-rule member of the [`ImplicitEM`](@ref)
+family, i.e. `ImplicitEM(theta = 1/2)`. The drift is discretized with the trapezoidal
+rule and the diffusion is kept explicit.
+
+## Method Properties
+
+  - **Strong Order**: 0.5
+  - **Weak Order**: 1.0
+  - **Time stepping**: Adaptive
+  - **Noise types**: All (diagonal, non-diagonal, scalar)
+  - **SDE interpretation**: Itô
+
+## When to Use
+
+  - Stiff Itô SDEs where the second-order accurate (in the deterministic part)
+    trapezoidal drift discretization is preferred over backward Euler
+  - Problems where backward Euler's numerical damping is undesirable
+
+Note that the trapezoidal rule is only A-stable, not L-stable, so for very stiff
+drifts the default `ImplicitEM()` (`theta = 1`) may be more robust.
+
+## Keyword Arguments
+
+All keyword arguments of [`ImplicitEM`](@ref) are accepted and forwarded, except
+that `theta` is fixed to `1/2`.
+"""
 STrapezoid(; kwargs...) = ImplicitEM(; theta = 1 / 2, kwargs...)
+
+"""
+    SImplicitMidpoint(; kwargs...)
+
+**SImplicitMidpoint: Stochastic Implicit Midpoint Rule (Stiff, Symplectic)**
+
+Convenience constructor for the symplectic midpoint member of the [`ImplicitEM`](@ref)
+family, i.e. `ImplicitEM(theta = 1/2, symplectic = true)`. The midpoint discretization
+of the drift makes the deterministic part of the integrator symplectic, so it preserves
+quadratic invariants and has good long-time energy behavior.
+
+## Method Properties
+
+  - **Strong Order**: 0.5
+  - **Weak Order**: 1.0
+  - **Time stepping**: Adaptive
+  - **Noise types**: All (diagonal, non-diagonal, scalar)
+  - **SDE interpretation**: Itô
+  - **Symplectic**: Yes (deterministic part)
+
+## When to Use
+
+  - Stiff Hamiltonian or otherwise structure-preserving SDEs
+  - Long-time integrations where drift in conserved quantities must be avoided
+  - When the non-damping behavior of the midpoint rule is preferable to the
+    dissipativity of backward Euler
+
+## Keyword Arguments
+
+All keyword arguments of [`ImplicitEM`](@ref) are accepted and forwarded, except
+that `theta` is fixed to `1/2` and `symplectic` is fixed to `true`.
+
+## References
+
+  - Milstein, G.N., Repin, Yu.M., Tretyakov, M.V., "Numerical Methods for Stochastic
+    Systems Preserving Symplectic Structure", SIAM J. Numer. Anal., 40 (4),
+    pp. 1583–1604 (2002). DOI: 10.1137/S0036142901395588.
+"""
 SImplicitMidpoint(; kwargs...) = ImplicitEM(; theta = 1 / 2, symplectic = true, kwargs...)
 
+"""
+    ImplicitEulerHeun(; theta = 1, symplectic = false, linsolve = nothing,
+                        nlsolve = NLNewton(), extrapolant = :constant,
+                        new_jac_conv_bound = 1e-3,
+                        autodiff = AutoForwardDiff(), concrete_jac = nothing)
+
+**ImplicitEulerHeun: Drift-Implicit Euler-Heun (Stiff, Stratonovich)**
+
+Drift-implicit theta-method version of the Euler-Heun scheme, the Stratonovich
+counterpart of [`ImplicitEM`](@ref). The drift is treated implicitly while the
+Stratonovich diffusion is handled with the explicit Heun predictor-corrector.
+
+## Method Properties
+
+  - **Strong Order**: 0.5
+  - **Weak Order**: 1.0
+  - **Time stepping**: Adaptive
+  - **Noise types**: All (diagonal, non-diagonal, scalar)
+  - **SDE interpretation**: Stratonovich
+
+## When to Use
+
+  - Stratonovich SDEs with a stiff drift term
+  - Physical models where the noise is a smooth approximation limit (Wong-Zakai),
+    which is naturally Stratonovich
+  - As the Stratonovich analogue of `ImplicitEM()`
+
+If the diffusion is also stiff, prefer the split-step method [`ISSEulerHeun`](@ref).
+
+## Keyword Arguments
+
+  - `theta`: Implicitness parameter of the drift discretization (default: `1`, i.e.
+    drift-implicit Euler). `theta = 1/2` gives the trapezoidal rule.
+  - `symplectic`: If `true`, uses the symplectic midpoint discretization
+    (forces `theta = 1/2`).
+  - `linsolve`: LinearSolve.jl algorithm used for the Newton linear systems
+    (default: `nothing`, i.e. the LinearSolve.jl default).
+  - `nlsolve`: Nonlinear solver used for the implicit stage (default: `NLNewton()`).
+  - `extrapolant`: Initial guess method for the nonlinear solve (default: `:constant`).
+  - `new_jac_conv_bound`: Convergence bound below which the Jacobian is reused
+    instead of recomputed (default: `1e-3`).
+  - `autodiff`: ADTypes.jl backend used for the Jacobian (default: `AutoForwardDiff()`).
+  - `concrete_jac`: Whether to build a concrete Jacobian matrix even when a
+    matrix-free linear solver is used (default: `nothing`, i.e. decided automatically).
+
+## References
+
+  - Kloeden, P.E., Platen, E., "Numerical Solution of Stochastic Differential
+    Equations", Springer (1992).
+"""
 struct ImplicitEulerHeun{AD, F, N, T2, T3, CJ} <:
     StochasticDiffEqNewtonAdaptiveAlgorithm
     linsolve::F
@@ -61,6 +238,62 @@ function ImplicitEulerHeun(;
     )
 end
 
+"""
+    ImplicitRKMil(; theta = 1, symplectic = false, linsolve = nothing,
+                    nlsolve = NLNewton(), extrapolant = :constant,
+                    new_jac_conv_bound = 1e-3,
+                    interpretation = AlgorithmInterpretation.Ito,
+                    autodiff = AutoForwardDiff(), concrete_jac = nothing)
+
+**ImplicitRKMil: Drift-Implicit Runge-Kutta Milstein (Stiff)**
+
+Drift-implicit theta-method version of the derivative-free Runge-Kutta Milstein
+scheme. The Milstein correction gives strong order 1.0, twice the strong order of
+[`ImplicitEM`](@ref), at the cost of being restricted to diagonal and scalar noise.
+
+## Method Properties
+
+  - **Strong Order**: 1.0
+  - **Weak Order**: 1.0
+  - **Time stepping**: Adaptive
+  - **Noise types**: Diagonal and scalar noise only
+  - **SDE interpretation**: Itô or Stratonovich (selected by `interpretation`)
+
+## When to Use
+
+  - Stiff SDEs with diagonal or scalar noise where strong order 1.0 is needed
+  - When [`ImplicitEM`](@ref) converges too slowly in the strong sense
+  - Pathwise-accurate simulations (e.g. multilevel Monte Carlo) of stiff problems
+
+Note that `ImplicitRKMil` is only compatible with diagonal-noise problems; for
+non-diagonal noise use [`ImplicitEM`](@ref) or [`ISSEM`](@ref).
+
+## Keyword Arguments
+
+  - `theta`: Implicitness parameter of the drift discretization (default: `1`, i.e.
+    drift-implicit Euler). `theta = 1/2` gives the trapezoidal rule.
+  - `symplectic`: If `true`, uses the symplectic midpoint discretization
+    (forces `theta = 1/2`).
+  - `interpretation`: `AlgorithmInterpretation.Ito` (default) or
+    `AlgorithmInterpretation.Stratonovich`, selecting which SDE interpretation the
+    Milstein correction is built for.
+  - `linsolve`: LinearSolve.jl algorithm used for the Newton linear systems
+    (default: `nothing`, i.e. the LinearSolve.jl default).
+  - `nlsolve`: Nonlinear solver used for the implicit stage (default: `NLNewton()`).
+  - `extrapolant`: Initial guess method for the nonlinear solve (default: `:constant`).
+  - `new_jac_conv_bound`: Convergence bound below which the Jacobian is reused
+    instead of recomputed (default: `1e-3`).
+  - `autodiff`: ADTypes.jl backend used for the Jacobian (default: `AutoForwardDiff()`).
+  - `concrete_jac`: Whether to build a concrete Jacobian matrix even when a
+    matrix-free linear solver is used (default: `nothing`, i.e. decided automatically).
+
+## References
+
+  - Milstein, G.N., "Numerical Integration of Stochastic Differential Equations",
+    Kluwer (1995).
+  - Kloeden, P.E., Platen, E., "Numerical Solution of Stochastic Differential
+    Equations", Springer (1992).
+"""
 struct ImplicitRKMil{AD, F, N, T2, T3, interpretation, CJ} <:
     StochasticDiffEqNewtonAdaptiveAlgorithm
     linsolve::F
@@ -93,6 +326,69 @@ function ImplicitRKMil(;
     )
 end
 
+"""
+    ISSEM(; theta = 1, symplectic = false, linsolve = nothing,
+            nlsolve = NLNewton(), extrapolant = :constant,
+            new_jac_conv_bound = 1e-3,
+            autodiff = AutoForwardDiff(), concrete_jac = nothing)
+
+**ISSEM: Implicit Split-Step Euler-Maruyama (Fully Stiff)**
+
+Implicit split-step Euler-Maruyama method for Itô SDEs. Unlike [`ImplicitEM`](@ref),
+which is implicit only in the drift, the split-step formulation applies the implicit
+solve to an intermediate state and then adds the diffusion, which gives stability for
+problems where the *diffusion* term is stiff as well.
+
+## Method Properties
+
+  - **Strong Order**: 0.5
+  - **Weak Order**: 1.0
+  - **Time stepping**: Adaptive
+  - **Noise types**: All (diagonal, non-diagonal, scalar)
+  - **SDE interpretation**: Itô
+
+## Mathematical Formulation
+
+The step is split into a purely deterministic implicit solve followed by the
+diffusion update, so the noise never enters the nonlinear system:
+
+```math
+u^* = u_n + dt (θ f(u^*, t_{n+1}) + (1 - θ) f(u_n, t_n))
+```
+
+```math
+u_{n+1} = u^* + g(u_n, t_n) ΔW_n
+```
+
+## When to Use
+
+  - SDEs that are stiff in both the drift and the diffusion
+  - Problems where [`ImplicitEM`](@ref) still requires very small time steps
+  - Mean-square stability sensitive problems (e.g. large multiplicative noise)
+
+For Stratonovich problems, use [`ISSEulerHeun`](@ref).
+
+## Keyword Arguments
+
+  - `theta`: Implicitness parameter of the drift solve (default: `1`).
+  - `symplectic`: If `true`, uses the symplectic midpoint discretization
+    (forces `theta = 1/2`).
+  - `linsolve`: LinearSolve.jl algorithm used for the Newton linear systems
+    (default: `nothing`, i.e. the LinearSolve.jl default).
+  - `nlsolve`: Nonlinear solver used for the implicit stage (default: `NLNewton()`).
+  - `extrapolant`: Initial guess method for the nonlinear solve (default: `:constant`).
+  - `new_jac_conv_bound`: Convergence bound below which the Jacobian is reused
+    instead of recomputed (default: `1e-3`).
+  - `autodiff`: ADTypes.jl backend used for the Jacobian (default: `AutoForwardDiff()`).
+  - `concrete_jac`: Whether to build a concrete Jacobian matrix even when a
+    matrix-free linear solver is used (default: `nothing`, i.e. decided automatically).
+
+## References
+
+  - Higham, D.J., Mao, X., Stuart, A.M., "Strong Convergence of Euler-Type Methods
+    for Nonlinear Stochastic Differential Equations", SIAM J. Numer. Anal., 40 (3),
+    pp. 1041–1063 (2002). DOI: 10.1137/S0036142901389530.
+"""
 struct ISSEM{AD, F, N, T2, T3, CJ} <:
     StochasticDiffEqNewtonAdaptiveAlgorithm
     linsolve::F
@@ -122,6 +418,55 @@ function ISSEM(;
     )
 end
 
+"""
+    ISSEulerHeun(; theta = 1, symplectic = false, linsolve = nothing,
+                   nlsolve = NLNewton(), extrapolant = :constant,
+                   new_jac_conv_bound = 1e-3,
+                   autodiff = AutoForwardDiff(), concrete_jac = nothing)
+
+**ISSEulerHeun: Implicit Split-Step Euler-Heun (Fully Stiff, Stratonovich)**
+
+Implicit split-step Euler-Heun method, the Stratonovich counterpart of
+[`ISSEM`](@ref). The drift is advanced with an implicit solve that contains no noise
+terms, and the Stratonovich diffusion is then applied with the Heun
+predictor-corrector, giving stability for problems that are stiff in both the drift
+and the diffusion.
+
+## Method Properties
+
+  - **Strong Order**: 0.5
+  - **Weak Order**: 1.0
+  - **Time stepping**: Adaptive
+  - **Noise types**: All (diagonal, non-diagonal, scalar)
+  - **SDE interpretation**: Stratonovich
+
+## When to Use
+
+  - Stratonovich SDEs that are stiff in both drift and diffusion
+  - Problems where [`ImplicitEulerHeun`](@ref) still requires very small time steps
+  - Physical models with large multiplicative noise in the Stratonovich sense
+
+## Keyword Arguments
+
+  - `theta`: Implicitness parameter of the drift solve (default: `1`).
+  - `symplectic`: If `true`, uses the symplectic midpoint discretization
+    (forces `theta = 1/2`).
+  - `linsolve`: LinearSolve.jl algorithm used for the Newton linear systems
+    (default: `nothing`, i.e. the LinearSolve.jl default).
+  - `nlsolve`: Nonlinear solver used for the implicit stage (default: `NLNewton()`).
+  - `extrapolant`: Initial guess method for the nonlinear solve (default: `:constant`).
+  - `new_jac_conv_bound`: Convergence bound below which the Jacobian is reused
+    instead of recomputed (default: `1e-3`).
+  - `autodiff`: ADTypes.jl backend used for the Jacobian (default: `AutoForwardDiff()`).
+  - `concrete_jac`: Whether to build a concrete Jacobian matrix even when a
+    matrix-free linear solver is used (default: `nothing`, i.e. decided automatically).
+
+## References
+
+  - Higham, D.J., Mao, X., Stuart, A.M., "Strong Convergence of Euler-Type Methods
+    for Nonlinear Stochastic Differential Equations", SIAM J. Numer. Anal., 40 (3),
+    pp. 1041–1063 (2002). DOI: 10.1137/S0036142901389530.
+"""
 struct ISSEulerHeun{AD, F, N, T2, T3, CJ} <:
     StochasticDiffEqNewtonAdaptiveAlgorithm
     linsolve::F
@@ -151,6 +496,68 @@ function ISSEulerHeun(;
     )
 end
 
+"""
+    SKenCarp(; linsolve = nothing, nlsolve = NLNewton(),
+               smooth_est = true, extrapolant = :min_correct,
+               new_jac_conv_bound = 1e-3, ode_error_est = true,
+               autodiff = AutoForwardDiff(), concrete_jac = nothing)
+
+**SKenCarp: Stochastic KenCarp for Additive Noise (Stiff, Recommended)**
+
+Stochastic extension of the KenCarp4 additive Runge-Kutta (ESDIRK) method for SDEs
+with additive noise. The deterministic part is integrated with the L-stable,
+stiffly-accurate KenCarp4 tableau, while the additive noise is handled with the
+higher-order stochastic quadrature of Rößler's SRA schemes, so the method retains
+strong order 1.5 on additive-noise problems.
+
+## Method Properties
+
+  - **Strong Order**: 1.5 (for additive noise)
+  - **Deterministic Order**: 4 (KenCarp4)
+  - **Time stepping**: Adaptive
+  - **Noise types**: Additive noise (diagonal, non-diagonal, and scalar)
+  - **SDE interpretation**: Itô (Itô and Stratonovich coincide for additive noise)
+  - **Stability**: L-stable, stiffly accurate
+
+## When to Use
+
+  - The recommended default for stiff SDEs with additive noise
+  - Problems where the deterministic dynamics dominate and need high accuracy
+  - Chemical, mechanical, or PDE-discretization models driven by additive forcing
+
+Additive noise means the diffusion function does not depend on the state (`g(u,p,t)`
+is independent of `u`); for state-dependent noise use [`ImplicitEM`](@ref),
+[`ImplicitRKMil`](@ref), or [`ISSEM`](@ref).
+
+## Keyword Arguments
+
+  - `smooth_est`: Whether to use the smoothed error estimate, which is more robust
+    for stiff problems (default: `true`).
+  - `ode_error_est`: Whether the deterministic (ODE) embedded error estimate is
+    included in the adaptivity controller (default: `true`).
+  - `linsolve`: LinearSolve.jl algorithm used for the Newton linear systems
+    (default: `nothing`, i.e. the LinearSolve.jl default).
+  - `nlsolve`: Nonlinear solver used for the implicit stages (default: `NLNewton()`).
+  - `extrapolant`: Initial guess method for the nonlinear solves
+    (default: `:min_correct`).
+  - `new_jac_conv_bound`: Convergence bound below which the Jacobian is reused
+    instead of recomputed (default: `1e-3`).
+  - `autodiff`: ADTypes.jl backend used for the Jacobian (default: `AutoForwardDiff()`).
+  - `concrete_jac`: Whether to build a concrete Jacobian matrix even when a
+    matrix-free linear solver is used (default: `nothing`, i.e. decided automatically).
+
+## References
+
+  - Kennedy, C.A., Carpenter, M.H., "Additive Runge-Kutta schemes for
+    convection-diffusion-reaction equations", Applied Numerical Mathematics, 44 (1-2),
+    pp. 139–181 (2003). DOI: 10.1016/S0168-9274(02)00138-1.
+  - Rackauckas, C., Nie, Q., "Stability-Optimized High Order Methods and Stiffness
+    Detection for Pathwise Stiff Stochastic Differential Equations", 2020 IEEE High
+    Performance Extreme Computing Conference (HPEC). DOI: 10.1109/HPEC43674.2020.9286178.
+  - Rößler A., "Runge-Kutta Methods for the Strong Approximation of Solutions of
+    Stochastic Differential Equations", SIAM J. Numer. Anal., 48 (3), pp. 922–952
+    (2010). DOI: 10.1137/09076636X.
+"""
 struct SKenCarp{AD, F, N, T2, CJ} <:
     StochasticDiffEqNewtonAdaptiveAlgorithm
     linsolve::F


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

Fixes the `public API has docstrings` QA failure in `OrdinaryDiffEqExponentialRK`, `StochasticDiffEqImplicit`, and `StochasticDiffEqLeaping` by writing the missing docstrings. No names were unexported and no ignore lists were touched.

## What was actually broken

**`OrdinaryDiffEqExponentialRK`** — the docstrings existed but were not attached. In the EPIRK loop, a blank line sits between `@doc generic_solver_docstring(...)` and the `struct` it documents, inside `@eval begin ... end`. Julia silently drops the docstring in that case:

```julia
julia> module M
       for (A,D) in [(:Foo,"foo desc")]
           @eval begin
               @doc $D

               struct $A end
           end
       end
       end
julia> module M2   # identical, minus the blank line
       for (A,D) in [(:Foo,"foo desc")]
           @eval begin
               @doc $D
               struct $A end
           end
       end
       end
Main.M.Foo => UNDOCUMENTED
Main.M2.Foo => documented
```

`ETD1` is a separate case: it is `const ETD1 = NorsettEuler`, and `NorsettEuler` is a `UnionAll`, which `Base.Docs` does not follow as an alias, so it needs its own entry.

**`StochasticDiffEqImplicit` / `StochasticDiffEqLeaping`** — the bulk of the undocumented names were not owned by these packages at all. Both do `@reexport using StochasticDiffEqCore`, and `public_api_names` = `names(pkg; all=false, imported=false)` includes reexports, so all 51 undocumented `StochasticDiffEqCore` exports showed up in both lanes. `StochasticDiffEqLeaping`'s own four algorithms were already documented; `StochasticDiffEqImplicit`'s eight were not.

## Changes

1. `OrdinaryDiffEqExponentialRK` — remove the detaching blank line, add an `ETD1` docstring, fix the mangled indentation of the `iop` bullet (it rendered as a nested list), and expand the one-line EPIRK descriptions.
2. `StochasticDiffEqCore` — docstrings for all 51 exported names: solver-author traits, the iterated-integral/Lévy-area interface, the composite-algorithm machinery, the weak-scheme discrete random variables, the `DiffCache` helpers, the noise-resize entry points, and the `SDEIntegrator` aliases. Comments sitting between a docstring and its definition detach it the same way a blank line does, so those were folded into the docstrings.
3. `StochasticDiffEqImplicit` — docstrings for `ImplicitEM`, `ImplicitEulerHeun`, `ImplicitRKMil`, `STrapezoid`, `SImplicitMidpoint`, `ISSEM`, `ISSEulerHeun`, `SKenCarp`. The umbrella manual already had `@docs` blocks for six of these (`lib/StochasticDiffEq/docs/src/stiff/implicit_methods.md`) that were rendering empty; `STrapezoid` and `SImplicitMidpoint` had no `@docs` entry, so one was added.

## `u_cache` / `du_cache`

These were also reported undocumented in `StochasticDiffEqImplicit`. The cause is a latent bug: `sdirk_caches.jl` and `kencarp_caches.jl` define `u_cache(c::...)`/`du_cache(c::...)` without importing the names, which creates a **new local function shadowing** the SciMLBase interface function instead of extending it — so `StochasticDiffEqImplicit.u_cache !== SciMLBase.u_cache`. Importing them from DiffEqBase (matching what `StochasticDiffEqCore` already does) makes them real interface methods and resolves the name to its documented owner.

Behavior is unchanged. Verified locally that `resize!(integrator, 3)` gives an identical result with and without the import:

```
u_cache === SciMLBase.u_cache: true
resize! ImplicitEM => OK
resize! ImplicitEulerHeun => FAIL: DimensionMismatch: array could not be broadcast to match destination
resize! SKenCarp => OK
```

The `ImplicitEulerHeun` `DimensionMismatch` reproduces identically on unmodified master (import stashed), i.e. it is pre-existing and tracked separately, not introduced here.

`StochasticDiffEqHighOrder` has the same shadowing pattern in `sra_caches.jl`; it is left alone to keep this PR scoped.

## Test output

`ODEDIFFEQ_TEST_GROUP=QA julia +1.12 --startup-file=no --project=lib/<Pkg> -e 'using Pkg; Pkg.test()'`

### Before

`OrdinaryDiffEqExponentialRK`:
```
public API has docstrings: Test Failed at .../SciMLTesting/bvGdH/src/SciMLTesting.jl:1157
  Expression: isempty(undocumented)
   Evaluated: isempty([:EPIRK4s3A, :EPIRK4s3B, :EPIRK5P1, :EPIRK5P2, :EPIRK5s3, :EXPRB53s3, :Exp4])
Test Summary:                                  | Pass  Fail  Total     Time
Aqua                                           |   19     1     20  1m56.1s
    Public API documentation                   |          1      1    15.7s
      public API has docstrings                |          1      1     3.8s
ERROR: LoadError: Some tests did not pass: 19 passed, 1 failed, 0 errored, 0 broken.
```

`StochasticDiffEqImplicit`:
```
public API has docstrings: Test Failed at .../SciMLTesting/bvGdH/src/SciMLTesting.jl:1157
  Expression: isempty(undocumented)
   Evaluated: isempty([:AbstractJ, :AbstractJCommute, :AbstractJDiagonal, :AutoAlgSwitch, :AutoSwitch, :DiffCache, :DiffEqNLSolveTag, :IICommutative, :IIFNLSolveFunc, :IILevyArea  …  :get_Jalg, :get_chunksize, :get_current_alg_order, :get_iterated_I, :get_iterated_I!, :is_split_step, :resize_noise!, :supports_regular_jumps, :u_cache, :unwrap_alg])
┌ Info: run_api_docs: public API names missing a docstring
│   pkg = StochasticDiffEqImplicit
│   undocumented =
│    53-element Vector{Symbol}:
Test Summary:                                  | Pass  Fail  Total     Time
QA (Aqua and JET)                              |   19     1     20  2m24.4s
      public API has docstrings                |          1      1     4.4s
ERROR: LoadError: Some tests did not pass: 19 passed, 1 failed, 0 errored, 0 broken.
```

`StochasticDiffEqLeaping`:
```
public API has docstrings: Test Failed at .../SciMLTesting/bvGdH/src/SciMLTesting.jl:1157
  Expression: isempty(undocumented)
   Evaluated: isempty([:AbstractJ, :AbstractJCommute, :AbstractJDiagonal, :AutoAlgSwitch, :AutoSwitch, :DiffCache, :DiffEqNLSolveTag, :IICommutative, :IIFNLSolveFunc, :IILevyArea  …  :fill_new_noise_caches!, :get_Jalg, :get_chunksize, :get_current_alg_order, :get_iterated_I, :get_iterated_I!, :is_split_step, :resize_noise!, :supports_regular_jumps, :unwrap_alg])
┌ Info: run_api_docs: public API names missing a docstring
│   pkg = StochasticDiffEqLeaping
│   undocumented =
│    51-element Vector{Symbol}:
Test Summary:                                  | Pass  Fail  Total     Time
QA (Aqua and JET)                              |   19     1     20  2m19.6s
      public API has docstrings                |          1      1     4.3s
ERROR: LoadError: Some tests did not pass: 19 passed, 1 failed, 0 errored, 0 broken.
```

### After

```
########## OrdinaryDiffEqExponentialRK ##########
Test Summary: | Pass  Total     Time
Aqua          |   20     20  1m14.5s
     Testing OrdinaryDiffEqExponentialRK tests passed

########## StochasticDiffEqImplicit ##########
Test Summary:     | Pass  Total     Time
QA (Aqua and JET) |   20     20  1m58.1s
     Testing StochasticDiffEqImplicit tests passed

########## StochasticDiffEqLeaping ##########
Test Summary:     | Pass  Total     Time
QA (Aqua and JET) |   20     20  1m55.9s
     Testing StochasticDiffEqLeaping tests passed
```

All three lanes are fully green — not just the docstring check.

### `StochasticDiffEqCore`

Its own QA lane also improves: `Public API documentation` goes from failing to passing. The lane is still red on two pre-existing, unrelated failures that this PR does not touch:

```
    ExplicitImports                            |    4            2      6    32.2s
      all_qualified_accesses_are_public        |                 1      1     2.4s
      all_explicit_imports_are_public          |                 1      1     2.0s
    Public API documentation                   |    1                   1    11.1s
    No unapproved public reexports             |          1             1     3.4s
```

The reexport failure is the subject of #4031.

### Functional smoke test

```
ImplicitEM retcode=Success u_end=[0.37845218833291916, 0.8050468457815497]
ImplicitEulerHeun retcode=Success u_end=[0.3804302668289573, 0.8087105027199113]
ImplicitRKMil retcode=Success u_end=[0.37845218833291916, 0.8050468457815496]
STrapezoid retcode=Success u_end=[0.37660828869403057, 0.8013754699349482]
SImplicitMidpoint retcode=Success u_end=[0.3766082886940308, 0.801375469934948]
ISSEM retcode=Success u_end=[0.3785207265144634, 0.8056947390706974]
ISSEulerHeun retcode=Success u_end=[0.38048456063052194, 0.8090726651763634]
SKenCarp retcode=Success u_end=[0.3411691167387071, 0.8940164704166302]
```

Runic 1.7.0 `--check` passes on every changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPHRh64BLfoXSzQ3AxKNwC
