### PR TITLE
Size RKMilGeneral's Lévy area truncation from MronRoe's error bound

### DIFF
--- a/lib/DelayDiffEq/ext/DelayDiffEqStochasticDiffEqCoreExt.jl
+++ b/lib/DelayDiffEq/ext/DelayDiffEqStochasticDiffEqCoreExt.jl
@@ -55,7 +55,7 @@ function DelayDiffEq._create_sdde_noise(
     if prob.noise === nothing
         if iip
             if needs_dZ
-                rand_prototype2 = _z_prototype(alg, rand_prototype, true)
+                rand_prototype2 = _z_prototype(alg, rand_prototype, true, dt)
                 W = WienerProcess!(
                     t0, rand_prototype, rand_prototype2,
                     save_everystep = save_noise, rng = _rng
@@ -68,7 +68,7 @@ function DelayDiffEq._create_sdde_noise(
             end
         else
             if needs_dZ
-                rand_prototype2 = _z_prototype(alg, rand_prototype, false)
+                rand_prototype2 = _z_prototype(alg, rand_prototype, false, dt)
                 W = WienerProcess(
                     t0, rand_prototype, rand_prototype2,
                     save_everystep = save_noise, rng = _rng

--- a/lib/StochasticDiffEq/test/levy_areas.jl
+++ b/lib/StochasticDiffEq/test/levy_areas.jl
@@ -135,6 +135,40 @@ end
     end
 end
 
+@testset "RKMilGeneral dZ truncation sizing" begin
+    # The MronRoe Fourier coefficients are drawn as the noise process' dZ, so every
+    # step of them lands in the saved noise history. Sizing them from the order-1/2
+    # truncation rule (O(1/dt) terms) instead of MronRoe's own (O(1/√dt)) grows the
+    # saved noise by a factor of ~340 at dt = 2^-12, which is enough to take a
+    # 500-trajectory convergence study past 250 GiB. See issue #4036.
+    mm = 4
+    f!(du, u, p, t) = (du .= 0; nothing)
+    g!(du, u, p, t) = (du .= 1; nothing)
+    prob = SDEProblem(f!, g!, [2.0, 2.0], (0.0, 0.5); noise_rate_prototype = zeros(2, mm))
+
+    n_tail = (mm^2 + mm) ÷ 2
+    implied_terms(sol) = (length(sol.W.Z[1]) - n_tail) ÷ (2 * mm)
+
+    for dt in (1 / 2^6, 1 / 2^12)
+        expected = terms_needed(mm, dt, dt^(3 // 2), MronRoe(), MaxL2())
+        sol = solve(prob, RKMilGeneral(), dt = dt, adaptive = false, save_noise = true)
+        @test implied_terms(sol) == expected
+        # `p = true` used to bake floor(1/dt) + 1 terms into the algorithm object, so
+        # the truncation neither tracked the solver's step size nor the noise dimension.
+        sol_ptrue = solve(
+            prob, RKMilGeneral(p = true, dt = 1 / 2^12), dt = dt,
+            adaptive = false, save_noise = true
+        )
+        @test implied_terms(sol_ptrue) == expected
+    end
+
+    # An explicitly requested truncation is still honoured.
+    sol_fixed = solve(
+        prob, RKMilGeneral(p = 7), dt = 1 / 2^6, adaptive = false, save_noise = true
+    )
+    @test implied_terms(sol_fixed) == 7
+end
+
 @testset "Simulate non-com. SDEs tests" begin
     u₀ = [0.0, 0.0, 0.0]
     f(u, p, t) = [0.0, 0.0, 0.0]

--- a/lib/StochasticDiffEq/test/noncommutative_tests.jl
+++ b/lib/StochasticDiffEq/test/noncommutative_tests.jl
@@ -106,7 +106,7 @@ sim5 = analyticless_test_convergence(
 @test abs(sim5.𝒪est[:final] - 0.5) < 0.2
 test_dt_mil = 1 / 2^(12)
 sim6 = analyticless_test_convergence(
-    dts, prob2, RKMilGeneral(p = true, dt = test_dt_mil),
+    dts, prob2, RKMilGeneral(),
     test_dt_mil, trajectories = 500, use_noise_grid = false
 )
 @test abs(sim6.𝒪est[:final] - 1.0) < 0.2

--- a/lib/StochasticDiffEq/test/test_groups.toml
+++ b/lib/StochasticDiffEq/test/test_groups.toml
@@ -12,8 +12,7 @@ versions = ["1"]
 
 [NoncommutativeConvergence]
 versions = ["1"]
-runner = ["self-hosted", "Linux", "X64", "high-memory"]
-timeout = 240
+timeout = 60
 
 [AlgConvergence2]
 versions = ["1"]

--- a/lib/StochasticDiffEqCore/src/solve.jl
+++ b/lib/StochasticDiffEqCore/src/solve.jl
@@ -108,6 +108,25 @@ function _z_prototype(alg, rand_prototype, iip::Bool)
     return rand_prototype
 end
 
+"""
+    _z_prototype(alg, rand_prototype, iip::Bool, dt) -> rand_prototype2
+
+Step-size aware form of [`_z_prototype`](@ref), used when the size of the Z process
+depends on the step size — as it does for Lévy area truncations, where the number of
+retained series terms is chosen from the accuracy the step size demands.
+
+`dt` is the initial step size as passed to `solve`, which is zero when the caller left
+it to be determined automatically. Since the Z prototype must be built before the
+initial step size is known, an algorithm that sizes from `dt` needs a fallback for
+that case.
+
+Defaults to the three-argument form, so an override only has to be added by
+algorithms that actually need the step size.
+"""
+function _z_prototype(alg, rand_prototype, iip::Bool, dt)
+    return _z_prototype(alg, rand_prototype, iip)
+end
+
 function SciMLBase.__init(
         _prob::Union{SciMLBase.AbstractRODEProblem, JumpProblem},
         alg::Union{StochasticDiffEqAlgorithm, StochasticDiffEqRODEAlgorithm};
@@ -404,7 +423,7 @@ function _sde_init(
         rswm = isadaptive(alg) ? RSWM(adaptivealg = :RSwM3) : RSWM(adaptivealg = :RSwM1)
         if isinplace(prob)
             if alg_needs_extra_process(alg)
-                rand_prototype2 = _z_prototype(alg, rand_prototype, true)
+                rand_prototype2 = _z_prototype(alg, rand_prototype, true, dt)
                 W = WienerProcess!(
                     t, rand_prototype, rand_prototype2,
                     save_everystep = save_noise,
@@ -419,7 +438,7 @@ function _sde_init(
             end
         else
             if alg_needs_extra_process(alg)
-                rand_prototype2 = _z_prototype(alg, rand_prototype, false)
+                rand_prototype2 = _z_prototype(alg, rand_prototype, false, dt)
                 W = WienerProcess(
                     t, rand_prototype, rand_prototype2,
                     save_everystep = save_noise,

--- a/lib/StochasticDiffEqMilstein/src/alg_utils.jl
+++ b/lib/StochasticDiffEqMilstein/src/alg_utils.jl
@@ -18,23 +18,47 @@ alg_compatible(prob::SciMLBase.AbstractSDEProblem, alg::WangLi3SMil_F) = true
 
 alg_needs_extra_process(alg::RKMilGeneral) = true
 
+"""
+    _levyarea_terms(alg::RKMilGeneral, m, dt) -> n
+
+Number of Fourier terms to retain in the Lévy area series for `m`-dimensional noise at
+step size `dt`, honouring an explicit `alg.p` when the user set one.
+
+`perform_step!` always evaluates the Lévy area with `MronRoe()`, which is order 1 in
+`n`, so the count must come from that algorithm's error bound and the same accuracy
+target `ε = c dt^(γ + 1/2)` that `get_iterated_I!` uses. That takes
+`O(dt^(-1/2))` terms, not the `O(dt^(-1))` of an order-1/2 Fourier expansion. Getting
+this wrong is expensive in memory and not just in `randn` calls, because the
+coefficients are drawn as the noise process' `dZ`, so every step of them is kept in the
+saved noise history.
+
+Falls back to a fixed count when the step size is not a real number known up front —
+the Z prototype has to be built before an automatically chosen initial step size is
+known, and unitful step sizes do not go through `terms_needed`.
+"""
+function _levyarea_terms(alg::RKMilGeneral, m, dt)
+    alg.p isa Integer && return max(1, alg.p)
+    (dt isa Real && isfinite(dt) && !iszero(dt)) || return max(10, m)
+    h = abs(float(dt))
+    ε = alg.c * h^(alg_order(alg) + 1 // 2)
+    n = StochasticDiffEqLevyArea.terms_needed(
+        m, h, ε, MronRoe(), StochasticDiffEqLevyArea.MaxL2()
+    )
+    return max(1, n)
+end
+
 # Size dZ to carry MronRoe Fourier coefficients.
 # MronRoe needs: 2*m*n + (m²+m)/2 random values.
 # The noise process generates dZ as N(0,1) white noise of this length,
 # which perform_step! unpacks into LevyAreaCoefficients.
 function StochasticDiffEqCore._z_prototype(alg::RKMilGeneral, rand_prototype, iip::Bool)
+    return StochasticDiffEqCore._z_prototype(alg, rand_prototype, iip, nothing)
+end
+
+function StochasticDiffEqCore._z_prototype(alg::RKMilGeneral, rand_prototype, iip::Bool, dt)
     rand_prototype isa Number && return rand_prototype
     m = length(rand_prototype)
-    # Determine truncation level
-    p = alg.p
-    if p === nothing
-        # Default: use automatic truncation for a reasonable dt
-        # This will be recomputed at solve time, but we need a size now.
-        # Use a conservative n that covers typical step sizes.
-        p = max(10, m)
-    end
-    n = p
-    n_coeffs = StochasticDiffEqLevyArea.norv(m, n, MronRoe())
+    n_coeffs = StochasticDiffEqLevyArea.norv(m, _levyarea_terms(alg, m, dt), MronRoe())
     rp2 = similar(rand_prototype, n_coeffs)
     rp2 .= false
     return rp2

--- a/lib/StochasticDiffEqMilstein/src/algorithms.jl
+++ b/lib/StochasticDiffEqMilstein/src/algorithms.jl
@@ -19,9 +19,20 @@ noise via iterated stochastic integrals (Levy area approximation).
   - `interpretation`: `SciMLBase.AlgorithmInterpretation.Ito` (default) or
     `SciMLBase.AlgorithmInterpretation.Stratonovich`
   - `ii_approx`: Iterated integral approximation method (default: `IILevyArea()`)
-  - `c`: Truncation parameter for Levy area computation (default: 1)
-  - `p`: Truncation level (default: `nothing` for automatic; set `true` with `dt` for manual)
-  - `dt`: Time step (used only when `p=true` for manual truncation)
+  - `c`: Constant in the Levy area accuracy target `ε = c dt^(3/2)` (default: 1)
+  - `p`: Number of Fourier terms retained in the Levy area series. `nothing` (the
+    default) picks it from the noise dimension and the solver's step size so that the
+    truncation error meets `ε`; pass an `Integer` to fix it instead.
+  - `dt`: Ignored, accepted for backwards compatibility.
+
+!!! note "`p = true`"
+
+    `p = true` together with `dt` used to select the truncation from
+    `floor(c dt^(-1)) + 1`. That is the rule for an order-1/2 Fourier expansion, while
+    the Levy area here is evaluated with the order-1 `MronRoe()` scheme, which reaches
+    the same accuracy with `O(dt^(-1/2))` terms — at `dt = 2^-12` the old rule asked
+    for 4097 terms where 12 suffice. `p = true` is now equivalent to `p = nothing`,
+    which applies the correct rule at solve time.
 
 ## When to Use
 
@@ -52,8 +63,7 @@ function RKMilGeneral(;
         interpretation = SciMLBase.AlgorithmInterpretation.Ito,
         ii_approx = IILevyArea(), c = 1, p = nothing, dt = nothing
     )
-    gamma = 1 // 1
-    p == true && (p = Int(floor(c * dt^(1 // 1 - 2 // 1 * gamma)) + 1))
+    p === true && (p = nothing)
     return RKMilGeneral{typeof(ii_approx), typeof(p)}(interpretation, ii_approx, c, p)
 end
 


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Fixes SciML/OrdinaryDiffEq.jl#4036 — the `NoncommutativeConvergence` test group grew past 51 GiB with no plateau, on a projected path to ~268 GiB, so no runner size could have made it pass. Full root-cause writeup is in [this comment](https://github.com/SciML/OrdinaryDiffEq.jl/issues/4036#issuecomment-5092155670); the short version follows.

## The bug

`RKMilGeneral(p = true, dt = h)` selected the Lévy area truncation as

```julia
p = Int(floor(c * dt^(1//1 - 2//1 * gamma)) + 1)    # = 1/h + 1
```

`errcoeff ∝ h` for every iterated-integral algorithm and the target is `ε = c·h^(γ+1/2)`, so `terms_needed = ceil((errcoeff/ε)^(1/convorder))` scales as `h^(-1/(2·convorder))`:

| alg | `convorder` | terms needed |
|---|---|---|
| `Fourier()`, `Milstein()` | `1//2` | `O(h⁻¹)` |
| `Wiktorsson()`, `MronRoe()` | `1//1` | `O(h^(-1/2))` |

That formula is the rule for an **order-1/2** expansion, but `perform_step!` evaluates the Lévy area with **`MronRoe()`**, which is order 1. At `h = 2^-12, m = 4` it asks for **4097** terms where `terms_needed(4, 2^-12, (2^-12)^(3/2), MronRoe(), MaxL2())` is **12**.

That used to be only wasted `randn` calls. Since 5a43bd21d the coefficients are drawn as the noise process' `dZ`, so `_z_prototype` sizes `dZ` at `norv(m, p, MronRoe()) = 2mp + (m²+m)/2` = 32786 Float64 **per step**, and every step of it lands in the saved noise history:

```
reference solve, dt = 2^-12, save_noise = true:
  nsteps = 2049, length(W.Z) = 2049, length(W.Z[1]) = 32786
  summarysize(sol.W) = 0.502 GiB
```

`analyticless_test_convergence(use_noise_grid = false)` pins that per trajectory (each `err_sol` holds a `NoiseWrapper` back to it), so `sim6` retained **+0.537 GiB of live, post-`GC.gc(true)` bytes per Monte-Carlo iteration** × 500 trajectories.

A second bug fell out of the same code: with `p = nothing` the size came from `p = max(10, m)` under a comment saying "This will be recomputed at solve time". It is not — `_unpack_dZ_to_coefficients` back-computes `n` from `length(dZ)`, so the automatic path was silently pinned at `n = 10` regardless of `dt`, and the documented accuracy target was never actually applied.

## The fix

Derive the truncation where both `m` and `dt` are known, instead of baking a number into the algorithm object.

- **`StochasticDiffEqCore`**: new `_z_prototype(alg, rand_prototype, iip, dt)` that defaults to the existing three-argument form, so this is additive — the `StochasticDiffEqWeak` (`PL1WM`, `W2Ito1`) and `DelayDiffEq` overrides are untouched and keep working. `dt` is passed at the noise-creation call sites in `_sde_init` and in `DelayDiffEq._create_sdde_noise`.
- **`StochasticDiffEqMilstein`**: `_levyarea_terms` computes the count from `MronRoe()`'s error bound and the same `ε = c·dt^(γ + 1/2)` that `get_iterated_I!` uses. An explicit `Integer` `p` is still honoured. It falls back to the old fixed count when `dt` is not a real number known up front — an automatically chosen initial step size (`dt = 0`) or a unitful time.
- **`RKMilGeneral(p = true, dt = …)`** now means `p = nothing`, i.e. the (now correct) automatic rule. `dt` is accepted and ignored. The docstring documents the change and why.

## Effect

`sim6` from `noncommutative_tests.jl` — same problem, same `dts`, same `test_dt_mil = 1/2^12`, 500 trajectories, `use_noise_grid = false`:

| truncation | `𝒪est[:final]` | wall time | peak RSS |
|---|---|---|---|
| 4097 (before) | — | ~50 min (extrapolated) | ~268 GiB (extrapolated) |
| 12 (after) | 0.947 / 0.928 / 0.929 (seeds 100/200/300) | 70–74 s | 1.95 GiB |

The measured order is unchanged and `@test abs(𝒪est[:final] - 1.0) < 0.2` still passes, so the extra 4085 terms bought no accuracy.

Full group, `ODEDIFFEQ_TEST_GROUP=NoncommutativeConvergence julia --project=. -e 'using Pkg; Pkg.test()'` (Julia 1.12.6, `JULIA_NUM_THREADS=1`):

```
Test Summary:              | Pass  Total     Time
Noncommutative Noise Tests |    7      7  3m38.3s
     Testing StochasticDiffEq tests passed
        Maximum resident set size (kbytes): 6186820      # 5.90 GiB, whole process
```

So the group now fits on an ordinary runner: this PR drops the `runner = [… "high-memory"]` pin (that label is carried by no runner in the fleet — SciML/OrdinaryDiffEq.jl#4030) and cuts the timeout from 240 to 60 minutes.

## Tests

New `RKMilGeneral dZ truncation sizing` testset in `lib/StochasticDiffEq/test/levy_areas.jl` (group `Interface3`) asserting that the `dZ` length implies exactly `terms_needed(m, dt, dt^(3/2), MronRoe(), MaxL2())` at two step sizes, that `p = true` no longer overrides it, and that an explicit `p` is still honoured.

Run locally on Julia 1.12.6, `JULIA_NUM_THREADS=1` — every group touching `RKMilGeneral`:

| group | result |
|---|---|
| `NoncommutativeConvergence` | `Noncommutative Noise Tests \| 7 7`, 3m38s, 5.90 GiB peak |
| `Interface3` (has `levy_areas.jl`) | `Stochastic iterated integrals \| 71 71` (66 before + the 5 new), group passed |
| `AlgConvergence` | passed |
| `AlgConvergence2` (commutative) | passed |
| `AlgConvergence3` (Stratonovich) | passed |
| `StochasticDiffEqMilstein` `Pkg.test()` | functional tests pass (`Module loads and constructors` 7/7, `RKMilGeneral diagonal vector noise (issue #3863)` 9/9); QA fails — see below |

`StochasticDiffEqMilstein`'s QA group reports `14 passed, 1 failed, 1 errored, 4 broken` (a JET failure and a `Public API documentation` error). **These are pre-existing on master, not from this PR** — a `master @ 0f84b10` worktree gives byte-for-byte the same tally, the same 15 JET issues, and the same `Public API documentation` error. None of the JET issues mention the new code; they are all in `_compute_II_from_S2` / `_compute_II_from_grid` / `perform_step!`, which this PR does not touch. Worth a separate look.

## Note for review

Two things I found but deliberately did not change here, to keep this reviewable:

1. `ii_approx` is not honoured on the non-diagonal path. `get_Jalg` resolves `IILevyArea()` via `optimal_algorithm`, but `_compute_iterated_I` hardcodes `MronRoe()` for both the `dZ` layout and the `levyarea` call, so `Jalg` only matters for the scalar/diagonal fallback. The sizing here matches what `perform_step!` actually does (MronRoe), which is the correct pairing; making `ii_approx` mean something for general noise is a separate change.
2. The truncation is now genuinely `O(dt^(-1/2))`, so a user solving with a very small fixed `dt` and `save_noise = true` will see the saved noise grow accordingly. That is the honest cost of keeping the coefficients in `dZ`, and it replaces silently under-resolving at `n = 10`; it is not a regression against the documented accuracy target.

Weak-convergence groups (`IIPWeakConvergence`, `OOPWeakConvergence`, …) fail for an unrelated reason — `test_convergence` retaining millions of full `RODESolution` objects — split out as SciML/OrdinaryDiffEq.jl#4037 and not addressed here.
