### PR TITLE
Wire embedding metadata through TKYY 6A-D and MikkawyEisa tableaus

### DIFF
--- a/lib/OrdinaryDiffEqExplicitTableaus/src/tableaus_order6.jl
+++ b/lib/OrdinaryDiffEqExplicitTableaus/src/tableaus_order6.jl
@@ -1352,7 +1352,12 @@ function TanakaKasugaYamashitaYazaki6D(::Type{T} = Float64, ::Type{T_time} = T) 
     α = map(T, α)
     c = map(T_time, c)
     αEEst = map(T, αEEst)
-    return (DiffEqBase.ExplicitRKTableau(A, c, α, 6, stability_size = 7.723403386984321))
+    return (
+        DiffEqBase.ExplicitRKTableau(
+            A, c, α, 6, adaptiveorder = 5, αEEst = αEEst,
+            stability_size = 7.723403386984321
+        )
+    )
 end
 
 """
@@ -1451,7 +1456,12 @@ function TanakaKasugaYamashitaYazaki6C(::Type{T} = Float64, ::Type{T_time} = T) 
     α = map(T, α)
     c = map(T_time, c)
     αEEst = map(T, αEEst)
-    return (DiffEqBase.ExplicitRKTableau(A, c, α, 6, stability_size = 9.727143096983585))
+    return (
+        DiffEqBase.ExplicitRKTableau(
+            A, c, α, 6, adaptiveorder = 5, αEEst = αEEst,
+            stability_size = 9.727143096983585
+        )
+    )
 end
 
 """
@@ -1535,7 +1545,12 @@ function TanakaKasugaYamashitaYazaki6B(::Type{T} = Float64, ::Type{T_time} = T) 
     α = map(T, α)
     c = map(T_time, c)
     αEEst = map(T, αEEst)
-    return (DiffEqBase.ExplicitRKTableau(A, c, α, 6, stability_size = 6.007860841958881))
+    return (
+        DiffEqBase.ExplicitRKTableau(
+            A, c, α, 6, adaptiveorder = 5, αEEst = αEEst,
+            stability_size = 6.007860841958881
+        )
+    )
 end
 
 """
@@ -1636,7 +1651,12 @@ function TanakaKasugaYamashitaYazaki6A(::Type{T} = Float64, ::Type{T_time} = T) 
     α = map(T, α)
     c = map(T_time, c)
     αEEst = map(T, αEEst)
-    return (DiffEqBase.ExplicitRKTableau(A, c, α, 6, stability_size = 4.730235594027788))
+    return (
+        DiffEqBase.ExplicitRKTableau(
+            A, c, α, 6, adaptiveorder = 5, αEEst = αEEst,
+            stability_size = 4.730235594027788
+        )
+    )
 end
 
 """
@@ -1700,7 +1720,12 @@ function MikkawyEisa(::Type{T} = Float64, ::Type{T_time} = T) where {T, T_time}
     α = map(T, α)
     c = map(T_time, c)
     αEEst = map(T, αEEst)
-    return (DiffEqBase.ExplicitRKTableau(A, c, α, 6, stability_size = 3.932606644665211))
+    return (
+        DiffEqBase.ExplicitRKTableau(
+            A, c, α, 6, adaptiveorder = 4, αEEst = αEEst,
+            stability_size = 3.932606644665211
+        )
+    )
 end
 
 """

--- a/lib/OrdinaryDiffEqExplicitTableaus/test/ode_tableau_convergence_tests.jl
+++ b/lib/OrdinaryDiffEqExplicitTableaus/test/ode_tableau_convergence_tests.jl
@@ -19,13 +19,39 @@ dts = 1 .// 2 .^ (8:-1:4)
 testTol = 0.3
 superduperbool = Vector{Bool}(undef, 2)
 
-for tab in [ET.Ralston4(Rational{BigInt}), ET.TsitourasPapakostas6(Rational{BigInt}), ET.DormandLockyerMcCorriganPrince6(Rational{BigInt})]
+for tab in [
+        ET.Ralston4(Rational{BigInt}),
+        ET.TsitourasPapakostas6(Rational{BigInt}),
+        ET.DormandLockyerMcCorriganPrince6(Rational{BigInt}),
+        ET.TanakaKasugaYamashitaYazaki6A(Rational{BigInt}),
+        ET.TanakaKasugaYamashitaYazaki6B(Rational{BigInt}),
+        ET.TanakaKasugaYamashitaYazaki6C(Rational{BigInt}),
+        ET.TanakaKasugaYamashitaYazaki6D(Rational{BigInt}),
+        ET.MikkawyEisa(Rational{BigInt}),
+    ]
     @test all(i -> residual_order_condition(tab, i, +, abs) < 10eps(1.0), 1:(tab.order))
     if tab.adaptiveorder != 0
+        @test !isempty(tab.αEEst)
         @test all(
             i -> residual_order_condition(tab, i, +, abs; embedded = true) < 10eps(1.0),
             tab.adaptiveorder
         )
+    end
+end
+
+# Regression for SciML/OrdinaryDiffEq.jl#3285: embedding weights must be wired through.
+let
+    for (tab, ao) in (
+            (ET.TanakaKasugaYamashitaYazaki6A(), 5),
+            (ET.TanakaKasugaYamashitaYazaki6B(), 5),
+            (ET.TanakaKasugaYamashitaYazaki6C(), 5),
+            (ET.TanakaKasugaYamashitaYazaki6D(), 5),
+            (ET.MikkawyEisa(), 4),
+        )
+        @test tab.order == 6
+        @test tab.adaptiveorder == ao
+        @test length(tab.αEEst) == tab.stages
+        @test !tab.fsal
     end
 end
 


### PR DESCRIPTION
## Summary
- Pass `αEEst` and `adaptiveorder` through `TanakaKasugaYamashitaYazaki6A`–`6D` (6(5)) and `MikkawyEisa` (6(4)); these constructors already built the embedding weights but dropped them on return (#3285).
- Leave `fsal=false` (TKYY coefficients are not classical FSAL; Mikkawy is documented as non-FSAL).
- Extend tableau residual/metadata tests so the embedding wiring cannot regress silently.

## Test plan
- [ ] `OrdinaryDiffEqExplicitTableaus` tableau convergence tests (new metadata asserts + embedded residual checks)
- [ ] Adaptive `ExplicitRK(tableau = …)` on the five tableaus no longer hits an empty `αEEst` BoundsError