### PR TITLE
Reuse nonlinear caches for ImplicitDiscreteSolve reinitialization

### DIFF
--- a/lib/ImplicitDiscreteSolve/Project.toml
+++ b/lib/ImplicitDiscreteSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "ImplicitDiscreteSolve"
 uuid = "3263718b-31ed-49cf-8a0f-35a466e8af96"
 authors = ["vyudu <vincent.duyuan@gmail.com>"]
-version = "2.1.4"
+version = "2.1.5"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
@@ -29,7 +29,7 @@ SciMLTesting = "2.1"
 CommonSolve = "0.2.6"
 Pkg = "1"
 Test = "1.10.0"
-NonlinearSolveBase = "2.31.0"
+NonlinearSolveBase = "2.40"
 OrdinaryDiffEqSDIRK = "2"
 SafeTestsets = "0.1.0"
 SciMLBase = "3.39"

--- a/lib/ImplicitDiscreteSolve/src/ImplicitDiscreteSolve.jl
+++ b/lib/ImplicitDiscreteSolve/src/ImplicitDiscreteSolve.jl
@@ -6,9 +6,10 @@ using SciMLBase: SciMLBase, ImplicitDiscreteProblem, NonlinearFunction,
 import SciMLBase: alg_order, isadaptive
 using NonlinearSolveBase: NonlinearSolveBase
 using NonlinearSolveFirstOrder: NewtonRaphson
-using CommonSolve: init, solve, step!
+using CommonSolve: init
 using DiffEqBase: DefaultInit
 import DiffEqBase: initialize!
+using SymbolicIndexingInterface: state_values
 using OrdinaryDiffEqCore: OrdinaryDiffEqCore, OrdinaryDiffEqAlgorithm,
     OrdinaryDiffEqMutableCache, AbstractController, AbstractControllerCache
 import OrdinaryDiffEqCore: alg_cache, get_fsalfirstlast, isfsal, perform_step!,

--- a/lib/ImplicitDiscreteSolve/src/cache.jl
+++ b/lib/ImplicitDiscreteSolve/src/cache.jl
@@ -4,12 +4,37 @@ struct ImplicitDiscreteState{uType, pType, tType}
     t::tType
 end
 
-mutable struct IDSolveCache{uType, cType, thetaType} <: OrdinaryDiffEqMutableCache
+mutable struct IDSolveStepObserver{T, V}
+    residualnormprev::T
+    Θks::V
+end
+
+function (observer::IDSolveStepObserver)(u, fu, iteration)
+    residualnorm = NonlinearSolveBase.L2_NORM(fu)
+    if iteration > 1
+        if observer.residualnormprev ≈ zero(observer.residualnormprev)
+            push!(observer.Θks, zero(eltype(observer.Θks)))
+        else
+            push!(observer.Θks, residualnorm / observer.residualnormprev)
+        end
+    end
+    observer.residualnormprev = residualnorm
+    return nothing
+end
+
+function reset!(observer::IDSolveStepObserver)
+    empty!(observer.Θks)
+    observer.residualnormprev = zero(observer.residualnormprev)
+    return nothing
+end
+
+mutable struct IDSolveCache{uType, cType, thetaType, observerType} <: OrdinaryDiffEqMutableCache
     u::uType
     uprev::uType
     z::uType
     nlcache::cType
     Θks::thetaType
+    observer::observerType
 end
 
 # u === nothing path: no state to evolve (e.g. MTK systems with only callbacks).
@@ -23,7 +48,9 @@ function alg_cache(
         dt, reltol, p, calck,
         ::Val{true}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    return IDSolveCache(nothing, nothing, nothing, nothing, uBottomEltypeNoUnits[])
+    return IDSolveCache(
+        nothing, nothing, nothing, nothing, uBottomEltypeNoUnits[], nothing
+    )
 end
 function alg_cache(
         alg::IDSolve, ::Nothing, rate_prototype, ::Type{uEltypeNoUnits},
@@ -31,7 +58,9 @@ function alg_cache(
         dt, reltol, p, calck,
         ::Val{false}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
-    return IDSolveCache(nothing, nothing, nothing, nothing, uBottomEltypeNoUnits[])
+    return IDSolveCache(
+        nothing, nothing, nothing, nothing, uBottomEltypeNoUnits[], nothing
+    )
 end
 
 function alg_cache(
@@ -54,8 +83,13 @@ function alg_cache(
     end
 
     nlcache = init(prob, alg.nlsolve)
+    Θks = uBottomEltypeNoUnits[]
+    residual_prototype = isnothing(f.resid_prototype) ? u : f.resid_prototype
+    observer = IDSolveStepObserver(
+        zero(NonlinearSolveBase.L2_NORM(residual_prototype)), Θks
+    )
 
-    return IDSolveCache(u, uprev, state.u, nlcache, uBottomEltypeNoUnits[])
+    return IDSolveCache(u, uprev, state.u, nlcache, Θks, observer)
 end
 
 isdiscretecache(cache::IDSolveCache) = true
@@ -80,9 +114,14 @@ function alg_cache(
     end
 
     nlcache = init(prob, alg.nlsolve)
+    Θks = uBottomEltypeNoUnits[]
+    residual_prototype = isnothing(f.resid_prototype) ? u : f.resid_prototype
+    observer = IDSolveStepObserver(
+        zero(NonlinearSolveBase.L2_NORM(residual_prototype)), Θks
+    )
 
     # FIXME Use IDSolveConstantCache?
-    return IDSolveCache(u, uprev, state.u, nlcache, uBottomEltypeNoUnits[])
+    return IDSolveCache(u, uprev, state.u, nlcache, Θks, observer)
 end
 
 get_fsalfirstlast(cache::IDSolveCache, rate_prototype) = (nothing, nothing)

--- a/lib/ImplicitDiscreteSolve/src/solve.jl
+++ b/lib/ImplicitDiscreteSolve/src/solve.jl
@@ -8,7 +8,7 @@ end
 
 function perform_step!(integrator, cache::IDSolveCache, repeat_step = false)
     (; alg, u, uprev, dt, t, tprev, f, p) = integrator
-    (; nlcache, Θks) = cache
+    (; nlcache, observer) = cache
 
     # initial guess
     if alg.extrapolant == :constant
@@ -19,58 +19,20 @@ function perform_step!(integrator, cache::IDSolveCache, repeat_step = false)
     state = ImplicitDiscreteState(cache.z, p, t + dt)
 
     # nonlinear solve step
-    SciMLBase.reinit!(nlcache, p = state)
-
-    # solve!(nlcache)
-    # The solve here is simply unrolled by hand to query the convergence rate estimates "manually" for now
-    if nlcache.retcode == ReturnCode.InitialFailure
-        integrator.force_stepfail = true
-        return
-    end
-
-    resize!(Θks, 0)
-    residualnormprev = zero(eltype(u))
-    while NonlinearSolveBase.not_terminated(nlcache)
-        step!(nlcache)
-        residualnorm = NonlinearSolveBase.L2_NORM(nlcache.fu)
-        if nlcache.nsteps > 1
-            # Θk = min(residualnorm/residualnormprev, incrementnorm/incrementnormprev)
-            Θk = residualnorm / residualnormprev
-            if residualnormprev ≈ 0.0 #|| incrementnormprev ≈ 0.0
-                push!(Θks, 0.0)
-            else
-                push!(Θks, Θk)
-            end
-            # if nlcache.parameters.enforce_monotonic_convergence && Θk ≥ 1.0
-            #     @debug "Newton-Raphson diverged. Aborting. ||r|| = $residualnorm" _group=:nlsolve
-            #     return false
-            # end
-        end
-        residualnormprev = residualnorm
-    end
-
-    # The solver might have set a different `retcode`
-    if nlcache.retcode == ReturnCode.Default
-        nlcache.retcode = ifelse(
-            nlcache.nsteps ≥ nlcache.maxiters, ReturnCode.MaxIters, ReturnCode.Success
-        )
-    end
-
-    NonlinearSolveBase.update_from_termination_cache!(nlcache.termination_cache, nlcache)
-
-    NonlinearSolveBase.update_trace!(
-        nlcache.trace, nlcache.nsteps, NonlinearSolveBase.get_u(nlcache),
-        NonlinearSolveBase.get_fu(nlcache), nothing, nothing, nothing;
-        last = Val(true)
-    )
-
-    if nlcache.retcode != ReturnCode.Success
+    SciMLBase.reinit!(nlcache, cache.z; p = state)
+    if !_solve_nonlinear!(nlcache, observer)
         integrator.force_stepfail = true
         return
     end
 
     # Accept step
-    return u .= nlcache.u
+    return u .= state_values(nlcache)
+end
+
+function _solve_nonlinear!(nlcache, observer)
+    reset!(observer)
+    retcode = NonlinearSolveBase.solve_cache!(nlcache; step_observer = observer)
+    return retcode == ReturnCode.Success
 end
 
 function initialize!(integrator, cache::IDSolveCache)
@@ -89,27 +51,13 @@ function _initialize_dae!(
             OverrideInit(atol), x
         )
     else
-        (; u, p, t, f) = integrator
-        initstate = ImplicitDiscreteState(u, p, t)
-
-        _f = if isinplace(f)
-            (resid, u_next, p) -> f(resid, u_next, p.u, p.p, p.t)
-        else
-            (u_next, p) -> f(u_next, p.u, p.p, p.t)
-        end
-
-        nlls = !isnothing(f.resid_prototype) &&
-            (length(f.resid_prototype) != length(integrator.u))
-        prob = if nlls
-            NonlinearLeastSquaresProblem{isinplace(f)}(
-                NonlinearFunction(_f; resid_prototype = f.resid_prototype), u, initstate
-            )
-        else
-            NonlinearProblem{isinplace(f)}(_f, u, initstate)
-        end
-        sol = solve(prob, integrator.alg.nlsolve)
-        if sol.retcode == ReturnCode.Success
-            integrator.u = sol
+        (; u, p, t) = integrator
+        (; z, nlcache, observer) = integrator.cache
+        z .= u
+        initstate = ImplicitDiscreteState(z, p, t)
+        SciMLBase.reinit!(nlcache, u; p = initstate)
+        if _solve_nonlinear!(nlcache, observer)
+            integrator.u .= state_values(nlcache)
         else
             integrator.sol = SciMLBase.solution_new_retcode(
                 integrator.sol, ReturnCode.InitialFailure

--- a/lib/ImplicitDiscreteSolve/test/qa/qa.jl
+++ b/lib/ImplicitDiscreteSolve/test/qa/qa.jl
@@ -11,9 +11,6 @@ run_qa(
                 # OrdinaryDiffEqCore controller-resolution internal (owner-internal,
                 # deliberately kept non-public in the make-public extension surface).
                 :_resolved_QT,
-                # NonlinearSolveBase solver internals (external, not public).
-                :get_fu, :get_u, :not_terminated,
-                :update_from_termination_cache!, :update_trace!,
                 # SciMLBase initialization-problem predicate (external, not public).
                 :has_initializeprob,
             ),

--- a/lib/ImplicitDiscreteSolve/test/runtests.jl
+++ b/lib/ImplicitDiscreteSolve/test/runtests.jl
@@ -80,6 +80,139 @@ if TEST_GROUP != "QA"
         end
     end
 
+    @testset "Reinitialize integrator" begin
+        function recurrence!(resid, u_next, u, p, t)
+            resid[1] = u_next[1] - u[1] - 1
+            return nothing
+        end
+
+        idprob = ImplicitDiscreteProblem(
+            recurrence!, [0.0], (0.0, 2.0), nothing; dt = 1.0
+        )
+        integ = init(idprob, IDSolve(); adaptive = false)
+        nlcache = integ.cache.nlcache
+        fresh = solve!(integ)
+        fresh_t = copy(fresh.t)
+        fresh_u = deepcopy(fresh.u)
+
+        reinit!(integ, [0.0]; t0 = 0.0, tf = 2.0)
+        @test integ.u == [1.0]
+        @test integ.cache.nlcache === nlcache
+        reused = solve!(integ)
+        @test reused.t == fresh_t
+        @test reused.u == fresh_u
+
+        integ = init(
+            idprob, IDSolve(); adaptive = false, save_start = false
+        )
+        fresh = solve!(integ)
+        fresh_t = copy(fresh.t)
+        fresh_u = deepcopy(fresh.u)
+        reinit!(integ, [0.0]; t0 = 0.0, tf = 2.0)
+        @test integ.u == [1.0]
+        reused = solve!(integ)
+        @test reused.t == fresh_t
+        @test reused.u == fresh_u
+
+        function redundant_recurrence!(resid, u_next, u, p, t)
+            step_residual = u_next[1] - u[1] - 1
+            resid[1] = step_residual
+            resid[2] = 2step_residual
+            return nothing
+        end
+
+        nllsprob = ImplicitDiscreteProblem(
+            ImplicitDiscreteFunction(
+                redundant_recurrence!; resid_prototype = zeros(2)
+            ),
+            [0.0], (0.0, 2.0), nothing; dt = 1.0
+        )
+        integ = init(nllsprob, IDSolve(); adaptive = false)
+        nlcache = integ.cache.nlcache
+        fresh = solve!(integ)
+        fresh_t = copy(fresh.t)
+        fresh_u = deepcopy(fresh.u)
+        reinit!(integ, [0.0]; t0 = 0.0, tf = 2.0)
+        @test integ.u == [1.0]
+        @test integ.cache.nlcache === nlcache
+        reused = solve!(integ)
+        @test reused.t == fresh_t
+        @test reused.u == fresh_u
+
+        inconsistent = [false]
+        function conditional_recurrence!(resid, u_next, u, p, t)
+            step_residual = u_next[1] - u[1] - 1
+            resid[1] = step_residual
+            resid[2] = p[1] ? step_residual + 1 : 2step_residual
+            return nothing
+        end
+
+        failureprob = ImplicitDiscreteProblem(
+            ImplicitDiscreteFunction(
+                conditional_recurrence!; resid_prototype = zeros(2)
+            ),
+            [0.0], (0.0, 1.0), inconsistent; dt = 1.0
+        )
+        integ = init(failureprob, IDSolve(); adaptive = false)
+        @test check_error(integ) == ReturnCode.Success
+        inconsistent[1] = true
+        reinit!(integ, [0.0]; t0 = 0.0, tf = 1.0)
+        @test check_error(integ) == ReturnCode.InitialFailure
+        inconsistent[1] = false
+        reinit!(integ, [0.0]; t0 = 0.0, tf = 1.0)
+        @test check_error(integ) == ReturnCode.Success
+        @test integ.u == [1.0]
+    end
+
+    @testset "Constant extrapolant resets nonlinear iterate" begin
+        first_guess = Ref(NaN)
+        recording = Ref(false)
+        function recording_recurrence!(resid, u_next, u, p, t)
+            if recording[] && eltype(u_next) === Float64 && isnan(first_guess[])
+                first_guess[] = u_next[1]
+            end
+            resid[1] = u_next[1] - u[1] - 1
+            return nothing
+        end
+
+        idprob = ImplicitDiscreteProblem(
+            recording_recurrence!, [0.0], (0.0, 2.0), nothing; dt = 1.0
+        )
+        integ = init(idprob, IDSolve(); adaptive = false)
+        accepted_u = copy(integ.u)
+        SciMLBase.reinit!(integ.cache.nlcache, [100.0])
+        recording[] = true
+        step!(integ)
+        @test first_guess[] == only(accepted_u)
+        @test integ.u == [2.0]
+    end
+
+    if VERSION >= v"1.11"
+        @testset "Cached operations do not allocate" begin
+            function nonlinear_recurrence!(resid, u_next, u, p, t)
+                resid[1] = u_next[1]^2 - u[1]^2 - 1
+                return nothing
+            end
+            function step_allocations!(integ)
+                return @allocated step!(integ)
+            end
+            function reinit_allocations!(integ, u0)
+                return @allocated reinit!(integ, u0; t0 = 0.0, tf = 100.0)
+            end
+
+            u0 = [1.0]
+            idprob = ImplicitDiscreteProblem(
+                nonlinear_recurrence!, u0, (0.0, 100.0), nothing; dt = 1.0
+            )
+            integ = init(idprob, IDSolve(); adaptive = false, save_on = false)
+
+            step_allocations!(integ)
+            @test step_allocations!(integ) == 0
+            reinit_allocations!(integ, u0)
+            @test reinit_allocations!(integ, u0) == 0
+        end
+    end
+
     @testset "Hard problem" begin
         function hard!(resid, u, u_prev, p, t)
             resid[1] = tanh((u[1] - 10t)^2) / 2

--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.11.0"
+version = "4.11.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
@@ -538,6 +538,20 @@ function SciMLBase.reinit!(
     integrator.t = t0
     integrator.tprev = t0
 
+    # Initialization changes the ImplicitDiscrete start state, so run it before
+    # save_start and preserve any InitialFailure instead of resetting it below.
+    implicit_discrete = integrator.sol.prob isa SciMLBase.ImplicitDiscreteProblem
+    if reinit_dae && implicit_discrete
+        if reinit_retcode
+            integrator.sol = SciMLBase.solution_new_retcode(
+                integrator.sol, ReturnCode.Default
+            )
+        end
+        SciMLBase.initialize_dae!(integrator)
+        update_uprev!(integrator)
+        u0 = integrator.u
+    end
+
     tType = typeof(integrator.t)
     tspan = (tType(t0), tType(tf))
     reinit_tstops!(
@@ -593,7 +607,7 @@ function SciMLBase.reinit!(
         auto_dt_reset!(integrator)
     end
 
-    if reinit_dae &&
+    if reinit_dae && !implicit_discrete &&
             (integrator.isdae || SciMLBase.has_initializeprob(integrator.sol.prob.f))
         SciMLBase.initialize_dae!(integrator)
         update_uprev!(integrator)
@@ -607,7 +621,7 @@ function SciMLBase.reinit!(
         initialize!(integrator, integrator.cache)
     end
 
-    if reinit_retcode
+    if reinit_retcode && !(reinit_dae && implicit_discrete)
         integrator.sol = SciMLBase.solution_new_retcode(integrator.sol, ReturnCode.Default)
     end
 


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this draft until reviewed by @ChrisRackauckas.

## Summary

- Replace ImplicitDiscreteSolve's hand-unrolled loop over private NonlinearSolve cache fields with the public, allocation-free `NonlinearSolveBase.solve_cache!` driver.
- Preserve the existing per-Newton residual-contraction history through a reusable step observer.
- Reuse the integrator's nonlinear cache during initial-condition solving and `reinit!`, including rectangular nonlinear least-squares problems.
- Pass the accepted constant extrapolant explicitly as the nonlinear initial guess so a rejected or externally modified iterate cannot leak into the next step.
- Run ImplicitDiscrete initialization before `save_start` during integrator reinitialization and preserve `InitialFailure` instead of resetting it afterward.

## Dependencies

This draft depends on [NonlinearSolve.jl #1100](https://github.com/SciML/NonlinearSolve.jl/pull/1100), specifically `NonlinearSolveBase.solve_cache!` in NonlinearSolveBase 2.40. The tested dependency head was `dca80d83c2d74483d1308c70f4315b69a9cbdf85`.

QA also exposed an independent SciMLTesting clean-master harness regression. It was bisected and fixed in [SciMLTesting.jl #38](https://github.com/SciML/SciMLTesting.jl/pull/38); both QA runs below used its exact head `0afa642162a91f8e4df88803690664ded5c52daf`. This is not a runtime dependency of the patch.

The related reusable homotopy-cache integration is [OrdinaryDiffEq.jl #3985](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3985). The final design/benchmark follow-up is also recorded on the merged controller PR [#3908](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3908).

## Root cause

The ImplicitDiscrete initialization added in #2624/#2626 only ran on initial integrator construction. Generic OrdinaryDiffEq `reinit!` saved the raw `u0` before the ImplicitDiscrete consistency solve, and its later retcode reset could erase an initialization failure.

ImplicitDiscreteSolve also rebuilt and solved a fresh `NonlinearProblem` during every initialization. Its time-step path reused a cache, but drove it by reading and mutating private NonlinearSolve fields and helpers. Reinitializing only the parameters left the previous nonlinear iterate in place instead of applying the documented constant extrapolant.

This patch keeps the native IDS Newton/Kantorovich controller rather than replacing it with an artificial per-step `HomotopyProblem`. It shares the new reusable NonlinearSolve cache-driving path with the homotopy solvers while retaining the substantially faster native recurrence solve measured below.

## Correctness and allocation coverage

The new tests cover:

- fresh solve versus `reinit!` + reused solve, with `save_start=true` and `false`;
- nonlinear-cache identity across reinitialization;
- rectangular nonlinear least-squares cache reuse;
- initialization failure and subsequent recovery;
- stale nonlinear iterates being replaced by the accepted constant extrapolant;
- exact zero steady-state allocations for cached `step!` and public integrator `reinit!` on Julia 1.11+.

A separate 20-sample warmed probe on Julia 1.12.6 produced:

- `step!`: first measurement-site warmup 144 B, then 0 B for all 19 samples;
- `reinit!` with a preallocated `u0`: first measurement-site warmup 144 B, then 0 B for all 19 samples;
- `solve!`: 80 B in every sample because it constructs/returns the solution wrapper.

The official regression asserts the two cache operations that are expected to be allocation-free; it does not disguise the solution-construction allocation.

## Performance comparison

Twenty warmed Julia 1.12.6 samples, using `AutoFiniteDiff` consistently and solving the same 50-step implicit recurrence:

| Path | Median time | Bytes | Residual calls | Endpoint |
|---|---:|---:|---:|---|
| fresh IDS | 0.1925435 ms | 8,896 | 565 | `(1.5531006208104776, 0.4090814367409633)` |
| cached IDS | 0.103924 ms | 192 | 561 | `(1.5531006208104776, 0.4090814367409633)` |
| one-shot Kantorovich | 3.3344115 ms | 901,104 | 2,244 | `(1.5531006208114124, 0.4090814367406754)` |
| cached Kantorovich | 0.280863 ms | 32 | 2,040 | `(1.5531006208114124, 0.4090814367406754)` |
| one-shot HomotopySweep | 3.339966 ms | 891,312 | 2,550 | `(1.5531006237647473, 0.4090814358834119)` |
| cached HomotopySweep | 0.294148 ms | 32 | 2,346 | `(1.5531006237647473, 0.4090814358834119)` |

Cache reuse makes IDS 1.85x faster and removes 8,704 B (97.84%) while preserving the endpoint exactly and using four fewer residual evaluations. Cached IDS is 2.70x faster than cached Kantorovich and 2.83x faster than cached HomotopySweep on this recurrence. Between the two homotopy methods, cached Kantorovich is 4.52% faster and uses 13.04% fewer residual calls than Sweep. The Kantorovich and Sweep endpoint deltas from IDS are approximately `(9.35e-13, -2.88e-13)` and `(2.95e-9, -8.58e-10)`, respectively.

These numbers support retaining the IDS-specific solve strategy; they are workload-specific rather than a general ranking of homotopy algorithms.

## Local validation

All commands ran from the exact upstream `master` base `fd8861edd500f8bba76a4f2a865e304d10881fe8` on Julia 1.12:

- `ODEDIFFEQ_TEST_GROUP=Core ... Pkg.test()` for ImplicitDiscreteSolve: 53/53 passed, including cached allocation 2/2, reinitialization 15/15, constant extrapolant 2/2, NLLS 3/3, null state 3/3, and initialization failure 3/3.
- `GROUP=Integrators_I ... Pkg.test()` at the repository root: all active checks passed, including reinitialization 31/31 and integrator interface 36/36. The two existing marked-broken checks remained marked broken.
- ImplicitDiscreteSolve QA against SciMLTesting #38: JET 1/1 and Aqua 20/20 passed.
- OrdinaryDiffEqCore QA against SciMLTesting #38: AllocCheck 1/1, JET 30 passed with one pre-existing marked-broken check, and Aqua 19/19 passed.
- Repository-wide Runic `--inplace` and `--check`: exit 0.
- `git diff --check`: exit 0.

No test was skipped, silenced, deleted, loosened, or converted to a warning.

## Process notes

The work followed the request to evaluate whether IDS should become a homotopy adapter, then narrowed the actual issue to reusable `init`/cache solving. It traced the initialization history, benchmarked fresh and cached IDS against both current homotopy solvers, added the required public cache-driver API upstream instead of depending on private NonlinearSolve internals, implemented the downstream reuse path, reproduced the QA failure on clean master, and validated the independently bisected SciMLTesting fix before publishing this draft.