### PR TITLE
NonlinearSolveAlg: do not freeze the Jacobian when adaptive = false

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -122,8 +122,11 @@ function initialize!(
             # Mirror the legacy do_newJW split: a fresh Jacobian is only needed when the
             # iteration failed or on first use, while a dt/gamma change merely requires
             # reassembling W = J - M/γdt from the stored J (jacobian2W! is O(nnz), a
-            # Jacobian evaluation is not).
-            new_jac = first_call || alg.always_new || nlsolver.status === Divergence
+            # Jacobian evaluation is not). Without adaptivity there is no error test to
+            # catch the step a stale Jacobian degrades and no way to pull it back, so
+            # `do_newJW` refuses to freeze `J` there and this must too.
+            new_jac = first_call || alg.always_new || nlsolver.status === Divergence ||
+                !integrator.opts.adaptive
             # `oftype`: `new_W_dt_cutoff` defaults to a `Rational`, and comparing a `Float64`
             # against one goes through the slow mixed-type path on every stage.
             new_w = new_jac ||

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_jacobian_reuse_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_jacobian_reuse_tests.jl
@@ -1,6 +1,6 @@
 using OrdinaryDiffEqBDF, OrdinaryDiffEqSDIRK, OrdinaryDiffEqRosenbrock
 using OrdinaryDiffEqNonlinearSolve
-using OrdinaryDiffEqNonlinearSolve: NonlinearSolveAlg
+using OrdinaryDiffEqNonlinearSolve: NonlinearSolveAlg, NLNewton
 using NonlinearSolve: NewtonRaphson, TrustRegion
 using ADTypes, LinearAlgebra, SciMLBase
 using Test
@@ -99,4 +99,18 @@ end
     sol_def = solve(prob, FBDF(nlsolve = nsa_tr))
     @test SciMLBase.successful_retcode(sol_def)
     @test norm(sol_def.u[end] .- refsol.u[end]) / norm(refsol.u[end]) < 1.0e-3
+end
+
+@testset "non-adaptive solves do not freeze the Jacobian" begin
+    # `do_newJW` returns `(true, true)` whenever `adaptive = false`: with a prescribed
+    # step sequence there is no error test to catch the step a stale Jacobian degrades
+    # and no way to pull it back. `NonlinearSolveAlg` has to make the same call —
+    # freezing `J` for the whole solve here would silently diverge from `NLNewton`.
+    fixedprob = ODEProblem(f, [1.0, 0.0, 0.0], (0.0, 1.0), [0.04, 3.0e7, 1.0e4])
+    for nl in (NLNewton(), nsa)
+        JAC_CALLS[] = 0
+        sol = solve(fixedprob, TRBDF2(nlsolve = nl); dt = 1.0e-4, adaptive = false)
+        @test SciMLBase.successful_retcode(sol)
+        @test JAC_CALLS[] >= sol.stats.naccept
+    end
 end


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

`do_newJW` refuses to reuse a Jacobian when the integrator is not adaptive:

```julia
!integrator.opts.adaptive && return true, true
```

With a prescribed step sequence there is no error test to catch the step a stale Jacobian degrades, and no way to pull it back once taken. `NonlinearSolveAlg`'s `initialize!` had no equivalent rule, so it took the `first_call || always_new || status === Divergence` path and reused the Jacobian built on the first step for the whole solve.

### Effect

ROBER, `dt = 1e-4`, `adaptive = false`, tspan `(0, 1)`:

| | njacs | nw | nf | error |
|---|---|---|---|---|
| NLNewton | 20002 | 20002 | 80013 | 2.834323e-12 |
| NSA before | **1** | 2 | 20010 | 3.223422e-12 |
| NSA after | 20001 | 20002 | 80013 | 2.834323e-12 |

One Jacobian evaluation for 10001 steps. After the change NSA matches NLNewton exactly.

### Scope

Gated on `!adaptive`, so it is a no-op for every adaptive solve. The four NSA test files are unchanged at 49/49 (`smooth_est` 10, `sparse` 10, `matrixfree` 14, `jacreuse` 15).

Other non-adaptive paths were checked, since this is the branch that changes: sparse KLU, matrix-free Krylov, mass-matrix DAE, fixed-dt FBDF and out-of-place. None regress, and several converge onto NLNewton's answer where they previously differed (sparse KLU `7.3173e-12 -> 6.8190e-12` = NLNewton's; mass-matrix DAE `3.2287e-12 -> 2.8325e-12` = NLNewton's). One moves the other way in absolute terms while matching NLNewton: fixed-dt FBDF `3.8150e-07 -> 4.8790e-07`, which is NLNewton's value exactly.

### Test

`nsa_jacobian_reuse_tests.jl` gains a non-adaptive case asserting `JAC_CALLS[] >= naccept` for both `NLNewton` and `NonlinearSolveAlg`. Verified it fails without the source change:

```
non-adaptive solves do not freeze the Jacobian: Test Failed
   Evaluated: 1 >= 10001
Test Summary:                                    | Pass  Fail  Total
jacreuse                                         |   14     1     15
```

Runic clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
