### PR TITLE
NonlinearSolveAlg: report the work actually performed

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -42,8 +42,17 @@ function initialize!(
 
     (; ustep, tstep, k, invγdt) = cache
     if SciMLBase.has_stats(integrator)
-        integrator.stats.nf += cache.cache.stats.nf
-        integrator.stats.njacs += cache.cache.stats.njacs
+        # The `reinit!` below evaluates the residual at the new `z` and *then* zeroes the
+        # inner cache's counters, so that evaluation is never visible in
+        # `cache.cache.stats.nf`. Left uncounted it loses one `f` call per stage.
+        integrator.stats.nf += cache.cache.stats.nf + 1
+        # Under `W` reuse the inner solver's "Jacobian" is `WReuseJac`, which copies the
+        # `W` assembled here rather than evaluating anything, so its `njacs` counts copies
+        # (it tracks `nw`, not Jacobian evaluations). `_update_nlsolvealg_W!` counts the
+        # real ones. Without reuse the inner solver owns the Jacobian and its count stands.
+        if cache.W === nothing
+            integrator.stats.njacs += cache.cache.stats.njacs
+        end
         integrator.stats.nsolve += cache.cache.stats.nsolve
     end
     if f isa DAEFunction
@@ -77,8 +86,17 @@ function initialize!(
     (; ustep, atmp, tstep, k, invγdt) = cache
 
     if SciMLBase.has_stats(integrator)
-        integrator.stats.nf += cache.cache.stats.nf
-        integrator.stats.njacs += cache.cache.stats.njacs
+        # The `reinit!` below evaluates the residual at the new `z` and *then* zeroes the
+        # inner cache's counters, so that evaluation is never visible in
+        # `cache.cache.stats.nf`. Left uncounted it loses one `f` call per stage.
+        integrator.stats.nf += cache.cache.stats.nf + 1
+        # Under `W` reuse the inner solver's "Jacobian" is `WReuseJac`, which copies the
+        # `W` assembled here rather than evaluating anything, so its `njacs` counts copies
+        # (it tracks `nw`, not Jacobian evaluations). `_update_nlsolvealg_W!` counts the
+        # real ones. Without reuse the inner solver owns the Jacobian and its count stands.
+        if cache.W === nothing
+            integrator.stats.njacs += cache.cache.stats.njacs
+        end
         integrator.stats.nsolve += cache.cache.stats.nsolve
     end
 
@@ -175,6 +193,9 @@ function _update_nlsolvealg_W!(nlcache, integrator, dtgamma, tstep, new_jac = tr
                 end
                 jacobian!(J, uf, uprev, du1, integrator, jac_config)
             end
+            # `calc_J!` is bypassed here, so this is the only place the reused-`W`
+            # path can record a Jacobian evaluation.
+            integrator.stats.njacs += 1
         end
         jacobian2W!(W, mass_matrix, dtgamma, J)
     end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_stats_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_stats_tests.jl
@@ -1,0 +1,59 @@
+using OrdinaryDiffEqBDF, OrdinaryDiffEqSDIRK
+using OrdinaryDiffEqNonlinearSolve
+using OrdinaryDiffEqNonlinearSolve: NonlinearSolveAlg, NLNewton
+using NonlinearSolve: NewtonRaphson
+using ADTypes, SciMLBase
+using Test
+
+const FCALLS = Ref(0)
+const JCALLS = Ref(0)
+
+function rober!(du, u, p, t)
+    FCALLS[] += 1
+    y₁, y₂, y₃ = u
+    k₁, k₂, k₃ = p
+    du[1] = -k₁ * y₁ + k₃ * y₂ * y₃
+    du[2] = k₁ * y₁ - k₂ * y₂^2 - k₃ * y₂ * y₃
+    du[3] = k₂ * y₂^2
+    return nothing
+end
+
+function rober_jac!(J, u, p, t)
+    JCALLS[] += 1
+    y₁, y₂, y₃ = u
+    k₁, k₂, k₃ = p
+    J[1, 1] = -k₁
+    J[1, 2] = k₃ * y₃
+    J[1, 3] = k₃ * y₂
+    J[2, 1] = k₁
+    J[2, 2] = -2k₂ * y₂ - k₃ * y₃
+    J[2, 3] = -k₃ * y₂
+    J[3, 1] = 0
+    J[3, 2] = 2k₂ * y₂
+    J[3, 3] = 0
+    return nothing
+end
+
+prob = ODEProblem(
+    ODEFunction(rober!; jac = rober_jac!), [1.0, 0.0, 0.0],
+    (0.0, 1.0e5), [0.04, 3.0e7, 1.0e4]
+)
+nsa = NonlinearSolveAlg(NewtonRaphson(; autodiff = AutoForwardDiff()))
+
+@testset "reported work matches the work actually performed" begin
+    # `stats` is what every work-precision comparison reads, so it has to count the same
+    # quantity for both nonlinear solvers. `NonlinearSolveAlg` used to forward the inner
+    # cache's counters verbatim: that missed the residual evaluation `reinit!` performs
+    # before zeroing them, and counted `WReuseJac` copies as Jacobian evaluations.
+    for A in (KenCarp4, TRBDF2, FBDF), nl in (NLNewton(), nsa)
+        FCALLS[] = 0
+        JCALLS[] = 0
+        sol = solve(prob, A(nlsolve = nl); reltol = 1.0e-8, abstol = 1.0e-10)
+        @test SciMLBase.successful_retcode(sol)
+        # Never claim more work than was done, and account for all but a handful of
+        # calls (cache construction is outside the per-stage accounting).
+        @test sol.stats.nf <= FCALLS[]
+        @test sol.stats.nf >= 0.99 * FCALLS[]
+        @test sol.stats.njacs == JCALLS[]
+    end
+end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
@@ -41,6 +41,7 @@ if TEST_GROUP ∉ ("QA", "ModelingToolkit")
     @time @safetestset "NonlinearSolveAlg Sparse Jacobian Tests" include("nsa_sparse_tests.jl")
     @time @safetestset "NonlinearSolveAlg Matrix-Free WOperator Tests" include("nsa_matrixfree_tests.jl")
     @time @safetestset "NonlinearSolveAlg Smoothed Error Estimate Tests" include("nsa_smooth_est_tests.jl")
+    @time @safetestset "NonlinearSolveAlg Stats Tests" include("nsa_stats_tests.jl")
 end
 
 # Run QA tests (JET, Aqua)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

`initialize!` forwarded the inner `NonlinearSolve` cache's counters verbatim. That gets both `nf` and `njacs` wrong, in opposite directions, so any work-precision comparison between `NonlinearSolveAlg` and `NLNewton` is reading a different quantity for each.

Measured against a counting `f`/`jac` on ROBER, `rtol=1e-8`, `atol=1e-10`:

| | `nf` reported / real | `njacs` reported / real |
|---|---|---|
| TRBDF2 NLNewton | 20050 / 20050 | 9 / 9 |
| TRBDF2 NSA | 21326 / 27833 (**−23.4%**) | 1598 / 34 (**+4600%**) |
| KenCarp4 NSA | 7009 / 9024 (−22.3%) | 205 / 59 (+247%) |
| FBDF NSA | 1317 / 2085 (−36.8%) | 115 / 10 (+1050%) |

### `nf`

`reinit!` evaluates the residual at the new `z` and *then* zeroes the inner counters, so that evaluation never appears in `cache.cache.stats.nf`. It is exactly one lost `f` call per stage, which the arithmetic confirms: FBDF misses 768 calls over 768 stages, TRBDF2 misses 6507 over 2 stages x ~3254 steps.

### `njacs`

Under `W` reuse the inner solver's "Jacobian" is `WReuseJac`, which copies the `W` assembled here rather than evaluating anything — its `njacs` equals `nw` in every configuration. Meanwhile the real evaluations in `_update_nlsolvealg_W!` were counted nowhere, because `calc_J!` (which does the counting for the legacy path) is bypassed there.

So: count `reinit!`'s evaluation, record the real Jacobian evaluation where it happens, and only take the inner cache's `njacs` when the inner solver actually owns the Jacobian.

### After

| case | `nf` err | `njacs` reported / real |
|---|---|---|
| analytic jac | −0.0% | 59 / 59 |
| AD jac | −0.0% | 59 / — |
| NLNewton (unchanged) | 0.0% | 53 / 53 |

`njacs` is exact; `nf` is within 0.1%. The few remaining calls are the inner cache's construction, which happens outside the per-stage accounting.

### Known remaining gap

Out-of-place improves from −50% to −25% but is still short. There `W === nothing`, the inner solver owns the Jacobian, and it does not count the `f` evaluations its AD performs — that is upstream in `NonlinearSolve` rather than here, so I did not paper over it from this side. Its `njacs` (1145) is genuine: without `W` reuse the inner solver really does build a Jacobian per iteration.

### Test

New `nsa_stats_tests.jl`, registered in `runtests.jl`, asserting for `KenCarp4`/`TRBDF2`/`FBDF` x `NLNewton`/`NonlinearSolveAlg` that `nf` never overstates, is within 1% of the real count, and `njacs` matches exactly. Verified it fails without the source change:

```
   Evaluated: 1598 == 34
   Evaluated: 1317 >= 2064.15
   Evaluated: 115 == 10
Test Summary:                                       | Pass  Fail  Total
stats                                               |   18     6     24
```

The six failures are exactly the `NonlinearSolveAlg` rows; the `NLNewton` rows pass either way, as they should. With the change 24/24, and the other four NSA files are unchanged (`smooth_est` 10, `sparse` 10, `matrixfree` 14, `jacreuse` 11). Runic clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
