### PR TITLE
Import the SciMLOperators names from their owner, and require SciMLBase 3.40

### DIFF
--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.9.0"
+version = "7.10.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -112,7 +112,7 @@ RespecializeParams = "1"
 ReverseDiff = "1"
 RecursiveArrayToolsRaggedArrays = "1"
 SafeTestsets = "0.1"
-SciMLBase = "3.39"
+SciMLBase = "3.40"
 SciMLLogging = "1.10.1, 2.0"
 SciMLOperators = "1.7.0"
 SciMLStructures = "1.5"

--- a/lib/DiffEqBase/src/DiffEqBase.jl
+++ b/lib/DiffEqBase/src/DiffEqBase.jl
@@ -43,6 +43,8 @@ using SciMLLogging: SciMLLogging, AbstractVerbositySpecifier, AbstractVerbosityP
     MessageLevel, @verbosity_specifier, verbosity_to_bool
 
 using SciMLOperators: AbstractSciMLOperator, AbstractSciMLScalarOperator, DEFAULT_UPDATE_FUNC
+using SciMLOperators: isconstant, islinear
+import SciMLOperators: update_coefficients, update_coefficients!
 
 using SciMLBase: @def, DEIntegrator, AbstractDEProblem,
     AbstractDiffEqInterpolation,
@@ -76,7 +78,7 @@ using SciMLBase: @def, DEIntegrator, AbstractDEProblem,
     AbstractODEIntegrator, AbstractSDEIntegrator, AbstractRODEIntegrator,
     AbstractDDEIntegrator, AbstractSDDEIntegrator,
     AbstractDAEIntegrator, unwrap_cache, has_reinit, reinit!,
-    postamble!, last_step_failed, islinear, has_stats,
+    postamble!, last_step_failed, has_stats,
     initialize_dae!, build_solution, solution_new_retcode,
     solution_new_tslocation, plot_indices, NonlinearAliasSpecifier,
     NullParameters, isinplace, AbstractADType, AbstractDiscretization,
@@ -87,13 +89,13 @@ using SciMLBase: @def, DEIntegrator, AbstractDEProblem,
     interp_summary, AbstractHistoryFunction, LinearInterpolation,
     ConstantInterpolation, HermiteInterpolation, SensitivityInterpolation,
     NoAD, @add_kwonly,
-    calculate_ensemble_errors, isconstant,
+    calculate_ensemble_errors,
     DEFAULT_REDUCTION, isautodifferentiable,
     isadaptive, isdiscrete, has_syms, AbstractAnalyticalSolution,
     wrap_sol
 
-import SciMLBase: solve, init, step!, solve!, __init, __solve, update_coefficients!,
-    update_coefficients, isadaptive, wrapfun_oop, wrapfun_iip,
+import SciMLBase: solve, init, step!, solve!, __init, __solve,
+    isadaptive, wrapfun_oop, wrapfun_iip,
     unwrap_fw, promote_tspan, set_u!, set_t!, set_ut!,
     extract_alg, checkkwargs, has_kwargs, _concrete_solve_adjoint, _concrete_solve_forward,
     eltypedual, get_updated_symbolic_problem, get_concrete_p, get_concrete_u0, promote_u0,

--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.11.1"
+version = "4.12.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -86,7 +86,7 @@ Random = "<0.0.1, 1"
 RecursiveArrayTools = "4.2.0"
 Reexport = "1.2.2"
 SafeTestsets = "0.1.0"
-SciMLBase = "3.39"
+SciMLBase = "3.40"
 SciMLLogging = "1.10.1, 2"
 SciMLOperators = "1.24.3"
 SciMLStructures = "1.7"

--- a/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
+++ b/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
@@ -94,7 +94,7 @@ using CommonSolve: solve
 
 import SciMLBase: AbstractNonlinearProblem, alg_order, LinearAliasSpecifier
 
-import SciMLBase: islinear
+import SciMLOperators: islinear
 # `calculate_residuals`/`calculate_residuals!` are unused here but re-exported for
 # dependent OrdinaryDiffEq.jl sublibraries that import them from this package.
 import DiffEqBase: timedepentdtmin, calculate_residuals, calculate_residuals!

--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "3.5.0"
+version = "3.6.0"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 
@@ -24,7 +24,7 @@ DifferentiationInterface = "0.7.18"
 LinearSolve = "5.1"
 ConstructionBase = "1.5.8"
 LinearAlgebra = "1.10"
-SciMLBase = "3.39"
+SciMLBase = "3.40"
 OrdinaryDiffEqCore = "4"
 OrdinaryDiffEqBDF = "2"
 OrdinaryDiffEqRosenbrock = "2"

--- a/lib/OrdinaryDiffEqDifferentiation/src/OrdinaryDiffEqDifferentiation.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/OrdinaryDiffEqDifferentiation.jl
@@ -21,8 +21,9 @@ import StaticArraysCore: StaticArray, StaticMatrix
 # SciMLBase (OrdinaryDiffEqCore/DiffEqBase only re-export them), so import them
 # from the owner to satisfy `all_explicit_imports_via_owners`.
 using SciMLBase: UJacobianWrapper, UDerivativeWrapper, _vec, _unwrap_val
-import SciMLBase: SciMLBase, @set, DEIntegrator, ODEFunction, SplitFunction, DAEFunction, islinear, remake, solve!, isconstant
-import SciMLOperators: SciMLOperators, update_coefficients, update_coefficients!, MatrixOperator, AbstractSciMLOperator
+import SciMLBase: SciMLBase, @set, DEIntegrator, ODEFunction, SplitFunction, DAEFunction, remake, solve!
+import SciMLOperators: SciMLOperators, update_coefficients, update_coefficients!, MatrixOperator, AbstractSciMLOperator,
+    islinear, isconstant
 import SparseMatrixColorings: ConstantColoringAlgorithm, GreedyColoringAlgorithm, ColoringProblem,
     ncolors, column_colors, coloring, sparsity_pattern
 import OrdinaryDiffEqCore

--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.5.4"
+version = "2.6.0"
 
 [deps]
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
@@ -67,7 +67,7 @@ OrdinaryDiffEqFIRK = "2"
 OrdinaryDiffEqRosenbrock = "2"
 OrdinaryDiffEqSDIRK = "2"
 Statistics = "1.10.0"
-SciMLBase = "3.39"
+SciMLBase = "3.40"
 OrdinaryDiffEqCore = "4.6"
 SimpleNonlinearSolve = "2.11.1"
 FastClosures = "0.3.2"

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
@@ -4,9 +4,10 @@ using ADTypes: ADTypes, AutoForwardDiff, AutoFiniteDiff
 
 import SciMLBase
 import SciMLBase: init, solve, remake
+using SciMLOperators: update_coefficients!
 using SciMLBase: DAEFunction, DEIntegrator, NonlinearFunction, NonlinearProblem,
     NonlinearLeastSquaresProblem, LinearProblem, ODEProblem, DAEProblem,
-    update_coefficients!, get_tmp_cache, ReturnCode,
+    get_tmp_cache, ReturnCode,
     AbstractNonlinearProblem, LinearAliasSpecifier,
     _vec, _reshape, postamble!, alg_order, isadaptive
 import DiffEqBase


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

`isconstant`, `islinear`, `update_coefficients`, and `update_coefficients!` are owned by SciMLOperators. Four sublibraries take them from SciMLBase's reexport, which SciMLBase 3.40 drops:

| Sublibrary | Names | Where |
| --- | --- | --- |
| DiffEqBase | `isconstant`, `islinear`, `update_coefficients`, `update_coefficients!` | `using SciMLBase:` list and `import SciMLBase:` list |
| OrdinaryDiffEqCore | `islinear` | `import SciMLBase: islinear` |
| OrdinaryDiffEqDifferentiation | `isconstant`, `islinear` | `import SciMLBase:` list |
| OrdinaryDiffEqNonlinearSolve | `update_coefficients!` | `using SciMLBase:` list |

All four already depend on SciMLOperators, so this only repoints the imports — no new dependencies. `update_coefficients`/`update_coefficients!` keep using `import` since they are extended with methods; the read-only traits move to `using`.

The SciMLBase floor moves to `3.40` in these four so their next releases are distinct from the versions capped at `3.39` in https://github.com/JuliaRegistries/General/pull/162635.

### Not changed

OrdinaryDiffEqRosenbrock, OrdinaryDiffEqBDF, OrdinaryDiffEqSDIRK and OrdinaryDiffEqExtrapolation reference `WOperator`, but they take it from OrdinaryDiffEqDifferentiation, which already imports it from SciMLOperators (`derivative_utils.jl:1`). No change needed.

### Verification

Loaded DiffEqBase 7.10.0 against SciMLBase 3.40 with the reexport removed:

```
DiffEqBase LOADED OK 7.10.0
```

All four edited files parse. Full behaviour is left to CI here — the monorepo test matrix is far wider than what I can run locally.

Corresponding SciMLBase change: https://github.com/SciML/SciMLBase.jl/pull/1476

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFVmGLPUsWbRgkLJckxUGy
