### PR TITLE
Correct seven subpackage versions to the next sequential release

### DIFF
--- a/lib/DiffEqDevTools/Project.toml
+++ b/lib/DiffEqDevTools/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqDevTools"
 uuid = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "3.1.6"
+version = "3.1.4"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/OrdinaryDiffEqLowStorageRK/Project.toml
+++ b/lib/OrdinaryDiffEqLowStorageRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqLowStorageRK"
 uuid = "b0944070-b475-4768-8dec-fb6eb410534d"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "3.2.4"
+version = "3.2.2"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/OrdinaryDiffEqRosenbrock/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrock/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqRosenbrock"
 uuid = "43230ef6-c299-4910-a778-202eb28ce4ce"
-version = "2.6.2"
+version = "2.6.1"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 
 [deps]

--- a/lib/OrdinaryDiffEqSDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqSDIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSDIRK"
 uuid = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.8.3"
+version = "2.8.2"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/lib/OrdinaryDiffEqSSPRK/Project.toml
+++ b/lib/OrdinaryDiffEqSSPRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSSPRK"
 uuid = "669c94d9-1f4b-4b64-b377-1aa079aa2388"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.3"
+version = "2.2.1"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqTsit5/Project.toml
+++ b/lib/OrdinaryDiffEqTsit5/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqTsit5"
 uuid = "b1df2697-797e-41e3-8120-5422d3b24e4a"
-version = "2.1.3"
+version = "2.1.1"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 
 [deps]

--- a/lib/OrdinaryDiffEqVerner/Project.toml
+++ b/lib/OrdinaryDiffEqVerner/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqVerner"
 uuid = "79d7bb75-1356-48c1-b8c0-6832512096c2"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.3"
+version = "2.2.1"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Seven subpackages carry a version on `master` that jumps over one or more unregistered versions. AutoMerge rejects these under the [sequential version number guideline](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/), so none of them can currently register. This lowers each to the patch successor of its latest registered version.

| Package | master | corrected | registered (live) |
| --- | --- | --- | --- |
| DiffEqDevTools | 3.1.6 | **3.1.4** | 3.1.3 |
| OrdinaryDiffEqLowStorageRK | 3.2.4 | **3.2.2** | 3.2.1 |
| OrdinaryDiffEqRosenbrock | 2.6.2 | **2.6.1** | 2.6.0 |
| OrdinaryDiffEqSDIRK | 2.8.3 | **2.8.2** | 2.8.1 |
| OrdinaryDiffEqSSPRK | 2.2.3 | **2.2.1** | 2.2.0 |
| OrdinaryDiffEqTsit5 | 2.1.3 | **2.1.1** | 2.1.0 |
| OrdinaryDiffEqVerner | 2.2.3 | **2.2.1** | 2.2.0 |

Only the `version = ` line of each `Project.toml` changes — 7 files, 7 lines.

### Why these numbers

"Registered (live)" is the highest **non-yanked** version in `Versions.toml`. Worth noting for DiffEqDevTools: `4.0.0` **is** registered but yanked, so the highest live release is `3.1.3`, not `4.0.0`. (`OrdinaryDiffEqCore 5.0.0` is likewise yanked, which is why master continues the 4.x line.)

The intervening versions were never released, so collapsing them loses no published history.

### No compat bound is invalidated

Lowering a version can make a sibling `[compat]` bound unsatisfiable. I checked every in-repo bound on all seven: all are major-level (`"2"`, `"3"`, `"2, 3"`) except `OrdinaryDiffEqBDF`'s `OrdinaryDiffEqSDIRK = "2.5"`, which `2.8.2` still satisfies. No bound needs to move in this PR.

### Not included

`OrdinaryDiffEqCore` (master 4.12.0, live 4.8.0) and `DiffEqBase` (master 7.10.0, live 7.7.0) are also skips, but are **deliberately excluded**. Nine libs pin `OrdinaryDiffEqCore = "4.10"`, so renumbering Core down to 4.9.0 would make them uninstallable. Those two are instead being filled in sequentially — 4.8.1 / 4.9.0 / 4.10.0 and DiffEqBase 7.8.0 are open in General now.