### PR TITLE
Drop the high-memory label from WeakConvergence3

### DIFF
--- a/lib/StochasticDiffEqWeak/test/test_groups.toml
+++ b/lib/StochasticDiffEqWeak/test/test_groups.toml
@@ -23,7 +23,7 @@ local_only = true
 
 [WeakConvergence3]
 versions = ["1"]
-runner = ["self-hosted", "Linux", "X64", "high-memory"]
+runner = ["self-hosted", "Linux", "X64"]
 timeout = 300
 local_only = true
 


### PR DESCRIPTION
> **Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

`WeakConvergence3` (`srk_weak_final_non_diagonal.jl`) is pinned to a `high-memory` runner label that **no runner in the SciML fleet carries**, so the job is never scheduled — it sits queued for 24 h, is expired by GitHub, and holds the whole Sublibrary CI run open behind it (https://github.com/SciML/OrdinaryDiffEq.jl/issues/4030).

The label is not needed. This group's studies pass a reducing `output_func` to `EnsembleProblem` and an `expected_value` to `test_convergence`:

```julia
ensemble_prob = EnsembleProblem(prob;
    output_func = (sol, ctx) -> (h2(sol.u[end][1]), false), prob_func = prob_func)
```

so each trajectory contributes **8 bytes** to the retained result rather than a whole solution object — measured at exactly 8.0 B/trajectory. It is a *slow* group, not a memory-hungry one.

## Measured

Run to completion on an 8 vCPU box, `GROUP=WeakConvergence3`, `JULIA_NUM_THREADS=8`:

```
peak RSS 2.56 GiB
wall     1:26:23
         Testing StochasticDiffEqWeak tests passed
```

2.56 GiB fits the standard self-hosted pool with room to spare, so point it there. The 300-minute timeout is left alone — at 86 minutes the group genuinely is slow, and that is the real reason it is expensive.

## Scope

Only this group. The other four `high-memory` groups in this file are being measured separately and are **not** touched here — three of them did not finish inside the two-hour budget I first gave them, so I have no completed figure for those yet and will not unpin on a projection. I have already been wrong once about which groups a memory fix rescues (`SROCKC2WeakConvergence` turned out unaffected by the `test_convergence` retention fix in https://github.com/SciML/OrdinaryDiffEq.jl/pull/4056), so these are going one at a time on completed runs only.

---

### Links

- Blocked-CI issue: https://github.com/SciML/OrdinaryDiffEq.jl/issues/4030
- Memory survey: https://github.com/SciML/OrdinaryDiffEq.jl/issues/4036#issuecomment-5092118693
- Companion PR reducing the genuinely-large groups: https://github.com/SciML/OrdinaryDiffEq.jl/pull/4056

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WW2jGeoWZVZu7AiscUNSz
