### PR TITLE
Filter callable tstops at init like array tstops

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/solve.jl
+++ b/lib/OrdinaryDiffEqCore/src/solve.jl
@@ -843,9 +843,19 @@ Base.@constprop :aggressive function _ode_init(
     end
 
     if !(_tstops_cache isa AbstractArray || _tstops_cache isa Tuple || _tstops_cache isa Number)
+        # Match initialize_tstops / reinit_tstops!: drop endpoints so a callable
+        # that returns tspan[1] cannot zero dt via the SDE init modify_dt_for_tstops!
+        # path (SciML/OrdinaryDiffEq.jl#3165).
+        t0, tf = prob.tspan
+        tdir = sign(tf - t0)
+        tdir_t0 = tdir * t0
+        tdir_tf = tdir * tf
         tstops = _tstops_cache(parameter_values(integrator), prob.tspan)
         for tstop in tstops
-            add_tstop!(integrator, tstop)
+            tdir_t = tdir * tstop
+            if tdir_t0 < tdir_t < tdir_tf
+                add_tstop!(integrator, tstop)
+            end
         end
     end
 

--- a/lib/StochasticDiffEq/test/callable_tstops_tests.jl
+++ b/lib/StochasticDiffEq/test/callable_tstops_tests.jl
@@ -200,4 +200,43 @@ using SDEProblemLibrary: prob_sde_linear
             @test 3.0 ∈ sol.t
         end
     end
+
+    # SciML/OrdinaryDiffEq.jl#3165 / StochasticDiffEq.jl#679:
+    # callable returning tspan[1] must not zero dt at SDE init.
+    @testset "Callable tstops including tspan[1] (#3165)" begin
+        sde_f(u, p, t) = -0.1 * u
+        sde_g(u, p, t) = 0.01 * u
+        sprob = SDEProblem(sde_f, sde_g, [1.0], (0.0, 3.0))
+        tstops_callable = (p, tspan) -> [tspan[1], 1.0, 2.0]
+
+        sol_sde = solve(sprob, SOSRI(); tstops = tstops_callable)
+        @test sol_sde.retcode == ReturnCode.Success
+        @test 1.0 ∈ sol_sde.t
+        @test 2.0 ∈ sol_sde.t
+        @test sol_sde.t[end] == 3.0
+
+        sprob_kw = remake(sprob; kwargs = (; tstops = tstops_callable))
+        sol_remake = solve(sprob_kw, SOSRI())
+        @test sol_remake.retcode == ReturnCode.Success
+        @test 1.0 ∈ sol_remake.t
+        @test 2.0 ∈ sol_remake.t
+
+        # Array path already filtered endpoints; keep as control.
+        sol_arr = solve(sprob, SOSRI(); tstops = [0.0, 1.0, 2.0])
+        @test sol_arr.retcode == ReturnCode.Success
+        @test 1.0 ∈ sol_arr.t
+        @test 2.0 ∈ sol_arr.t
+
+        sol_em = solve(sprob, EM(); dt = 0.05, tstops = tstops_callable)
+        @test sol_em.retcode == ReturnCode.Success
+        @test 1.0 ∈ sol_em.t
+        @test 2.0 ∈ sol_em.t
+
+        # Callable may also name tf; endpoint is already on the heap.
+        tstops_with_tf = (p, tspan) -> [tspan[1], 1.5, tspan[2]]
+        sol_tf = solve(sprob, SRIW1(); tstops = tstops_with_tf)
+        @test sol_tf.retcode == ReturnCode.Success
+        @test 1.5 ∈ sol_tf.t
+        @test sol_tf.t[end] == 3.0
+    end
 end


### PR DESCRIPTION
## Summary
- Callable `tstops` evaluated at init were pushed with `add_tstop!` without the open-interval filter used by `initialize_tstops` / `reinit_tstops!`.
- For SDEs, init then calls `modify_dt_for_tstops!`; a stop at `tspan[1]` zeros `dt` and adaptive solves return `DtLessThanMin` (#3165 / StochasticDiffEq#679).
- Drop callable endpoints with the same `tdir_t0 < tdir_t < tdir_tf` rule, and add regression coverage in `callable_tstops_tests.jl`.

## Test plan
- [ ] `lib/StochasticDiffEq/test/callable_tstops_tests.jl` (new `#3165` cases)
- [ ] MWE: callable `[tspan[1], 1.0, 2.0]` with `SOSRI()` returns `Success` and hits interior stops
- [ ] Same via `remake(...; kwargs = (; tstops = ...))`
- [ ] Array `tstops = [0.0, 1.0, 2.0]` control still succeeds
- [ ] Existing callable tstops tests remain green