### PR TITLE
Develop local sources in Julia 1.10 root tests

### DIFF
--- a/test/Integrators_I/step_limiter_test.jl
+++ b/test/Integrators_I/step_limiter_test.jl
@@ -12,6 +12,13 @@ using OrdinaryDiffEqExtrapolation
 using OrdinaryDiffEqFIRK: AdaptiveRadau, RadauIIA9, RadauIIA5, RadauIIA3
 using LinearAlgebra
 
+@testset "Tests use local monorepo sources" begin
+    repo = normpath(joinpath(@__DIR__, "..", ".."))
+    @test pkgdir(OrdinaryDiffEqCore) == joinpath(repo, "lib", "OrdinaryDiffEqCore")
+    @test pkgdir(OrdinaryDiffEqLowOrderRK) == joinpath(repo, "lib", "OrdinaryDiffEqLowOrderRK")
+    @test pkgdir(OrdinaryDiffEqSSPRK) == joinpath(repo, "lib", "OrdinaryDiffEqSSPRK")
+end
+
 # define the counting variable
 const STEP_LIMITER_VAR = Ref(0)
 # define the step_limiter! function which just counts the number of step_limiter calls

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -279,6 +279,9 @@ end
             Pkg.test(base_group, julia_args = ["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version = false, allow_reresolve = true)
         end
     else
+        # Julia 1.10 does not resolve root [sources], so develop local sublibraries explicitly.
+        develop_sources!(dirname(@__DIR__))
+
         # Root-package group dispatch. `run_tests` owns the All / Interface /
         # Integrators / Regression / QA / functional-group routing that the old
         # hand-written `if GROUP == ...` ladder expressed. The group bodies


### PR DESCRIPTION
> Ignore this draft until reviewed by @ChrisRackauckas.

Depends on #4066. This branch intentionally contains only the test-harness and regression-test changes; it does not duplicate the compatibility-floor changes from #4066.

## Summary

- Call SciMLTesting's public `develop_sources!` helper before root-package group dispatch so Julia 1.10 tests the monorepo's local sublibraries. The helper is a no-op on Julia 1.11 and later, where `[sources]` is native.
- Assert that the limiter integration test loads OrdinaryDiffEqCore, OrdinaryDiffEqLowOrderRK, and OrdinaryDiffEqSSPRK from this checkout.

## Problem

Julia 1.10 ignores the root project's `[sources]` section when `Pkg.test()` creates its temporary environment. A clean `GROUP=Integrators_I Pkg.test()` at `fd3f95bb99` therefore selected registered OrdinaryDiffEqCore 4.11.0, OrdinaryDiffEqLowOrderRK 2.2.1, and OrdinaryDiffEqSSPRK 2.2.0 instead of the local Core 4.12.0, LowOrderRK 2.2.2, and SSPRK 2.2.3. The Step Limiter test then reported 170 passes, 2 failures, and 1 error.

The hosted Julia 1.10 jobs for #3835 and #4003 passed because the reusable workflow separately developed in-repo sources before testing. The package's direct test harness should establish the same coherent source graph itself.

This is a test-environment issue, not a regression in the recent stage-limiter trait. The immediate parent of #4003 also fails with registered siblings. Older checkouts are not stable bisect endpoints against today's moving registry: the pre-#3835 checkout fails all 129 old constructor-level limiter assertions because newer registered siblings call those callbacks twice. Commit `fe90a44dd8` is relevant only as the structural introduction of the root `[sources]` assumption that Julia 1.10 cannot honor natively.

## Local verification

- Julia 1.10.11, `GROUP=Integrators_I`, on #4066 plus this focused diff:
  - Step Limiter Tests: 254 passed / 254 total
  - Discontinuity Detection Tests: 28 passed / 28 total
  - `Testing OrdinaryDiffEq tests passed`
- Julia 1.12.6, `GROUP=Integrators_I`, on #4066 plus this focused diff:
  - Step Limiter Tests: 254 passed / 254 total
  - Discontinuity Detection Tests: 28 passed / 28 total
  - `Testing OrdinaryDiffEq tests passed`
- Runic passes both changed files.
- `git diff --check` passes.

A repository-wide Runic check identifies only the pre-existing `test/Integrators_I/disco_tests.jl` formatting failure handled independently by #4064.
