### PR TITLE
Initialize the DISCO checkpoint from the time value

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/solve.jl
+++ b/lib/OrdinaryDiffEqCore/src/solve.jl
@@ -760,7 +760,7 @@ Base.@constprop :aggressive function _ode_init(
     controller_cache = setup_controller_cache(_alg, cache, controller, EEstT, disco_probs)
 
     is_disco_step = false
-    disco_checkpoint = zero(tType)
+    disco_checkpoint = zero(t)
     # Seed the initial EEst on the controller cache (was previously
     # `integrator.EEst = oneunit(EEstT)`).
     set_EEst!(controller_cache, EEst)

--- a/test/Downstream/dynamicquantities_measurements.jl
+++ b/test/Downstream/dynamicquantities_measurements.jl
@@ -10,7 +10,11 @@ using Test
     f(u, p, t) = u / (1u"s")
     prob = ODEProblem(f, u0, tspan)
 
-    sol = solve(prob, Tsit5(); abstol = 1.0e-9, reltol = 1.0e-9)
+    integrator = init(prob, Tsit5(); abstol = 1.0e-9, reltol = 1.0e-9)
+    @test integrator.disco_checkpoint == zero(first(tspan))
+    @test typeof(integrator.disco_checkpoint) == typeof(first(tspan))
+
+    sol = solve!(integrator)
 
     @test sol.u[end] isa typeof(u0)
     @test eltype(sol.u) == typeof(u0)


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- initialize `disco_checkpoint` with `zero(t)` instead of `zero(tType)`
- preserve runtime dimensions for time representations whose type alone does not encode them
- strengthen the existing DynamicQuantities + Measurements downstream regression to inspect the initialized checkpoint and complete through `solve!`

## Root cause

The DISCO optimization added `disco_checkpoint = zero(tType)`. DynamicQuantities deliberately rejects `zero(::Type{<:Quantity})` when dimensions are runtime data, so ODE initialization failed before the first step. The initial time value already carries those dimensions, and `zero(t)` produces the correctly typed additive identity.

A controlled parent/child test with an otherwise identical dependency graph passed 4/4 at `c538565b25` and failed during initialization at `408a7a30fe0`; `git bisect` identifies `408a7a30fe0` (`disco optimizations`) as the first bad commit. The failure is present with DynamicQuantities 1.12.2 and 1.13.0, so it is not a 1.13-only behavior change.

## CI prerequisite

#4066 is the current resolver prerequisite for testing this branch against registry SciMLBase 3.39.1. The code change itself is independent; the official Downstream validation below used a test-only stack of #4066 plus this commit.

## Validation

- Julia 1.12, DynamicQuantities 1.12.2 + Measurements 2.14.1: focused test 6/6
- Julia 1.12, DynamicQuantities 1.13.0 + Measurements 2.14.1: focused test 6/6
- Julia 1.10 LTS, DynamicQuantities 1.13.0 + Measurements 2.14.1, local DiffEqBase/Core/Tsit5 stack: focused test 6/6
- Julia 1.12 official `GROUP=Downstream` on #4066 + this commit: Time derivative 202/202, DynamicQuantities + Measurements 6/6, `Pkg.test` passed in 1879.4 seconds
- Runic check passes on both changed files
- whole-repository Runic reports only the three pre-existing DISCO formatting files addressed by #4064; neither changed file appears in that diff
- `git diff --check` passes