### PR TITLE
Test FunctionMap keyword compatibility

### DIFF
--- a/lib/OrdinaryDiffEqFunctionMap/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/src/algorithms.jl
@@ -17,15 +17,16 @@ FunctionMap{scale_by_time}() where {scale_by_time} = FunctionMap{scale_by_time, 
     trivial_limiter!
 )
 function FunctionMap(; scale_by_time = false, step_limiter = trivial_limiter!, kwargs...)
+    kwargs_nt = values(kwargs)
     old_kw = Symbol("step_limiter!")
-    if haskey(kwargs, old_kw)
+    if haskey(kwargs_nt, old_kw)
         if step_limiter === trivial_limiter!
-            step_limiter = get(kwargs, old_kw, trivial_limiter!)
+            step_limiter = get(kwargs_nt, old_kw, trivial_limiter!)
         end
     end
-    unsupported_kwargs = filter(!=(old_kw), keys(kwargs))
-    if !isempty(unsupported_kwargs)
-        throw(ArgumentError("Unsupported keyword argument(s): $(unsupported_kwargs)"))
+    extra_kwargs = Base.structdiff(kwargs_nt, NamedTuple{(old_kw,)})
+    if !isempty(extra_kwargs)
+        throw(ArgumentError("Unsupported keyword argument(s): $(keys(extra_kwargs))"))
     end
 
     return FunctionMap{scale_by_time, typeof(step_limiter)}(step_limiter)

--- a/lib/OrdinaryDiffEqFunctionMap/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/src/algorithms.jl
@@ -17,16 +17,15 @@ FunctionMap{scale_by_time}() where {scale_by_time} = FunctionMap{scale_by_time, 
     trivial_limiter!
 )
 function FunctionMap(; scale_by_time = false, step_limiter = trivial_limiter!, kwargs...)
-    kwargs_nt = values(kwargs)
     old_kw = Symbol("step_limiter!")
-    if haskey(kwargs_nt, old_kw)
+    if haskey(kwargs, old_kw)
         if step_limiter === trivial_limiter!
-            step_limiter = get(kwargs_nt, old_kw, trivial_limiter!)
+            step_limiter = get(kwargs, old_kw, trivial_limiter!)
         end
     end
-    extra_kwargs = Base.structdiff(kwargs_nt, NamedTuple{(old_kw,)})
-    if !isempty(extra_kwargs)
-        throw(ArgumentError("Unsupported keyword argument(s): $(keys(extra_kwargs))"))
+    unsupported_kwargs = filter(!=(old_kw), keys(kwargs))
+    if !isempty(unsupported_kwargs)
+        throw(ArgumentError("Unsupported keyword argument(s): $(unsupported_kwargs)"))
     end
 
     return FunctionMap{scale_by_time, typeof(step_limiter)}(step_limiter)

--- a/lib/OrdinaryDiffEqFunctionMap/test/discrete_algorithm_test.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/test/discrete_algorithm_test.jl
@@ -63,3 +63,17 @@ end
 
     @test sol3.u == [[0, 0], [1, 1], [2, 3], [3, 6], [4, 10], [5, 15]]
 end
+
+@testset "FunctionMap keyword validation" begin
+    current_limiter!(u, integrator, p, t) = nothing
+    legacy_limiter!(u, integrator, p, t) = nothing
+
+    @test FunctionMap(step_limiter = current_limiter!).step_limiter! === current_limiter!
+    @test FunctionMap(; step_limiter! = legacy_limiter!).step_limiter! === legacy_limiter!
+    @test_throws ArgumentError("Unsupported keyword argument(s): (:unsupported,)") FunctionMap(
+        unsupported = true
+    )
+    @test_throws ArgumentError(
+        "Unsupported keyword argument(s): (:unsupported, :also_unsupported)"
+    ) FunctionMap(unsupported = true, also_unsupported = true)
+end

--- a/lib/OrdinaryDiffEqFunctionMap/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/test/qa/qa.jl
@@ -12,9 +12,14 @@ run_qa(
             # OrdinaryDiffEqCore owner-internal no-op limiter (deliberately not public).
             ignore = (:trivial_limiter!,),
         ),
-        # SciMLBase-owned default-solve sentinels; non-public in SciMLBase.
         all_qualified_accesses_are_public = (;
-            ignore = (:DISCRETE_INPLACE_DEFAULT, :DISCRETE_OUTOFPLACE_DEFAULT),
+            ignore = (
+                # SciMLBase-owned default-solve sentinels; non-public in SciMLBase.
+                :DISCRETE_INPLACE_DEFAULT,
+                :DISCRETE_OUTOFPLACE_DEFAULT,
+                # Preserves the statically known NamedTuple type after field removal.
+                :structdiff,
+            ),
         ),
     ),
 )


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- retain `Base.structdiff` in the FunctionMap compatibility constructor, as requested in review
- narrowly allow that qualified access in FunctionMap QA because it preserves the statically known `NamedTuple` type after field removal
- add regression coverage for the current `step_limiter` keyword, the legacy `step_limiter!` compatibility path, and exact errors for one or multiple unsupported keywords

There is no production-source change relative to current `master`; this PR adds regression tests and the focused ExplicitImports exception for the reviewed implementation.

## Why the exception is narrow

`Base.structdiff` is deliberately used here to remove `step_limiter!` while retaining a statically known `NamedTuple` type. The QA allow-list is scoped to `:structdiff` in `OrdinaryDiffEqFunctionMap` and records that type-stability requirement.

## Validation

All commands were run locally on Julia 1.12 with a workspace-local depot.

- post-rebase focused constructor regressions: 4/4 passed
- official `OrdinaryDiffEqFunctionMap_Core` on the validation-only #4066 dependency stack: `DiscreteProblem Defaults` 21/21 and `Discrete Algorithm Tests` 18/18; package tests passed
- post-rebase official `OrdinaryDiffEqFunctionMap_QA` on the same stack: AllocCheck 2/2, JET 1/1, Aqua/ExplicitImports 19/19; package tests passed
- Runic on both changed files: exit 0
- whole-repository Runic on this exact change plus the independent formatting-only #4064 prerequisite: exit 0
- `git diff --check`: passed

Clean `master` currently cannot resolve the official group before reaching FunctionMap because the local NonlinearSolve subpackage requires SciMLBase 3.40 while the root project still caps it at 3.39. That independent dependency-floor correction is #4066 and was applied only in a disposable validation worktree; it is absent from this two-file PR.