### PR TITLE
Keep OrdinaryDiffEqDefault precompile helpers local

### DIFF
--- a/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
+++ b/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
@@ -6,7 +6,6 @@ using OrdinaryDiffEqVerner: Vern7
 using OrdinaryDiffEqTsit5: Tsit5
 using OrdinaryDiffEqRosenbrock: Rosenbrock23, Rodas5P
 using OrdinaryDiffEqBDF: FBDF, DFBDF
-import OrdinaryDiffEqCore
 
 import OrdinaryDiffEqCore: is_mass_matrix_alg, default_autoswitch, isdefaultalg
 import ADTypes: AutoFiniteDiff
@@ -20,11 +19,31 @@ using SciMLBase: SciMLBase, ODEProblem, DAEProblem, solve
 
 include("default_alg.jl")
 
+function _lorenz!(du, u, p, t)
+    du[1] = 10.0(u[2] - u[1])
+    du[2] = u[1] * (28.0 - u[3]) - u[2]
+    return du[3] = u[1] * u[2] - (8 / 3) * u[3]
+end
+
+function _lorenz_p!(du, u, p, t)
+    du[1] = p.σ * (u[2] - u[1])
+    du[2] = u[1] * (p.ρ - u[3]) - u[2]
+    return du[3] = u[1] * u[2] - p.β * u[3]
+end
+
+const _lorenz_p_params = (σ = 10.0, ρ = 28.0, β = 8 / 3)
+
+function _lorenz_pref!(du, u, p, t)
+    du[1] = p[1] * (u[2] - u[1])
+    du[2] = u[1] * (p[2] - u[3]) - u[2]
+    return du[3] = u[1] * u[2] - p[3] * u[3]
+end
+
+const _lorenz_pref_params = [10.0, 28.0, 8 / 3]
+
 import PrecompileTools
 import Preferences
 PrecompileTools.@compile_workload begin
-    lorenz = OrdinaryDiffEqCore.lorenz
-    lorenz_oop = OrdinaryDiffEqCore.lorenz_oop
     solver_list = []
     prob_list = []
 
@@ -45,22 +64,22 @@ PrecompileTools.@compile_workload begin
     end
 
     if Preferences.@load_preference("PrecompileDefaultSpecialize", true)
-        push!(prob_list, ODEProblem(lorenz, [1.0; 0.0; 0.0], (0.0, 1.0)))
-        push!(prob_list, ODEProblem(lorenz, [1.0; 0.0; 0.0], (0.0, 1.0), Float64[]))
+        push!(prob_list, ODEProblem(_lorenz!, [1.0; 0.0; 0.0], (0.0, 1.0)))
+        push!(prob_list, ODEProblem(_lorenz!, [1.0; 0.0; 0.0], (0.0, 1.0), Float64[]))
     end
 
     if Preferences.@load_preference("PrecompileAutoSpecialize", false)
         push!(
             prob_list,
             ODEProblem{true, SciMLBase.AutoSpecialize}(
-                lorenz, [1.0; 0.0; 0.0],
+                _lorenz!, [1.0; 0.0; 0.0],
                 (0.0, 1.0)
             )
         )
         push!(
             prob_list,
             ODEProblem{true, SciMLBase.AutoSpecialize}(
-                lorenz, [1.0; 0.0; 0.0],
+                _lorenz!, [1.0; 0.0; 0.0],
                 (0.0, 1.0), Float64[]
             )
         )
@@ -74,16 +93,16 @@ PrecompileTools.@compile_workload begin
     if Preferences.@load_preference("PrecompileAutoDePSpecialize", true)
         push!(
             depspecialize_prob_list,
-            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
-                OrdinaryDiffEqCore.lorenz_p, [1.0; 0.0; 0.0],
-                (0.0, 1.0), OrdinaryDiffEqCore.lorenz_p_params
+            ODEProblem{true, SciMLBase.AutoDePSpecialize}(
+                _lorenz_p!, [1.0; 0.0; 0.0],
+                (0.0, 1.0), _lorenz_p_params
             )
         )
         push!(
             depspecialize_prob_list,
-            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
-                OrdinaryDiffEqCore.lorenz_pref, [1.0; 0.0; 0.0],
-                (0.0, 1.0), OrdinaryDiffEqCore.lorenz_pref_params
+            ODEProblem{true, SciMLBase.AutoDePSpecialize}(
+                _lorenz_pref!, [1.0; 0.0; 0.0],
+                (0.0, 1.0), _lorenz_pref_params
             )
         )
         append!(prob_list, depspecialize_prob_list)
@@ -93,14 +112,14 @@ PrecompileTools.@compile_workload begin
         push!(
             prob_list,
             ODEProblem{true, SciMLBase.FunctionWrapperSpecialize}(
-                lorenz, [1.0; 0.0; 0.0],
+                _lorenz!, [1.0; 0.0; 0.0],
                 (0.0, 1.0)
             )
         )
         push!(
             prob_list,
             ODEProblem{true, SciMLBase.FunctionWrapperSpecialize}(
-                lorenz, [1.0; 0.0; 0.0],
+                _lorenz!, [1.0; 0.0; 0.0],
                 (0.0, 1.0), Float64[]
             )
         )
@@ -109,12 +128,14 @@ PrecompileTools.@compile_workload begin
     if Preferences.@load_preference("PrecompileNoSpecialize", false)
         push!(
             prob_list,
-            ODEProblem{true, SciMLBase.NoSpecialize}(lorenz, [1.0; 0.0; 0.0], (0.0, 1.0))
+            ODEProblem{true, SciMLBase.NoSpecialize}(
+                _lorenz!, [1.0; 0.0; 0.0], (0.0, 1.0)
+            )
         )
         push!(
             prob_list,
             ODEProblem{true, SciMLBase.NoSpecialize}(
-                lorenz, [1.0; 0.0; 0.0], (0.0, 1.0),
+                _lorenz!, [1.0; 0.0; 0.0], (0.0, 1.0),
                 Float64[]
             )
         )

--- a/lib/OrdinaryDiffEqDefault/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqDefault/test/qa/qa.jl
@@ -50,12 +50,6 @@ without_local_project_sources(OrdinaryDiffEqDefault) do
                 # stale because of the unanalyzable enum submodule above.
                 ignore = (:Tsit5, :Vern7, :Rosenbrock23, :Rodas5P, :FBDF),
             ),
-            all_qualified_accesses_are_public = (;
-                # `lorenz`/`lorenz_oop` are OrdinaryDiffEqCore precompile-workload
-                # test problems (defined in `precompilation_setup.jl`), deliberately
-                # not part of its public extension surface.
-                ignore = (:lorenz, :lorenz_oop, :lorenz_p, :lorenz_p_params),
-            ),
         ),
         api_docs_kwargs = (;
             rendered = false,


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- define the small Lorenz precompile workloads locally in `OrdinaryDiffEqDefault`
- use `SciMLBase.AutoDePSpecialize` through its public owner
- remove the dead `OrdinaryDiffEqCore.lorenz_oop` access
- remove the ExplicitImports exception for four private Core workload names

The earlier version/floor commits were dropped during the rebase because current master already contains the required `OrdinaryDiffEqDefault` 2.4.2 release and `OrdinaryDiffEqCore` 4.11 floor.

## Root cause

`OrdinaryDiffEqDefault` reached into private workload fixtures defined by `OrdinaryDiffEqCore`. The QA exception covered the original four names, but commit `5d640b89a756fd0c81e86f2a09b91862a85be555` added `lorenz_pref` and `lorenz_pref_params` without extending the exception. Its parent `f06fd803209efb1fae0f5130c70574546f1bd7bc` has no unignored private accesses; the commit has exactly those two.

Adding another exception would preserve the private dependency. The workload RHS functions are tiny and package-specific, so this copies them locally and lets the public-access QA run without a Lorenz allow-list.

## Validation

Rebased onto current upstream master `a7080c6f6d992edee79fa40450e0bd6eb0b8f735`.

- clean baseline, `GROUP=OrdinaryDiffEqDefault_QA`: JET 1/1; Aqua 18 passed and 1 errored on `lorenz_pref` / `lorenz_pref_params`
- patched, `GROUP=OrdinaryDiffEqDefault_QA`: JET 1/1; Aqua 19/19
- patched, `GROUP=OrdinaryDiffEqDefault_Core`: Default Solver Tests 46/46
- Runic: both changed Julia files pass

## Follow-up audit

Other solver sublibraries have their own explicit exceptions for the same Core workload fixtures. They are independent packages and are intentionally left for separate focused cleanup PRs.
