### PR TITLE
Keep callback controller resets opt-in

### DIFF
--- a/lib/DiffEqBase/test/downstream/callback_detection.jl
+++ b/lib/DiffEqBase/test/downstream/callback_detection.jl
@@ -58,6 +58,23 @@ using OrdinaryDiffEq, SciMLBase
     @test record == [2, 2, 1, 2, 2, 1, 2, 2]
 end
 
+@testset "Discontinuity detection is opt-in" begin
+    prob = ODEProblem((u, p, t) -> u, 1.0, (0.0, 2.0))
+
+    function solve_with_callback(maybe_discontinuity)
+        callback = ContinuousCallback(
+            (u, t, integrator) -> t - 0.5,
+            integrator -> nothing;
+            maybe_discontinuity
+        )
+        return solve(prob, Tsit5(); callback)
+    end
+
+    sol_default = solve_with_callback(false)
+    sol_discontinuity_candidate = solve_with_callback(true)
+    @test sol_default.t == sol_discontinuity_candidate.t
+end
+
 @testset "Successive same event detection" begin
     @testset "affect_integrator: affect_integrator" for affect_integrator in [false, true]
         @testset "tdir: $tdir" for tdir in [1, -1]

--- a/lib/OrdinaryDiffEqCore/src/disco.jl
+++ b/lib/OrdinaryDiffEqCore/src/disco.jl
@@ -19,6 +19,13 @@ get_disco_probs(cache::AbstractControllerCache) = cache.controller.basic.disco_p
 get_disco_probs(cache::DummyControllerCache) = cache.disco_probs
 get_disco_probs(cache::CompositeControllerCache) = get_disco_probs(first(cache.caches))
 
+_discontinuity_detection_enabled(cache::AbstractControllerCache) =
+    cache.controller.basic.discontinuity_detection
+_discontinuity_detection_enabled(cache::DummyControllerCache) =
+    cache.discontinuity_detection
+_discontinuity_detection_enabled(cache::CompositeControllerCache) =
+    _discontinuity_detection_enabled(first(cache.caches))
+
 function find_discontinuity(integrator)
     cb = integrator.opts.callback
     dt = integrator.dt

--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
@@ -789,7 +789,8 @@ function handle_callbacks!(integrator)
                 idx,
                 continuous_callbacks
             )
-            if _fired_cb_maybe_discontinuity(idx, continuous_callbacks)
+            if _discontinuity_detection_enabled(integrator.controller_cache) &&
+                    _fired_cb_maybe_discontinuity(idx, continuous_callbacks)
                 reinit_controller!(integrator, integrator.controller_cache)
             end
         else


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- Gate callback-triggered controller reinitialization on the controller's `discontinuity_detection` option.
- Preserve `maybe_discontinuity = true` behavior when discontinuity detection is explicitly enabled.
- Add a regression test proving that `maybe_discontinuity` does not perturb the time grid under the default controller.

## Root cause

Commit `a95e473561c939f01eaa4f22a609ef975d31ed4a` added an unconditional controller reset after a continuous callback whose `maybe_discontinuity` flag is true. That flag defaults to true, while controller discontinuity detection defaults to false. The reset therefore changed PI-controller history and post-event step sizes even when the feature was not enabled, which changed the ordering of near-simultaneous roots in `callback_detection.jl`.

The callback-order regression was reproduced twice on clean upstream `e5489faa50878b5c7921c1a33cef189b2bb02f72`. An automated bisect found `a95e473561c939f01eaa4f22a609ef975d31ed4a` as the first bad commit; its first-parent predecessor `268bbb0c46` passed the minimal reproducer.

## Validation

On rebased commit `db5244977f4efd0f45f0bb5c0c08ab48cae565c0`:

- Exact downstream `callback_detection.jl`: 21/21 assertions passed (4 callback-order, 1 opt-in regression, 16 repeated-event assertions).
- Existing `Integrators_I/disco_tests.jl` in a disposable environment using the branch's local packages: 28/28 passed.
- `git diff --check upstream/master...HEAD`: passed.
- Runic was applied to every changed range and left the patch unchanged.

The full official `GROUP=Integrators_I Pkg.test()` was also run on this patch and reported `Testing OrdinaryDiffEq tests passed` (including DISCO 28/28 and Step Limiter 251/251) after temporarily adding the public-owner `SciMLOperators: MatrixOperator` imports needed to get past an independent clean-master test import regression. Those validation-only imports were removed before commit and are not part of this PR.

The whole-tree Runic check still reports pre-existing formatting differences in `lib/OrdinaryDiffEqCore/src/disco.jl`, `lib/OrdinaryDiffEqCore/src/controllers.jl`, and `test/Integrators_I/disco_tests.jl`; this PR does not include that unrelated formatting churn.