### PR TITLE
Import MatrixOperator from SciMLOperators in integrator tests

### DIFF
--- a/test/Integrators_I/ode_event_tests.jl
+++ b/test/Integrators_I/ode_event_tests.jl
@@ -3,6 +3,7 @@ using OrdinaryDiffEq,
     SparseArrays,
     LinearAlgebra
 using OrdinaryDiffEqLinear, OrdinaryDiffEqLowOrderRK, OrdinaryDiffEqRosenbrock
+using SciMLOperators: MatrixOperator
 
 f = function (u, p, t)
     return -u + sin(-t)

--- a/test/Integrators_I/step_limiter_test.jl
+++ b/test/Integrators_I/step_limiter_test.jl
@@ -11,6 +11,7 @@ using OrdinaryDiffEqAdamsBashforthMoulton
 using OrdinaryDiffEqExtrapolation
 using OrdinaryDiffEqFIRK: AdaptiveRadau, RadauIIA9, RadauIIA5, RadauIIA3
 using LinearAlgebra
+using SciMLOperators: MatrixOperator
 
 # define the counting variable
 const STEP_LIMITER_VAR = Ref(0)


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- Import `MatrixOperator` directly from its public owner, SciMLOperators, in the Events test.
- Do the same in the Step Limiter test, including its ExponentialRK coverage.
- Keep the production API and dependency compatibility unchanged; SciMLOperators is already a root test extra and target.

## Investigation

These isolated test files currently receive `MatrixOperator` indirectly through SciMLBase's former `@reexport using SciMLOperators`.

- SciMLBase `7b806c50` (v3.40.0) still makes `MatrixOperator` visible after `using SciMLBase`.
- Its immediate child `b9c3507a` removes the SciMLOperators reexport, so the name is no longer visible through SciMLBase.
- SciMLOperators itself reports `MatrixOperator` public and exported, has its constructor docstring, and renders it in `docs/src/premade_operators.md`.

This is therefore an owner-import cleanup and forward-stack runtime fix. It is not a failure with the currently registered stack: master itself first hits the independent SciMLBase floor conflict tracked by #4066, and master plus #4066 resolves SciMLBase 3.39.1, where both test files still pass through the old reexport.

With the owner-clean local SciMLBase 3.40.1 source stack, the unmodified Events test errors with `UndefVarError: MatrixOperator not defined`. The direct imports remove that dependency on a transitive binding.

## Local validation

- Full repository: `Runic --check .` — passed.
- Owner-clean SciMLBase 3.40.1 validation stack (current master + exact #4066 compatibility patch + #4075 callback fix, with only this PR's two imports uncommitted):
  - Official `Integrators_I` harness, Events: 57/57 passed.
  - Step Limiter file in the `Pkg.test`-generated environment:
    - main limiter tests: 149/149
    - solve-level limiter tests: 3/3
    - ExponentialRK limiter tests: 16/16
    - deprecated-field tests: 3/3
    - stage-limiter trait tests: 80/80
- Registered SciMLBase 3.39.1 validation:
  - Events: 57/57
  - official Step Limiter safe testset: 251/251

The #4066 and #4075 commits were used only in disposable validation worktrees and are absent from this branch.
