### PR TITLE
Align NLStep TRBDF2 parity test estimator

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/nlstep_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/nlstep_tests.jl
@@ -87,8 +87,10 @@ sol2 = solve(prob2, FBDF(autodiff = AutoFiniteDiff(), nlsolve = nlalg));
 # the number of saved points even when every component is close.
 @test maximum_saved_trajectory_delta(sol1, sol2) < 5.0e-4
 
-sol1 = solve(prob, TRBDF2(autodiff = AutoFiniteDiff(), nlsolve = nlalg));
-sol2 = solve(prob2, TRBDF2(autodiff = AutoFiniteDiff(), nlsolve = nlalg));
+# NLStep cannot supply the full-state W solve used by the smoothed estimate, so
+# compare both nonlinear-solve paths with the raw estimator.
+sol1 = solve(prob, TRBDF2(autodiff = AutoFiniteDiff(), nlsolve = nlalg, smooth_est = false));
+sol2 = solve(prob2, TRBDF2(autodiff = AutoFiniteDiff(), nlsolve = nlalg, smooth_est = false));
 
 @test sol1.t != sol2.t
 @test sol1 != sol2


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- compare the standard and `nlstep = true` TRBDF2 paths with `smooth_est = false`
- keep the existing `2e-4` saved-trajectory threshold unchanged
- leave solver behavior unchanged; this only restores the intended parity-test semantics

## Cause

The smoothed-estimator change in #3823 lets the full-state `NonlinearSolveAlg` path reuse its W solve. The reduced MTK NLStep problem intentionally cannot provide that full-state solve and falls back to the raw estimator. The parity test therefore compares two different error-estimation strategies rather than only the two nonlinear-solve paths.

An exact diagnostic gave a maximum saved-trajectory delta of `3.052191084731426e-4` with the default mixed estimators and `1.2863503533355747e-4` when both paths use the raw estimator. The latter satisfies the existing threshold without weakening it. Smoothed-error behavior remains covered separately by `nsa_smooth_est_tests.jl`.

## Local verification

On an untouched current-master checkout at `a7080c6f6d`:

- `GROUP=OrdinaryDiffEqNonlinearSolve_ModelingToolkit julia +1.12 --project -e 'using Pkg; Pkg.test()'` — fails with `0.0003052191084731426 < 0.0002`

On the rebased branch at `3f802179a8`:

- the same official group passes: NLStep 23 pass / 2 existing broken, preconditioners 18/18, DAE initialization 21/21
- Runic passes on the changed file
- `git diff --check` passes

