### PR TITLE
Release DelayDiffEq 6.1.1 and OrdinaryDiffEqDefault 2.4.2 with correct OrdinaryDiffEqCore floors

### DIFF
--- a/lib/DelayDiffEq/Project.toml
+++ b/lib/DelayDiffEq/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.1.0"
+version = "6.1.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -73,7 +73,7 @@ LinearAlgebra = "1"
 LinearSolve = "5.1"
 Logging = "1"
 OrdinaryDiffEqBDF = "2"
-OrdinaryDiffEqCore = "4"
+OrdinaryDiffEqCore = "4.8.1"
 OrdinaryDiffEqDefault = "2"
 OrdinaryDiffEqDifferentiation = "3"
 OrdinaryDiffEqFeagin = "2"

--- a/lib/OrdinaryDiffEqDefault/Project.toml
+++ b/lib/OrdinaryDiffEqDefault/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqDefault"
 uuid = "50262376-6c5a-4cf5-baba-aaf4f84d72d7"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.4.1"
+version = "2.4.2"
 
 [deps]
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
@@ -55,7 +55,7 @@ PrecompileTools = "1.2.1, 1.3"
 EnumX = "1.0.4"
 LinearAlgebra = "1.10"
 SciMLBase = "3.39"
-OrdinaryDiffEqCore = "4.8"
+OrdinaryDiffEqCore = "4.8.1"
 SparseArrays = "1.10"
 Preferences = "1.5.0"
 StaticArrays = "1.9.18"


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

Metadata-only. Fixes two independent registry breakages; the source in this repo is already correct.

## 1. DelayDiffEq 6.1.0 is broken against every OrdinaryDiffEqCore ≥ 4.8.1

#3835 reworked limiters as solve-level options, taking `DEOptions` from 21 type params / 41 fields to 23 / 43 (`stage_limiter!`, `step_limiter!`). It updated `lib/DelayDiffEq/src/solve.jl` in the same commit, so the monorepo stayed self-consistent — monorepo CI builds with `path =` deps and never sees the mismatch.

What it missed: bumping DelayDiffEq's version and its `OrdinaryDiffEqCore` floor. DelayDiffEq 6.1.0 was registered from `56ffb5267` (2026-07-23 15:22), three hours *before* #3835, and declares `OrdinaryDiffEqCore = "4"`. So a plain `Pkg.add("DelayDiffEq")` resolves 6.1.0 + 4.11.0 and every DDE solve throws:

```
ERROR: MethodError: no method matching (OrdinaryDiffEqCore.DEOptions{...})(...)
  @ DelayDiffEq ~/.julia/packages/DelayDiffEq/wWvEW/src/solve.jl:341
```

The "closest candidate" Julia prints is the *older* 46-arg shim kept for DelayDiffEq ≤5.x. No shim exists for the intermediate 41-arg layout that 6.0.0–6.1.0 uses.

Layout boundary, checked against registry tree hashes:

| | `DEOptions` |
|---|---|
| OrdinaryDiffEqCore 4.0.0 – 4.8.0 | 21 params / 41 fields |
| OrdinaryDiffEqCore 4.8.1 – 4.11.0 | 23 params / 43 fields |
| DelayDiffEq 6.0.0 – 6.1.0 (all registered 6.x) | constructs with 21 params / 41 args |
| DelayDiffEq on master | 23 params / 43 args ✓ |

→ version 6.1.1, `OrdinaryDiffEqCore = "4.8.1"`.

## 2. OrdinaryDiffEqDefault 2.4.1 has an off-by-one floor

It declares `OrdinaryDiffEqCore = "4.8"` but references `OrdinaryDiffEqCore.AutoDePSpecialize`, added in #3692 and first present in **4.8.1**. Against 4.8.0 it fails to precompile:

```
ERROR: LoadError: UndefVarError: `AutoDePSpecialize` not defined in `OrdinaryDiffEqCore`
```

This is what made a DelayDiffEq-only retrocap insufficient — capping DelayDiffEq at ≤4.8.0 leaves `OrdinaryDiffEqDefault` 2.4.1 in the resolution, which then needs ≥4.8.1. `OrdinaryDiffEqTsit5` (≥2.1.1) and `OrdinaryDiffEqRosenbrock` (≥2.6.1) already declare `4.10.0`; `OrdinaryDiffEqDefault` is the one that was missed.

→ version 2.4.2, `OrdinaryDiffEqCore = "4.8.1"`.

## Verification

Ran locally, not inferred:

- **Reproduced** the failure: fresh env, `Pkg.add("DelayDiffEq")` → 6.1.0 + OrdinaryDiffEqCore 4.11.0 → the `MethodError` above at `solve.jl:341`, matching a downstream StateSelection.jl report verbatim.
- **Confirmed** `AutoDePSpecialize` is absent from OrdinaryDiffEqCore 4.8.0 and present in 4.8.1 by scanning the sources of every installed 4.x.
- **This branch**: `lib/DelayDiffEq` at 6.1.1 with the 4.8.1 floor, developed against *released* OrdinaryDiffEqCore 4.11.0, solves a constant-lag `DDEProblem` with `MethodOfSteps(Tsit5())` → `SOLVED, retcode=Success`.

I did not run the in-repo DelayDiffEq test suite for this change: the monorepo resolves sublibraries via `[sources]` path deps, so it is structurally insensitive to compat metadata and would exercise nothing here. The end-to-end check against registered packages above is the test that actually covers it.

## Follow-up

Retroactive compat bounds are still wanted in General for the already-registered broken versions (DelayDiffEq 6.0.0–6.1.0 → `"4.0.0 - 4.8.0"`, OrdinaryDiffEqDefault 2.4.1 → floor `4.8.1`); handled separately.

Worth a separate discussion: `DEOptions` is documented public API and #3835 changed its field layout under a minor bump. The existing 46-arg shim shows source compatibility was the intent — the 41-arg path was simply overlooked. Adding a 41-arg/21-param shim to OrdinaryDiffEqCore would heal 6.0.0–6.1.0 without registry surgery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KA1YU64UArbEbZrzF5Mvdz
