### PR TITLE
Don't skip pending versions in the 3.3 floor bump

### DIFF
--- a/lib/DelayDiffEq/Project.toml
+++ b/lib/DelayDiffEq/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.1.2"
+version = "6.1.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/OrdinaryDiffEqBDF/Project.toml
+++ b/lib/OrdinaryDiffEqBDF/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqBDF"
 uuid = "6ad6398a-0878-4a85-9266-38940aa047c8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.4.2"
+version = "2.4.1"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.6.1"
+version = "2.6.0"
 
 [deps]
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"

--- a/lib/OrdinaryDiffEqSDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqSDIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSDIRK"
 uuid = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.8.3"
+version = "2.8.2"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"


### PR DESCRIPTION
Follow-up to #4085.

Four sublibraries already had an unreleased version pending when #4085 patch-bumped them, so the bump skipped a version and AutoMerge refuses the registration:

> Does not meet sequential version number guideline: version 2.6.1 skips over 2.6.0

| package | #4085 set | should be | registry |
|---|---|---|---|
| DelayDiffEq | 6.1.2 | **6.1.1** | 6.1.0 |
| OrdinaryDiffEqBDF | 2.4.2 | **2.4.1** | 2.4.0 |
| OrdinaryDiffEqNonlinearSolve | 2.6.1 | **2.6.0** | 2.5.0 |
| OrdinaryDiffEqSDIRK | 2.8.3 | **2.8.2** | 2.8.1 |

Those pending versions already contain the `OrdinaryDiffEqDifferentiation = "3.3"` floor, so nothing is lost by releasing them rather than a fresh patch on top.

The other nine sublibraries in #4085 were at registry+1 and registered fine — ExponentialRK 2.2.1, Extrapolation 2.4.1 and Rosenbrock 2.6.3 are already merged into General.