### PR TITLE
Bump StochasticDiffEqCore to 2.0.4 for release

### DIFF
--- a/lib/StochasticDiffEqCore/Project.toml
+++ b/lib/StochasticDiffEqCore/Project.toml
@@ -1,6 +1,6 @@
 name = "StochasticDiffEqCore"
 uuid = "19c5a474-6cd1-4a5f-be79-46dc34e54d7f"
-version = "2.0.3"
+version = "2.0.4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

## Why

The registered `StochasticDiffEqCore` 2.0.3 declares `SciMLBase = "3.35.1 - 3.39"`. Master widened that to `SciMLBase = "3.39"` in #4010 but never bumped the version, so the fix is not installable. That makes 2.0.3 the effective cap on the whole SDE stack, and anything requiring SciMLBase 3.40+ fails to resolve.

Concretely, this is currently breaking SciMLSensitivity CI (https://github.com/SciML/SciMLSensitivity.jl/actions/runs/30650807324) — SciMLSensitivity requires `SciMLBase = "3.40"`:

```
ERROR: Unsatisfiable requirements detected for package StochasticDiffEqCore [19c5a474]:
 ├─restricted by compatibility requirements with SciMLBase to versions: uninstalled
 └─restricted by compatibility requirements with StochasticDiffEq to versions: 2.0.0 - 2.0.3 — no versions left
```

Registering OrdinaryDiffEq 7.2.1 and StochasticDiffEq 7.1.3 already cleared the layer above this one; `StochasticDiffEqCore` is what is left.

## What this does

Bumps `lib/StochasticDiffEqCore/Project.toml` from 2.0.3 to 2.0.4. Nothing else. 2.0.4 matches the version the General registry already has a staged compat entry for (`["2.0.4 - 2"] SciMLBase = "3.35.1 - 3"`), and `StochasticDiffEq` v7 declares `StochasticDiffEqCore = "2"`, so it picks the new version up with no further changes.

Unreleased work that ships with it: #4010, #4018, #4031, #4033, #4038.

Once merged, this needs `@JuliaRegistrator register subdir=lib/StochasticDiffEqCore` on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016urAXSHsbD8mW7Zs2sbgLk