### PR TITLE
Release StochasticDiffEqCore 2.0.4

### DIFF
--- a/lib/StochasticDiffEqCore/Project.toml
+++ b/lib/StochasticDiffEqCore/Project.toml
@@ -1,6 +1,6 @@
 name = "StochasticDiffEqCore"
 uuid = "19c5a474-6cd1-4a5f-be79-46dc34e54d7f"
-version = "2.0.3"
+version = "2.0.4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Patch bump so the changes accumulated since 2.0.3 can be registered.

2.0.3 was registered 2026-07-13 (General#161070). Five commits have touched `lib/StochasticDiffEqCore` since, with no version bump, so none of them are released:

- `Use GROUP consistently for sublibrary tests (#3909)`
- `Size RKMilGeneral's Lévy area truncation from MronRoe's error estimate`
- `Write the missing docstrings for the SDE/exponential-RK public API`
- `Resolve the unapproved-public-reexport QA failures per name`
- `Configure the sublibrary QA lanes for monorepo docs and facade`