### PR TITLE
Fix get_du/get_du! reading the wrong derivative under CompositeAlgorithm

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.12.0"
+version = "4.12.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqCore/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/alg_utils.jl
@@ -127,6 +127,15 @@ Return whether `alg` provides a special interpolant for its stiff branch
 has_stiff_interpolation(alg) = false
 
 """
+    get_current_has_stiff_interpolation(alg, cache) -> Bool
+
+`has_stiff_interpolation` for the algorithm that is currently active, which for a
+`CompositeAlgorithm` is the sub-algorithm selected by `cache.current` rather than
+the wrapper itself.
+"""
+get_current_has_stiff_interpolation(alg, cache) = has_stiff_interpolation(alg)
+
+"""
     OrdinaryDiffEqCore.has_stage_limiter(alg)
 
 Trait declaring whether `alg`'s `perform_step!` applies a stage limiter, i.e.
@@ -158,6 +167,10 @@ end
 
 function get_current_isfsal(alg::CompositeAlgorithm, cache)
     return _eval_index(isfsal, alg.algs, cache.current)::Bool
+end
+
+function get_current_has_stiff_interpolation(alg::CompositeAlgorithm, cache)
+    return _eval_index(has_stiff_interpolation, alg.algs, cache.current)::Bool
 end
 
 all_fsal(alg, cache) = isfsal(alg)

--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
@@ -81,8 +81,8 @@ end
 @inline function SciMLBase.get_du(integrator::ODEIntegrator)
     isdiscretecache(integrator.cache) &&
         error("Derivatives are not defined for this stepper.")
-    return if isfsal(integrator.alg) &&
-            !has_stiff_interpolation(integrator.alg)
+    return if get_current_isfsal(integrator.alg, integrator.cache) &&
+            !get_current_has_stiff_interpolation(integrator.alg, integrator.cache)
         # Special stiff interpolations do not store the
         # right value in fsallast
         integrator.fsallast
@@ -116,8 +116,8 @@ end
     if isdiscretecache(integrator.cache)
         out .= integrator.cache.tmp
     else
-        return if isfsal(integrator.alg) &&
-                !has_stiff_interpolation(integrator.alg)
+        return if get_current_isfsal(integrator.alg, integrator.cache) &&
+                !get_current_has_stiff_interpolation(integrator.alg, integrator.cache)
             # Special stiff interpolations do not store the
             # right value in fsallast
             out .= integrator.fsallast

--- a/test/InterfaceII/get_du.jl
+++ b/test/InterfaceII/get_du.jl
@@ -23,6 +23,10 @@ res = copy(cache)
 for alg in [
         Vern6(), Vern7(), Vern8(), Vern9(), Rodas4(), Rodas4P(),
         Rodas5(), Rodas5P(), TRBDF2(), KenCarp4(), FBDF(), QNDF(),
+        # A CompositeAlgorithm must report the derivative of whichever
+        # sub-algorithm is currently active, not of the wrapper.
+        AutoTsit5(Rosenbrock23()), AutoTsit5(Rodas5P()),
+        AutoVern7(Rodas4()), AutoVern9(Rodas4()), AutoVern9(Rodas5P()),
     ]
     sol = solve(
         prob, alg, tstops = [0.2], callback = dusave, abstol = 1.0e-12, reltol = 1.0e-12


### PR DESCRIPTION
> [!NOTE]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

Fixes the underlying cause of SciML/DifferentialEquations.jl#1058, including the quieter variant reported in [this comment](https://github.com/SciML/DifferentialEquations.jl/issues/1058#issuecomment-4970089972).

## The bug

`get_du` and `get_du!` choose between reading `integrator.fsallast` and evaluating the interpolant using the traits of `integrator.alg`:

```julia
# lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl:84, :119
return if isfsal(integrator.alg) && !has_stiff_interpolation(integrator.alg)
    integrator.fsallast
```

`CompositeAlgorithm <: OrdinaryDiffEqCompositeAlgorithm <: OrdinaryDiffEqAlgorithm`, and neither trait has a `CompositeAlgorithm` method — `isfsal(alg::CompositeAlgorithm)` is commented out at `alg_utils.jl:83`. So both fall back to the generic defaults:

```
CompositeAlgorithm   isfsal=true  has_stiff_interpolation=false
Rodas5P              isfsal=false has_stiff_interpolation=true
Vern9                isfsal=false has_stiff_interpolation=false
```

Every `Auto*` algorithm therefore takes the `fsallast` branch regardless of which sub-algorithm is running. The buffer read there belongs to whichever sub-cache supplied it via `get_fsalfirstlast`, and a non-FSAL sub-algorithm never writes it:

- `AutoVern9(Rodas4())` → `Rodas4Cache.fsallast`, allocated but never written → **exact zeros**
- `AutoTsit5(Rodas5P())` on the stiff branch → same → **exact zeros**
- default algorithm → `get_fsalfirstlast(::DefaultCache, u) = (cache.u, cache.u)` → **`u` itself, not `du`**

Every other consumer in the integrator already routes through `get_current_isfsal(integrator.alg, integrator.cache)` (`integrator_utils.jl:191`, `solve.jl:888`, `initdt.jl:71`). `get_du`/`get_du!` were the exception.

## Why this is worse than the original report

Issue #1058 reported a loud `MethodError` (`fsallast === nothing` → `fill!(dest, nothing)`). That crash is gone, but only because Rosenbrock caches gained real `fsalfirst`/`fsallast` buffers — turning `nothing` into an allocated buffer that Rosenbrock never writes. The failure became silent.

On `OrdinaryDiffEq v7.2.1` / `DiffEqCallbacks v4.19.0`, the MRE from #1058 no longer errors; it returns `retcode = Terminated` on a trajectory that has not converged:

```
Vern9()               retcode=Terminated t_end=117.909  true|du|=[8.6e-10, 7.5e-9]  converged=true
Rodas4()              retcode=Terminated t_end=124.293  true|du|=[4.1e-10, 3.6e-9]  converged=true
AutoVern9(Rodas4())   retcode=Terminated t_end=0.11889  true|du|=[0.0275, 0.0185]   converged=false
```

It terminates on the first step, because `get_du!` reports zero at every step:

```
step 1  t=0.11889  current=1  get_du!=[0.0, 0.0]  truth=[0.02751, -0.01851]
step 2  t=0.5347   current=1  get_du!=[0.0, 0.0]  truth=[0.03032, -0.017]
```

The scope is wider than `TerminateSteadyState` + `AutoVern*`: it is any `get_du`/`get_du!` caller under any composite algorithm, including the plain default solver with no algorithm specified.

## The fix

Route both functions through the currently-active sub-algorithm's traits, reusing the existing `get_current_isfsal` and adding a matching `get_current_has_stiff_interpolation`.

## Verification

Ran locally against the issue's MRE, a stiff variant that forces the Rosenbrock branch to be active at termination, and the default-algorithm path:

| case | before | after |
| --- | --- | --- |
| `AutoVern9(Rodas4())`, RM model | `t_end=0.11889`, not converged | `t_end=117.909`, converged (matches `Vern9()` exactly) |
| `AutoTsit5(Rodas5P())`, stiff | `t_end=0.0267`, not converged | `t_end=10778.6`, converged (`Rodas5P()` standalone: `10975.2`) |
| default alg, `get_du!` | `[0.1017, 0.09878]` (= `u`) | `[0.02716, -0.01871]` (= truth) |

`test/InterfaceII/get_du.jl` covered 12 standalone algorithms but no composite ones — that is the gap that let this through. Extended with five composites. On unpatched `OrdinaryDiffEqCore` the new cases fail:

```
Test Failed at test/InterfaceII/get_du.jl:34
  Expression: ≈(res, cache, rtol = 1.0e-5)
   Evaluated: [45.19984609080418, 96.17270725538896, 29.61827095739944] ≈ [0.0, 0.0, 0.0]
```

With the fix the whole file passes (exit 0) for all 17 algorithms.

Runic clean; no reformatting needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNSoDRgtXouPK8UgKz7avi
