### PR TITLE
Raise OrdinaryDiffEqBDF/Rosenbrock floors so the broken Differentiation 3.2.3 is unreachable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEq"
 uuid = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "7.2.1"
+version = "7.3.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -59,10 +59,10 @@ DifferentiationInterface = "0.7.18"
 DocStringExtensions = "0.9.5"
 ForwardDiff = "1.3.3"
 NonlinearSolve = "4.20.3"
-OrdinaryDiffEqBDF = "2"
+OrdinaryDiffEqBDF = "2.4.1"
 OrdinaryDiffEqCore = "4.8, 5.0"
 OrdinaryDiffEqDefault = "2"
-OrdinaryDiffEqRosenbrock = "2"
+OrdinaryDiffEqRosenbrock = "2.6.3"
 OrdinaryDiffEqTsit5 = "2"
 OrdinaryDiffEqVerner = "2"
 RecursiveArrayTools = "4.2.0"


### PR DESCRIPTION
## Problem

`OrdinaryDiffEqDifferentiation` 3.2.3 has a precompilation bug. The subpackages that depend on it already exclude it:

| Package | Version | OrdinaryDiffEqDifferentiation compat |
|---|---|---|
| OrdinaryDiffEqRosenbrock | >= 2.6.3 | `3.3.0 - 3` |
| OrdinaryDiffEqBDF | >= 2.4.1 | `3.3.0 - 3` |
| OrdinaryDiffEqSDIRK | >= 2.8.2 | `3.3.0 - 3` |
| OrdinaryDiffEqNonlinearSolve | >= 2.6 | `3.6.0 - 3` |

But `OrdinaryDiffEq` itself declares `OrdinaryDiffEqRosenbrock = "2"` and `OrdinaryDiffEqBDF = "2"` — the whole 2.x range — and Rosenbrock 2.4.0–2.6.2 / BDF 2.0.0–2.4.0 all still permit 3.2.3.

So a downstream package that bounds only `OrdinaryDiffEq = "7"` can still resolve onto the broken version. Verified against the registry, with no explicit `OrdinaryDiffEqDifferentiation` bound in play:

```
RESOLVED OrdinaryDiffEq                7.0.0
RESOLVED OrdinaryDiffEqRosenbrock      2.4.0
RESOLVED OrdinaryDiffEqDifferentiation 3.2.3
```

That is not hypothetical — it is exactly what a Downgrade CI job selects, since those drive deps toward their lower bounds.

## Fix

Raise the two floors to the versions carrying the fix:

```diff
-OrdinaryDiffEqBDF = "2"
+OrdinaryDiffEqBDF = "2.4.1"
-OrdinaryDiffEqRosenbrock = "2"
+OrdinaryDiffEqRosenbrock = "2.6.3"
```

Either one alone is sufficient; both are bumped so the guarantee does not depend on which solver path a downstream package pulls in. Both floors are the current released versions of those subpackages and match the versions in `lib/` on master, so this does not pin anyone to something unreleased.

Minor version bump to 7.3.0 (dependency floor raise, no API change).

## Effect

With this in place, `OrdinaryDiffEqDifferentiation` 3.2.3 becomes unsatisfiable rather than merely un-preferred:

```
Unsatisfiable requirements detected for package OrdinaryDiffEqDifferentiation [4302a76b]:
 ├─restricted to versions 3.2.3 by an explicit requirement, leaving only versions: 3.2.3
 └─restricted by compatibility requirements with OrdinaryDiffEqRosenbrock [43230ef6]
   to versions: 3.3.0 - 3.6.0 — no versions left
```

That means downstream packages no longer need to carry their own `OrdinaryDiffEqDifferentiation` bound just to dodge 3.2.3. MinimallyDisruptiveCurves.jl currently does exactly that (https://github.com/SciML/MinimallyDisruptiveCurves.jl/pull/79); once 7.3.0 is registered it can bound `OrdinaryDiffEq = "7.3"` and drop the phantom dep entirely.

## Verification (Julia 1.12.4, local)

Resolves and precompiles cleanly:

```
RESOLVED OrdinaryDiffEq                7.3.0
RESOLVED OrdinaryDiffEqRosenbrock      2.6.3
RESOLVED OrdinaryDiffEqBDF             2.4.1
RESOLVED OrdinaryDiffEqDifferentiation 3.6.0
```

Stiff and non-stiff smoke solves on a stiff 2-state problem, all agreeing to 6 digits:

```
SOLVE Rosenbrock23  Success  u_end=[0.556909, 0.505927]
SOLVE Rodas5P       Success  u_end=[0.556909, 0.505927]
SOLVE FBDF          Success  u_end=[0.556909, 0.505927]
SOLVE Tsit5         Success  u_end=[0.556909, 0.505927]
SOLVE Vern7         Success  u_end=[0.556909, 0.505927]
DEFAULT: Success
```

`GROUP=InterfaceI Pkg.test()` passes — exit 0, no failures or errors (the only non-Pass column is a pre-existing `Broken`):

```
1743.029575 seconds (1.69 G allocations: 84.124 GiB, 2.83% gc time)
     Testing OrdinaryDiffEq tests passed
```

I ran InterfaceI rather than the full suite; this is a compat-floor-only change, so the meaningful risk is resolution rather than numerics, and the remaining groups are covered by CI on this PR.

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeSUEdXcEGHSFemNfThw8t
