### PR TITLE
Bridge SDE noise when a late tstop shortens dt

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
@@ -50,6 +50,25 @@ reinit_noise!(::Nothing, dt) = nothing
 @inline _get_W(integrator) = hasfield(typeof(integrator), :W) ? getfield(integrator, :W) : nothing
 @inline _get_P(integrator) = hasfield(typeof(integrator), :P) ? getfield(integrator, :P) : nothing
 
+# `fix_dt_at_bounds!`/`modify_dt_for_tstops!` can shorten `dt` after the pending
+# noise increment was already drawn for the longer step (e.g. `add_tstop!` called
+# between `init` and the first `step!`). Shrinking the step from the same start
+# time is exactly the situation a step rejection describes, so reuse the rejection
+# path: it bridges the drawn increment down to `dt` and keeps the remainder of the
+# path on the RSWM stack. Growing the step cannot be bridged, so the increment is
+# left alone; `perform_step!` then sees the noise the process was already
+# committed to.
+function shrink_noise_to_integrator_dt!(integrator)
+    W = _get_W(integrator)
+    isnothing(W) && return nothing
+    if abs(integrator.dt) < abs(W.dt)
+        reject_noise!(W, integrator.dt, integrator.u, integrator.p)
+        reject_noise!(_get_P(integrator), integrator.dt, integrator.u, integrator.p)
+        integrator.sqdt = integrator.tdir * sqrt(abs(integrator.dt))
+    end
+    return nothing
+end
+
 # Trait: does the integrator+solution support dense output k-array storage?
 # True for ODEIntegrator (has integrator.k and sol.k), false for SDEIntegrator
 # (no integrator.k) and RODESolution/DAESolution (no sol.k).
@@ -95,6 +114,7 @@ function loopheader!(integrator)
     choose_algorithm!(integrator, integrator.cache)
     fix_dt_at_bounds!(integrator)
     modify_dt_for_tstops!(integrator)
+    shrink_noise_to_integrator_dt!(integrator)
     integrator.force_stepfail = false
     return nothing
 end

--- a/lib/StochasticDiffEq/test/tstops_tests.jl
+++ b/lib/StochasticDiffEq/test/tstops_tests.jl
@@ -1,4 +1,5 @@
 using StochasticDiffEq, Test, Random
+using DiffEqNoiseProcess: WienerProcess, RSWM
 using SDEProblemLibrary: prob_sde_linear
 Random.seed!(100)
 prob = prob_sde_linear
@@ -35,4 +36,71 @@ for (i, tdir) in enumerate([-1.0; 1.0])
     for tstop in tstops
         @test tstop ∈ integrator.sol.t
     end
+end
+
+# SciML/OrdinaryDiffEq.jl#3175 / StochasticDiffEq.jl#413:
+# late add_tstop! after init must shorten the first EM step to the tstop.
+f3175(u, p, t) = 1.0
+g3175(u, p, t) = 0.1
+prob3175 = SDEProblem(f3175, g3175, [1.0], (0.0, 1.0))
+
+i_em = init(prob3175, EM(); dt = 0.02)
+add_tstop!(i_em, 0.01)
+step!(i_em)
+@test i_em.t == 0.01
+
+i_lamba = init(prob3175, LambaEM(); dt = 0.02)
+add_tstop!(i_lamba, 0.01)
+step!(i_lamba)
+@test i_lamba.t == 0.01
+
+# Past-time add_tstop! is rejected for both fixed-step and adaptive EM.
+i_past = init(prob3175, EM(); dt = 0.02)
+step!(i_past)
+@test_throws ErrorException add_tstop!(i_past, 0.01)
+
+# The noise has to follow the solver onto the shortened step. Without bridging,
+# W keeps stepping on the original dt grid and drifts away from sol.t for the
+# rest of the integration.
+for alg in (EM(), LambaEM())
+    i = init(prob3175, alg; dt = 0.02, save_noise = true)
+    add_tstop!(i, 0.01)
+    solve!(i)
+    @test i.W.t == i.sol.t
+    @test i.W.curt == i.t
+end
+
+# ... and bridging is what it must do: committing the pending increment instead
+# would make the noise take a step the solver never took.
+for alg in (EM(), LambaEM())
+    i = init(prob3175, alg; dt = 0.02)
+    add_tstop!(i, 0.01)
+    solve!(i)
+    @test i.W.iter == i.iter
+end
+
+# For du = dW the Euler step is exact, so the endpoints must agree with the
+# Brownian path the solution was built from.
+fexact(u, p, t) = 0.0
+gexact(u, p, t) = 1.0
+probexact = SDEProblem(fexact, gexact, [0.0], (0.0, 1.0))
+
+for alg in (EM(), LambaEM())
+    i = init(probexact, alg; dt = 0.02, save_noise = true)
+    add_tstop!(i, 0.01)
+    solve!(i)
+    @test i.sol.u[end][1] ≈ only(i.W.curW) atol = 1.0e-12
+end
+
+# RSwM1 hands a stack chunk back through W.dt, so the tstop shortening has to
+# bridge that chunk rather than relabel it.
+for adaptivealg in (:RSwM1, :RSwM2, :RSwM3)
+    W1 = WienerProcess(0.0, 0.0; rswm = RSWM(adaptivealg = adaptivealg))
+    prob1 = SDEProblem(fexact, gexact, 0.0, (0.0, 1.0), noise = W1)
+    i = init(prob1, LambaEM(); dt = 0.02, tstops = [0.331], save_noise = true)
+    add_tstop!(i, 0.01)
+    solve!(i)
+    @test 0.01 ∈ i.sol.t
+    @test 0.331 ∈ i.sol.t
+    @test i.sol.u[end] ≈ i.W.curW atol = 1.0e-12
 end


### PR DESCRIPTION
> [!NOTE]
> Draft — please ignore until reviewed by @ChrisRackauckas.

> [!IMPORTANT]
> **This does not fix #3175, and #3175 should stay open.** The error that issue reports no longer reproduces on master — see the section at the bottom. This PR fixes a different defect found while reviewing #4041.

## The bug

`init` draws the pending Brownian increment for the configured `dt`. If the step is then shortened before `perform_step!` runs — `add_tstop!` after `init` — the solver steps the new, shorter `dt` while the noise process still holds an increment drawn for the old one. `accept_step!` advances `W.curt` by that stale `W.dt`, so the noise grid slides off the solution grid and never returns:

```julia
f(u, p, t) = 1.0
g(u, p, t) = 0.1
prob = SDEProblem(f, g, [1.0], (0.0, 1.0))

i = init(prob, EM(); dt = 0.02, save_noise = true)
add_tstop!(i, 0.01)
solve!(i)

i.sol.t[1:4]   # [0.0, 0.01, 0.03, 0.05]
i.W.t[1:4]     # [0.0, 0.02, 0.04, 0.06]   <-- noise on the old grid
i.sol.t[end]   # 1.0
i.W.t[end]     # 1.0099999999999998
```

The first increment also carries variance 0.02 across a step of 0.01.

## The fix

Shrinking a pending step from the same start time is exactly what a step rejection already describes, so `loopheader!` routes it through the existing `reject_noise!` hook. `DiffEqNoiseProcess.reject_step!` bridges the drawn increment down to the new `dt` and keeps the remainder on the RSWM stack; `W.curt`/`W.curW` are untouched.

```julia
function shrink_noise_to_integrator_dt!(integrator)
    W = _get_W(integrator)
    isnothing(W) && return nothing
    if abs(integrator.dt) < abs(W.dt)
        reject_noise!(W, integrator.dt, integrator.u, integrator.p)
        reject_noise!(_get_P(integrator), integrator.dt, integrator.u, integrator.p)
        integrator.sqdt = integrator.tdir * sqrt(abs(integrator.dt))
    end
    return nothing
end
```

Instrumenting the comparison shows it firing only for a late `add_tstop!`; plain fixed-step and adaptive solves, `tstops` passed up front, `dtmax`-limited solves, `saveat`, and reverse-time solves never reach it, so existing random streams are unchanged.

## Distributional verification

`du = dW`, where Euler-Maruyama is exact and `u(t)` **is** the Brownian path. 20,000 seeded paths per configuration, tolerances at 4σ:

```
=== late add_tstop!(0.01), dt = 0.02, EM: per-interval increments ===
var   ΔW[0, 0.01]      0.01009   target 0.01000   ok
var   ΔW[0.01, 0.03]   0.02036   target 0.02000   ok
var   ΔW[0.03, 0.05]   0.02030   target 0.02000   ok
cor   ΔW1, ΔW2        -0.00081   target 0.00000   ok
cor   ΔW1, ΔW3        -0.00146   target 0.00000   ok
cor   ΔW2, ΔW3        -0.01148   target 0.00000   ok
kurtosis ΔW1           3.05895   target 3.00000   ok
var   u(1)             1.00661   target 1.00000   ok
```

The bridged increment carries the variance of the step it spans, the stashed remainder is reused without double-counting (uncorrelated successors), and `u(T) == W(T)` held on every one of the 20,000 paths for: no tstop, tstop at init, one late tstop, three late tstops, adaptive, and `RSwM1`/`RSwM2`/`RSwM3`.

Since `du = dW` produces no step rejections, the reject path was checked separately on multiplicative noise (`du = 1.01u dt + 0.87u dW`) where `W(1) ~ N(0, 1)` is grid-independent:

```
multiplicative LambaEM tol 1e-3            11491 rejections   var W(1) 1.00078  kurt 2.977  ok
multiplicative LambaEM tol 1e-4, 3 tstops  50733 rejections   var W(1) 0.98184  kurt 2.950  ok
multiplicative SOSRI tol 1e-4              48000 rejections   var W(1) 0.98104  kurt 2.930  ok
```

## Known gap: the grow direction

`fix_dt_at_bounds!` can also raise `dt` (`max(dt, dtmin)`), and growth cannot be bridged, so this PR leaves that case exactly as master has it — which is wrong, by a factor of 10⁴ in the reproduction. Filed as #4097 rather than fixed here, to keep this PR to the direction it verifies.

## Tests

Added to `lib/StochasticDiffEq/test/tstops_tests.jl`, covering both failure directions:

- the noise grid must track `sol.t`, and `W.curt == integrator.t` at the end — these fail on master (`[0.0, 0.02, 1.01]` vs `[0.0, 0.01, 1.0]`);
- the noise must not take a step the solver never took: `W.iter == integrator.iter`, and `u(T) == W(T)` for `du = dW` — these guard against "fixing" the grid by committing the stale increment instead of bridging it;
- all three `RSWM` variants, since only `RSwM1` hands a stack chunk back through `W.dt`.

31/31 pass here, 27/31 on unmodified master. A 34-file local SDE sweep passes. Runic clean.

## Why #3175 is not fixed by this

StochasticDiffEq.jl#413, which #3175 was migrated from, reports:

> `Something went wrong. Integrator stepped past tstops but the algorithm was dtchangeable. Please report this error.`

That error does not reproduce on master. Running the MWE across 8 variants × `EM`/`LambaEM` — float and integer `tspan`, scalar and vector `u0`, rational `dt`, tstop on/off the step grid, tstop equal to `dt`, tstop at `1e-9` — all 16 land on the tstop and finish with `ReturnCode.Success`.

The only part of #413's MWE that still fails is `u0 = [1]`, which throws `InexactError: Int64(0.78…)` — an integer state vector that cannot hold the value after a continuous noise increment. That is unrelated to tstops and reproduces identically on master.

#4041 targets the same area and asserts `step!` lands at `t == 0.01`; that assertion also passes on master and on #4041's own parent commit. Separately, its `resync_noise!` calls `DiffEqNoiseProcess.accept_step!`, which advances `W.curt`, increments `W.iter`, folds the stale increment into `W.curW`, and pushes a point into the saved path, despite documenting itself as resyncing "without advancing the noise clock". On that branch `du = dW` gives `|u(T) - W(T)| = 0.128` — exactly the discarded increment — and `W.iter == 52` against 51 solver steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QSn6HPV8G8NWLpUeAEVA9b