### PR TITLE
Give the SRI weak-order study enough trajectories for its own tolerance

### DIFF
--- a/lib/StochasticDiffEq/test/weak_convergence/iip_weak.jl
+++ b/lib/StochasticDiffEq/test/weak_convergence/iip_weak.jl
@@ -179,8 +179,12 @@ sim = test_convergence(
 #@test abs(sim.𝒪est[:weak_l∞]-1) < 0.3
 println("SRI")
 dts = 1 .// 2 .^ (8:-1:2)
+# 2e4 trajectories leaves the weak-order estimate with a standard deviation of 0.17
+# against a 0.5 tolerance, so a ~3σ draw breaches it — which is what this study's own
+# RNG state produced (𝒪 off by 0.553). 4e5 brings the spread to 0.049, worst case 0.09
+# over 12 seeds. See issue #4061.
 sim = test_convergence(
-    dts, prob, SRI(), save_everystep = false, trajectories = Int(2.0e4),
+    dts, prob, SRI(), save_everystep = false, trajectories = Int(4.0e5),
     weak_timeseries_errors = false
 )
 @test abs(sim.𝒪est[:weak_final] - 2) < 0.5


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Fixes SciML/OrdinaryDiffEq.jl#4061.

## The problem

`iip_weak.jl`'s SRI study asserts `abs(sim.𝒪est[:weak_final] - 2) < 0.5` from 2e4 trajectories, and fails:

```
Test Failed at lib/StochasticDiffEq/test/weak_convergence/iip_weak.jl:186
  Expression: abs(sim.𝒪est[:weak_final] - 2) < 0.5
   Evaluated: 0.5533865655544976 < 0.5
```

It is deterministic — it reproduces to the last digit across runs — and it is not new. The group simply never got this far: the file was OOM-killed at the `SROCK2` call on line 71, 115 lines earlier, until SciML/OrdinaryDiffEq.jl#4060 landed. Everything after line 186 had never executed.

## Why more trajectories rather than a wider tolerance

Sampling the estimator over 12 independent seeds:

| trajectories | 𝒪 range | mean | sd | max &#124;𝒪−2&#124; | fails `< 0.5` |
|---|---|---|---|---|---|
| 2e4 (current) | [1.822, 2.277] | 2.006 | 0.172 | 0.277 | 0/12 |
| 1e5 | [1.892, 2.214] | 2.008 | 0.100 | 0.214 | 0/12 |
| **4e5** | [1.910, 2.078] | 1.972 | **0.049** | **0.090** | 0/12 |

The mean sits on 2 at every count and `sd` falls as `1/sqrt(n)` to within noise — 1e5 → 4e5 is a 4× increase in samples and `sd` goes 0.100 → 0.050 predicted, 0.049 observed. So the estimator is unbiased and the sole problem is spread: 2e4 gives it a standard deviation of 0.172 against a 0.5 tolerance, and the file's own RNG state (seeded once at the top, then advanced by the fifteen studies before it) lands about 3σ out.

At 4e5 the worst of 12 seeds is 0.09 from 2, more than five times inside the existing bound, so the assertion still has the resolution to catch a genuine order regression. Widening the tolerance to admit a 0.553 estimate would not — it would remove exactly the signal the test exists to provide. The cost is ~4 minutes for that one study (16.3 s → 254.1 s here).

## Verification

Whole group through the normal harness, in a 16 GiB cgroup (`systemd-run --scope -p MemoryMax=16G -p MemorySwapMax=0`) at `JULIA_NUM_THREADS=2`, matching the self-hosted pool and its `num-threads: auto` default:

```
GROUP=IIPWeakConvergence julia --project=. -e 'using Pkg; Pkg.test()'

     Testing StochasticDiffEq tests passed
        Elapsed (wall clock) time (h:mm:ss or m:ss): 17:00.35
        Maximum resident set size (kbytes): 1623164
```

The log reaches `SRI` and `SRIW1`, i.e. this is the first end-to-end run of the file.
