### PR TITLE
Fix StochasticDiffEqWeak JET and API docs QA

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -37,6 +37,7 @@ OrdinaryDiffEqSymplecticRK = "fa646aed-7ef9-47eb-84c4-9443fc8cbfa8"
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 OrdinaryDiffEqVerner = "79d7bb75-1356-48c1-b8c0-6832512096c2"
 StochasticDiffEqLevyArea = "90dbc90e-856a-4131-af2c-e8c5aa0f35b5"
+StochasticDiffEqWeak = "af2a2fcd-1c36-4cbe-a6d0-5afda784a085"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 
@@ -77,6 +78,7 @@ OrdinaryDiffEqSymplecticRK = {path = "../lib/OrdinaryDiffEqSymplecticRK"}
 OrdinaryDiffEqTsit5 = {path = "../lib/OrdinaryDiffEqTsit5"}
 OrdinaryDiffEqVerner = {path = "../lib/OrdinaryDiffEqVerner"}
 StochasticDiffEqLevyArea = {path = "../lib/StochasticDiffEqLevyArea"}
+StochasticDiffEqWeak = {path = "../lib/StochasticDiffEqWeak"}
 
 [compat]
 DiffEqBase = "7.6.1"
@@ -117,5 +119,6 @@ OrdinaryDiffEqSymplecticRK = "2.0.0"
 OrdinaryDiffEqTsit5 = "2.0.0"
 OrdinaryDiffEqVerner = "2.0.0"
 StochasticDiffEqLevyArea = "2"
+StochasticDiffEqWeak = "2"
 SciMLBase = "3.39"
 SciMLLogging = "2.0.0"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,6 +11,7 @@ using OrdinaryDiffEqDifferentiation
 using OrdinaryDiffEqNonlinearSolve
 using ImplicitDiscreteSolve
 using StochasticDiffEqLevyArea
+using StochasticDiffEqWeak
 
 # Register the re-exported bindings with the umbrella module for Documenter.
 for (name, owner) in (
@@ -131,6 +132,7 @@ makedocs(
         OrdinaryDiffEqAMF,
         ImplicitDiscreteSolve,
         StochasticDiffEqLevyArea,
+        StochasticDiffEqWeak,
         DiffEqDevTools,
         GlobalDiffEq,
     ],

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -49,6 +49,7 @@ pages = [
     ],
     "Stochastic Utilities" => [
         "stochastic/LevyArea.md",
+        "stochastic/Weak.md",
     ],
     "Fully Implicit DAE Solvers" => [
         "fullyimplicitdae/BDF.md",

--- a/docs/src/stochastic/Weak.md
+++ b/docs/src/stochastic/Weak.md
@@ -1,0 +1,23 @@
+# Weak SDE solver API
+
+```@docs
+StochasticDiffEqWeak.DRI1
+StochasticDiffEqWeak.IRI1
+StochasticDiffEqWeak.KomoriNON2
+StochasticDiffEqWeak.constructDRI1
+StochasticDiffEqWeak.constructRI1
+StochasticDiffEqWeak.constructRI3
+StochasticDiffEqWeak.constructRI5
+StochasticDiffEqWeak.constructRI6
+StochasticDiffEqWeak.constructRDI1WM
+StochasticDiffEqWeak.constructRDI2WM
+StochasticDiffEqWeak.constructRDI3WM
+StochasticDiffEqWeak.constructRDI4WM
+StochasticDiffEqWeak.constructRS1
+StochasticDiffEqWeak.constructRS2
+StochasticDiffEqWeak.constructNON
+StochasticDiffEqWeak.constructNON2
+StochasticDiffEqWeak.checkRIOrder
+StochasticDiffEqWeak.checkRSOrder
+StochasticDiffEqWeak.checkNONOrder
+```

--- a/lib/StochasticDiffEqWeak/Project.toml
+++ b/lib/StochasticDiffEqWeak/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqWeak"
 uuid = "af2a2fcd-1c36-4cbe-a6d0-5afda784a085"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.1.2"
+version = "2.1.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/StochasticDiffEqWeak/src/algorithms.jl
+++ b/lib/StochasticDiffEqWeak/src/algorithms.jl
@@ -1,3 +1,10 @@
+"""
+    DRI1()
+
+Adaptive Debrabant-Rößler method for weak approximation of Itô SDEs. `DRI1`
+has weak order 2 and deterministic order 3 and supports scalar, diagonal, and
+non-diagonal noise.
+"""
 struct DRI1 <: StochasticDiffEqAdaptiveAlgorithm end
 
 """
@@ -707,6 +714,15 @@ struct SMEB <: StochasticDiffEqAlgorithm end
 
 using ADTypes: AutoForwardDiff
 
+"""
+    IRI1(; autodiff=AutoForwardDiff(), concrete_jac=nothing, linsolve=nothing,
+         nlsolve=NLNewton(), extrapolant=:constant, theta=1,
+         new_jac_conv_bound=1e-3)
+
+Adaptive drift-implicit variant of the Rößler `RI1` method for weak
+approximation of Itô SDEs. The nonlinear and linear solves can be customized
+with `nlsolve` and `linsolve`; `autodiff` controls Jacobian differentiation.
+"""
 struct IRI1{AD, F, F2, T2, T3, CJ} <:
     StochasticDiffEqNewtonAdaptiveAlgorithm
     linsolve::F

--- a/lib/StochasticDiffEqWeak/src/caches/implicit_weak_caches.jl
+++ b/lib/StochasticDiffEqWeak/src/caches/implicit_weak_caches.jl
@@ -8,7 +8,9 @@
 Constant cache for the IRI1 (Implicit Rößler 1) method.
 Contains the nlsolver for implicit drift treatment and the RI1 tableau coefficients.
 """
-mutable struct IRI1ConstantCache{N, T, T2} <: StochasticDiffEqConstantCache
+mutable struct IRI1ConstantCache{
+        N <: OrdinaryDiffEqCore.AbstractNLSolver, T, T2,
+    } <: StochasticDiffEqConstantCache
     nlsolver::N
     # RI1 Tableau coefficients (same as DRI1ConstantCache but stored directly)
     a021::T
@@ -119,7 +121,8 @@ end
 # IRI1Cache: Mutable cache for the IRI1 (Implicit Rößler 1) method (in-place version).
 # Contains all the working arrays needed for the implicit weak order 2 SRK method.
 @cache mutable struct IRI1Cache{
-        uType, randType, rateNoiseType, rateType, noUnitsType, N, T, T2,
+        uType, randType, rateNoiseType, rateType, noUnitsType,
+        N <: OrdinaryDiffEqCore.AbstractNLSolver, T, T2,
     } <:
     StochasticDiffEqMutableCache
     u::uType

--- a/lib/StochasticDiffEqWeak/src/perform_step/implicit_weak.jl
+++ b/lib/StochasticDiffEqWeak/src/perform_step/implicit_weak.jl
@@ -28,12 +28,7 @@ based on the RI1 scheme with theta-method implicitization of the drift.
     _dW = map(x -> calc_threepoint_random(sq3dt, NORMAL_ONESIX_QUANTILE, x), dW_scaled)
     chi1 = map(x -> (x^2 - dt) / 2, _dW)  # diagonal of Ihat2
 
-    if !(W.dW isa Number)
-        m = length(W.dW)
-        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
-    else
-        m = 1
-    end
+    m = length(W.dW)
 
     # Stage 1: Compute k1 implicitly
     # For implicit treatment: k1 = f(Y1) where Y1 = uprev + theta*dt*k1
@@ -109,11 +104,17 @@ based on the RI1 scheme with theta-method implicitization of the drift.
         end
     end
 
-    # Compute g2 and g3 at H12 and H13
+    # Final update: combine drift (implicit) and diffusion (explicit)
+    u = uprev + α1 * k1 * dt + α2 * k2 * dt + α3 * k3 * dt
+
+    # Compute g2 and g3 at H12 and H13, then add noise contribution (same as explicit RI1)
     if W.dW isa Number
         g2 = integrator.f.g(H12, p, t + c12 * dt)
         g3 = integrator.f.g(H13, p, t + c13 * dt)
+        u += g1 * (_dW * beta11) + g2 * (_dW * beta12 + chi1 * beta22 / integrator.sqdt) +
+            g3 * (_dW * beta13 + chi1 * beta23 / integrator.sqdt)
     else
+        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
         g2 = [integrator.f.g(H12[k], p, t + c12 * dt) for k in 1:m]
         g3 = [integrator.f.g(H13[k], p, t + c13 * dt) for k in 1:m]
         H22 = [copy(uprev) for k in 1:m]
@@ -132,16 +133,6 @@ based on the RI1 scheme with theta-method implicitization of the drift.
                     integrator.sqdt
             end
         end
-    end
-
-    # Final update: combine drift (implicit) and diffusion (explicit)
-    u = uprev + α1 * k1 * dt + α2 * k2 * dt + α3 * k3 * dt
-
-    # Add noise contribution (same as explicit RI1)
-    if W.dW isa Number
-        u += g1 * (_dW * beta11) + g2 * (_dW * beta12 + chi1 * beta22 / integrator.sqdt) +
-            g3 * (_dW * beta13 + chi1 * beta23 / integrator.sqdt)
-    else
         if is_diagonal_noise(integrator.sol.prob)
             u += g1 .* _dW * beta11
             for k in 1:m

--- a/lib/StochasticDiffEqWeak/src/perform_step/srk_weak.jl
+++ b/lib/StochasticDiffEqWeak/src/perform_step/srk_weak.jl
@@ -11,11 +11,7 @@
     sq3dt = sqrt(3 * dt)
     _dW = map(x -> calc_threepoint_random(sq3dt, NORMAL_ONESIX_QUANTILE, x), dW_scaled)
     chi1 = map(x -> (x^2 - dt) / 2, _dW) # diagonal of Ihat2
-    if !(W.dW isa Number)
-        m = length(W.dW)
-        # define two-point distributed random variables
-        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
-    end
+    m = length(W.dW)
 
     # compute stage values
     k1 = integrator.f(uprev, p, t)
@@ -67,11 +63,22 @@
     # H21 = uprev
     # H^_i^(k), stage 2 and 3
 
+    # add stages together Eq. (3)
+    u = uprev + α1 * k1 * dt + α2 * k2 * dt + α3 * k3 * dt
+
     if W.dW isa Number
         g2 = integrator.f.g(H12, p, t + c12 * dt)
         g3 = integrator.f.g(H13, p, t + c13 * dt)
         # for m=1:  H22 = uprev
+
+        # add noise, lines 2 and 3
+        u += g1 * (_dW * beta11) + g2 * (_dW * beta12 + chi1 * beta22 / integrator.sqdt) +
+            g3 * (_dW * beta13 + chi1 * beta23 / integrator.sqdt)
+        # lines 4 and 5 are zero by construction
+        # u += g1*(_dW*(beta31+beta32+beta33)+chi1*integrator.sqdt*(beta42+beta43))
     else
+        # define two-point distributed random variables
+        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
         g2 = [integrator.f.g(H12[k], p, t + c12 * dt) for k in 1:m]
         g3 = [integrator.f.g(H13[k], p, t + c13 * dt) for k in 1:m]
         H22 = [copy(uprev) for k in 1:m]
@@ -85,23 +92,12 @@
                 tmp[k] = b231 * g1[k] + b232 * g2[k][k] + b233 * g3[k][k]
                 H23[k] += tmp * integrator.sqdt
             else
-                H22[k] += (b221 * g1[:, l] + b222 * g2[l][:, l] + b223 * g3[l][:, l]) * integrator.sqdt
-                H23[k] += (b231 * g1[:, l] + b232 * g2[l][:, l] + b233 * g3[l][:, l]) * integrator.sqdt
+                H22[k] += (b221 * g1[:, k] + b222 * g2[k][:, k] + b223 * g3[k][:, k]) * integrator.sqdt
+                H23[k] += (b231 * g1[:, k] + b232 * g2[k][:, k] + b233 * g3[k][:, k]) * integrator.sqdt
             end
         end
-    end
 
-    # add stages together Eq. (3)
-    u = uprev + α1 * k1 * dt + α2 * k2 * dt + α3 * k3 * dt
-
-    # add noise
-    if W.dW isa Number
-        # lines 2 and 3
-        u += g1 * (_dW * beta11) + g2 * (_dW * beta12 + chi1 * beta22 / integrator.sqdt) +
-            g3 * (_dW * beta13 + chi1 * beta23 / integrator.sqdt)
-        # lines 4 and 5 are zero by construction
-        # u += g1*(_dW*(beta31+beta32+beta33)+chi1*integrator.sqdt*(beta42+beta43))
-    else
+        # add noise
         if is_diagonal_noise(integrator.sol.prob)
             u += g1 .* _dW * beta11
             for k in 1:m
@@ -458,6 +454,7 @@ end
     (; a021, b021, α1, α2, c02, beta11, NORMAL_ONESIX_QUANTILE) = cache
     (; t, dt, uprev, u, W, p, f) = integrator
 
+    m = length(W.dW)
     # define three-point distributed random variables
     dW_scaled = W.dW / sqrt(dt)
     sq3dt = sqrt(3 * dt)
@@ -562,11 +559,7 @@ end
     dW_scaled = W.dW / sqrt(dt)
     sq3dt = sqrt(3 * dt)
     _dW = map(x -> calc_threepoint_random(sq3dt, NORMAL_ONESIX_QUANTILE, x), dW_scaled)
-    if !(W.dW isa Number)
-        m = length(W.dW)
-        # define two-point distributed random variables
-        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
-    end
+    m = length(W.dW)
     # compute stage values
     k1 = integrator.f(uprev, p, t)
     g1 = integrator.f.g(uprev, p, t)
@@ -684,7 +677,18 @@ end
     # H21 = uprev
     # H^_2^(k) # H^_3^(k)
 
-    if !(W.dW isa Number)
+    # H^_4^(k)
+    # H24 = uprev
+
+    if W.dW isa Number
+        # add stages together Eq. (5.1)
+        u = uprev + (α1 * k1 + α2 * k2 + α3 * k3 + α4 * k1) * dt
+
+        # add noise
+        u += (g1 * beta11 + g2 * beta12 + g3 * beta13 + g4 * beta14) * _dW # beta2 terms are zero by construction
+    else
+        # define two-point distributed random variables
+        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
         H22 = [copy(uprev) for k in 1:m]
         H23 = [copy(uprev) for k in 1:m]
         # add inbounds for speed if working properly
@@ -703,17 +707,11 @@ end
                 end
             end
         end
-    end
-    # H^_4^(k)
-    # H24 = uprev
 
-    # add stages together Eq. (5.1)
-    u = uprev + (α1 * k1 + α2 * k2 + α3 * k3 + α4 * k1) * dt
+        # add stages together Eq. (5.1)
+        u = uprev + (α1 * k1 + α2 * k2 + α3 * k3 + α4 * k1) * dt
 
-    # add noise
-    if W.dW isa Number
-        u += (g1 * beta11 + g2 * beta12 + g3 * beta13 + g4 * beta14) * _dW # beta2 terms are zero by construction
-    else
+        # add noise
         if is_diagonal_noise(integrator.sol.prob)
             u += g1 .* _dW * beta11
             for k in 1:m
@@ -954,10 +952,6 @@ end
     dW_scaled = W.dW / integrator.sqdt
     _dW = map(x -> calc_threepoint_random(sq3dt, NORMAL_ONESIX_QUANTILE, x), dW_scaled)
     chi1 = map(x -> (x^2 - dt) / 4, _dW)
-    if !(W.dW isa Number)
-        # define two-point distributed random variables
-        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
-    end
     # compute stage values
     k1 = integrator.f(uprev, p, t)
     g1 = integrator.f.g(uprev, p, t)
@@ -999,6 +993,8 @@ end
         g2m = integrator.f.g(Ym, p, t)
         u += 1 // 4 * (g2p + g2m + 2 * g1) * _dW + (g2p - g2m) * chi1 / integrator.sqdt #(1.1)
     else
+        # define two-point distributed random variables
+        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
         if is_diagonal_noise(integrator.sol.prob)
             for k in 1:m
                 tmpg1 = integrator.f.g(Yp[k], p, t)
@@ -1235,10 +1231,8 @@ end
     dW_scaled = W.dW / integrator.sqdt
     _dW = map(x -> calc_threepoint_random(sq3dt, NORMAL_ONESIX_QUANTILE, x), dW_scaled)
 
-    if !(W.dW isa Number)
-        # define two-point distributed random variables
-        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
-    end
+    # define two-point distributed random variables (only consumed on the vector-noise paths)
+    _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
 
     # compute stage values
     # stage 1
@@ -1259,15 +1253,15 @@ end
                 if is_diagonal_noise(integrator.sol.prob)
                     tmpu = zero(integrator.u)
                     tmpu[jb] = gtmp[jb]
-                    @.. Y1jajb[ja, jb] = Ihat2 * tmpu
+                    @.. Y1jajb[ja, jb] = ihat2 * tmpu
                     if ja != jb
-                        @.. Y4jajb[ja, jb] = Ihat2 * tmpu
+                        @.. Y4jajb[ja, jb] = ihat2 * tmpu
                     end
                 else
                     gtmpjb = @view gtmp[:, jb]
-                    @.. Y1jajb[ja, jb] = Ihat2 * gtmpjb
+                    @.. Y1jajb[ja, jb] = ihat2 * gtmpjb
                     if ja != jb
-                        @.. Y4jajb[ja, jb] = Ihat2 * gtmpjb
+                        @.. Y4jajb[ja, jb] = ihat2 * gtmpjb
                     end
                 end
             end
@@ -1297,7 +1291,7 @@ end
                     gtmp = integrator.f.g(tmpu, p, t)
                     tmpjb = @view gtmp[:, jb]
                     ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
-                    @.. Y2jajb[ja, jb] = Ihat2 * tmpjb
+                    @.. Y2jajb[ja, jb] = ihat2 * tmpjb
                 end
             end
         else
@@ -1317,7 +1311,7 @@ end
                     tmpu = zero(integrator.u)
                     tmpu[jb] = gtmp[jb]
                     ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
-                    @.. Y2jajb[ja, jb] = Ihat2 * tmpu
+                    @.. Y2jajb[ja, jb] = ihat2 * tmpu
                 end
             end
         end
@@ -1667,6 +1661,11 @@ end
     # add stages together
     @.. u = uprev + c01 * Y100 + c02 * Y200 + c03 * Y300 + c04 * Y400
     if W.dW isa Number
+        # scalar noise: m == 1, so the only stage values are the [1, 1] entries
+        Y1jj = Y1jajb[1, 1]
+        Y2jj = Y2jajb[1, 1]
+        Y3jj = Y3jajb[1, 1]
+        Y4jj = Y4jajb[1, 1]
         @.. u = u + cj1 * Y1jj + cj2 * Y2jj + cj3 * Y3jj + cj4 * Y4jj
     else
         if is_diagonal_noise(integrator.sol.prob)
@@ -2019,17 +2018,6 @@ end
     chi1 = W.dW / integrator.sqdt
     _dW = map(x -> calc_threepoint_random(sq3dt, NORMAL_ONESIX_QUANTILE, x), chi1)
 
-    if !(W.dW isa Number)
-        # define two-point distributed random variables
-        _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
-        ihat2 = zeros(eltype(W.dZ), m, m) # I^_(k,l)
-        for j in 1:m
-            for l in 1:(j - 1)
-                Ihat2[j, l] = -_dZ[j] * _dW[l] / integrator.sqdt
-                Ihat2[l, j] = _dW[l] * _dZ[j] / integrator.sqdt
-            end
-        end
-    end
     # compute stage values
     # stage 1
     ktmp = integrator.f(uprev, p, t)
@@ -2152,11 +2140,20 @@ end
         if is_diagonal_noise(integrator.sol.prob)
             u += @. cj1 * Y1j + cj2 * Y2j + cj3 * Y3j + cj4 * Y4j
         else
+            # define two-point distributed random variables
+            _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x), W.dZ)
+            ihat2 = zeros(eltype(W.dZ), m, m)
+            for j in 1:m
+                for l in 1:(j - 1)
+                    ihat2[j, l] = -_dZ[j] * _dW[l] / integrator.sqdt
+                    ihat2[l, j] = _dW[l] * _dZ[j] / integrator.sqdt
+                end
+            end
             for j in 1:m
                 u += @. cj1 * Y1j[:, j] + cj2 * Y2j[:, j] + cj3 * Y3j[:, j] + cj4 * Y4j[:, j]
                 #add stage values for non-commutative processes, Y3^(k(j)j) and Y4^(k(j)j)
                 for k in 1:m
-                    η2 = @view Ihat2[k, :]
+                    η2 = @view ihat2[k, :]
                     tmp = gtmp1 * η2 / (4 * γ)
                     Y3kj = integrator.sqdt * integrator.f.g(uprev + tmp, p, t)
                     Y4kj = integrator.sqdt * integrator.f.g(uprev - tmp, p, t)

--- a/lib/StochasticDiffEqWeak/src/tableaus.jl
+++ b/lib/StochasticDiffEqWeak/src/tableaus.jl
@@ -22,6 +22,12 @@ struct RoesslerRI{T, T2} <: Tableau
     quantile::T
 end
 
+"""
+    constructDRI1([T=Float64], [T2=Float64])
+
+Construct the `RoesslerRI` tableau used by `DRI1`, with coefficient element
+type `T` and abscissa element type `T2`.
+"""
 function constructDRI1(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 1 // 2; 1]
     c₁ = [0; 342 // 491; 342 // 491]
@@ -72,6 +78,12 @@ function constructDRI1(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     )
 end
 
+"""
+    constructRI1([T=Float64], [T2=Float64])
+
+Construct the `RoesslerRI` tableau used by `RI1`, with coefficient element type
+`T` and abscissa element type `T2`.
+"""
 function constructRI1(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 2 // 3; 2 // 3]
     c₁ = [0; 1; 1]
@@ -122,6 +134,12 @@ function constructRI1(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     )
 end
 
+"""
+    constructRI3([T=Float64], [T2=Float64])
+
+Construct the `RoesslerRI` tableau used by `RI3`, with coefficient element type
+`T` and abscissa element type `T2`.
+"""
 function constructRI3(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 1; 1 // 2]
     c₁ = [0; 1; 1]
@@ -172,6 +190,12 @@ function constructRI3(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     )
 end
 
+"""
+    constructRI5([T=Float64], [T2=Float64])
+
+Construct the `RoesslerRI` tableau used by `RI5`, with coefficient element type
+`T` and abscissa element type `T2`.
+"""
 function constructRI5(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 1; 5 // 12]
     c₁ = [0; 1 // 4; 1 // 4]
@@ -222,6 +246,12 @@ function constructRI5(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     )
 end
 
+"""
+    constructRI6([T=Float64], [T2=Float64])
+
+Construct the `RoesslerRI` tableau used by `RI6`, with coefficient element type
+`T` and abscissa element type `T2`.
+"""
 function constructRI6(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 1; 0]
     c₁ = [0; 1; 1]
@@ -272,6 +302,12 @@ function constructRI6(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     )
 end
 
+"""
+    constructRDI1WM([T=Float64], [T2=Float64])
+
+Construct the `RoesslerRI` tableau used by `RDI1WM`, with coefficient element
+type `T` and abscissa element type `T2`.
+"""
 function constructRDI1WM(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 2 // 3]
     c₁ = [0; 0]
@@ -316,6 +352,12 @@ function constructRDI1WM(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2
     )
 end
 
+"""
+    constructRDI2WM([T=Float64], [T2=Float64])
+
+Construct the `RoesslerRI` tableau used by `RDI2WM`, with coefficient element
+type `T` and abscissa element type `T2`.
+"""
 function constructRDI2WM(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 1; 0]
     c₁ = [0; 2 // 3; 2 // 3]
@@ -366,6 +408,12 @@ function constructRDI2WM(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2
     )
 end
 
+"""
+    constructRDI3WM([T=Float64], [T2=Float64])
+
+Construct the `RoesslerRI` tableau used by `RDI3WM`, with coefficient element
+type `T` and abscissa element type `T2`.
+"""
 function constructRDI3WM(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 1 // 2; 3 // 4]
     c₁ = [0; 2 // 3; 2 // 3]
@@ -416,6 +464,12 @@ function constructRDI3WM(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2
     )
 end
 
+"""
+    constructRDI4WM([T=Float64], [T2=Float64])
+
+Construct the `RoesslerRI` tableau used by `RDI4WM`, with coefficient element
+type `T` and abscissa element type `T2`.
+"""
 function constructRDI4WM(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 1 // 2; 1]
     c₁ = [0; 2 // 3; 2 // 3]
@@ -466,6 +520,13 @@ function constructRDI4WM(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2
     )
 end
 
+"""
+    checkRIOrder(tableau; tol=1e-6, ps=2)
+
+Evaluate the weak order conditions of a `RoesslerRI` tableau through order
+`ps`. Returns one Boolean per condition, using `tol` for coefficient
+comparisons. Supported values of `ps` are 1 and 2.
+"""
 function checkRIOrder(RI; tol = 1.0e-6, ps = 2)
     (; c₀, c₁, c₂, A₀, A₁, A₂, B₀, B₁, B₂, α, β₁, β₂, β₃, β₄) = RI
     e = ones(size(α))
@@ -566,6 +627,12 @@ struct RoesslerRS{T, T2} <: Tableau
     quantile::T
 end
 
+"""
+    constructRS1([T=Float64], [T2=Float64])
+
+Construct the `RoesslerRS` tableau used by `RS1`, with coefficient element type
+`T` and abscissa element type `T2`.
+"""
 function constructRS1(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 0; 1; 0]
     c₁ = [0; 0; 1; 1]
@@ -626,6 +693,12 @@ function constructRS1(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     )
 end
 
+"""
+    constructRS2([T=Float64], [T2=Float64])
+
+Construct the `RoesslerRS` tableau used by `RS2`, with coefficient element type
+`T` and abscissa element type `T2`.
+"""
 function constructRS2(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     c₀ = [0; 2 // 3; 2 // 3; 0]
     c₁ = [0; 0; 1; 1]
@@ -686,6 +759,13 @@ function constructRS2(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
     )
 end
 
+"""
+    checkRSOrder(tableau; tol=1e-6, ps=2)
+
+Evaluate the weak order conditions of a `RoesslerRS` tableau through order
+`ps`. Returns one Boolean per condition, using `tol` for coefficient
+comparisons. Supported values of `ps` are 1 and 2.
+"""
 function checkRSOrder(RS; tol = 1.0e-6, ps = 2)
     (; c₀, c₁, c₂, A₀, A₁, A₂, B₀, B₁, B₂, B₂, B₃, α, β₁, β₂) = RS
     e = ones(size(α))
@@ -783,6 +863,12 @@ struct KomoriNON{T} <: Tableau
     quantile::T
 end
 
+"""
+    constructNON([T=Float64])
+
+Construct the `KomoriNON` tableau used by `NON`, with coefficient element type
+`T`.
+"""
 function constructNON(::Type{T} = Float64) where {T}
     c0 = [1 // 6; 1 // 3; 1 // 3; 1 // 6]
     cj = [1 // 8; 3 // 8; 3 // 8; 1 // 8]
@@ -846,14 +932,15 @@ function constructNON(::Type{T} = Float64) where {T}
     )
 end
 
+"""
+    checkNONOrder(tableau; tol=1e-6)
+
+Evaluate the weak and deterministic order conditions of a `KomoriNON` or
+`KomoriNON2` tableau. Returns one Boolean per condition, using `tol` for
+coefficient comparisons.
+"""
 function checkNONOrder(NON; tol = 1.0e-6)
-    if NON isa KomoriNON
-        (; c0, cj, cjl, clj, α00, α0j, αj0, αjj, αjl, αjljj, αljjl) = NON
-    elseif NON isa KomoriNON2
-        (; c0, cj, ckj, α00, α0j, αj0, αjj, αjl, αkjjl) = NON
-    else
-        (; c0, cj, α00, α0j, αj0, αjj, αjl) = NON
-    end
+    (; c0, cj, α00, α0j, αj0, αjj, αjl) = NON
     e = ones(size(c0))
 
     conditions = Vector{Bool}(undef, 44) # 38 conditions for second order, 6 extra conditions for fourth deterministic order, 44 in total
@@ -893,6 +980,7 @@ function checkNONOrder(NON; tol = 1.0e-6)
     conditions[32] = abs(dot(cj, (αjj * e) .* (αjl * e)) - 1 / 4) < tol
 
     if NON isa KomoriNON
+        (; cjl, clj, αjljj, αljjl) = NON
         conditions[33] = abs(dot(clj, e) - 0) < tol
         conditions[34] = abs(dot(cjl, e) - 0) < tol
         conditions[35] = abs(dot(clj, αljjl * e) - 1 / 2) < tol
@@ -900,12 +988,16 @@ function checkNONOrder(NON; tol = 1.0e-6)
         conditions[37] = abs(dot(clj .* (αljjl * e), αljjl * (αjljj * e)) - 0) < tol
         conditions[38] = abs(dot(clj, (αljjl * e) .^ 2) - 0) < tol
     elseif NON isa KomoriNON2
+        (; ckj, αkjjl) = NON
         conditions[33] = abs(ckj[4] + ckj[3] - 0) < tol
         conditions[34] = abs(ckj[2] - 0) < tol
         conditions[35] = abs(αkjjl[4, 3] - 0) < tol
         conditions[36] = true # we set alpha^(k(j),j,0,0) = 0
         conditions[37] = abs(ckj[3] * αkjjl[3, 2]^2 + ckj[4] * αkjjl[4, 2]^2 - 0) < tol
         conditions[38] = abs(ckj[3] * αkjjl[3, 2] + ckj[4] * αkjjl[4, 2] - 1 / 2) < tol
+    else
+        # Tableaus without the extra noise coefficients cannot satisfy conditions 33–38.
+        conditions[33:38] .= false
     end
     # deterministic fourth order
     conditions[39] = abs(dot(c0, α00 * α00 * (α00 * e)) - 1 / 24) < tol
@@ -918,6 +1010,12 @@ function checkNONOrder(NON; tol = 1.0e-6)
     return (conditions)
 end
 
+"""
+    KomoriNON2
+
+Butcher tableau for the second-order weak Komori `NON2` method for
+Stratonovich SDEs.
+"""
 struct KomoriNON2{T} <: Tableau
     c0::Vector{T}
     cj::Vector{T}
@@ -934,6 +1032,12 @@ struct KomoriNON2{T} <: Tableau
     quantile::T
 end
 
+"""
+    constructNON2([T=Float64])
+
+Construct the `KomoriNON2` tableau used by `NON2`, with coefficient element
+type `T`.
+"""
 function constructNON2(::Type{T} = Float64) where {T}
     # gamma is a free parameter
     γ = 1


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- make the scalar- and vector-noise branches in the weak SRK implementations explicit so JET no longer sees path-dependent undefined or incorrectly typed values
- constrain the IRI1 nonlinear-solver cache parameters and initialize every weak-order condition
- document the 19 exported definitions reported by Aqua and render them in the umbrella documentation
- bump StochasticDiffEqWeak to 2.1.3

This recovers the focused StochasticDiffEqWeak portion of the closed omnibus #3861 and resolves the remaining conflicts against current master.

## Clean-master failure

The StochasticDiffEqWeak QA lane was first exposed by `c538565b25ff19e661e5bf788fe1953a154d64e9` (#3738) and has not had a green run since that exposure. On an untouched `a7080c6f6d` checkout, the official QA group reports 89 JET possible errors and 19 exported definitions without docstrings, ending with 13 passes, 2 failures, and 5 existing broken tests.

## Local verification

At `cb0ed5752c`:

- `GROUP=StochasticDiffEqWeak_QA julia +1.12 --project -e 'using Pkg; Pkg.test()'` — pass: 15 passes and 5 existing broken tests
- `GROUP=StochasticDiffEqWeak_Core julia +1.12 --project -e 'using Pkg; Pkg.test()'` — pass: 23/23
- umbrella `docs/make.jl` build — pass
- Runic over every changed Julia file — pass
- `git diff --check` — pass

The docs build used the sibling SciMLBase prerequisite commit `185512d15`, because current OrdinaryDiffEq master independently fails on SciMLBase's unresolved `check_error` documentation reference. No SciMLBase changes are included here.

