### PR TITLE
Require AllocCheck 0.2 in StochasticDiffEq tests

### DIFF
--- a/lib/StochasticDiffEq/Project.toml
+++ b/lib/StochasticDiffEq/Project.toml
@@ -1,6 +1,6 @@
 name = "StochasticDiffEq"
 uuid = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
-version = "7.1.3"
+version = "7.1.4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -46,6 +46,7 @@ StochasticDiffEqWeak = {path = "../StochasticDiffEqWeak"}
 
 [compat]
 ADTypes = "1.22.0"
+AllocCheck = "0.2"
 DiffEqBase = "7"
 DiffEqNoiseProcess = "5.30.0"
 LinearAlgebra = "1.6"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- require AllocCheck 0.2 for the StochasticDiffEq test target
- bump StochasticDiffEq to 7.1.4

## Clean-master failure

Commit `07d93a606d` added AllocCheck as a test extra without a compatibility floor. The sublibrary downgrade action therefore selects AllocCheck 0.1.0 together with GPUCompiler 0.24.5 and LLVM 6.6.3. On Julia 1.12, that stack fails while precompiling AllocCheck with:

```
InitError: type Nothing has no field major
```

The error originates in GPUCompiler 0.24.5 before any StochasticDiffEq tests can run.

## Local verification

I reproduced the exact mutable downgrade action at `30b83cf94e89744fcbd7ea5496be4967d6fbe540` on untouched master `a7080c6f6d`:

- without this compat floor: resolver selects AllocCheck 0.1.0 / GPUCompiler 0.24.5 / LLVM 6.6.3, and `GROUP=Core` exits during AllocCheck precompilation
- with this branch's exact Project.toml change: resolver selects AllocCheck 0.2.0 / GPUCompiler 0.27.8 / LLVM 9.11.0, and the full official Core group passes, including solver-reversal 152/152
- `git diff --check` passes

