### PR TITLE
Use the analytic event Jacobian as the AD test oracle

### DIFF
--- a/test/AD/autodiff_events.jl
+++ b/test/AD/autodiff_events.jl
@@ -10,7 +10,7 @@
 const JULIA_VERSION_ALLOWS_ZYGOTE = VERSION < v"1.12" && isempty(VERSION.prerelease)
 
 using SciMLSensitivity
-using OrdinaryDiffEq, OrdinaryDiffEqCore, FiniteDiff, Test
+using OrdinaryDiffEq, OrdinaryDiffEqCore, Test
 using OrdinaryDiffEqSDIRK
 using OrdinaryDiffEqCore: IController, PIController, PIDController
 using ADTypes
@@ -58,15 +58,20 @@ function test_f(p)
         save_everystep = false
     ).u[end]
 end
-findiff = FiniteDiff.finite_difference_jacobian(test_f, p)
-findiff
+# There is exactly one bounce on this interval, so the final-state Jacobian has
+# a closed form that avoids finite-difference noise from perturbing the root time.
+impact_speed = sqrt(2 * p[1])
+expected = [
+    (1 + p[2]) / impact_speed - 1 / 2 impact_speed - 2
+    (1 + p[2]) / impact_speed - 1 impact_speed
+]
 
 # Test jacobians with all available backends
 @testset "Jacobian tests" begin
     for backend in get_jacobian_backends()
         @testset "$(typeof(backend))" begin
             ad = DI.jacobian(test_f, backend, p)
-            @test ad ≈ findiff
+            @test ad ≈ expected
         end
     end
 end
@@ -75,7 +80,7 @@ end
 @testset "Enzyme callback limitation (jacobian)" begin
     @test_broken (
         ad = DI.jacobian(test_f, AutoEnzyme(mode = Enzyme.set_runtime_activity(Enzyme.Forward)), p);
-        ad ≈ findiff
+        ad ≈ expected
     )
 end
 
@@ -129,20 +134,20 @@ end
         p
     )
 
-    @test g1 ≈ findiff[2, 1:2]
-    @test g2 ≈ findiff[2, 1:2]
-    @test g3 ≈ findiff[2, 1:2]
-    @test g4 ≈ findiff[2, 1:2]
-    @test g5 ≈ findiff[2, 1:2]
-    @test g6 ≈ findiff[2, 1:2]
-    @test_broken g7 ≈ findiff[2, 1:2]
+    @test g1 ≈ expected[2, 1:2]
+    @test g2 ≈ expected[2, 1:2]
+    @test g3 ≈ expected[2, 1:2]
+    @test g4 ≈ expected[2, 1:2]
+    @test g5 ≈ expected[2, 1:2]
+    @test g6 ≈ expected[2, 1:2]
+    @test_broken g7 ≈ expected[2, 1:2]
 end
 
 # Enzyme fails on ContinuousCallback with "mixed activity for jl_new_struct"
 @testset "Enzyme callback limitation (gradient)" begin
     @test (
         g = DI.gradient(θ -> test_f2(θ, ForwardDiffSensitivity()), AutoEnzyme(mode = Enzyme.set_runtime_activity(Enzyme.Reverse)), p);
-        g ≈ findiff[2, 1:2]
+        g ≈ expected[2, 1:2]
     )
 end
 
@@ -179,6 +184,6 @@ end
         backend,
         p
     )
-    @test g1 ≈ findiff[2, 1:2] rtol = 1.0e-5
-    @test g6 ≈ findiff[2, 1:2] rtol = 1.0e-5
+    @test g1 ≈ expected[2, 1:2] rtol = 1.0e-5
+    @test g6 ≈ expected[2, 1:2] rtol = 1.0e-5
 end


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- replace the bouncing-ball event test's finite-difference Jacobian oracle with its exact one-bounce Jacobian
- use the same analytic reference for Jacobian and gradient backends
- leave every tolerance and the existing broken Enzyme assertion unchanged

This is a test-oracle correction; it does not change solver behavior.

## Clean-master failure

The trajectory contains exactly one bounce. Perturbing the parameters for finite differences also perturbs the located root time, so the finite-difference reference carries enough event-time noise to fail the default comparison:

- ForwardDiff differs from the analytic Jacobian by at most about `2.7e-9`
- the finite-difference oracle differs by about `7.5e-8`

On untouched master `a7080c6f6d`, the full AD group passes its 28,299 general checks, then the event set ends with 3 passes, 2 failures, and 1 existing broken test. The failures are the ForwardDiff Jacobian and Enzyme gradient comparisons against that noisy finite-difference oracle.

Hosted history brackets the exposure after the last passing `275ed1e4` run and the shared-controller merge `fd3f95bb99` (#3720); the test itself did not change across that boundary. The closed-form reference distinguishes a small numerical trajectory shift from an AD regression.

## Analytic reference

For initial height `h` and restitution `e`, the impact speed is `v = sqrt(2h)`. The final-state Jacobian used here is:

```
[(1 + e) / v - 1/2    v - 2
 (1 + e) / v - 1      v]
```

## Local verification

At `05db644879`, the exact full `GROUP=AD julia +1.12 --project -e 'using Pkg; Pkg.test()'` run passes:

- AD tests: 28,299/28,299
- autodiff event tests: 5 passes and the same 1 existing broken test
- discrete adjoint: 1/1
- Runic on the changed file: pass
- `git diff --check`: pass

