### PR TITLE
Run dependabot on the lib/ subpackages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,19 @@ updates:
     directories:
       - "/"
       - "/docs"
-      - "/test"
+      - "/lib/*"
+      - "/test/AD"
+      - "/test/Downstream"
+      - "/test/ODEInterfaceRegression"
+      - "/test/gpu"
+      - "/test/modelingtoolkit"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10
     groups:
       all-julia-packages:
+        # One PR per dependency spanning every directory, so a compat bump lands
+        # in all of the sublibraries at once rather than one package at a time.
+        group-by: dependency-name
         patterns:
           - "*"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Fixes #3978.

## What was wrong

The julia ecosystem entry in `.github/dependabot.yml` covered `/`, `/docs`, and `/test`:

- **`lib/` was never covered.** All 57 subpackages have their own `Project.toml` with their own `[compat]`, and dependabot never looked at any of them. That's why e.g. LinearSolve v5 support had to be bumped by hand.
- **`/test` matched nothing.** The root `test/` directory has no `Project.toml` — the actual test environments are `test/AD`, `test/Downstream`, `test/ODEInterfaceRegression`, `test/gpu`, `test/modelingtoolkit`. So that entry has been dead the whole time.

## Change

```yaml
    directories:
      - "/"
      - "/docs"
      - "/lib/*"
      - "/test/AD"
      - "/test/Downstream"
      - "/test/ODEInterfaceRegression"
      - "/test/gpu"
      - "/test/modelingtoolkit"
    schedule:
      interval: "daily"
    open-pull-requests-limit: 10
    groups:
      all-julia-packages:
        group-by: dependency-name
        patterns:
          - "*"
```

`directories` supports globbing (`directory`, singular, does not), so `/lib/*` picks up all 57 subpackages and stays correct as sublibraries are added or removed.

### Why `group-by: dependency-name`

This is the part worth arguing about, and it's a separable hunk if you disagree.

Without it, the existing `patterns: ["*"]` group produces one PR per run covering every dependency in every directory — today that's ["Bump the all-julia-packages group across 2 directories with 28 updates"](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3571); after this change it would be one PR touching ~64 `Project.toml`s at once. Looking at the history, those omnibus PRs mostly get closed rather than merged (#3537, #3496, #3477, #3424, ...).

`group-by: dependency-name` ([shipped Feb 2026](https://github.blog/changelog/2026-02-24-dependabot-can-group-updates-by-dependency-name-across-multiple-directories/)) instead gives one PR *per dependency*, spanning all directories — i.e. "Bump LinearSolve from 4 to 5" touching every sublibrary that pins it, in one commit. That matches how compat actually has to move in this monorepo: sublibraries are `dev`'d against each other in CI, so a bump has to land everywhere simultaneously or resolution breaks. It's also the reviewable unit.

`open-pull-requests-limit` is raised from the default 5 to 10 since there are now more PRs, each smaller.

## Verification

I can't exercise dependabot's scheduler from here — that only runs once this is on the default branch. What I did check locally:

- The file parses as YAML and validates clean against [SchemaStore's dependabot-2.0 schema](https://json.schemastore.org/dependabot-2.0.json). That schema sets `additionalProperties: false` on group objects (I confirmed it rejects an invented key), and it defines `group-by` as `{"type": "string", "const": "dependency-name"}` — it rejects `group-by: directory`. So the key and value are genuinely valid config, not just tolerated.
- Every directory the config expands to actually contains a `Project.toml`: 1 + 1 + 57 + 5 = 64 directories, no misses. This is what caught the dead `/test` entry — `/test/*` would have pointed dependabot at 15 manifest-less directories like `test/qa` and `test/InterfaceI`.

## Not included

Deliberately left out to keep this reviewable; happy to add in a follow-up if you want them:

- `lib/*/test/*` — ~75 more test environments (`qa`, `gpu`, `sundials`, ...), each with its own pinned `[compat]` for Aqua/JET/SciMLTesting. Real manifests, but it would roughly triple the directory count.
- `lib/StochasticDiffEq/docs` — the only docs environment under `lib/` (`lib/DiffEqDevTools/docs` has no `Project.toml`, so a `/lib/*/docs` glob would half-miss and error).
