### PR TITLE
Test that ABM methods restart their history after a callback discontinuity

### DIFF
--- a/lib/OrdinaryDiffEqAdamsBashforthMoulton/test/abm_discontinuity_restart_tests.jl
+++ b/lib/OrdinaryDiffEqAdamsBashforthMoulton/test/abm_discontinuity_restart_tests.jl
@@ -1,0 +1,66 @@
+using OrdinaryDiffEqAdamsBashforthMoulton, DiffEqBase, Test
+
+# A callback that jumps `u` invalidates the multistep history: the stored `k`
+# values describe the pre-jump trajectory, so continuing the Adams formula across
+# the jump extrapolates through the discontinuity and excites the parasitic roots.
+# The caches guard against this by resetting their step counter whenever
+# `integrator.derivative_discontinuity` is set, which restarts the low-order
+# startup procedure from the post-jump state.
+
+f_iip(du, u, p, t) = (du[1] = -u[1])
+f_oop(u, p, t) = -u
+
+const u0_iip = [10.0]
+const u0_oop = 10.0
+const tjump = 4.0
+
+reset_iip!(integrator) = (integrator.u[1] = u0_iip[1])
+reset_oop!(integrator) = (integrator.u = u0_oop)
+
+# u' = -u restarted from u0 at tjump repeats the initial value problem verbatim, so
+# a correctly restarted multistep method must reproduce its own opening segment
+# step for step. Any surviving pre-jump history shows up as a mismatch here.
+@testset "fixed-step restart: $(nameof(typeof(alg)))" for alg in (
+        AB3(), AB4(), AB5(), ABM32(), ABM43(), ABM54(),
+    )
+    @testset "$name" for (name, f, u0, affect!) in (
+            ("in-place", f_iip, u0_iip, reset_iip!),
+            ("out-of-place", f_oop, u0_oop, reset_oop!),
+        )
+        dt = 0.5
+        cb = DiscreteCallback((u, t, integrator) -> t == tjump, affect!)
+        reference = solve(
+            ODEProblem(f, u0, (0.0, tjump)), alg; adaptive = false, dt = dt
+        )
+        sol = solve(
+            ODEProblem(f, u0, (0.0, 2tjump)), alg;
+            callback = cb, tstops = [tjump], adaptive = false, dt = dt
+        )
+
+        # `save_positions` stores the jump twice; the later save holds the reset state.
+        jump = findlast(==(tjump), sol.t)
+        @test sol.u[jump] == u0
+        for k in 1:(length(reference.t) - 1)
+            @test sol.t[jump + k] ≈ tjump + reference.t[1 + k]
+            @test sol.u[jump + k] == reference.u[1 + k]
+        end
+    end
+end
+
+# The adaptive variable-coefficient methods carry a variable-order divided-difference
+# history rather than a step counter, so check the user-visible consequence instead:
+# after the jump the solution must track the exact decay to the requested tolerance.
+@testset "adaptive restart: $(nameof(typeof(alg)))" for alg in (
+        VCAB3(), VCAB4(), VCAB5(), VCABM3(), VCABM4(), VCABM5(), VCABM(),
+    )
+    cb = DiscreteCallback((u, t, integrator) -> t == tjump, reset_iip!)
+    sol = solve(
+        ODEProblem(f_iip, u0_iip, (0.0, 2tjump)), alg;
+        callback = cb, tstops = [tjump], abstol = 1.0e-8, reltol = 1.0e-8
+    )
+    exact(t) = u0_iip[1] * exp(-(t < tjump ? t : t - tjump))
+    @test all(
+        isapprox(sol.u[i][1], exact(sol.t[i]); atol = 1.0e-5)
+            for i in eachindex(sol.t) if sol.t[i] != tjump
+    )
+end

--- a/lib/OrdinaryDiffEqAdamsBashforthMoulton/test/runtests.jl
+++ b/lib/OrdinaryDiffEqAdamsBashforthMoulton/test/runtests.jl
@@ -17,6 +17,7 @@ end
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "ABM Convergence Tests" include("abm_convergence_tests.jl")
     @time @safetestset "Adams Variable Coefficients Tests" include("adams_tests.jl")
+    @time @safetestset "ABM Discontinuity Restart Tests" include("abm_discontinuity_restart_tests.jl")
 end
 
 # Threaded tests require Polyester.jl (for FastBroadcast.Threaded() support).


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Regression test only — no source changes.

### Context

https://github.com/SciML/DifferentialEquations.jl/issues/1154 reports `AB3` ringing after a `DiscreteCallback` jumps `u`. The reporter's diagnosis was correct: the ABM caches reset their step counter when `integrator.derivative_discontinuity` is set,

```julia
if integrator.derivative_discontinuity
    cache.step = 1
end
```

but the flag never survived to `perform_step!`. `apply_discrete_callback!` returned `integrator.derivative_discontinuity` *after* `reeval_internals_due_to_modification!` had cleared it, so the `||`-fold in `handle_callbacks!` folded in a `false` and the pre-jump `k` history was carried across the discontinuity.

That was already fixed in DiffEqBase 7.5.7 by https://github.com/SciML/OrdinaryDiffEq.jl/pull/3771 (capture the verdict into a local *before* the reeval). Current `OrdinaryDiffEqCore` requires `DiffEqBase = "7.10"`, so no released combination can still hit it.

### Why this test

What #3771 added is a *flag-level* test in `lib/DiffEqBase/test/downstream/callback_merging.jl`. Nothing asserts the user-visible consequence — that a multistep method actually discards its history at a discontinuity. This adds that.

`u' = -u` reset to `u0` at `t = 4` repeats the original initial value problem verbatim, so a correctly restarted multistep method must reproduce its own opening segment step for step. Any surviving pre-jump history shows up as a mismatch.

- `AB3`/`AB4`/`AB5`/`ABM32`/`ABM43`/`ABM54`, in-place and out-of-place: post-jump values must equal the reference segment exactly.
- `VCAB3`/`VCAB4`/`VCAB5`/`VCABM3`/`VCABM4`/`VCABM5`/`VCABM`: these carry a variable-order divided-difference history rather than a step counter, so assert the outcome — the solution tracks the exact decay across the jump to the requested tolerance. (These were never broken; the assertion guards the restart path going forward.)

### Verification

Discriminating — the fixed-step assertions fail on the reporter's `DiffEqBase 7.5.3` environment and pass on master:

```
# DiffEqBase 7.5.3 + OrdinaryDiffEqCore 4.3.0
fixed-step restart: AB3 |   18    16     34
ERROR: Some tests did not pass: 18 passed, 16 failed

# master
Test Summary:                   | Pass  Total     Time
ABM Discontinuity Restart Tests |  211    211  1m02.4s
```

Full `GROUP=Core` for the sublibrary is green locally (Julia 1.12.6):

```
Test Summary:                     | Pass  Total     Time
ABM Convergence Tests             |   24     24  1m34.5s
Adams Variable Coefficients Tests |   16     16     2.9s
ABM Discontinuity Restart Tests   |  211    211  1m02.4s
     Testing OrdinaryDiffEqAdamsBashforthMoulton tests passed
```

Runic clean.

### Separate finding, not addressed here

`CNAB2`/`CNLF2` in `lib/OrdinaryDiffEqIMEXMultistep` gate their startup step on `integrator.iter == 1` only and never consult `derivative_discontinuity`, so they have no restart guard at all. That is an independent gap from the one this issue reported; it will get its own PR rather than being folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTV83FAFhirzPQsopEXNDe