### PR TITLE
Restart CNAB2/CNLF2 after a derivative discontinuity

### DIFF
--- a/lib/OrdinaryDiffEqIMEXMultistep/Project.toml
+++ b/lib/OrdinaryDiffEqIMEXMultistep/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqIMEXMultistep"
 uuid = "9f002381-b378-40b7-97a6-27a27c83f129"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.1"
+version = "2.1.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqIMEXMultistep/src/imex_multistep_perform_step.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/src/imex_multistep_perform_step.jl
@@ -1,3 +1,10 @@
+# Both methods here are two-step: they combine the current state with history
+# (`k2`, `uprev2`) carried over from the previous step. A callback that jumps `u`
+# invalidates that history — it describes the pre-jump trajectory — so the step
+# after a discontinuity has to fall back to the one-step startup formula, exactly
+# as on the very first step.
+is_startup_step(integrator) = integrator.iter == 1 || integrator.derivative_discontinuity
+
 # CNAB2
 
 function initialize!(integrator, cache::CNAB2ConstantCache)
@@ -16,14 +23,14 @@ end
 function perform_step!(integrator, cache::CNAB2ConstantCache, repeat_step = false)
     (; t, dt, uprev, u, f, p) = integrator
     (; k2, nlsolver) = cache
-    cnt = integrator.iter
+    startup = is_startup_step(integrator)
     f1 = integrator.f.f1
     f2 = integrator.f.f2
     du₁ = f1(uprev, p, t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     k1 = integrator.fsalfirst - du₁
     # Explicit part
-    if cnt == 1
+    if startup
         tmp = uprev + dt * k1
     else
         tmp = uprev + dt * (3 // 2 * k1 - 1 // 2 * k2)
@@ -68,13 +75,13 @@ function perform_step!(integrator, cache::CNAB2Cache, repeat_step = false)
     (; k1, k2, du₁, nlsolver) = cache
     (; z, tmp) = nlsolver
     (; f1) = f
-    cnt = integrator.iter
+    startup = is_startup_step(integrator)
 
     f1(du₁, uprev, p, t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     @.. broadcast = false k1 = integrator.fsalfirst - du₁
     # Explicit part
-    if cnt == 1
+    if startup
         @.. broadcast = false tmp = uprev + dt * k1
     else
         @.. broadcast = false tmp = uprev + dt * (3 // 2 * k1 - 1 // 2 * k2)
@@ -115,13 +122,13 @@ end
 function perform_step!(integrator, cache::CNLF2ConstantCache, repeat_step = false)
     (; t, dt, uprev, u, f, p) = integrator
     (; k2, uprev2, nlsolver) = cache
-    cnt = integrator.iter
+    startup = is_startup_step(integrator)
     f1 = integrator.f.f1
     f2 = integrator.f.f2
     du₁ = f1(uprev, p, t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     # Explicit part
-    if cnt == 1
+    if startup
         tmp = uprev + dt * (integrator.fsalfirst - du₁)
     else
         tmp = uprev2 + 2 // 1 * dt * (integrator.fsalfirst - du₁)
@@ -129,7 +136,7 @@ function perform_step!(integrator, cache::CNLF2ConstantCache, repeat_step = fals
     # Implicit part
     # precalculations
     γ = 1 // 1
-    if cnt != 1
+    if !startup
         tmp += γ * dt * k2
     end
     γdt = γ * dt
@@ -169,12 +176,12 @@ function perform_step!(integrator, cache::CNLF2Cache, repeat_step = false)
     (; uprev2, k2, du₁, nlsolver) = cache
     (; z, tmp) = nlsolver
     (; f1) = f
-    cnt = integrator.iter
+    startup = is_startup_step(integrator)
 
     f1(du₁, uprev, p, t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     # Explicit part
-    if cnt == 1
+    if startup
         @.. broadcast = false tmp = uprev + dt * (integrator.fsalfirst - du₁)
     else
         @.. broadcast = false tmp = uprev2 + 2 // 1 * dt * (integrator.fsalfirst - du₁)
@@ -182,7 +189,7 @@ function perform_step!(integrator, cache::CNLF2Cache, repeat_step = false)
     # Implicit part
     # precalculations
     γ = 1 // 1
-    if cnt != 1
+    if !startup
         @.. broadcast = false tmp += γ * dt * k2
     end
     γdt = γ * dt

--- a/lib/OrdinaryDiffEqIMEXMultistep/test/imex_discontinuity_restart_tests.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/test/imex_discontinuity_restart_tests.jl
@@ -1,0 +1,52 @@
+using OrdinaryDiffEqIMEXMultistep, DiffEqBase, Test
+
+# CNAB2 and CNLF2 are two-step: they combine the current state with `k2`/`uprev2`
+# carried over from the previous step. A callback that jumps `u` invalidates that
+# history, so the step after the jump must fall back to the one-step startup
+# formula. Before the `is_startup_step` guard, the startup branch was selected by
+# `integrator.iter == 1` alone, so the pre-jump history was reused: CNLF2's
+# leapfrog step ran from the stale `uprev2` and immediately produced a negative
+# value on a problem whose exact solution is a positive decay.
+
+# u' = -u, split evenly between the implicitly and explicitly treated parts.
+f1_iip(du, u, p, t) = (du[1] = -0.5 * u[1])
+f2_iip(du, u, p, t) = (du[1] = -0.5 * u[1])
+f1_oop(u, p, t) = -0.5 * u
+f2_oop(u, p, t) = -0.5 * u
+
+const u0_iip = [10.0]
+const u0_oop = 10.0
+const tjump = 4.0
+
+reset_iip!(integrator) = (integrator.u[1] = u0_iip[1])
+reset_oop!(integrator) = (integrator.u = u0_oop)
+
+# Resetting to u0 at tjump repeats the original initial value problem, so a
+# correctly restarted two-step method reproduces its own opening segment exactly.
+@testset "$(nameof(typeof(alg)))" for alg in (CNAB2(), CNLF2())
+    @testset "$name" for (name, f1, f2, u0, affect!) in (
+            ("in-place", f1_iip, f2_iip, u0_iip, reset_iip!),
+            ("out-of-place", f1_oop, f2_oop, u0_oop, reset_oop!),
+        )
+        dt = 0.5
+        cb = DiscreteCallback((u, t, integrator) -> t == tjump, affect!)
+        reference = solve(
+            SplitODEProblem(f1, f2, u0, (0.0, tjump)), alg; adaptive = false, dt = dt
+        )
+        sol = solve(
+            SplitODEProblem(f1, f2, u0, (0.0, 2tjump)), alg;
+            callback = cb, tstops = [tjump], adaptive = false, dt = dt
+        )
+
+        # `save_positions` stores the jump twice; the later save holds the reset state.
+        jump = findlast(==(tjump), sol.t)
+        @test sol.u[jump] == u0
+        for k in 1:(length(reference.t) - 1)
+            @test sol.t[jump + k] ≈ tjump + reference.t[1 + k]
+            @test sol.u[jump + k] == reference.u[1 + k]
+        end
+
+        # The exact solution is a positive decay on both sides of the jump.
+        @test all(all(>(0), u) for u in sol.u)
+    end
+end

--- a/lib/OrdinaryDiffEqIMEXMultistep/test/runtests.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/test/runtests.jl
@@ -7,6 +7,8 @@ function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])
 end
 
+@time @safetestset "Discontinuity restart" include("imex_discontinuity_restart_tests.jl")
+
 # Run QA tests (AllocCheck, JET, Aqua) - skip on pre-release Julia
 # Allocation tests must run before JET because JET's static analysis
 # invalidates compiled code and causes spurious runtime allocations.


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

### The bug

`CNAB2` and `CNLF2` are two-step: they combine the current state with `k2`/`uprev2` carried over from the previous step. The startup branch that avoids using that history was selected by `integrator.iter == 1` alone:

```julia
cnt = integrator.iter
if cnt == 1
    tmp = uprev + dt * (integrator.fsalfirst - du₁)
else
    tmp = uprev2 + 2 // 1 * dt * (integrator.fsalfirst - du₁)
end
```

So a callback that jumps `u` left the pre-jump history in place, and the next step extrapolated straight across the discontinuity. Every other multistep family in the repo already guards on `integrator.derivative_discontinuity` — the ABM caches reset `cache.step`, BDF and Nordsieck gate their startup on it. IMEXMultistep was the one that did not.

`CNLF2` is the visible case. On `u' = -u` split evenly between the implicit and explicit parts, `dt = 0.5`, with `u` reset to `10` at `t = 4`, its leapfrog step runs from the stale `uprev2` and returns a **negative** value on the very next step, for a problem whose exact solution is a positive decay:

```
# master
CNAB2   restart-mismatch=1.074   u(4.5)= 4.481  vs reference u(0.5)=5.556
CNLF2   restart-mismatch=9.832   u(4.5)=-3.832  vs reference u(0.5)=6.000

# this branch
CNAB2   restart-mismatch=0.0     u(4.5)= 5.556  vs reference u(0.5)=5.556
CNLF2   restart-mismatch=0.0     u(4.5)= 6.000  vs reference u(0.5)=6.000
```

### The fix

Select the startup branch on a named predicate that also fires when the discontinuity flag is set:

```julia
is_startup_step(integrator) = integrator.iter == 1 || integrator.derivative_discontinuity
```

Normal integration is unaffected — the flag is only true on the step following a callback that reports a modification.

### Test

Resetting to `u0` at `t = 4` repeats the original initial value problem, so a correctly restarted two-step method reproduces its own opening segment step for step. The test asserts that exactly, for both methods in both in-place and out-of-place form, plus positivity across the whole solve. It fails on **both** methods without the source change.

This sublibrary had no functional tests at all before this (only the QA lane), so the test include goes in unconditionally, matching the `OrdinaryDiffEqSDIRK` pattern for sublibs without a `test_groups.toml`.

### Verification

```
# sublibrary, GROUP=Core (confirms the new testset is wired into runtests.jl)
Test Summary:         | Pass  Total   Time
Discontinuity restart |   72     72  25.8s
     Testing OrdinaryDiffEqIMEXMultistep tests passed

# sublibrary, full Pkg.test() including QA (AllocCheck / JET / Aqua)
     Testing OrdinaryDiffEqIMEXMultistep tests passed

# root GROUP=AlgConvergence_III — CNAB2/CNLF2 convergence orders, unchanged
Test Summary:       | Pass  Broken  Total      Time
Split Methods Tests |   81      12     93  28m42.9s
     Testing OrdinaryDiffEq tests passed
```

The 12 broken are pre-existing `@test_broken` markers already in `split_methods_tests.jl` on master, not introduced here. Julia 1.12.6. Runic clean. Patch bump to 2.1.2.

### Context

Found while checking the "and other multistep methods" part of https://github.com/SciML/DifferentialEquations.jl/issues/1154. That issue's actual report (AB3) was a different, already-fixed problem — the flag never reaching `perform_step!`, fixed in DiffEqBase 7.5.7 by https://github.com/SciML/OrdinaryDiffEq.jl/pull/3771. This one is independent: the flag arrives correctly, CNAB2/CNLF2 just never consult it. Related test-only PR: https://github.com/SciML/OrdinaryDiffEq.jl/pull/4105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTV83FAFhirzPQsopEXNDe