### PR TITLE
Fix SERK2 stage times for non-autonomous problems

### DIFF
--- a/lib/OrdinaryDiffEqStabilizedRK/src/rkc_perform_step.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/rkc_perform_step.jl
@@ -988,15 +988,17 @@ end
     uᵢ₋₁ = uprev
     uᵢ₋₂ = uprev
     Sᵢ = Bᵢ[start] * uprev
+    # the recurrence places the stage produced at index j of block i at
+    # t + (j² + (i-1)·internal_deg²)·α·dt, so f must be evaluated one stage back
     for i in 1:10
-        k = f(uᵢ₋₁, p, t + (1 + (i - 1) * internal_deg^2) * α * dt)
+        k = f(uᵢ₋₁, p, t + ((i - 1) * internal_deg^2) * α * dt)
         OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
         u = uᵢ₋₁ + α * dt * k
         Sᵢ = Sᵢ + Bᵢ[start + (i - 1) * internal_deg + 1] * u
         uᵢ₋₂ = uᵢ₋₁
         uᵢ₋₁ = u
         for j in 2:internal_deg
-            k = f(uᵢ₋₁, p, t + (j^2 + (i - 1) * internal_deg^2) * α * dt)
+            k = f(uᵢ₋₁, p, t + ((j - 1)^2 + (i - 1) * internal_deg^2) * α * dt)
             OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
             u = 2 * uᵢ₋₁ - uᵢ₋₂ + 2 * α * dt * k
             Sᵢ = Sᵢ + Bᵢ[start + j + (i - 1) * internal_deg] * u
@@ -1054,15 +1056,17 @@ end
     @.. broadcast = false uᵢ₋₁ = uprev
     @.. broadcast = false tmp = uprev
     @.. broadcast = false Sᵢ = Bᵢ[start] * uprev
+    # the recurrence places the stage produced at index j of block i at
+    # t + (j² + (i-1)·internal_deg²)·α·dt, so f must be evaluated one stage back
     for i in 1:10
-        f(k, uᵢ₋₁, p, t + (1 + (i - 1) * internal_deg^2) * α * dt)
+        f(k, uᵢ₋₁, p, t + ((i - 1) * internal_deg^2) * α * dt)
         OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
         @.. broadcast = false u = uᵢ₋₁ + α * dt * k
         @.. broadcast = false Sᵢ = Sᵢ + Bᵢ[start + (i - 1) * internal_deg + 1] * u
         @.. broadcast = false tmp = uᵢ₋₁
         @.. broadcast = false uᵢ₋₁ = u
         for j in 2:internal_deg
-            f(k, uᵢ₋₁, p, t + (j^2 + (i - 1) * internal_deg^2) * α * dt)
+            f(k, uᵢ₋₁, p, t + ((j - 1)^2 + (i - 1) * internal_deg^2) * α * dt)
             OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
             @.. broadcast = false u = 2 * uᵢ₋₁ - tmp + 2 * α * dt * k
             @.. broadcast = false Sᵢ = Sᵢ + Bᵢ[start + j + (i - 1) * internal_deg] * u

--- a/lib/OrdinaryDiffEqStabilizedRK/test/rkc_tests.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/rkc_tests.jl
@@ -317,6 +317,59 @@ end
     end
 end
 
+@testset "SERK2 non-autonomous convergence" begin
+    # Prothero-Robinson-type problem: uᵢ' = -λᵢ*(uᵢ - cos(t)) - sin(t), exact uᵢ = cos(t).
+    # Catches wrong or missing stage times, which autonomous problems cannot see.
+    lams = [1.0, 5.0, 20.0, 50.0]
+    f_na_oop(u, p, t) = @. -p * (u - cos(t)) - sin(t)
+    f_na_iip(du, u, p, t) = (@. du = -p * (u - cos(t)) - sin(t); nothing)
+    na_analytic(u0, p, t) = cos(t) .* ones(length(p))
+    prob_na_oop = ODEProblem(
+        ODEFunction{false}(f_na_oop, analytic = na_analytic), ones(4), (0.0, 1.0), lams
+    )
+    prob_na_iip = ODEProblem(
+        ODEFunction{true}(f_na_iip, analytic = na_analytic), ones(4), (0.0, 1.0), lams
+    )
+    # pure quadrature: u' = cos(t), any correct second-order method gets order 2
+    fq_oop(u, p, t) = fill(cos(t), 2)
+    fq_iip(du, u, p, t) = (du .= cos(t); nothing)
+    q_analytic(u0, p, t) = u0 .+ sin(t)
+    prob_q_oop = ODEProblem(
+        ODEFunction{false}(fq_oop, analytic = q_analytic), zeros(2), (0.0, 1.0)
+    )
+    prob_q_iip = ODEProblem(
+        ODEFunction{true}(fq_iip, analytic = q_analytic), zeros(2), (0.0, 1.0)
+    )
+
+    dts = 1 .// 2 .^ (10:-1:5)
+    testTol = 0.25
+    # fixed estimate exercises the classical dt -> 0 regime; the 1/dt-scaled
+    # estimate keeps the stage count constant (stiff regime)
+    fixed_eig = (integrator) -> integrator.eigen_est = 55.0
+    scaled_eig = (integrator) -> integrator.eigen_est = 500 / abs(integrator.dt)
+    for prob in [prob_na_oop, prob_na_iip, prob_q_oop, prob_q_iip],
+            eig in [fixed_eig, scaled_eig]
+
+        sim = test_convergence(dts, prob, SERK2(eigen_est = eig))
+        @test sim.𝒪est[:l∞] ≈ 2 atol = testTol
+    end
+end
+
+@testset "SERK2 stage times are internally consistent" begin
+    # Each f evaluation must sit at the row-sum time of the stage it is evaluated
+    # at. Reconstruct the c vector by running the integrator on u' = 1, where the
+    # stage value directly reports its own row sum.
+    seen = Tuple{Float64, Float64}[]
+    f_probe(u, p, t) = (push!(seen, (u[1], t)); [one(u[1])])
+    prob = ODEProblem(ODEFunction{false}(f_probe), [0.0], (0.0, 1.0))
+    eig = (integrator) -> integrator.eigen_est = 500 / abs(integrator.dt)
+    solve(prob, SERK2(eigen_est = eig), dt = 1 // 32, adaptive = false)
+    @test length(seen) > 10
+    for (uval, tval) in seen
+        @test uval ≈ tval atol = 1.0e-10
+    end
+end
+
 @testset "eigen_est_interval" begin
     # Stiff parabolic problem solved with the internal power iteration. The default
     # sparse recompute interval (25) must stay accurate while spending fewer f


### PR DESCRIPTION
Fixes https://github.com/SciML/OrdinaryDiffEq.jl/issues/3950.

> **Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Root cause

Not what the issue hypothesized. The issue guessed that the `Bᵢ` tableau and the stage-time layout disagreed and that the SERK2 papers would be needed to resolve it. They don't disagree — the tableau is correct, and the bug is an off-by-one in exactly the same family as https://github.com/SciML/OrdinaryDiffEq.jl/pull/3948 and https://github.com/SciML/OrdinaryDiffEq.jl/pull/3949.

`perform_step!` evaluated `f` at the time of the stage it was *producing*, not the stage it was *evaluating at*:

```julia
for j in 2:internal_deg
    k = f(uᵢ₋₁, p, t + (j^2 + (i - 1) * internal_deg^2) * α * dt)   # time of u, not uᵢ₋₁
    u = 2 * uᵢ₋₁ - uᵢ₋₂ + 2 * α * dt * k
```

Applying the recurrence to `u' = 1` does give `cⱼ = (j² + (i-1)·d²)·α` — the issue is right about that — but that is the row sum of the stage being *written*, while `f` is applied to `uᵢ₋₁`. The consistent argument is therefore `((j-1)² + (i-1)·d²)·α`, and the leading forward-Euler stage of block `i` sits at the last stage time of block `i-1`, i.e. `(i-1)·d²·α` rather than `(1 + (i-1)·d²)·α`.

## Evidence

Reconstructing `A` and `B` from the implementation and forming `bₗ = Σᵢ Bᵢ Aᵢₗ`, for every `mdeg` in the tableau:

| mdeg | ΣB | Σb | Σb·ĉ (as shipped) | Σb·c (consistent) |
|---|---|---|---|---|
| 10 | 1.0 | 1.0 | 0.525 | 0.5 |
| 30 | 1.0 | 1.0 | 0.5076301 | 0.5 |
| 100 | 1.0 | 1.0 | 0.5018747 | 0.5 |
| 250 | 1.0 | 1.0 | 0.5006952 | 0.5 |

`Σb·c = 1/2` holds exactly with the internally consistent times, so the generated `Bᵢ` are fine and no paper/Fortran reference is needed. The shipped times miss the second-order condition by `O(1/mdeg)`, a fixed defect that does not shrink with `dt` — hence order ~1 rather than 2.

Directly probing the times the integrator passes to `f` while solving `u' = 1` (where a stage value equals its own row sum) gives `max|u - t|`:

| | before | after |
|---|---|---|
| SERK2 | 4.34e-4 | 1.4e-12 |

## Measured convergence

`dts = 2⁻¹⁰..2⁻⁵`, forced `eigen_est`; `fixed` = 55.0, `scaled` = 500/dt.

| problem | eigen_est | before | after |
|---|---|---|---|
| quadrature `u' = cos(t)` oop | fixed | 0.953 | 2.000 |
| quadrature `u' = cos(t)` oop | scaled | 0.804 | 2.000 |
| quadrature `u' = cos(t)` iip | fixed | 0.953 | 2.000 |
| quadrature `u' = cos(t)` iip | scaled | 0.804 | 2.000 |
| Prothero–Robinson oop | fixed | 1.011 | 2.004 |
| Prothero–Robinson oop | scaled | 1.032 | 2.003 |
| Prothero–Robinson iip | fixed | 1.011 | 2.004 |
| Prothero–Robinson iip | scaled | 1.032 | 2.003 |
| linear autonomous | fixed | 1.998 | 1.998 |
| linear autonomous | scaled | 1.994 | 1.994 |

Autonomous convergence is unchanged, as expected.

## Tests

Two new testsets in `lib/OrdinaryDiffEqStabilizedRK/test/rkc_tests.jl`, mirroring the RKL/RKG ones:

- `SERK2 non-autonomous convergence` — Prothero–Robinson and pure quadrature, oop and iip, both `eigen_est` regimes.
- `SERK2 stage times are internally consistent` — probes every `f` call on `u' = 1` and asserts the stage value equals the time argument. Separates fixed from broken by eight orders of magnitude (4.3e-4 vs 1.4e-12), so it is a tight regression guard.

Both fail on master and pass here.

Full group run on this branch:

```
$ GROUP=Core julia --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
RKC Tests     | 1258   1258  9m12.9s
     Testing OrdinaryDiffEqStabilizedRK tests passed
```

Runic clean.

## Note on ESERK4/ESERK5

The issue's closing note that ESERK4/ESERK5 are unaffected holds up. Their stage times are laid out differently (the time argument lags by one stage but is recomputed from a global stage counter that does not reset per block), and probing `u' = 1` shows a 0.053/0.057 discrepancy against the stage row sums — but it does not cost them order. Measuring on a `dt` range where the error is above roundoff, on the same quadrature problem:

| dts | ESERK4 fixed | ESERK4 scaled | ESERK5 fixed | ESERK5 scaled |
|---|---|---|---|---|
| 2⁻⁶..2⁻² | 4.911 | 3.975 | 4.101 | 3.689 |
| 2⁻⁵..2⁻¹ | 5.192 | 3.943 | 5.939 | 5.535 |

At the `dts = 2⁻¹⁰..2⁻⁵` used for SERK2 above, ESERK errors are already down at 1e-13, so an order estimate there measures roundoff rather than truncation. Nothing to fix here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPE849e5oSrZreh3mkE8AJ

