### PR TITLE
Drop the stale trivial_limiter! import from OrdinaryDiffEqStabilizedRK

### DIFF
--- a/lib/OrdinaryDiffEqStabilizedRK/src/OrdinaryDiffEqStabilizedRK.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/OrdinaryDiffEqStabilizedRK.jl
@@ -9,8 +9,7 @@ import OrdinaryDiffEqCore: alg_adaptive_order,
     OrdinaryDiffEqAdaptiveAlgorithm,
     alg_cache, @cache,
     constvalue, full_cache, get_fsalfirstlast,
-    generic_solver_docstring,
-    trivial_limiter!
+    generic_solver_docstring
 import OrdinaryDiffEqCore
 using FastBroadcast: FastBroadcast, @..
 using MuladdMacro: MuladdMacro, @muladd

--- a/lib/OrdinaryDiffEqStabilizedRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/qa/qa.jl
@@ -11,8 +11,6 @@ run_qa(
             ignore = (
                 # SciMLBase-owned helpers not yet declared public (pending release).
                 :_vec, :value,
-                # OrdinaryDiffEqCore owner-internal no-op limiter (deliberately not public).
-                :trivial_limiter!,
             ),
         ),
     ),


### PR DESCRIPTION
> **Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

Found while checking CI on https://github.com/SciML/OrdinaryDiffEq.jl/pull/4108 — this failure is pre-existing on master and unrelated to that PR.

https://github.com/SciML/OrdinaryDiffEq.jl/pull/4059 added `trivial_limiter!` to the `OrdinaryDiffEqCore` import list in `OrdinaryDiffEqStabilizedRK`, but nothing in the package uses it — the stabilized RK methods take no limiter. `grep` finds it only at the import site and in the QA ignore list. ExplicitImports flags it, which errors the StabilizedRK QA group:

```
no_stale_explicit_imports: Error During Test
  StaleImportsException
  Module `OrdinaryDiffEqStabilizedRK` has stale (unused) explicit imports for:
  * `trivial_limiter!`

ERROR: LoadError: Some tests did not pass: 19 passed, 0 failed, 1 errored, 0 broken.
```

Confirmed pre-existing rather than introduced downstream: reverting `lib/OrdinaryDiffEqStabilizedRK/src/` to `a351aa2` (master before #4108) and running the check locally still reports it.

```
PRE-FIX MASTER stale imports: StaleImportsException(OrdinaryDiffEqStabilizedRK,
  [(name = :trivial_limiter!, location = ".../src/OrdinaryDiffEqStabilizedRK.jl:13:5")])
```

## Change

Remove the import, and remove the `all_explicit_imports_are_public` ignore entry that was carrying it (that ignore only suppressed the *public* check; the *stale* check is separate and was never suppressed).

## Verification

All three ExplicitImports checks clean after the change:

```
stale:  nothing
public: nothing
owners: nothing
```

Full QA group:

```
$ GROUP=QA julia --project -e 'using Pkg; Pkg.test()'
Test Summary:    | Broken  Total     Time
Allocation Tests |     13     13  1m31.0s
Test Summary:          | Pass  Total     Time
Type Agnosticism Tests |  104    104  1m53.4s
Test Summary: | Pass  Total     Time
JET Tests     |   27     27  1m55.5s
Test Summary: | Pass  Total     Time
Aqua          |   20     20  2m36.0s
     Testing OrdinaryDiffEqStabilizedRK tests passed
```

Aqua is 20/20 here against the 20 the CI job attempted (19 passed + 1 errored), so this is the only thing that was failing. The 13 broken allocation tests are pre-existing and marked broken.

Runic clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPE849e5oSrZreh3mkE8AJ
