### PR TITLE
Make failfactor_default and qmax_first_step_default public

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
+++ b/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
@@ -495,6 +495,11 @@ include("precompilation_setup.jl")
             # methods to them for their own integrator types.
             :fix_dt_at_bounds!, :handle_tstop!,
             :initialize_tstops, :initialize_saveat, :initialize_d_discontinuities,
+            # The two per-algorithm controller defaults that were left out of the
+            # already-public rest of that family (qmin_default, qmax_default,
+            # gamma_default, qsteady_*_default, beta*_default); both are documented
+            # in docs/src/api/controllers.md and specialized by solver packages.
+            :failfactor_default, :qmax_first_step_default,
         )
     )
 end


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

`failfactor_default` and `qmax_first_step_default` are per-algorithm controller defaults that solver packages specialize, and both are already documented and rendered in `docs/src/api/controllers.md`. They were the only two members of that family left out of the `public` list — `qmin_default`, `qmax_default`, `gamma_default`, `qsteady_min_default`, `qsteady_max_default`, `beta1_default`, `beta2_default` and `default_controller` are all public already.

Downstream packages that add methods to them currently need an ExplicitImports ignore entry to keep QA green. Concretely, [OrdinaryDiffEqOperatorSplitting.jl](https://github.com/SciML/OrdinaryDiffEqOperatorSplitting.jl) defines `OrdinaryDiffEqCore.failfactor_default(::AbstractOperatorSplittingAlgorithm) = 4`, which `check_all_qualified_accesses_are_public` flags.

No version bump: `lib/OrdinaryDiffEqCore/Project.toml` is already at an unreleased `4.13.0` (latest registered 4.x is 4.12.0), and adding public API is a minor bump.

Verified locally on Julia 1.12.6:

```
julia> Base.ispublic(OrdinaryDiffEqCore, :failfactor_default)
true

julia> Base.ispublic(OrdinaryDiffEqCore, :qmax_first_step_default)
true
```

Runic reports no changes for the edited file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jcWBstA52cVLXo1L38ZPm