### PR TITLE
Fix Newmark crash with polyalgorithm nonlinear solvers

### DIFF
--- a/lib/OrdinaryDiffEqNewmark/Project.toml
+++ b/lib/OrdinaryDiffEqNewmark/Project.toml
@@ -35,6 +35,7 @@ JET = "0.9, 0.11"
 LinearAlgebra = "<0.0.1, 1"
 MacroTools = "0.5.13"
 MuladdMacro = "0.2.4"
+NonlinearSolve = "4.20.3"
 NonlinearSolveFirstOrder = "2.1.1"
 OrdinaryDiffEqCore = "4"
 Pkg = "1"
@@ -51,6 +52,7 @@ julia = "1.10"
 [extras]
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
@@ -58,4 +60,4 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DiffEqDevTools", "Random", "SafeTestsets", "Test", "Pkg", "SciMLTesting"]
+test = ["DiffEqDevTools", "NonlinearSolve", "Random", "SafeTestsets", "Test", "Pkg", "SciMLTesting"]

--- a/lib/OrdinaryDiffEqNewmark/src/newmark_caches.jl
+++ b/lib/OrdinaryDiffEqNewmark/src/newmark_caches.jl
@@ -1,4 +1,4 @@
-@cache struct NewmarkBetaCache{uType, rateType, parameterType, N, Thread} <:
+@cache struct NewmarkBetaCache{uType, rateType, parameterType, N, EC, Thread} <:
     OrdinaryDiffEqMutableCache
     u::uType # Current solution
     uprev::uType # Previous solution
@@ -6,6 +6,7 @@
     β::parameterType # newmark parameter 1
     γ::parameterType # newmark parameter 2
     nlcache::N # Inner solver
+    evalcache::EC # Discretization state passed to the inner solver as its parameter
     tmp::uType # temporary, because it is required.
     atmp::uType
     thread::Thread
@@ -38,7 +39,7 @@ function alg_cache(
 
     tmp = zero(u)
     atmp = zero(u)
-    return NewmarkBetaCache(u, uprev, fsalfirst, β, γ, nlcache, tmp, atmp, thread)
+    return NewmarkBetaCache(u, uprev, fsalfirst, β, γ, nlcache, evalcache, tmp, atmp, thread)
 end
 
 @cache struct NewmarkBetaConstantCache{uType, rateType, parameterType, N, Thread} <:
@@ -63,32 +64,20 @@ function alg_cache(
     (; β, γ, thread) = alg
     fsalfirst = zero(rate_prototype)
 
-    # Temporary terms
-    aₙ = fsalfirst.x[1]
-    vₙ, uₙ = uprev.x
-    evalcache = NewmarkDiscretizationCache(
-        f, t, p,
-        dt, β, γ,
-        zero(β), zero(β),   # αm = αf = 0 recovers Newmark
-        aₙ, vₙ, uₙ,
-        nothing, nothing, nothing,
-    )
-
     tmp = zero(u)
     atmp = zero(u)
     return NewmarkBetaConstantCache(u, uprev, fsalfirst, β, γ, alg.nlsolve, tmp, atmp, thread)
 end
 
-@cache struct GeneralizedAlphaCache{uType, rateType, parameterType, N, Thread} <:
+@cache struct GeneralizedAlphaCache{uType, rateType, parameterType, N, EC, Thread} <:
     OrdinaryDiffEqMutableCache
     u::uType # Current solution
     uprev::uType # Previous solution
     fsalfirst::rateType
-    αm::parameterType # generalized alpha parameter 1
-    αf::parameterType # generalized alpha parameter 2
     β::parameterType # newmark parameter 1
     γ::parameterType # newmark parameter 2
     nlcache::N
+    evalcache::EC # Discretization state passed to the inner solver as its parameter
     tmp::uType
     atmp::uType
     thread::Thread
@@ -120,7 +109,9 @@ function alg_cache(
 
     tmp = zero(u)
     atmp = zero(u)
-    return GeneralizedAlphaCache(u, uprev, fsalfirst, αm, αf, β, γ, nlcache, tmp, atmp, thread)
+    return GeneralizedAlphaCache(
+        u, uprev, fsalfirst, β, γ, nlcache, evalcache, tmp, atmp, thread
+    )
 end
 
 @cache struct GeneralizedAlphaConstantCache{uType, rateType, parameterType, N, Thread} <:
@@ -146,16 +137,6 @@ function alg_cache(
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
     (; αm, αf, β, γ, thread) = alg
     fsalfirst = zero(rate_prototype)
-
-    aₙ = fsalfirst.x[1]
-    vₙ, uₙ = uprev.x
-    evalcache = NewmarkDiscretizationCache(
-        f, t, p,
-        dt, β, γ,
-        αm, αf,
-        aₙ, vₙ, uₙ,
-        nothing, nothing, nothing,
-    )
 
     tmp = zero(u)
     atmp = zero(u)

--- a/lib/OrdinaryDiffEqNewmark/src/newmark_perform_step.jl
+++ b/lib/OrdinaryDiffEqNewmark/src/newmark_perform_step.jl
@@ -1,4 +1,8 @@
-function initialize!(integrator, cache::NewmarkBetaCache)
+# Newmark-β is generalized-α with αm = αf = 0, and both schemes reach the inner solver
+# through the same discretization cache, so the in-place step is shared.
+function initialize!(
+        integrator, cache::Union{NewmarkBetaCache, GeneralizedAlphaCache}
+    )
     integrator.f(cache.fsalfirst, integrator.uprev, integrator.p, integrator.t)
     integrator.stats.nf += 1
     integrator.fsalfirst = cache.fsalfirst
@@ -6,9 +10,12 @@ function initialize!(integrator, cache::NewmarkBetaCache)
     return
 end
 
-@muladd function perform_step!(integrator, cache::NewmarkBetaCache, repeat_step = false)
+@muladd function perform_step!(
+        integrator, cache::Union{NewmarkBetaCache, GeneralizedAlphaCache},
+        repeat_step = false
+    )
     (; t, dt, u, f, p) = integrator
-    (; β, γ, thread, nlcache, atmp) = cache
+    (; β, γ, thread, nlcache, evalcache, atmp) = cache
 
     # Evaluate predictor
     vₙ, uₙ = integrator.uprev.x
@@ -18,20 +25,27 @@ end
     end
     aₙ = integrator.fsalfirst.x[1]
 
-    evalcache = NewmarkDiscretizationCache(
-        f, t, p,
-        dt, β, γ,
-        zero(β), zero(β),
-        aₙ, vₙ, uₙ,
-        nlcache.p.atmp, nlcache.p.vₙ₊₁, nlcache.p.uₙ₊₁,
-    )
+    # The AD buffers inside `evalcache` have to survive across steps, and not every inner
+    # cache type exposes the parameter object it was handed, so the discretization state
+    # is owned here and refreshed in place rather than rebuilt out of `nlcache`.
+    evalcache.f = f
+    evalcache.t = t
+    evalcache.p = p
+    evalcache.dt = dt
+    evalcache.aₙ = aₙ
+    evalcache.vₙ = vₙ
+    evalcache.uₙ = uₙ
+
     SciMLBase.reinit!(nlcache, aₙ, p = evalcache)
-    solve!(nlcache)
-    if nlcache.retcode != ReturnCode.Success
+    # A polyalgorithm cache delegates to its subcaches and a no-init cache delegates to a
+    # one-shot `solve`, so neither holds the accepted iterate and both leave their own
+    # retcode at `Default`; the outcome only exists on the solution `solve!` returns.
+    nlsol = solve!(nlcache)
+    if nlsol.retcode != ReturnCode.Success
         integrator.force_stepfail = true
         return
     end
-    aₙ₊₁ = nlcache.u
+    aₙ₊₁ = nlsol.u
 
     @.. thread = thread u.x[1] = vₙ + dt * ((1 - γ) * aₙ + γ * aₙ₊₁)
     @.. thread = thread u.x[2] = uₙ + dt * vₙ + dt^2 / 2 * ((1 - 2β) * aₙ + 2β * aₙ₊₁)
@@ -99,63 +113,6 @@ end
 
     if integrator.opts.adaptive
         integrator.fsallast .= f(u, p, t + dt)
-        integrator.stats.nf += 1
-
-        if integrator.success_iter == 0
-            OrdinaryDiffEqCore.set_EEst!(integrator, one(OrdinaryDiffEqCore.get_EEst(integrator)))
-        else
-            # Zienkiewicz and Xie (1991) Eq. 21
-            @.. thread = thread atmp = (integrator.fsallast.x[1] - aₙ₊₁)
-            OrdinaryDiffEqCore.set_EEst!(
-                integrator,
-                dt * dt * (β - 1 // 6) *
-                    integrator.opts.internalnorm(atmp, t)
-            )
-        end
-    end
-
-    return
-end
-
-function initialize!(integrator, cache::GeneralizedAlphaCache)
-    integrator.f(cache.fsalfirst, integrator.uprev, integrator.p, integrator.t)
-    integrator.stats.nf += 1
-    integrator.fsalfirst = cache.fsalfirst
-    integrator.fsallast = cache.fsalfirst
-    return
-end
-
-@muladd function perform_step!(integrator, cache::GeneralizedAlphaCache, repeat_step = false)
-    (; t, dt, u, f, p) = integrator
-    (; αm, αf, β, γ, thread, nlcache, atmp) = cache
-
-    vₙ, uₙ = integrator.uprev.x
-    if integrator.derivative_discontinuity || !integrator.opts.adaptive
-        f(integrator.fsalfirst, integrator.u, p, t + dt)
-        integrator.stats.nf += 1
-    end
-    aₙ = integrator.fsalfirst.x[1]
-
-    evalcache = NewmarkDiscretizationCache(
-        f, t, p,
-        dt, β, γ,
-        αm, αf,
-        aₙ, vₙ, uₙ,
-        nlcache.p.atmp, nlcache.p.vₙ₊₁, nlcache.p.uₙ₊₁,
-    )
-    SciMLBase.reinit!(nlcache, aₙ, p = evalcache)
-    solve!(nlcache)
-    if nlcache.retcode != ReturnCode.Success
-        integrator.force_stepfail = true
-        return
-    end
-    aₙ₊₁ = nlcache.u
-
-    @.. thread = thread u.x[1] = vₙ + dt * ((1 - γ) * aₙ + γ * aₙ₊₁)
-    @.. thread = thread u.x[2] = uₙ + dt * vₙ + dt^2 / 2 * ((1 - 2β) * aₙ + 2β * aₙ₊₁)
-
-    if integrator.opts.adaptive
-        f(integrator.fsallast, u, p, t + dt)
         integrator.stats.nf += 1
 
         if integrator.success_iter == 0

--- a/lib/OrdinaryDiffEqNewmark/test/nlsolve_cache_tests.jl
+++ b/lib/OrdinaryDiffEqNewmark/test/nlsolve_cache_tests.jl
@@ -1,0 +1,191 @@
+using OrdinaryDiffEqNewmark, Test
+using NonlinearSolve: NewtonRaphson, RobustMultiNewton, FastShortcutNonlinearPolyalg,
+    SimpleNewtonRaphson, SimpleTrustRegion
+using SciMLBase
+
+# u'' = -u with u(0) = 1, u'(0) = 0, so u(1) = cos(1) and u'(1) = -sin(1).
+function accel!(dv, v, u, p, t)
+    @. dv = -u
+    return nothing
+end
+prob = SecondOrderODEProblem(accel!, [0.0], [1.0], (0.0, 1.0))
+
+newmark_beta(nlsolve) = NewmarkBeta(; nlsolve)
+generalized_alpha(nlsolve) = GeneralizedAlpha(rho_inf = 0.8; nlsolve)
+
+schemes = ["NewmarkBeta" => newmark_beta, "GeneralizedAlpha" => generalized_alpha]
+
+function discretization_params(alg::NewmarkBeta)
+    return (; alg.β, alg.γ, αm = zero(alg.β), αf = zero(alg.β))
+end
+discretization_params(alg::GeneralizedAlpha) = (; alg.β, alg.γ, alg.αm, alg.αf)
+
+# Inner solvers whose caches expose neither the parameter object nor the solved state at
+# top level: `NonlinearSolvePolyAlgorithmCache` for the polyalgorithms, and
+# `NonlinearSolveNoInitCache` for the SimpleNonlinearSolve algorithms, which have no
+# `__init` of their own.
+polyalgorithms = [
+    "RobustMultiNewton" => RobustMultiNewton(),
+    "FastShortcutNonlinearPolyalg" => FastShortcutNonlinearPolyalg(),
+]
+simple_solvers = [
+    "SimpleNewtonRaphson" => SimpleNewtonRaphson(),
+    "SimpleTrustRegion" => SimpleTrustRegion(),
+]
+inner_solvers = vcat(polyalgorithms, simple_solvers)
+
+# The residual the schemes hand to the inner solver is linear in aₙ₊₁ for u'' = -u, so
+# each step inverts in closed form. Consuming an explicit step sequence makes the
+# reference sensitive to the dt used per step, which the solver reads out of its
+# discretization cache.
+function reference_endpoint(dts; β, γ, αm, αf)
+    v, u = 0.0, 1.0
+    for dt in dts
+        aₙ = -u
+        aₙ₊₁ = (
+            -αm * aₙ - αf * u - (1 - αf) * (u + dt * v + dt^2 * (0.5 - β) * aₙ)
+        ) / ((1 - αm) + (1 - αf) * β * dt^2)
+        v, u = v + dt * ((1 - γ) * aₙ + γ * aₙ₊₁),
+            u + dt * v + dt^2 / 2 * ((1 - 2β) * aₙ + 2β * aₙ₊₁)
+    end
+    return v, u
+end
+
+# The step-failure branch is unreachable from a problem every inner solver converges on,
+# so exercising it needs an inner solve that reports failure on demand.
+struct FailingNonlinearSolver <: SciMLBase.AbstractNonlinearAlgorithm end
+
+mutable struct FailingNonlinearCache{P}
+    prob::P
+end
+
+function SciMLBase.__init(
+        prob::SciMLBase.AbstractNonlinearProblem, ::FailingNonlinearSolver, args...;
+        kwargs...
+    )
+    return FailingNonlinearCache(prob)
+end
+
+function SciMLBase.reinit!(cache::FailingNonlinearCache, u0; p = cache.prob.p, kwargs...)
+    cache.prob = SciMLBase.remake(cache.prob; u0, p)
+    return cache
+end
+
+# Reports the failure alongside a finite, plausible-looking iterate, so a caller that
+# ignores the retcode keeps integrating with a wrong acceleration instead of blowing up.
+function SciMLBase.solve!(cache::FailingNonlinearCache)
+    return SciMLBase.build_solution(
+        cache.prob, FailingNonlinearSolver(), cache.prob.u0, copy(cache.prob.u0);
+        retcode = ReturnCode.ConvergenceFailure
+    )
+end
+
+@testset "Newmark inner nonlinear solvers" begin
+    @testset "$scheme" for (scheme, make_alg) in schemes
+        alg = make_alg(NewtonRaphson())
+        params = discretization_params(alg)
+
+        ref = solve(prob, alg, dt = 0.1, adaptive = false)
+        ref_tstop = solve(prob, alg, dt = 0.1, adaptive = false, tstops = [0.25])
+        @test ref.retcode == ReturnCode.Success
+        @test ref_tstop.retcode == ReturnCode.Success
+
+        # Absolute anchors on both components, so an error shared by every inner solver
+        # still shows up.
+        @test ref.u[end].x[1][1] ≈ -sin(1.0) atol = 2.0e-3
+        @test ref.u[end].x[2][1] ≈ cos(1.0) atol = 2.0e-3
+
+        # The tstop clips one step to dt = 0.05; pin both step sequences against the
+        # closed-form map so a stale dt in the discretization cache cannot pass.
+        @test sort(unique(round.(diff(ref_tstop.t), digits = 12))) == [0.05, 0.1]
+        for sol in (ref, ref_tstop)
+            v, u = reference_endpoint(diff(sol.t); params...)
+            @test sol.u[end].x[1][1] ≈ v atol = 1.0e-12
+            @test sol.u[end].x[2][1] ≈ u atol = 1.0e-12
+        end
+
+        @testset "$name" for (name, nlsolve) in inner_solvers
+            sol = solve(prob, make_alg(nlsolve), dt = 0.1, adaptive = false)
+            @test sol.retcode == ReturnCode.Success
+            @test sol.u[end].x[1][1] ≈ ref.u[end].x[1][1] rtol = 1.0e-8
+            @test sol.u[end].x[2][1] ≈ ref.u[end].x[2][1] rtol = 1.0e-8
+        end
+
+        @testset "$name across a clipped step" for (name, nlsolve) in polyalgorithms
+            sol = solve(
+                prob, make_alg(nlsolve), dt = 0.1, adaptive = false, tstops = [0.25]
+            )
+            @test sol.retcode == ReturnCode.Success
+            @test sol.u[end].x[1][1] ≈ ref_tstop.u[end].x[1][1] rtol = 1.0e-8
+            @test sol.u[end].x[2][1] ≈ ref_tstop.u[end].x[2][1] rtol = 1.0e-8
+        end
+
+        # The discretization state is one long-lived object that every step refreshes,
+        # not a fresh one recycling buffers out of the inner cache. Stepping across a
+        # tstop varies dt, which a cache refreshed only at init would miss.
+        @testset "discretization cache is refreshed per step" begin
+            integrator = init(prob, alg, dt = 0.1, adaptive = false, tstops = [0.25])
+            evalcache = integrator.cache.evalcache
+            step!(integrator)                     # 0.0 -> 0.1
+            step!(integrator)                     # 0.1 -> 0.2
+            step!(integrator)                     # 0.2 -> 0.25, dt clipped to 0.05
+            @test integrator.cache.evalcache === evalcache
+            @test evalcache.t ≈ 0.2 atol = 1.0e-12
+            @test evalcache.dt ≈ 0.05 atol = 1.0e-12
+            step!(integrator)                     # 0.25 -> 0.35, dt back to 0.1
+            @test evalcache.t ≈ 0.25 atol = 1.0e-12
+            @test evalcache.dt ≈ 0.1 atol = 1.0e-12
+        end
+
+        @testset "failing inner solve fails the step" begin
+            sol = solve(
+                prob, make_alg(FailingNonlinearSolver()), dt = 0.1,
+                adaptive = false, maxiters = 20
+            )
+            @test !SciMLBase.successful_retcode(sol.retcode)
+            @test sol.t[end] == 0.0
+        end
+
+        # `evalcache.p` has to track `integrator.p`: a callback may rebind it, and the
+        # residual reads the parameters out of the discretization cache. The reference
+        # is two chained constant-parameter solves, which a correct solver reproduces
+        # exactly and a cache holding its construction-time parameters does not.
+        @testset "rebound parameters reach the inner solve" begin
+            function stiff_accel!(dv, v, u, p, t)
+                @. dv = -p[1] * u
+                return nothing
+            end
+            pprob = SecondOrderODEProblem(
+                stiff_accel!, [0.0], [1.0], (0.0, 1.0), [1.0]
+            )
+            rebind = SciMLBase.DiscreteCallback(
+                (u, t, integ) -> t ≥ 0.5 - 1.0e-12,
+                integ -> (integ.p = [4.0]; nothing);
+                save_positions = (false, false)
+            )
+
+            first_half = solve(
+                SciMLBase.remake(pprob; tspan = (0.0, 0.5)), alg,
+                dt = 0.1, adaptive = false
+            )
+            second_half = solve(
+                SciMLBase.remake(
+                    pprob; tspan = (0.5, 1.0), u0 = copy(first_half.u[end]), p = [4.0]
+                ), alg, dt = 0.1, adaptive = false
+            )
+            vref = second_half.u[end].x[1][1]
+            uref = second_half.u[end].x[2][1]
+
+            solvers = vcat(["NewtonRaphson" => NewtonRaphson()], inner_solvers)
+            @testset "$name" for (name, nlsolve) in solvers
+                sol = solve(
+                    pprob, make_alg(nlsolve), dt = 0.1,
+                    adaptive = false, callback = rebind
+                )
+                @test sol.retcode == ReturnCode.Success
+                @test sol.u[end].x[1][1] ≈ vref atol = 1.0e-12
+                @test sol.u[end].x[2][1] ≈ uref atol = 1.0e-12
+            end
+        end
+    end
+end

--- a/lib/OrdinaryDiffEqNewmark/test/runtests.jl
+++ b/lib/OrdinaryDiffEqNewmark/test/runtests.jl
@@ -218,6 +218,8 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
         @test_throws AssertionError GeneralizedAlpha(0.3, 0.1, 0.25, 0.5)
         @test_throws AssertionError GeneralizedAlpha(0.0, 0.6, 0.25, 0.5)
     end
+
+    @time @safetestset "Inner Nonlinear Solver Caches" include("nlsolve_cache_tests.jl")
 end
 
 # Run QA tests (AllocCheck, JET) - skip on pre-release Julia


### PR DESCRIPTION
`nlsolve` is a public keyword argument on both `NewmarkBeta` and `GeneralizedAlpha`.
The default `NewtonRaphson` works, and so does any other algorithm whose cache steps
in place, such as `TrustRegion`, `Broyden` and `Klement`. Everything else crashed on the first
step. `RobustMultiNewton` and `FastShortcutNonlinearPolyalg` threw `type
NonlinearSolvePolyAlgorithmCache has no field p`; every SimpleNonlinearSolve
algorithm threw `type NonlinearSolveNoInitCache has no field p`. Same bug class as
#3859, fixed for `NonlinearSolveAlg` in #3959, in a different sublibrary.

The integrator cache was using the inner nonlinear cache as its own storage.
`perform_step!` constructed a fresh `NewmarkDiscretizationCache` on every step, and
recovered the three `DiffCache` AD buffers it needed by reaching into `nlcache.p`.
A cache that keeps its parameter object somewhere other than a `p` field has nothing
to reach into. The discretization state now lives on the integrator cache and is
refreshed in place per step, so nothing is read back out of the inner cache.

That alone is not sufficient. `NonlinearSolveBase`'s `@generated CommonSolve.solve!`
specialization for `NonlinearSolvePolyAlgorithmCache` returns the winning
sub-cache's solution and never writes back the parent cache's `retcode`, which stays
at `ReturnCode.Default`; the `NonlinearSolveNoInitCache` specialization delegates to
a one-shot `solve` and likewise leaves the cache's own `retcode` untouched. A caller
that drives these caches through `solve!` therefore has to read the returned
solution rather than the cache. This is specific to `solve!`. `InternalAPI.step!`
does assign `cache.retcode` (NonlinearSolveBase/src/polyalg.jl:316, 323, 359), which
is why the `newton.jl` path merged in #3959 drives with `step!` and is unaffected.

Both halves are load-bearing. With only the storage defect fixed, the guard reads
`nlcache.retcode`, sees `Default`, sets `force_stepfail` on every step, and the solve
returns `ReturnCode.ConvergenceFailure` with the state still at `u0` and
`t[end] == 0.0`, a crash traded for a silent stall.

The two in-place `perform_step!` bodies and the two `initialize!` bodies differed
only in which `αm`/`αf` they passed into the discretization cache, so they are now
shared `Union` methods. Newmark-β is generalized-α with `αm = αf = 0`, and those two
parameters enter only through the residual the inner solver evaluates. Neither the
state update nor the Zienkiewicz-Xie error estimate references them, so the merge is
exact, not an approximation. They no longer need to live on `GeneralizedAlphaCache`
at all, since they are read once when the discretization cache is built. Output was
checked bit-identical against master across 285 configurations. Across the changed
source files the diff removes more lines than it adds.

Result matrix, `u'' = -u` as a `SecondOrderODEProblem`, `dt = 0.1`,
`adaptive = false`, identical for both schemes:

| inner solver | before | after |
| --- | --- | --- |
| `NewtonRaphson` (default), `TrustRegion`, `Broyden`, `Klement` | Success | Success, unchanged to the last bit |
| `RobustMultiNewton`, `FastShortcutNonlinearPolyalg` | throws, no field `p` | Success |
| `SimpleNewtonRaphson`, `SimpleTrustRegion`, `SimpleBroyden`, `SimpleKlement` | throws, no field `p` | Success |

All twenty configurations agree with the reference to 1e-8 relative and sit at the
expected second-order error against the analytic solution (7.0e-4 for Newmark-β,
1.11e-3 for generalized-α at `rho_inf = 0.8`).

Not rebuilding a cache per step also drops allocations: on a two-DOF harmonic
oscillator at `dt = 0.01`, `perform_step!` goes from 2512 to 2336 bytes for
`NewmarkBeta` and from 2528 to 2336 for `GeneralizedAlpha`. AllocCheck's static site
count goes from 518 to 517; that test is still `broken` on both sides.

The new `test/nlsolve_cache_tests.jl` adds 98 assertions, taking the sublibrary's
Core group from 16 to 114. The six pre-existing testsets are unchanged at 16 of 16 on
both trees. The new file pins both state components of both schemes against a
closed-form step map rather than against each other, so an error common to every
inner solver still shows; it steps across a `tstop` that clips `dt` to 0.05, so a
discretization cache refreshed only at init cannot pass; it rebinds `integrator.p`
from a callback and checks the result against two chained constant-parameter solves,
so the parameters actually reaching the residual are pinned; and it drives a stub
inner solver that reports `ConvergenceFailure` alongside a finite iterate, so the
step-failure branch is exercised rather than assumed. Against master the file gives
24 passed and 24 errored.

Mutation testing confirms it discriminates. Deleting `evalcache.dt = dt`, deleting
`evalcache.t = t`, deleting `evalcache.p = p`, deleting the retcode guard, reverting
`nlsol.u` to `nlcache.u`, reverting `nlsol.retcode` to `nlcache.retcode`, and
building the generalized-α cache with `αm = αf = 0` each leave the suite red.

`NonlinearSolve` enters the sublibrary as a test-only dependency; 4.20.3 is the
lowest floor that resolves against the rest of the downgrade floor set, and the new
tests pass there.

Every number above is an `adaptive = false` number. Adaptive Newmark is separately
broken on master: `solve(prob, NewmarkBeta(), dt = 0.1)` with no further keyword
arguments throws `DimensionMismatch` from the error-estimate broadcast, on master and
on this branch alike. That is unrelated to the inner solver and is fixed in a
separate PR.

This does not route Newmark through `build_nlsolver`/`NonlinearSolveAlg`. That path's
unknown is the full state under a single scalar `γ`, while Newmark solves for the
acceleration alone, which enters position with `dt²β` and velocity with `dt·γ`.
Mapping it onto the DIRK form pins `β = γ²`, i.e. Trapezoid. `NewmarkBeta()` and
`Trapezoid()` already agree to 3e-16 on `u'' = -u`. The `rho_inf`
parameterization of generalized-α gives `β = γ²/4` identically, so no dissipative
member is representable. Reaching the shared path needs a second-order residual mode
and a second-order Jacobian interface for `(1-αm)M - (1-αf)(dt²β ∂fᵤ + dt·γ ∂fᵥ)`,
which is #1570 / #3474 territory. The two changes here are correct either way: both
replace reaching into a foreign cache's internals with the public API.

## AI Disclosure

Claude assisted with this work.
