### PR TITLE
Stop ExplicitTaylorAdaptiveOrder from dropping Taylor coefficients

### DIFF
--- a/lib/OrdinaryDiffEqTaylorSeries/src/TaylorSeries_caches.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/src/TaylorSeries_caches.jl
@@ -130,12 +130,12 @@ function alg_cache(
         dt, reltol, p, calck,
         ::Val{true}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    min_order_value, max_order_value = order_window(alg)
     utaylor = TaylorDiff.make_seed(u, zero(u), alg.max_order)
     jets = FunctionWrapper{Nothing, Tuple{typeof(utaylor), typeof(u), typeof(t)}}[]
-    min_order_value = get_value(alg.min_order)
-    max_order_value = get_value(alg.max_order)
+    # every order shares the single `max_order` buffer, so the jets have to fill it
     for order in min_order_value:max_order_value
-        jet_iip = build_jet(f, p, Val(order), length(u))[2]
+        jet_iip = build_jet(f, p, Val(order), length(u), alg.max_order)[2]
         push!(jets, jet_iip)
     end
     utilde = zero(u)
@@ -166,19 +166,19 @@ function alg_cache(
         dt, reltol, p, calck,
         ::Val{false}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    min_order_value, max_order_value = order_window(alg)
     utaylor = TaylorDiff.make_seed(u, zero(u), alg.max_order) # not used, but needed for type
     jets = FunctionWrapper{typeof(utaylor), Tuple{typeof(u), typeof(t)}}[]
-    min_order_value = get_value(alg.min_order)
-    max_order_value = get_value(alg.max_order)
+    # the wrapper's return type is pinned at `max_order`, so the jets have to match it
     for order in min_order_value:max_order_value
         if u isa AbstractArray
-            jet, _ = build_jet(f, p, Val(order), length(u))
+            jet, _ = build_jet(f, p, Val(order), length(u), alg.max_order)
         else
-            jet = build_jet(f, p, Val(order))
+            jet = build_jet(f, p, Val(order), nothing, alg.max_order)
         end
         push!(jets, jet)
     end
-    current_order = Ref(min_order_value)
+    current_order = Ref(max_order_value - 1)
     return ExplicitTaylorAdaptiveOrderConstantCache(
         alg.min_order, alg.max_order, current_order, jets
     )

--- a/lib/OrdinaryDiffEqTaylorSeries/src/TaylorSeries_perform_step.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/src/TaylorSeries_perform_step.jl
@@ -133,6 +133,14 @@ end
 end
 
 function initialize!(integrator, cache::ExplicitTaylorAdaptiveOrderCache)
+    max_order_value = get_value(cache.max_order)
+    integrator.kshortsize = max_order_value
+    resize!(integrator.k, max_order_value)
+    # Setup k pointers
+    for i in 1:max_order_value
+        integrator.k[i] = TaylorDiff.get_coefficient(cache.utaylor, i)
+    end
+    return nothing
 end
 
 @muladd function perform_step!(
@@ -153,6 +161,11 @@ end
         u[i] = @inline evaluate_polynomial(utaylor[i], dt)
     end
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, current_order[] + 1)
+    # Copy Taylor coefficients into k for dense output interpolation.
+    # Coefficients above the order of this step's jet are zero.
+    for i in 1:max_order_value
+        map!(ts -> TaylorDiff.get_coefficient(ts, i), integrator.k[i], utaylor)
+    end
     if integrator.opts.adaptive
         min_work = Inf
         start_order = max(min_order_value, current_order[] - 1)
@@ -217,12 +230,19 @@ end
     # compute one additional order for adaptive order
     jet = jets[jet_index + 1]
     utaylor = jet(uprev, t)
-    u = map(x -> evaluate_polynomial(x, dt), utaylor)
+    u = eval_taylor_polynomial(utaylor, dt)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, current_order[] + 1)
+    # Save Taylor coefficients for dense output interpolation.
+    # Coefficients above the order of this step's jet are zero.
+    for i in 1:max_order_value
+        integrator.k[i] = _taylor_get_coefficient(utaylor, i)
+    end
     if integrator.opts.adaptive
         min_work = Inf
         start_order = max(min_order_value, current_order[] - 1)
-        end_order = min(max_order_value, current_order[] + 1)
+        # one order above `current_order` is still jetted next step, so it has to stay
+        # within `jets`
+        end_order = min(max_order_value - 1, current_order[] + 1)
         for i in start_order:end_order
             A = i * i
             utilde = TaylorDiff.get_coefficient(utaylor, i) * dt^i
@@ -256,5 +276,6 @@ end
             end
         end
     end
+    integrator.u = u
     return nothing
 end

--- a/lib/OrdinaryDiffEqTaylorSeries/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/src/alg_utils.jl
@@ -16,6 +16,23 @@ alg_order(alg::ExplicitTaylorAdaptiveOrder) = get_value(alg.min_order)
 get_current_adaptive_order(::ExplicitTaylorAdaptiveOrder, cache) = cache.current_order[]
 get_current_alg_order(::ExplicitTaylorAdaptiveOrder, cache) = cache.current_order[]
 
+# A step at `current_order` is jetted one order higher, so `current_order` has to
+# stay below `max_order`. With an empty window the order loop never runs and the
+# step is accepted on a stale error estimate.
+function order_window(alg::ExplicitTaylorAdaptiveOrder)
+    min_order_value = get_value(alg.min_order)
+    max_order_value = get_value(alg.max_order)
+    if max_order_value <= min_order_value
+        throw(
+            ArgumentError(
+                "ExplicitTaylorAdaptiveOrder requires max_order > min_order, got " *
+                    "min_order = $min_order_value, max_order = $max_order_value"
+            )
+        )
+    end
+    return min_order_value, max_order_value
+end
+
 JET_CACHE = IdDict()
 
 # Helper functions to unwrap Symbolics.Num to concrete values (needed for Symbolics v7+)
@@ -49,18 +66,35 @@ end
 # Fallback for other types (e.g., already-concrete values)
 @inline sym_unwrap_taylor(x, ::Type{T}) where {T} = x
 
-function build_jet(f::ODEFunction{iip}, p, order, length = nothing) where {iip}
+# A jet of order `P` does not always fill a Taylor buffer of the same order:
+# `ExplicitTaylorAdaptiveOrder` sizes one buffer at `max_order` and runs every
+# order through it. Assigning a `TaylorScalar{T, P}` where a `TaylorScalar{T, Q}`
+# is expected goes through TaylorDiff's number-promotion constructor, which keeps
+# the constant term and silently drops every derivative, so widen through the
+# order-changing constructor instead. It zero-pads coefficients above `P`, which
+# is exactly the polynomial the order-`P` jet represents.
+@inline set_taylor_order(t::TaylorScalar, ::Val{Q}) where {Q} = TaylorScalar{Q}(t)
+# `ExplicitTaylor` always jets straight into a buffer of its own order; rebuilding the
+# `TaylorScalar` there is a copy that the compiler does not always elide.
+@inline set_taylor_order(t::TaylorScalar{T, Q}, ::Val{Q}) where {T, Q} = t
+
+function build_jet(
+        f::ODEFunction{iip}, p, order, length = nothing, buffer_order = order
+    ) where {iip}
     # Unwrap FunctionWrappers since TaylorDiff/Symbolics types don't match wrapper signatures
     f = unwrapped_f(f)
-    return build_jet(f, Val{iip}(), p, order, length)
+    return build_jet(f, Val{iip}(), p, order, length, buffer_order)
 end
 
-# cache format: Dict{typeof(f), Vector{Tuple{order, p, jet}}}
-function build_jet(f, ::Val{iip}, p, order::Val{P}, length = nothing) where {P, iip}
+# cache format: Dict{typeof(f), Vector{Tuple{order, p, buffer_order, jet}}}
+function build_jet(
+        f, ::Val{iip}, p, order::Val{P}, length = nothing,
+        buffer_order::Val{Q} = order
+    ) where {P, Q, iip}
     if haskey(JET_CACHE, f)
         list = JET_CACHE[f]
-        index = findfirst(x -> x[1] == order && x[2] == p, list)
-        index !== nothing && return list[index][3]
+        index = findfirst(x -> x[1] == order && x[2] == p && x[3] == buffer_order, list)
+        index !== nothing && return list[index][4]
     end
     @variables t0::Real
     u0 = isnothing(length) ? Symbolics.variable(:u0) : Symbolics.variables(:u0, 1:length)
@@ -91,7 +125,9 @@ function build_jet(f, ::Val{iip}, p, order::Val{P}, length = nothing) where {P, 
         coeffs = collect(TaylorDiff.flatten(u))
         jet_coeffs = build_function(coeffs, u0, t0; expression = Val(false), cse = true)
         # Wrap to return TaylorScalar
-        jet = (u0_val, t0_val) -> TaylorScalar(Tuple(jet_coeffs[1](u0_val, t0_val)))
+        jet = (u0_val, t0_val) -> set_taylor_order(
+            TaylorScalar(Tuple(jet_coeffs[1](u0_val, t0_val))), buffer_order
+        )
     elseif u isa AbstractArray && eltype(u) <: TaylorScalar
         # Array case: build function for matrix of coefficients
         # Each row is the coefficients of one TaylorScalar
@@ -102,14 +138,19 @@ function build_jet(f, ::Val{iip}, p, order::Val{P}, length = nothing) where {P, 
         jet = (
             (u0_val, t0_val) -> begin
                 coeffs_out = jet_coeffs[1](u0_val, t0_val)
-                return [TaylorScalar(Tuple(coeffs_out[i, :])) for i in 1:n]
+                return [
+                    set_taylor_order(TaylorScalar(Tuple(coeffs_out[i, :])), buffer_order)
+                        for i in 1:n
+                ]
             end,
             (out, u0_val, t0_val) -> begin
                 coeffs_out = jet_coeffs[2](
                     similar(coeffs_matrix, eltype(u0_val)), u0_val, t0_val
                 )
                 for i in 1:n
-                    out[i] = TaylorScalar(Tuple(coeffs_out[i, :]))
+                    out[i] = set_taylor_order(
+                        TaylorScalar(Tuple(coeffs_out[i, :])), buffer_order
+                    )
                 end
                 return out
             end,
@@ -122,7 +163,7 @@ function build_jet(f, ::Val{iip}, p, order::Val{P}, length = nothing) where {P, 
     if !haskey(JET_CACHE, f)
         JET_CACHE[f] = []
     end
-    push!(JET_CACHE[f], (order, p, jet))
+    push!(JET_CACHE[f], (order, p, buffer_order, jet))
     return jet
 end
 

--- a/lib/OrdinaryDiffEqTaylorSeries/src/interpolants.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/src/interpolants.jl
@@ -11,7 +11,13 @@ where h = Θ·dt and Θ ∈ [0,1].
 """
 
 const ExplicitTaylor2Caches = Union{ExplicitTaylor2Cache, ExplicitTaylor2ConstantCache}
-const ExplicitTaylorCaches = Union{ExplicitTaylorCache, ExplicitTaylorConstantCache}
+const ExplicitTaylorConstantCaches = Union{
+    ExplicitTaylorConstantCache, ExplicitTaylorAdaptiveOrderConstantCache,
+}
+const ExplicitTaylorMutableCaches = Union{
+    ExplicitTaylorCache, ExplicitTaylorAdaptiveOrderCache,
+}
+const ExplicitTaylorCaches = Union{ExplicitTaylorConstantCaches, ExplicitTaylorMutableCaches}
 const AllTaylorCaches = Union{ExplicitTaylor2Caches, ExplicitTaylorCaches}
 
 # ============================================================================
@@ -161,9 +167,10 @@ end
 
 function _ode_interpolant(
         Θ, dt, y₀, y₁, k,
-        cache::ExplicitTaylorConstantCache{P},
+        cache::ExplicitTaylorConstantCaches,
         idxs::Nothing, T::Type{Val{0}}, differential_vars
-    ) where {P}
+    )
+    P = _taylor_order(cache)
     h = Θ * dt
     # Horner's method: y₀ + h*(k[1] + h*(k[2] + ... + h*k[P]))
     @inbounds begin
@@ -177,9 +184,10 @@ end
 
 function _ode_interpolant(
         Θ, dt, y₀, y₁, k,
-        cache::ExplicitTaylorConstantCache{P},
+        cache::ExplicitTaylorConstantCaches,
         idxs, T::Type{Val{0}}, differential_vars
-    ) where {P}
+    )
+    P = _taylor_order(cache)
     h = Θ * dt
     @inbounds begin
         result = k[P][idxs]
@@ -192,9 +200,10 @@ end
 
 function _ode_interpolant(
         Θ, dt, y₀, y₁, k,
-        cache::ExplicitTaylorCache{P},
+        cache::ExplicitTaylorMutableCaches,
         idxs::Nothing, T::Type{Val{0}}, differential_vars
-    ) where {P}
+    )
+    P = _taylor_order(cache)
     h = Θ * dt
     @inbounds begin
         result = copy(k[P])
@@ -207,9 +216,10 @@ end
 
 function _ode_interpolant(
         Θ, dt, y₀, y₁, k,
-        cache::ExplicitTaylorCache{P},
+        cache::ExplicitTaylorMutableCaches,
         idxs, T::Type{Val{0}}, differential_vars
-    ) where {P}
+    )
+    P = _taylor_order(cache)
     h = Θ * dt
     @inbounds begin
         result = k[P][idxs]
@@ -260,9 +270,10 @@ end
 
 function _ode_interpolant(
         Θ, dt, y₀, y₁, k,
-        cache::ExplicitTaylorConstantCache{P},
+        cache::ExplicitTaylorConstantCaches,
         idxs::Nothing, T::Type{Val{1}}, differential_vars
-    ) where {P}
+    )
+    P = _taylor_order(cache)
     h = Θ * dt
     @inbounds begin
         result = @.. P * k[P]
@@ -275,9 +286,10 @@ end
 
 function _ode_interpolant(
         Θ, dt, y₀, y₁, k,
-        cache::ExplicitTaylorConstantCache{P},
+        cache::ExplicitTaylorConstantCaches,
         idxs, T::Type{Val{1}}, differential_vars
-    ) where {P}
+    )
+    P = _taylor_order(cache)
     h = Θ * dt
     @inbounds begin
         result = @.. P * k[P][idxs]
@@ -290,9 +302,10 @@ end
 
 function _ode_interpolant(
         Θ, dt, y₀, y₁, k,
-        cache::ExplicitTaylorCache{P},
+        cache::ExplicitTaylorMutableCaches,
         idxs::Nothing, T::Type{Val{1}}, differential_vars
-    ) where {P}
+    )
+    P = _taylor_order(cache)
     h = Θ * dt
     @inbounds begin
         result = @.. P * k[P]
@@ -305,9 +318,10 @@ end
 
 function _ode_interpolant(
         Θ, dt, y₀, y₁, k,
-        cache::ExplicitTaylorCache{P},
+        cache::ExplicitTaylorMutableCaches,
         idxs, T::Type{Val{1}}, differential_vars
-    ) where {P}
+    )
+    P = _taylor_order(cache)
     h = Θ * dt
     @inbounds begin
         result = @.. P * k[P][idxs]
@@ -374,3 +388,7 @@ end
 
 _taylor_order(::ExplicitTaylorCache{P}) where {P} = P
 _taylor_order(::ExplicitTaylorConstantCache{P}) where {P} = P
+# The adaptive-order caches carry `max_order` coefficients; the ones above the
+# order actually used on a step are zero, so a fixed-length Horner is exact.
+_taylor_order(::ExplicitTaylorAdaptiveOrderCache{P, Q}) where {P, Q} = Q
+_taylor_order(::ExplicitTaylorAdaptiveOrderConstantCache{P, Q}) where {P, Q} = Q

--- a/lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl
@@ -39,6 +39,139 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
         sol = solve(prob_ode_linear, ExplicitTaylorAdaptiveOrder(min_order = Val(6), max_order = Val(10)))
         @test length(sol.t) < 20
         @test SciMLBase.successful_retcode(sol)
+        # a step count and a retcode alone are satisfied by a solver that never
+        # leaves `u0`, which is exactly what issue #3976 was
+        @test sol.u[end] ≈ prob_ode_linear.f.analytic(
+            prob_ode_linear.u0, prob_ode_linear.p, sol.t[end]
+        ) atol = 1.0e-6
+    end
+
+    # Issue #3976. Every order's jet writes into one Taylor buffer sized at
+    # `max_order`. Storing a lower-order `TaylorScalar` there went through
+    # TaylorDiff's number-promotion constructor, which keeps the constant term and
+    # drops every derivative, so the step collapsed to `u = uprev`, the error
+    # estimate was exactly zero and the solver reported Success after a handful of
+    # enormous steps.
+    @testset "ExplicitTaylorAdaptiveOrder keeps every Taylor coefficient" begin
+        TaylorDiff = OrdinaryDiffEqTaylorSeries.TaylorDiff
+        function f_exp!(du, u, p, t)
+            du .= u
+            return nothing
+        end
+        prob = ODEProblem{true, SciMLBase.FullSpecialize}(f_exp!, [1.0, 2.0], (0.0, 1.0))
+        integ = init(
+            prob, ExplicitTaylorAdaptiveOrder(min_order = Val(2), max_order = Val(6)),
+            abstol = 1.0e-10, reltol = 1.0e-10
+        )
+        cache = integ.cache
+        # `jets[i]` has order `min_order + i - 1`, and for u' = u it owes the buffer
+        # that many nonzero coefficients on top of the value
+        for (i, jet) in enumerate(cache.jets)
+            fill!(cache.utaylor, zero(eltype(cache.utaylor)))
+            jet(cache.utaylor, integ.uprev, integ.t)
+            @test count(!iszero, TaylorDiff.flatten(cache.utaylor[1])) == i + 2
+        end
+    end
+
+    @testset "ExplicitTaylorAdaptiveOrder accuracy tracks tolerance" begin
+        for prob in (prob_ode_linear, prob_ode_2Dlinear)
+            for tol in (1.0e-8, 1.0e-10)
+                sol = solve(prob, ExplicitTaylorAdaptiveOrder(), abstol = tol, reltol = tol)
+                @test SciMLBase.successful_retcode(sol)
+                @test sol.u[end] != prob.u0
+                exact = prob.f.analytic(prob.u0, prob.p, sol.t[end])
+                @test maximum(abs.(sol.u[end] .- exact)) < 1.0e-6 * maximum(abs.(exact))
+            end
+        end
+
+        # out-of-place array problems additionally hit an UndefRefError while
+        # saving: `initialize!` sized `integrator.k` but `perform_step!` never
+        # filled it
+        prob_arr = ODEProblem((u, p, t) -> [-u[2], u[1]], [1.0, 0.0], (0.0, 1.0))
+        sol = solve(
+            prob_arr, ExplicitTaylorAdaptiveOrder(),
+            abstol = 1.0e-10, reltol = 1.0e-10
+        )
+        @test SciMLBase.successful_retcode(sol)
+        @test sol.u[end] ≈ [cos(1.0), sin(1.0)] atol = 1.0e-8
+        @test sol(0.5) ≈ [cos(0.5), sin(0.5)] atol = 1.0e-8
+
+        # the order window has to leave room for the extra jet the error estimate
+        # rides on, otherwise the order loop never runs and a stale estimate is
+        # what the step is accepted on
+        @test_throws ArgumentError solve(
+            prob_ode_linear,
+            ExplicitTaylorAdaptiveOrder(min_order = Val(4), max_order = Val(4))
+        )
+    end
+
+    # `test_convergence` solves with `adaptive = false`, which pins the order at
+    # `max_order - 1` for the whole run. The jet order then equals the buffer
+    # order, so this covers the top of the window only.
+    @testset "ExplicitTaylorAdaptiveOrder Convergence Tests" begin
+        dts = 2.0 .^ (-6:-2)
+        testTol = 0.2
+        for N in 3:5
+            alg = ExplicitTaylorAdaptiveOrder(min_order = Val(N - 2), max_order = Val(N))
+            sim = test_convergence(dts, prob_ode_linear, alg)
+            @test sim.𝒪est[:final] ≈ N atol = testTol
+            sim = test_convergence(dts, prob_ode_2Dlinear, alg)
+            @test sim.𝒪est[:final] ≈ N atol = testTol
+        end
+    end
+
+    # The mismatch of #3976 only exists below the top of the window, so hold the
+    # order there by hand and check that the method still converges at the order
+    # its jet claims. With the coefficients dropped the step is a no-op and the
+    # error stops depending on `dt` at all.
+    @testset "ExplicitTaylorAdaptiveOrder Convergence Below max_order" begin
+        alg = ExplicitTaylorAdaptiveOrder(min_order = Val(2), max_order = Val(6))
+        dts = 2.0 .^ (-8:-4)
+        for prob in (prob_ode_linear, prob_ode_2Dlinear)
+            exact = prob.f.analytic(prob.u0, prob.p, prob.tspan[end])
+            errors = map(dts) do dt
+                integrator = init(prob, alg; dt = dt, adaptive = false)
+                integrator.cache.current_order[] = 3
+                solve!(integrator)
+                maximum(abs.(integrator.sol.u[end] .- exact))
+            end
+            slopes = diff(log2.(errors)) ./ diff(log2.(dts))
+            @test sum(slopes) / length(slopes) ≈ 4 atol = 0.2
+        end
+    end
+
+    # Dense output on the in-place cache reads `max_order` coefficients back out
+    # of `integrator.k`, which the adaptive-order step has to fill and the
+    # interpolant has to read at the buffer order rather than at `min_order`.
+    @testset "ExplicitTaylorAdaptiveOrder Dense Output" begin
+        for prob in (prob_ode_linear, prob_ode_2Dlinear)
+            sol = solve(
+                prob, ExplicitTaylorAdaptiveOrder(),
+                abstol = 1.0e-10, reltol = 1.0e-10, dense = true
+            )
+            for t in (0.25, 0.5, 0.75)
+                exact = prob.f.analytic(prob.u0, prob.p, t)
+                @test maximum(abs.(sol(t) .- exact)) < 1.0e-8 * maximum(abs.(exact))
+            end
+        end
+    end
+
+    # Issue #3976: once the order dropped off `max_order` the step froze, so the
+    # solver walked to the end of the span in a handful of steps and reported
+    # Success on a 96% error (7 steps here, 60 once the coefficients survive).
+    @testset "ExplicitTaylorAdaptiveOrder on Pleiades" begin
+        prob = remake(prob_ode_pleiades, tspan = (0.0, 1.0))
+        ref = solve(
+            prob, ExplicitTaylor(order = Val(6)),
+            abstol = 1.0e-12, reltol = 1.0e-12
+        )
+        sol = solve(
+            prob, ExplicitTaylorAdaptiveOrder(min_order = Val(2), max_order = Val(6)),
+            abstol = 1.0e-8, reltol = 1.0e-8
+        )
+        @test SciMLBase.successful_retcode(sol)
+        @test length(sol.t) > 30
+        @test maximum(abs.(sol.u[end] .- ref.u[end])) < 1.0e-6 * maximum(abs.(ref.u[end]))
     end
 
     # `get_fsalfirstlast` used to alias the FSAL buffer to `cache.u`, which is


### PR DESCRIPTION
`ExplicitTaylorAdaptiveOrder` returned `retcode = Success` while never moving the state.
On `prob_ode_pleiades` at `abstol = reltol = 1e-10` it took 3 steps over a span of 3,
`sol.u[end] == prob.u0` held exactly, and the answer was 133 percent wrong against
`Vern9` at 1e-14. Fixes #3976.

The cache allocates one Taylor buffer sized at `max_order` and runs every candidate
order's jet through it, as a `Vector{FunctionWrapper}` whose signature is pinned to that
buffer's element type. `build_jet` emitted `TaylorScalar(Tuple(coeffs_out[i, :]))`, a
`TaylorScalar{T, P}` with `P` the jet's own order. Storing that into a
`TaylorScalar{T, Q}` slot with `P != Q` selects TaylorDiff's number-promotion
constructor, `TaylorScalar{T, Q}(x) = TaylorScalar{Q}(T(x))`, which converts the
polynomial to its constant term and rebuilds it with every partial zero. No error, no
warning.

So whenever `current_order + 1 != max_order` the jet returned a constant. `u` came back
equal to `uprev`, every Taylor coefficient was zero, `utilde` was zero, `EEst` was
exactly zero, and the controller saw a perfect step and grew `dt` to the end of the
span. The first `perform_step!` attempt uses the one jet whose order matches the buffer
and is rejected; the retry inside that same call already uses a mismatched jet, so the
first accepted step is already degenerate.

The fix threads an explicit `buffer_order` through `build_jet` and widens with
TaylorDiff's order-changing constructor `TaylorScalar{Q}(t)`, which zero-pads the
uncomputed coefficients. That is exactly the order-`P` polynomial viewed at order `Q`.
A no-op specialization for `P == Q` keeps the fixed-order path from rebuilding a
`TaylorScalar` it already has.

Two further defects turned up in the out-of-place path while tracing this. Its
`perform_step!` never assigned `integrator.u`, so it always returned `u0`, and
`initialize!` sized `integrator.k` with `undef` entries that nothing filled, giving an
`UndefRefError` on out-of-place array problems.

## Before and after

| case | master | this branch |
| --- | --- | --- |
| Pleiades, `abstol = reltol = 1e-6` | 6 steps, max-relative error 1.33 | 714 steps, 1.20e-5 |
| Pleiades, 1e-8 | 3 steps, `u[end] == u0`, 1.33 | 1354 steps, 4.06e-8 |
| Pleiades, 1e-10 | 3 steps, `u[end] == u0`, 1.33 | 2757 steps, 4.72e-10 |
| out-of-place array problem, 1e-10 | `UndefRefError` | correct to 1e-13 |

The Pleiades figures are the max-relative metric,
`maximum(abs.(delta)) / maximum(abs.(ref))`, against `Vern9` at 1e-14.

`ExplicitTaylor` and `ExplicitTaylor2` are unaffected. Full trajectories are
bit-identical to master at orders 4, 6 and 8, and allocations are unchanged at 287560,
99848 and 62984 bytes per solve on `prob_ode_2Dlinear` at 1e-10, minimum of seven
samples.

## A limitation this does not fix

A separate path still yields `EEst = 0`, and it is not an indexing bug.

```julia
solve(ODEProblem((du, u, p, t) -> (du[1] = 20t^19), [0.0], (0.0, 1.0)),
      ExplicitTaylorAdaptiveOrder(), abstol = 1e-8, reltol = 1e-8)
```

returns `Success` with `u(1) = 1.26e-8` where the exact answer is 1. Master returns
exactly 0 on the same problem, so this is strictly better, but it is worth stating
plainly rather than leaving under a closing keyword.

The solution is `u = t^20`, so every Taylor coefficient through degree 19 vanishes at
`t = 0` and all ten jets are identically zero there. No estimate built from the local
jet can be nonzero, whichever coefficient it scores. Scoring the first omitted term
instead does not help: the jet stops at exactly the last degree the step uses, so degree
`p+1` is a zero-padded buffer slot rather than a computed derivative, and forcing that
index makes the top candidate always score zero, always win the order ladder, and
trigger the `iszero(EEst)` growth branch. Measured, it takes Pleiades from 3.98e-08 to
1.2e+15. This is a limitation of derivative-only local error estimation and needs a
different estimator, which I will file separately.

## Behaviour change

`min_order == max_order` now throws an `ArgumentError`. A step at `current_order` is
jetted one order higher, so `current_order` has to stay strictly below `max_order`; with
an empty window the order loop never runs and the step is accepted on a stale estimate.
On master that configuration was already broken, silently in place and with a
`BoundsError` out of place, so the throw replaces a wrong answer with a clear message.

## Tests

Core group 127 assertions on this branch. The same file against pristine master fails at
`ExplicitTaylorAdaptiveOrder Tests` and aborts the run.

Two of the new testsets exist because the obvious ones do not discriminate. The
pre-existing convergence testset uses `DiffEqDevTools.test_convergence`, which solves
with `adaptive = false` and therefore pins the order at `max_order - 1` for the whole
run, so the jet order always equals the buffer order and the bug never fires. The new
`Convergence Below max_order` testset sets `current_order[]` by hand to hold the order
below the top of the window, which is the only place the mismatch exists. Similarly, a
first draft of the Pleiades regression used a `min_order = 4, max_order = 8` window that
never leaves order 7 and so passed on unfixed master; the shipped version uses
`min_order = 2, max_order = 6`.

In-place dense output also had no coverage, which mutation testing exposed: changing the
interpolant to read `min_order` instead of the buffer order left the whole suite green.
That is now covered.

Depends on the `isfsal` fix in #3975, which removed a `DtNaN` crash that had been
masking this. #4006 and #3112 also edit
`lib/OrdinaryDiffEqTaylorSeries/src/alg_utils.jl`, so whichever of the three lands
second will want a rebase. They add implicit Taylor solvers in a new sublibrary and do
not otherwise overlap with this.

## AI Disclosure

Claude assisted with this work.
