### PR TITLE
Rebase #3920: GaussLegendre dense extrapolant and embedded error estimate

### DIFF
--- a/lib/OrdinaryDiffEqFIRK/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/alg_utils.jl
@@ -34,10 +34,10 @@ default_controller(QT, alg::GaussLegendre) = PIController(QT, alg)
 
 isfirk(alg::GaussLegendre) = true
 
-# Richardson step-doubling controller
+# Embedded error estimate controller using s-1 stages
 isadaptive(alg::GaussLegendre) = alg.num_stages >= 2
-alg_adaptive_order(alg::GaussLegendre) = 2 * alg.num_stages
+alg_adaptive_order(alg::GaussLegendre) = alg.num_stages - 1
 has_stiff_interpolation(::GaussLegendre) = false
 
 get_current_alg_order(alg::GaussLegendre, cache) = 2 * alg.num_stages
-get_current_adaptive_order(alg::GaussLegendre, cache) = 2 * alg.num_stages
+get_current_adaptive_order(alg::GaussLegendre, cache) = alg.num_stages - 1

--- a/lib/OrdinaryDiffEqFIRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/algorithms.jl
@@ -228,26 +228,31 @@ author={Butcher, John Charles},
 year={2008},
 publisher={Wiley}}"""
 
+gauss_extra_keyword_description = """
+- `extrapolant`: `:dense` uses the previous collocation polynomial as the Newton guess; `:constant` starts from zero
+- `step_limiter!`: function of the form `limiter!(u, integrator, p, t)`"""
+gauss_extra_keyword_default = """
+extrapolant = :dense,
+step_limiter! = trivial_limiter!"""
+
 @doc differentiation_rk_docstring(
     "A symplectic fully implicit Runge-Kutta method based on Gauss-Legendre quadrature.
 With s stages, the method has order 2s. Symplectic and A-stable, making it suitable
 for Hamiltonian systems and problems requiring long-time geometric integration.
 
-!!! warning \"Experimental\"
-    `GaussLegendre` is experimental. Adaptive stepping currently uses Richardson
-    step-doubling (roughly 3× the work per accepted step) and requires `num_stages ≥ 2`;
-    Details may change as the implementation is refined.",
+Adaptive stepping uses a same-node embedded method of order s-1
+(err = dt * Σ (bᵢ - b̂ᵢ) f(Yᵢ), with bhat fixed by the s-1 moment
+conditions and a zero s-th moment) and requires num_stages ≥ 2.",
     "GaussLegendre",
     "Fully-Implicit Runge-Kutta Method.";
     references = gauss_legendre_docstring,
-    extra_keyword_description = extra_keyword_description,
-    extra_keyword_default = extra_keyword_default
+    extra_keyword_description = gauss_extra_keyword_description,
+    extra_keyword_default = gauss_extra_keyword_default
 )
 struct GaussLegendre{AD, F, P, Tol, C1, C2, StepLimiter, CJ} <:
     OrdinaryDiffEqNewtonAdaptiveAlgorithm
     linsolve::F
     precs::P
-    smooth_est::Bool
     extrapolant::Symbol
     κ::Tol
     maxiters::Int
@@ -267,7 +272,7 @@ function GaussLegendre(;
         linsolve = nothing, precs = nothing,
         extrapolant = :dense, fast_convergence_cutoff = 1 // 5,
         new_W_γdt_cutoff = 1 // 5,
-        controller = :PI, κ = nothing, maxiters = 10, smooth_est = true,
+        controller = :PI, κ = nothing, maxiters = 10,
         step_limiter! = trivial_limiter!
     )
     autodiff = _fixup_ad(autodiff)
@@ -275,7 +280,6 @@ function GaussLegendre(;
     return GaussLegendre(
         linsolve,
         precs,
-        smooth_est,
         extrapolant,
         κ,
         maxiters,

--- a/lib/OrdinaryDiffEqFIRK/src/firk_caches.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_caches.jl
@@ -763,18 +763,18 @@ end
 
 
 mutable struct GaussLegendreCache{
-        uType, uNoUnitsType, rateType, JType, WType, Buff,
+        uType, tType, uNoUnitsType, rateType, JType, WType, Buff,
         UF, JC, F1, Tab, Tol, Dt, rTol, aTol, StepLimiter,
     } <: FIRKMutableCache
     u::uType
     uprev::uType
     z::Vector{uType}
-    z_last::Vector{uType}
     w::Vector{uType}
+    c_prime::Vector{tType}
     dw::Vector{uType}
     ubuff::Buff
-    u_full::uType
-    u_half::uType
+    utilde::uType
+    derivatives::Matrix{uType}
     du1::rateType
     fsalfirst::rateType
     k::rateType
@@ -813,14 +813,21 @@ function alg_cache(
     κ = alg.κ !== nothing ? convert(uToltype, alg.κ) : convert(uToltype, 1 // 100)
 
     z = [zero(u) for _ in 1:num_stages]
-    z_last = [zero(u) for _ in 1:num_stages]
     w = [zero(u) for _ in 1:num_stages]
+    c_prime = Vector{typeof(t)}(undef, num_stages) #time stepping
+    for i in 1:num_stages
+        c_prime[i] = zero(t)
+    end
     dw = [zero(u) for _ in 1:num_stages]
     n = length(_vec(u))
     ubuff = similar(_vec(u), num_stages * n)
     recursivefill!(ubuff, false)
-    u_full = zero(u)
-    u_half = zero(u)
+    utilde = zero(u)
+
+    derivatives = Matrix{typeof(u)}(undef, num_stages, num_stages)
+    for i in 1:num_stages, j in 1:num_stages
+        derivatives[i, j] = zero(u)
+    end
 
     fsalfirst = zero(rate_prototype)
     k = zero(rate_prototype)
@@ -854,7 +861,7 @@ function alg_cache(
     atol = reltol isa Number ? reltol : zero(reltol)
 
     return GaussLegendreCache(
-        u, uprev, z, z_last, w, dw, ubuff, u_full, u_half,
+        u, uprev, z, w, c_prime, dw, ubuff, utilde, derivatives,
         du1, fsalfirst, k, ks, fw,
         J, W,
         uf, tab, κ, one(uToltype), 10000,

--- a/lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
@@ -2220,13 +2220,11 @@ function initialize!(integrator, cache::GaussLegendreConstantCache)
         integrator.k[i] = zero(integrator.fsalfirst)
     end
 
-    # adaptive Richardson controller requires num_stages >= 2
+    # embeddedd error estimate requires num_stages >= 2
     if integrator.opts.adaptive && integrator.alg.num_stages < 2
         throw(
             ArgumentError(
-                "GaussLegendre with num_stages = $(integrator.alg.num_stages) " *
-                    "does not support adaptive stepping (Richardson controller " *
-                    "requires num_stages ≥ 2). Use num_stages ≥ 2 or pass adaptive = false."
+                "GaussLegendre with num_stages = $(integrator.alg.num_stages) does not support adaptive stepping (embedded error estimate requires num_stages ≥ 2). Use num_stages ≥ 2 or pass adaptive = false."
             )
         )
     end
@@ -2248,8 +2246,7 @@ function initialize!(integrator, cache::GaussLegendreCache)
             throw(
                 ArgumentError(
                     "GaussLegendre with num_stages = $(cache.num_stages) " *
-                        "does not support adaptive stepping (Richardson controller " *
-                        "requires num_stages ≥ 2). Use num_stages ≥ 2 or pass adaptive = false."
+                        "does not support adaptive stepping (embedded error estimate requires num_stages ≥ 2). Use num_stages ≥ 2 or pass adaptive = false."
                 )
             )
         end
@@ -2265,12 +2262,12 @@ function initialize!(integrator, cache::GaussLegendreCache)
     return nothing
 end
 
-# Newton iteration helper for a single GaussLegendre sub-step
+# Newton iteration for one GaussLegendre step
 
 @muladd function _gausslegendre_substep_constant(
         integrator, cache::GaussLegendreConstantCache, alg,
         uprev_local, t_local, dt_local, J_local,
-        atol, rtol
+        atol, rtol, z
     )
     (; tab, κ, num_stages) = cache
     (; A, b, c) = tab
@@ -2283,13 +2280,11 @@ end
     LU_full = lu(W_full)
     integrator.stats.nw += 1
 
-    z = [map(zero, uprev_local) for _ in 1:num_stages]
-
     ndw = one(eltype(uprev_local))
     η = max(cache.ηold, eps(eltype(integrator.opts.reltol)))^(0.8)
     success = false
     iter = 0
-    local ff
+    ff = [map(zero, uprev_local) for _ in 1:num_stages]
 
     while iter < maxiters
         iter += 1
@@ -2353,7 +2348,7 @@ end
     cache.iter = iter
 
     if !success
-        return (uprev_local, z, false)
+        return (uprev_local, z, ff, false)
     end
 
     ff_final = [f(uprev_local + z[i], p, t_local + c[i] * dt_local) for i in 1:num_stages]
@@ -2363,7 +2358,7 @@ end
         u_out = @.. u_out + dt_local * b[i] * ff_final[i]
     end
 
-    return (u_out, z, true)
+    return (u_out, z, ff_final, true)
 end
 
 @muladd function perform_step!(
@@ -2372,6 +2367,7 @@ end
     )
     (; t, dt, uprev, f, p) = integrator
     (; num_stages) = cache
+    (; c, e) = cache.tab
     (; internalnorm, abstol, reltol, adaptive) = integrator.opts
     alg = unwrap_alg(integrator, true)
 
@@ -2380,63 +2376,72 @@ end
 
     J = calc_J(integrator, cache)
 
-    if adaptive && num_stages >= 2
-        # Richardson step-doubling: one full step at dt, two successive half-steps.
-        u_H, z_full, ok1 = _gausslegendre_substep_constant(
-            integrator, cache, alg, uprev, t, dt, J, atol, rtol
-        )
-        if !ok1
-            integrator.force_stepfail = true
-            integrator.stats.nnonlinconvfail += 1
-            return
+    # TODO better initial guess
+    z = Vector{typeof(uprev)}(undef, num_stages)
+    if integrator.iter == 1 || integrator.derivative_discontinuity || alg.extrapolant == :constant
+        cache.dtprev = one(cache.dtprev)
+        for i in 1:num_stages
+            z[i] = @.. map(zero, uprev)
+            integrator.k[i + 2] = map(zero, uprev)
         end
-
-        half_dt = dt / 2
-        u_h1, _, ok2 = _gausslegendre_substep_constant(
-            integrator, cache, alg, uprev, t, half_dt, J, atol, rtol
-        )
-        if !ok2
-            integrator.force_stepfail = true
-            integrator.stats.nnonlinconvfail += 1
-            return
-        end
-
-        u_h, _, ok3 = _gausslegendre_substep_constant(
-            integrator, cache, alg, u_h1, t + half_dt, half_dt, J, atol, rtol
-        )
-        if !ok3
-            integrator.force_stepfail = true
-            integrator.stats.nnonlinconvfail += 1
-            return
-        end
-
-        p_order = 2 * num_stages
-        utilde = @.. (u_h - u_H) / (2^p_order - 1)
-        OrdinaryDiffEqCore.set_EEst!(
-            integrator,
-            internalnorm(calculate_residuals(utilde, uprev, u_h, atol, rtol, internalnorm, t), t),
-        )
-
-        u = u_h
-        z_for_fsal = z_full
     else
-        u_out, z_out, ok = _gausslegendre_substep_constant(
-            integrator, cache, alg, uprev, t, dt, J, atol, rtol
-        )
-        if !ok
-            integrator.force_stepfail = true
-            integrator.stats.nnonlinconvfail += 1
-            return
+        # Collocation polynomial through (0,0), (c_i, z_i)
+        c_prime = Vector{typeof(dt)}(undef, num_stages)
+        dt_ratio = dt / cache.dtprev
+        derivatives = Matrix{typeof(uprev)}(undef, num_stages, num_stages)
+        for i in 1:num_stages
+            z[i] = @.. integrator.k[i + 2]
+            c_prime[i] = c[i] * dt_ratio
         end
-        u = u_out
-        z_for_fsal = z_out
+        derivatives[1, 1] = @.. z[1] / c[1]
+        for j in 2:num_stages
+            derivatives[1, j] = @.. (z[j - 1] - z[j]) / (c[j - 1] - c[j])
+        end
+        for i in 2:num_stages
+            derivatives[i, i] = @.. (
+                derivatives[i - 1, i] -
+                    derivatives[i - 1, i - 1]
+            ) / c[i]
+            for j in (i + 1):num_stages
+                derivatives[i, j] = @.. (
+                    derivatives[i - 1, j - 1] -
+                        derivatives[i - 1, j]
+                ) / (c[j - i] - c[j])
+            end
+        end
+        for i in 1:num_stages
+            z[i] = @.. derivatives[num_stages, num_stages]
+            j = num_stages - 1
+            while j > 0
+                z[i] = @.. derivatives[j, j] + z[i] * (c_prime[i] - c[j])
+                j = j - 1
+            end
+            z[i] = @.. z[i] * c_prime[i]
+        end
+    end
+
+    u, z, ff, ok = _gausslegendre_substep_constant(integrator, cache, alg, uprev, t, dt, J, atol, rtol, z)
+    if !ok
+        integrator.force_stepfail = true
+        integrator.stats.nnonlinconvfail += 1
+        return
+    end
+
+    # Embedded error of the s stage method coming from the s-1 quadrature and the error estimate
+    if adaptive
+        utilde = @.. dt * e[1] * ff[1]
+        for i in 2:num_stages
+            utilde = @.. utilde + dt * e[i] * ff[i]
+        end
+        atmp = calculate_residuals(utilde, uprev, u, atol, rtol, internalnorm, t)
+        OrdinaryDiffEqCore.set_EEst!(integrator, internalnorm(atmp, t))
     end
 
     if OrdinaryDiffEqCore.get_EEst(integrator) <= oneunit(OrdinaryDiffEqCore.get_EEst(integrator))
         cache.dtprev = dt
         if alg.extrapolant != :constant
             for i in 1:num_stages
-                integrator.k[i + 2] = z_for_fsal[i]
+                integrator.k[i + 2] = z[i]
             end
         end
     end
@@ -2448,8 +2453,6 @@ end
     integrator.u = u
     return
 end
-
-# Mutable-cache Newton iteration helper
 
 @muladd function _gausslegendre_substep!(
         u_dest, uprev_local, t_local, dt_local, J_local,
@@ -2467,10 +2470,6 @@ end
 
     W .= kron(I(num_stages), I(n)) .- dt_local .* kron(A, J_local)
     integrator.stats.nw += 1
-
-    for i in 1:num_stages
-        @.. z[i] = zero(eltype(uprev_local))
-    end
 
     ndw = one(eltype(uprev_local))
     η = max(cache.ηold, eps(eltype(integrator.opts.reltol)))^(0.8)
@@ -2558,66 +2557,78 @@ end
 
 @muladd function perform_step!(integrator, cache::GaussLegendreCache, repeat_step = false)
     (; t, dt, uprev, u, f, p, fsallast) = integrator
-    (; atmp, J, z, z_last, u_full, u_half, rtol, atol, num_stages) = cache
+    (; atmp, J, z, w, c_prime, derivatives, utilde, ks, rtol, atol, num_stages) = cache
+    (; c, e) = cache.tab
     (; internalnorm, adaptive) = integrator.opts
     alg = unwrap_alg(integrator, true)
 
     new_jac = do_newJ(integrator, alg, cache, repeat_step)
     new_jac && (calc_J!(J, integrator, cache); cache.W_γdt = dt)
 
-    if adaptive && num_stages >= 2
-        # fll step at dt
-        ok1 = _gausslegendre_substep!(u_full, uprev, t, dt, J, cache, integrator, alg)
-        if !ok1
-            integrator.force_stepfail = true
-            integrator.stats.nnonlinconvfail += 1
-            return
-        end
+    # TODO better initial guess
+    if integrator.iter == 1 || integrator.derivative_discontinuity || alg.extrapolant == :constant
+        cache.dtprev = one(cache.dtprev)
         for i in 1:num_stages
-            @.. z_last[i] = z[i]
+            @.. z[i] = map(zero, u)
+            @.. w[i] = map(zero, u)
+            integrator.k[i + 2] = map(zero, u)
         end
-
-        half_dt = dt / 2
-
-        # first half step at dt/2
-        ok2 = _gausslegendre_substep!(u_half, uprev, t, half_dt, J, cache, integrator, alg)
-        if !ok2
-            integrator.force_stepfail = true
-            integrator.stats.nnonlinconvfail += 1
-            return
-        end
-
-        # second half step at dt/2
-        ok3 = _gausslegendre_substep!(u, u_half, t + half_dt, half_dt, J, cache, integrator, alg)
-        if !ok3
-            integrator.force_stepfail = true
-            integrator.stats.nnonlinconvfail += 1
-            return
-        end
-
-
-        p_order = 2 * num_stages
-        denom = 2^p_order - 1
-        @.. u_full = (u - u_full) / denom
-        calculate_residuals!(atmp, u_full, uprev, u, atol, rtol, internalnorm, t)
-        OrdinaryDiffEqCore.set_EEst!(integrator, internalnorm(atmp, t))
     else
-        ok = _gausslegendre_substep!(u, uprev, t, dt, J, cache, integrator, alg)
-        if !ok
-            integrator.force_stepfail = true
-            integrator.stats.nnonlinconvfail += 1
-            return
+        # Collocation polynomial through (0,0), (c_i, z_i)
+        dt_ratio = dt / cache.dtprev
+        for i in 1:num_stages
+            @.. z[i] = integrator.k[i + 2]
+            c_prime[i] = c[i] * dt_ratio
+        end
+        @.. derivatives[1, 1] = z[1] / c[1]
+        for j in 2:num_stages
+            @.. derivatives[1, j] = (z[j - 1] - z[j]) / (c[j - 1] - c[j])
+        end
+        for i in 2:num_stages
+            @.. derivatives[i, i] = (
+                derivatives[i - 1, i] -
+                    derivatives[i - 1, i - 1]
+            ) / c[i]
+            for j in (i + 1):num_stages
+                @.. derivatives[i, j] = (
+                    derivatives[i - 1, j - 1] -
+                        derivatives[i - 1, j]
+                ) / (c[j - i] - c[j])
+            end
         end
         for i in 1:num_stages
-            @.. z_last[i] = z[i]
+            @.. z[i] = derivatives[num_stages, num_stages]
+            j = num_stages - 1
+            while j > 0
+                @.. z[i] = derivatives[j, j] + z[i] * (c_prime[i] - c[j])
+                j = j - 1
+            end
+            @.. z[i] = z[i] * c_prime[i]
         end
+    end
+
+    ok = _gausslegendre_substep!(u, uprev, t, dt, J, cache, integrator, alg)
+    if !ok
+        integrator.force_stepfail = true
+        integrator.stats.nnonlinconvfail += 1
+        return
+    end
+
+    # Embedded error of the s stage method coming from the s-1 quadrature and the error estimate
+    if adaptive
+        @.. utilde = dt * e[1] * ks[1]
+        for i in 2:num_stages
+            @.. utilde = utilde + dt * e[i] * ks[i]
+        end
+        calculate_residuals!(atmp, utilde, uprev, u, atol, rtol, internalnorm, t)
+        OrdinaryDiffEqCore.set_EEst!(integrator, internalnorm(atmp, t))
     end
 
     if OrdinaryDiffEqCore.get_EEst(integrator) <= oneunit(OrdinaryDiffEqCore.get_EEst(integrator))
         cache.dtprev = dt
         if alg.extrapolant != :constant
             for i in 1:num_stages
-                integrator.k[i + 2] .= z_last[i]
+                integrator.k[i + 2] .= z[i]
             end
         end
     end

--- a/lib/OrdinaryDiffEqFIRK/src/firk_tableaus.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_tableaus.jl
@@ -369,11 +369,10 @@ function GaussLegendreTableau(::Type{T1}, ::Type{T2}, num_stages::Int) where {T1
     return GaussLegendreTableau{T1, T2}(tab.A, tab.b, tab.c, tab.e)
 end
 
-# TODO: embedded error coefficients use s-1 GL rule interpolated to s nodes
-# a proper derivation following Hairer Vol I would improve adaptive performance
-
-# TODO: add the symplectic integrator stage decoupling from Antonan et al to increase efficiency
-
+# Embedded weights (bhat) share nodes c with the main method and satisfy the
+# quadrature conditions of order s-1, with the s-th moment set to 0
+# (instead of 1/s). Then e = b - bbhat and the local error estimate is
+#  u - uhat = dt * Σ eᵢ f(Yᵢ), which becomes the embedded error estimate
 function generateGaussLegendreTableau(::Type{T1}, ::Type{T2}, num_stages::Int) where {T1, T2}
     x, w = gausslegendre(promote_type(T1, T2), num_stages)
     c = T2.((x .+ 1) ./ 2)
@@ -395,24 +394,11 @@ function generateGaussLegendreTableau(::Type{T1}, ::Type{T2}, num_stages::Int) w
         end
     end
 
-
-    # error estimate coefficients: embed using s-1 GL weights via interpolation
     if num_stages > 1
-        x_low, w_low = gausslegendre(T1, num_stages - 1)
-        c_low = T1.((x_low .+ 1) ./ 2)
-        b_low = zeros(T1, num_stages)
-        for i in 1:num_stages
-            for j in 1:(num_stages - 1)
-                Lj = one(T1)
-                for k in 1:(num_stages - 1)
-                    if k != j
-                        Lj *= (c[i] - c_low[k]) / (c_low[j] - c_low[k])
-                    end
-                end
-                b_low[i] += T1(w_low[j] / 2) * Lj
-            end
-        end
-        e = b .- b_low
+        V = [T1(c[j])^(i - 1) for i in 1:num_stages, j in 1:num_stages]
+        rhs = [i < num_stages ? T1(1 // i) : zero(T1) for i in 1:num_stages]
+        bhat = V \ rhs
+        e = b .- bhat
     else
         e = b
     end

--- a/lib/OrdinaryDiffEqFIRK/test/ode_firk_tests.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/ode_firk_tests.jl
@@ -160,7 +160,7 @@ end
     end
 end
 
-@testset "GaussLegendre Richardson tightens step count when tol tightens" begin
+@testset "GaussLegendre adaptive tightens step count when tol tightens" begin
     s = 3
     sol_loose = solve(
         prob_ode_linear, GaussLegendre(num_stages = s);


### PR DESCRIPTION
Rebase of #3920 ("First Updates for GaussLegendre FIRK", by @Sreeram-Shankar) onto current master. That PR had gone `CONFLICTING`; I don't have push access to the author's fork, so this opens the rebased commit from a fork I can push to. Original authorship is preserved on the commit — this is not new work, it is #3920 made mergeable.

**Please ignore until reviewed by @ChrisRackauckas.** If @Sreeram-Shankar prefers to update #3920 directly, the rebased head can be pulled from `https://github.com/ChrisRackauckas-Claude/OrdinaryDiffEq.jl.git` branch `gauss-legendre-updates-rebased` and force-pushed there instead, and this PR closed.

## What #3920 does

Replaces the Richardson step-doubling adaptivity in `GaussLegendre` with:
- a dense collocation-polynomial extrapolant as the Newton initial guess (previous step's `z` reused via divided differences), and
- a same-node embedded error estimate of order `s-1` (`err = dt * Σ (bᵢ - b̂ᵢ) f(Yᵢ)`), replacing the ~3× work per accepted step that step-doubling required.

`alg_adaptive_order` / `get_current_adaptive_order` change from `2s` to `s-1` accordingly, and the "Experimental" warning in the docstring is replaced with a description of the embedded pair.

## Rebase resolution

Base moved from d69e784e to 280bd5b46. One file conflicted — `lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl`, 3 hunks — entirely against #3835 ("Rework limiters as solve-level options applied at the integrator level"), which landed after #3920 branched. Taking #3920's side for the GaussLegendre rewrite, adapted to master's limiter convention:

- dropped `step_limiter!` from the `GaussLegendreCache` destructuring;
- removed the `step_limiter!(u, integrator, p, t + dt)` call in the mutable `perform_step!`, and the `alg.step_limiter!(u, ...)` call #3920 added to the constant-cache `perform_step!`.

Master applies step limiters centrally once per accepted step, so keeping those calls would double-apply them. Also fixed one trailing-whitespace hit from the original diff; Runic is clean on all changed files.

## Tests

`GROUP=Core` on `lib/OrdinaryDiffEqFIRK`, Julia 1.11, run locally on the rebased head:

```
Test Summary: | Pass  Total     Time
FIRK Tests    |  105    105  4m01.3s
     Testing OrdinaryDiffEqFIRK tests passed
```

QA/JET/Aqua were not run locally; leaving that to CI.

## For review

Two things in #3920 that are independent of the rebase and worth a look before merge:

1. It removes the `smooth_est` field and keyword from the `GaussLegendre` struct — breaking for anyone passing it, so the OrdinaryDiffEqFIRK version bump needs to be sized for that.
2. The adaptive order change (`2s` → `s-1`) changes controller behavior, which is the intent, but the accompanying benchmark @Sreeram-Shankar offered in https://github.com/SciML/OrdinaryDiffEq.jl/pull/3920#issuecomment-4997509005 would be useful to see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015m3Rp1gpqdLNdtuHp5UmpA
