### PR TITLE
Document OrdinaryDiffEqCore developer time-queue API

### DIFF
--- a/docs/src/devtools/internals/public_api.md
+++ b/docs/src/devtools/internals/public_api.md
@@ -104,6 +104,7 @@ OrdinaryDiffEqCore.isautoswitch
 OrdinaryDiffEqCore.default_autoswitch
 OrdinaryDiffEqCore.unwrap_alg
 OrdinaryDiffEqCore.isdefaultalg
+OrdinaryDiffEqCore.is_composite_algorithm
 ```
 
 ## Algorithm trait functions
@@ -280,6 +281,8 @@ OrdinaryDiffEqCore.get_differential_vars
 OrdinaryDiffEqCore.handle_callback_modifiers!
 OrdinaryDiffEqCore.resolve_stage_step_limiters
 OrdinaryDiffEqCore.trivial_limiter!
+OrdinaryDiffEqCore.DEOptions
+OrdinaryDiffEqCore.DummyController
 ```
 
 ### Time-stop and saving queues

--- a/docs/src/devtools/internals/public_api.md
+++ b/docs/src/devtools/internals/public_api.md
@@ -263,8 +263,10 @@ OrdinaryDiffEqCore.alg_cache
 OrdinaryDiffEqCore.get_fsalfirstlast
 OrdinaryDiffEqCore.perform_step!
 OrdinaryDiffEqCore.apply_step!
-OrdinaryDiffEqCore.postamble!
-OrdinaryDiffEqCore.last_step_failed
+SciMLBase.postamble!
+SciMLBase.last_step_failed
+SciMLBase.check_error
+SciMLBase.check_error!
 OrdinaryDiffEqCore.set_discontinuity
 OrdinaryDiffEqCore.increment_accept!
 OrdinaryDiffEqCore.increment_reject!
@@ -278,6 +280,20 @@ OrdinaryDiffEqCore.get_differential_vars
 OrdinaryDiffEqCore.handle_callback_modifiers!
 OrdinaryDiffEqCore.resolve_stage_step_limiters
 OrdinaryDiffEqCore.trivial_limiter!
+```
+
+### Time-stop and saving queues
+
+Custom integrator initialization and stepping loops use these hooks to preserve
+the standard `tstops`, `saveat`, derivative-discontinuity, and time-step-bound
+semantics. They are versioned developer API, not user-facing solver controls.
+
+```@docs
+OrdinaryDiffEqCore.initialize_tstops
+OrdinaryDiffEqCore.initialize_saveat
+OrdinaryDiffEqCore.initialize_d_discontinuities
+OrdinaryDiffEqCore.fix_dt_at_bounds!
+OrdinaryDiffEqCore.handle_tstop!
 ```
 
 ## Dense output / interpolation

--- a/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
+++ b/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
@@ -45,9 +45,7 @@ import DiffEqBase: ODE_DEFAULT_NORM,
     ODE_DEFAULT_UNSTABLE_CHECK,
     DEVerbosity, _process_verbose_param
 
-import SciMLOperators: MatrixOperator,
-    update_coefficients, update_coefficients!,
-    isconstant
+import SciMLOperators: MatrixOperator
 
 import Random
 import Printf: @sprintf
@@ -93,9 +91,7 @@ using SciMLBase: SciMLBase, CallbackSet, ContinuousCallback, DAEProblem,
 using SciMLOperators: SciMLOperators
 using CommonSolve: solve
 
-import SciMLBase: AbstractNonlinearProblem, alg_order, LinearAliasSpecifier, log_numerical_instability, has_mtk_sys
-
-import SciMLOperators: islinear
+import SciMLBase: AbstractNonlinearProblem, alg_order, LinearAliasSpecifier
 # `calculate_residuals`/`calculate_residuals!` are unused here but re-exported for
 # dependent OrdinaryDiffEq.jl sublibraries that import them from this package.
 import DiffEqBase: timedepentdtmin, calculate_residuals, calculate_residuals!

--- a/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
+++ b/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
@@ -45,7 +45,7 @@ import DiffEqBase: ODE_DEFAULT_NORM,
     ODE_DEFAULT_UNSTABLE_CHECK,
     DEVerbosity, _process_verbose_param
 
-import SciMLOperators: MatrixOperator, FunctionOperator,
+import SciMLOperators: MatrixOperator,
     update_coefficients, update_coefficients!,
     isconstant
 
@@ -61,8 +61,8 @@ using ArrayInterface: ArrayInterface
 import TruncatedStacktraces: @truncate_stacktrace, VERBOSE_MSG
 
 # Integrator Interface
-import Base: resize!
-import SciMLBase: deleteat!, addat!, full_cache, user_cache, u_cache, du_cache,
+import Base: resize!, deleteat!
+import SciMLBase: addat!, full_cache, user_cache, u_cache, du_cache,
     resize_non_user_cache!, deleteat_non_user_cache!, addat_non_user_cache!,
     terminate!, get_du, get_dt, get_proposed_dt, set_proposed_dt!,
     savevalues!,

--- a/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
+++ b/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
@@ -479,6 +479,8 @@ include("precompilation_setup.jl")
             :_ode_init, :_determine_initdt, :ode_determine_initdt, :_initialize_dae!,
             :find_algebraic_vars_eqs, :postamble!, :apply_step!, :last_step_failed, :reset_alg_dependent_opts!,
             :handle_callback_modifiers!, :resolve_basic, :resolve_stage_step_limiters,
+            :fix_dt_at_bounds!, :handle_tstop!, :initialize_d_discontinuities,
+            :initialize_saveat, :initialize_tstops,
             # Noise hooks used by the SDE/RODE solver sublibs.
             :accept_noise!, :reinit_noise!, :reject_noise!, :save_noise!, :noise_curt,
             :is_noise_saveable,

--- a/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
@@ -506,6 +506,16 @@ New code should prefer dedicated controllers like
 [`OrdinaryDiffEqBDF.BDFController`](@ref) or
 [`OrdinaryDiffEqNordsieck.JVODEController`](@ref), which expose the
 knobs as real, settable controller fields.
+
+# Rules
+
+Extend the controller dispatch hooks for an algorithm that owns its step-size
+logic. Do not select `DummyController` for new algorithms when a dedicated
+controller can represent their parameters.
+
+!!! warning "Developer API"
+    This transitional controller is intended for solver implementations, not
+    application code.
 """
 struct DummyController <: AbstractController
 end

--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
@@ -676,12 +676,27 @@ sub-caches for a composite algorithm.
 """
 is_composite_cache(cache) = cache isa CompositeCache
 
-# Trait: is this a composite algorithm? Override to include SDE composite algorithms.
 """
     is_composite_algorithm(alg) -> Bool
 
-Return whether `alg isa OrdinaryDiffEqCompositeAlgorithm`, i.e. whether it
-dispatches between several sub-algorithms at runtime.
+Return whether `alg` dispatches between several sub-algorithms at runtime.
+
+# Arguments
+
+- `alg`: An algorithm instance.
+
+# Returns
+
+`true` for an `OrdinaryDiffEqCompositeAlgorithm`, and `false` otherwise.
+
+# Rules
+
+Sibling solver packages with their own composite-algorithm type must extend this
+trait to return `true` for that type.
+
+!!! warning "Developer API"
+    This trait is for solver-package extensions; application code should not
+    dispatch on it.
 """
 is_composite_algorithm(alg) = alg isa OrdinaryDiffEqCompositeAlgorithm
 

--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
@@ -1118,6 +1118,37 @@ function calc_dt_propose!(integrator, dtnew)
     return nothing
 end
 
+"""
+    fix_dt_at_bounds!(integrator)
+
+Clamp `integrator.dt` to the active `dtmin` and `dtmax` bounds while preserving
+the integration direction.
+
+# Arguments
+
+- `integrator`: An OrdinaryDiffEq integrator with `dt`, `tdir`, and time-step bound options.
+
+# Returns
+
+- `nothing`
+
+# Rules
+
+- Call this from a solver-specific stepping or initialization path after modifying `dt`
+  directly.
+- The result lies between the active `dtmin` and `dtmax` bounds in the direction of
+  integration.
+
+!!! warning "Developer API, not user API"
+    Application code should configure `dtmin` and `dtmax` through `solve` or
+    `init`, rather than mutating an integrator's time step.
+
+# Example
+```julia
+integrator.dt = proposed_dt
+fix_dt_at_bounds!(integrator)
+```
+"""
 function fix_dt_at_bounds!(integrator)
     if integrator.tdir > 0
         integrator.dt = min(integrator.opts.dtmax, integrator.dt)
@@ -1133,6 +1164,38 @@ function fix_dt_at_bounds!(integrator)
     return nothing
 end
 
+"""
+    handle_tstop!(integrator)
+
+Process the current time stop after a solver step. This removes reached stops,
+sets `integrator.just_hit_tstop`, and handles a fixed-step integrator that
+crossed a stop by interpolating back to it.
+
+# Arguments
+
+- `integrator`: An OrdinaryDiffEq integrator that has just advanced its time state.
+
+# Returns
+
+- `nothing`
+
+# Rules
+
+- Solver authors that own a stepping loop should call this after advancing time.
+- Duplicate stops at the current time are consumed together.
+- A fixed-step integrator that crosses a stop is interpolated back to the stop; a
+  time-step-changeable integrator crossing a stop is an invariant violation.
+
+!!! warning "Developer API, not user API"
+    Application code should manage time stops with `add_tstop!` or the `tstops`
+    keyword, not call this hook.
+
+# Example
+```julia
+perform_step!(integrator, cache, false)
+handle_tstop!(integrator)
+```
+"""
 function handle_tstop!(integrator)
     if has_tstop(integrator)
         tdir_t = integrator.tdir * integrator.t

--- a/lib/OrdinaryDiffEqCore/src/integrators/type.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/type.jl
@@ -1,15 +1,31 @@
 """
     DEOptions
 
-Mutable container holding the resolved common solver options for a running
-integrator, reachable as `integrator.opts`. Fields include the tolerances
-(`abstol`, `reltol`), the norm (`internalnorm`), step-size bounds
-(`dtmax`, `dtmin`, `failfactor`), the saving controls (`saveat`, `save_everystep`,
-`dense`, `save_start`, `save_end`, …), the `tstops`/`d_discontinuities` schedules
-and their caches, callback (`callback`), domain/stability checks
-(`isoutofdomain`, `unstable_check`), progress-logging options, and the
-`verbose`/`maxiters` settings. Mutating a field changes the solver behavior for
-subsequent steps.
+Mutable container of resolved common solver options, stored on a running
+integrator as `integrator.opts`.
+
+# Fields
+
+- `abstol`, `reltol`, `internalnorm`, and `internalopnorm` control error tests.
+- `dtmin`, `dtmax`, `failfactor`, `force_dtmin`, `advance_to_tstop`, and
+  `stop_at_next_tstop` control time-step selection.
+- `tstops`, `saveat`, `d_discontinuities`, and their corresponding caches manage
+  scheduled times.
+- `save_everystep`, `save_idxs`, `dense`, `save_on`, `save_start`, `save_end`,
+  `save_noise`, `save_discretes`, and `save_end_user` control output.
+- `callback`, `isoutofdomain`, and `unstable_check` configure step checks.
+- `maxiters`, `verbose`, and the `progress` fields configure reporting.
+
+# Rules
+
+Solver implementations may read or update these fields while stepping, but must
+preserve the queue invariants maintained by the initialization and time-stop
+hooks. Application code should configure these options through `solve` or
+`init`, rather than constructing `DEOptions` directly.
+
+!!! warning "Developer API"
+    `DEOptions` is a versioned interface for solver implementations. It is not a
+    user-facing solver configuration type.
 """
 mutable struct DEOptions{
         absType, relType, QT, tType, F1, F2, F3, F4, F5, F6,

--- a/lib/OrdinaryDiffEqCore/src/solve.jl
+++ b/lib/OrdinaryDiffEqCore/src/solve.jl
@@ -974,7 +974,40 @@ function handle_dt!(integrator, dt)
     end
 end
 
-# time stops
+"""
+    initialize_tstops(::Type{T}, tstops, d_discontinuities, tspan) -> BinaryHeap{T}
+
+Build the internal directional time-stop queue for a solver integrator.
+
+# Arguments
+
+- `T::Type`: Element type of the queue.
+- `tstops`: Iterable of requested stopping times.
+- `d_discontinuities`: Iterable of derivative-discontinuity times.
+- `tspan::Tuple`: Integration start and end times.
+
+# Returns
+
+- `BinaryHeap{T}`: Directional times strictly inside `tspan`, followed by the final time.
+
+# Rules
+
+- Times are stored multiplied by the integration direction, so `pop!` visits the next
+  physical time for both forward and reverse integrations.
+- Entries at or outside the initial and final bounds are discarded; the final bound is
+  inserted exactly once.
+- Solver authors implementing a custom `init` path must use this helper so `tstops`
+  and derivative discontinuities preserve the standard ordering semantics.
+
+!!! warning "Developer API, not user API"
+    Application code should pass `tstops` and `d_discontinuities` to `solve` or
+    `init`; it must not construct this queue directly.
+
+# Example
+```julia
+tstops_internal = initialize_tstops(Float64, (0.25, 0.75), (), (0.0, 1.0))
+```
+"""
 @inline function initialize_tstops(::Type{T}, tstops, d_discontinuities, tspan) where {T}
     tstops_internal = BinaryHeap{T}(FasterForward())
 
@@ -1026,7 +1059,37 @@ function reinit_tstops!(
     return push!(tstops_internal, tdir_tf)
 end
 
-# saving time points
+"""
+    initialize_saveat(::Type{T}, saveat, tspan) -> BinaryHeap{T}
+
+Build the internal directional queue of output times for a solver integrator.
+
+# Arguments
+
+- `T::Type`: Element type of the queue.
+- `saveat`: A positive output interval or iterable of requested output times.
+- `tspan::Tuple`: Integration start and end times.
+
+# Returns
+
+- `BinaryHeap{T}`: Directional output times accepted by the standard `saveat` rules.
+
+# Rules
+
+- A scalar `saveat` is treated as a positive interval in the integration direction.
+- An iterable `saveat` contributes only times strictly after the initial bound and at or
+  before the final bound.
+- Solver authors implementing a custom `init` path must use this helper to preserve
+  forward and reverse integration semantics.
+
+!!! warning "Developer API, not user API"
+    Application code should set the `saveat` keyword on `solve` or `init`.
+
+# Example
+```julia
+saveat_internal = initialize_saveat(Float64, 0.1, (0.0, 1.0))
+```
+"""
 function initialize_saveat(::Type{T}, saveat, tspan) where {T}
     saveat_internal = BinaryHeap{T}(FasterForward())
 
@@ -1071,7 +1134,35 @@ function reinit_saveat!(::Type{T}, saveat_internal, saveat, tspan) where {T}
     end
 end
 
-# discontinuities
+"""
+    initialize_d_discontinuities(::Type{T}, d_discontinuities, tspan) -> BinaryHeap{T}
+
+Build the internal directional queue of derivative-discontinuity times.
+
+# Arguments
+
+- `T::Type`: Element type of the queue.
+- `d_discontinuities`: Iterable of derivative-discontinuity times.
+- `tspan::Tuple`: Integration start and end times; its direction determines queue order.
+
+# Returns
+
+- `BinaryHeap{T}`: All requested discontinuities stored in integration direction.
+
+# Rules
+
+- Unlike `initialize_tstops`, this helper does not filter times against `tspan`.
+- Solver authors use this queue only when their initialization path supports the
+  `d_discontinuities` solve keyword.
+
+!!! warning "Developer API, not user API"
+    Application code should supply `d_discontinuities` to `solve` or `init`.
+
+# Example
+```julia
+discontinuities = initialize_d_discontinuities(Float64, (0.5,), (0.0, 1.0))
+```
+"""
 function initialize_d_discontinuities(::Type{T}, d_discontinuities, tspan) where {T}
     d_discontinuities_internal = BinaryHeap{T}(FasterForward())
     sizehint!(d_discontinuities_internal, length(d_discontinuities))

--- a/lib/OrdinaryDiffEqCore/test/developer_time_queue_api_tests.jl
+++ b/lib/OrdinaryDiffEqCore/test/developer_time_queue_api_tests.jl
@@ -1,0 +1,38 @@
+using OrdinaryDiffEqCore, Test
+
+function popall!(queue)
+    values = eltype(queue)[]
+    while !isempty(queue)
+        push!(values, pop!(queue))
+    end
+    return values
+end
+
+@testset "Time queue initialization" begin
+    @test popall!(
+        OrdinaryDiffEqCore.initialize_tstops(
+            Float64, (0.75, 0.25, -1.0, 2.0), (0.5,), (0.0, 1.0)
+        )
+    ) == [0.25, 0.5, 0.75, 1.0]
+
+    @test popall!(
+        OrdinaryDiffEqCore.initialize_tstops(
+            Float64, (0.75, 0.25, -1.0, 2.0), (0.5,), (1.0, 0.0)
+        )
+    ) == [-0.75, -0.5, -0.25, 0.0]
+
+    @test popall!(OrdinaryDiffEqCore.initialize_saveat(Float64, 0.25, (0.0, 1.0))) ==
+        [0.25, 0.5, 0.75, 1.0]
+    @test popall!(
+        OrdinaryDiffEqCore.initialize_saveat(Float64, (0.25, 1.0, 2.0), (1.0, 0.0))
+    ) == [-0.25]
+
+    @test popall!(
+        OrdinaryDiffEqCore.initialize_d_discontinuities(Float64, (0.25, 0.75), (1.0, 0.0))
+    ) == [-0.75, -0.25]
+
+    float32_tstops = OrdinaryDiffEqCore.initialize_tstops(
+        Float32, (Float32(0.5),), (), (Float32(0), Float32(1))
+    )
+    @test popall!(float32_tstops) == Float32[0.5, 1.0]
+end

--- a/lib/OrdinaryDiffEqCore/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqCore/test/qa/qa.jl
@@ -86,9 +86,4 @@ run_qa(
             ),
         ),
     ),
-    api_docs_kwargs = (;
-        rendered = false,
-        # Reexported upstream SciMLOperators names are documented at their owner.
-        ignore = (:StaticWOperator, :has_concretization),
-    ),
 )

--- a/lib/OrdinaryDiffEqCore/test/runtests.jl
+++ b/lib/OrdinaryDiffEqCore/test/runtests.jl
@@ -32,6 +32,7 @@ end
 
 # Functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
+    @time @safetestset "Developer Time Queue API" include("developer_time_queue_api_tests.jl")
     @time @safetestset "Sparse isdiag Performance" include("sparse_isdiag_tests.jl")
     @time @safetestset "Algebraic Vars Detection" include("algebraic_vars_detection_tests.jl")
     @time @safetestset "Interpolation Search Hint" include("interpolation_hint_tests.jl")


### PR DESCRIPTION
## Summary
- put SciMLStyle docstrings directly on the five public custom-integrator time-queue hooks
- render them on the OrdinaryDiffEqCore developer API page, explicitly separated from user-facing API
- add generic forward/reverse time-queue tests
- correct two QA imports: `deleteat!` is owned by `Base`, and remove the unused `FunctionOperator` import

## Dependency
This depends on SciMLBase making the diagnostic hooks used by OrdinaryDiffEqCore a documented developer API: https://github.com/SciML/SciMLBase.jl/pull/1495. Strict full QA is intentionally not given a local source override; it must run against that released owner API.

## Validation
- `developer_time_queue_api_tests.jl`: `6/6` passed
- Runic on touched source

Ignore until reviewed by @ChrisRackauckas.