### PR TITLE
Remove OrdinaryDiffEqCore blanket SciMLBase reexport

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
+++ b/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
@@ -6,9 +6,6 @@ if isdefined(Base, :Experimental) &&
 end
 
 import DocStringExtensions
-import Reexport: @reexport
-using Reexport: @reexport
-@reexport using SciMLBase
 import DiffEqBase
 
 import Logging: @logmsg, LogLevel
@@ -35,9 +32,8 @@ import DiffEqBase: initialize!
 import DiffEqBase: DefaultInit, ShampineCollocationInit, BrownFullBasicInit
 
 # Specialization level owned by SciMLBase (declared `public` there, not
-# exported). Re-exported here so `using OrdinaryDiffEq` surfaces it unqualified.
+# exported). The umbrella package imports and exports it directly.
 import SciMLBase: AutoDePSpecialize
-export AutoDePSpecialize
 
 # Internal utils. `DEVerbosity` is re-exported for dependent sublibraries.
 import DiffEqBase: ODE_DEFAULT_NORM,
@@ -473,7 +469,7 @@ include("precompilation_setup.jl")
             :error_constant, :unitfulvalue,
             # Integrator step / cache / initialization hooks.
             :_ode_init, :_determine_initdt, :ode_determine_initdt, :_initialize_dae!,
-            :find_algebraic_vars_eqs, :postamble!, :apply_step!, :last_step_failed, :reset_alg_dependent_opts!,
+            :find_algebraic_vars_eqs, :apply_step!, :reset_alg_dependent_opts!,
             :handle_callback_modifiers!, :resolve_basic, :resolve_stage_step_limiters,
             :fix_dt_at_bounds!, :handle_tstop!, :initialize_d_discontinuities,
             :initialize_saveat, :initialize_tstops,

--- a/lib/OrdinaryDiffEqCore/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqCore/test/qa/qa.jl
@@ -16,15 +16,6 @@ end
 
 run_qa(
     OrdinaryDiffEqCore;
-    reexports_allow = union(
-        public_api_names(SciMLBase), (:SciMLBase,),
-        # `last_step_failed`/`postamble!` are SciMLBase-owned generic functions that
-        # OrdinaryDiffEqCore imports, extends, and re-declares `public` as part of the
-        # documented solver-author surface (docs/src/devtools/internals/public_api.md).
-        # SciMLBase has not declared them `public` yet, so `public_reexports` sees them
-        # as owned outside this package; drop these once SciMLBase marks them public.
-        (:last_step_failed, :postamble!),
-    ),
     aqua_kwargs = (; piracies = false, unbound_args = false),
     explicit_imports = true,
     ei_kwargs = (;


### PR DESCRIPTION
Removes `@reexport using SciMLBase` from OrdinaryDiffEqCore and the corresponding broad `reexports_allow` QA exemption. SciMLBase-owned `last_step_failed` and `postamble!` are no longer redeclared public by Core; the umbrella already surfaces `AutoDePSpecialize` directly from its owner.

Validation:
- Core functional suite: 95/95 passing through the root monorepo route.
- Umbrella `AutoDePSpecialize` owner-binding check passed.
- Strict reexport QA passes with no allowlist.

The remaining strict QA owner/doc findings reproduce on master and are handled separately by SciMLBase #1495, OrdinaryDiffEq #4118, and SciMLTesting #43.

Ignore until reviewed by @ChrisRackauckas.