### PR TITLE
Format OrdinaryDiffEqCore sources with Runic

### DIFF
--- a/lib/OrdinaryDiffEqCore/ext/OrdinaryDiffEqCoreSparseArraysExt.jl
+++ b/lib/OrdinaryDiffEqCore/ext/OrdinaryDiffEqCoreSparseArraysExt.jl
@@ -24,10 +24,10 @@ end
 
 # only look at nonzero vals
 function _find_large_jac_entries!(rows::Set{Int}, cols::Set{Int}, entries::Vector, jac::SparseMatrixCSC)
-    @inbounds for j in axes(jac, 2)
+    return @inbounds for j in axes(jac, 2)
         for k in jac.colptr[j]:(jac.colptr[j + 1] - 1)
             val = jac.nzval[k]
-            if !isfinite(val) || abs(val) > 1e6
+            if !isfinite(val) || abs(val) > 1.0e6
                 i = jac.rowval[k]
                 push!(rows, i)
                 push!(cols, j)

--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
@@ -773,7 +773,7 @@ function SciMLBase.log_numerical_instability(integrator::ODEIntegrator; jacobian
         # keep only components within 20 orders of magnitude of the largest
         if !isempty(blown_idxs)
             max_blown = maximum(abs(u[i]) for i in blown_idxs)
-            cutoff = max_blown * 1e-20
+            cutoff = max_blown * 1.0e-20
             filter!(i -> abs(u[i]) >= cutoff, blown_idxs)
             sort!(blown_idxs, by = i -> abs(u[i]), rev = true)
         end
@@ -804,14 +804,14 @@ function SciMLBase.log_numerical_instability(integrator::ODEIntegrator; jacobian
         _find_large_jac_entries!(rows, cols, entries, jac)
 
         # keep only entries within 10 orders of magnitude of the largest finite entry,
-        # plus any non-finite entries. filters out large-but-normal model parameters 
+        # plus any non-finite entries. filters out large-but-normal model parameters
         max_finite = 0.0
         for (_, _, v) in entries
             if isfinite(v)
                 max_finite = max(max_finite, abs(v))
             end
         end
-        cutoff = max_finite * 1e-10
+        cutoff = max_finite * 1.0e-10
         filter!(t -> !isfinite(t[3]) || abs(t[3]) >= cutoff, entries) #only keep those vals within 1e10 of max or inf/nan
         sort!(entries, by = t -> (!isfinite(t[3]), abs(t[3])), rev = true)
 
@@ -935,7 +935,7 @@ function SciMLBase.log_numerical_instability(integrator::ODEIntegrator; jacobian
     sections = (
         ("State Analysis", state_analysis),
         ("Jacobian Analysis", jacobian_analysis),
-        ("Error Analysis", error_analysis)
+        ("Error Analysis", error_analysis),
     )
     all(isempty(msgs) for (_, msgs) in sections) && return ""
 

--- a/lib/OrdinaryDiffEqCore/src/misc_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/misc_utils.jl
@@ -235,17 +235,18 @@ end
 # Sparse specialization is provided in OrdinaryDiffEqCoreSparseArraysExt
 _isdiag(A::AbstractMatrix) = isdiag(A)
 
-# Dense fallback to find large Jacobian entries. 
+# Dense fallback to find large Jacobian entries.
 # Sparse specialization is provided in OrdinaryDiffEqCoreSparseArraysExt
 function _find_large_jac_entries!(rows::Set{Int}, cols::Set{Int}, entries::Vector, jac::AbstractMatrix)
     for i in axes(jac, 1), j in axes(jac, 2)
         val = jac[i, j]
-        if !isfinite(val) || abs(val) > 1e6
+        if !isfinite(val) || abs(val) > 1.0e6
             push!(rows, i)
             push!(cols, j)
             push!(entries, (i, j, val))
         end
     end
+    return
 end
 """
     find_algebraic_vars_eqs(M)


### PR DESCRIPTION
Applies the current Runic formatting to the three OrdinaryDiffEqCore files that fail the repository format check on clean `master`.

Validation:
- Repository-wide Runic 1.7 check passed.
- `GROUP=OrdinaryDiffEqCore julia --project=. -e 'using Pkg; Pkg.test()'` passed: 89 assertions, including sparse-extension coverage.\n\nIgnore until reviewed by @ChrisRackauckas.