### PR TITLE
Bump 30 package versions for release

### DIFF
--- a/lib/OrdinaryDiffEqAMF/Project.toml
+++ b/lib/OrdinaryDiffEqAMF/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqAMF"
 uuid = "08082164-f6a1-4363-b3df-3aa6fcf571ad"
 authors = ["Utkarsh <rajpututkarsh530@gmail.com>"]
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/lib/OrdinaryDiffEqAdamsBashforthMoulton/Project.toml
+++ b/lib/OrdinaryDiffEqAdamsBashforthMoulton/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqAdamsBashforthMoulton"
 uuid = "89bda076-bce5-4f1c-845f-551c83cdda9a"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.1"
+version = "2.1.2"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqDefault/Project.toml
+++ b/lib/OrdinaryDiffEqDefault/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqDefault"
 uuid = "50262376-6c5a-4cf5-baba-aaf4f84d72d7"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.4.2"
+version = "2.4.3"
 
 [deps]
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"

--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "3.6.0"
+version = "3.7.0"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 

--- a/lib/OrdinaryDiffEqExplicitTableaus/Project.toml
+++ b/lib/OrdinaryDiffEqExplicitTableaus/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExplicitTableaus"
 uuid = "3278f1b1-0f5c-4cde-98e0-ba5eb00db955"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.2.0"
+version = "2.3.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFIRK"
 uuid = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.5.1"
+version = "2.6.0"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqFeagin/Project.toml
+++ b/lib/OrdinaryDiffEqFeagin/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFeagin"
 uuid = "101fe9f7-ebb6-4678-b671-3a81e7194747"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.0"
+version = "2.2.0"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqFunctionMap/Project.toml
+++ b/lib/OrdinaryDiffEqFunctionMap/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFunctionMap"
 uuid = "d3585ca7-f5d3-4ba6-8057-292ed1abd90f"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.0"
+version = "2.2.0"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqLinear/Project.toml
+++ b/lib/OrdinaryDiffEqLinear/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqLinear"
 uuid = "521117fe-8c41-49f8-b3b6-30780b3f0fb5"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"

--- a/lib/OrdinaryDiffEqLowStorageRK/Project.toml
+++ b/lib/OrdinaryDiffEqLowStorageRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqLowStorageRK"
 uuid = "b0944070-b475-4768-8dec-fb6eb410534d"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "3.4.0"
+version = "3.3.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/OrdinaryDiffEqNewmark/Project.toml
+++ b/lib/OrdinaryDiffEqNewmark/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqNewmark"
 uuid = "d204908a-63b9-11ef-18f5-cfec7123a93b"
-version = "2.2.1"
+version = "2.2.2"
 authors = ["Dennis Ogiermann <termi-official@users.noreply.github.com>"]
 
 [deps]

--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.6.0"
+version = "2.6.1"
 
 [deps]
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"

--- a/lib/OrdinaryDiffEqNordsieck/Project.toml
+++ b/lib/OrdinaryDiffEqNordsieck/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNordsieck"
 uuid = "c9986a66-5c92-4813-8696-a7ec84c806c8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.1"
+version = "2.2.2"
 
 [deps]
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"

--- a/lib/OrdinaryDiffEqPRK/Project.toml
+++ b/lib/OrdinaryDiffEqPRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqPRK"
 uuid = "5b33eab2-c0f1-4480-b2c3-94bc1e80bda1"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.1"
+version = "2.2.2"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqRKIP/Project.toml
+++ b/lib/OrdinaryDiffEqRKIP/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqRKIP"
 uuid = "a4daff8c-1d43-4ff3-8eff-f78720aeecdc"
 authors = ["Azercoco <20425137+Azercoco@users.noreply.github.com>"]
-version = "2.1.1"
+version = "2.1.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/lib/OrdinaryDiffEqRKN/Project.toml
+++ b/lib/OrdinaryDiffEqRKN/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqRKN"
 uuid = "af6ede74-add8-4cfd-b1df-9a4dbb109d7a"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.1"
+version = "2.1.2"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqRosenbrockTableaus/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrockTableaus/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqRosenbrockTableaus"
 uuid = "b4bd8bb3-f80f-41d2-9b21-73a655b304b9"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.4.0"
+version = "2.4.1"
 
 [extras]
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"

--- a/lib/OrdinaryDiffEqSIMDRK/Project.toml
+++ b/lib/OrdinaryDiffEqSIMDRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSIMDRK"
 uuid = "dc97f408-7a72-40e4-9b0d-228a53b292f8"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Elrod <elrodc@gmail.com>"]
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqStabilizedRK/Project.toml
+++ b/lib/OrdinaryDiffEqStabilizedRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqStabilizedRK"
 uuid = "358294b1-0aab-51c3-aafe-ad5ab194a2ad"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.5.0"
+version = "2.5.1"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqSymplecticRK/Project.toml
+++ b/lib/OrdinaryDiffEqSymplecticRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSymplecticRK"
 uuid = "fa646aed-7ef9-47eb-84c4-9443fc8cbfa8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqTaylorSeries/Project.toml
+++ b/lib/OrdinaryDiffEqTaylorSeries/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqTaylorSeries"
 uuid = "9c7f1690-dd92-42a3-8318-297ee24d8d39"
 authors = ["Songchen Tan <i@tansongchen.com>"]
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/SimpleImplicitDiscreteSolve/Project.toml
+++ b/lib/SimpleImplicitDiscreteSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleImplicitDiscreteSolve"
 uuid = "8b67ef88-54bd-43ff-aca0-8be02588656a"
 authors = ["vyudu <vincent.duyuan@gmail.com>"]
-version = "2.0.2"
+version = "2.0.3"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/StochasticDiffEqCore/Project.toml
+++ b/lib/StochasticDiffEqCore/Project.toml
@@ -1,6 +1,6 @@
 name = "StochasticDiffEqCore"
 uuid = "19c5a474-6cd1-4a5f-be79-46dc34e54d7f"
-version = "2.0.4"
+version = "2.0.5"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]

--- a/lib/StochasticDiffEqHighOrder/Project.toml
+++ b/lib/StochasticDiffEqHighOrder/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqHighOrder"
 uuid = "0520c28c-50fd-4d16-9c96-902fc80b3bab"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.1.2"
+version = "2.1.3"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/StochasticDiffEqIIF/Project.toml
+++ b/lib/StochasticDiffEqIIF/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqIIF"
 uuid = "ebf54054-c36b-4494-9aba-657e36df524f"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.2"
+version = "2.0.3"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/StochasticDiffEqLeaping/Project.toml
+++ b/lib/StochasticDiffEqLeaping/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqLeaping"
 uuid = "aefaaa88-39f2-4e89-b162-d61b7e8cc81b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.2"
+version = "2.0.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/StochasticDiffEqLevyArea/Project.toml
+++ b/lib/StochasticDiffEqLevyArea/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqLevyArea"
 uuid = "90dbc90e-856a-4131-af2c-e8c5aa0f35b5"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.2"
+version = "2.0.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/lib/StochasticDiffEqLowOrder/Project.toml
+++ b/lib/StochasticDiffEqLowOrder/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqLowOrder"
 uuid = "d15fe365-ce7f-450a-828a-7985bd5b681b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.2"
+version = "2.0.3"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/StochasticDiffEqMilstein/Project.toml
+++ b/lib/StochasticDiffEqMilstein/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqMilstein"
 uuid = "8c95a807-c8e7-4581-8419-890d001af53e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.2"
+version = "2.0.3"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/StochasticDiffEqRODE/Project.toml
+++ b/lib/StochasticDiffEqRODE/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqRODE"
 uuid = "49714585-0aa1-4f53-b1e6-a9b8c0d5e03f"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.2"
+version = "2.0.3"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"


### PR DESCRIPTION
        These packages have unreleased changes to `src`, `ext`, or `Project.toml` relative to the
        tree recorded in the General registry for their current version, but the version was never
        bumped — so the changes cannot be released.

        | package | from | to | kind | why |
        |---|---|---|---|---|
        | `OrdinaryDiffEqAMF` | 2.2.0 | **2.2.1** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `OrdinaryDiffEqAdamsBashforthMoulton` | 2.1.1 | **2.1.2** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `OrdinaryDiffEqDefault` | 2.4.2 | **2.4.3** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `OrdinaryDiffEqDifferentiation` | 3.6.0 | **3.7.0** | minor | adds logging for singular cases during integration |
| `OrdinaryDiffEqExplicitTableaus` | 2.2.0 | **2.3.0** | minor | wires embedding metadata through the TKYY 6A-D and MikkawyEisa tableaus |
| `OrdinaryDiffEqFIRK` | 2.5.1 | **2.6.0** | minor | Gauss-Legendre dense extrapolant and embedded error estimate |
| `OrdinaryDiffEqFeagin` | 2.1.0 | **2.2.0** | minor | limiters reworked as solve-level options |
| `OrdinaryDiffEqFunctionMap` | 2.1.0 | **2.2.0** | minor | limiters reworked as solve-level options |
| `OrdinaryDiffEqLinear` | 2.2.0 | **2.2.1** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `OrdinaryDiffEqLowStorageRK` | 3.4.0 | **3.3.0** | correction | master skipped 3.3.0 over the registry latest 3.2.2; both unreleased changes are features, so they ship together as 3.3.0 |
| `OrdinaryDiffEqNewmark` | 2.2.1 | **2.2.2** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `OrdinaryDiffEqNonlinearSolve` | 2.6.0 | **2.6.1** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `OrdinaryDiffEqNordsieck` | 2.2.1 | **2.2.2** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `OrdinaryDiffEqPRK` | 2.2.1 | **2.2.2** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `OrdinaryDiffEqRKIP` | 2.1.1 | **2.1.2** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `OrdinaryDiffEqRKN` | 2.1.1 | **2.1.2** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `OrdinaryDiffEqRosenbrockTableaus` | 2.4.0 | **2.4.1** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `OrdinaryDiffEqSIMDRK` | 2.1.0 | **2.1.1** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `OrdinaryDiffEqStabilizedRK` | 2.5.0 | **2.5.1** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `OrdinaryDiffEqSymplecticRK` | 2.2.0 | **2.2.1** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `OrdinaryDiffEqTaylorSeries` | 2.1.0 | **2.1.1** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `SimpleImplicitDiscreteSolve` | 2.0.2 | **2.0.3** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `StochasticDiffEqCore` | 2.0.4 | **2.0.5** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `StochasticDiffEqHighOrder` | 2.1.2 | **2.1.3** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `StochasticDiffEqIIF` | 2.0.2 | **2.0.3** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `StochasticDiffEqLeaping` | 2.0.2 | **2.0.3** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `StochasticDiffEqLevyArea` | 2.0.2 | **2.0.3** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `StochasticDiffEqLowOrder` | 2.0.2 | **2.0.3** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `StochasticDiffEqMilstein` | 2.0.2 | **2.0.3** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `StochasticDiffEqRODE` | 2.0.2 | **2.0.3** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |

### One of these is a correction, not a bump

`OrdinaryDiffEqLowStorageRK` is being moved **down**, from `3.4.0` to `3.3.0`.
The registry latest is `3.2.2`, so `3.4.0` skips `3.3.0` and AutoMerge rejects it under
the sequential version number guideline. `3.3.0` was never registered, so the two
unreleased feature commits (`Add ES-DG optimized 3S* low-storage RK methods` and
`Fold RK46NL into the generic LowStorageRK2N dispatch`) simply ship together as `3.3.0`.
The only `[compat]` bounds on it in this repo are `"2, 3"`, which `3.3.0` still satisfies.

        ### How the versions were chosen

        Patch by default. A package was promoted to a **minor** bump only where it gained public API
        or a user-facing capability. For `0.y.z` packages the non-breaking slot is `z`, so those stay
        in the patch position regardless of what they added.

        No package in this PR needs a major bump: comparing the exported/`@public` name sets between
        each package's released commit and master, **no name that the package itself defines was
        removed**. The removals that do appear are blanket reexports of names owned by other packages
        (e.g. `BVPJacobianAlgorithm` and `integral`, which belong to `BoundaryValueDiffEqCore`), which
        SciML does not treat as documented public API.

        Registration follows once this merges.

        ---

        Found by a `/sciml-release-sweep` pass over the org. **Please ignore until reviewed by @ChrisRackauckas.**
