### PR TITLE
Remove PRK blanket SciMLBase reexport

### DIFF
--- a/lib/OrdinaryDiffEqPRK/Project.toml
+++ b/lib/OrdinaryDiffEqPRK/Project.toml
@@ -7,7 +7,6 @@ version = "2.2.1"
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
-Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
@@ -36,7 +35,6 @@ OrdinaryDiffEqCore = "4"
 julia = "1.10"
 DiffEqBase = "7"
 SafeTestsets = "0.1.0"
-Reexport = "1.2.2"
 
 [targets]
 test = ["DiffEqDevTools", "Random", "SafeTestsets", "Test", "Pkg", "SciMLTesting"]

--- a/lib/OrdinaryDiffEqPRK/src/OrdinaryDiffEqPRK.jl
+++ b/lib/OrdinaryDiffEqPRK/src/OrdinaryDiffEqPRK.jl
@@ -3,16 +3,11 @@ module OrdinaryDiffEqPRK
 import OrdinaryDiffEqCore: OrdinaryDiffEqAlgorithm, OrdinaryDiffEqMutableCache,
     OrdinaryDiffEqConstantCache, constvalue, @cache,
     alg_cache, get_fsalfirstlast,
-    unwrap_alg, perform_step!, @threaded, isthreaded,
-    generic_solver_docstring
+    unwrap_alg, perform_step!, @threaded, isthreaded
 import SciMLBase: alg_order, full_cache
 import DiffEqBase: initialize!
 import MuladdMacro: @muladd
 import FastBroadcast: @..
-
-using Reexport: Reexport, @reexport
-using SciMLBase: SciMLBase
-@reexport using SciMLBase
 
 include("algorithms.jl")
 include("alg_utils.jl")

--- a/lib/OrdinaryDiffEqPRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqPRK/src/algorithms.jl
@@ -1,19 +1,36 @@
-@doc generic_solver_docstring(
-    "A 5 parallel, 2 processor method of 5th order.",
-    "KuttaPRK2p5",
-    "Explicit Runge-Kutta Method",
-    """@article{jackson1995potential,
-    title={The potential for parallelism in Runge--Kutta methods. Part 1: RK formulas in standard form},
-    author={Jackson, Kenneth R and Norsett, Syvert Paul},
-    journal={SIAM journal on numerical analysis},
-    volume={32},
-    number={1},
-    pages={49--82},
-    year={1995},
-    publisher={SIAM}}""",
-    "- `thread`: determines whether internal broadcasting on appropriate CPU arrays should be serial (`thread = Serial()`) or use multiple threads (`thread = Threaded()`) when Julia is started with multiple threads.",
-    "thread = Threaded(),"
-)
+"""
+    KuttaPRK2p5(; threading = true)
+
+Fifth-order explicit parallel Runge-Kutta method with five stages arranged for two
+processors. It is useful when each right-hand-side evaluation is sufficiently expensive
+to benefit from the available stage parallelism.
+
+# Fields
+
+  - `threading`: threading configuration used for the parallel stages. It must be a
+    `Bool` or an OrdinaryDiffEqCore threading option such as `BaseThreads()`.
+
+# Keywords
+
+  - `threading = true`: threading configuration for the parallel stages. `true` uses
+    `Threads.@threads`, `false` is serial, and `BaseThreads()` or `PolyesterThreads()`
+    select the corresponding OrdinaryDiffEqCore backend.
+
+# Examples
+
+```julia
+using OrdinaryDiffEq
+
+prob = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 1.0))
+sol = solve(prob, KuttaPRK2p5())
+```
+
+# References
+
+K. R. Jackson and S. P. Norsett, "The potential for parallelism in Runge--Kutta
+methods. Part 1: RK formulas in standard form," *SIAM Journal on Numerical Analysis*,
+32(1), 49-82 (1995).
+"""
 Base.@kwdef struct KuttaPRK2p5{TO} <: OrdinaryDiffEqAlgorithm
     threading::TO = true
 end

--- a/lib/OrdinaryDiffEqPRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqPRK/test/qa/qa.jl
@@ -2,9 +2,6 @@ using SciMLTesting, OrdinaryDiffEqPRK, Test
 
 run_qa(
     OrdinaryDiffEqPRK;
-    # No docs/ tree here; the umbrella manual renders this package's API.
-    api_docs_kwargs = (; rendered = false),
-    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;
         all_explicit_imports_are_public = (;


### PR DESCRIPTION
Removes OrdinaryDiffEqPRK’s unused `@reexport using SciMLBase` and its broad QA reexport exemption, including the now-unused Reexport dependency.

`KuttaPRK2p5` now has a definition-site SciMLStyle docstring documenting its field and keyword, usage, and reference. The parent manual continues to render the algorithm.

Validation:
- Runic 1.7 check passed.
- Owner-module public API smoke check passed.
- The full leaf QA process was started locally but this executor terminated its child while the fresh QA environment was precompiling; CI is required for the completed strict QA result.

Ignore until reviewed by @ChrisRackauckas.