### PR TITLE
Remove QPRK blanket SciMLBase reexport

### DIFF
--- a/docs/src/explicit/QPRK.md
+++ b/docs/src/explicit/QPRK.md
@@ -77,6 +77,7 @@ For ultra-high precision, also consider:
 
 ```julia
 using OrdinaryDiffEqQPRK
+using SciMLBase: ODEProblem, solve
 # Ensure using Float128 for ultra-high precision
 u0 = Float128[1.0, 0.0]
 tspan = (Float128(0.0), Float128(10.0))

--- a/lib/OrdinaryDiffEqQPRK/Project.toml
+++ b/lib/OrdinaryDiffEqQPRK/Project.toml
@@ -8,7 +8,6 @@ MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
-Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
@@ -40,7 +39,6 @@ RecursiveArrayTools = "4.2.0"
 ODEProblemLibrary = "1"
 DiffEqBase = "7"
 SafeTestsets = "0.1.0"
-Reexport = "1.2.2"
 
 [targets]
 test = ["DiffEqDevTools", "Random", "SafeTestsets", "Test", "ODEProblemLibrary", "Pkg", "SciMLTesting"]

--- a/lib/OrdinaryDiffEqQPRK/src/OrdinaryDiffEqQPRK.jl
+++ b/lib/OrdinaryDiffEqQPRK/src/OrdinaryDiffEqQPRK.jl
@@ -1,7 +1,7 @@
 module OrdinaryDiffEqQPRK
 
 import OrdinaryDiffEqCore: OrdinaryDiffEqAdaptiveAlgorithm, OrdinaryDiffEqConstantCache,
-    explicit_rk_docstring, @cache,
+    @cache,
     OrdinaryDiffEqMutableCache,
     @fold, @OnDemandTableauExtract,
     trivial_limiter!, alg_cache,
@@ -13,10 +13,6 @@ using FastBroadcast: FastBroadcast, Serial, @..
 using MuladdMacro: MuladdMacro, @muladd
 using RecursiveArrayTools: recursive_unitless_bottom_eltype, recursivefill!
 import OrdinaryDiffEqCore
-
-using SciMLBase: SciMLBase
-using Reexport: Reexport, @reexport
-@reexport using SciMLBase
 
 include("algorithms.jl")
 include("alg_utils.jl")

--- a/lib/OrdinaryDiffEqQPRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqQPRK/src/algorithms.jl
@@ -1,9 +1,42 @@
-@doc explicit_rk_docstring(
-    "Runge–Kutta pairs of orders 9(8) for use in quadruple precision computations", "QPRK98",
-    references = "Kovalnogov VN, Fedorov RV, Karpukhina TV, Simos TE, Tsitouras C. Runge–Kutta pairs 
-    of orders 9 (8) for use in quadruple precision computations. Numerical Algorithms, 2023. 
-    doi: https://doi.org/10.1007/s11075-023-01632-8"
-)
+"""
+    QPRK98(; stage_limiter! = trivial_limiter!, step_limiter! = trivial_limiter!,
+        thread = Serial())
+
+Ninth-order explicit embedded Runge-Kutta pair with an eighth-order error estimate,
+designed for quadruple-precision computations. Its parallel tableau is most useful when
+function evaluations are expensive and extended-precision accuracy is required.
+
+# Fields
+
+  - `stage_limiter!`: function applied after every Runge-Kutta stage.
+  - `step_limiter!`: function applied after every accepted step.
+  - `thread`: OrdinaryDiffEqCore threading option for independent stage work.
+
+# Keywords
+
+  - `stage_limiter! = trivial_limiter!`: stage limiter with the OrdinaryDiffEq limiter
+    calling convention. Use this to enforce stage-wise constraints.
+  - `step_limiter! = trivial_limiter!`: limiter applied to the completed step. Use this
+    to enforce solution constraints after an accepted update.
+  - `thread = Serial()`: threading configuration. Use `BaseThreads()` or
+    `PolyesterThreads()` to enable the corresponding OrdinaryDiffEqCore backend.
+
+# Examples
+
+```julia
+using OrdinaryDiffEqQPRK
+using SciMLBase: ODEProblem, solve
+
+prob = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 1.0))
+sol = solve(prob, QPRK98())
+```
+
+# References
+
+V. N. Kovalnogov, R. V. Fedorov, T. V. Karpukhina, T. E. Simos, and C. Tsitouras,
+"Runge-Kutta pairs of orders 9(8) for use in quadruple precision computations,"
+*Numerical Algorithms* (2023). https://doi.org/10.1007/s11075-023-01632-8
+"""
 Base.@kwdef struct QPRK98{StageLimiter, StepLimiter, Thread} <:
     OrdinaryDiffEqAdaptiveAlgorithm
     stage_limiter!::StageLimiter = trivial_limiter!

--- a/lib/OrdinaryDiffEqQPRK/test/ode_quadruple_precision_tests.jl
+++ b/lib/OrdinaryDiffEqQPRK/test/ode_quadruple_precision_tests.jl
@@ -1,4 +1,5 @@
 using OrdinaryDiffEqQPRK, DiffEqDevTools, Test, Random
+using SciMLBase: SciMLBase, ODEProblem, ODEFunction, solve
 import ODEProblemLibrary: prob_ode_linear, prob_ode_2Dlinear, prob_ode_bigfloat2Dlinear
 
 Random.seed!(100)

--- a/lib/OrdinaryDiffEqQPRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqQPRK/test/qa/qa.jl
@@ -2,9 +2,6 @@ using SciMLTesting, OrdinaryDiffEqQPRK, Test
 
 run_qa(
     OrdinaryDiffEqQPRK;
-    # No docs/ tree here; the umbrella manual renders this package's API.
-    api_docs_kwargs = (; rendered = false),
-    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (
         all_explicit_imports_are_public = (


### PR DESCRIPTION
Removes the QPRK leaf package blanket `SciMLBase` reexport and its matching QA waiver. The public `QPRK98` docstring now lives at its definition and follows the SciMLStyle structure, including an executable usage example. The umbrella manual imports `ODEProblem` and `solve` from their owner.

Tests run locally:
- `Runic` 1.7 check on the edited Julia files
- Direct strict QA environment: `Quality Assurance | 20 / 20` with SciMLTesting 2.6.1

The full `GROUP=QA Pkg.test()` harness was started but its child test process was terminated by the executor after precompilation, before outputting a result; the direct QA execution above completed.

Ignore until reviewed by @ChrisRackauckas.