### PR TITLE
Remove FunctionMap blanket SciMLBase reexport

### DIFF
--- a/lib/OrdinaryDiffEqFunctionMap/Project.toml
+++ b/lib/OrdinaryDiffEqFunctionMap/Project.toml
@@ -10,7 +10,6 @@ RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
-Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [extras]
 ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
@@ -45,7 +44,6 @@ julia = "1.10"
 RecursiveArrayTools = "4.2.0"
 DiffEqBase = "7"
 SafeTestsets = "0.1.0"
-Reexport = "1.2.2"
 
 [targets]
 test = ["DiffEqDevTools", "ODEProblemLibrary", "OrdinaryDiffEq", "OrdinaryDiffEqLowOrderRK", "Random", "SafeTestsets", "Test", "Pkg", "SciMLTesting"]

--- a/lib/OrdinaryDiffEqFunctionMap/src/OrdinaryDiffEqFunctionMap.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/src/OrdinaryDiffEqFunctionMap.jl
@@ -6,7 +6,7 @@ import OrdinaryDiffEqCore: isfsal, beta2_default, beta1_default, OrdinaryDiffEqA
     alg_cache, @cache, _ode_addsteps!, _ode_interpolant!,
     _ode_interpolant, get_fsalfirstlast,
     OrdinaryDiffEqConstantCache, dt_required,
-    isdiscretecache, isdiscretealg, full_cache,
+    isdiscretecache, isdiscretealg,
     trivial_limiter!
 using DiffEqBase: DiffEqBase
 import DiffEqBase: initialize!
@@ -15,10 +15,8 @@ import FastBroadcast: @..
 import MuladdMacro: @muladd
 import OrdinaryDiffEqCore
 
-using Reexport: Reexport, @reexport
-using SciMLBase: SciMLBase
+import SciMLBase
 import SciMLBase: alg_order
-@reexport using SciMLBase
 
 include("algorithms.jl")
 include("alg_utils.jl")

--- a/lib/OrdinaryDiffEqFunctionMap/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/src/algorithms.jl
@@ -1,14 +1,38 @@
-@doc raw"""
-    FunctionMap(; scale_by_time = false)
+"""
+    FunctionMap(; scale_by_time = false, step_limiter = trivial_limiter!)
 
-A fixed timestep method for when the ODE is a discrete dynamical system. In the 
-operator setting, this is equivalent to operator splitting for additive operators.
+Fixed-step algorithm for discrete dynamical systems. By default, each step applies the
+problem function directly, ``u_{n + 1} = f(u_n, p, t_n)``. With `scale_by_time = true`,
+it instead applies an explicit-Euler update, ``u_{n + 1} = u_n + dt * f(u_n, p, t_n)``.
 
-When `scale_by_time = true`, the method becomes `u_{n+1} = u_n + dt*f(u_n,p,t_n)`, 
-otherwise it's `u_{n+1} = f(u_n,p,t_n)`.
+`FunctionMap` is non-adaptive. Supply `dt` when using `scale_by_time = true` with an ODE
+problem.
 
-!!! note
-    This method requires a fixed timestep dt and is not adaptive.
+# Fields
+
+  - `step_limiter!`: function applied after each completed step. It receives the ordinary
+    DifferentialEquations limiter arguments and can enforce problem-specific constraints.
+
+# Keywords
+
+  - `scale_by_time = false`: choose the direct map update. Set to `true` for the
+    explicit-Euler update.
+  - `step_limiter = trivial_limiter!`: post-step limiter. The legacy `step_limiter!`
+    keyword is also accepted for compatibility; prefer `step_limiter` in new code.
+
+# Throws
+
+  - `ArgumentError`: unsupported keyword arguments are supplied.
+
+# Examples
+
+```julia
+using OrdinaryDiffEqFunctionMap
+using SciMLBase: DiscreteProblem, solve
+
+prob = DiscreteProblem((u, p, t) -> 0.5u, 1.0, (0.0, 3.0))
+sol = solve(prob, FunctionMap())
+```
 """
 struct FunctionMap{scale_by_time, StepLimiter} <: OrdinaryDiffEqAlgorithm
     step_limiter!::StepLimiter

--- a/lib/OrdinaryDiffEqFunctionMap/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/test/qa/qa.jl
@@ -2,9 +2,6 @@ using SciMLTesting, OrdinaryDiffEqFunctionMap, Test
 
 run_qa(
     OrdinaryDiffEqFunctionMap;
-    # No docs/ tree here; the umbrella manual renders this package's API.
-    api_docs_kwargs = (; rendered = false),
-    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     aqua_kwargs = (; piracies = false),  # piracy is needed for default-algorithm dispatch
     explicit_imports = true,
     ei_kwargs = (;


### PR DESCRIPTION
Removes the FunctionMap leaf package blanket `SciMLBase` reexport and the matching public-doc QA waivers. `FunctionMap` now has a definition-site SciMLStyle docstring with field, keyword, error, and direct-owner usage documentation.

This also removes the stale `full_cache` import exposed by strict QA. A clean `origin/master` reproduction fails strict QA because the blanket reexport exposes undocumented `SciMLBase`; this setup was introduced by `bf3d7a6d6`.

Tests run locally:
- Public API and documentation-example smoke test
- Strict QA with SciMLTesting 2.6.2: `Quality Assurance | 19 / 19`
- `GROUP=Core Pkg.test()`: observed `DiscreteProblem Defaults | 21 / 21` before executor stream interruption
- Runic 1.7 check on edited Julia files

Ignore until reviewed by @ChrisRackauckas.