### PR TITLE
Harden Default public API QA

### DIFF
--- a/docs/src/api/common_interface.md
+++ b/docs/src/api/common_interface.md
@@ -69,6 +69,7 @@ OrdinaryDiffEq.AutoSparse
 
 ```@docs
 OrdinaryDiffEq.DefaultODEAlgorithm
+OrdinaryDiffEq.DefaultImplicitODEAlgorithm
 ```
 
 ## Interface modules

--- a/lib/OrdinaryDiffEqDefault/Project.toml
+++ b/lib/OrdinaryDiffEqDefault/Project.toml
@@ -17,7 +17,6 @@ Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
-Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
@@ -30,15 +29,6 @@ DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
-
-[sources]
-DiffEqBase = {path = "../DiffEqBase"}
-DiffEqDevTools = {path = "../DiffEqDevTools"}
-OrdinaryDiffEqBDF = {path = "../OrdinaryDiffEqBDF"}
-OrdinaryDiffEqCore = {path = "../OrdinaryDiffEqCore"}
-OrdinaryDiffEqRosenbrock = {path = "../OrdinaryDiffEqRosenbrock"}
-OrdinaryDiffEqTsit5 = {path = "../OrdinaryDiffEqTsit5"}
-OrdinaryDiffEqVerner = {path = "../OrdinaryDiffEqVerner"}
 
 [compat]
 Aqua = "0.8.11"
@@ -64,7 +54,6 @@ julia = "1.10"
 ADTypes = "1.22.0"
 OrdinaryDiffEqRosenbrock = "2"
 DiffEqBase = "7"
-Reexport = "1.2.2"
 SafeTestsets = "0.1.0"
 
 [targets]

--- a/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
+++ b/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
@@ -13,9 +13,8 @@ import LinearSolve
 using LinearAlgebra: I
 using EnumX: EnumX
 
-using Reexport: Reexport, @reexport
-using SciMLBase: SciMLBase, ODEProblem, DAEProblem, solve
-@reexport using SciMLBase
+import SciMLBase
+using SciMLBase: ODEProblem, DAEProblem, solve
 
 include("default_alg.jl")
 

--- a/lib/OrdinaryDiffEqDefault/src/default_alg.jl
+++ b/lib/OrdinaryDiffEqDefault/src/default_alg.jl
@@ -41,7 +41,7 @@ methods when stiffness is detected. It chooses among `Tsit5`, `Vern7`,
 `Rosenbrock23`, `Rodas5P`, and `FBDF`, using Krylov-based `FBDF` for larger stiff
 systems.
 
-# Keyword Arguments
+# Keywords
 
   - `lazy`: controls lazy tableau construction for `Vern7`.
   - `stiffalgfirst`: start on the stiff solver branch when `true`.
@@ -51,6 +51,7 @@ systems.
 
 ```julia
 using OrdinaryDiffEqDefault
+using SciMLBase: ODEProblem, solve
 
 function f!(du, u, p, t)
     du[1] = -u[1]
@@ -216,7 +217,7 @@ This is useful when a problem is expected to be stiff but can still benefit from
 automatic switching. The nonstiff branch contains `Tsit5` and `Vern7`; the stiff
 branch contains `Rosenbrock23`, `Rodas5P`, and `FBDF` variants.
 
-# Keyword Arguments
+# Keywords
 
   - `lazy`: controls lazy tableau construction for `Vern7`.
   - `stol`: stiffness-detection tolerance passed as `stifftol`.
@@ -227,6 +228,7 @@ branch contains `Rosenbrock23`, `Rodas5P`, and `FBDF` variants.
 
 ```julia
 using OrdinaryDiffEqDefault
+using SciMLBase: ODEProblem, solve
 
 function f!(du, u, p, t)
     du[1] = -1000u[1]

--- a/lib/OrdinaryDiffEqDefault/test/gpu/Project.toml
+++ b/lib/OrdinaryDiffEqDefault/test/gpu/Project.toml
@@ -4,12 +4,6 @@ OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 OrdinaryDiffEqLowOrderRK = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources.OrdinaryDiffEq]
-path = "../../../.."
-
-[sources.OrdinaryDiffEqLowOrderRK]
-path = "../../../OrdinaryDiffEqLowOrderRK"
-
 [compat]
 CUDA = "6"
 OrdinaryDiffEq = "7"

--- a/lib/OrdinaryDiffEqDefault/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqDefault/test/qa/qa.jl
@@ -1,5 +1,4 @@
 using SciMLTesting, OrdinaryDiffEqDefault, Test
-using Pkg: Pkg
 
 # `DefaultSolverChoice` is an `EnumX.@enumx`-generated submodule that
 # ExplicitImports cannot statically analyze. Its members (`Tsit5`, `Vern7`,
@@ -8,53 +7,17 @@ using Pkg: Pkg
 # mis-attributes those still-used imports as unused.
 const ENUM_SUBMODULE = (OrdinaryDiffEqDefault.DefaultSolverChoice,)
 
-function without_local_project_sources(f, pkg)
-    project_file = joinpath(pkgdir(pkg), "Project.toml")
-    manifest_file = joinpath(pkgdir(pkg), "Manifest.toml")
-    project = Pkg.TOML.parsefile(project_file)
-    if !haskey(project, "sources") && !isfile(manifest_file)
-        return f()
-    end
-    original = read(project_file, String)
-    manifest = isfile(manifest_file) ? read(manifest_file, String) : nothing
-    delete!(project, "sources")
-    open(project_file, "w") do io
-        Pkg.TOML.print(io, project)
-    end
-    rm(manifest_file; force = true)
-    try
-        return f()
-    finally
-        open(project_file, "w") do io
-            write(io, original)
-        end
-        if manifest !== nothing
-            open(manifest_file, "w") do io
-                write(io, manifest)
-            end
-        end
-    end
-end
-
-without_local_project_sources(OrdinaryDiffEqDefault) do
-    run_qa(
-        OrdinaryDiffEqDefault;
-        reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
-        aqua_kwargs = (; piracies = false),
-        explicit_imports = true,
-        ei_kwargs = (;
-            no_implicit_imports = (; allow_unanalyzable = ENUM_SUBMODULE),
-            no_stale_explicit_imports = (;
-                allow_unanalyzable = ENUM_SUBMODULE,
-                # Used by `default_alg.jl` (solver constructors) but mis-flagged
-                # stale because of the unanalyzable enum submodule above.
-                ignore = (:Tsit5, :Vern7, :Rosenbrock23, :Rodas5P, :FBDF),
-            ),
+run_qa(
+    OrdinaryDiffEqDefault;
+    aqua_kwargs = (; piracies = false),
+    explicit_imports = true,
+    ei_kwargs = (;
+        no_implicit_imports = (; allow_unanalyzable = ENUM_SUBMODULE),
+        no_stale_explicit_imports = (;
+            allow_unanalyzable = ENUM_SUBMODULE,
+            # Used by `default_alg.jl` (solver constructors) but mis-flagged
+            # stale because of the unanalyzable enum submodule above.
+            ignore = (:Tsit5, :Vern7, :Rosenbrock23, :Rodas5P, :FBDF),
         ),
-        api_docs_kwargs = (;
-            rendered = false,
-            # Reexported upstream SciMLOperators names are documented at their owner.
-            ignore = (:StaticWOperator, :has_concretization),
-        ),
-    )
-end
+    ),
+)


### PR DESCRIPTION
Removes the Default leaf package blanket `SciMLBase` reexport, static `Project.toml` source paths, and QA code that rewrote `Project.toml` to bypass those paths. Standard SciMLTesting now checks documented and rendered public API without package-specific waivers.

Both public constructors use SciMLStyle `# Keywords` sections, direct owner imports in examples, and are rendered on the common-interface page.

Tests run locally:
- Public API and documentation-example smoke test
- Strict QA with SciMLTesting 2.6.2: `Quality Assurance | 19 / 19`
- Runic 1.7 check on edited Julia files
- `GROUP=Core Pkg.test()` was launched after the successful QA run; its executor stream ended after precompilation without a terminal test summary.

Ignore until reviewed by @ChrisRackauckas.