### PR TITLE
Bump DiffEqBase version

### DIFF
--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.11.0"
+version = "7.12.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"


### PR DESCRIPTION
I think a new release is needed to fix failures like these: https://github.com/SciML/NonlinearSolve.jl/actions/runs/30998975546/job/92282849950?pr=1138#step:7:1874

As far as I can tell from debugging with Claude, the problem is that:
- SciMLBase added support for a `symbolic_diagnostic` field in https://github.com/SciML/SciMLBase.jl/pull/1434, which is now released.
- That was added to DiffEqBase in https://github.com/SciML/OrdinaryDiffEq.jl/pull/3731, which was not released yet.
- So in CI the registered SciMLBase requires a field that only the unregistered DiffEqBase has.

## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API