### PR TITLE
Harden PDIRK public API QA

### DIFF
--- a/lib/OrdinaryDiffEqPDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqPDIRK/Project.toml
@@ -12,7 +12,6 @@ OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 OrdinaryDiffEqNonlinearSolve = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
-Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [extras]
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
@@ -22,10 +21,6 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
-
-[sources]
-DiffEqBase = {path = "../DiffEqBase"}
-DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 SciMLTesting = "2.1"
@@ -40,7 +35,6 @@ OrdinaryDiffEqDifferentiation = "3.3"
 OrdinaryDiffEqNonlinearSolve = "2"
 Pkg = "1"
 Random = "<0.0.1, 1"
-Reexport = "1.2.2"
 SciMLBase = "3.39"
 SafeTestsets = "0.1.0"
 Test = "<0.0.1, 1"
@@ -48,12 +42,3 @@ julia = "1.10"
 
 [targets]
 test = ["DiffEqDevTools", "ODEProblemLibrary", "Random", "SafeTestsets", "Test", "Pkg", "SciMLTesting"]
-
-[sources.OrdinaryDiffEqDifferentiation]
-path = "../OrdinaryDiffEqDifferentiation"
-
-[sources.OrdinaryDiffEqNonlinearSolve]
-path = "../OrdinaryDiffEqNonlinearSolve"
-
-[sources.OrdinaryDiffEqCore]
-path = "../OrdinaryDiffEqCore"

--- a/lib/OrdinaryDiffEqPDIRK/src/OrdinaryDiffEqPDIRK.jl
+++ b/lib/OrdinaryDiffEqPDIRK/src/OrdinaryDiffEqPDIRK.jl
@@ -5,7 +5,7 @@ import OrdinaryDiffEqCore: isfsal,
     OrdinaryDiffEqMutableCache, constvalue, alg_cache,
     unwrap_alg, @cache,
     @threaded, perform_step!, isthreaded,
-    full_cache, get_fsalfirstlast, differentiation_rk_docstring,
+    get_fsalfirstlast,
     _fixup_ad
 import SciMLBase: alg_order, _unwrap_val
 import DiffEqBase: initialize!
@@ -13,9 +13,7 @@ import MuladdMacro: @muladd
 import FastBroadcast: @..
 
 
-using Reexport: Reexport, @reexport
-using SciMLBase: SciMLBase
-@reexport using SciMLBase
+import SciMLBase
 
 using OrdinaryDiffEqNonlinearSolve: NLNewton, build_nlsolver, nlsolve!, nlsolvefail,
     markfirststage!

--- a/lib/OrdinaryDiffEqPDIRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqPDIRK/src/algorithms.jl
@@ -1,27 +1,49 @@
-@doc differentiation_rk_docstring(
-    "A 2 processor 4th order diagonally non-adaptive implicit method.",
-    "PDIRK44",
-    "Parallel Diagonally Implicit Runge-Kutta Method.";
-    references = """"@article{iserles1990theory,
-    title={On the theory of parallel Runge—Kutta methods},
-    author={Iserles, Arieh and Norrsett, SP},
-    journal={IMA Journal of numerical Analysis},
-    volume={10},
-    number={4},
-    pages={463--488},
-    year={1990},
-    publisher={Oxford University Press}}""",
-    extra_keyword_description = """
-    - `nlsolve`: TBD,
-    - `extrapolant`: TBD,
-    - `thread`: determines whether internal broadcasting on appropriate CPU arrays should be serial (`thread = Serial()`) or use multiple threads (`thread = Threaded()`) when Julia is started with multiple threads.
-    """,
-    extra_keyword_default = """
-    nlsolve = NLNewton(),
-    extrapolant = :constant,
-    thread = Threaded(),
-    """
-)
+"""
+    PDIRK44(; autodiff = AutoForwardDiff(), concrete_jac = nothing, linsolve = nothing,
+        nlsolve = NLNewton(), extrapolant = :constant, threading = true)
+
+Fourth-order, parallel diagonally implicit Runge-Kutta method. It evaluates the
+independent diagonal stages concurrently when `threading = true`, making it useful
+when stage solves are expensive and the problem can use CPU parallelism.
+
+`PDIRK44` is non-adaptive. Supply `dt` when solving an `ODEProblem`.
+
+# Fields
+
+  - `linsolve`: optional linear solver configuration used by the implicit stages.
+  - `nlsolve`: nonlinear solver algorithm used for the stage equations.
+  - `extrapolant`: initial-stage extrapolation strategy.
+  - `threading`: whether eligible internal stage work uses threaded execution.
+  - `autodiff`: automatic-differentiation backend used to form Jacobians.
+  - `concrete_jac`: controls whether a concrete Jacobian is cached when supported.
+
+# Keywords
+
+  - `autodiff = AutoForwardDiff()`: ADTypes backend for Jacobian construction.
+  - `concrete_jac = nothing`: retain the default Jacobian-concretization policy. Set a
+    boolean value to request or disable a concrete Jacobian where the problem supports it.
+  - `linsolve = nothing`: linear solver algorithm or configuration. `nothing` selects
+    the OrdinaryDiffEq default.
+  - `nlsolve = NLNewton()`: nonlinear solver for each implicit stage.
+  - `extrapolant = :constant`: extrapolation strategy used to initialize stage solves.
+  - `threading = true`: enable threaded independent stage work. Set to `false` for
+    serial execution.
+
+# Examples
+
+```julia
+using OrdinaryDiffEqPDIRK
+using SciMLBase: ODEProblem, solve
+
+prob = ODEProblem((u, p, t) -> -10u, 1.0, (0.0, 1.0))
+sol = solve(prob, PDIRK44(), dt = 0.1)
+```
+
+# References
+
+A. Iserles and S. P. Norsett, "On the theory of parallel Runge-Kutta methods,"
+*IMA Journal of Numerical Analysis* 10 (1990), pp. 463-488.
+"""
 struct PDIRK44{AD, F, F2, TO, CJ} <:
     OrdinaryDiffEqNewtonAlgorithm
     linsolve::F

--- a/lib/OrdinaryDiffEqPDIRK/test/qa/Project.toml
+++ b/lib/OrdinaryDiffEqPDIRK/test/qa/Project.toml
@@ -8,9 +8,6 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources.OrdinaryDiffEqCore]
-path = "../../../OrdinaryDiffEqCore"
-
 [compat]
 AllocCheck = "0.2"
 Aqua = "0.8.11"

--- a/lib/OrdinaryDiffEqPDIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqPDIRK/test/qa/qa.jl
@@ -2,9 +2,6 @@ using SciMLTesting, OrdinaryDiffEqPDIRK, Test
 
 run_qa(
     OrdinaryDiffEqPDIRK;
-    # No docs/ tree here; the umbrella manual renders this package's API.
-    api_docs_kwargs = (; rendered = false),
-    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;
         all_explicit_imports_are_public = (;


### PR DESCRIPTION
Removes the PDIRK leaf package blanket `SciMLBase` reexport, all PDIRK source-path overrides (including QA), and rendered-public-doc/reexport QA waivers.

`PDIRK44` is now documented at its definition with a SciMLStyle field and keyword contract, fixed-step requirement, executable direct-owner example, and reference. The strict QA check exposed and this PR removes the stale `full_cache` import.

Tests run locally after rebasing onto current master:
- Public API and documentation-example smoke test
- Strict QA with SciMLTesting 2.6.2: `Quality Assurance | 20 / 20`
- Runic 1.7 check on edited Julia files

Ignore until reviewed by @ChrisRackauckas.