### PR TITLE
Harden IMEX multistep public API QA

### DIFF
--- a/docs/common_imex_first_steps.jl
+++ b/docs/common_imex_first_steps.jl
@@ -19,6 +19,7 @@ function imex_first_steps(name, solver)
 
         ```julia
         using $name
+        using SciMLBase: SplitODEProblem, solve
 
         # Example: A 1D reaction-diffusion system
         # du/dt = f₁(u,p,t) + f₂(u,p,t)

--- a/lib/OrdinaryDiffEqIMEXMultistep/Project.toml
+++ b/lib/OrdinaryDiffEqIMEXMultistep/Project.toml
@@ -9,7 +9,6 @@ FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 OrdinaryDiffEqDifferentiation = "4302a76b-040a-498a-8c04-15b101fed76b"
 OrdinaryDiffEqNonlinearSolve = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
-Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
@@ -21,12 +20,8 @@ DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 
-[sources]
-DiffEqBase = {path = "../DiffEqBase"}
-DiffEqDevTools = {path = "../DiffEqDevTools"}
-
 [compat]
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 Pkg = "1"
 Test = "<0.0.1, 1"
 FastBroadcast = "1.3"
@@ -39,17 +34,7 @@ julia = "1.10"
 ADTypes = "1.22.0"
 OrdinaryDiffEqNonlinearSolve = "2"
 DiffEqBase = "7"
-Reexport = "1.2.2"
 SafeTestsets = "0.1.0"
 
 [targets]
 test = ["DiffEqDevTools", "Random", "SafeTestsets", "Test", "Pkg", "SciMLTesting"]
-
-[sources.OrdinaryDiffEqDifferentiation]
-path = "../OrdinaryDiffEqDifferentiation"
-
-[sources.OrdinaryDiffEqNonlinearSolve]
-path = "../OrdinaryDiffEqNonlinearSolve"
-
-[sources.OrdinaryDiffEqCore]
-path = "../OrdinaryDiffEqCore"

--- a/lib/OrdinaryDiffEqIMEXMultistep/src/OrdinaryDiffEqIMEXMultistep.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/src/OrdinaryDiffEqIMEXMultistep.jl
@@ -4,8 +4,7 @@ import OrdinaryDiffEqCore: issplit, OrdinaryDiffEqNewtonAlgorithm,
     OrdinaryDiffEqConstantCache,
     OrdinaryDiffEqMutableCache,
     @cache, alg_cache, perform_step!,
-    full_cache, get_fsalfirstlast,
-    generic_solver_docstring, _fixup_ad
+    get_fsalfirstlast, _fixup_ad
 import SciMLBase: alg_order, _unwrap_val
 import DiffEqBase: initialize!
 
@@ -14,9 +13,6 @@ import OrdinaryDiffEqCore
 using OrdinaryDiffEqNonlinearSolve: NLNewton, build_nlsolver, markfirststage!, nlsolve!,
     nlsolvefail, du_alias_or_new
 import ADTypes: AutoForwardDiff
-
-using Reexport: @reexport
-@reexport using SciMLBase
 
 include("algorithms.jl")
 include("alg_utils.jl")

--- a/lib/OrdinaryDiffEqIMEXMultistep/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/src/algorithms.jl
@@ -1,27 +1,56 @@
 # IMEX Multistep methods
 
-@doc generic_solver_docstring(
-    "Crank-Nicolson Adams Bashforth Order 2 (fixed time step)",
-    "CNAB2",
-    "IMEX Multistep method.",
-    "@article{jorgenson2014unconditional,
-    title={Unconditional stability of a Crank-Nicolson Adams-Bashforth 2 numerical method},
-    author={JORGENSON, ANDREW D},
-    journal={A (A- C)},
-    volume={1},
-    number={2},
-    pages={1},
-    year={2014}}
-    @article{he2010numerical,
-    title={Numerical implementation of the Crank--Nicolson/Adams--Bashforth scheme for the time-dependent Navier--Stokes equations},
-    author={He, Yinnian and Li, Jian},
-    journal={International journal for numerical methods in fluids},
-    volume={62},
-    number={6},
-    pages={647--659},
-    year={2010},
-    publisher={Wiley Online Library}}", "", ""
-)
+"""
+    CNAB2(; autodiff = AutoForwardDiff(), concrete_jac = nothing, linsolve = nothing,
+        nlsolve = NLNewton(), extrapolant = :linear)
+
+Second-order Crank-Nicolson Adams-Bashforth IMEX multistep method. The first
+component of a `SplitODEProblem` is treated implicitly with Crank-Nicolson, while
+the second component is treated explicitly with Adams-Bashforth.
+
+`CNAB2` uses fixed time steps. Supply `dt` when solving and do not enable adaptive
+time stepping.
+
+# Fields
+
+  - `linsolve`: optional linear solver configuration used by the implicit solve.
+  - `nlsolve`: nonlinear solver algorithm used for the implicit equation.
+  - `extrapolant`: strategy used to initialize the nonlinear solve.
+  - `autodiff`: automatic-differentiation backend used to construct Jacobians.
+  - `concrete_jac`: controls whether a concrete Jacobian is cached when supported.
+
+# Keywords
+
+  - `autodiff = AutoForwardDiff()`: ADTypes backend used for Jacobian construction.
+  - `concrete_jac = nothing`: retain the default Jacobian-concretization policy. Set a
+    boolean value to request or disable a concrete Jacobian where supported.
+  - `linsolve = nothing`: linear solver algorithm or configuration. `nothing` selects
+    the OrdinaryDiffEq default.
+  - `nlsolve = NLNewton()`: nonlinear solver used for the implicit equation.
+  - `extrapolant = :linear`: initial-guess strategy for the nonlinear solve.
+
+# Returns
+
+An algorithm object that can solve split ODE problems with fixed time steps.
+
+# Examples
+
+```julia
+using OrdinaryDiffEqIMEXMultistep: CNAB2
+using SciMLBase: SplitODEProblem, solve
+
+f_implicit(u, p, t) = -9u
+f_explicit(u, p, t) = -u
+prob = SplitODEProblem(f_implicit, f_explicit, 1.0, (0.0, 1.0))
+sol = solve(prob, CNAB2(), dt = 0.05)
+```
+
+# References
+
+Y. He and J. Li, "Numerical implementation of the Crank-Nicolson/Adams-Bashforth
+scheme for the time-dependent Navier-Stokes equations," *International Journal for
+Numerical Methods in Fluids* 62 (2010), pp. 647-659.
+"""
 struct CNAB2{AD, F, F2, CJ} <:
     OrdinaryDiffEqNewtonAlgorithm
     linsolve::F
@@ -49,27 +78,57 @@ function CNAB2(;
     )
 end
 
-@doc generic_solver_docstring(
-    "Crank-Nicholson Leapfrong 2.",
-    "CNLF2",
-    "IMEX Multistep method.",
-    "@article{han2020second,
-    title={A second order, linear, unconditionally stable, Crank--Nicolson--Leapfrog scheme for phase field models of two-phase incompressible flows},
-    author={Han, Daozhi and Jiang, Nan},
-    journal={Applied Mathematics Letters},
-    volume={108},
-    pages={106521},
-    year={2020},
-    publisher={Elsevier}}
-    @article{jiang2015crank,
-    title={A Crank--Nicolson Leapfrog stabilization: Unconditional stability and two applications},
-    author={Jiang, Nan and Kubacki, Michaela and Layton, William and Moraiti, Marina and Tran, Hoang},
-    journal={Journal of Computational and Applied Mathematics},
-    volume={281},
-    pages={263--276},
-    year={2015},
-    publisher={Elsevier}}", "", ""
-)
+"""
+    CNLF2(; autodiff = AutoForwardDiff(), concrete_jac = nothing, linsolve = nothing,
+        nlsolve = NLNewton(), extrapolant = :linear)
+
+Second-order Crank-Nicolson Leapfrog IMEX multistep method. The first component of
+a `SplitODEProblem` is treated implicitly with Crank-Nicolson, while the second
+component is advanced with an explicit leapfrog formula.
+
+`CNLF2` uses fixed time steps. Supply `dt` when solving and do not enable adaptive
+time stepping.
+
+# Fields
+
+  - `linsolve`: optional linear solver configuration used by the implicit solve.
+  - `nlsolve`: nonlinear solver algorithm used for the implicit equation.
+  - `extrapolant`: strategy used to initialize the nonlinear solve.
+  - `autodiff`: automatic-differentiation backend used to construct Jacobians.
+  - `concrete_jac`: controls whether a concrete Jacobian is cached when supported.
+
+# Keywords
+
+  - `autodiff = AutoForwardDiff()`: ADTypes backend used for Jacobian construction.
+  - `concrete_jac = nothing`: retain the default Jacobian-concretization policy. Set a
+    boolean value to request or disable a concrete Jacobian where supported.
+  - `linsolve = nothing`: linear solver algorithm or configuration. `nothing` selects
+    the OrdinaryDiffEq default.
+  - `nlsolve = NLNewton()`: nonlinear solver used for the implicit equation.
+  - `extrapolant = :linear`: initial-guess strategy for the nonlinear solve.
+
+# Returns
+
+An algorithm object that can solve split ODE problems with fixed time steps.
+
+# Examples
+
+```julia
+using OrdinaryDiffEqIMEXMultistep: CNLF2
+using SciMLBase: SplitODEProblem, solve
+
+f_implicit(u, p, t) = -9u
+f_explicit(u, p, t) = -u
+prob = SplitODEProblem(f_implicit, f_explicit, 1.0, (0.0, 1.0))
+sol = solve(prob, CNLF2(), dt = 0.05)
+```
+
+# References
+
+N. Jiang, M. Kubacki, W. Layton, M. Moraiti, and H. Tran, "A Crank-Nicolson
+Leapfrog stabilization: Unconditional stability and two applications," *Journal of
+Computational and Applied Mathematics* 281 (2015), pp. 263-276.
+"""
 struct CNLF2{AD, F, F2, CJ} <:
     OrdinaryDiffEqNewtonAlgorithm
     linsolve::F

--- a/lib/OrdinaryDiffEqIMEXMultistep/test/qa/Project.toml
+++ b/lib/OrdinaryDiffEqIMEXMultistep/test/qa/Project.toml
@@ -11,12 +11,6 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-DiffEqBase = {path = "../../../DiffEqBase"}
-OrdinaryDiffEqCore = {path = "../../../OrdinaryDiffEqCore"}
-OrdinaryDiffEqDifferentiation = {path = "../../../OrdinaryDiffEqDifferentiation"}
-OrdinaryDiffEqNonlinearSolve = {path = "../../../OrdinaryDiffEqNonlinearSolve"}
-
 [compat]
 AllocCheck = "0.2"
 Aqua = "0.8.11"
@@ -24,5 +18,5 @@ JET = "0.9, 0.11"
 OrdinaryDiffEqCore = "4"
 OrdinaryDiffEqIMEXMultistep = "2"
 SciMLBase = "3"
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 julia = "1.10"

--- a/lib/OrdinaryDiffEqIMEXMultistep/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/test/qa/qa.jl
@@ -2,23 +2,13 @@ using SciMLTesting, OrdinaryDiffEqIMEXMultistep, Test
 
 run_qa(
     OrdinaryDiffEqIMEXMultistep;
-    # No docs/ tree here; the umbrella manual renders this package's API.
-    api_docs_kwargs = (; rendered = false),
-    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;
-        # `@reexport using SciMLBase` brings the `SciMLBase` module name into scope
-        # implicitly; this is the intended SciML re-export pattern, not a stray import.
-        no_implicit_imports = (; ignore = (:SciMLBase,)),
-        # Solver-internal helpers imported from their owning packages but deliberately
-        # kept non-public there:
-        #   OrdinaryDiffEqCore: `_fixup_ad` (autodiff-fixup private helper)
-        #   SciMLBase:          `_unwrap_val`
-        # OrdinaryDiffEqNonlinearSolve owner-internal cross-sublibrary hooks;
-        # no public wrapper exists.
         all_explicit_imports_are_public = (;
             ignore = (
+                # OrdinaryDiffEqCore: private algorithm-construction helper.
                 :_fixup_ad, :_unwrap_val,
+                # OrdinaryDiffEqNonlinearSolve owner-internal cross-sublibrary hooks.
                 :build_nlsolver, :du_alias_or_new, :markfirststage!, :nlsolve!,
                 :nlsolvefail,
             ),


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- replace forwarded generic documentation for `CNAB2` and `CNLF2` with definition-site SciMLStyle docstrings, including fields, keyword behavior, fixed-step constraints, examples, and references
- remove the leaf's blanket SciMLBase reexport and update the shared IMEX example to import `SplitODEProblem` and `solve` from their owner
- remove leaf-local source paths and public-doc/reexport QA exceptions, with SciMLTesting `2.4` as the minimum supported strict QA release

## Validation

- `Pkg.test()` on Julia 1.12.6: passed; discontinuity restart 72/72, JET 1/1, Aqua 21/21, with the two pre-existing allocation checks remaining marked broken
- strict `run_qa` with SciMLTesting 2.6.2: 20/20 passed
- exact `CNAB2` and `CNLF2` documentation examples: passed, including successful retcodes and the non-reexported `solve` boundary
- Runic 1.7 check on the changed Julia files: passed
