### PR TITLE
Harden Feagin public API documentation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,7 +31,6 @@ OrdinaryDiffEqExplicitTableaus = {path = "lib/OrdinaryDiffEqExplicitTableaus"}
 OrdinaryDiffEqExponentialRK = {path = "lib/OrdinaryDiffEqExponentialRK"}
 OrdinaryDiffEqExtrapolation = {path = "lib/OrdinaryDiffEqExtrapolation"}
 OrdinaryDiffEqFIRK = {path = "lib/OrdinaryDiffEqFIRK"}
-OrdinaryDiffEqFeagin = {path = "lib/OrdinaryDiffEqFeagin"}
 OrdinaryDiffEqFunctionMap = {path = "lib/OrdinaryDiffEqFunctionMap"}
 OrdinaryDiffEqHighOrderRK = {path = "lib/OrdinaryDiffEqHighOrderRK"}
 OrdinaryDiffEqIMEXMultistep = {path = "lib/OrdinaryDiffEqIMEXMultistep"}

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -56,7 +56,6 @@ OrdinaryDiffEqExplicitRK = {path = "../lib/OrdinaryDiffEqExplicitRK"}
 OrdinaryDiffEqExponentialRK = {path = "../lib/OrdinaryDiffEqExponentialRK"}
 OrdinaryDiffEqExtrapolation = {path = "../lib/OrdinaryDiffEqExtrapolation"}
 OrdinaryDiffEqFIRK = {path = "../lib/OrdinaryDiffEqFIRK"}
-OrdinaryDiffEqFeagin = {path = "../lib/OrdinaryDiffEqFeagin"}
 OrdinaryDiffEqHighOrderRK = {path = "../lib/OrdinaryDiffEqHighOrderRK"}
 OrdinaryDiffEqIMEXMultistep = {path = "../lib/OrdinaryDiffEqIMEXMultistep"}
 OrdinaryDiffEqLinear = {path = "../lib/OrdinaryDiffEqLinear"}

--- a/docs/src/explicit/Feagin.md
+++ b/docs/src/explicit/Feagin.md
@@ -69,7 +69,7 @@ first_steps("OrdinaryDiffEqFeagin", "Feagin14")
 ## Full list of solvers
 
 ```@docs
-Feagin10
-Feagin12
-Feagin14
+OrdinaryDiffEqFeagin.Feagin10
+OrdinaryDiffEqFeagin.Feagin12
+OrdinaryDiffEqFeagin.Feagin14
 ```

--- a/lib/OrdinaryDiffEqFeagin/Project.toml
+++ b/lib/OrdinaryDiffEqFeagin/Project.toml
@@ -8,7 +8,6 @@ MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
-Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
@@ -21,12 +20,8 @@ ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 
-[sources]
-DiffEqBase = {path = "../DiffEqBase"}
-DiffEqDevTools = {path = "../DiffEqDevTools"}
-
 [compat]
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 Pkg = "1"
 Test = "<0.0.1, 1"
 FastBroadcast = "1.3"
@@ -40,10 +35,6 @@ RecursiveArrayTools = "4.2.0"
 ODEProblemLibrary = "1"
 DiffEqBase = "7"
 SafeTestsets = "0.1.0"
-Reexport = "1.2.2"
 
 [targets]
 test = ["DiffEqDevTools", "Random", "SafeTestsets", "Test", "ODEProblemLibrary", "Pkg", "SciMLTesting"]
-
-[sources.OrdinaryDiffEqCore]
-path = "../OrdinaryDiffEqCore"

--- a/lib/OrdinaryDiffEqFeagin/src/OrdinaryDiffEqFeagin.jl
+++ b/lib/OrdinaryDiffEqFeagin/src/OrdinaryDiffEqFeagin.jl
@@ -3,9 +3,9 @@ module OrdinaryDiffEqFeagin
 import OrdinaryDiffEqCore: perform_step!,
     OrdinaryDiffEqMutableCache, OrdinaryDiffEqConstantCache,
     OrdinaryDiffEqAdaptiveAlgorithm, CompiledFloats,
-    alg_cache, @cache, full_cache,
+    alg_cache, @cache,
     constvalue, get_fsalfirstlast,
-    generic_solver_docstring, trivial_limiter!
+    trivial_limiter!
 import SciMLBase: alg_order
 import DiffEqBase: initialize!, calculate_residuals, calculate_residuals!
 import FastBroadcast: @..
@@ -13,9 +13,6 @@ import MuladdMacro: @muladd
 import RecursiveArrayTools: recursivefill!
 using DiffEqBase: @tight_loop_macros
 import OrdinaryDiffEqCore
-
-using Reexport: @reexport
-@reexport using SciMLBase
 
 include("algorithms.jl")
 include("alg_utils.jl")

--- a/lib/OrdinaryDiffEqFeagin/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqFeagin/src/algorithms.jl
@@ -1,56 +1,122 @@
-@doc generic_solver_docstring(
-    "Feagin's 10th-order method.", "Feagin10", "Explicit Runge-Kutta Method. ",
-    """@article{feagin2012high,
-    title={High-order explicit Runge-Kutta methods using m-symmetry},
-    author={Feagin, Terry},
-    year={2012},
-    publisher={Neural, Parallel \\& Scientific Computations}
-    }""",
-    """
-     - `stage_limiter!`: function of the form `limiter!(u, integrator, p, t)`
-    """,
-    """
-    step_limiter! = OrdinaryDiffEq.trivial_limiter!,
-    """
-)
+"""
+    Feagin10(; step_limiter! = trivial_limiter!) -> Feagin10
+
+Tenth-order explicit Runge-Kutta method for high-accuracy integration of non-stiff
+ordinary differential equations. Its embedded error estimate has order eight.
+
+# Fields
+
+  - `step_limiter!`: deprecated algorithm-level step limiter. It is called as
+    `step_limiter!(u, integrator, p, t)` after each accepted step when no solve-level
+    limiter is supplied.
+
+# Keywords
+
+  - `step_limiter! = trivial_limiter!`: step limiter stored in the algorithm. Prefer the
+    `step_limiter` keyword of `solve` or `init`; the constructor keyword is retained for
+    compatibility.
+
+# Returns
+
+  - A `Feagin10` algorithm instance for use with `solve` or `init`.
+
+# Examples
+
+```julia
+using OrdinaryDiffEqFeagin: Feagin10
+using SciMLBase: ODEProblem, solve
+
+prob = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 1.0))
+sol = solve(prob, Feagin10(); abstol = 1.0e-12, reltol = 1.0e-12)
+```
+
+# References
+
+T. Feagin, "High-order explicit Runge-Kutta methods using m-symmetry,"
+*Neural, Parallel & Scientific Computations* (2012).
+"""
 Base.@kwdef struct Feagin10{StepLimiter} <: OrdinaryDiffEqAdaptiveAlgorithm
     step_limiter!::StepLimiter = trivial_limiter!
 end
 
-@doc generic_solver_docstring(
-    "Feagin's 12th-order method.", "Feagin12", "Explicit Runge-Kutta Method. ",
-    """@article{feagin2012high,
-    title={High-order explicit Runge-Kutta methods using m-symmetry},
-    author={Feagin, Terry},
-    year={2012},
-    publisher={Neural, Parallel \\& Scientific Computations}
-    }""",
-    """
-     - `stage_limiter!`: function of the form `limiter!(u, integrator, p, t)`
-    """,
-    """
-    step_limiter! = OrdinaryDiffEq.trivial_limiter!,
-    """
-)
+"""
+    Feagin12(; step_limiter! = trivial_limiter!) -> Feagin12
+
+Twelfth-order explicit Runge-Kutta method for high-accuracy integration of non-stiff
+ordinary differential equations.
+
+# Fields
+
+  - `step_limiter!`: deprecated algorithm-level step limiter. It is called as
+    `step_limiter!(u, integrator, p, t)` after each accepted step when no solve-level
+    limiter is supplied.
+
+# Keywords
+
+  - `step_limiter! = trivial_limiter!`: step limiter stored in the algorithm. Prefer the
+    `step_limiter` keyword of `solve` or `init`; the constructor keyword is retained for
+    compatibility.
+
+# Returns
+
+  - A `Feagin12` algorithm instance for use with `solve` or `init`.
+
+# Examples
+
+```julia
+using OrdinaryDiffEqFeagin: Feagin12
+using SciMLBase: ODEProblem, solve
+
+prob = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 1.0))
+sol = solve(prob, Feagin12(); abstol = 1.0e-12, reltol = 1.0e-12)
+```
+
+# References
+
+T. Feagin, "High-order explicit Runge-Kutta methods using m-symmetry,"
+*Neural, Parallel & Scientific Computations* (2012).
+"""
 Base.@kwdef struct Feagin12{StepLimiter} <: OrdinaryDiffEqAdaptiveAlgorithm
     step_limiter!::StepLimiter = trivial_limiter!
 end
 
-@doc generic_solver_docstring(
-    "Feagin's 14th-order method.", "Feagin14", "Explicit Runge-Kutta Method. ",
-    """@article{feagin2009explicit,
-    title={An Explicit Runge-Kutta Method of Order Fourteen},
-    author={Feagin, Terry},
-    year={2009},
-    publisher={Numerical Algorithms}
-    }""",
-    """
-     - `stage_limiter!`: function of the form `limiter!(u, integrator, p, t)`
-    """,
-    """
-    step_limiter! = OrdinaryDiffEq.trivial_limiter!,
-    """
-)
+"""
+    Feagin14(; step_limiter! = trivial_limiter!) -> Feagin14
+
+Fourteenth-order explicit Runge-Kutta method for high-accuracy integration of non-stiff
+ordinary differential equations. Its embedded error estimate has order twelve.
+
+# Fields
+
+  - `step_limiter!`: deprecated algorithm-level step limiter. It is called as
+    `step_limiter!(u, integrator, p, t)` after each accepted step when no solve-level
+    limiter is supplied.
+
+# Keywords
+
+  - `step_limiter! = trivial_limiter!`: step limiter stored in the algorithm. Prefer the
+    `step_limiter` keyword of `solve` or `init`; the constructor keyword is retained for
+    compatibility.
+
+# Returns
+
+  - A `Feagin14` algorithm instance for use with `solve` or `init`.
+
+# Examples
+
+```julia
+using OrdinaryDiffEqFeagin: Feagin14
+using SciMLBase: ODEProblem, solve
+
+prob = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 1.0))
+sol = solve(prob, Feagin14(); abstol = 1.0e-12, reltol = 1.0e-12)
+```
+
+# References
+
+T. Feagin, "An explicit Runge-Kutta method of order fourteen," *Numerical Algorithms*
+(2009).
+"""
 Base.@kwdef struct Feagin14{StepLimiter} <: OrdinaryDiffEqAdaptiveAlgorithm
     step_limiter!::StepLimiter = trivial_limiter!
 end

--- a/lib/OrdinaryDiffEqFeagin/test/qa/Project.toml
+++ b/lib/OrdinaryDiffEqFeagin/test/qa/Project.toml
@@ -9,19 +9,13 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources.DiffEqBase]
-path = "../../../DiffEqBase"
-
-[sources.OrdinaryDiffEqCore]
-path = "../../../OrdinaryDiffEqCore"
-
 [compat]
 AllocCheck = "0.2"
 Aqua = "0.8.11"
 DiffEqBase = "7"
 JET = "0.9, 0.11"
-SciMLTesting = "2.1"
-julia = "1.10"
 OrdinaryDiffEqCore = "4"
 OrdinaryDiffEqFeagin = "2"
 SciMLBase = "3"
+SciMLTesting = "2.4"
+julia = "1.10"

--- a/lib/OrdinaryDiffEqFeagin/test/qa/allocation_tests.jl
+++ b/lib/OrdinaryDiffEqFeagin/test/qa/allocation_tests.jl
@@ -1,6 +1,6 @@
 using OrdinaryDiffEqFeagin
 using OrdinaryDiffEqCore
-using SciMLBase: FullSpecialize
+using SciMLBase: FullSpecialize, ODEProblem, init, step!
 using AllocCheck
 using Test
 

--- a/lib/OrdinaryDiffEqFeagin/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFeagin/test/qa/qa.jl
@@ -2,14 +2,8 @@ using SciMLTesting, OrdinaryDiffEqFeagin, Test
 
 run_qa(
     OrdinaryDiffEqFeagin;
-    # No docs/ tree here; the umbrella manual renders this package's API.
-    api_docs_kwargs = (; rendered = false),
-    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;
-        # `@reexport using SciMLBase` deliberately re-exports SciMLBase's API
-        # as part of this solver package's public surface.
-        no_implicit_imports = (; ignore = (:SciMLBase,)),
         all_explicit_imports_are_public = (;
             ignore = (
                 # OrdinaryDiffEqCore-owned internals, deliberately not `public`.


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary
- replace generated `@doc` attachments with definition-site SciMLStyle documentation for `Feagin10`, `Feagin12`, and `Feagin14`
- remove the blanket SciMLBase reexport and import dependency-owned API from its owner
- require SciMLTesting 2.4, remove leaf-specific source paths and public-doc/reexport QA waivers, and keep caches internal

## Local validation
- `Pkg.test()` on Julia 1.12.6: Feagin 6/6, allocation 3/3, JET 1/1, Aqua 21/21; package tests passed
- plain strict SciMLTesting 2.6.2 QA: 20/20 passed
- all three documented solve examples passed
- runtime public API audit found exactly the three documented algorithm exports
- Runic 1.7.0 and `git diff --check` passed