### PR TITLE
Harden Extrapolation public API documentation

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
@@ -55,7 +56,6 @@ OrdinaryDiffEqDefault = {path = "../lib/OrdinaryDiffEqDefault"}
 OrdinaryDiffEqDifferentiation = {path = "../lib/OrdinaryDiffEqDifferentiation"}
 OrdinaryDiffEqExplicitRK = {path = "../lib/OrdinaryDiffEqExplicitRK"}
 OrdinaryDiffEqExponentialRK = {path = "../lib/OrdinaryDiffEqExponentialRK"}
-OrdinaryDiffEqExtrapolation = {path = "../lib/OrdinaryDiffEqExtrapolation"}
 OrdinaryDiffEqFIRK = {path = "../lib/OrdinaryDiffEqFIRK"}
 OrdinaryDiffEqHighOrderRK = {path = "../lib/OrdinaryDiffEqHighOrderRK"}
 OrdinaryDiffEqIMEXMultistep = {path = "../lib/OrdinaryDiffEqIMEXMultistep"}
@@ -81,6 +81,7 @@ StochasticDiffEqLevyArea = {path = "../lib/StochasticDiffEqLevyArea"}
 StochasticDiffEqWeak = {path = "../lib/StochasticDiffEqWeak"}
 
 [compat]
+CommonSolve = "0.2.6"
 DiffEqBase = "7.6.1"
 DiffEqDevTools = "3, 4.0"
 Documenter = "0.27, 1"

--- a/docs/src/api/controllers.md
+++ b/docs/src/api/controllers.md
@@ -47,7 +47,6 @@ update lives in the algorithm-specific `stepsize_controller!` /
 ```@docs
 OrdinaryDiffEqBDF.BDFController
 OrdinaryDiffEqNordsieck.JVODEController
-OrdinaryDiffEqExtrapolation.ExtrapolationController
 ImplicitDiscreteSolve.KantorovichTypeController
 ```
 

--- a/lib/OrdinaryDiffEqExtrapolation/Project.toml
+++ b/lib/OrdinaryDiffEqExtrapolation/Project.toml
@@ -4,6 +4,7 @@ authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <maying
 version = "2.4.1"
 
 [deps]
+CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
 LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
@@ -14,13 +15,11 @@ ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 FastPower = "a4df4552-cc26-4903-aec0-212e50a0e84b"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
-Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
@@ -28,12 +27,15 @@ RecursiveFactorization = "f2c3362d-daeb-58d1-803e-2bc74f2840b4"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 
-[sources]
-DiffEqBase = {path = "../DiffEqBase"}
-DiffEqDevTools = {path = "../DiffEqDevTools"}
+[weakdeps]
+Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
+
+[extensions]
+OrdinaryDiffEqExtrapolationPolyesterExt = "Polyester"
 
 [compat]
-SciMLTesting = "2.1"
+CommonSolve = "0.2.6"
+SciMLTesting = "2.4"
 Pkg = "1"
 Test = "<0.0.1, 1"
 FastBroadcast = "1.3"
@@ -51,16 +53,9 @@ FastPower = "1.1.2"
 RecursiveFactorization = "0.2"
 DiffEqBase = "7"
 Polyester = "0.7"
-Reexport = "1.2.2"
 SafeTestsets = "0.1.0"
 SciMLLogging = "2"
 SciMLOperators = "1.24.3"
 
 [targets]
 test = ["DiffEqDevTools", "Polyester", "Random", "RecursiveFactorization", "SafeTestsets", "Test", "Pkg", "SciMLTesting"]
-
-[sources.OrdinaryDiffEqDifferentiation]
-path = "../OrdinaryDiffEqDifferentiation"
-
-[sources.OrdinaryDiffEqCore]
-path = "../OrdinaryDiffEqCore"

--- a/lib/OrdinaryDiffEqExtrapolation/ext/OrdinaryDiffEqExtrapolationPolyesterExt.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/ext/OrdinaryDiffEqExtrapolationPolyesterExt.jl
@@ -1,0 +1,12 @@
+module OrdinaryDiffEqExtrapolationPolyesterExt
+
+using Polyester: @batch
+import OrdinaryDiffEqExtrapolation: _polyester_foreach
+
+@inline function _polyester_foreach(f, range)
+    return @batch for i in range
+        f(i)
+    end
+end
+
+end

--- a/lib/OrdinaryDiffEqExtrapolation/src/OrdinaryDiffEqExtrapolation.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/OrdinaryDiffEqExtrapolation.jl
@@ -11,21 +11,19 @@ import OrdinaryDiffEqCore: alg_maximum_order, get_current_adaptive_order,
     step_accept_controller!, step_reject_controller!,
     OrdinaryDiffEqAdaptiveAlgorithm,
     OrdinaryDiffEqAdaptiveImplicitAlgorithm,
-    alg_cache, CompiledFloats, @threaded, stepsize_controller!,
-    full_cache, qmin_default,
+    alg_cache, CompiledFloats, stepsize_controller!,
+    qmin_default,
     constvalue, PolyesterThreads,
     _fixup_ad,
-    get_fsalfirstlast, generic_solver_docstring,
-    differentiation_rk_docstring,
+    get_fsalfirstlast,
     LinearAliasSpecifier
 import OrdinaryDiffEqCore: default_controller, AbstractControllerCache, setup_controller_cache,
     get_qmin, get_qmax
 import OrdinaryDiffEqCore
 
-# Owned by SciMLBase / DiffEqBase / SciMLOperators, re-exported through
-# OrdinaryDiffEqCore / OrdinaryDiffEqDifferentiation — import from the owners directly so
-# ExplicitImports' owner check is satisfied.
-import SciMLBase: alg_order, _unwrap_val, _reshape, _vec,
+# Owned by SciMLBase / DiffEqBase, re-exported through OrdinaryDiffEqCore /
+# OrdinaryDiffEqDifferentiation.
+import SciMLBase: alg_order,
     TimeDerivativeWrapper, UDerivativeWrapper,
     TimeGradientWrapper, UJacobianWrapper
 import DiffEqBase: initialize!, calculate_residuals, calculate_residuals!, timedepentdtmin
@@ -34,7 +32,7 @@ using FastBroadcast: FastBroadcast, @..
 using MuladdMacro: MuladdMacro, @muladd
 using RecursiveArrayTools: RecursiveArrayTools, recursivefill!
 using LinearSolve: LinearSolve, RFLUFactorization
-import FastPower
+using FastPower: fastpower
 using SciMLOperators: SciMLOperators, WOperator
 import SciMLLogging: @SciMLMessage
 import OrdinaryDiffEqDifferentiation: calc_J,
@@ -42,10 +40,10 @@ import OrdinaryDiffEqDifferentiation: calc_J,
     build_jac_config, calc_J!, jacobian2W!, dolinsolve
 import ADTypes: AutoForwardDiff
 
-using Reexport: Reexport, @reexport
-@reexport using SciMLBase
-using SciMLBase: SciMLBase, LinearProblem, init
+using CommonSolve: init
+using SciMLBase: SciMLBase, LinearProblem
 
+include("utils.jl")
 include("algorithms.jl")
 include("alg_utils.jl")
 include("controllers.jl")

--- a/lib/OrdinaryDiffEqExtrapolation/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/algorithms.jl
@@ -2,33 +2,43 @@ abstract type OrdinaryDiffEqExtrapolationVarOrderVarStepAlgorithm <:
 OrdinaryDiffEqAdaptiveAlgorithm end
 abstract type OrdinaryDiffEqImplicitExtrapolationAlgorithm <:
 OrdinaryDiffEqAdaptiveImplicitAlgorithm end
-reference = """@inproceedings{elrod2022parallelizing,
-  title={Parallelizing explicit and implicit extrapolation methods for ordinary differential equations},
-  author={Elrod, Chris and Ma, Yingbo and Althaus, Konstantin and Rackauckas, Christopher and others},
-  booktitle={2022 IEEE High Performance Extreme Computing Conference (HPEC)},
-  pages={1--9},
-  year={2022},
-  organization={IEEE}}
 """
+    AitkenNeville(; max_order = 10, min_order = 1, init_order = 5,
+        threading = false) -> AitkenNeville
 
-@doc generic_solver_docstring(
-    "Euler extrapolation using Aitken-Neville with the Romberg Sequence.",
-    "AitkenNeville",
-    "Parallelized Explicit Extrapolation Method.",
-    reference,
-    """
-    - `max_order`: maximum order of the adaptive order algorithm.
-    - `min_order`: minimum order of the adaptive order algorithm.
-    - `init_order`: initial order of the adaptive order algorithm.
-    - `thread`: determines whether internal broadcasting on appropriate CPU arrays should be serial (`thread = Serial()`) or use multiple threads (`thread = Threaded()`) when Julia is started with multiple threads.
-    """,
-    """
-    max_order::Int = 10,
-    min_order::Int = 1,
-    init_order = 3,
-    thread = Serial(),
-    """
-)
+Adaptive explicit Euler extrapolation using the Aitken-Neville scheme and a Romberg
+subdivision sequence. The method varies both its step size and extrapolation order and
+is intended for smooth, non-stiff problems at tight tolerances.
+
+# Keywords
+
+- `max_order::Integer = 10`: largest extrapolation order the controller may select.
+- `min_order::Integer = 1`: smallest extrapolation order the controller may select.
+- `init_order::Integer = 5`: extrapolation order used for the first step. Choose values
+  satisfying `1 <= min_order <= init_order <= max_order`.
+- `threading = false`: enable concurrent internal extrapolation work when `true`; use
+  `false` for serial execution.
+
+# Returns
+
+- `AitkenNeville`: configured adaptive extrapolation algorithm for `CommonSolve.solve`.
+
+# Examples
+
+```julia
+using OrdinaryDiffEqExtrapolation: AitkenNeville
+using CommonSolve: solve
+using SciMLBase: ODEProblem
+
+prob = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 1.0))
+sol = solve(prob, AitkenNeville(max_order = 8); abstol = 1.0e-10, reltol = 1.0e-8)
+```
+
+# References
+
+C. Elrod et al., "Parallelizing explicit and implicit extrapolation methods for
+ordinary differential equations," HPEC 2022, pp. 1-9.
+"""
 Base.@kwdef struct AitkenNeville{TO} <: OrdinaryDiffEqExtrapolationVarOrderVarStepAlgorithm
     max_order::Int = 10
     min_order::Int = 1
@@ -36,27 +46,51 @@ Base.@kwdef struct AitkenNeville{TO} <: OrdinaryDiffEqExtrapolationVarOrderVarSt
     threading::TO = false
 end
 
-@doc differentiation_rk_docstring(
-    "Extrapolation of implicit Euler method with Romberg sequence.
-Similar to Hairer's SEULEX.",
-    "ImplicitEulerExtrapolation",
-    "Parallelized Explicit Extrapolation Method.",
-    references = reference,
-    extra_keyword_description = """
-    - `max_order`: maximum order of the adaptive order algorithm.
-    - `min_order`: minimum order of the adaptive order algorithm.
-    - `init_order`: initial order of the adaptive order algorithm.
-    - `thread`: determines whether internal broadcasting on appropriate CPU arrays should be serial (`thread = Serial()`) or use multiple threads (`thread = Threaded()`) when Julia is started with multiple threads.
-    - `sequence`: the step-number sequences, also called the subdividing sequence. Possible values are `:harmonic`, `:romberg` or `:bulirsch`.
-    """,
-    extra_keyword_default = """
-    max_order = 12,
-    min_order = 3,
-    init_order = 5,
-    thread = Serial(),
-    sequence = :harmonic
-    """
-)
+"""
+    ImplicitEulerExtrapolation(; autodiff = AutoForwardDiff(), concrete_jac = nothing,
+        linsolve = nothing, max_order = 12, min_order = 3, init_order = 5,
+        threading = false, sequence = :harmonic) -> ImplicitEulerExtrapolation
+
+Adaptive implicit Euler extrapolation, similar to SEULEX. It is intended for stiff
+problems and varies both its step size and extrapolation order.
+
+# Keywords
+
+- `autodiff = AutoForwardDiff()`: ADTypes backend used to construct Jacobians.
+- `concrete_jac = nothing`: Jacobian materialization policy. `nothing` lets the solver
+  choose; use `true` or `false` to request or disable a concrete Jacobian.
+- `linsolve = nothing`: LinearSolve algorithm for implicit stage systems. `nothing`
+  selects the OrdinaryDiffEq default.
+- `max_order::Integer = 12`: largest internal extrapolation order.
+- `min_order::Integer = 3`: smallest internal extrapolation order; values below `3`
+  are raised to `3`.
+- `init_order::Integer = 5`: initial internal order. It is raised when necessary so
+  that `min_order < init_order < max_order`.
+- `threading = false`: enable concurrent extrapolation columns when `true`.
+- `sequence::Symbol = :harmonic`: subdivision sequence. Supported values are
+  `:harmonic`, `:romberg`, and `:bulirsch`; other values warn and use `:harmonic`.
+
+# Returns
+
+- `ImplicitEulerExtrapolation`: configured implicit extrapolation algorithm for
+  `CommonSolve.solve`.
+
+# Examples
+
+```julia
+using OrdinaryDiffEqExtrapolation: ImplicitEulerExtrapolation
+using CommonSolve: solve
+using SciMLBase: ODEProblem
+
+prob = ODEProblem((u, p, t) -> -100u, 1.0, (0.0, 1.0))
+sol = solve(prob, ImplicitEulerExtrapolation(); abstol = 1.0e-10, reltol = 1.0e-8)
+```
+
+# References
+
+C. Elrod et al., "Parallelizing explicit and implicit extrapolation methods for
+ordinary differential equations," HPEC 2022, pp. 1-9.
+"""
 struct ImplicitEulerExtrapolation{AD, F, TO, CJ} <:
     OrdinaryDiffEqImplicitExtrapolationAlgorithm
     linsolve::F
@@ -116,28 +150,51 @@ Initial order: " * lpad(init_order, 2, " ") * " --> " * lpad(init_order, 2, " ")
     )
 end
 
-@doc generic_solver_docstring(
-    "Midpoint extrapolation using Barycentric coordinates.",
-    "ExtrapolationMidpointDeuflhard",
-    "Parallelized Explicit Extrapolation Method.",
-    reference,
-    """
-    - `max_order`: maximum order of the adaptive order algorithm.
-    - `min_order`: minimum order of the adaptive order algorithm.
-    - `init_order`: initial order of the adaptive order algorithm.
-    - `thread`: determines whether internal broadcasting on appropriate CPU arrays should be serial (`thread = Serial()`) or use multiple threads (`thread = Threaded()`) when Julia is started with multiple threads.
-    - `sequence`: the step-number sequences, also called the subdividing sequence. Possible values are `:harmonic`, `:romberg` or `:bulirsch`.
-    - `sequence_factor`: denotes which even multiple of sequence to take while evaluating internal discretizations.
-    """,
-    """
-    max_order = 10,
-    min_order = 1,
-    init_order = 5,
-    thread = Threaded(),
-    sequence = :harmonic,
-    sequence_factor = 2,
-    """
-)
+"""
+    ExtrapolationMidpointDeuflhard(; min_order = 1, init_order = 5,
+        max_order = 10, sequence = :harmonic, threading = true,
+        sequence_factor = 2) -> ExtrapolationMidpointDeuflhard
+
+Adaptive explicit midpoint extrapolation with Deuflhard's order and step-size
+selection. Barycentric extrapolation combines the midpoint approximations. The
+independent extrapolation columns can run concurrently.
+
+# Keywords
+
+- `min_order::Integer = 1`: smallest internal extrapolation order; values below `1`
+  are raised to `1`.
+- `init_order::Integer = 5`: initial internal order. It is raised to at least
+  `min_order`.
+- `max_order::Integer = 10`: largest internal order. It is raised to at least
+  `init_order`.
+- `sequence::Symbol = :harmonic`: subdivision sequence. Supported values are
+  `:harmonic`, `:romberg`, and `:bulirsch`; other values warn and use `:harmonic`.
+- `threading = true`: enable concurrent extrapolation columns when `true`.
+- `sequence_factor::Integer = 2`: even multiplier applied to the subdivision
+  sequence. Odd values warn and are replaced by `2`.
+
+# Returns
+
+- `ExtrapolationMidpointDeuflhard`: configured explicit extrapolation algorithm for
+  `CommonSolve.solve`.
+
+# Examples
+
+```julia
+using OrdinaryDiffEqExtrapolation: ExtrapolationMidpointDeuflhard
+using CommonSolve: solve
+using SciMLBase: ODEProblem
+
+prob = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 1.0))
+alg = ExtrapolationMidpointDeuflhard(sequence = :romberg, threading = false)
+sol = solve(prob, alg; abstol = 1.0e-10, reltol = 1.0e-8)
+```
+
+# References
+
+C. Elrod et al., "Parallelizing explicit and implicit extrapolation methods for
+ordinary differential equations," HPEC 2022, pp. 1-9.
+"""
 struct ExtrapolationMidpointDeuflhard{TO} <:
     OrdinaryDiffEqExtrapolationVarOrderVarStepAlgorithm
     min_order::Int # Minimal extrapolation order
@@ -192,26 +249,55 @@ Initial order: " * lpad(init_order, 2, " ") * " --> " * lpad(init_order, 2, " ")
     )
 end
 
-@doc differentiation_rk_docstring(
-    "Midpoint extrapolation using Barycentric coordinates.",
-    "ImplicitDeuflhardExtrapolation",
-    "Parallelized Explicit Extrapolation Method.",
-    references = reference,
-    extra_keyword_description = """
-    - `max_order`: maximum order of the adaptive order algorithm.
-    - `min_order`: minimum order of the adaptive order algorithm.
-    - `init_order`: initial order of the adaptive order algorithm.
-    - `thread`: determines whether internal broadcasting on appropriate CPU arrays should be serial (`thread = Serial()`) or use multiple threads (`thread = Threaded()`) when Julia is started with multiple threads.
-    - `sequence`: the step-number sequences, also called the subdividing sequence. Possible values are `:harmonic`, `:romberg` or `:bulirsch`.
-    """,
-    extra_keyword_default = """
-    max_order = 10,
-    min_order = 1,
-    init_order = 5,
-    thread = Serial(),
-    sequence = :harmonic,
-    """
-)
+"""
+    ImplicitDeuflhardExtrapolation(; autodiff = AutoForwardDiff(),
+        concrete_jac = nothing, linsolve = nothing, min_order = 1,
+        init_order = 5, max_order = 10, sequence = :harmonic,
+        threading = false) -> ImplicitDeuflhardExtrapolation
+
+Adaptive implicit midpoint extrapolation with Deuflhard's order and step-size
+selection. It targets stiff problems and uses barycentric extrapolation of the
+implicit midpoint approximations.
+
+# Keywords
+
+- `autodiff = AutoForwardDiff()`: ADTypes backend used to construct Jacobians.
+- `concrete_jac = nothing`: Jacobian materialization policy. `nothing` lets the solver
+  choose; use `true` or `false` to request or disable a concrete Jacobian.
+- `linsolve = nothing`: LinearSolve algorithm for implicit stage systems. `nothing`
+  selects the OrdinaryDiffEq default.
+- `min_order::Integer = 1`: smallest internal extrapolation order; values below `1`
+  are raised to `1`.
+- `init_order::Integer = 5`: initial internal order. It is raised to at least
+  `min_order`.
+- `max_order::Integer = 10`: largest internal order. It is raised to at least
+  `init_order`.
+- `sequence::Symbol = :harmonic`: subdivision sequence. Supported values are
+  `:harmonic`, `:romberg`, and `:bulirsch`; other values warn and use `:harmonic`.
+- `threading = false`: enable concurrent extrapolation columns when `true`.
+
+# Returns
+
+- `ImplicitDeuflhardExtrapolation`: configured implicit extrapolation algorithm for
+  `CommonSolve.solve`.
+
+# Examples
+
+```julia
+using OrdinaryDiffEqExtrapolation: ImplicitDeuflhardExtrapolation
+using CommonSolve: solve
+using SciMLBase: ODEProblem
+
+prob = ODEProblem((u, p, t) -> -100u, 1.0, (0.0, 1.0))
+alg = ImplicitDeuflhardExtrapolation(sequence = :romberg)
+sol = solve(prob, alg; abstol = 1.0e-10, reltol = 1.0e-8)
+```
+
+# References
+
+C. Elrod et al., "Parallelizing explicit and implicit extrapolation methods for
+ordinary differential equations," HPEC 2022, pp. 1-9.
+"""
 struct ImplicitDeuflhardExtrapolation{AD, F, TO, CJ} <:
     OrdinaryDiffEqImplicitExtrapolationAlgorithm
     linsolve::F
@@ -273,29 +359,51 @@ Initial order: " * lpad(init_order, 2, " ") * " --> " * lpad(init_order, 2, " ")
     )
 end
 
-@doc generic_solver_docstring(
-    "Midpoint extrapolation using Barycentric coordinates,
-    following Hairer's ODEX in the adaptivity behavior.",
-    "ExtrapolationMidpointHairerWanner",
-    "Parallelized Explicit Extrapolation Method.",
-    reference,
-    """
-    - `max_order`: maximum order of the adaptive order algorithm.
-    - `min_order`: minimum order of the adaptive order algorithm.
-    - `init_order`: initial order of the adaptive order algorithm.
-    - `thread`: determines whether internal broadcasting on appropriate CPU arrays should be serial (`thread = Serial()`) or use multiple threads (`thread = Threaded()`) when Julia is started with multiple threads.
-    - `sequence`: the step-number sequences, also called the subdividing sequence. Possible values are `:harmonic`, `:romberg` or `:bulirsch`.
-    - `sequence_factor`: denotes which even multiple of sequence to take while evaluating internal discretizations.
-    """,
-    """
-    max_order = 10,
-    min_order = 2,
-    init_order = 5,
-    thread = Threaded(),
-    sequence = :harmonic,
-    sequence_factor = 2,
-    """
-)
+"""
+    ExtrapolationMidpointHairerWanner(; min_order = 2, init_order = 5,
+        max_order = 10, sequence = :harmonic, threading = true,
+        sequence_factor = 2) -> ExtrapolationMidpointHairerWanner
+
+Adaptive explicit midpoint extrapolation with the order and step-size controller from
+Hairer and Wanner's ODEX algorithm. Barycentric extrapolation combines the midpoint
+approximations, whose independent columns can run concurrently.
+
+# Keywords
+
+- `min_order::Integer = 2`: smallest internal extrapolation order; values below `2`
+  are raised to `2`.
+- `init_order::Integer = 5`: initial internal order. It is raised when necessary so
+  that `min_order < init_order`.
+- `max_order::Integer = 10`: largest internal order. It is raised when necessary so
+  that `init_order < max_order`.
+- `sequence::Symbol = :harmonic`: subdivision sequence. Supported values are
+  `:harmonic`, `:romberg`, and `:bulirsch`; other values warn and use `:harmonic`.
+- `threading = true`: enable concurrent extrapolation columns when `true`.
+- `sequence_factor::Integer = 2`: even multiplier applied to the subdivision
+  sequence. Odd values warn and are replaced by `2`.
+
+# Returns
+
+- `ExtrapolationMidpointHairerWanner`: configured explicit extrapolation algorithm
+  for `CommonSolve.solve`.
+
+# Examples
+
+```julia
+using OrdinaryDiffEqExtrapolation: ExtrapolationMidpointHairerWanner
+using CommonSolve: solve
+using SciMLBase: ODEProblem
+
+prob = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 1.0))
+alg = ExtrapolationMidpointHairerWanner(threading = false)
+sol = solve(prob, alg; abstol = 1.0e-10, reltol = 1.0e-8)
+```
+
+# References
+
+C. Elrod et al., "Parallelizing explicit and implicit extrapolation methods for
+ordinary differential equations," HPEC 2022, pp. 1-9.
+"""
 struct ExtrapolationMidpointHairerWanner{TO} <:
     OrdinaryDiffEqExtrapolationVarOrderVarStepAlgorithm
     min_order::Int # Minimal extrapolation order
@@ -351,27 +459,55 @@ Initial order: " * lpad(init_order, 2, " ") * " --> " * lpad(init_order, 2, " ")
     )
 end
 
-@doc differentiation_rk_docstring(
-    "Midpoint extrapolation using Barycentric coordinates,
-    following Hairer's SODEX in the adaptivity behavior.",
-    "ImplicitHairerWannerExtrapolation",
-    "Parallelized Explicit Extrapolation Method.",
-    references = reference,
-    extra_keyword_description = """
-    - `max_order`: maximum order of the adaptive order algorithm.
-    - `min_order`: minimum order of the adaptive order algorithm.
-    - `init_order`: initial order of the adaptive order algorithm.
-    - `thread`: determines whether internal broadcasting on appropriate CPU arrays should be serial (`thread = Serial()`) or use multiple threads (`thread = Threaded()`) when Julia is started with multiple threads.
-    - `sequence`: the step-number sequences, also called the subdividing sequence. Possible values are `:harmonic`, `:romberg` or `:bulirsch`.
-    """,
-    extra_keyword_default = """
-    max_order = 10,
-    min_order = 2,
-    init_order = 5,
-    thread = Serial(),
-    sequence = :harmonic,
-    """
-)
+"""
+    ImplicitHairerWannerExtrapolation(; autodiff = AutoForwardDiff(),
+        concrete_jac = nothing, linsolve = nothing, min_order = 2,
+        init_order = 5, max_order = 10, sequence = :harmonic,
+        threading = false) -> ImplicitHairerWannerExtrapolation
+
+Adaptive implicit midpoint extrapolation with the order and step-size controller from
+Hairer and Wanner's SODEX algorithm. It is intended for stiff problems and supports
+parallel evaluation of independent extrapolation columns.
+
+# Keywords
+
+- `autodiff = AutoForwardDiff()`: ADTypes backend used to construct Jacobians.
+- `concrete_jac = nothing`: Jacobian materialization policy. `nothing` lets the solver
+  choose; use `true` or `false` to request or disable a concrete Jacobian.
+- `linsolve = nothing`: LinearSolve algorithm for implicit stage systems. `nothing`
+  selects the OrdinaryDiffEq default.
+- `min_order::Integer = 2`: smallest internal extrapolation order; values below `2`
+  are raised to `2`.
+- `init_order::Integer = 5`: initial internal order. It is raised when necessary so
+  that `min_order < init_order`.
+- `max_order::Integer = 10`: largest internal order. It is raised when necessary so
+  that `init_order < max_order`.
+- `sequence::Symbol = :harmonic`: subdivision sequence. Supported values are
+  `:harmonic`, `:romberg`, and `:bulirsch`; other values warn and use `:harmonic`.
+- `threading = false`: enable concurrent extrapolation columns when `true`.
+
+# Returns
+
+- `ImplicitHairerWannerExtrapolation`: configured implicit extrapolation algorithm
+  for `CommonSolve.solve`.
+
+# Examples
+
+```julia
+using OrdinaryDiffEqExtrapolation: ImplicitHairerWannerExtrapolation
+using CommonSolve: solve
+using SciMLBase: ODEProblem
+
+prob = ODEProblem((u, p, t) -> -100u, 1.0, (0.0, 1.0))
+alg = ImplicitHairerWannerExtrapolation(sequence = :bulirsch)
+sol = solve(prob, alg; abstol = 1.0e-10, reltol = 1.0e-8)
+```
+
+# References
+
+C. Elrod et al., "Parallelizing explicit and implicit extrapolation methods for
+ordinary differential equations," HPEC 2022, pp. 1-9.
+"""
 struct ImplicitHairerWannerExtrapolation{AD, F, TO, CJ} <:
     OrdinaryDiffEqImplicitExtrapolationAlgorithm
     linsolve::F
@@ -436,29 +572,57 @@ Initial order: " * lpad(init_order, 2, " ") * " --> " * lpad(init_order, 2, " ")
     )
 end
 
-@doc differentiation_rk_docstring(
-    "Euler extrapolation using Barycentric coordinates,
-    following Hairer's SODEX in the adaptivity behavior.",
-    "ImplicitEulerBarycentricExtrapolation",
-    "Parallelized Explicit Extrapolation Method.",
-    references = reference,
-    extra_keyword_description = """
-    - `max_order`: maximum order of the adaptive order algorithm.
-    - `min_order`: minimum order of the adaptive order algorithm.
-    - `init_order`: initial order of the adaptive order algorithm.
-    - `thread`: determines whether internal broadcasting on appropriate CPU arrays should be serial (`thread = Serial()`) or use multiple threads (`thread = Threaded()`) when Julia is started with multiple threads.
-    - `sequence`: the step-number sequences, also called the subdividing sequence. Possible values are `:harmonic`, `:romberg` or `:bulirsch`.
-    - `sequence_factor`: denotes which even multiple of sequence to take while evaluating internal discretizations.
-    """,
-    extra_keyword_default = """
-    max_order = 10,
-    min_order = 3,
-    init_order = 5,
-    thread = Serial(),
-    sequence = :harmonic,
-    sequence_factor = 2,
-    """
-)
+"""
+    ImplicitEulerBarycentricExtrapolation(; autodiff = AutoForwardDiff(),
+        concrete_jac = nothing, linsolve = nothing, min_order = 3,
+        init_order = 5, max_order = 12, sequence = :harmonic,
+        threading = false, sequence_factor = 2) -> ImplicitEulerBarycentricExtrapolation
+
+Adaptive implicit Euler extrapolation using barycentric coordinates and the
+Hairer-Wanner order and step-size strategy. It targets stiff problems and can evaluate
+independent extrapolation columns concurrently.
+
+# Keywords
+
+- `autodiff = AutoForwardDiff()`: ADTypes backend used to construct Jacobians.
+- `concrete_jac = nothing`: Jacobian materialization policy. `nothing` lets the solver
+  choose; use `true` or `false` to request or disable a concrete Jacobian.
+- `linsolve = nothing`: LinearSolve algorithm for implicit stage systems. `nothing`
+  selects the OrdinaryDiffEq default.
+- `min_order::Integer = 3`: smallest internal extrapolation order; values below `3`
+  are raised to `3`.
+- `init_order::Integer = 5`: initial internal order. It is raised when necessary so
+  that `min_order < init_order`.
+- `max_order::Integer = 12`: largest internal order. It is raised when necessary so
+  that `init_order < max_order`.
+- `sequence::Symbol = :harmonic`: subdivision sequence. Supported values are
+  `:harmonic`, `:romberg`, and `:bulirsch`; other values warn and use `:harmonic`.
+- `threading = false`: enable concurrent extrapolation columns when `true`.
+- `sequence_factor::Integer = 2`: positive multiplier applied to the subdivision
+  sequence used by the implicit Euler base method.
+
+# Returns
+
+- `ImplicitEulerBarycentricExtrapolation`: configured implicit extrapolation algorithm
+  for `CommonSolve.solve`.
+
+# Examples
+
+```julia
+using OrdinaryDiffEqExtrapolation: ImplicitEulerBarycentricExtrapolation
+using CommonSolve: solve
+using SciMLBase: ODEProblem
+
+prob = ODEProblem((u, p, t) -> -100u, 1.0, (0.0, 1.0))
+alg = ImplicitEulerBarycentricExtrapolation(sequence = :romberg)
+sol = solve(prob, alg; abstol = 1.0e-10, reltol = 1.0e-8)
+```
+
+# References
+
+C. Elrod et al., "Parallelizing explicit and implicit extrapolation methods for
+ordinary differential equations," HPEC 2022, pp. 1-9.
+"""
 struct ImplicitEulerBarycentricExtrapolation{AD, F, TO, CJ} <:
     OrdinaryDiffEqImplicitExtrapolationAlgorithm
     linsolve::F

--- a/lib/OrdinaryDiffEqExtrapolation/src/controllers.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/controllers.jl
@@ -1,18 +1,47 @@
 """
-    ExtrapolationController(; qmin, qmax, gamma, qsteady_min, qsteady_max,
-                            qmax_first_step, failfactor)
-    ExtrapolationController(::Type{QT}, alg; kwargs...)
+    ExtrapolationController(; kwargs...) -> ExtrapolationController
+    ExtrapolationController(::Type{QT}, alg; kwargs...) -> ExtrapolationController
 
-Step-size controller for the extrapolation family
-(`ExtrapolationMidpointDeuflhard`, `ExtrapolationMidpointHairerWanner`,
-`ImplicitDeuflhardExtrapolation`, `ImplicitHairerWannerExtrapolation`,
-`ImplicitEulerExtrapolation`, `ImplicitEulerBarycentricExtrapolation`).
-Composes the standard step-size knobs via `CommonControllerOptions`; the
-per-step order-and-stepsize selection (Deuflhard / Hairer–Wanner style
-"work per step" minimization) lives in the algorithm-specific
-`stepsize_controller_internal!` / `step_accept_controller!` /
-`step_reject_controller!` methods, so the controller-cache dispatch falls
-through to alg-level logic.
+Internal step-size controller for the extrapolation algorithms. OrdinaryDiffEq selects
+this controller automatically; solver users should not construct or dispatch on it.
+
+!!! warning "Developer implementation"
+    This type is implementation machinery, not user-facing API. Its representation and
+    direct construction may change as the extrapolation controller evolves.
+
+# Arguments
+
+- `QT::Type`: scalar type used to resolve controller options.
+- `alg`: extrapolation algorithm whose default controller options are used.
+
+# Keywords
+
+- `qmin`: lower bound on the step-size reduction factor.
+- `qmax`: upper bound on the step-size growth factor.
+- `qmax_first_step`: upper growth bound after the first accepted step.
+- `gamma`: safety factor applied to a proposed step-size change.
+- `qsteady_min`: lower edge of the interval in which the step size is unchanged.
+- `qsteady_max`: upper edge of the interval in which the step size is unchanged.
+- `failfactor`: step-size reduction factor after a nonlinear-solver failure.
+- `discontinuity_detection`: enable autonomous discontinuity detection when `true`.
+
+Omitted keywords use the defaults associated with `alg` when the controller cache is
+created.
+
+# Returns
+
+- `ExtrapolationController`: unresolved controller when `QT` and `alg` are omitted, or
+  a controller whose common options have been resolved to `QT` otherwise.
+
+# Examples
+
+```julia
+import OrdinaryDiffEqExtrapolation
+using OrdinaryDiffEqExtrapolation: ExtrapolationMidpointDeuflhard
+
+alg = ExtrapolationMidpointDeuflhard()
+controller = OrdinaryDiffEqExtrapolation.ExtrapolationController(Float64, alg)
+```
 """
 struct ExtrapolationController{B <: Union{NamedTuple, OrdinaryDiffEqCore.CommonControllerOptions}} <: AbstractController
     basic::B
@@ -35,7 +64,7 @@ mutable struct ExtrapolationControllerCache{QT, E, NLPType} <: AbstractControlle
 end
 
 function setup_controller_cache(alg, cache, controller::ExtrapolationController, ::Type{E}, disco_probs) where {E}
-    QT = OrdinaryDiffEqCore._resolved_QT(controller.basic)
+    QT = _controller_scalar_type(controller.basic)
     basic = OrdinaryDiffEqCore.resolve_basic(controller.basic, alg, QT; disco_probs)
     resolved = ExtrapolationController(basic)
     T = QT
@@ -97,12 +126,12 @@ function stepsize_controller_internal!(
     else
         # Update gamma and beta1
         cache.beta1 = typeof(cache.beta1)(1 // (2integrator.cache.n_curr + 1))
-        cache.gamma = FastPower.fastpower(
+        cache.gamma = fastpower(
             typeof(cache.gamma)(1 // 4),
             cache.beta1
         )
         # Compute new stepsize scaling
-        qtmp = FastPower.fastpower(OrdinaryDiffEqCore.get_EEst(integrator), cache.beta1) /
+        qtmp = fastpower(OrdinaryDiffEqCore.get_EEst(integrator), cache.beta1) /
             cache.gamma
         @fastmath q = max(inv(get_qmax(integrator)), min(inv(get_qmin(integrator)), qtmp))
     end
@@ -132,14 +161,14 @@ function stepsize_predictor!(
         s_new = stage_number[n_new - alg.min_order + 1]
         # Update gamma and beta1
         cache.beta1 = typeof(cache.beta1)(1 // (2integrator.cache.n_curr + 1))
-        cache.gamma = FastPower.fastpower(
+        cache.gamma = fastpower(
             typeof(cache.gamma)(1 // 4),
             cache.beta1
         )
         # Compute new stepsize scaling
         qtmp = EEst *
-            FastPower.fastpower(
-            FastPower.fastpower(tol, (1.0 - s_curr / s_new)),
+            fastpower(
+            fastpower(tol, (1.0 - s_curr / s_new)),
             cache.beta1
         ) / cache.gamma
         @fastmath q = max(inv(get_qmax(integrator)), min(inv(get_qmin(integrator)), qtmp))
@@ -248,7 +277,7 @@ function stepsize_controller_internal!(
                         (integrator.cache.n_curr - 1)
                 )
             end
-            cache.gamma = FastPower.fastpower(
+            cache.gamma = fastpower(
                 typeof(cache.gamma)(
                     65 //
                         100
@@ -256,7 +285,7 @@ function stepsize_controller_internal!(
                 cache.beta1
             )
             # Compute new stepsize scaling
-            qtmp = FastPower.fastpower(OrdinaryDiffEqCore.get_EEst(integrator), cache.beta1) /
+            qtmp = fastpower(OrdinaryDiffEqCore.get_EEst(integrator), cache.beta1) /
                 (cache.gamma)
             @fastmath q = max(
                 inv(get_qmax(integrator)),
@@ -270,7 +299,7 @@ function stepsize_controller_internal!(
         else
             # Update gamma and beta1
             cache.beta1 = typeof(cache.beta1)(1 // (2integrator.cache.n_curr + 1))
-            cache.gamma = FastPower.fastpower(
+            cache.gamma = fastpower(
                 typeof(cache.gamma)(
                     65 //
                         100
@@ -278,7 +307,7 @@ function stepsize_controller_internal!(
                 cache.beta1
             )
             # Compute new stepsize scaling
-            qtmp = FastPower.fastpower(OrdinaryDiffEqCore.get_EEst(integrator), cache.beta1) /
+            qtmp = fastpower(OrdinaryDiffEqCore.get_EEst(integrator), cache.beta1) /
                 cache.gamma
             @fastmath q = max(
                 inv(get_qmax(integrator)),

--- a/lib/OrdinaryDiffEqExtrapolation/src/extrapolation_caches.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/extrapolation_caches.jl
@@ -2,9 +2,8 @@ abstract type ExtrapolationMutableCache <: OrdinaryDiffEqMutableCache end
 get_fsalfirstlast(cache::ExtrapolationMutableCache, u) = (cache.fsalfirst, cache.k)
 
 # Helper function to determine appropriate thread count for array allocation
-# Uses maxthreadid() when threading is enabled, otherwise just 1 for maximum memory efficiency
 @inline function get_thread_count(alg)
-    return isthreaded(alg.threading) ? Threads.maxthreadid() : 1
+    return isthreaded(alg.threading) ? _thread_storage_size() : 1
 end
 
 @cache mutable struct AitkenNevilleCache{
@@ -257,7 +256,7 @@ function alg_cache(
     du1 = zero(rate_prototype)
     du2 = zero(rate_prototype)
 
-    if SciMLBase.has_jac(f) && !SciMLBase.has_Wfact(f) && f.jac_prototype !== nothing
+    if SciMLBase.has_jac(f) && !_has_Wfact(f) && f.jac_prototype !== nothing
         W_el = WOperator(f, dt, true)
         J = nothing # is J = W.J better?
     else
@@ -1271,7 +1270,7 @@ function alg_cache(
     du1 = zero(rate_prototype)
     du2 = zero(rate_prototype)
 
-    if SciMLBase.has_jac(f) && !SciMLBase.has_Wfact(f) && f.jac_prototype !== nothing
+    if SciMLBase.has_jac(f) && !_has_Wfact(f) && f.jac_prototype !== nothing
         W_el = WOperator(f, dt, true)
         J = nothing # is J = W.J better?
     else
@@ -1630,7 +1629,7 @@ function alg_cache(
     du1 = zero(rate_prototype)
     du2 = zero(rate_prototype)
 
-    if SciMLBase.has_jac(f) && !SciMLBase.has_Wfact(f) && f.jac_prototype !== nothing
+    if SciMLBase.has_jac(f) && !_has_Wfact(f) && f.jac_prototype !== nothing
         W_el = WOperator(f, dt, true)
         J = nothing # is J = W.J better?
     else
@@ -1845,7 +1844,7 @@ function alg_cache(
     du1 = zero(rate_prototype)
     du2 = zero(rate_prototype)
 
-    if SciMLBase.has_jac(f) && !SciMLBase.has_Wfact(f) && f.jac_prototype !== nothing
+    if SciMLBase.has_jac(f) && !_has_Wfact(f) && f.jac_prototype !== nothing
         W_el = WOperator(f, dt, true)
         J = nothing # is J = W.J better?
     else

--- a/lib/OrdinaryDiffEqExtrapolation/src/utils.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/utils.jl
@@ -1,0 +1,59 @@
+@inline _unwrap_val(::Val{B}) where {B} = B
+@inline _unwrap_val(value) = value
+
+@inline _vec(value::Union{Number, AbstractVector, SciMLOperators.AbstractSciMLScalarOperator}) =
+    value
+@inline _vec(value) = vec(value)
+
+@inline _reshape(value::Union{Number, SciMLOperators.AbstractSciMLScalarOperator}, _) = value
+@inline _reshape(value, dimensions) = reshape(value, dimensions)
+
+@inline _has_Wfact(f) = hasproperty(f, :Wfact) && getproperty(f, :Wfact) !== nothing
+
+@inline _float_controller_type(::Type{T}) where {T <: Integer} = float(T)
+@inline _float_controller_type(::Type{T}) where {T} = T
+@inline _controller_scalar_type(
+    ::OrdinaryDiffEqCore.CommonControllerOptions{T}
+) where {T} = _float_controller_type(T)
+@inline _controller_scalar_type(::NamedTuple{(), Tuple{}}) = Float64
+@inline _controller_scalar_type(overrides::NamedTuple) =
+    _float_controller_type(promote_type(map(typeof, values(overrides))...))
+
+@inline function _threaded_foreach(f, ::Union{Bool, OrdinaryDiffEqCore.BaseThreads}, range)
+    return Threads.@threads :static for i in range
+        f(i)
+    end
+end
+
+function _polyester_foreach(args...)
+    throw(
+        ArgumentError(
+            "PolyesterThreads() requires Polyester.jl to be loaded. Add `using Polyester` to your code."
+        )
+    )
+end
+
+@inline function _threaded_foreach(f, ::PolyesterThreads, range)
+    return _polyester_foreach(f, range)
+end
+
+macro threaded(option, ex)
+    ex.head === :for || error("@threaded expects a for loop")
+    loop_var = esc(ex.args[1].args[1])
+    range_expr = esc(ex.args[1].args[2])
+    body = esc(ex.args[2])
+    return quote
+        option = $(esc(option))
+        if isthreaded(option)
+            _threaded_foreach(option, $range_expr) do $loop_var
+                $body
+            end
+        else
+            $(esc(ex))
+        end
+    end
+end
+
+@inline function _thread_storage_size()
+    return Threads.threadpoolsize(:default) + Threads.threadpoolsize(:interactive)
+end

--- a/lib/OrdinaryDiffEqExtrapolation/test/multithreading/ode_extrapolation_tests.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/multithreading/ode_extrapolation_tests.jl
@@ -1,5 +1,7 @@
 # Import packages
 using OrdinaryDiffEqExtrapolation, RecursiveFactorization, DiffEqDevTools, Test, Random
+using CommonSolve: solve
+using SciMLBase: SciMLBase, ODEFunction, ODEProblem
 using OrdinaryDiffEqCore: Sequential, BaseThreads, PolyesterThreads
 using Polyester
 

--- a/lib/OrdinaryDiffEqExtrapolation/test/ode_extrapolation_tests.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/ode_extrapolation_tests.jl
@@ -1,5 +1,7 @@
 # Import packages
 using OrdinaryDiffEqExtrapolation, DiffEqDevTools, Test, Random
+using CommonSolve: solve
+using SciMLBase: SciMLBase, ODEFunction, ODEProblem
 
 # Define test problems
 # Note that the time span in ODEProblemLibrary is given by

--- a/lib/OrdinaryDiffEqExtrapolation/test/qa/Project.toml
+++ b/lib/OrdinaryDiffEqExtrapolation/test/qa/Project.toml
@@ -8,14 +8,11 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources.OrdinaryDiffEqCore]
-path = "../../../OrdinaryDiffEqCore"
-
 [compat]
 AllocCheck = "0.2"
 Aqua = "0.8.11"
 JET = "0.9, 0.11"
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 julia = "1.10"
 OrdinaryDiffEqCore = "4"
 OrdinaryDiffEqExtrapolation = "2"

--- a/lib/OrdinaryDiffEqExtrapolation/test/qa/allocation_tests.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/qa/allocation_tests.jl
@@ -1,6 +1,7 @@
 using OrdinaryDiffEqExtrapolation
 using OrdinaryDiffEqCore
-using SciMLBase: FullSpecialize
+using CommonSolve: init, step!
+using SciMLBase: FullSpecialize, ODEProblem
 using AllocCheck
 using Test
 

--- a/lib/OrdinaryDiffEqExtrapolation/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/qa/qa.jl
@@ -1,33 +1,3 @@
 using SciMLTesting, OrdinaryDiffEqExtrapolation, Test
 
-run_qa(
-    OrdinaryDiffEqExtrapolation;
-    # No docs/ tree here; the umbrella manual renders this package's API.
-    api_docs_kwargs = (; rendered = false),
-    reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
-    explicit_imports = true,
-    ei_kwargs = (;
-        all_explicit_imports_are_public = (;
-            ignore = (
-                # OrdinaryDiffEqCore private codegen macro (deliberately kept non-public)
-                Symbol("@threaded"),
-                # OrdinaryDiffEqDifferentiation owner-internal cross-sublibrary hooks;
-                # no public wrapper exists.
-                :build_grad_config, :build_jac_config, :calc_J, :calc_J!,
-                :dolinsolve, :jacobian2W!,
-                # SciMLBase internals (reshaping / val-unwrap helpers, no public replacement)
-                :_reshape, :_unwrap_val, :_vec,
-            ),
-        ),
-        all_qualified_accesses_are_public = (;
-            ignore = (
-                # OrdinaryDiffEqCore owner-internal (controller QT resolution)
-                :_resolved_QT,
-                # other upstream internals
-                :fastpower,     # FastPower
-                :has_Wfact,     # SciMLBase
-                :maxthreadid,   # Base.Threads
-            ),
-        ),
-    ),
-)
+run_qa(OrdinaryDiffEqExtrapolation)

--- a/lib/OrdinaryDiffEqExtrapolation/test/runtests.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/runtests.jl
@@ -9,6 +9,7 @@ end
 
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
+    @time @safetestset "Extrapolation Utility Tests" include("utils_tests.jl")
     @time @safetestset "Extrapolation Tests" include("ode_extrapolation_tests.jl")
 end
 

--- a/lib/OrdinaryDiffEqExtrapolation/test/utils_tests.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/utils_tests.jl
@@ -1,0 +1,31 @@
+using OrdinaryDiffEqExtrapolation
+using SciMLBase: ODEFunction
+using Test
+
+const ODEX = OrdinaryDiffEqExtrapolation
+
+@testset "Local dependency-independent utilities" begin
+    @test ODEX._unwrap_val(Val(true))
+    @test !ODEX._unwrap_val(Val(false))
+    @test ODEX._unwrap_val(nothing) === nothing
+
+    vector = [1.0, 2.0]
+    matrix = [1.0 2.0; 3.0 4.0]
+    @test ODEX._vec(1.0) === 1.0
+    @test ODEX._vec(vector) === vector
+    @test ODEX._vec(matrix) == vec(matrix)
+    @test ODEX._reshape(1.0, (1,)) === 1.0
+    @test ODEX._reshape(vector, (1, 2)) == reshape(vector, 1, 2)
+
+    f = ODEFunction((u, p, t) -> u)
+    f_with_Wfact = ODEFunction((u, p, t) -> u; Wfact = (u, p, dtgamma, t) -> u)
+    @test !ODEX._has_Wfact(f)
+    @test ODEX._has_Wfact(f_with_Wfact)
+
+    @test ODEX._controller_scalar_type((;)) === Float64
+    @test ODEX._controller_scalar_type((; qmax = 2)) === Float64
+    @test ODEX._controller_scalar_type((; qmax = Float32(2))) === Float32
+
+    @test ODEX._thread_storage_size() ==
+        Threads.threadpoolsize(:default) + Threads.threadpoolsize(:interactive)
+end


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- move all seven exported extrapolation algorithm docstrings to their definitions and expand their arguments, keyword contracts, returns, examples, and references
- remove the leaf blanket SciMLBase reexport, source paths, rendered-doc waiver, reexport allowance, and every ExplicitImports exception
- import CommonSolve and dependency APIs through their owners
- replace private reshaping, trait, thread-count, and Core threading helpers with tested leaf-owned utilities
- keep ExtrapolationController and its cache private and remove the controller from rendered public documentation
- run strict SciMLTesting through plain `run_qa(OrdinaryDiffEqExtrapolation)` with a 2.4 compat floor

## Validation

- plain strict QA: 21/21 passed
- JET: 1/1 passed
- utility tests: 14/14 passed
- core solver tests: 284/284 passed
- BaseThreads and Polyester tests: 620/620 passed
- direct-owner documented examples: 7/7 passed
- Julia 1.10 public thread-pool API smoke passed
- Runic and `git diff --check` passed

The seven existing allocation expectations remain broken and unchanged; this PR does not skip or alter them.