### PR TITLE
Document solver code-generation APIs

### DIFF
--- a/docs/src/devtools/internals/public_api.md
+++ b/docs/src/devtools/internals/public_api.md
@@ -43,6 +43,18 @@ DiffEqBase.stripunits
 DiffEqBase.timedepentdtmin
 ```
 
+## Solver code-generation utilities
+
+These macros are versioned for solver packages, not application code. Generated
+tableau bindings are local implementation details. Foldability and loop-policy
+annotations may only be applied when their documented effect assumptions hold.
+
+```@docs
+DiffEqBase.@tight_loop_macros
+OrdinaryDiffEqCore.@OnDemandTableauExtract
+OrdinaryDiffEqCore.@fold
+```
+
 ## Algorithm type hierarchy
 
 Every solver subtypes one of these abstract algorithm types.

--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.12.0"
+version = "7.13.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/DiffEqBase/src/DiffEqBase.jl
+++ b/lib/DiffEqBase/src/DiffEqBase.jl
@@ -218,7 +218,7 @@ export AutoDePSpecialize
             :calculate_residuals, :calculate_residuals!,
             # Algorithm/dt setup hooks solvers specialize
             :prepare_alg, :prob2dtmin, :timedepentdtmin, :check_prob_alg_pairing,
-            :default_factorize, :stripunits,
+            :default_factorize, :stripunits, Symbol("@tight_loop_macros"),
             # Solver-author wrapper/tag types and convergence-testing entry type
             :EvalFunc, :OrdinaryDiffEqTag, :ConvergenceSetup
         )

--- a/lib/DiffEqBase/src/utils.jl
+++ b/lib/DiffEqBase/src/utils.jl
@@ -1,3 +1,43 @@
+"""
+    @tight_loop_macros loop_expr
+
+Apply the DiffEqBase loop policy to `loop_expr`. Solver packages use this macro
+around scalar stage loops so DiffEqBase can select common loop annotations without
+duplicating them in every solver implementation.
+
+# Arguments
+
+  - `loop_expr`: loop expression to emit in the caller's scope, normally a `for`
+    loop over state indices.
+
+# Returns
+
+The escaped loop expression with the current DiffEqBase loop policy applied. The
+current policy preserves the expression unchanged; solver packages must not rely
+on that implementation detail.
+
+# Developer contract
+
+The loop body must be valid under reordering and vectorization policies that a
+future DiffEqBase release may apply. Do not use the loop body for externally
+observable iteration ordering or cross-iteration dependencies. This is versioned
+solver-development API, not an application-facing loop macro.
+
+# Examples
+
+```julia
+using DiffEqBase: @tight_loop_macros
+
+function add_one!(out, x)
+    @tight_loop_macros for i in eachindex(out, x)
+        @inbounds out[i] = x[i] + 1
+    end
+    return out
+end
+
+add_one!(zeros(2), [1.0, 2.0]) == [2.0, 3.0]
+```
+"""
 macro tight_loop_macros(ex)
     return :($(esc(ex)))
 end

--- a/lib/DiffEqBase/test/developer_codegen_api_tests.jl
+++ b/lib/DiffEqBase/test/developer_codegen_api_tests.jl
@@ -1,0 +1,20 @@
+using DiffEqBase: DiffEqBase, @tight_loop_macros
+using Test
+
+module ExternalDiffEqBaseCodegen
+    using DiffEqBase: @tight_loop_macros
+
+    function add_one!(out, x)
+        @tight_loop_macros for i in eachindex(out, x)
+            @inbounds out[i] = x[i] + 1
+        end
+        return out
+    end
+end
+
+@test ExternalDiffEqBaseCodegen.add_one!(zeros(3), [1.0, 2.0, 3.0]) == [2.0, 3.0, 4.0]
+
+@static if isdefined(Base, :ispublic)
+    @test Base.ispublic(DiffEqBase, Symbol("@tight_loop_macros"))
+    @test Base.Docs.hasdoc(DiffEqBase, Symbol("@tight_loop_macros"))
+end

--- a/lib/DiffEqBase/test/runtests.jl
+++ b/lib/DiffEqBase/test/runtests.jl
@@ -41,6 +41,7 @@ end
         @time @safetestset "Internal Euler" include("internal_euler_test.jl")
         @time @safetestset "Norm" include("norm.jl")
         @time @safetestset "Utils" include("utils.jl")
+        @time @safetestset "Developer Codegen API" include("developer_codegen_api_tests.jl")
         @time @safetestset "ForwardDiff Dual Detection" include("forwarddiff_dual_detection.jl")
         @time @safetestset "ODE default norm" include("ode_default_norm.jl")
         @time @safetestset "DynamicQuantities extension" include("dynamicquantities_ext.jl")

--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.13.0"
+version = "4.14.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -51,7 +51,7 @@ OrdinaryDiffEqCorePolyesterExt = "Polyester"
 OrdinaryDiffEqCoreSparseArraysExt = "SparseArrays"
 
 [compat]
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 ADTypes = "1.22.0"
 Accessors = "0.1.42"
 ConstructionBase = "1.5.8"
@@ -113,16 +113,3 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["DiffEqDevTools", "SafeTestsets", "SparseArrays", "Test", "Pkg", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqTsit5", "DifferentiationInterface", "SciMLTesting"]
-
-[sources]
-DiffEqBase = {path = "../DiffEqBase"}
-DiffEqDevTools = {path = "../DiffEqDevTools"}
-
-[sources.OrdinaryDiffEqFIRK]
-path = "../OrdinaryDiffEqFIRK"
-
-[sources.OrdinaryDiffEqRosenbrock]
-path = "../OrdinaryDiffEqRosenbrock"
-
-[sources.OrdinaryDiffEqTsit5]
-path = "../OrdinaryDiffEqTsit5"

--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -113,3 +113,16 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["DiffEqDevTools", "SafeTestsets", "SparseArrays", "Test", "Pkg", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqTsit5", "DifferentiationInterface", "SciMLTesting"]
+
+[sources]
+DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
+
+[sources.OrdinaryDiffEqFIRK]
+path = "../OrdinaryDiffEqFIRK"
+
+[sources.OrdinaryDiffEqRosenbrock]
+path = "../OrdinaryDiffEqRosenbrock"
+
+[sources.OrdinaryDiffEqTsit5]
+path = "../OrdinaryDiffEqTsit5"

--- a/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
+++ b/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
@@ -56,13 +56,12 @@ import TruncatedStacktraces: @truncate_stacktrace, VERBOSE_MSG
 
 # Integrator Interface
 import Base: resize!, deleteat!
-import SciMLBase: addat!, full_cache, user_cache, u_cache, du_cache,
+import SciMLBase: addat!, full_cache,
     resize_non_user_cache!, deleteat_non_user_cache!, addat_non_user_cache!,
-    terminate!, get_du, get_dt, get_proposed_dt, set_proposed_dt!,
+    terminate!, get_proposed_dt, set_proposed_dt!,
     savevalues!,
     add_tstop!, has_tstop, first_tstop, pop_tstop!,
-    add_saveat!, set_reltol!,
-    set_abstol!, postamble!, last_step_failed
+    postamble!, last_step_failed
 import DiffEqBase: get_tstops, get_tstops_array
 
 # `check_error!` is owned by (and public in) SciMLBase, re-exported through DiffEqBase.
@@ -84,10 +83,11 @@ using SciMLBase: SciMLBase, CallbackSet, ContinuousCallback, DAEProblem,
     ODEProblem, ReturnCode, SplitFunction, SplitSDEFunction,
     VectorContinuousCallback, auto_dt_reset!, derivative_discontinuity!,
     get_tmp_cache, isinplace, reinit!
+const LinearAliasSpecifier = SciMLBase.LinearAliasSpecifier
 using SciMLOperators: SciMLOperators
 using CommonSolve: solve
 
-import SciMLBase: AbstractNonlinearProblem, alg_order, LinearAliasSpecifier
+import SciMLBase: AbstractNonlinearProblem, alg_order
 # `calculate_residuals`/`calculate_residuals!` are unused here but re-exported for
 # dependent OrdinaryDiffEq.jl sublibraries that import them from this package.
 import DiffEqBase: timedepentdtmin, calculate_residuals, calculate_residuals!
@@ -416,8 +416,8 @@ include("precompilation_setup.jl")
 # that downstream OrdinaryDiffEq.jl / StochasticDiffEq.jl solver packages subtype,
 # extend, or call. They are made public (not exported) so that ExplicitImports'
 # public-API checks recognize them as the supported extension surface. Genuine
-# codegen/perf internals (@fold/@threaded/@OnDemandTableauExtract/@swap!) and
-# precompile-workload helpers are deliberately NOT included here.
+# package-local codegen internals (@threaded/@swap!) and precompile-workload
+# helpers are deliberately NOT included here.
 @static if VERSION >= v"1.11.0-DEV.469"
     eval(
         Expr(
@@ -425,7 +425,7 @@ include("precompilation_setup.jl")
             :AbstractController, :AbstractControllerCache, :AbstractNLSolver, :AbstractNLSolverAlgorithm, :AbstractNLSolverCache, :AbstractThreadingOption,
             :accept_step_controller, :alg_adaptive_order, :alg_autodiff, :alg_cache, :alg_difftype, :alg_extrapolates,
             :alg_maximum_order, :alg_stability_size, :AutoAlgSwitch, :AutoSwitch, :AutoSwitchCache, :BaseThreads,
-            :beta1_default, :beta2_default, Symbol("@cache"), :COEFFICIENT_MULTISTEP, :CommonControllerOptions, :CompositeAlgorithm,
+            :beta1_default, :beta2_default, Symbol("@cache"), Symbol("@fold"), Symbol("@OnDemandTableauExtract"), :COEFFICIENT_MULTISTEP, :CommonControllerOptions, :CompositeAlgorithm,
             :CompositeController, :constvalue, :Convergence, :current_extrapolant,
             :current_interpolant, :DAEAlgorithm, :default_autoswitch, :DefaultCache, :default_controller, :default_linear_interpolation,
             :default_nlsolve, :DEOptions, :DIRK, :Divergence, :dt_required, :DummyController,

--- a/lib/OrdinaryDiffEqCore/src/misc_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/misc_utils.jl
@@ -157,6 +157,55 @@ macro threaded(option, ex)
     end
 end
 
+"""
+    @OnDemandTableauExtract TableauType T
+    @OnDemandTableauExtract TableauType T T2
+
+Construct `TableauType` from one or two scalar types and bind each field of the
+constructed tableau to a same-named local variable in the invocation scope.
+Solver implementations use this macro to expose coefficient fields to stage code
+without storing a runtime tableau object.
+
+# Arguments
+
+  - `TableauType`: concrete or parametric tableau type defined in the invoking
+    module. Its field names determine the generated local bindings.
+  - `T`: scalar type passed as the first constructor argument.
+  - `T2`: optional scalar type passed as the second constructor argument, commonly
+    used for time nodes.
+
+# Returns
+
+An expression that constructs the tableau once and assigns every field value to a
+local variable with the corresponding field name.
+
+# Developer contract
+
+`TableauType` must resolve in the invoking module and provide the selected
+constructor. Its field layout is part of the solver implementation using the
+macro. Invoke the macro inside a function before reading the generated names, and
+do not use those generated locals as application API.
+
+# Examples
+
+```julia
+using OrdinaryDiffEqCore: @OnDemandTableauExtract
+
+struct ExampleTableau{T, T2}
+    weight::T
+    node::T2
+end
+ExampleTableau(::Type{T}, ::Type{T2}) where {T, T2} =
+    ExampleTableau(one(T), convert(T2, 1 // 2))
+
+function coefficients(T, T2)
+    @OnDemandTableauExtract ExampleTableau T T2
+    return weight, node
+end
+
+coefficients(Float64, Float64) == (1.0, 0.5)
+```
+"""
 macro OnDemandTableauExtract(S_T, T, T2)
     S = getproperty(__module__, S_T)
     s = gensym(:s)
@@ -182,6 +231,41 @@ macro OnDemandTableauExtract(S_T, T)
     return esc(q)
 end
 
+"""
+    @fold function_definition
+
+Declare `function_definition` foldable using `Base.@assume_effects :foldable`.
+OrdinaryDiffEq solver packages use this macro for deterministic tableau and
+coefficient constructors that the compiler may evaluate at compile time.
+
+# Arguments
+
+  - `function_definition`: a function definition whose result depends only on its
+    arguments and immutable global constants.
+
+# Returns
+
+The escaped function definition wrapped in the Julia foldability annotation.
+
+# Developer contract
+
+Only annotate functions that are deterministic, effect-free, and safe to evaluate
+or eliminate at compile time. Incorrect use can cause invalid compiler
+optimizations; functions that mutate external state, perform I/O, inspect mutable
+globals, or depend on task state must not use `@fold`.
+
+# Examples
+
+```julia
+using OrdinaryDiffEqCore: @fold
+
+@fold function coefficient_pair(::Type{T}) where {T}
+    return convert(T, 1 // 2), one(T)
+end
+
+coefficient_pair(Float64) == (0.5, 1.0)
+```
+"""
 macro fold(arg)
     return esc(:(Base.@assume_effects :foldable $arg))
 end

--- a/lib/OrdinaryDiffEqCore/test/developer_codegen_api_tests.jl
+++ b/lib/OrdinaryDiffEqCore/test/developer_codegen_api_tests.jl
@@ -1,0 +1,45 @@
+using OrdinaryDiffEqCore: OrdinaryDiffEqCore, @fold, @OnDemandTableauExtract
+using Test
+
+module ExternalOrdinaryDiffEqCodegen
+    using OrdinaryDiffEqCore: @fold, @OnDemandTableauExtract
+
+    struct OneTypeTableau{T}
+        first::T
+        second::T
+    end
+    OneTypeTableau(::Type{T}) where {T} = OneTypeTableau(one(T), convert(T, 1 // 2))
+
+    struct TwoTypeTableau{T, T2}
+        weight::T
+        node::T2
+    end
+    TwoTypeTableau(::Type{T}, ::Type{T2}) where {T, T2} =
+        TwoTypeTableau(one(T), convert(T2, 1 // 4))
+
+    function one_type_coefficients(T)
+        @OnDemandTableauExtract OneTypeTableau T
+        return first, second
+    end
+
+    function two_type_coefficients(T, T2)
+        @OnDemandTableauExtract TwoTypeTableau T T2
+        return weight, node
+    end
+
+    @fold function folded_pair(::Type{T}) where {T}
+        return convert(T, 1 // 2), one(T)
+    end
+end
+
+@test ExternalOrdinaryDiffEqCodegen.one_type_coefficients(Float64) == (1.0, 0.5)
+@test ExternalOrdinaryDiffEqCodegen.two_type_coefficients(Float64, Float32) ==
+    (1.0, 0.25f0)
+@test ExternalOrdinaryDiffEqCodegen.folded_pair(Float64) == (0.5, 1.0)
+
+@static if isdefined(Base, :ispublic)
+    for name in (Symbol("@fold"), Symbol("@OnDemandTableauExtract"))
+        @test Base.ispublic(OrdinaryDiffEqCore, name)
+        @test Base.Docs.hasdoc(OrdinaryDiffEqCore, name)
+    end
+end

--- a/lib/OrdinaryDiffEqCore/test/gpu/Project.toml
+++ b/lib/OrdinaryDiffEqCore/test/gpu/Project.toml
@@ -12,6 +12,15 @@ RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[sources.OrdinaryDiffEq]
+path = "../../../.."
+
+[sources.DiffEqBase]
+path = "../../../DiffEqBase"
+
+[sources.OrdinaryDiffEqCore]
+path = "../.."
+
 [compat]
 ADTypes = "1"
 Adapt = "4"

--- a/lib/OrdinaryDiffEqCore/test/gpu/Project.toml
+++ b/lib/OrdinaryDiffEqCore/test/gpu/Project.toml
@@ -12,15 +12,6 @@ RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources.OrdinaryDiffEq]
-path = "../../../.."
-
-[sources.DiffEqBase]
-path = "../../../DiffEqBase"
-
-[sources.OrdinaryDiffEqCore]
-path = "../.."
-
 [compat]
 ADTypes = "1"
 Adapt = "4"

--- a/lib/OrdinaryDiffEqCore/test/qa/Project.toml
+++ b/lib/OrdinaryDiffEqCore/test/qa/Project.toml
@@ -6,13 +6,10 @@ OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources.DiffEqBase]
-path = "../../../DiffEqBase"
-
 [compat]
 Aqua = "0.8.11"
 DiffEqBase = "7"
 JET = "0.9, 0.11"
 OrdinaryDiffEqCore = "4"
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 julia = "1.10"

--- a/lib/OrdinaryDiffEqCore/test/qa/Project.toml
+++ b/lib/OrdinaryDiffEqCore/test/qa/Project.toml
@@ -6,6 +6,9 @@ OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[sources.DiffEqBase]
+path = "../../../DiffEqBase"
+
 [compat]
 Aqua = "0.8.11"
 DiffEqBase = "7"

--- a/lib/OrdinaryDiffEqCore/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqCore/test/qa/qa.jl
@@ -17,7 +17,6 @@ end
 run_qa(
     OrdinaryDiffEqCore;
     aqua_kwargs = (; piracies = false, unbound_args = false),
-    explicit_imports = true,
     ei_kwargs = (;
         no_implicit_imports = (; allow_unanalyzable = UNANALYZABLE),
         # These names are not used by OrdinaryDiffEqCore itself, but are imported
@@ -41,8 +40,6 @@ run_qa(
                 :NAN_CHECK,
                 # Base / Core internals
                 Symbol("@max_methods"), :Experimental, :Typeof, :promote_op,
-                # SciMLOperators internal
-                :AbstractSciMLOperator,
                 # EnzymeCore / EnzymeCore.EnzymeRules internals
                 :EnzymeRules, :inactive_noinl,
                 # SciMLBase internals with no public replacement yet
@@ -67,7 +64,7 @@ run_qa(
                 # FastPower internal
                 :fastpower,
                 # SciMLBase internals
-                :SENSITIVITY_INTERP_MESSAGE, :_unwrap_val, :last_step_failed,
+                :SENSITIVITY_INTERP_MESSAGE, :last_step_failed,
                 :postamble!,
                 # DiffEqBase internal
                 :_process_verbose_param,

--- a/lib/OrdinaryDiffEqCore/test/runtests.jl
+++ b/lib/OrdinaryDiffEqCore/test/runtests.jl
@@ -6,18 +6,11 @@ const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_gpu_env()
     Pkg.activate(joinpath(@__DIR__, "gpu"))
-    Pkg.develop(
-        [
-            PackageSpec(path = joinpath(@__DIR__, "..", "..", "..")),
-            PackageSpec(path = joinpath(@__DIR__, "..", "..", "DiffEqBase")),
-            PackageSpec(path = joinpath(@__DIR__, "..")),
-        ]
-    )
     return Pkg.instantiate()
 end
 
 function activate_qa_env()
-    return activate_group_env(joinpath(@__DIR__, "qa"))
+    return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])
 end
 
 # Run GPU tests

--- a/lib/OrdinaryDiffEqCore/test/runtests.jl
+++ b/lib/OrdinaryDiffEqCore/test/runtests.jl
@@ -6,11 +6,18 @@ const TEST_GROUP = get(ENV, "GROUP", "ALL")
 
 function activate_gpu_env()
     Pkg.activate(joinpath(@__DIR__, "gpu"))
+    Pkg.develop(
+        [
+            PackageSpec(path = joinpath(@__DIR__, "..", "..", "..")),
+            PackageSpec(path = joinpath(@__DIR__, "..", "..", "DiffEqBase")),
+            PackageSpec(path = joinpath(@__DIR__, "..")),
+        ]
+    )
     return Pkg.instantiate()
 end
 
 function activate_qa_env()
-    return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])
+    return activate_group_env(joinpath(@__DIR__, "qa"))
 end
 
 # Run GPU tests
@@ -33,6 +40,7 @@ end
 # Functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "Developer Time Queue API" include("developer_time_queue_api_tests.jl")
+    @time @safetestset "Developer Codegen API" include("developer_codegen_api_tests.jl")
     @time @safetestset "Sparse isdiag Performance" include("sparse_isdiag_tests.jl")
     @time @safetestset "Algebraic Vars Detection" include("algebraic_vars_detection_tests.jl")
     @time @safetestset "Interpolation Search Hint" include("interpolation_hint_tests.jl")


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- declare `DiffEqBase.@tight_loop_macros`, `OrdinaryDiffEqCore.@OnDemandTableauExtract`, and `OrdinaryDiffEqCore.@fold` as versioned solver-developer API
- move detailed SciMLStyle docstrings to the definition sites, render them on the warned developer API page, and test them from external client modules
- bump the two owning subpackages for the new public API
- update OrdinaryDiffEqCore QA to SciMLTesting 2.4 defaults, remove source-path metadata, narrow the QA environment to the Core package, and remove owner-public exceptions for `_unwrap_val` and `AbstractSciMLOperator`
- remove stale SciMLBase imports while retaining a private, unexported `LinearAliasSpecifier` compatibility binding for released Rosenbrock/FIRK versions

## Prerequisites

The removed owner-public exceptions require:

- SciML/SciMLOperators.jl#418
- SciML/SciMLBase.jl#1495

The local SciMLBase validation stack also included SciML/SciMLBase.jl#1500, which fixes the current clean-main Makie QA regression.

## Local validation

- DiffEqBase full tests passed on release Julia; focused external-interface tests passed on release and Julia 1.10
- OrdinaryDiffEqCore full Core tests passed on release and Julia 1.10
- final strict QA against the prerequisite owner branches passed on release: allocation 1/1, JET 30/30 with one pre-existing broken test, Aqua/QA 26/26
- final strict QA against the prerequisite owner branches passed on Julia 1.10: allocation 1/1, JET 30/30 with one pre-existing broken test, Aqua/QA 17/17
- GPU environment owner-resolution smoke test passed; CUDA tests were not run because this host has no NVIDIA GPU
- full-repository Runic check and `git diff --check` passed
- the repository-wide docs build remains blocked by the existing OrdinaryDiffEq missing-doc/cross-reference backlog; the three new bindings resolve and their examples have external functional tests