### PR TITLE
Fix NonlinearSolveAlg crash with SimpleNonlinearSolve inner solvers

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
@@ -22,8 +22,12 @@ using NonlinearSolve: FastShortcutNonlinearPolyalg, FastShortcutNLLSPolyalg, New
 import NonlinearSolveBase
 # `get_u`/`get_fu` are the only inner-state reads that hold for every inner cache type:
 # polyalgorithm caches keep `u`/`fu` on the active branch, not as top-level fields.
+# `NonlinearSolveNoInitCache` is the fallback cache for algorithms with no `__init` (every
+# SimpleNonlinearSolve algorithm): it holds no iteration state, so `step!`, `get_fu`,
+# `.stats` and `not_terminated` are all off-limits and it can only be driven by `solve!`.
 using NonlinearSolveBase:
     ArcLengthContinuation, HomotopyPolyAlgorithm, HomotopySweep, KantorovichHomotopy,
+    NonlinearSolveNoInitCache,
     get_linear_cache, get_u, get_fu
 using MuladdMacro: @muladd
 using FastBroadcast: @..

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -41,7 +41,11 @@ function initialize!(
     cache.tstep = integrator.t + nlsolver.c * dt
 
     (; ustep, tstep, k, invγdt) = cache
-    if SciMLBase.has_stats(integrator)
+    # A no-init cache has no `stats` (SimpleNonlinearSolve builds every solution with
+    # `stats === nothing`), and its `reinit!` only remakes the problem without evaluating
+    # the residual, so neither the copies below nor the `+1` apply: nothing is counted and
+    # nothing is invented.
+    if SciMLBase.has_stats(integrator) && !(cache.cache isa NonlinearSolveNoInitCache)
         # The `reinit!` below evaluates the residual at the new `z` and *then* zeroes the
         # inner cache's counters, so that evaluation is never visible in
         # `cache.cache.stats.nf`. Left uncounted it loses one `f` call per stage.
@@ -85,7 +89,12 @@ function initialize!(
 
     (; ustep, atmp, tstep, k, invγdt) = cache
 
-    if SciMLBase.has_stats(integrator)
+    # A no-init cache has no `stats` (SimpleNonlinearSolve builds every solution with
+    # `stats === nothing`), and its `reinit!` only remakes the problem without evaluating
+    # the residual, so neither the copies below nor the `+1` apply: nothing is counted and
+    # nothing is invented. `njacs`/`nw` for the reused `W` are still recorded by
+    # `_update_nlsolvealg_W!` — that assembly is the integrator's own work.
+    if SciMLBase.has_stats(integrator) && !(cache.cache isa NonlinearSolveNoInitCache)
         # The `reinit!` below evaluates the residual at the new `z` and *then* zeroes the
         # inner cache's counters, so that evaluation is never visible in
         # `cache.cache.stats.nf`. Left uncounted it loses one `f` call per stage.
@@ -152,21 +161,39 @@ function initialize!(
                 SciMLBase.remake(cache.prob; u0 = copy(z), p = nlp_params)
             end
             cache.prob = new_prob
-            # Same tolerances and termination mode as `build_nlsolver`: the integrator owns
-            # convergence, so the inner criterion must stay inert here too (otherwise a resized
-            # cache could terminate on its own again), and the mode is part of the cache's type,
-            # so rebuilding with a different one would not even be assignable.
-            uT = real(eltype(z))
-            cache.cache = init(
-                new_prob, cache.cache.alg;
-                verbose = integrator.opts.verbose.nonlinear_verbosity,
-                abstol = zero(uT), reltol = zero(uT),
-                termination_condition = _inner_termination()
-            )
+            if cache.cache isa NonlinearSolveNoInitCache
+                # A no-init cache is `solve!`-driven, so it must keep terminating on its own
+                # (nonzero, default) tolerances here exactly as on the build path: rebuilding
+                # it with the zeroed tolerances below would leave every complete inner solve
+                # returning `MaxIters`.
+                cache.cache = init(
+                    new_prob, cache.cache.alg;
+                    verbose = integrator.opts.verbose.nonlinear_verbosity
+                )
+            else
+                # Same tolerances and termination mode as `build_nlsolver`: the integrator owns
+                # convergence, so the inner criterion must stay inert here too (otherwise a resized
+                # cache could terminate on its own again), and the mode is part of the cache's type,
+                # so rebuilding with a different one would not even be assignable.
+                uT = real(eltype(z))
+                cache.cache = init(
+                    new_prob, cache.cache.alg;
+                    verbose = integrator.opts.verbose.nonlinear_verbosity,
+                    abstol = zero(uT), reltol = zero(uT),
+                    termination_condition = _inner_termination()
+                )
+            end
             # re-point the estimator linsolve alias at the rebuilt inner cache
             cache.linsolve = cache.W !== nothing ? get_linear_cache(cache.cache) : nothing
         else
-            SciMLBase.reinit!(cache.cache, z, p = nlp_params)
+            # A no-init cache's `reinit!` is `remake(prob; u0, p)`: it stores the array it is
+            # handed and `get_u` reads it straight back. Handing it `z` itself would alias
+            # them, so after `resize!` grows `z` in place the length-mismatch rebuild above
+            # could never fire and the inner problem would keep a stale `WReuseJac` over the
+            # old, smaller `W` — a `SingularException` here, a silently wrong Jacobian at
+            # other sizes. A no-init cache gets a copy of its own.
+            znew = cache.cache isa NonlinearSolveNoInitCache ? copy(z) : z
+            SciMLBase.reinit!(cache.cache, znew, p = nlp_params)
         end
     end
     return nothing
@@ -241,18 +268,32 @@ end
     (; tstep, invγdt) = cache
 
     nlcache = nlsolver.cache.cache
-    recompute_jacobian = nlsolver.iter == 1 && (cache.W === nothing || cache.new_W)
-    # A terminated inner cache makes `step!` a no-op, which would leave `ndz == 0` and read to
-    # the outer convergence test as a perfect solve. Terminating *successfully* is the normal
-    # path (the inner solve converged before the integrator's own test was satisfied); any
-    # other terminal state is a genuine failure and must reach the step controller, so report
-    # it the way `NLNewton` reports a failed linear solve.
-    if !NonlinearSolveBase.not_terminated(nlcache) &&
-            !SciMLBase.successful_retcode(nlcache.retcode)
-        return convert(eltype(z), Inf)
+    if nlcache isa NonlinearSolveNoInitCache
+        # A no-init cache holds no iteration state, so it cannot be driven one `step!` at a
+        # time: `solve!` runs the complete inner solve and its returned solution is the only
+        # trustworthy record of it (`get_u` on the cache still reads the *initial* iterate,
+        # and `.stats`/`get_fu` do not exist). Each outer iteration therefore costs one full
+        # inner solve; an unsuccessful one is a genuine failure and reaches the step
+        # controller the way `NLNewton` reports a failed linear solve.
+        innersol = solve!(nlcache)
+        if !SciMLBase.successful_retcode(innersol.retcode)
+            return convert(eltype(z), Inf)
+        end
+        active_u = innersol.u
+    else
+        recompute_jacobian = nlsolver.iter == 1 && (cache.W === nothing || cache.new_W)
+        # A terminated inner cache makes `step!` a no-op, which would leave `ndz == 0` and read to
+        # the outer convergence test as a perfect solve. Terminating *successfully* is the normal
+        # path (the inner solve converged before the integrator's own test was satisfied); any
+        # other terminal state is a genuine failure and must reach the step controller, so report
+        # it the way `NLNewton` reports a failed linear solve.
+        if !NonlinearSolveBase.not_terminated(nlcache) &&
+                !SciMLBase.successful_retcode(nlcache.retcode)
+            return convert(eltype(z), Inf)
+        end
+        step!(nlcache; recompute_jacobian)
+        active_u = get_u(nlcache)
     end
-    step!(nlcache; recompute_jacobian)
-    active_u = get_u(nlcache)
     nlsolver.ztmp = active_u
 
     ustep = compute_ustep(tmp, γ, z, method)
@@ -276,27 +317,52 @@ end
 
     nlstep_data = integrator.f.nlstep_data
     nlcache = nlsolver.cache.cache
-    recompute_jacobian = nlsolver.iter == 1 && (cache.W === nothing || cache.new_W)
-    # A terminated inner cache makes `step!` a no-op, which would leave `ndz == 0` and read to
-    # the outer convergence test as a perfect solve. Terminating *successfully* is the normal
-    # path (the inner solve converged before the integrator's own test was satisfied); any
-    # other terminal state is a genuine failure and must reach the step controller, so report
-    # it the way `NLNewton` reports a failed linear solve.
-    if !NonlinearSolveBase.not_terminated(nlcache) &&
-            !SciMLBase.successful_retcode(nlcache.retcode)
-        return convert(eltype(atmp), Inf)
+    if nlcache isa NonlinearSolveNoInitCache
+        # A no-init cache holds no iteration state, so it cannot be driven one `step!` at a
+        # time: `solve!` runs the complete inner solve and its returned solution is the only
+        # trustworthy record of it (`get_u` on the cache still reads the *initial* iterate,
+        # and `.stats`/`get_fu` do not exist). Each outer iteration therefore costs one full
+        # inner solve; an unsuccessful one is a genuine failure and reaches the step
+        # controller the way `NLNewton` reports a failed linear solve. No stale-`W` rescale
+        # either: the reused `W` only serves as the inner Newton's Jacobian (`WReuseJac`),
+        # where staleness costs convergence rate, not the root the full solve lands on.
+        innersol = solve!(nlcache)
+        if !SciMLBase.successful_retcode(innersol.retcode)
+            return convert(eltype(atmp), Inf)
+        end
+    else
+        recompute_jacobian = nlsolver.iter == 1 && (cache.W === nothing || cache.new_W)
+        # A terminated inner cache makes `step!` a no-op, which would leave `ndz == 0` and read to
+        # the outer convergence test as a perfect solve. Terminating *successfully* is the normal
+        # path (the inner solve converged before the integrator's own test was satisfied); any
+        # other terminal state is a genuine failure and must reach the step controller, so report
+        # it the way `NLNewton` reports a failed linear solve.
+        if !NonlinearSolveBase.not_terminated(nlcache) &&
+                !SciMLBase.successful_retcode(nlcache.retcode)
+            return convert(eltype(atmp), Inf)
+        end
+        rescale_stale_W_rhs!(nlcache, nlsolver, integrator, nlstep_data)
+        step!(nlcache; recompute_jacobian)
     end
-    rescale_stale_W_rhs!(nlcache, nlsolver, integrator, nlstep_data)
-    step!(nlcache; recompute_jacobian)
 
     if nlstep_data !== nothing
-        active_fu = get_fu(nlcache)
-        # No `trace` is attached: this solution only feeds `nlprobmap` right below, and
-        # polyalgorithm caches keep the trace on the active branch with no accessor for it.
-        nlstepsol = SciMLBase.build_solution(
-            nlcache.prob, nlcache.alg, get_u(nlcache), active_fu;
-            nlcache.retcode, nlcache.stats
-        )
+        if nlcache isa NonlinearSolveNoInitCache
+            # `f.nlstep_data !== nothing` selects `f.nlstep_data.nlprob`, which is `init`ed
+            # with whatever inner algorithm was given, so a SimpleNonlinearSolve one lands
+            # in a no-init cache here too. The solution `solve!` already returned is used
+            # as-is instead of rebuilding one from `nlcache.retcode`/`nlcache.stats`/
+            # `get_fu`, none of which exist on this cache.
+            active_fu = innersol.resid
+            nlstepsol = innersol
+        else
+            active_fu = get_fu(nlcache)
+            # No `trace` is attached: this solution only feeds `nlprobmap` right below, and
+            # polyalgorithm caches keep the trace on the active branch with no accessor for it.
+            nlstepsol = SciMLBase.build_solution(
+                nlcache.prob, nlcache.alg, get_u(nlcache), active_fu;
+                nlcache.retcode, nlcache.stats
+            )
+        end
         nlstep_data.nlprobmap(ztmp, nlstepsol)
         ustep = compute_ustep!(ustep, tmp, γ, z, method)
         atmp_sub = @view(atmp[nlstep_data.u0perm])
@@ -313,7 +379,7 @@ end
         # convergence check to declare success ~sqrt(n_full/n_sub) early.
         ndz = opts.internalnorm(atmp_sub, t)
     else
-        active_u = get_u(nlcache)
+        active_u = nlcache isa NonlinearSolveNoInitCache ? innersol.u : get_u(nlcache)
         @.. broadcast = false ztmp = active_u
         ustep = compute_ustep!(ustep, tmp, γ, z, method)
         @.. broadcast = false atmp = z - ztmp

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/nlsolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/nlsolve.jl
@@ -11,7 +11,12 @@
 # "already at the root" and "has not decided anything yet".
 _rejected_trial_step(nlsolver, ndz) = false
 function _rejected_trial_step(nlsolver::NLSolver{<:NonlinearSolveAlg}, ndz)
-    return iszero(ndz) && NonlinearSolveBase.not_terminated(nlsolver.cache.cache)
+    nlcache = nlsolver.cache.cache
+    # A no-init cache is `solve!`-driven, so it has no trial-step state to reject (and no
+    # `force_stop`/`nsteps` for `not_terminated` to read): a zero `ndz` there means a
+    # complete inner solve returned the iterate unchanged, which is genuine convergence.
+    nlcache isa NonlinearSolveNoInitCache && return false
+    return iszero(ndz) && NonlinearSolveBase.not_terminated(nlcache)
 end
 
 """

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -502,6 +502,16 @@ function build_nlsolver(
                     abstol = _inner_lintol(uTolType), reltol = _inner_lintol(uTolType),
                 )
             )
+            if cache isa NonlinearSolveNoInitCache
+                # An inner algorithm with no `__init` (every SimpleNonlinearSolve algorithm)
+                # lands in this fallback cache, which only records the kwargs and splats them
+                # into a complete `solve` per outer iteration — it cannot be driven one
+                # `step!` at a time, so the integrator cannot own its convergence. The zeroed
+                # tolerances above would then make every inner solve run to `MaxIters`
+                # (except when the residual lands on exactly 0.0), so rebuild without them:
+                # the inner solver terminates on its own default (nonzero) tolerances.
+                cache = init(prob, inner_alg; verbose = verbose.nonlinear_verbosity)
+            end
             # Smoothed estimate `W \ tmp` reuses the inner solver's own W factorization (see
             # NonlinearSolveCache); `nothing` when it exposes none (native scalar/StaticArray
             # solve) falls back to the raw estimate.
@@ -692,6 +702,11 @@ function build_nlsolver(
                     abstol = _inner_lintol(uTolType), reltol = _inner_lintol(uTolType),
                 )
             )
+            if cache isa NonlinearSolveNoInitCache
+                # `solve!`-driven fallback cache: it must keep terminating on its own
+                # default (nonzero) tolerances (see the in-place branch above).
+                cache = init(prob, inner_alg; verbose = verbose.nonlinear_verbosity)
+            end
             nlcache = NonlinearSolveCache(
                 nothing, tstep, nothing, nothing, invγdt, prob, cache,
                 nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing,

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_noinit_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_noinit_tests.jl
@@ -1,0 +1,164 @@
+# NonlinearSolveAlg with inner algorithms that have no `init` (every SimpleNonlinearSolve
+# algorithm): these land in `NonlinearSolveBase.NonlinearSolveNoInitCache`, a fallback with
+# no iteration state, so `step!`, `get_fu`, `.stats` and `not_terminated` are all
+# unavailable and the cache can only be driven by complete `solve!` calls that must
+# terminate on their own (nonzero) tolerances.
+using OrdinaryDiffEqBDF, OrdinaryDiffEqSDIRK, OrdinaryDiffEqRosenbrock
+using OrdinaryDiffEqNonlinearSolve
+using OrdinaryDiffEqNonlinearSolve: NonlinearSolveAlg
+using NonlinearSolve: NewtonRaphson
+using SimpleNonlinearSolve
+using NonlinearSolveBase
+using SciMLBase, LinearAlgebra
+using Test
+
+prob_scalar = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 1.0))
+
+function vdp!(du, u, p, t)
+    du[1] = u[2]
+    du[2] = p * ((1 - u[1]^2) * u[2]) - u[1]
+    return nothing
+end
+prob_vdp = ODEProblem(vdp!, [2.0, 0.0], (0.0, 1.0), 10.0)
+
+function rober_mm!(du, u, p, t)
+    y₁, y₂, y₃ = u
+    du[1] = -0.04y₁ + 1.0e4 * y₂ * y₃
+    du[2] = 0.04y₁ - 1.0e4 * y₂ * y₃ - 3.0e7 * y₂^2
+    du[3] = y₁ + y₂ + y₃ - 1
+    return nothing
+end
+prob_mm = ODEProblem(
+    ODEFunction(rober_mm!, mass_matrix = Diagonal([1.0, 1.0, 0.0])),
+    [1.0, 0.0, 0.0], (0.0, 0.1)
+)
+
+noinit_cache(integrator) = integrator.cache.nlsolver.cache
+
+@testset "cache-type identification" begin
+    integ = init(prob_vdp, TRBDF2(nlsolve = NonlinearSolveAlg(SimpleNewtonRaphson())))
+    nlc = noinit_cache(integ)
+    @test nlc.cache isa NonlinearSolveBase.NonlinearSolveNoInitCache
+    # W reuse stays enabled for no-init caches in place: the reused W is handed to the
+    # inner solver as `prob.f.jac`, which SimpleNonlinearSolve honours, and the residual
+    # writes through preallocated Float64 buffers that AD cannot go through.
+    @test nlc.W !== nothing
+    integ_oop = init(prob_scalar, TRBDF2(nlsolve = NonlinearSolveAlg(SimpleNewtonRaphson())))
+    nlc_oop = noinit_cache(integ_oop)
+    @test nlc_oop.cache isa NonlinearSolveBase.NonlinearSolveNoInitCache
+    @test nlc_oop.W === nothing
+    integ_tr = init(prob_vdp, TRBDF2(nlsolve = NonlinearSolveAlg(SimpleTrustRegion())))
+    @test noinit_cache(integ_tr).cache isa NonlinearSolveBase.NonlinearSolveNoInitCache
+    integ_nr = init(prob_vdp, TRBDF2(nlsolve = NonlinearSolveAlg(NewtonRaphson())))
+    @test !(noinit_cache(integ_nr).cache isa NonlinearSolveBase.NonlinearSolveNoInitCache)
+end
+
+inner_algs = [
+    ("SimpleNewtonRaphson", SimpleNewtonRaphson()),
+    ("SimpleTrustRegion", SimpleTrustRegion()),
+    ("SimpleKlement", SimpleKlement()),
+    ("SimpleBroyden", SimpleBroyden()),
+]
+
+@testset "functional matrix: $pname" for (pname, prob, reltol) in [
+        ("scalar oop", prob_scalar, 1.0e-5),
+        ("vdp iip", prob_vdp, 1.0e-6),
+        ("rober-mm iip", prob_mm, 1.0e-7),
+    ]
+    ref = solve(prob, Rodas5P(); reltol = 1.0e-12, abstol = 1.0e-12)
+    for method in (Trapezoid, TRBDF2, FBDF), (iname, ialg) in inner_algs
+        # SimpleBroyden diverges on this one cell (a clear failure, not a wrong answer):
+        # its secant update cannot hold the algebraic row of the singular mass matrix.
+        pname == "rober-mm iip" && method === Trapezoid && iname == "SimpleBroyden" &&
+            continue
+        sol = solve(
+            prob, method(nlsolve = NonlinearSolveAlg(ialg));
+            reltol = 1.0e-8, abstol = 1.0e-10
+        )
+        @test SciMLBase.successful_retcode(sol.retcode)
+        refu = ref(sol.t[end])
+        @test norm(sol.u[end] .- refu) / max(norm(refu), 1.0e-16) < reltol
+    end
+end
+
+@testset "tolerances" begin
+    # The build paths zero the inner tolerances so the integrator owns convergence on the
+    # `step!`-driven path — but a no-init cache is `solve!`-driven, so zeroed tolerances
+    # would leave every complete inner solve returning `MaxIters` (except when the residual
+    # lands on exactly 0.0, which is why easy problems cannot see the bug). The rebuilt
+    # cache must carry neither the zeroed tolerances nor the stepped-path-only kwargs that
+    # would be splatted into `solve`.
+    for integ in (
+            init(prob_vdp, TRBDF2(nlsolve = NonlinearSolveAlg(SimpleNewtonRaphson()))),
+            init(prob_scalar, TRBDF2(nlsolve = NonlinearSolveAlg(SimpleNewtonRaphson()))),
+        )
+        nlcache = noinit_cache(integ).cache
+        @test !iszero(NonlinearSolveBase.get_abstol(nlcache))
+        @test !iszero(NonlinearSolveBase.get_reltol(nlcache))
+        @test !haskey(nlcache.kwargs, :termination_condition)
+        @test !haskey(nlcache.kwargs, :linsolve_kwargs)
+    end
+end
+
+@testset "resize" begin
+    condition(u, t, integrator) = t == 0.5
+    function affect!(integrator)
+        resize!(integrator, 2)
+        integrator.u[2] = 1.0
+        return nothing
+    end
+    cb = DiscreteCallback(condition, affect!)
+    decay!(du, u, p, t) = (@. du = -u; nothing)
+    prob_grow = ODEProblem(decay!, [1.0], (0.0, 1.0))
+    for (iname, ialg) in [
+            ("SimpleNewtonRaphson", SimpleNewtonRaphson()),
+            ("SimpleTrustRegion", SimpleTrustRegion()),
+        ]
+        integ = init(
+            prob_grow, TRBDF2(nlsolve = NonlinearSolveAlg(ialg));
+            callback = cb, tstops = [0.5], reltol = 1.0e-8, abstol = 1.0e-10
+        )
+        sol = solve!(integ)
+        @test SciMLBase.successful_retcode(sol.retcode)
+        # The second component decays from 1.0 at t = 0.5; a stale 1x1 `WReuseJac` left
+        # aliased across the resize surfaces as a `SingularException` here (and would be
+        # a silently wrong Jacobian at other sizes).
+        @test isapprox(sol.u[end][1], exp(-1); atol = 1.0e-5)
+        @test isapprox(sol.u[end][2], exp(-0.5); atol = 1.0e-5)
+        nlcache = noinit_cache(integ).cache
+        @test nlcache isa NonlinearSolveBase.NonlinearSolveNoInitCache
+        # The post-resize rebuild must preserve the no-init tolerances exactly as the
+        # build path does.
+        @test !iszero(NonlinearSolveBase.get_abstol(nlcache))
+        @test !haskey(nlcache.kwargs, :termination_condition)
+    end
+end
+
+@testset "rejected trial step" begin
+    integ = init(
+        prob_vdp, TRBDF2(nlsolve = NonlinearSolveAlg(SimpleTrustRegion()));
+        reltol = 1.0e-8, abstol = 1.0e-10
+    )
+    step!(integ)
+    nls = integ.cache.nlsolver
+    @test nls.cache.cache isa NonlinearSolveBase.NonlinearSolveNoInitCache
+    # A no-init cache has no trial-step state to reject: a zero displacement after a
+    # complete `solve!` is genuine convergence, and `not_terminated` has nothing to read.
+    @test !OrdinaryDiffEqNonlinearSolve._rejected_trial_step(nls, 0.0)
+    @test !OrdinaryDiffEqNonlinearSolve._rejected_trial_step(nls, 1.0)
+    # The stepped path keeps its #3817 discrimination untouched.
+    integ_nr = init(
+        prob_vdp, TRBDF2(nlsolve = NonlinearSolveAlg(NewtonRaphson()));
+        reltol = 1.0e-8, abstol = 1.0e-10
+    )
+    step!(integ_nr)
+    nls_nr = integ_nr.cache.nlsolver
+    @test OrdinaryDiffEqNonlinearSolve._rejected_trial_step(nls_nr, 0.0) ==
+        NonlinearSolveBase.not_terminated(nls_nr.cache.cache)
+    @test !OrdinaryDiffEqNonlinearSolve._rejected_trial_step(nls_nr, 1.0)
+    sol = solve(
+        prob_vdp, TRBDF2(nlsolve = NonlinearSolveAlg(SimpleTrustRegion()));
+        reltol = 1.0e-8, abstol = 1.0e-10
+    )
+    @test SciMLBase.successful_retcode(sol.retcode)
+end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
@@ -43,6 +43,7 @@ if TEST_GROUP ∉ ("QA", "ModelingToolkit")
     @time @safetestset "NonlinearSolveAlg Smoothed Error Estimate Tests" include("nsa_smooth_est_tests.jl")
     @time @safetestset "NonlinearSolveAlg Stats Tests" include("nsa_stats_tests.jl")
     @time @safetestset "NonlinearSolveAlg Polyalgorithm Inner Solver Tests" include("nsa_polyalg_tests.jl")
+    @time @safetestset "NonlinearSolveAlg No-Init Inner Solver Tests" include("nsa_noinit_tests.jl")
 end
 
 # Run QA tests (JET, Aqua)


### PR DESCRIPTION
`NonlinearSolveAlg` crashes with every SimpleNonlinearSolve inner algorithm. Those
define no `__init`, so NonlinearSolveBase hands back a `NonlinearSolveNoInitCache`,
which carries only `prob, alg, args, kwargs, initializealg, retcode, verbose`. The
first raw field read then throws:

```julia
solve(prob, Trapezoid(nlsolve = NonlinearSolveAlg(SimpleNewtonRaphson())))
ERROR: type NonlinearSolveNoInitCache has no field stats
```

This is the last of the #3859 bug class. #3959 routed `u` and `fu` through
`get_u`/`get_fu` but left the raw `stats` reads, which I said I would fix when it came
up on #4112. Extracted from #3798 so the crash fix lands independently of the W-reuse
feature still under discussion there; #3798 rebases onto this once it lands.

Every guard dispatches on the cache type, not on a list of algorithm types, so a newly
exported SimpleNonlinearSolve algorithm is picked up automatically. The changes: the
stats copies in both `initialize!` methods skip a cache that has no counters;
`compute_step!` drives a no-init cache with `solve!` (it has no `step!`) and reads the
returned solution; `_rejected_trial_step` skips it; the builds and the post-`resize!`
rebuild keep the solver's own tolerances instead of the zeroed ones the stepped path
uses, which would send every inner solve to `MaxIters`; and `initialize!` hands the
cache a copy of `z` rather than `z` itself, since `reinit!` on this cache stores the
array it is given and a later in-place `resize!` of `z` otherwise defeats the
length-mismatch rebuild and leaves a stale, wrongly sized Jacobian buffer behind.

Stats on this path are honest rather than invented. SimpleNonlinearSolve builds every
solution with `stats === nothing`, so the residual and Jacobian work its solvers do
cannot be attributed to the integrator; nothing is counted for `nf` and `nsolve`, and
`njacs`/`nw` count only the W assemblies performed on this side of the boundary.

Verified on a matrix of three problems (scalar decay, stiff in-place Van der Pol,
singular-mass-matrix Robertson) times three methods (Trapezoid, TRBDF2, FBDF): every
SimpleNonlinearSolve cell crashes on master and succeeds on this branch with worst
error 1.9e-6 at reltol 1e-8, and every already-working cell (NewtonRaphson,
TrustRegion, RobustMultiNewton, FastShortcutNonlinearPolyalg and the rest) produces
byte-for-byte identical trajectories to master.

The new `test/nsa_noinit_tests.jl` passes 102 assertions on this branch; against
master's source it errors out on the exact crash above. Mutation testing was run guard
by guard when this change was first assembled: deleting any of the guards leaves the
suite red, including the tolerance guards, which needed a singular-mass-matrix stage
to discriminate because an easy problem's residual can hit exact zero and terminate
`Success` under `MaxIters` tolerances. The full Core group is 707 passing with no
regressions.

Two upstream findings from the same investigation, filed separately rather than
patched here: `Broyden` and `Klement` diverge on the second solve after `reinit!`
because their update-rule caches never reset the stored previous residual, and
`NonlinearSolveAlg(LevenbergMarquardt())` on the stepped path returns `Success` with a
materially wrong answer on a scalar problem.

## AI Disclosure

Claude assisted with this work.
