### PR TITLE
Publish the nonlinear solver developer interface

### DIFF
--- a/docs/src/devtools/internals/public_api.md
+++ b/docs/src/devtools/internals/public_api.md
@@ -209,6 +209,30 @@ OrdinaryDiffEqCore.resize_nlsolver!
 OrdinaryDiffEqCore.default_nlsolve
 ```
 
+### OrdinaryDiffEqNonlinearSolve driver hooks
+
+These hooks are a version-controlled, developer-only contract for implicit
+solver packages. Cache constructors create an opaque nonlinear solver with
+`build_nlsolver`; step implementations mark stages, drive the solve, classify
+failure, and query optional workspace capabilities through the remaining
+functions. `compute_step!` and `initial_η` are extension points for sibling
+packages that implement an `AbstractNLSolver` subtype. The Anderson helpers are
+shared implementations, but their concrete workspace types and fields remain
+internal.
+
+```@docs
+OrdinaryDiffEqNonlinearSolve.build_nlsolver
+OrdinaryDiffEqNonlinearSolve.nlsolve!
+OrdinaryDiffEqNonlinearSolve.nlsolvefail
+OrdinaryDiffEqNonlinearSolve.markfirststage!
+OrdinaryDiffEqNonlinearSolve.du_alias_or_new
+OrdinaryDiffEqNonlinearSolve.can_smooth_est
+OrdinaryDiffEqNonlinearSolve.compute_step!
+OrdinaryDiffEqNonlinearSolve.initial_η
+OrdinaryDiffEqNonlinearSolve.anderson
+OrdinaryDiffEqNonlinearSolve.anderson!
+```
+
 ## Jacobian / W-matrix / differentiation configuration
 
 Provided by `OrdinaryDiffEqDifferentiation`.

--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.6.1"
+version = "2.7.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
@@ -25,6 +25,7 @@ RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 PreallocationTools = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
+SciMLPublic = "431bcebd-1456-4ced-9d72-93c2757fff0b"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 
 [extras]
@@ -85,6 +86,7 @@ PreallocationTools = "1.1.2"
 DiffEqBase = "7.10"
 SafeTestsets = "0.1.0"
 SciMLOperators = "1.24.4"
+SciMLPublic = "1"
 SparseConnectivityTracer = "1"
 ConstructionBase = "1.5.8"
 

--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -45,12 +45,8 @@ SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
-[sources]
-DiffEqBase = {path = "../DiffEqBase"}
-DiffEqDevTools = {path = "../DiffEqDevTools"}
-
 [compat]
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 CommonSolve = "0.2.6"
 Pkg = "1"
 NonlinearSolve = "4.24"
@@ -92,21 +88,3 @@ ConstructionBase = "1.5.8"
 
 [targets]
 test = ["DiffEqDevTools", "LineSearches", "ODEProblemLibrary", "OrdinaryDiffEqBDF", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "Random", "SafeTestsets", "SparseConnectivityTracer", "StaticArrays", "Statistics", "Test", "Pkg", "SciMLTesting"]
-
-[sources.OrdinaryDiffEqDifferentiation]
-path = "../OrdinaryDiffEqDifferentiation"
-
-[sources.OrdinaryDiffEqCore]
-path = "../OrdinaryDiffEqCore"
-
-[sources.OrdinaryDiffEqBDF]
-path = "../OrdinaryDiffEqBDF"
-
-[sources.OrdinaryDiffEqFIRK]
-path = "../OrdinaryDiffEqFIRK"
-
-[sources.OrdinaryDiffEqRosenbrock]
-path = "../OrdinaryDiffEqRosenbrock"
-
-[sources.OrdinaryDiffEqSDIRK]
-path = "../OrdinaryDiffEqSDIRK"

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
@@ -18,6 +18,7 @@ import ConstructionBase
 import PreallocationTools: DiffCache, get_tmp
 using SimpleNonlinearSolve: SimpleTrustRegion, SimpleGaussNewton
 using NonlinearSolve: FastShortcutNonlinearPolyalg, FastShortcutNLLSPolyalg, NewtonRaphson
+using SciMLPublic: @public
 # The operator Jacobian path is implemented in NonlinearSolveBase and needs its own floor.
 import NonlinearSolveBase
 # `get_u`/`get_fu` are the only inner-state reads that hold for every inner cache type:
@@ -77,18 +78,10 @@ include("initialize_dae.jl")
 
 export BrownFullBasicInit, ShampineCollocationInit
 
-# Nonlinear-solver algorithms accepted by OrdinaryDiffEq implicit methods and the
-# solver-author hooks extended by sibling integrator packages.
-# The `public` keyword is only parseable on Julia >= 1.11.0-DEV.469, so it is
-# gated to keep the 1.10 floor parsing.
-@static if VERSION >= v"1.11.0-DEV.469"
-    eval(
-        Expr(
-            :public,
-            :NLNewton, :NLFunctional, :NLAnderson, :HomotopyNonlinearSolveAlg,
-            :NonlinearSolveAlg
-        )
-    )
-end
+@public NLNewton, NLFunctional, NLAnderson, HomotopyNonlinearSolveAlg, NonlinearSolveAlg
+
+# Solver-author interface called or extended by sibling integrator packages.
+@public build_nlsolver, nlsolve!, nlsolvefail, markfirststage!, du_alias_or_new
+@public can_smooth_est, compute_step!, initial_η, anderson, anderson!
 
 end

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/nlsolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/nlsolve.jl
@@ -15,7 +15,36 @@ function _rejected_trial_step(nlsolver::NLSolver{<:NonlinearSolveAlg}, ndz)
 end
 
 """
-    nlsolve!(nlsolver::AbstractNLSolver, integrator)
+    compute_step!(nlsolver, integrator[, γW]) -> residual_norm
+
+Compute one candidate nonlinear iteration and return its scaled residual or
+increment norm.
+
+# Arguments
+
+  - `nlsolver`: the nonlinear solver whose candidate iterate and workspace are
+    updated.
+  - `integrator`: the differential-equation integrator that supplies the current
+    state, tolerances, right-hand side, and statistics.
+  - `γW`: the current `γ * dt` scaling for Newton-type methods. Fixed-point
+    methods omit this argument.
+
+# Returns
+
+A finite, nonnegative norm when a candidate iteration was computed. Returning a
+non-finite value reports divergence to [`nlsolve!`](@ref). This function mutates
+the candidate iterate and its workspace and may update the integrator's nonlinear
+evaluation statistics. The shared driver calls
+[`OrdinaryDiffEqCore.apply_step!`](@ref) after accepting the candidate.
+
+Solver packages that subtype [`OrdinaryDiffEqCore.AbstractNLSolver`](@ref) extend
+this function to participate in the shared [`nlsolve!`](@ref) convergence loop.
+"""
+function compute_step! end
+
+"""
+    nlsolve!(nlsolver::AbstractNLSolver, integrator, cache = nothing,
+             repeat_step = false)
 
 Solve
 
@@ -23,7 +52,42 @@ Solve
 dt⋅f(innertmp + γ⋅z, p, t + c⋅dt) + outertmp = z
 ```
 
-where `dt` is the step size and `γ` and `c` are constants, and return the solution `z`.
+where `dt` is the step size and `γ` and `c` are stage constants.
+
+# Arguments
+
+  - `nlsolver`: a solver returned by [`build_nlsolver`](@ref), or another
+    [`OrdinaryDiffEqCore.AbstractNLSolver`](@ref) implementation of this driver
+    contract.
+  - `integrator`: the current differential-equation integrator.
+  - `cache`: the owning implicit algorithm's cache. Newton-type solvers require
+    it for `W` updates; fixed-point solvers may leave it as `nothing`.
+  - `repeat_step`: whether this solve is retrying the same integrator step after
+    a rejection.
+
+# Mutation and return value
+
+The solve updates the nonlinear iterate, convergence estimate, status, failure
+counters, and solver workspace. It may update the integrator state while forming
+a new `W`, and its postamble updates integrator statistics and
+`force_stepfail`. The return value is the result of the solver's
+`SciMLBase.postamble!` method; the solvers constructed by [`build_nlsolver`](@ref)
+return the converged stage increment `z`.
+
+# Failure behavior
+
+Non-convergence is recorded in the solver status rather than thrown: inspect it
+with [`nlsolvefail`](@ref). A stale-Jacobian failure is retried once with a fresh
+Jacobian. Calling a Newton-type solver without `cache` throws `ArgumentError`,
+and exceptions raised by residual, Jacobian, or linear-solver evaluations
+propagate.
+
+# Extension contract
+
+Custom nonlinear solvers extend [`compute_step!`](@ref) and [`initial_η`](@ref),
+and provide the `AbstractNLSolver` state queried by the documented
+`OrdinaryDiffEqCore` nonlinear-solver hooks. Candidate acceptance and finalization
+are dispatched through `OrdinaryDiffEqCore.apply_step!` and `SciMLBase.postamble!`.
 
 Whether `innertmp` and `outertmp` is used for the evaluation is controlled by setting `nlsolver.method`.
 In both cases the variable name is actually `nlsolver.tmp`.
@@ -199,7 +263,13 @@ initialize!(::AbstractNLSolver, integrator::SciMLBase.DEIntegrator) = nothing
 
 Return the initial convergence-rate estimate `η` for a fresh nonlinear solve.
 Functional/Anderson solvers reuse the previous `ηold`; the Newton solver method
-derives it from the tolerance. Consumed by [`nlsolve!`](@ref).
+derives it from the tolerance. The return value must be a finite nonnegative
+number compatible with the integrator tolerances.
+
+Solver packages that define an [`OrdinaryDiffEqCore.AbstractNLSolver`](@ref)
+subtype extend this function when their initial estimate differs from the default
+tolerance-based rule. The function does not mutate the solver or integrator and
+is consumed by [`nlsolve!`](@ref).
 """
 function initial_η(nlsolver::NLSolver, integrator)
     return max(nlsolver.ηold, eps(eltype(integrator.opts.reltol)))^(0.8)

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -15,11 +15,23 @@ get_new_W_γdt_cutoff(nlsolver::AbstractNLSolver) = nlsolver.cache.new_W_γdt_cu
 get_new_W_γdt_cutoff(alg::NewtonAlgorithm) = alg.new_W_γdt_cutoff
 
 """
-    nlsolvefail(nlsolver) -> Bool
+    nlsolvefail(nlsolver::AbstractNLSolver) -> Bool
     nlsolvefail(status::NLStatus) -> Bool
 
-Return whether a nonlinear solve failed, i.e. whether the solver's
-[`NLStatus`](@ref) is non-positive (`SlowConvergence` or worse).
+Return whether a nonlinear solve failed.
+
+# Arguments
+
+  - `nlsolver`: a nonlinear solver whose current outcome is stored in its `status`
+    property.
+  - `status`: an [`OrdinaryDiffEqCore.NLStatus`](@ref) to classify directly.
+
+# Returns
+
+`true` for a non-positive status (`SlowConvergence`, `VerySlowConvergence`, or
+`Divergence`) and `false` for `Convergence` or `FastConvergence`. Sibling solver
+packages use this predicate after [`nlsolve!`](@ref) to decide whether to abandon
+the current integrator step.
 """
 nlsolvefail(nlsolver::AbstractNLSolver) = nlsolvefail(get_status(nlsolver))
 nlsolvefail(status::NLStatus) = Int8(status) <= 0
@@ -32,8 +44,16 @@ isnewton(nlsolver::AbstractNLSolver) = isnewton(nlsolver.cache)
 isnewton(::AbstractNLSolverCache) = false
 isnewton(::Union{NLNewtonCache, NLNewtonConstantCache}) = true
 
-# Whether the solver can supply the W linear solve for the SDIRK/ESDIRK `smooth_est` estimate;
-# otherwise the caller falls back to the raw embedded estimate.
+"""
+    can_smooth_est(nlsolver::AbstractNLSolver) -> Bool
+
+Return whether `nlsolver` can reuse its current `W` linear solve for an implicit
+method's smoothed error estimate.
+
+This capability query does not expose the nonlinear solver's cache or
+factorization representation. A solver-author caller must use the ordinary
+embedded estimate when this function returns `false`.
+"""
 can_smooth_est(nlsolver::AbstractNLSolver) = can_smooth_est(nlsolver.cache)
 can_smooth_est(cache::AbstractNLSolverCache) = isnewton(cache)
 can_smooth_est(cache::NonlinearSolveCache) = cache.linsolve !== nothing
@@ -51,13 +71,20 @@ function setfirststage!(nlcache::Union{NLNewtonCache, NLNewtonConstantCache}, va
 end
 setfirststage!(::Any, val::Bool) = nothing
 """
-    markfirststage!(nlsolver)
+    markfirststage!(nlsolver::AbstractNLSolver) -> Nothing
 
-Mark the nonlinear solver as being on the first implicit stage of the current
-step (sets the cache's `firststage` flag to `true`). Used so predictor/`W`-reuse
-logic can distinguish the first stage from later ones.
+Mark `nlsolver` as being on the first implicit stage of the current integrator
+step.
+
+This mutates the solver's stage state when its algorithm tracks one and is a
+no-op otherwise. Predictor and `W`-reuse logic may query the marker through
+[`OrdinaryDiffEqCore.isfirststage`](@ref). The marker is cleared by
+[`nlsolve!`](@ref)'s postamble after a solve.
 """
-markfirststage!(nlsolver::AbstractNLSolver) = setfirststage!(nlsolver, true)
+function markfirststage!(nlsolver::AbstractNLSolver)
+    setfirststage!(nlsolver, true)
+    return nothing
+end
 
 getnfails(_) = 0
 getnfails(nlsolver::AbstractNLSolver) = nlsolver.nfails
@@ -83,10 +110,23 @@ du_cache(::AbstractNLSolverCache) = nothing
 du_cache(nlcache::Union{NLFunctionalCache, NLAndersonCache, NLNewtonCache}) = (nlcache.k,)
 
 """
-    du_alias_or_new(nlsolver, rate_prototype)
+    du_alias_or_new(nlsolver::AbstractNLSolver, rate_prototype)
 
-Return a derivative buffer for the nonlinear solve: reuse the solver cache's
-existing `du` buffer when it has one, otherwise allocate `zero(rate_prototype)`.
+Return a derivative buffer compatible with `rate_prototype`.
+
+# Arguments
+
+  - `nlsolver`: the nonlinear solver that may already own a reusable derivative
+    workspace.
+  - `rate_prototype`: the integrator's derivative prototype and the template for
+    a newly allocated buffer.
+
+# Returns
+
+The solver-owned derivative workspace when one is available; otherwise
+`zero(rate_prototype)`. The returned object is mutable solver workspace when it
+aliases an existing buffer, so callers may use it while constructing their
+integrator cache but must not retain it beyond the nonlinear solver's lifetime.
 """
 function du_alias_or_new(nlsolver::AbstractNLSolver, rate_prototype)
     _du_cache = du_cache(nlsolver)
@@ -309,12 +349,54 @@ end
                    uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits, γ, c, [α,]
                    iip, verbose) -> AbstractNLSolver
 
-Construct the nonlinear solver object (an [`AbstractNLSolver`](@ref)) that an
-implicit algorithm `alg` uses to solve its stage equations. `γ` and `c` are the
-stage's diagonal coefficient and abscissa, `α` an optional scaling, `iip` the
-in-place flag; the nonlinear-solver algorithm defaults to `alg.nlsolve`. Allocates
-the appropriate cache (Newton `W`/factorization, functional/Anderson buffers, …)
-for the chosen `nlalg`.
+Construct the nonlinear solver used by an implicit integrator algorithm.
+
+# Arguments
+
+  - `alg`: the implicit ODE, DAE, or stochastic integrator algorithm that owns
+    the stage equation and differentiation configuration.
+  - `nlalg`: optional nonlinear-solver algorithm. When omitted, `alg.nlsolve` is
+    used.
+  - `u`, `uprev`: current- and previous-state prototypes used to size solver
+    workspaces.
+  - `p`, `t`, `dt`: problem parameters, initial time, and initial step size.
+  - `f`: the ODE or DAE function used by the implicit stage equation.
+  - `rate_prototype`: derivative prototype used to size rate workspaces.
+  - `uEltypeNoUnits`, `uBottomEltypeNoUnits`, `tTypeNoUnits`: unitless scalar
+    types chosen by the integrator cache constructor.
+  - `γ`, `c`: diagonal stage coefficient and stage abscissa.
+  - `α`: optional stage scaling; defaults to `1`.
+  - `iip`: `Val(true)` for an in-place problem and `Val(false)` for an
+    out-of-place problem.
+  - `verbose`: the integrator's differential-equation verbosity configuration.
+
+# Returns
+
+An [`OrdinaryDiffEqCore.AbstractNLSolver`](@ref). Its concrete type and cache are
+implementation details; solver packages should retain the returned object and
+operate on it through the documented nonlinear-solver interfaces. The factory
+may retain aliases to the supplied prototypes as solver-owned workspace.
+
+# Failure behavior
+
+Unsupported nonlinear-solver algorithms fail by dispatch. A homotopy nonlinear
+solver requested for a DAE throws `ArgumentError`; failures from Jacobian,
+linear-solver, or inner nonlinear-solver initialization propagate to the caller.
+
+# Solver-author usage
+
+Implicit algorithm cache constructors call this factory once with their real
+algorithm and problem prototypes, then pass the returned object to
+[`nlsolve!`](@ref) for each stage. For example, a DIRK cache constructor uses the
+form
+
+```julia
+nlsolver = build_nlsolver(
+    alg, u, uprev, p, t, dt, f, rate_prototype,
+    uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits,
+    gamma, stage_abscissa, iip, verbose
+)
+```
 """
 function build_nlsolver(
         alg, u, uprev, p, t, dt, f::F, rate_prototype,
@@ -754,10 +836,18 @@ end
 ## Anderson acceleration
 
 """
-    anderson(z, cache)
+    anderson(z, cache) -> accelerated_z
 
-Return the next iterate of the fixed-point iteration `z = g(z)` by performing Anderson
-acceleration based on the current iterate `z` and the settings and history in the `cache`.
+Return an Anderson-accelerated iterate for the fixed-point iteration `z = g(z)`.
+
+`z` is the current iterate and `cache` is the Anderson workspace initialized by
+the calling nonlinear solver. The function updates the workspace's iteration
+history but returns the accelerated state rather than mutating `z`. Solver
+packages that reuse this helper own the workspace's construction and lifetime;
+no concrete Anderson cache type is part of this API.
+
+Linear-algebra failures while updating or solving the history least-squares
+system propagate to the caller.
 """
 @muladd function anderson(z, cache)
     (; dz, Δz₊s, z₊old, dzold, R, Q, γs, history, droptol) = cache
@@ -820,10 +910,15 @@ acceleration based on the current iterate `z` and the settings and history in th
 end
 
 """
-    anderson!(z, cache)
+    anderson!(z, cache) -> Nothing
 
-Update the current iterate `z` of the fixed-point iteration `z = g(z)` in-place
-by performing Anderson acceleration based on the settings and history in the `cache`.
+Update the current iterate `z` of the fixed-point iteration `z = g(z)` in place
+using Anderson acceleration.
+
+`cache` is the Anderson workspace initialized by the calling nonlinear solver.
+Both `z` and the workspace history are mutated. Solver packages that reuse this
+helper own the workspace's construction and lifetime; no concrete Anderson cache
+type is part of this API. Linear-algebra failures propagate to the caller.
 """
 @muladd function anderson!(z, cache)
     (; dz, z₊old, dzold, Δz₊s, γs, R, Q, history, droptol) = cache

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/developer_api_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/developer_api_tests.jl
@@ -1,0 +1,99 @@
+module ExternalNonlinearSolverClient
+
+    using CommonSolve: init, step!
+    using DiffEqBase: DEVerbosity
+    using OrdinaryDiffEqCore:
+        AbstractNLSolver, Convergence, Divergence, FastConvergence, SlowConvergence,
+        VerySlowConvergence, isfirststage
+    using OrdinaryDiffEqNonlinearSolve:
+        NLAnderson, NLFunctional, NLNewton, anderson, anderson!, build_nlsolver,
+        can_smooth_est, compute_step!, du_alias_or_new, initial_η, markfirststage!,
+        nlsolve!, nlsolvefail
+    using OrdinaryDiffEqSDIRK: ImplicitEuler
+    using SciMLBase: ODEProblem
+
+    function build_solver(prob, nlalg, iip; dt = 0.1)
+        alg = ImplicitEuler(nlsolve = nlalg)
+        u = copy(prob.u0)
+        return build_nlsolver(
+            alg, u, copy(u), prob.p, first(prob.tspan), dt, prob.f, zero(u),
+            Float64, Float64, Float64, 1.0, 1.0, iip, DEVerbosity()
+        )
+    end
+
+    function solve_stage(prob, nlalg, iip; dt = 0.1)
+        alg = ImplicitEuler(nlsolve = nlalg)
+        integrator = init(prob, alg; dt, adaptive = false)
+        nlsolver = build_solver(prob, nlalg, iip; dt)
+        initial_rate = initial_η(nlsolver, integrator)
+        z = nlsolve!(nlsolver, integrator)
+        return (; nlsolver, z, initial_rate)
+    end
+
+    function solve_integrator_step(prob, nlalg; dt = 0.1)
+        integrator = init(prob, ImplicitEuler(nlsolve = nlalg); dt, adaptive = false)
+        step!(integrator)
+        return integrator.u
+    end
+
+end
+
+using .ExternalNonlinearSolverClient
+using Test
+
+const ExternalClient = ExternalNonlinearSolverClient
+
+@testset "Developer nonlinear-solver API" begin
+    oop_prob = ExternalClient.ODEProblem((u, p, t) -> -u, 1.0, (0.0, 1.0))
+    iip_prob = ExternalClient.ODEProblem(
+        (du, u, p, t) -> (du .= -u), [1.0], (0.0, 1.0)
+    )
+
+    functional = ExternalClient.build_solver(
+        iip_prob, ExternalClient.NLFunctional(), Val(true)
+    )
+    @test functional isa ExternalClient.AbstractNLSolver
+    @test !ExternalClient.can_smooth_est(functional)
+    @test ExternalClient.markfirststage!(functional) === nothing
+
+    du = ExternalClient.du_alias_or_new(functional, zeros(1))
+    du_again = ExternalClient.du_alias_or_new(functional, zeros(1))
+    @test du === du_again
+    du[1] = 2.0
+    @test ExternalClient.du_alias_or_new(functional, zeros(1)) == [2.0]
+
+    newton = ExternalClient.build_solver(iip_prob, ExternalClient.NLNewton(), Val(true))
+    @test ExternalClient.can_smooth_est(newton)
+    @test ExternalClient.markfirststage!(newton) === nothing
+    @test ExternalClient.isfirststage(newton)
+
+    @test !ExternalClient.nlsolvefail(ExternalClient.FastConvergence)
+    @test !ExternalClient.nlsolvefail(ExternalClient.Convergence)
+    @test ExternalClient.nlsolvefail(ExternalClient.SlowConvergence)
+    @test ExternalClient.nlsolvefail(ExternalClient.VerySlowConvergence)
+    @test ExternalClient.nlsolvefail(ExternalClient.Divergence)
+
+    alg = ExternalClient.NLFunctional(κ = 1.0e-10, max_iter = 20)
+    integrator = ExternalClient.init(
+        oop_prob, ExternalClient.ImplicitEuler(nlsolve = alg); dt = 0.1,
+        adaptive = false
+    )
+    single_step_solver = ExternalClient.build_solver(oop_prob, alg, Val(false))
+    @test ExternalClient.initial_η(single_step_solver, integrator) >= 0
+    @test isfinite(ExternalClient.compute_step!(single_step_solver, integrator))
+
+    oop_result = ExternalClient.solve_stage(oop_prob, alg, Val(false))
+    @test !ExternalClient.nlsolvefail(oop_result.nlsolver)
+    @test oop_result.initial_rate >= 0
+    @test oop_result.z ≈ -1 / 11 atol = 1.0e-10
+
+    anderson_alg = ExternalClient.NLAnderson(
+        κ = 1.0e-10, max_iter = 20, max_history = 3, aa_start = 1
+    )
+    oop_anderson = ExternalClient.solve_stage(oop_prob, anderson_alg, Val(false))
+    @test !ExternalClient.nlsolvefail(oop_anderson.nlsolver)
+    @test oop_anderson.z ≈ -1 / 11 atol = 1.0e-10
+
+    @test ExternalClient.solve_integrator_step(iip_prob, anderson_alg) ≈ [10 / 11] atol =
+        1.0e-10
+end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit/Project.toml
@@ -13,13 +13,6 @@ OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-ImplicitDiscreteSolve = {path = "../../../ImplicitDiscreteSolve"}
-OrdinaryDiffEq = {path = "../../../.."}
-OrdinaryDiffEqBDF = {path = "../../../OrdinaryDiffEqBDF"}
-OrdinaryDiffEqRosenbrock = {path = "../../../OrdinaryDiffEqRosenbrock"}
-OrdinaryDiffEqSDIRK = {path = "../../../OrdinaryDiffEqSDIRK"}
-
 [compat]
 DiffEqDevTools = "3"
 ImplicitDiscreteSolve = "2"

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/qa/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/qa/Project.toml
@@ -10,15 +10,6 @@ OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources.OrdinaryDiffEqCore]
-path = "../../../OrdinaryDiffEqCore"
-
-[sources.OrdinaryDiffEqBDF]
-path = "../../../OrdinaryDiffEqBDF"
-
-[sources.OrdinaryDiffEqRosenbrock]
-path = "../../../OrdinaryDiffEqRosenbrock"
-
 [compat]
 ADTypes = "1.16"
 Aqua = "0.8.11"
@@ -27,5 +18,5 @@ OrdinaryDiffEqBDF = "2"
 OrdinaryDiffEqCore = "4"
 OrdinaryDiffEqNonlinearSolve = "2"
 OrdinaryDiffEqRosenbrock = "2"
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 julia = "1.10"

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/qa/qa.jl
@@ -2,10 +2,18 @@ using SciMLTesting, OrdinaryDiffEqNonlinearSolve, Test
 using Aqua
 
 @static if VERSION >= v"1.11.0-DEV.469"
-    for name in (:NLNewton, :NLFunctional, :NLAnderson, :NonlinearSolveAlg, :HomotopyNonlinearSolveAlg)
+    for name in (
+            :NLNewton, :NLFunctional, :NLAnderson, :NonlinearSolveAlg,
+            :HomotopyNonlinearSolveAlg, :build_nlsolver, :nlsolve!, :nlsolvefail,
+            :markfirststage!, :du_alias_or_new, :can_smooth_est, :compute_step!,
+            :initial_η, :anderson, :anderson!,
+        )
         @test Base.ispublic(OrdinaryDiffEqNonlinearSolve, name)
     end
-    for name in (:anderson, :anderson!, :compute_step!, :initial_η, :nlsolve!, :nlsolvefail)
+    for name in (
+            :NLSolver, :NLFunctionalCache, :NLAndersonCache, :NLNewtonCache,
+            :NonlinearSolveCache, :HomotopyNonlinearSolveCache,
+        )
         @test !Base.ispublic(OrdinaryDiffEqNonlinearSolve, name)
     end
 end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/qa/qa.jl
@@ -28,7 +28,6 @@ run_qa(
     # `using OrdinaryDiffEq` keeps surfacing them unqualified.
     reexports_allow = (:BrownFullBasicInit, :ShampineCollocationInit),
     aqua_kwargs = (; piracies = false, ambiguities = false),
-    explicit_imports = true,
     ei_kwargs = (;
         # Imported into this namespace for dependent sublibraries; ExplicitImports
         # cannot see that cross-package use and reports them as stale.

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
@@ -20,7 +20,16 @@ function activate_modelingtoolkit_env()
 end
 
 function activate_qa_env()
-    return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])
+    lib_dir = dirname(dirname(@__DIR__))
+    return activate_group_env(
+        joinpath(@__DIR__, "qa");
+        parent = [
+            dirname(@__DIR__),
+            joinpath(lib_dir, "OrdinaryDiffEqCore"),
+            joinpath(lib_dir, "OrdinaryDiffEqBDF"),
+            joinpath(lib_dir, "OrdinaryDiffEqRosenbrock"),
+        ],
+    )
 end
 
 # Run functional tests

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
@@ -25,6 +25,7 @@ end
 
 # Run functional tests
 if TEST_GROUP ∉ ("QA", "ModelingToolkit")
+    @time @safetestset "Developer API Tests" include("developer_api_tests.jl")
     @time @safetestset "Newton Tests" include("newton_tests.jl")
     @time @safetestset "Sparse DAE Initialization" include("sparse_dae_initialization_tests.jl")
     @time @safetestset "Linear Nonlinear Solver Tests" include("linear_nonlinear_tests.jl")


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- declare the five user-facing nonlinear solver algorithms as public without exporting them
- declare the cross-solver nonlinear driver hooks as developer public API while keeping `NLSolver` and all concrete cache types private
- add detailed definition-site docstrings, render the hooks on the warned developer API page, and exercise the contract from an external client module
- require SciMLTesting 2.4+, remove committed source-path metadata, and use the standard temporary QA activation flow for local monorepo siblings

This is a minor release of `OrdinaryDiffEqNonlinearSolve` because it adds documented public API.

## Validation

- Julia release, `GROUP=QA Pkg.test()`: JET 13 passed / 33 pre-existing broken; Aqua 41/41; package tests passed
- Julia 1.10, core suite: package tests passed, including developer API 21/21
- Julia 1.10, `GROUP=QA Pkg.test()`: 5 passed / 8 failed / 33 broken in the existing JET type-stability group; the eight failures reproduce without algorithm or JET-test changes and are being bisected separately rather than weakened here
- release core suite reached and passed the new developer API tests, then hit the separately reproduced clean-master `njacs` assertion in `linear_solver_tests.jl`
- Runic `--check .`: passed

The root docs build still encounters the existing `DummyControllerCache` cross-reference backlog; all new `OrdinaryDiffEqNonlinearSolve` `@docs` bindings resolve.