### PR TITLE
NonlinearSolveAlg: let the residual veto a stalled inner step

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -33,6 +33,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
+LineSearch = "87fe0de2-c867-4266-b59a-2f0a94fc965b"
 LineSearches = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
 OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
@@ -58,6 +59,7 @@ Random = "<0.0.1, 1"
 DiffEqDevTools = "3"
 MuladdMacro = "0.2.4"
 LinearSolve = "5.2"
+LineSearch = "0.1.7"
 LineSearches = "7.5.1"
 LinearAlgebra = "1.10"
 OrdinaryDiffEqDifferentiation = "3.6"
@@ -87,4 +89,4 @@ SparseConnectivityTracer = "1"
 ConstructionBase = "1.5.8"
 
 [targets]
-test = ["DiffEqDevTools", "LineSearches", "ODEProblemLibrary", "OrdinaryDiffEqBDF", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "Random", "SafeTestsets", "SparseConnectivityTracer", "StaticArrays", "Statistics", "Test", "Pkg", "SciMLTesting"]
+test = ["DiffEqDevTools", "LineSearch", "LineSearches", "ODEProblemLibrary", "OrdinaryDiffEqBDF", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "Random", "SafeTestsets", "SparseConnectivityTracer", "StaticArrays", "Statistics", "Test", "Pkg", "SciMLTesting"]

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -269,6 +269,92 @@ function rescale_stale_W_rhs!(nlcache, nlsolver, integrator, nlstep_data)
     return nothing
 end
 
+"""
+    inner_solve_failed(nlcache) -> Bool
+
+Whether the inner `NonlinearSolve` cache has stopped for a reason other than reaching its
+root. Stopping *successfully* is the normal path — the inner solve converged before the
+integrator's own weighted test was satisfied — while every other terminal state (a collapsed
+line search, an exhausted trust region, a stalled iteration) is a failure that must reach the
+step controller the way `NLNewton` reports a failed linear solve. A stopped cache also makes
+`step!` a no-op, so left unreported it would leave `ndz == 0` for the outer test to read as a
+perfect solve.
+"""
+function inner_solve_failed(nlcache)
+    return !NonlinearSolveBase.not_terminated(nlcache) &&
+        !SciMLBase.successful_retcode(nlcache.retcode)
+end
+
+"""
+    stage_unsolved(nlcache, γΔt) -> Bool
+
+Whether the residual still says the stage equation is unsolved. `γΔt · fu` carries the units
+of the iterate `u` it corrects, so `‖γΔt·fu‖ / max(‖u‖, ‖u + γΔt·fu‖)` is the relative residual
+of the stage equation — invariant to the problem's units, and independent of the inner solver's
+own tolerances, which `build_nlsolver` deliberately zeroes. At the cancellation floor of that
+subtraction there is nothing left to solve.
+"""
+function stage_unsolved(nlcache, γΔt)
+    fu = get_fu(nlcache)
+    u = get_u(nlcache)
+    resid = abs(γΔt) * maxabs(fu)
+    scale = max(maxabs_axpy(γΔt, u, fu), maxabs(u))
+    return resid > roundoff_level(typeof(resid)) * scale
+end
+
+# A step that moves the iterate by no more than a handful of ulps, and a residual that small
+# relative to the terms it is the difference of, are both indistinguishable from zero in the
+# arithmetic that produced them.
+@inline roundoff_level(::Type{T}) where {T} = 8 * eps(real(one(T)))
+
+maxabs(x::Number) = abs(x)
+maxabs(x) = maximum(abs, x)
+
+function maxabs_axpy(a, x, y)
+    m = abs(a * zero(eltype(y)) + zero(eltype(x)))
+    for (xi, yi) in zip(x, y)
+        m = max(m, abs(xi + a * yi))
+    end
+    return m
+end
+maxabs_axpy(a, x::Number, y::Number) = abs(x + a * y)
+
+"""
+    stalled_inner_step(nlcache, ndisp, nz, fnorm_prev, γΔt) -> Bool
+
+Whether the `step!` just taken produced no usable iterate: it moved the iterate by less than
+floating-point roundoff *and* failed to reduce the residual, while the residual itself says the
+stage equation is not yet solved.
+
+The outer convergence test reads a small displacement as proximity to the root. That inference
+is only sound for a step that solves the Newton system, where the displacement is `W⁻¹F` and so
+vanishes only with the residual. A globalized inner solver whose line search collapses instead
+returns a displacement orders of magnitude below roundoff with the residual bit-for-bit
+unchanged: `ndz` is then tiny for a reason that has nothing to do with the distance to the root.
+
+The residual has the last word. `γΔt · fu` carries the units of the iterate `u` it corrects, so
+`‖γΔt·fu‖ / max(‖u‖, ‖u + γΔt·fu‖)` is the relative residual of the stage equation — invariant
+to the problem's units, and independent of the inner solver's own tolerances, which
+`build_nlsolver` deliberately zeroes. Only when it sits at the cancellation floor of that
+subtraction is a motionless iterate genuine convergence rather than a stalled step.
+
+`ndisp` and `nz` are `‖u - u_before‖_∞` and `‖u_before‖_∞`, and `fnorm_prev` is `‖fu‖_∞` as it
+stood before the step.
+"""
+function stalled_inner_step(nlcache, ndisp, nz, fnorm_prev, γΔt)
+    ndisp > roundoff_level(typeof(ndisp)) * nz && return false
+    maxabs(get_fu(nlcache)) < fnorm_prev && return false
+    return stage_unsolved(nlcache, γΔt)
+end
+
+# Scale that carries the inner residual into the units of `z`: the stage equation is
+# `F(z) = 0` with `∂F/∂z = -W`, and `W` is assembled at this `γΔt` (see `initialize!`).
+function residual_to_z_scale(nlsolver, isdae)
+    (; α, cache, method) = nlsolver
+    return (isdae || method === COEFFICIENT_MULTISTEP) ? inv(α * cache.invγdt) :
+        inv(cache.invγdt)
+end
+
 ## compute_step!
 
 @muladd function compute_step!(nlsolver::NLSolver{<:NonlinearSolveAlg, false}, integrator)
@@ -283,25 +369,32 @@ end
         # trustworthy record of it (`get_u` on the cache still reads the *initial* iterate,
         # and `.stats`/`get_fu` do not exist). Each outer iteration therefore costs one full
         # inner solve; an unsuccessful one is a genuine failure and reaches the step
-        # controller the way `NLNewton` reports a failed linear solve.
+        # controller the way `NLNewton` reports a failed linear solve. A complete solve
+        # leaves no half-taken step behind, so there is nothing for the residual to veto.
         innersol = solve!(nlcache)
         if !SciMLBase.successful_retcode(innersol.retcode)
             return convert(eltype(z), Inf)
         end
         active_u = innersol.u
+        cache.stalled = false
     else
         recompute_jacobian = nlsolver.iter == 1 && (cache.W === nothing || cache.new_W)
-        # A terminated inner cache makes `step!` a no-op, which would leave `ndz == 0` and read to
-        # the outer convergence test as a perfect solve. Terminating *successfully* is the normal
-        # path (the inner solve converged before the integrator's own test was satisfied); any
-        # other terminal state is a genuine failure and must reach the step controller, so report
-        # it the way `NLNewton` reports a failed linear solve.
-        if !NonlinearSolveBase.not_terminated(nlcache) &&
-                !SciMLBase.successful_retcode(nlcache.retcode)
-            return convert(eltype(z), Inf)
-        end
+        inner_solve_failed(nlcache) && return convert(eltype(z), Inf)
+        fnorm_prev = maxabs(get_fu(nlcache))
+        γΔt = residual_to_z_scale(nlsolver, nlsolve_f(integrator) isa DAEFunction)
         step!(nlcache; recompute_jacobian)
+        # `step!` can *land* in a terminal state as well as start in one. Checking only on
+        # entry defers a failed step to the next call, which never comes: the iterate it
+        # leaves behind is unmoved, so the outer displacement test accepts the stage first.
+        # An inner solver can also give up *because* there is nothing left to correct — a
+        # line search collapses on a stage that is already solved — so the residual, not the
+        # retcode alone, has the say.
+        inner_solve_failed(nlcache) && stage_unsolved(nlcache, γΔt) &&
+            return convert(eltype(z), Inf)
         active_u = get_u(nlcache)
+        cache.stalled = stalled_inner_step(
+            nlcache, maxabs(z .- active_u), maxabs(z), fnorm_prev, γΔt
+        )
     end
     nlsolver.ztmp = active_u
 
@@ -334,24 +427,31 @@ end
         # inner solve; an unsuccessful one is a genuine failure and reaches the step
         # controller the way `NLNewton` reports a failed linear solve. No stale-`W` rescale
         # either: the reused `W` only serves as the inner Newton's Jacobian (`WReuseJac`),
-        # where staleness costs convergence rate, not the root the full solve lands on.
+        # where staleness costs convergence rate, not the root the full solve lands on. A
+        # complete solve leaves no half-taken step behind, so nothing for the residual to veto.
         innersol = solve!(nlcache)
         if !SciMLBase.successful_retcode(innersol.retcode)
             return convert(eltype(atmp), Inf)
         end
+        cache.stalled = false
     else
         recompute_jacobian = nlsolver.iter == 1 && (cache.W === nothing || cache.new_W)
-        # A terminated inner cache makes `step!` a no-op, which would leave `ndz == 0` and read to
-        # the outer convergence test as a perfect solve. Terminating *successfully* is the normal
-        # path (the inner solve converged before the integrator's own test was satisfied); any
-        # other terminal state is a genuine failure and must reach the step controller, so report
-        # it the way `NLNewton` reports a failed linear solve.
-        if !NonlinearSolveBase.not_terminated(nlcache) &&
-                !SciMLBase.successful_retcode(nlcache.retcode)
-            return convert(eltype(atmp), Inf)
-        end
+        inner_solve_failed(nlcache) && return convert(eltype(atmp), Inf)
+        # Read before `rescale_stale_W_rhs!`, which rewrites `fu` in place: the unscaled
+        # residual is the one `step!` will produce again, so it is the like-for-like
+        # comparison.
+        fnorm_prev = maxabs(get_fu(nlcache))
+        γΔt = residual_to_z_scale(nlsolver, nlsolve_f(integrator) isa DAEFunction)
         rescale_stale_W_rhs!(nlcache, nlsolver, integrator, nlstep_data)
         step!(nlcache; recompute_jacobian)
+        # `step!` can *land* in a terminal state as well as start in one. Checking only on
+        # entry defers a failed step to the next call, which never comes: the iterate it
+        # leaves behind is unmoved, so the outer displacement test accepts the stage first.
+        # An inner solver can also give up *because* there is nothing left to correct — a
+        # line search collapses on a stage that is already solved — so the residual, not the
+        # retcode alone, has the say.
+        inner_solve_failed(nlcache) && stage_unsolved(nlcache, γΔt) &&
+            return convert(eltype(atmp), Inf)
     end
 
     if nlstep_data !== nothing
@@ -387,11 +487,19 @@ end
         # (e.g. `ODE_DEFAULT_NORM` divides by `length`), causing the Newton
         # convergence check to declare success ~sqrt(n_full/n_sub) early.
         ndz = opts.internalnorm(atmp_sub, t)
+        # This branch already measures the residual rather than a displacement, so there is
+        # no displacement to be misled by.
+        cache.stalled = false
     else
         active_u = nlcache isa NonlinearSolveNoInitCache ? innersol.u : get_u(nlcache)
         @.. broadcast = false ztmp = active_u
         ustep = compute_ustep!(ustep, tmp, γ, z, method)
         @.. broadcast = false atmp = z - ztmp
+        if !(nlcache isa NonlinearSolveNoInitCache)
+            cache.stalled = stalled_inner_step(
+                nlcache, maxabs(atmp), maxabs(z), fnorm_prev, γΔt
+            )
+        end
         calculate_residuals!(
             atmp, atmp, uprev, ustep, opts.abstol, opts.reltol,
             opts.internalnorm, t

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/nlsolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/nlsolve.jl
@@ -1,22 +1,25 @@
 @inline eps_around_one(θ::T) where {T} = 100sqrt(eps(one(θ)))
 
-# A globalized inner solver (TrustRegion and friends) can reject its trial step: `step!`
-# returns with the iterate exactly unmoved and the cache not terminated, having only shrunk
-# its trust region for the next attempt. The zero displacement such a `step!` leaves behind
-# is not convergence evidence — the convergence tests below would read it as a perfect solve
-# (`ndz < 1e-5` on the first iteration, `η·ndz = 0 < κ` on later ones) and accept the stage
-# with no correction applied (#3817). A cache that instead *terminated* at zero displacement
-# either converged exactly (which genuinely is convergence) or failed, and failures were
-# already turned into `Inf` by `compute_step!`, so termination is the discriminator between
-# "already at the root" and "has not decided anything yet".
-_rejected_trial_step(nlsolver, ndz) = false
-function _rejected_trial_step(nlsolver::NLSolver{<:NonlinearSolveAlg}, ndz)
+# A globalized inner solver can return from `step!` with the iterate all but unmoved: a
+# TrustRegion that rejected its trial step and only shrank its radius (#3817), a line search
+# that collapsed to a near-zero step length. The convergence tests below would read that
+# displacement as a perfect solve (`ndz < 1e-5` on the first iteration, `η·ndz ≈ 0 < κ` on
+# later ones) and accept the stage with no correction applied.
+#
+# Two disjoint symptoms. An exactly unmoved iterate from a cache that has not terminated has
+# decided nothing yet (a cache that terminated at zero displacement either reached the root
+# exactly or failed, and `compute_step!` turns failures into `Inf`). A displacement that is
+# merely below roundoff is not self-evidently either, so `compute_step!` puts the question to
+# the residual — see `stalled_inner_step`.
+_uninformative_step(nlsolver, ndz) = false
+function _uninformative_step(nlsolver::NLSolver{<:NonlinearSolveAlg}, ndz)
     nlcache = nlsolver.cache.cache
     # A no-init cache is `solve!`-driven, so it has no trial-step state to reject (and no
     # `force_stop`/`nsteps` for `not_terminated` to read): a zero `ndz` there means a
     # complete inner solve returned the iterate unchanged, which is genuine convergence.
     nlcache isa NonlinearSolveNoInitCache && return false
-    return iszero(ndz) && NonlinearSolveBase.not_terminated(nlcache)
+    return (iszero(ndz) && NonlinearSolveBase.not_terminated(nlcache)) ||
+        nlsolver.cache.stalled
 end
 
 """
@@ -153,15 +156,15 @@ function nlsolve!(
             break
         end
 
-        if _rejected_trial_step(nlsolver, ndz)
+        if _uninformative_step(nlsolver, ndz)
             @SciMLMessage(
-                lazy"Inner nonlinear solver rejected its trial step (iter = $(iter)); the unmoved iterate is not treated as convergence",
+                lazy"Inner nonlinear solver made no progress (iter = $(iter)); the unmoved iterate is not treated as convergence",
                 integrator.opts.verbose, :newton_convergence
             )
             # No new iterate exists to judge: skip the convergence and divergence
-            # bookkeeping (a zero `ndz` would also poison the next iteration's `θ`)
-            # and let the inner solver retry with its shrunken trust region. If it
-            # never moves, the loop runs out and the step fails as unconverged.
+            # bookkeeping (a near-zero `ndz` would also poison the next iteration's
+            # `θ`) and let the inner solver retry with its shrunken trust region. If
+            # it never moves, the loop runs out and the step fails as unconverged.
             ndz = ndzprev
             continue
         end

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
@@ -595,6 +595,8 @@ mutable struct NonlinearSolveCache{uType, tType, rateType, tType2, P, C, JType, 
     linsolve::lsType
     W_γdt::tType
     new_W::Bool
+    # Whether the last `step!` produced no usable iterate (see `stalled_inner_step`).
+    stalled::Bool
     # Stage-coordinate adapters around the algorithm's `precondition`/`postcondition`
     # (see `StageConditioner`). `precondition` is composed into the inner problem's
     # residual by `init` and only kept here so the resize path can re-compose it;

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -868,7 +868,7 @@ function build_nlsolver(
                 weight,
                 use_w_reuse ? dz : nothing,
                 est_linsolve,
-                zero(tstep), true, precondition, postcondition
+                zero(tstep), true, false, precondition, postcondition
             )
         else
             du = isdae ? k : nothing # k will be overwritten at solve time, but has the right type.
@@ -1063,7 +1063,7 @@ function build_nlsolver(
             nlcache = NonlinearSolveCache(
                 nothing, tstep, nothing, nothing, invγdt, prob, cache,
                 nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing,
-                zero(tstep), true, precondition, postcondition
+                zero(tstep), true, false, precondition, postcondition
             )
         else
             # Build separated DAE Jacobian cache if applicable

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_noinit_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_noinit_tests.jl
@@ -144,8 +144,8 @@ end
     @test nls.cache.cache isa NonlinearSolveBase.NonlinearSolveNoInitCache
     # A no-init cache has no trial-step state to reject: a zero displacement after a
     # complete `solve!` is genuine convergence, and `not_terminated` has nothing to read.
-    @test !OrdinaryDiffEqNonlinearSolve._rejected_trial_step(nls, 0.0)
-    @test !OrdinaryDiffEqNonlinearSolve._rejected_trial_step(nls, 1.0)
+    @test !OrdinaryDiffEqNonlinearSolve._uninformative_step(nls, 0.0)
+    @test !OrdinaryDiffEqNonlinearSolve._uninformative_step(nls, 1.0)
     # The stepped path keeps its #3817 discrimination untouched.
     integ_nr = init(
         prob_vdp, TRBDF2(nlsolve = NonlinearSolveAlg(NewtonRaphson()));
@@ -153,9 +153,9 @@ end
     )
     step!(integ_nr)
     nls_nr = integ_nr.cache.nlsolver
-    @test OrdinaryDiffEqNonlinearSolve._rejected_trial_step(nls_nr, 0.0) ==
-        NonlinearSolveBase.not_terminated(nls_nr.cache.cache)
-    @test !OrdinaryDiffEqNonlinearSolve._rejected_trial_step(nls_nr, 1.0)
+    @test OrdinaryDiffEqNonlinearSolve._uninformative_step(nls_nr, 0.0) ==
+        (NonlinearSolveBase.not_terminated(nls_nr.cache.cache) || nls_nr.cache.stalled)
+    @test !OrdinaryDiffEqNonlinearSolve._uninformative_step(nls_nr, 1.0)
     sol = solve(
         prob_vdp, TRBDF2(nlsolve = NonlinearSolveAlg(SimpleTrustRegion()));
         reltol = 1.0e-8, abstol = 1.0e-10

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_residual_convergence_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_residual_convergence_tests.jl
@@ -1,0 +1,82 @@
+using OrdinaryDiffEqBDF, OrdinaryDiffEqSDIRK, OrdinaryDiffEqRosenbrock
+using OrdinaryDiffEqNonlinearSolve
+using OrdinaryDiffEqNonlinearSolve: NonlinearSolveAlg
+using NonlinearSolve: DFSane, NewtonRaphson, Broyden
+using LineSearch: BackTracking
+using ADTypes, LinearAlgebra, SciMLBase
+using Test
+
+# The outer convergence test used to infer "close to the root" from the displacement the inner
+# solver produced, and never from the residual. That inference is only sound for a step that
+# solves the Newton system, where the displacement is `W⁻¹F`. An inner solver whose line search
+# collapses leaves the iterate unmoved — either stopping the cache with a failure retcode that
+# `compute_step!` only looked for on *entry*, or returning a step orders of magnitude below
+# roundoff with the residual bit-for-bit unchanged. Either way `ndz` is tiny for a reason that
+# has nothing to do with the distance to the root, `iter == 1 && ndz < 1e-5` fires, and the
+# stage is accepted unconverged.
+#
+# `DFSane` and a back-tracking `Broyden` genuinely cannot solve these stages. The property
+# under test is only that the failure reaches the step controller instead of being dressed up
+# as a converged solve: on unfixed code ROBER + FBDF + DFSane runs 21 accepted steps and
+# returns the initial condition with `ReturnCode.Success`.
+
+function rober!(du, u, p, t)
+    y1, y2, y3 = u
+    k1, k2, k3 = p
+    du[1] = -k1 * y1 + k3 * y2 * y3
+    du[2] = k1 * y1 - k2 * y2^2 - k3 * y2 * y3
+    du[3] = k2 * y2^2
+    return nothing
+end
+const rober_prob = ODEProblem(
+    rober!, [1.0, 0.0, 0.0], (0.0, 1.0e5), (0.04, 3.0e7, 1.0e4)
+)
+
+function hires!(du, u, p, t)
+    y1, y2, y3, y4, y5, y6, y7, y8 = u
+    du[1] = -1.71y1 + 0.43y2 + 8.32y3 + 0.0007
+    du[2] = 1.71y1 - 8.75y2
+    du[3] = -10.03y3 + 0.43y4 + 0.035y5
+    du[4] = 8.32y2 + 1.71y3 - 1.12y4
+    du[5] = -1.745y5 + 0.43y6 + 0.43y7
+    du[6] = -280.0y6 * y8 + 0.69y4 + 1.71y5 - 0.43y6 + 0.69y7
+    du[7] = 280.0y6 * y8 - 1.81y7
+    du[8] = -280.0y6 * y8 + 1.81y7
+    return nothing
+end
+const hires_prob = ODEProblem(
+    hires!, [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0057], (0.0, 321.8122)
+)
+
+reference(prob) = solve(prob, Rodas5P(); reltol = 1.0e-13, abstol = 1.0e-15).u[end]
+relerr(sol, ref) = norm(sol.u[end] .- ref) / norm(ref)
+
+@testset "an unconverged stage is never reported as a successful solve" begin
+    for (prob, ODEAlg, inner) in (
+            (rober_prob, FBDF, () -> DFSane()),
+            (rober_prob, KenCarp4, () -> DFSane()),
+            (hires_prob, FBDF, () -> DFSane()),
+            (hires_prob, FBDF, () -> Broyden(; linesearch = BackTracking())),
+            (hires_prob, KenCarp4, () -> Broyden(; linesearch = BackTracking())),
+        )
+        ref = reference(prob)
+        sol = solve(
+            prob, ODEAlg(nlsolve = NonlinearSolveAlg(inner()));
+            reltol = 1.0e-6, abstol = 1.0e-9, maxiters = 10^5
+        )
+        @test !SciMLBase.successful_retcode(sol) || relerr(sol, ref) < 1.0e-3
+    end
+end
+
+@testset "a solvable stage still converges" begin
+    for prob in (rober_prob, hires_prob), ODEAlg in (FBDF, KenCarp4)
+        ref = reference(prob)
+        sol = solve(
+            prob,
+            ODEAlg(nlsolve = NonlinearSolveAlg(NewtonRaphson(; autodiff = AutoForwardDiff())));
+            reltol = 1.0e-6, abstol = 1.0e-9
+        )
+        @test SciMLBase.successful_retcode(sol)
+        @test relerr(sol, ref) < 1.0e-4
+    end
+end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
@@ -55,6 +55,7 @@ if TEST_GROUP ∉ ("QA", "ModelingToolkit")
     @time @safetestset "NonlinearSolveAlg Polyalgorithm Inner Solver Tests" include("nsa_polyalg_tests.jl")
     @time @safetestset "NonlinearSolveAlg No-Init Inner Solver Tests" include("nsa_noinit_tests.jl")
     @time @safetestset "NonlinearSolveAlg Preconditioning Tests" include("nsa_conditioning_tests.jl")
+    @time @safetestset "NonlinearSolveAlg Residual Convergence Tests" include("nsa_residual_convergence_tests.jl")
 end
 
 # Run QA tests (JET, Aqua)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Fixes #4125.

The outer convergence test in `nlsolve.jl` infers "close to the root" from the displacement the inner `NonlinearSolve` algorithm produced, and never from the residual:

```julia
if (iter == 1 && ndz < 1.0e-5) || (check_η_convergence && η >= 0 && η * ndz < κ)
    nlsolver.status = Convergence
```

That is only sound for a step that solves the Newton system, where the displacement is `W⁻¹F` and so vanishes only with the residual. #3893 fixed the case where the iterate does not move *at all*; this covers the two remaining ways an inner solver produces a tiny displacement that says nothing about the distance to the root.

### Two distinct mechanisms

**`DFSane`** — its line search fails, stopping the cache with `InternalLineSearchFailed` and leaving the iterate unmoved. `compute_step!` inspected the terminal state only on *entry*, so the failure was deferred to a next call that never came: `ndz == 0` satisfied `iter == 1 && ndz < 1e-5` first. `FBDF` then ran 21 accepted steps and returned the initial condition with `ReturnCode.Success`.

**`Broyden(linesearch = BackTracking())`** — does not stop the cache. Its line search collapses to a step of relative size ~1e-17 with the residual bit-for-bit unchanged, so #3893's exactly-zero guard does not see it.

### The fix

`compute_step!` re-checks the terminal state after `step!`, and asks the residual about a step that moved the iterate by less than roundoff without reducing `‖fu‖`. `γΔt·fu` carries the units of the iterate, so `‖γΔt·fu‖ / max(‖u‖, ‖u + γΔt·fu‖)` is the relative residual of the stage equation — invariant to the problem's units, and independent of the inner tolerances that `build_nlsolver` deliberately zeroes.

The residual gates the failure report in **both** directions. An inner solver can give up *because* there is nothing left to correct, and treating that as failure turns a correct solve into a hard one. Measured on a Brusselator started at an exact equilibrium (`‖f(u0)‖∞ = 0`, so `u(t) ≡ u0`):

| | terminal check ungated | gated on the residual |
|---|---|---|
| KenCarp4 + DFSane | `Unstable`, 0 steps | **`Success`, 3 steps, err 0.0** |
| FBDF + DFSane | `Unstable`, 0 steps | **`Success`, 3 steps, err 0.0** |

### Effect

ROBER/OREGO x FBDF/KenCarp4 x 7 inner algorithms, rtol 1e-6, error vs `Rodas5P` at 1e-13/1e-15. Five of the seven `Success`-with-a-wrong-answer configurations now fail loudly:

| config | before | after |
|---|---|---|
| ROBER FBDF DFSane | `Success`, err 1.00 (returns `u0`) | `MaxIters` |
| ROBER KenCarp4 DFSane | `Success`, err 4.00e+09 | `Unstable` |
| ROBER KenCarp4 Broyden+LS | `Success`, err 4.00e+09 | `Unstable` |
| OREGO FBDF DFSane | `Success`, err 1.04e+04 | `MaxIters` |
| OREGO KenCarp4 DFSane | `Success`, err 1.04e+04 | `Unstable` |

`LevenbergMarquardt` on ROBER/KenCarp4 still returns `Success` at err 5.03e+07. Its steps are real and its residual decreases, so it is a different mechanism; described in #4125 and not addressed here.

Failing loudly is sometimes more expensive than being wrong quickly — `ROBER FBDF DFSane` now runs to `MaxIters` (957332 steps) where it previously returned garbage in 21.

### NewtonRaphson and TrustRegion

Byte-identical to master on all 8 `NewtonRaphson`/`TrustRegion` rows of the sweep above, and on all 39 configurations of the `NLNewton`-vs-NSA parity matrix (5 problems x 4 algorithms x 2 tolerances at rtol 1e-6/1e-9), compared row by row rather than by summary.

At rtol **1e-12/1e-14** they are *not* identical: 11 of 24 rows shift. No retcode changes anywhere, and errors stay in the same ballpark (several improve — OREGO/FBDF/NR@1e-12 goes 25764 steps/1.59e-07 to 10180/1.18e-07; ROBER/TRBDF2/NR@1e-12 9.04e-14 to 3.77e-14; ROBER/KenCarp4/NR@1e-14 goes the other way, 2.59e-13 to 8.43e-13). At those tolerances the displacement between Newton iterates genuinely sits at the roundoff floor, so any predicate keyed on roundoff will occasionally fire. Disclosing it rather than claiming the change is inert.

The `8 * eps` floor was chosen by sweeping 1/8/64/1024: 1024 perturbed rtol=1e-9 (ROBER/QNDF error 6.65e-14 to 1.10e-12), while 1, 8 and 64 all leave 1e-6/1e-9 untouched and all still catch every silent-wrong configuration. 8 shifted the fewest tight-tolerance rows (11 vs 14 for 1).

### Test

`nsa_residual_convergence_tests.jl`, registered in `runtests.jl`, 13 assertions. Verified it fails on unmodified master:

```
an unconverged stage is never reported as a successful solve: Test Failed ... :67   (x5)
```

The other five NSA test files are unchanged: `smooth_est` 10, `sparse` 10, `matrixfree` 14, `jacreuse` 17, `stats` 24. Runic clean.

### Noted while testing, not fixed here

`NonlinearSolveAlg` passes `recompute_jacobian` to Jacobian-free inner solvers, so `DFSane` emits `GeneralizedDFSane is a Jacobian-Free Algorithm. Ignoring recompute_jacobian` on every iteration — a sweep produced a 1.98 GB log. Worth suppressing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
