### PR TITLE
Fix clean-master solver package test regressions

### DIFF
--- a/docs/src/devtools/internals/public_api.md
+++ b/docs/src/devtools/internals/public_api.md
@@ -256,6 +256,7 @@ OrdinaryDiffEqCore.DefaultCache
 OrdinaryDiffEqCore.@cache
 OrdinaryDiffEqCore.alg_cache
 OrdinaryDiffEqCore.get_fsalfirstlast
+OrdinaryDiffEqCore.get_fresh_jacobian
 OrdinaryDiffEqCore.perform_step!
 OrdinaryDiffEqCore.apply_step!
 SciMLBase.postamble!

--- a/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
+++ b/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
@@ -56,13 +56,12 @@ import TruncatedStacktraces: @truncate_stacktrace, VERBOSE_MSG
 
 # Integrator Interface
 import Base: resize!, deleteat!
-import SciMLBase: addat!, full_cache, user_cache, u_cache, du_cache,
+import SciMLBase: addat!, full_cache,
     resize_non_user_cache!, deleteat_non_user_cache!, addat_non_user_cache!,
-    terminate!, get_du, get_dt, get_proposed_dt, set_proposed_dt!,
+    terminate!, get_proposed_dt, set_proposed_dt!,
     savevalues!,
     add_tstop!, has_tstop, first_tstop, pop_tstop!,
-    add_saveat!, set_reltol!,
-    set_abstol!, postamble!, last_step_failed
+    postamble!, last_step_failed
 import DiffEqBase: get_tstops, get_tstops_array
 
 # `check_error!` is owned by (and public in) SciMLBase, re-exported through DiffEqBase.
@@ -87,7 +86,7 @@ using SciMLBase: SciMLBase, CallbackSet, ContinuousCallback, DAEProblem,
 using SciMLOperators: SciMLOperators
 using CommonSolve: solve
 
-import SciMLBase: AbstractNonlinearProblem, alg_order, LinearAliasSpecifier
+import SciMLBase: AbstractNonlinearProblem, alg_order
 # `calculate_residuals`/`calculate_residuals!` are unused here but re-exported for
 # dependent OrdinaryDiffEq.jl sublibraries that import them from this package.
 import DiffEqBase: timedepentdtmin, calculate_residuals, calculate_residuals!
@@ -431,7 +430,7 @@ include("precompilation_setup.jl")
             :default_nlsolve, :DEOptions, :DIRK, :Divergence, :dt_required, :DummyController,
             :explicit_rk_docstring, :ExponentialAlgorithm, :FastConvergence, :gamma_default, :generic_solver_docstring,
             :get_current_adaptive_order, :get_current_alg_autodiff, :get_differential_vars, :get_EEst, :get_failfactor, :get_fsalfirstlast,
-            :get_gamma, :get_new_W_γdt_cutoff, :get_qmax, :get_qmax_first_step, :get_qmin, :get_qsteady_max,
+            :get_fresh_jacobian, :get_gamma, :get_new_W_γdt_cutoff, :get_qmax, :get_qmax_first_step, :get_qmin, :get_qsteady_max,
             :get_qsteady_min, :get_W, :GLM, :hermite_interpolant, :IController,
             :ImplicitSecondOrderAlgorithm, :increment_accept!, :increment_nf!, :increment_reject!, :InterpolationData, :isautoswitch,
             :is_composite_algorithm, :isdefaultalg, :isdiscretecache, :isdtchangeable, :isfirstcall,

--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
@@ -743,7 +743,13 @@ function log_step!(progress_name, progress_id, progress_message, dt, u, p, t, ts
     )
 end
 
-# overrides this with a method that calls calc_J to get a fresh Jacobian.
+"""
+    get_fresh_jacobian(integrator, cache)
+
+Return a Jacobian suitable for numerical-instability diagnostics. Cache-specific
+packages may specialize this hook when the stored Jacobian is unavailable or
+stale. Diagnostic evaluation must not increment solver work statistics.
+"""
 get_fresh_jacobian(integrator, cache) = cache.J
 
 SciMLBase.has_mtk_sys(integrator::ODEIntegrator) = hasproperty(integrator.sol.prob.f, :sys) && integrator.sol.prob.f.sys !== nothing

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -354,7 +354,12 @@ function calc_J(integrator, cache, next_step::Bool = false)
     return J
 end
 
-get_fresh_jacobian(integrator, cache::OrdinaryDiffEqCache) = calc_J(integrator, cache)
+function get_fresh_jacobian(integrator, cache::OrdinaryDiffEqCache)
+    njacs = integrator.stats.njacs
+    J = calc_J(integrator, cache)
+    integrator.stats.njacs = njacs
+    return J
+end
 
 """
     calc_J!(J, integrator, cache, next_step::Bool = false) -> J

--- a/lib/OrdinaryDiffEqExtrapolation/src/OrdinaryDiffEqExtrapolation.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/OrdinaryDiffEqExtrapolation.jl
@@ -15,15 +15,14 @@ import OrdinaryDiffEqCore: alg_maximum_order, get_current_adaptive_order,
     qmin_default,
     constvalue, PolyesterThreads,
     _fixup_ad,
-    get_fsalfirstlast,
-    LinearAliasSpecifier
+    get_fsalfirstlast
 import OrdinaryDiffEqCore: default_controller, AbstractControllerCache, setup_controller_cache,
     get_qmin, get_qmax
 import OrdinaryDiffEqCore
 
 # Owned by SciMLBase / DiffEqBase, re-exported through OrdinaryDiffEqCore /
 # OrdinaryDiffEqDifferentiation.
-import SciMLBase: alg_order,
+import SciMLBase: alg_order, LinearAliasSpecifier,
     TimeDerivativeWrapper, UDerivativeWrapper,
     TimeGradientWrapper, UJacobianWrapper
 import DiffEqBase: initialize!, calculate_residuals, calculate_residuals!, timedepentdtmin

--- a/lib/OrdinaryDiffEqFIRK/src/OrdinaryDiffEqFIRK.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/OrdinaryDiffEqFIRK.jl
@@ -14,11 +14,11 @@ import OrdinaryDiffEqCore: unwrap_alg,
     get_current_alg_order,
     isfirk,
     _fixup_ad, perform_step!,
-    LinearAliasSpecifier, set_discontinuity,
+    set_discontinuity,
     Convergence, FastConvergence, NLStatus,
     VerySlowConvergence, Divergence, get_new_W_γdt_cutoff
 import SciMLBase
-import SciMLBase: alg_order, _vec, _reshape, _unwrap_val,
+import SciMLBase: alg_order, _vec, _reshape, _unwrap_val, LinearAliasSpecifier,
     UDerivativeWrapper, UJacobianWrapper, value,
     LinearProblem, get_tmp_cache, init
 import DiffEqBase: initialize!, calculate_residuals, calculate_residuals!

--- a/lib/OrdinaryDiffEqFunctionMap/test/qa/Project.toml
+++ b/lib/OrdinaryDiffEqFunctionMap/test/qa/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 OrdinaryDiffEqFunctionMap = "d3585ca7-f5d3-4ba6-8057-292ed1abd90f"
@@ -14,6 +15,7 @@ path = "../../../OrdinaryDiffEqCore"
 [compat]
 AllocCheck = "0.2"
 Aqua = "0.8.11"
+CommonSolve = "0.2.6"
 JET = "0.9, 0.11"
 SciMLTesting = "2.1"
 julia = "1.10"

--- a/lib/OrdinaryDiffEqFunctionMap/test/qa/allocation_tests.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/test/qa/allocation_tests.jl
@@ -1,6 +1,7 @@
 using OrdinaryDiffEqFunctionMap
 using OrdinaryDiffEqCore
-using SciMLBase: FullSpecialize, DiscreteFunction
+using CommonSolve: init, step!
+using SciMLBase: DiscreteFunction, DiscreteProblem, FullSpecialize
 using AllocCheck
 using Test
 

--- a/lib/OrdinaryDiffEqLowOrderRK/src/OrdinaryDiffEqLowOrderRK.jl
+++ b/lib/OrdinaryDiffEqLowOrderRK/src/OrdinaryDiffEqLowOrderRK.jl
@@ -13,11 +13,11 @@ import OrdinaryDiffEqCore: isfsal, beta2_default, beta1_default,
     OrdinaryDiffEqMutableCache,
     OrdinaryDiffEqConstantCache, @fold,
     @cache, CompiledFloats, alg_cache, CompositeAlgorithm,
-    AutoAlgSwitch, _ode_interpolant, _ode_interpolant!, full_cache,
+    AutoAlgSwitch, _ode_interpolant, _ode_interpolant!,
     accept_step_controller, DerivativeOrderNotPossibleError,
-    du_cache, u_cache, get_fsalfirstlast
+    get_fsalfirstlast
 using SciMLBase: SciMLBase
-import SciMLBase: alg_order, @def, _unwrap_val
+import SciMLBase: alg_order, @def, _unwrap_val, du_cache, full_cache, u_cache
 import MuladdMacro: @muladd
 import FastBroadcast: @..
 import LinearAlgebra: norm

--- a/lib/OrdinaryDiffEqPRK/src/OrdinaryDiffEqPRK.jl
+++ b/lib/OrdinaryDiffEqPRK/src/OrdinaryDiffEqPRK.jl
@@ -4,7 +4,7 @@ import OrdinaryDiffEqCore: OrdinaryDiffEqAlgorithm, OrdinaryDiffEqMutableCache,
     OrdinaryDiffEqConstantCache, constvalue, @cache,
     alg_cache, get_fsalfirstlast,
     unwrap_alg, perform_step!, @threaded, isthreaded
-import SciMLBase: alg_order, full_cache
+import SciMLBase: alg_order
 import DiffEqBase: initialize!
 import MuladdMacro: @muladd
 import FastBroadcast: @..

--- a/lib/OrdinaryDiffEqPRK/test/qa/Project.toml
+++ b/lib/OrdinaryDiffEqPRK/test/qa/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 OrdinaryDiffEqPRK = "5b33eab2-c0f1-4480-b2c3-94bc1e80bda1"
@@ -14,6 +15,7 @@ path = "../../../OrdinaryDiffEqCore"
 [compat]
 AllocCheck = "0.2"
 Aqua = "0.8.11"
+CommonSolve = "0.2.6"
 JET = "0.9, 0.11"
 SciMLTesting = "2.1"
 julia = "1.10"

--- a/lib/OrdinaryDiffEqPRK/test/qa/allocation_tests.jl
+++ b/lib/OrdinaryDiffEqPRK/test/qa/allocation_tests.jl
@@ -1,6 +1,7 @@
 using OrdinaryDiffEqPRK
 using OrdinaryDiffEqCore
-using SciMLBase: FullSpecialize
+using CommonSolve: init, step!
+using SciMLBase: FullSpecialize, ODEProblem
 using AllocCheck
 using Test
 

--- a/lib/OrdinaryDiffEqQPRK/test/qa/Project.toml
+++ b/lib/OrdinaryDiffEqQPRK/test/qa/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 OrdinaryDiffEqQPRK = "04162be5-8125-4266-98ed-640baecc6514"
@@ -14,6 +15,7 @@ path = "../../../OrdinaryDiffEqCore"
 [compat]
 AllocCheck = "0.2"
 Aqua = "0.8.11"
+CommonSolve = "0.2.6"
 JET = "0.9, 0.11"
 SciMLTesting = "2.1"
 julia = "1.10"

--- a/lib/OrdinaryDiffEqQPRK/test/qa/allocation_tests.jl
+++ b/lib/OrdinaryDiffEqQPRK/test/qa/allocation_tests.jl
@@ -1,6 +1,7 @@
 using OrdinaryDiffEqQPRK
 using OrdinaryDiffEqCore
-using SciMLBase: FullSpecialize
+using CommonSolve: init, step!
+using SciMLBase: FullSpecialize, ODEProblem
 using AllocCheck
 using Test
 

--- a/lib/OrdinaryDiffEqRosenbrock/src/OrdinaryDiffEqRosenbrock.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/OrdinaryDiffEqRosenbrock.jl
@@ -13,7 +13,7 @@ import OrdinaryDiffEqCore: alg_adaptive_order, isWmethod, isfsal, _unwrap_val,
     calculate_residuals, has_stiff_interpolation, ODEIntegrator,
     resize_non_user_cache!, _ode_addsteps!, full_cache,
     DerivativeOrderNotPossibleError, _fixup_ad,
-    LinearAliasSpecifier, copyat_or_push!, DifferentialVarsUndefined, resize_J_W!,
+    copyat_or_push!, DifferentialVarsUndefined, resize_J_W!,
     find_algebraic_vars_eqs
 using MuladdMacro: MuladdMacro, @muladd
 using FastBroadcast: FastBroadcast, @..
@@ -30,6 +30,7 @@ import ForwardDiff
 using FiniteDiff: FiniteDiff
 using LinearAlgebra: mul!, I, norm, lu, UniformScaling
 using ADTypes: ADTypes, AutoFiniteDiff, AutoForwardDiff
+using SciMLBase: LinearAliasSpecifier
 import OrdinaryDiffEqCore, OrdinaryDiffEqDifferentiation
 
 using OrdinaryDiffEqDifferentiation: wrapprecs, calc_tderivative, build_grad_config,


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- import `ODEProblem`/`DiscreteProblem` from SciMLBase and `init`/`step!` from CommonSolve in the PRK, QPRK, and FunctionMap allocation QA environments
- keep numerical-instability diagnostic Jacobian evaluation from inflating `stats.njacs`
- declare and document the Core diagnostic hook used by OrdinaryDiffEqDifferentiation
- remove stale Core imports and move affected solver imports to their owning public module

This is the separate clean-master failure investigation and does not include the documentation/compat rollout.

## Clean-master attribution

- PRK/QPRK/FunctionMap: parent `fc8d888959f7d43143f2a5e571e4bf75042f7cde` passes; first bad `4ca8a4c2ca24c871b0cd9308399473ffed3a2277` (`Remove Core blanket SciMLBase reexport (#4119)`). The package-local cleanup commits that made the missing test imports latent were `8abc676de9928fde7139b998d1307f4cb8a6102b`, `a1b5ad1e1661dbc12a7d5e5bda80d21c1c48b206`, and `2ca5bfcdab43025b5cd8caad698bec6ec064f65c`.
- NonlinearSolve: parent `3701e9e853afc6f72e5b60d07a1f1a99f08ed9a5` reports `[njacs, nw] == [0, 0]`; first bad `0237ef155245a4b7d4198fb87d3722854621d976` (`Support better logging for singular cases in integration (#3731)`) reports `[0, 1]` because the diagnostic fresh-Jacobian calculation increments `njacs`.
- Core: `4ca8a4c2ca24c871b0cd9308399473ffed3a2277` exposes nine stale explicit imports; `0237ef155245a4b7d4198fb87d3722854621d976` adds the diagnostic hooks. SciMLBase hook publication/documentation is tracked by SciML/SciMLBase.jl#1495.

## Local validation

Using Julia 1.12.6 and an isolated depot, complete `Pkg.test()` runs pass for OrdinaryDiffEqPRK, OrdinaryDiffEqQPRK, OrdinaryDiffEqFunctionMap, OrdinaryDiffEqNonlinearSolve, and OrdinaryDiffEqDifferentiation. OrdinaryDiffEqCore passes AllocCheck/JET and its corrected import/public-documentation checks; its only remaining Aqua errors are the two SciMLBase hooks covered by SciML/SciMLBase.jl#1495.

Complete direct-user validation also passes for OrdinaryDiffEqExtrapolation. FIRK and LowOrderRK pass functional/JET/ExplicitImports phases but retain their separate rollout's public-documentation findings. Rosenbrock passes functional, allocation, inference (40/40), and JET phases; Aqua retains unrelated existing owner/public cleanup findings.

Runic check and `git diff --check` pass for the full change.
