### PR TITLE
Preserve solver stats during instability diagnostics

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -354,7 +354,17 @@ function calc_J(integrator, cache, next_step::Bool = false)
     return J
 end
 
-get_fresh_jacobian(integrator, cache::OrdinaryDiffEqCache) = calc_J(integrator, cache)
+function get_fresh_jacobian(integrator, cache::OrdinaryDiffEqCache)
+    nf = integrator.stats.nf
+    njacs = integrator.stats.njacs
+    try
+        return calc_J(integrator, cache)
+    finally
+        # Diagnostic work must not alter the returned solve statistics.
+        integrator.stats.nf = nf
+        integrator.stats.njacs = njacs
+    end
+end
 
 """
     calc_J!(J, integrator, cache, next_step::Bool = false) -> J

--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -40,6 +40,7 @@ OrdinaryDiffEqFIRK = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
+SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -50,6 +51,7 @@ DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
 SciMLTesting = "2.1"
+SciMLLogging = "2"
 CommonSolve = "0.2.6"
 Pkg = "1"
 NonlinearSolve = "4.24"
@@ -89,7 +91,7 @@ SparseConnectivityTracer = "1"
 ConstructionBase = "1.5.8"
 
 [targets]
-test = ["DiffEqDevTools", "LineSearches", "ODEProblemLibrary", "OrdinaryDiffEqBDF", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "Random", "SafeTestsets", "SparseConnectivityTracer", "StaticArrays", "Statistics", "Test", "Pkg", "SciMLTesting"]
+test = ["DiffEqDevTools", "LineSearches", "ODEProblemLibrary", "OrdinaryDiffEqBDF", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "Random", "SafeTestsets", "SciMLLogging", "SparseConnectivityTracer", "StaticArrays", "Statistics", "Test", "Pkg", "SciMLTesting"]
 
 [sources.OrdinaryDiffEqDifferentiation]
 path = "../OrdinaryDiffEqDifferentiation"

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/linear_solver_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/linear_solver_tests.jl
@@ -2,6 +2,7 @@ using Test, OrdinaryDiffEqRosenbrock, OrdinaryDiffEqSDIRK, OrdinaryDiffEqBDF
 using SparseArrays, LinearSolve
 using LinearAlgebra, Random, StaticArrays
 using SciMLOperators: MatrixOperator
+import DiffEqBase, SciMLLogging
 N = 30
 AA = sprand(MersenneTwister(12), N, N, 0.5)
 mm = sprand(MersenneTwister(123), N, N, 0.5)
@@ -11,7 +12,10 @@ u0 = ones(N)
 prob = ODEProblem(ODEFunction(A; mass_matrix = M), u0, (0.0, 1.0))
 
 for alg in [Rosenbrock23(), Rosenbrock23(linsolve = KLUFactorization())]
+    silent_sol = solve(prob, alg; verbose = DiffEqBase.DEVerbosity(SciMLLogging.None()))
     sol = solve(prob, alg)
+    @test sol.stats.nf == silent_sol.stats.nf
+    @test sol.stats.njacs == silent_sol.stats.njacs
     @test sol.stats.njacs == 0
     @test sol.stats.nw == 1
 end


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- preserve `nf` and `njacs` while constructing a fresh Jacobian for post-failure diagnostics
- compare verbose and silent failure paths so diagnostics cannot change returned solver statistics
- retain the strict `sol.stats.njacs == 0` assertion

## Root cause

Commit `0237ef155245a4b7d4198fb87d3722854621d976` added post-failure Jacobian diagnostics through `get_fresh_jacobian`. Calling `calc_J` there increments the solve counters after integration has finished, so Julia 1.12's KLU failure path returns `njacs == 1` instead of `0`.

## Validation

- Julia 1.12.6: focused `linear_solver_tests.jl` passed (36/36 + 36/36 Float32)
- Julia 1.10.11: focused `linear_solver_tests.jl` passed (36/36 + 36/36 Float32)
- Julia 1.12.6: `GROUP=Core Pkg.test` for `OrdinaryDiffEqNonlinearSolve` passed
- Julia 1.12.6: `julia +release -m Runic --check .` passed