### PR TITLE
Count SDE EM/EulerHeun drift and diffusion evaluations in stats

### DIFF
--- a/lib/StochasticDiffEq/test/runtests.jl
+++ b/lib/StochasticDiffEq/test/runtests.jl
@@ -60,6 +60,9 @@ const is_APPVEYOR = Sys.iswindows() && haskey(ENV, "APPVEYOR")
         @time @safetestset "Callable tstops Tests" begin
             include("callable_tstops_tests.jl")
         end
+        @time @safetestset "SDE stats nf Tests" begin
+            include("stats_tests.jl")
+        end
         @time @safetestset "Integrator RNG Tests" begin
             include("rng_integrator_tests.jl")
         end

--- a/lib/StochasticDiffEq/test/stats_tests.jl
+++ b/lib/StochasticDiffEq/test/stats_tests.jl
@@ -1,0 +1,57 @@
+using StochasticDiffEq, Test
+
+# SciML/OrdinaryDiffEq.jl#3166 / StochasticDiffEq.jl#673:
+# SDE perform_step! must count drift (nf) and diffusion (nf2) evaluations.
+
+@testset "SDE stats.nf / nf2 (#3166)" begin
+    dt = 1 // 2^4
+    tspan = (0.0, 1.0)
+    nsteps = 16
+
+    @testset "EM out-of-place" begin
+        nf = Ref(0)
+        ng = Ref(0)
+        f(u, p, t) = (nf[] += 1; 1.0 * u)
+        g(u, p, t) = (ng[] += 1; 1.0 * u)
+        prob = SDEProblem(f, g, 0.5, tspan)
+        sol = solve(prob, EM(); dt = dt)
+        @test sol.retcode == ReturnCode.Success
+        @test sol.stats.naccept == nsteps
+        @test sol.stats.nf == nf[] == nsteps
+        @test sol.stats.nf2 == ng[] == nsteps
+    end
+
+    @testset "EM in-place" begin
+        nf = Ref(0)
+        ng = Ref(0)
+        function f!(du, u, p, t)
+            nf[] += 1
+            du[1] = 1.0 * u[1]
+            return nothing
+        end
+        function g!(du, u, p, t)
+            ng[] += 1
+            du[1] = 1.0 * u[1]
+            return nothing
+        end
+        prob = SDEProblem(f!, g!, [0.5], tspan)
+        sol = solve(prob, EM(); dt = dt)
+        @test sol.retcode == ReturnCode.Success
+        @test sol.stats.naccept == nsteps
+        @test sol.stats.nf == nf[] == nsteps
+        @test sol.stats.nf2 == ng[] == nsteps
+    end
+
+    @testset "EulerHeun out-of-place" begin
+        nf = Ref(0)
+        ng = Ref(0)
+        f(u, p, t) = (nf[] += 1; -u)
+        g(u, p, t) = (ng[] += 1; 0.1 * u)
+        prob = SDEProblem(f, g, 1.0, tspan)
+        sol = solve(prob, EulerHeun(); dt = dt)
+        @test sol.retcode == ReturnCode.Success
+        @test sol.stats.naccept == nsteps
+        @test sol.stats.nf == nf[] == 2 * nsteps
+        @test sol.stats.nf2 == ng[] == 2 * nsteps
+    end
+end

--- a/lib/StochasticDiffEqLowOrder/src/perform_step/low_order.jl
+++ b/lib/StochasticDiffEqLowOrder/src/perform_step/low_order.jl
@@ -2,6 +2,7 @@
     (; t, dt, uprev, u, W, P, c, p, f) = integrator
 
     K = uprev .+ dt .* integrator.f(uprev, p, t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 
     if is_split_step(integrator.alg)
         u_choice = K
@@ -14,6 +15,7 @@
     else
         noise = integrator.f.g(u_choice, p, t) .* W.dW
     end
+    integrator.stats.nf2 += 1
 
     if P !== nothing
         tmp = c(uprev, p, t, P.dW, nothing)
@@ -28,6 +30,7 @@ end
     (; tmp, rtmp1, rtmp2) = cache
     (; t, dt, uprev, u, W, P, c, p) = integrator
     integrator.f(rtmp1, uprev, p, t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 
     @.. u = uprev + dt * rtmp1
 
@@ -38,6 +41,7 @@ end
     end
 
     integrator.f.g(rtmp2, u_choice, p, t)
+    integrator.stats.nf2 += 1
 
     if P !== nothing
         c(tmp, uprev, p, t, P.dW, nothing)
@@ -64,6 +68,8 @@ end
     (; t, dt, uprev, u, W, p, f) = integrator
     ftmp = integrator.f(uprev, p, t)
     gtmp = integrator.f.g(uprev, p, t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.stats.nf2 += 1
     if is_diagonal_noise(integrator.sol.prob)
         noise = gtmp .* W.dW
     else
@@ -71,12 +77,14 @@ end
     end
     tmp = @.. uprev + dt * ftmp + noise
     gtmp2 = (gtmp .+ integrator.f.g(tmp, p, t + dt)) ./ 2
+    integrator.stats.nf2 += 1
     if is_diagonal_noise(integrator.sol.prob)
         noise2 = gtmp2 .* W.dW
     else
         noise2 = gtmp2 * W.dW
     end
     u = uprev .+ (dt / 2) .* (ftmp .+ integrator.f(tmp, p, t + dt)) .+ noise2
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     integrator.u = u
 end
 
@@ -85,6 +93,8 @@ end
     (; t, dt, uprev, u, W, p, f) = integrator
     integrator.f(ftmp1, uprev, p, t)
     integrator.f.g(gtmp1, uprev, p, t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.stats.nf2 += 1
 
     if is_diagonal_noise(integrator.sol.prob)
         @.. nrtmp = gtmp1 * W.dW
@@ -96,6 +106,8 @@ end
 
     integrator.f(ftmp2, tmp, p, t + dt)
     integrator.f.g(gtmp2, tmp, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.stats.nf2 += 1
 
     if is_diagonal_noise(integrator.sol.prob)
         @.. nrtmp = W.dW * (gtmp1 + gtmp2) / 2


### PR DESCRIPTION
## Summary
- SDE solvers share `sol.stats` / `naccept` with OrdinaryDiffEqCore, but `perform_step!` never incremented `nf` / `nf2`, so function-evaluation counters stayed at zero (#3166 / StochasticDiffEq#673).
- For EM and EulerHeun, count drift evaluations in `nf` and diffusion (`g`) evaluations in `nf2` (ODE SplitFunction convention).
- Add instrumented regression tests under StochasticDiffEq `stats_tests.jl`.

## Test plan
- [ ] `lib/StochasticDiffEq/test/stats_tests.jl`
- [ ] Issue MWE: `solve(..., EM(); dt=1//2^4)` has `stats.nf == stats.nf2 == 16` and `naccept == 16`
- [ ] EM in-place path matches instrumented counters
- [ ] EulerHeun fixed-step has `nf == nf2 == 2 * naccept`