### PR TITLE
Restore the SciMLBase integrator-interface imports sublibraries extend

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
+++ b/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
@@ -56,9 +56,9 @@ import TruncatedStacktraces: @truncate_stacktrace, VERBOSE_MSG
 
 # Integrator Interface
 import Base: resize!, deleteat!
-import SciMLBase: addat!, full_cache,
+import SciMLBase: addat!, full_cache, user_cache, u_cache, du_cache,
     resize_non_user_cache!, deleteat_non_user_cache!, addat_non_user_cache!,
-    terminate!, get_proposed_dt, set_proposed_dt!,
+    terminate!, get_du, get_dt, get_proposed_dt, set_proposed_dt!,
     savevalues!,
     add_tstop!, has_tstop, first_tstop, pop_tstop!,
     postamble!, last_step_failed


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

**Master is currently red.** `Documentation` fails and `CI` / `Sublibrary CI` /
`IntegrationTest` will too — nothing that loads a solver sublibrary can
precompile.

## The failure

```
ERROR: LoadError: invalid method definition in OrdinaryDiffEqLowOrderRK:
       exported function OrdinaryDiffEqCore.u_cache does not exist
ERROR: LoadError: Failed to precompile OrdinaryDiffEqLowOrderRK
```

## Cause

`585e5e919` (#4136, *Document solver code-generation APIs*) trimmed
OrdinaryDiffEqCore's `import SciMLBase: ...` list:

```diff
-import SciMLBase: addat!, full_cache, user_cache, u_cache, du_cache,
+import SciMLBase: addat!, full_cache,
-    terminate!, get_du, get_dt, get_proposed_dt, set_proposed_dt!,
+    terminate!, get_proposed_dt, set_proposed_dt!,
```

Those names are re-exported to the solver sublibraries, which import them from
OrdinaryDiffEqCore and define methods on them for their own cache types —
`lib/OrdinaryDiffEqLowOrderRK/src/low_order_rk_caches.jl:695`:

```julia
u_cache(c::RKO65Cache) = ()
du_cache(c::RKO65Cache) = (c.k, c.du, c.fsalfirst)
```

Once `OrdinaryDiffEqCore.u_cache` stops existing, defining a method on it is an
error, and every such package fails to precompile.

## Fix

Restore only the five names that still have downstream references:

| Name | downstream `lib/*/src` files |
|---|---|
| `du_cache` | 11 |
| `u_cache` | 9 |
| `get_du` | 6 |
| `user_cache` | 4 |
| `get_dt` | 1 |

`add_saveat!`, `set_reltol!`, `set_abstol!` and `terminate!` have **zero**
downstream references and stay dropped, so #4136's trim is preserved wherever it
is safe. `LinearAliasSpecifier` needs nothing — #4136 replaced its import with a
`const`.

## Verification

On clean master (`a7118ad91`):

```
$ julia +1.12 --project=lib/OrdinaryDiffEqLowOrderRK -e 'using OrdinaryDiffEqLowOrderRK'
ERROR: LoadError: invalid method definition in OrdinaryDiffEqLowOrderRK:
       exported function OrdinaryDiffEqCore.u_cache does not exist
```

With this patch:

```
$ julia +1.12 --project=lib/OrdinaryDiffEqLowOrderRK -e 'using OrdinaryDiffEqLowOrderRK; println("LOADED OK")'
LOADED OK
```

Also confirmed loading after the change: `DelayDiffEq` (heaviest user of these
accessors) and `StochasticDiffEqCore`, both **OK**.

## Note for @ChrisRackauckas

If #4136 intended to remove these from OrdinaryDiffEqCore's *public* surface
rather than break the extension point, the follow-up is to move the sublibraries
onto `SciMLBase.u_cache` directly — the way `@cache` already emits
`GlobalRef(SciMLBase, :full_cache)`. That is a larger change across ~11 packages;
this PR just unbreaks master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPHRh64BLfoXSzQ3AxKNwC