### PR TITLE
Fix adaptive Newmark error estimation, GA remake, and oop aliasing

### DIFF
--- a/lib/OrdinaryDiffEqNewmark/Project.toml
+++ b/lib/OrdinaryDiffEqNewmark/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqNewmark"
 uuid = "d204908a-63b9-11ef-18f5-cfec7123a93b"
-version = "2.2.2"
+version = "2.3.0"
 authors = ["Dennis Ogiermann <termi-official@users.noreply.github.com>"]
 
 [deps]
@@ -23,6 +23,7 @@ TruncatedStacktraces = "781d530d-4396-4725-bb49-402e4bee1e77"
 DiffEqBase = {path = "../DiffEqBase"}
 DiffEqDevTools = {path = "../DiffEqDevTools"}
 OrdinaryDiffEqCore = {path = "../OrdinaryDiffEqCore"}
+OrdinaryDiffEqSDIRK = {path = "../OrdinaryDiffEqSDIRK"}
 
 [compat]
 SciMLTesting = "2.1"
@@ -38,6 +39,7 @@ MuladdMacro = "0.2.4"
 NonlinearSolve = "4.20.3"
 NonlinearSolveFirstOrder = "2.1.1"
 OrdinaryDiffEqCore = "4"
+OrdinaryDiffEqSDIRK = "2.5"
 Pkg = "1"
 PreallocationTools = "1.1.2"
 Random = "<0.0.1, 1"
@@ -53,6 +55,7 @@ julia = "1.10"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
@@ -60,4 +63,4 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DiffEqDevTools", "NonlinearSolve", "Random", "SafeTestsets", "Test", "Pkg", "SciMLTesting"]
+test = ["DiffEqDevTools", "NonlinearSolve", "OrdinaryDiffEqSDIRK", "Random", "SafeTestsets", "Test", "Pkg", "SciMLTesting"]

--- a/lib/OrdinaryDiffEqNewmark/src/OrdinaryDiffEqNewmark.jl
+++ b/lib/OrdinaryDiffEqNewmark/src/OrdinaryDiffEqNewmark.jl
@@ -13,6 +13,7 @@ import OrdinaryDiffEqCore: initialize!, perform_step!, unwrap_alg,
     trivial_limiter!, _ode_interpolant!,
     get_fsalfirstlast, generic_solver_docstring,
     OrdinaryDiffEqCore
+import DiffEqBase: calculate_residuals, calculate_residuals!
 import PreallocationTools: DiffCache, get_tmp
 using TruncatedStacktraces, MuladdMacro, MacroTools, FastBroadcast, RecursiveArrayTools
 using SciMLBase: DynamicalODEFunction

--- a/lib/OrdinaryDiffEqNewmark/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqNewmark/src/alg_utils.jl
@@ -2,7 +2,11 @@ alg_extrapolates(alg::NewmarkBeta) = false
 alg_extrapolates(alg::GeneralizedAlpha) = false
 
 alg_order(alg::NewmarkBeta) = alg.γ ≈ 1 / 2 ? 2 : 1
-alg_order(alg::GeneralizedAlpha) = alg.γ ≈ 1 / 2 - alg.αm + alg.αf ? 2 : 1
+# The step re-derives aₙ from f at the accepted state instead of carrying the
+# algorithmic acceleration, so the velocity update is second order iff
+# γ(1 - αf) = (1 - αm)/2 rather than on the textbook locus γ = 1/2 - αm + αf
+# (measured fixed-step orders 2.000 and ~1 respectively for αm ≠ αf).
+alg_order(alg::GeneralizedAlpha) = alg.γ * (1 - alg.αf) ≈ (1 - alg.αm) / 2 ? 2 : 1
 
 is_mass_matrix_alg(alg::NewmarkBeta) = true
 is_mass_matrix_alg(alg::GeneralizedAlpha) = true

--- a/lib/OrdinaryDiffEqNewmark/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqNewmark/src/algorithms.jl
@@ -4,6 +4,25 @@
 Classical Newmark-β method to solve second order ODEs, possibly in mass matrix form.
 Local truncation errors are estimated with the estimate of Zienkiewicz and Xie.
 
+## Adaptive time stepping
+
+The Zienkiewicz-Xie estimate monitors both solution components. The position
+channel uses the leading local error (β - 1/6)·dt²·(aₙ₊₁ - aₙ). The velocity
+channel uses (γ - 1/2)·dt·(aₙ₊₁ - aₙ) with the coefficient magnitude clamped
+at 1/100 from below: on and near the second-order family γ = 1/2 the true
+coefficient vanishes, and the channel falls back to the surrogate
+dt·(aₙ₊₁ - aₙ)/100, one order below the true velocity error there. This keeps
+the velocity error tracking the tolerance at all frequencies — measured on
+u'' = -ω²u for ω = 1..1000, tol = 1e-4..1e-10, the global error stays below
+2.5·nsteps·tol everywhere, where without the clamp the velocity error reached
+the full peak-to-peak range with a Success return at ω = 1000 — at the price
+of dt ~ tol^(1/2) instead of tol^(1/3) where the surrogate binds: step counts
+at ω = 1 grow by 1.05x (tol = 1e-4) up to 9.1x (tol = 1e-10). Combinations
+with β within 1/24 of 1/6 and γ within 1/100 of 1/2 are rejected in adaptive
+mode because neither leading error coefficient is measurable there; the
+linear-acceleration method β = 1/6, γ = 1/2 remains available with
+`adaptive = false`.
+
 ## References
 
 Newmark, Nathan (1959), "A method of computation for structural dynamics",
@@ -95,6 +114,26 @@ Parameters are set optimally (Chung & Hulbert 1993):
 
 Sets αₘ = 0, αf = -α, γ = (1 - 2α)/2, β = (1 - α)²/4.
 
+## Order and adaptive time stepping
+
+This implementation re-derives the acceleration from `f` at the accepted state
+on every step instead of carrying the algorithmic acceleration, so it is second
+order iff γ(1 - αf) = (1 - αm)/2, which for αₘ ≠ αf differs from the textbook
+condition γ = 1/2 - αₘ + αf; the ρ∞ and HHT parameterizations with damping
+therefore converge at first order with a small leading constant (measured
+fixed-step order 2.00 on the implementation locus).
+
+The Zienkiewicz-Xie estimate is extended with the coefficients β - 1/(6κ)
+(position) and γ - 1/(2κ) (velocity), κ = (1 - αf)/(1 - αm), the velocity
+coefficient magnitude clamped at 1/100 from below so that the velocity channel
+stays live on the family γ = 1/(2κ) where it otherwise vanishes. Large ρ∞
+sits inside that clamp (ρ∞ = 0.9 has γ - 1/(2κ) ≈ 0.0026, ρ∞ = 1 is exactly
+on the family); measured on u'' = -ω²u at ω = 100, ρ∞ = 0.9 holds the global
+error below 0.7·nsteps·tol for tol = 1e-4..1e-6. Parameter sets with β
+within 1/24 of 1/(6κ) and γ within 1/100 of 1/(2κ) are rejected in adaptive
+mode because neither leading error coefficient is measurable there; they
+remain available with `adaptive = false`.
+
 ## References
 
 Chung, J., and Hulbert, G. M. (1993), "A time integration algorithm for structural
@@ -120,8 +159,12 @@ struct GeneralizedAlpha{PT, F, AD, Thread, CJ} <:
 end
 
 # handles multiple ways the user can call the method: standard rho_inf, explicit 4 parameter construction, or the HHT-alpha convention
+# The four parameters are also accepted as keywords because remake (reached
+# through prepare_alg whenever a sublibrary with AD preparation is loaded
+# alongside) reconstructs the algorithm from its field names.
 function GeneralizedAlpha(
-        αm = nothing, αf = nothing, β = nothing, γ = nothing;
+        αm_arg = nothing, αf_arg = nothing, β_arg = nothing, γ_arg = nothing;
+        αm = αm_arg, αf = αf_arg, β = β_arg, γ = γ_arg,
         rho_inf = nothing,
         alpha_hht = nothing,
         autodiff = AutoForwardDiff(),

--- a/lib/OrdinaryDiffEqNewmark/src/newmark_perform_step.jl
+++ b/lib/OrdinaryDiffEqNewmark/src/newmark_perform_step.jl
@@ -1,8 +1,92 @@
 # Newmark-β is generalized-α with αm = αf = 0, and both schemes reach the inner solver
 # through the same discretization cache, so the in-place step is shared.
+
+# The step re-derives aₙ from f at the accepted state while aₙ₊₁ solves the
+# interpolated-state balance M[(1 - αm)aₙ₊₁ + αm aₙ] = f(xₙ₊αf), which stretches
+# the solved acceleration difference: aₙ₊₁ - aₙ = κ dt u''' + O(dt²) with
+# κ = (1 - αf)/(1 - αm). Newmark-β has κ = 1.
+zx_kappa(αm, αf) = (1 - αf) / (1 - αm)
+
+# Zienkiewicz & Xie (1991) Eq. 21 generalized to that discretization: comparing
+# the update formulas against the Taylor expansion of the exact solution, the
+# leading local errors of a step are
+#   position: (βκ - 1/6) dt³ u''' = (β - 1/(6κ)) dt² (aₙ₊₁ - aₙ)
+#   velocity: (γκ - 1/2) dt² u''' = (γ - 1/(2κ)) dt  (aₙ₊₁ - aₙ)
+# For Newmark-β the position line is Eq. 21 verbatim.
+zx_position_coefficient(β, κ) = β - 1 / (6κ)
+zx_velocity_coefficient(γ, κ) = γ - 1 / (2κ)
+
+# Each channel reports an error arbitrarily smaller than the true one near its
+# vanishing locus: β = 1/(6κ) for position, γ = 1/(2κ) for velocity. The two
+# channels are not interchangeable. A healthy velocity channel does bound the
+# position error, because it watches the lower-order dt² term and the position
+# error is dt³ (measured on the harmonic oscillator: β = 1/6, γ = 0.7 — zero
+# position coefficient — holds Q = global error / (nsteps * tol) ≈ 1.0 over
+# tol = 1e-6..1e-10). A healthy position channel does NOT bound the velocity error:
+# on the family γ = 1/(2κ) both leading errors are O(dt³), but the velocity
+# term carries an extra factor of frequency (dt³ω³ against the position dt³ω²
+# on u'' = -ω²u), so the position-equilibrated dt lets the velocity error pass
+# the tolerance by a factor that grows linearly in ω — measured Qv ≈ 2.1/13.5/119
+# at ω = 1/10/100 (tol = 1e-6) and full 2.0 peak-to-peak velocity error with a
+# Success code at ω = 1000, before the clamp below existed.
+#
+# The velocity channel therefore never switches off. Inside the band
+# |γ - 1/(2κ)| < ZX_VELOCITY_BAND the measured coefficient is exactly the
+# quantity the band declares untrustworthy, so the channel is evaluated as if
+# γ sat on the band edge: Cv_eff = max(|γ - 1/(2κ)|, ZX_VELOCITY_BAND). The
+# in-band estimate Cv_eff·dt·(aₙ₊₁ - aₙ) ≈ (κ/100)·dt²·u''' is a surrogate one
+# order below the true on-family velocity error (γκ·c₂ - 1/6)·dt³·u'''' — the
+# next-order term is not measurable from a single step's Δa — hence
+# conservative for resolved motion and continuous in γ across the band edge.
+# The cost is that dt scales as tol^(1/2) instead of tol^(1/3) wherever the
+# surrogate binds; measured step counts at ω = 1 on the harmonic oscillator:
+# 1.05x/1.9x/4.2x/9.1x the position-only counts at tol = 1e-4/-6/-8/-10
+# (43/186/838/3863 steps before, 45/361/3481/35023 after), and with the
+# surrogate binding the omega sweep ω = 1..1000, tol = 1e-4..1e-10 measures
+# Q ≤ 2.5 everywhere (worst measured ≈ 2.46 near ω = 30, tol = 1e-4).
+#
+# Both bands together (position channel vanishing AND γ in the velocity band)
+# are still rejected: the estimate would consist solely of the surrogate,
+# which is a proxy for step control, not a measurement of either leading
+# error term. The position width 1/24 predates the surrogate (position-channel
+# quality degraded like ~0.19/|Cp| when nothing else bound the step) and is
+# kept as a conservative gate for that rejection. Baseline quality on the
+# harmonic oscillator over reltol = abstol in [1e-12, 1e-4] is Q ≈ 0.2-3
+# for every healthy configuration measured. Q is problem-dependent: the
+# near-separatrix pendulum (u0 = 2.5 rad, T = 10) measures Q ≈ 34-39 for the
+# velocity-channel configuration β = 1/6, γ = 0.7 at the same tolerances,
+# while a small-angle pendulum (u0 = 0.5 rad) stays at Q ≈ 0.6-1.4.
+const ZX_POSITION_BAND = 1 / 24
+const ZX_VELOCITY_BAND = 1 / 100
+
+function zx_band_check(β, γ, αm, αf)
+    κ = zx_kappa(αm, αf)
+    Cp = zx_position_coefficient(β, κ)
+    Cv = zx_velocity_coefficient(γ, κ)
+    if abs(Cp) < ZX_POSITION_BAND && abs(Cv) < ZX_VELOCITY_BAND
+        throw(
+            ArgumentError(
+                "The Zienkiewicz-Xie error estimate is blind for these " *
+                    "parameters: its position coefficient β - 1/(6κ) = $Cp and " *
+                    "velocity coefficient γ - 1/(2κ) = $Cv, κ = (1 - αf)/(1 - αm), " *
+                    "are both too close to their vanishing loci, so the estimated " *
+                    "error can be arbitrarily small next to the actual error and " *
+                    "the solver would return inaccurate results with a Success " *
+                    "code. Move β at least $ZX_POSITION_BAND away from $(1 / (6κ)) " *
+                    "or γ at least $ZX_VELOCITY_BAND away from $(1 / (2κ)), or " *
+                    "pass adaptive = false."
+            )
+        )
+    end
+    return nothing
+end
+
 function initialize!(
         integrator, cache::Union{NewmarkBetaCache, GeneralizedAlphaCache}
     )
+    if integrator.opts.adaptive
+        zx_band_check(cache.β, cache.γ, cache.evalcache.αm, cache.evalcache.αf)
+    end
     integrator.f(cache.fsalfirst, integrator.uprev, integrator.p, integrator.t)
     integrator.stats.nf += 1
     integrator.fsalfirst = cache.fsalfirst
@@ -19,7 +103,17 @@ end
 
     # Evaluate predictor
     vₙ, uₙ = integrator.uprev.x
-    if integrator.derivative_discontinuity || !integrator.opts.adaptive
+    if integrator.opts.adaptive
+        # After a rejected attempt fsalfirst holds the trial state's derivative
+        # (fsalfirst and fsallast share a buffer), so the left-endpoint
+        # acceleration is always refreshed from uprev.
+        f(integrator.fsalfirst, integrator.uprev, p, t)
+        integrator.stats.nf += 1
+    else
+        # Only reachable with adaptive stepping off; the old guard
+        # `derivative_discontinuity || !adaptive` was constant-true here and
+        # reduces to `else`. Fixed-step keeps the historical refresh at the
+        # trial state, pinned bit-for-bit by the fixed-step anchor tests.
         f(integrator.fsalfirst, integrator.u, p, t + dt)
         integrator.stats.nf += 1
     end
@@ -51,26 +145,40 @@ end
     @.. thread = thread u.x[2] = uₙ + dt * vₙ + dt^2 / 2 * ((1 - 2β) * aₙ + 2β * aₙ₊₁)
 
     if integrator.opts.adaptive
-        f(integrator.fsallast, u, p, t + dt)
-        integrator.stats.nf += 1
-
-        if integrator.success_iter == 0
-            OrdinaryDiffEqCore.set_EEst!(integrator, one(OrdinaryDiffEqCore.get_EEst(integrator)))
-        else
-            # Zienkiewicz and Xie (1991) Eq. 21
-            @.. thread = thread atmp = (integrator.fsallast.x[1] - aₙ₊₁)
-            OrdinaryDiffEqCore.set_EEst!(
-                integrator,
-                dt * dt * (β - 1 // 6) *
-                    integrator.opts.internalnorm(atmp, t)
-            )
-        end
+        κ = zx_kappa(evalcache.αm, evalcache.αf)
+        Cp = dt^2 * zx_position_coefficient(β, κ)
+        @.. thread = thread atmp.x[1] = Cp * (aₙ₊₁ - aₙ)
+        calculate_residuals!(
+            atmp.x[2], atmp.x[1], uₙ, u.x[2],
+            integrator.opts.abstol, integrator.opts.reltol,
+            integrator.opts.internalnorm, t
+        )
+        est = integrator.opts.internalnorm(atmp.x[2], t)
+        # Velocity channel, clamped at the band edge so it stays live on the
+        # family γ = 1/(2κ) where the measured coefficient vanishes; see the
+        # derivation at the top of this file.
+        Cv = dt * max(abs(zx_velocity_coefficient(γ, κ)), ZX_VELOCITY_BAND)
+        @.. thread = thread atmp.x[1] = Cv * (aₙ₊₁ - aₙ)
+        calculate_residuals!(
+            atmp.x[2], atmp.x[1], vₙ, u.x[1],
+            integrator.opts.abstol, integrator.opts.reltol,
+            integrator.opts.internalnorm, t
+        )
+        est = max(est, integrator.opts.internalnorm(atmp.x[2], t))
+        # A vanishing acceleration difference carries no step-size information, and
+        # EEst = 0 makes the controller grow dt by qmax every step; a marginal
+        # accept holds dt inside the controller's qsteady window instead.
+        iszero(est) && (est = one(est))
+        OrdinaryDiffEqCore.set_EEst!(integrator, est)
     end
 
     return
 end
 
 function initialize!(integrator, cache::NewmarkBetaConstantCache)
+    if integrator.opts.adaptive
+        zx_band_check(cache.β, cache.γ, zero(cache.β), zero(cache.β))
+    end
     cache.fsalfirst .= integrator.f(integrator.uprev, integrator.p, integrator.t)
     integrator.stats.nf += 1
     integrator.fsalfirst = cache.fsalfirst
@@ -81,12 +189,19 @@ end
 @muladd function perform_step!(
         integrator, cache::NewmarkBetaConstantCache, repeat_step = false
     )
-    (; t, u, dt, f, p) = integrator
-    (; β, γ, thread, nlsolver, atmp) = cache
+    (; t, dt, f, p) = integrator
+    (; β, γ, thread, nlsolver) = cache
 
     # Evaluate predictor
-    if integrator.derivative_discontinuity || !integrator.opts.adaptive
-        integrator.fsalfirst .= f(u, p, t + dt)
+    if integrator.opts.adaptive
+        integrator.fsalfirst .= f(integrator.uprev, p, t)
+        integrator.stats.nf += 1
+    else
+        # Only reachable with adaptive stepping off; the old guard
+        # `derivative_discontinuity || !adaptive` was constant-true here and
+        # reduces to `else`. Fixed-step keeps the historical refresh at the
+        # trial state, pinned bit-for-bit by the fixed-step anchor tests.
+        integrator.fsalfirst .= f(integrator.u, p, t + dt)
         integrator.stats.nf += 1
     end
     aₙ = integrator.fsalfirst.x[1] # = fsallast
@@ -107,31 +222,63 @@ end
     end
     aₙ₊₁ = nlsol.u
 
-    # The velocity component in uprev and u is shadowed, so the order of these two operation below matter.
-    @.. thread = thread u.x[2] = uₙ + dt * vₙ + dt^2 / 2 * ((1 - 2β) * aₙ + 2β * aₙ₊₁)
-    @.. thread = thread u.x[1] = vₙ + dt * ((1 - γ) * aₙ + γ * aₙ₊₁)
+    # `update_uprev!` rebinds uprev to u for out-of-place problems instead of
+    # copying, so the step must build fresh arrays and rebind u; mutating through
+    # the old binding would drag uprev along and collapse the interpolation
+    # interval to two identical endpoints.
+    vₙ₊₁ = similar(vₙ)
+    uₙ₊₁ = similar(uₙ)
+    @.. thread = thread uₙ₊₁ = uₙ + dt * vₙ + dt^2 / 2 * ((1 - 2β) * aₙ + 2β * aₙ₊₁)
+    @.. thread = thread vₙ₊₁ = vₙ + dt * ((1 - γ) * aₙ + γ * aₙ₊₁)
+    integrator.u = ArrayPartition((vₙ₊₁, uₙ₊₁))
 
     if integrator.opts.adaptive
-        integrator.fsallast .= f(u, p, t + dt)
-        integrator.stats.nf += 1
-
-        if integrator.success_iter == 0
-            OrdinaryDiffEqCore.set_EEst!(integrator, one(OrdinaryDiffEqCore.get_EEst(integrator)))
-        else
-            # Zienkiewicz and Xie (1991) Eq. 21
-            @.. thread = thread atmp = (integrator.fsallast.x[1] - aₙ₊₁)
-            OrdinaryDiffEqCore.set_EEst!(
-                integrator,
-                dt * dt * (β - 1 // 6) *
-                    integrator.opts.internalnorm(atmp, t)
-            )
-        end
+        zx_constant_cache_estimate!(
+            integrator, β, γ, zero(β), zero(β), dt, t, aₙ, aₙ₊₁, vₙ, uₙ, vₙ₊₁, uₙ₊₁
+        )
     end
 
     return
 end
 
+# Shared error estimate for the out-of-place steps; see the coefficient
+# derivation at the top of this file.
+function zx_constant_cache_estimate!(
+        integrator, β, γ, αm, αf, dt, t, aₙ, aₙ₊₁, vₙ, uₙ, vₙ₊₁, uₙ₊₁
+    )
+    κ = zx_kappa(αm, αf)
+    Cp = dt^2 * zx_position_coefficient(β, κ)
+    tmp = similar(uₙ₊₁)
+    @.. tmp = Cp * (aₙ₊₁ - aₙ)
+    atmp = calculate_residuals(
+        tmp, uₙ, uₙ₊₁,
+        integrator.opts.abstol, integrator.opts.reltol,
+        integrator.opts.internalnorm, t
+    )
+    est = integrator.opts.internalnorm(atmp, t)
+    # Velocity channel, clamped at the band edge so it stays live on the
+    # family γ = 1/(2κ) where the measured coefficient vanishes; see the
+    # derivation at the top of this file.
+    Cv = dt * max(abs(zx_velocity_coefficient(γ, κ)), ZX_VELOCITY_BAND)
+    @.. tmp = Cv * (aₙ₊₁ - aₙ)
+    atmp = calculate_residuals(
+        tmp, vₙ, vₙ₊₁,
+        integrator.opts.abstol, integrator.opts.reltol,
+        integrator.opts.internalnorm, t
+    )
+    est = max(est, integrator.opts.internalnorm(atmp, t))
+    # A vanishing acceleration difference carries no step-size information, and
+    # EEst = 0 makes the controller grow dt by qmax every step; a marginal
+    # accept holds dt inside the controller's qsteady window instead.
+    iszero(est) && (est = one(est))
+    OrdinaryDiffEqCore.set_EEst!(integrator, est)
+    return nothing
+end
+
 function initialize!(integrator, cache::GeneralizedAlphaConstantCache)
+    if integrator.opts.adaptive
+        zx_band_check(cache.β, cache.γ, cache.αm, cache.αf)
+    end
     cache.fsalfirst .= integrator.f(integrator.uprev, integrator.p, integrator.t)
     integrator.stats.nf += 1
     integrator.fsalfirst = cache.fsalfirst
@@ -142,11 +289,18 @@ end
 @muladd function perform_step!(
         integrator, cache::GeneralizedAlphaConstantCache, repeat_step = false
     )
-    (; t, u, dt, f, p) = integrator
-    (; αm, αf, β, γ, thread, nlsolver, atmp) = cache
+    (; t, dt, f, p) = integrator
+    (; αm, αf, β, γ, thread, nlsolver) = cache
 
-    if integrator.derivative_discontinuity || !integrator.opts.adaptive
-        integrator.fsalfirst .= f(u, p, t + dt)
+    if integrator.opts.adaptive
+        integrator.fsalfirst .= f(integrator.uprev, p, t)
+        integrator.stats.nf += 1
+    else
+        # Only reachable with adaptive stepping off; the old guard
+        # `derivative_discontinuity || !adaptive` was constant-true here and
+        # reduces to `else`. Fixed-step keeps the historical refresh at the
+        # trial state, pinned bit-for-bit by the fixed-step anchor tests.
+        integrator.fsalfirst .= f(integrator.u, p, t + dt)
         integrator.stats.nf += 1
     end
     aₙ = integrator.fsalfirst.x[1]
@@ -167,25 +321,20 @@ end
     end
     aₙ₊₁ = nlsol.u
 
-    # velocity component in uprev and u is shadowed, so order matters here
-    @.. thread = thread u.x[2] = uₙ + dt * vₙ + dt^2 / 2 * ((1 - 2β) * aₙ + 2β * aₙ₊₁)
-    @.. thread = thread u.x[1] = vₙ + dt * ((1 - γ) * aₙ + γ * aₙ₊₁)
+    # `update_uprev!` rebinds uprev to u for out-of-place problems instead of
+    # copying, so the step must build fresh arrays and rebind u; mutating through
+    # the old binding would drag uprev along and collapse the interpolation
+    # interval to two identical endpoints.
+    vₙ₊₁ = similar(vₙ)
+    uₙ₊₁ = similar(uₙ)
+    @.. thread = thread uₙ₊₁ = uₙ + dt * vₙ + dt^2 / 2 * ((1 - 2β) * aₙ + 2β * aₙ₊₁)
+    @.. thread = thread vₙ₊₁ = vₙ + dt * ((1 - γ) * aₙ + γ * aₙ₊₁)
+    integrator.u = ArrayPartition((vₙ₊₁, uₙ₊₁))
 
     if integrator.opts.adaptive
-        integrator.fsallast .= f(u, p, t + dt)
-        integrator.stats.nf += 1
-
-        if integrator.success_iter == 0
-            OrdinaryDiffEqCore.set_EEst!(integrator, one(OrdinaryDiffEqCore.get_EEst(integrator)))
-        else
-            # Zienkiewicz and Xie (1991) Eq. 21
-            @.. thread = thread atmp = (integrator.fsallast.x[1] - aₙ₊₁)
-            OrdinaryDiffEqCore.set_EEst!(
-                integrator,
-                dt * dt * (β - 1 // 6) *
-                    integrator.opts.internalnorm(atmp, t)
-            )
-        end
+        zx_constant_cache_estimate!(
+            integrator, β, γ, αm, αf, dt, t, aₙ, aₙ₊₁, vₙ, uₙ, vₙ₊₁, uₙ₊₁
+        )
     end
 
     return

--- a/lib/OrdinaryDiffEqNewmark/test/coload_tests.jl
+++ b/lib/OrdinaryDiffEqNewmark/test/coload_tests.jl
@@ -1,0 +1,31 @@
+# Loading a sublibrary that carries AD preparation (SDIRK, Rosenbrock, or the
+# umbrella) routes every solve through prepare_alg -> remake, which rebuilds
+# the algorithm from its field names as keyword arguments. GeneralizedAlpha
+# only accepted its parameters positionally, so any co-loaded solve threw a
+# MethodError before the keyword constructor existed.
+using OrdinaryDiffEqNewmark, OrdinaryDiffEqSDIRK, Test, RecursiveArrayTools
+using SciMLBase: ReturnCode
+
+f1_iip!(dv, v, u, p, t) = (dv .= -u)
+f2_iip!(du, v, u, p, t) = (du .= v)
+f1_oop(v, u, p, t) = -u
+f2_oop(v, u, p, t) = v
+
+@testset "Solves succeed with OrdinaryDiffEqSDIRK co-loaded" begin
+    prob_iip = DynamicalODEProblem(
+        DynamicalODEFunction(f1_iip!, f2_iip!), ones(2), zeros(2), (0.0, 1.0)
+    )
+    prob_oop = DynamicalODEProblem(
+        DynamicalODEFunction(f1_oop, f2_oop), ones(2), zeros(2), (0.0, 1.0)
+    )
+    algs = (
+        NewmarkBeta(),
+        GeneralizedAlpha(rho_inf = 0.9),
+        GeneralizedAlpha(alpha_hht = -0.1),
+        GeneralizedAlpha(0.1, 0.2, 0.25, 0.6),
+    )
+    for prob in (prob_iip, prob_oop), alg in algs
+        sol = solve(prob, alg, dt = 0.1)
+        @test sol.retcode == ReturnCode.Success
+    end
+end

--- a/lib/OrdinaryDiffEqNewmark/test/newmark_adaptive_tests.jl
+++ b/lib/OrdinaryDiffEqNewmark/test/newmark_adaptive_tests.jl
@@ -1,0 +1,309 @@
+using OrdinaryDiffEqNewmark, Test, RecursiveArrayTools
+using SciMLBase: ReturnCode
+
+# Harmonic oscillator with analytic solution
+f1_harmonic_iip!(dv, v, u, p, t) = (dv .= -u)
+f2_harmonic_iip!(du, v, u, p, t) = (du .= v)
+f1_harmonic_oop(v, u, p, t) = -u
+f2_harmonic_oop(v, u, p, t) = v
+function harmonic_analytic(y0, p, t)
+    v0, u0 = y0.x
+    return ArrayPartition(-u0 * sin(t) + v0 * cos(t), u0 * cos(t) + v0 * sin(t))
+end
+
+function harmonic_probs(N, T = 5.0)
+    v0 = ones(N)
+    u0 = zeros(N)
+    iip = DynamicalODEProblem(
+        DynamicalODEFunction(
+            f1_harmonic_iip!, f2_harmonic_iip!; analytic = harmonic_analytic
+        ),
+        v0, u0, (0.0, T)
+    )
+    oop = DynamicalODEProblem(
+        DynamicalODEFunction(
+            f1_harmonic_oop, f2_harmonic_oop; analytic = harmonic_analytic
+        ),
+        v0, u0, (0.0, T)
+    )
+    return iip, oop
+end
+
+function harmonic_maxerr(sol)
+    m = 0.0
+    for (i, t) in enumerate(sol.t)
+        ex = harmonic_analytic(sol.prob.u0, nothing, t)
+        m = max(m, maximum(abs.(sol.u[i] .- ex)))
+    end
+    return m
+end
+
+# Nonlinear pendulum
+f1_pendulum_iip!(dv, v, u, p, t) = (dv .= -9.81 .* sin.(u))
+f2_pendulum_iip!(du, v, u, p, t) = (du .= v)
+pendulum_prob() = DynamicalODEProblem(
+    DynamicalODEFunction(f1_pendulum_iip!, f2_pendulum_iip!),
+    [0.0], [0.5], (0.0, 5.0)
+)
+
+@testset "Adaptive solves with default options" begin
+    for N in (1, 2, 3)
+        prob_iip, prob_oop = harmonic_probs(N)
+        for prob in (prob_iip, prob_oop)
+            for alg in (NewmarkBeta(), GeneralizedAlpha(rho_inf = 0.9))
+                sol = solve(prob, alg, dt = 0.1)
+                @test sol.retcode == ReturnCode.Success
+                # default tolerances are reltol = 1e-3, so a few 1e-2 of
+                # accumulated error over five periods is in spec
+                @test harmonic_maxerr(sol) < 1.0e-1
+            end
+        end
+    end
+end
+
+@testset "Error tracks tolerance monotonically" begin
+    prob_iip, prob_oop = harmonic_probs(2)
+    for prob in (prob_iip, prob_oop)
+        errs = Float64[]
+        nsteps = Int[]
+        for tol in (1.0e-4, 1.0e-6, 1.0e-8, 1.0e-10, 1.0e-12)
+            sol = solve(prob, NewmarkBeta(), dt = 0.1, abstol = tol, reltol = tol)
+            @test sol.retcode == ReturnCode.Success
+            push!(errs, harmonic_maxerr(sol))
+            push!(nsteps, length(sol.t) - 1)
+            # The per-step error target is tol, so the global error on this
+            # non-dissipative problem accumulates to O(nsteps * tol); healthy
+            # baseline is Q ≈ 1-3.
+            @test errs[end] <= 10 * nsteps[end] * tol
+        end
+        @test issorted(errs, rev = true)
+        # While the position channel binds, dt ~ tol^(1/3) and 100x tighter
+        # tolerance costs 100^(1/3) ≈ 4.6x the steps; once the clamped
+        # velocity surrogate binds (γ = 1/2 is inside the velocity band),
+        # dt ~ tol^(1/2) and the factor approaches 100^(1/2) = 10.
+        for i in 1:(length(nsteps) - 1)
+            @test 3 < nsteps[i + 1] / nsteps[i] < 12
+        end
+        # global error ~ (mean dt)^2: adaptive attains the method order
+        slope = (log(errs[1]) - log(errs[end])) / (log(nsteps[end]) - log(nsteps[1]))
+        @test 1.7 < slope < 2.3
+    end
+end
+
+@testset "Uninformative estimator band is rejected" begin
+    prob_iip, prob_oop = harmonic_probs(2)
+    for β in (
+            1 / 6, nextfloat(1 / 6), prevfloat(1 / 6),
+            1 / 6 + 1.0e-6, 1 / 6 - 1.0e-6, 1 / 6 + 1.0e-8, 1 / 6 - 1.0e-8,
+            1 / 6 + 1.0e-10, 1 / 6 - 1.0e-10, 0.1667,
+        )
+        for prob in (prob_iip, prob_oop)
+            @test_throws ArgumentError solve(prob, NewmarkBeta(β, 0.5), dt = 0.1)
+            # the parameters stay usable with fixed steps
+            sol = solve(prob, NewmarkBeta(β, 0.5), dt = 0.1, adaptive = false)
+            @test sol.retcode == ReturnCode.Success
+        end
+    end
+    # γ within its band around 1/2 while β is inside its own band: rejected
+    @test_throws ArgumentError solve(
+        prob_iip, NewmarkBeta(1 / 6, 0.5 + 1.0e-3), dt = 0.1
+    )
+    # a healthy velocity channel rescues a vanishing position channel
+    for prob in (prob_iip, prob_oop)
+        sol = solve(prob, NewmarkBeta(1 / 6, 0.7), dt = 0.1)
+        @test sol.retcode == ReturnCode.Success
+        @test harmonic_maxerr(sol) < 1.0e-1
+    end
+    # generalized-α: the loci move to β = 1/(6κ), γ = 1/(2κ), κ = (1-αf)/(1-αm)
+    κ = (1 - 0.2) / (1 - 0.1)
+    @test_throws ArgumentError solve(
+        prob_iip, GeneralizedAlpha(0.1, 0.2, 1 / (6κ), 1 / (2κ)), dt = 0.1
+    )
+    @test_throws ArgumentError solve(
+        prob_oop, GeneralizedAlpha(0.1, 0.2, 1 / (6κ), 1 / (2κ)), dt = 0.1
+    )
+end
+
+@testset "Degenerate estimate cannot grow dt" begin
+    # Constant acceleration: aₙ₊₁ - aₙ = 0 on every step, so the estimate is
+    # exactly zero; the controller must hold the step size instead of walking
+    # it out to dtmax.
+    g1!(dv, v, u, p, t) = (dv .= -9.81)
+    g2!(du, v, u, p, t) = (du .= v)
+    gprob = DynamicalODEProblem(
+        DynamicalODEFunction(g1!, g2!), [1.0], [0.0], (0.0, 10.0)
+    )
+    sol = solve(gprob, NewmarkBeta(), dt = 0.5, dtmax = 1.0e6)
+    @test sol.retcode == ReturnCode.Success
+    @test maximum(diff(sol.t)) <= 0.5 + 1.0e-12
+    @test abs(sol.u[end].x[2][1] - (10.0 - 9.81 * 50.0)) < 1.0e-8
+    # same defence on the out-of-place estimate path
+    g1(v, u, p, t) = [-9.81]
+    g2(v, u, p, t) = v
+    gprob_oop = DynamicalODEProblem(
+        DynamicalODEFunction(g1, g2), [1.0], [0.0], (0.0, 10.0)
+    )
+    sol = solve(gprob_oop, NewmarkBeta(), dt = 0.5, dtmax = 1.0e6)
+    @test sol.retcode == ReturnCode.Success
+    @test maximum(diff(sol.t)) <= 0.5 + 1.0e-12
+    @test abs(sol.u[end].x[2][1] - (10.0 - 9.81 * 50.0)) < 1.0e-8
+end
+
+@testset "Velocity surrogate controls high-frequency error" begin
+    # u'' = -ω²u with unit velocity amplitude: the position tolerance scale is
+    # 1/ω smaller than the velocity scale, so a position-only estimate lets
+    # the velocity error through by a factor ~ω. Before the clamped velocity
+    # channel this case measured Q = verr/(nsteps*tol) ≈ 119 with a Success
+    # return; the surrogate holds it at ≈ 0.4.
+    ω = 100.0
+    s1!(dv, v, u, p, t) = (dv .= -ω^2 .* u)
+    s2!(du, v, u, p, t) = (du .= v)
+    s1(v, u, p, t) = -ω^2 .* u
+    s2(v, u, p, t) = v
+    tol = 1.0e-6
+    for (fns, alg) in (
+            ((s1!, s2!), NewmarkBeta()),
+            ((s1, s2), NewmarkBeta()),
+            ((s1!, s2!), GeneralizedAlpha(rho_inf = 0.9)),
+        )
+        prob = DynamicalODEProblem(
+            DynamicalODEFunction(fns...), [1.0], [0.0], (0.0, 5.0)
+        )
+        sol = solve(
+            prob, alg, dt = 0.01, abstol = tol, reltol = tol, maxiters = 10^7
+        )
+        @test sol.retcode == ReturnCode.Success
+        verr = maximum(
+            abs(sol.u[i].x[1][1] - cos(ω * t)) for (i, t) in enumerate(sol.t)
+        )
+        nsteps = length(sol.t) - 1
+        @test verr <= 20 * nsteps * tol
+    end
+end
+
+# Pins the position channel itself: with it zeroed, this configuration takes
+# 19 steps at Q ≈ 5.6 instead of 34 at Q ≈ 0.7, so either assertion fails.
+@testset "Position channel binds the step size" begin
+    prob = DynamicalODEProblem(
+        DynamicalODEFunction(
+            (dv, v, u, p, t) -> (dv .= -u), (du, v, u, p, t) -> (du .= v)
+        ), [0.0], [1.0], (0.0, 5.0)
+    )
+    tol = 1.0e-3
+    sol = solve(prob, NewmarkBeta(0.5, 0.5), dt = 0.1, abstol = tol, reltol = tol)
+    @test sol.retcode == ReturnCode.Success
+    @test sol.stats.naccept >= 30
+    nsteps = length(sol.t) - 1
+    maxerr = maximum(
+        abs(sol.u[i].x[2][1] - cos(t)) for (i, t) in enumerate(sol.t)
+    )
+    @test maxerr <= 2 * nsteps * tol
+end
+
+@testset "Out-of-place saveat interpolation" begin
+    prob = DynamicalODEProblem(
+        DynamicalODEFunction(f1_harmonic_oop, f2_harmonic_oop),
+        zeros(2), ones(2), (0.0, 1.0)
+    )
+    # GeneralizedAlpha(rho_inf = 1) runs the same update arithmetic as
+    # NewmarkBeta() but through the GeneralizedAlphaConstantCache step, whose
+    # uprev-aliasing behaviour is otherwise untested.
+    for alg in (NewmarkBeta(), GeneralizedAlpha(rho_inf = 1.0))
+        sol = solve(prob, alg, dt = 0.1, saveat = 0.25, adaptive = false)
+        @test sol.retcode == ReturnCode.Success
+        for (i, t) in enumerate(sol.t)
+            @test maximum(abs.(sol.u[i].x[1] .- (-sin(t)))) < 1.0e-3
+            @test maximum(abs.(sol.u[i].x[2] .- cos(t))) < 1.0e-3
+        end
+    end
+end
+
+@testset "Fixed-step results are unchanged" begin
+    # Damped oscillator, dt = 0.1, NewmarkBeta(): the final state is pinned
+    # bit-for-bit to the values the solver produced before adaptive support.
+    d1!(dv, v, u, p, t) = (dv .= -u .- 0.3 .* v)
+    d2!(du, v, u, p, t) = (du .= v)
+    d1(v, u, p, t) = -u .- 0.3 .* v
+    d2(v, u, p, t) = v
+    v0 = [1.0, 0.3]
+    u0 = [0.0, 0.7]
+    prob_iip = DynamicalODEProblem(DynamicalODEFunction(d1!, d2!), v0, u0, (0.0, 3.0))
+    prob_oop = DynamicalODEProblem(DynamicalODEFunction(d1, d2), v0, u0, (0.0, 3.0))
+    anchor = reinterpret.(
+        Float64,
+        [0xbfe4a7055bdc734a, 0xbfd181aebd616175, 0x3fbd3aaf9181c633, 0xbfd92fc96ff9344d]
+    )
+    sol_iip = solve(prob_iip, NewmarkBeta(), dt = 0.1, adaptive = false)
+    sol_oop = solve(prob_oop, NewmarkBeta(), dt = 0.1, adaptive = false)
+    @test collect(sol_iip.u[end]) == anchor
+    @test collect(sol_oop.u[end]) == anchor
+    # in-place and out-of-place steps run the same arithmetic
+    @test all(sol_iip.u[i] == sol_oop.u[i] for i in eachindex(sol_iip.u))
+end
+
+@testset "Parameter sweep stays within tolerance" begin
+    prob_iip, prob_oop = harmonic_probs(2)
+    in_band(β, γ) = abs(β - 1 / 6) < 1 / 24 && abs(γ - 1 / 2) < 1 / 100
+    n_success = 0
+    for β in (0.05, 1 / 6, 0.25, 1 / 3, 0.5)
+        for γ in (0.3, 0.5, 0.7, 1.0)
+            for tol in (1.0e-6, 1.0e-10)
+                for prob in (prob_iip, prob_oop)
+                    alg = NewmarkBeta(β, γ)
+                    if in_band(β, γ)
+                        @test_throws ArgumentError solve(
+                            prob, alg, dt = 0.1, abstol = tol, reltol = tol
+                        )
+                        continue
+                    end
+                    sol = solve(
+                        prob, alg, dt = 0.1, abstol = tol, reltol = tol,
+                        maxiters = 10^7
+                    )
+                    if sol.retcode == ReturnCode.Success
+                        n_success += 1
+                        nsteps = length(sol.t) - 1
+                        @test harmonic_maxerr(sol) <= 20 * nsteps * tol
+                    end
+                end
+            end
+        end
+    end
+    # The accuracy assertion above only runs on Success, so a regression that
+    # turns solves into failures would silently hollow the sweep out; pin the
+    # Success count (all 76 non-rejected combinations succeed today).
+    @test n_success == 76
+    for ρ in (0.4, 0.7, 1.0)
+        for tol in (1.0e-6, 1.0e-8)
+            sol = solve(
+                prob_iip, GeneralizedAlpha(rho_inf = ρ), dt = 0.1,
+                abstol = tol, reltol = tol, maxiters = 10^7
+            )
+            @test sol.retcode == ReturnCode.Success
+            @test harmonic_maxerr(sol) <= 20 * (length(sol.t) - 1) * tol
+        end
+    end
+    # ρ∞ < 1/3 implies γ > 1 and has never been constructible
+    @test_throws AssertionError GeneralizedAlpha(rho_inf = 0.2)
+
+    # Nonlinear pendulum against a tight-tolerance reference. Q = err/(n*tol)
+    # is problem-dependent: the harmonic-oscillator baseline is Q ≈ 0.2-3,
+    # while this near-separatrix pendulum (u0 = 2.5 rad) measures Q ≈ 34-39 for the velocity-channel
+    # configuration NewmarkBeta(1/6, 0.7), which is why only the default and
+    # ρ∞ = 0.9 configurations are asserted against the 20x bound here.
+    pprob = pendulum_prob()
+    ref = solve(
+        pprob, NewmarkBeta(), dt = 0.1, abstol = 1.0e-13, reltol = 1.0e-13,
+        save_everystep = false, maxiters = 10^7
+    )
+    for tol in (1.0e-6, 1.0e-10)
+        for alg in (NewmarkBeta(), GeneralizedAlpha(rho_inf = 0.9))
+            sol = solve(
+                pprob, alg, dt = 0.1, abstol = tol, reltol = tol,
+                save_everystep = false, maxiters = 10^7
+            )
+            @test sol.retcode == ReturnCode.Success
+            @test maximum(abs.(sol.u[end] .- ref.u[end])) <= 20 * sol.stats.naccept * tol
+        end
+    end
+end

--- a/lib/OrdinaryDiffEqNewmark/test/runtests.jl
+++ b/lib/OrdinaryDiffEqNewmark/test/runtests.jl
@@ -220,6 +220,8 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     end
 
     @time @safetestset "Inner Nonlinear Solver Caches" include("nlsolve_cache_tests.jl")
+    @time @safetestset "Adaptive Time Stepping" include("newmark_adaptive_tests.jl")
+    @time @safetestset "Co-loaded Sublibrary Remake" include("coload_tests.jl")
 end
 
 # Run QA tests (AllocCheck, JET) - skip on pre-release Julia


### PR DESCRIPTION
NewmarkBeta and GeneralizedAlpha default to adaptive time stepping, and on master the adaptive path throws a DimensionMismatch at its first error estimate for every configuration: the estimator broadcasts the acceleration difference, which has half the state's length, into the full-length residual buffer. The only way these solvers have ever produced an answer is `adaptive = false`, and every number reported in #4112 was fixed-step for that reason. This PR makes the default path work. Fixed-step results are preserved: trajectory dumps for five algorithm configurations, in place and out of place, on damped oscillator, pendulum, and saveat runs are bit-identical to master, except the out-of-place saveat values fixed below. The old step guard `derivative_discontinuity || !adaptive` was constant-true whenever its branch was reachable, so it is reduced to a plain `else` at its three sites, pinned by the same bit-for-bit anchors.

## Error estimator

The local error is the Zienkiewicz and Xie (1991) Eq. 21 estimate, extended to generalized alpha. Comparing the update formulas against the Taylor expansion of the exact solution gives a position error (beta - 1/(6 kappa)) dt^2 (a_{n+1} - a_n) and a velocity error (gamma - 1/(2 kappa)) dt (a_{n+1} - a_n), with kappa = (1 - alpha_f)/(1 - alpha_m). Newmark-beta has kappa = 1 and its position line is Eq. 21 verbatim. Both channels run through `calculate_residuals` against `abstol + reltol * |u|` and the estimate is the maximum of the two.

Both coefficients can vanish, and near a vanishing locus the channel reports an error arbitrarily smaller than the true one. The first version guarded the degenerate parameters with an exact `iszero` check, and `beta = nextfloat(1/6)` walked straight through it: the controller grew dt without bound and the solve returned Success with L-infinity error 1.576 on a problem of amplitude 1. A near-zero coefficient still produces a nonzero estimate, so shifting an exact threshold only moves that cliff, and the zero-estimate growth cap (a vanishing estimate is held at a marginal accept so dt cannot grow) catches only exact zeros. The guard is therefore a relative band: parameters with |beta - 1/(6 kappa)| < 1/24 and |gamma - 1/(2 kappa)| < 1/100 throw an ArgumentError under adaptive stepping that names both coefficients and points at `adaptive = false`. The linear acceleration method beta = 1/6, gamma = 1/2 stays available fixed-step.

## Velocity channel on the default family

The default parameters sit exactly on the vanishing locus of the velocity coefficient: gamma = 1/2 for NewmarkBeta, and every rho_inf parameterization of GeneralizedAlpha lies on gamma = 1/(2 kappa). A healthy position channel does not bound the velocity error there. Both leading errors are O(dt^3) on that family, but the velocity term carries an extra factor of frequency, so the position-equilibrated dt passes velocity error by a factor that grows linearly in omega. Measured on u'' = -omega^2 u at tol 1e-6 before the fix, Q = error / (nsteps * tol) on the velocity component was 2.04, 13.5, and 119 at omega = 1, 10, 100, and at omega = 1000 the solver returned Success with velocity error 2.0, the full peak-to-peak range.

The fix clamps the coefficient magnitude at the band edge: Cv = dt * max(|gamma - 1/(2 kappa)|, 1/100). This is identical outside the band, continuous in gamma across the edge, and inside the band it is a surrogate one order below the true velocity error, hence conservative for resolved motion. The blocker cell omega = 100, tol = 1e-6 went from Q = 119 to 0.35. A 49-cell grid over omega = 1..1000 and tol = 1e-4..1e-10 now returns Success everywhere with worst measured Q of about 2.46 at omega = 30, tol = 1e-4, and free-running omega = 1000 at tol = 1e-10 takes 32.8 million steps to Q = 0.0052.

The surrogate has a real cost where it binds: dt scales as tol^(1/2) instead of tol^(1/3). At omega = 1 the step counts against a position-only estimate go 43 to 45, 186 to 361, 838 to 3481, and 3863 to 35023 at tol = 1e-4 through 1e-10, about 9x at the tightest tolerance, and a nonlinear pendulum at T = 10 pays 203384 steps against 18188, an 11.2x factor. The docstrings state the scaling and the measured counts. One disclosed weak spot remains: parameters with a live velocity coefficient but vanishing position coefficient, such as NewmarkBeta(1/6, 0.7), hold Q near 1.0 on harmonic problems but measure Q = 29.8 to 39.5 on a near-separatrix pendulum (u0 = 2.5 rad, T = 10). Q is constant in tol there, so the error still scales linearly with the tolerance.

## Out-of-place aliasing and GeneralizedAlpha remake

For out-of-place problems `update_uprev!` rebinds uprev to u instead of copying, and the constant-cache step mutated u through the old binding, dragging uprev along and collapsing the interpolation onto a single point. The step now builds fresh arrays and rebinds `integrator.u`. Out-of-place saveat values now match the in-place ones to within 1 ulp, where master disagreed in the leading digits; reverting only this rebind produces saveat errors of 3.5e-2 against the test bound of 1e-3.

GeneralizedAlpha had only positional constructors, and `remake` reconstructs an algorithm from its field names whenever `prepare_alg` runs, which happens as soon as a sublibrary with AD preparation is loaded next to this one. `using OrdinaryDiffEqSDIRK` was enough to turn every GeneralizedAlpha solve into a MethodError; the round-one parameter sweep recorded 98 such throws. The constructor now accepts the four parameters as keywords as well, and a new co-load test file loads OrdinaryDiffEqSDIRK and solves through remake, 8 assertions that reproduce the MethodError before the fix. `alg_order(GeneralizedAlpha)` now keys on the implementation's second-order locus gamma (1 - alpha_f) = (1 - alpha_m)/2: the step re-derives the acceleration from f at the accepted state instead of carrying the algorithmic acceleration, so the textbook locus gamma = 1/2 - alpha_m + alpha_f is not where this discretization is second order (measured fixed-step orders 2.00 on the implementation locus, about 1 on the textbook one for alpha_m != alpha_f).

## Testing

The suite is 364 assertions: 114 pre-existing (unchanged files), 242 in a new adaptive test file, and 8 in the new co-load file, all passing. Running the new adaptive file against an unmodified master tree gives 37 passes, 29 failures, and 7 errors, so the file discriminates the fix from the bug it replaces. Each guard was deleted on a copy and the full suite rerun: removing the velocity clamp at both sites fails 2 assertions (the omega = 100 case measures Q = 119 again), removing it only on the out-of-place site fails 1, deleting the velocity channel fails 12 (2 surrogate plus 10 parameter-sweep cases), deleting the zero-estimate growth cap fails 1 on the in-place path and 1 on the constant-cache path, reverting the out-of-place rebind fails 7 (default-options and saveat testsets), and disabling the band check fails the band testset. Zeroing the position channel alone originally survived the suite, since the clamped velocity channel also bounds the position error on every admitted configuration (worst degradation without it: Q = 5.6 at beta = 0.5, tol = 1e-3, against 0.69 with it); a dedicated testset now pins that channel too, asserting the step count and error this configuration only reaches with the position channel live. A 677-case parameter sweep across both algorithm families, tolerances, and problems reports no unexpected failures; the 20 flagged cases are the disclosed near-separatrix pendulum configurations above. Version bumps 2.2.2 to 2.3.0 for the new constructor.

## AI Disclosure

Claude assisted with this work.
