### PR TITLE
Default NordsieckBDF corrector to max_iter=3 (CVODE MAXCOR)

### DIFF
--- a/lib/OrdinaryDiffEqBDF/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqBDF/src/algorithms.jl
@@ -802,11 +802,15 @@ end
     - `nlsolve`: nonlinear solver for the implicit stage. Its `κ` acts as CVODE's
       NLSCOEF, i.e. the fraction of the local error budget the corrector is allowed
       to consume, because the increment norm is scaled by the test quantity `tq[2]`.
+      The default caps the corrector at 3 iterations, matching CVODE's `MAXCOR`:
+      past that it is cheaper to give up, refresh `W`, and re-converge than to keep
+      iterating with a stale Jacobian — a trade this method can take because
+      refactorizing is comparatively rare for it.
     - `max_order`: maximum BDF order (1–5).
     - `step_limiter!`: function of the form `limiter!(u, integrator, p, t)`.
     """,
     """
-    nlsolve = NLNewton(),
+    nlsolve = NLNewton(max_iter = 3),
     extrapolant = :linear,
     max_order::Val{MO} = Val{5}(),
     step_limiter! = trivial_limiter!,
@@ -831,7 +835,7 @@ end
 function NordsieckBDF(;
         max_order::Val{MO} = Val{5}(),
         autodiff = AutoForwardDiff(), concrete_jac = nothing,
-        linsolve = nothing, nlsolve = NLNewton(), tol = nothing,
+        linsolve = nothing, nlsolve = NLNewton(max_iter = 3), tol = nothing,
         extrapolant = :linear, step_limiter! = trivial_limiter!, stald = false,
         qsteady_min = 1 // 1, qsteady_max = 1 // 1, qmax = 10 // 1
     ) where {MO}
@@ -866,7 +870,7 @@ end
     - `max_order`: maximum BDF order (1–5).
     """,
     """
-    nlsolve = NLNewton(),
+    nlsolve = NLNewton(max_iter = 3),
     extrapolant = :linear,
     max_order::Val{MO} = Val{5}(),
     """
@@ -888,7 +892,7 @@ end
 function DNordsieckBDF(;
         max_order::Val{MO} = Val{5}(),
         autodiff = AutoForwardDiff(), concrete_jac = nothing,
-        linsolve = nothing, nlsolve = NLNewton(), tol = nothing,
+        linsolve = nothing, nlsolve = NLNewton(max_iter = 3), tol = nothing,
         extrapolant = :linear, stald = false,
         qsteady_min = 1 // 1, qsteady_max = 1 // 1, qmax = 10 // 1
     ) where {MO}

--- a/lib/OrdinaryDiffEqBDF/test/nordsieck_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/nordsieck_tests.jl
@@ -4,6 +4,12 @@ using SciMLBase: DAEProblem, ODEProblem, ODEFunction, successful_retcode, remake
 using OrdinaryDiffEqNonlinearSolve: NLNewton, NonlinearSolveAlg
 using LinearAlgebra, Test
 
+@testset "NordsieckBDF / DNordsieckBDF: default max_iter matches CVODE MAXCOR" begin
+    @test NordsieckBDF().nlsolve.max_iter == 3
+    @test DNordsieckBDF().nlsolve.max_iter == 3
+    @test NordsieckBDF(nlsolve = NLNewton(max_iter = 10)).nlsolve.max_iter == 10
+end
+
 @testset "NordsieckBDF: adaptive accuracy" begin
     for (nm, prob) in (
             ("out-of-place", ODEProblemLibrary.prob_ode_linear),


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

## What changed and why

Lands the post-merge follow-up from [#4017](https://github.com/SciML/OrdinaryDiffEq.jl/pull/4017) ([comment](https://github.com/SciML/OrdinaryDiffEq.jl/pull/4017#issuecomment-5210726211) / commit `952ffe2`) that never made it into master because it landed on the feature branch after the PR merged.

`NordsieckBDF` / `DNordsieckBDF` now default to `nlsolve = NLNewton(max_iter = 3)`, matching CVODE's `MAXCOR`. The Nordsieck history tolerates a cheap corrector: past iteration 3 it is cheaper to give up, refresh `W`, and re-converge than to keep grinding a stale Jacobian. Measured on ROBER/HIRES/OREGO/POLLU/VDPOL/BRUSS1D at matched accuracy (relative to FBDF):

| | time | nf | nW | steps |
|---|---|---|---|---|
| NordsieckBDF (`max_iter = 10`) | 0.64x | 0.98x | 0.68x | 1.19x |
| **NordsieckBDF (`max_iter = 3`, new default)** | **0.56x** | 0.81x | 0.75x | 1.20x |
| CVODE_BDF | 0.53x | 0.60x | 0.82x | 1.31x |

Step count is essentially unchanged, so this is not the usual trade of iterations for steps — it removes work that was buying nothing. Puts the solver within ~6% of `CVODE_BDF` at matched accuracy (from 21% before).

Also locks the default with a unit test.

## Verification

### Discriminating test (fail before / pass after)

```text
# master algorithms.jl (nlsolve = NLNewton()):
NordsieckBDF default max_iter = 10
DNordsieckBDF default max_iter = 10
Test Summary:    | Pass  Fail  Total  Time
default max_iter |    1     2      3  2.8s
  Expression: (NordsieckBDF()).nlsolve.max_iter == 3
   Evaluated: 10 == 3
  Expression: (DNordsieckBDF()).nlsolve.max_iter == 3
   Evaluated: 10 == 3

# with this PR:
NordsieckBDF default max_iter = 3
DNordsieckBDF default max_iter = 3
Test Summary:    | Pass  Total  Time
default max_iter |    3      3  0.0s
```

### `GROUP=Core` for OrdinaryDiffEqBDF

```text
Test Summary:                       | Pass  Broken  Total     Time
DAE Convergence Tests               |   50            50  1m34.8s
DAE AD Tests                        |   16            16  10m27.9s
DAE Event Tests                     |    4             4  11.3s
DAE derivative_discontinuity! Tests |    5             5  21.5s
DAE Initialization Tests            |   38       2    40  1m37.7s
BDF Inference Tests                 |    1             1  2.0s
BDF Convergence Tests               |   84            84  3m52.6s
BDF Regression Tests                |   35            35  3m51.8s
Nordsieck BDF Tests                 |  101           101  3m48.2s
     Testing OrdinaryDiffEqBDF tests passed
```

`typos` clean on the touched files. Runic format check exit 0.

## What was not verified

- Full `GROUP=QA` (Aqua / ExplicitImports / JET) — not run this PR; only the Core group above.
- GPU / Downstream / docs build (docs not touched; docstring default string only).
- The original matched-accuracy timing table is from the #4017 follow-up comment, not re-run here.

## Source

Cherry-pick of https://github.com/SciML/OrdinaryDiffEq.jl/commit/952ffe2b253909316182898e94ec47286bdae102 plus a regression test for the default.