### PR TITLE
Support matrix-free Krylov linear solves in RadauIIA5

### DIFF
--- a/docs/src/implicit/FIRK.md
+++ b/docs/src/implicit/FIRK.md
@@ -65,6 +65,21 @@ Gauss–Legendre methods use the roots of the Legendre polynomial directly as co
   - **Systems < 200**: FIRK methods are competitive due to better multithreading
   - **Systems > 200**: Consider SDIRK or BDF methods instead
 
+### Matrix-free (Krylov) linear solves
+
+`RadauIIA5` supports matrix-free linear solves, so large stiff systems can be handled
+without ever forming the Jacobian:
+
+```julia
+using LinearSolve
+solve(prob, RadauIIA5(linsolve = KrylovJL_GMRES()))
+```
+
+The W-transform splits the stage system into one real-shifted and one complex-shifted
+linear system per step, and both are applied lazily through Jacobian-vector products.
+`RadauIIA3`, `RadauIIA9`, `AdaptiveRadau` and `GaussLegendre` still require a Jacobian that
+can be materialized, and error if given a matrix-free `linsolve`.
+
 ## Performance Guidelines
 
   - **Best for tolerances ≤ 1e-9** where high accuracy justifies the cost

--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFIRK"
 uuid = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.6.1"
+version = "2.7.0"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqFIRK/src/OrdinaryDiffEqFIRK.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/OrdinaryDiffEqFIRK.jl
@@ -36,8 +36,9 @@ using OrdinaryDiffEqDifferentiation: build_J_W, build_jac_config,
     calc_J!, dolinsolve, calc_J,
     islinearfunction
 import ADTypes: AutoForwardDiff
+import LinearAlgebra
 import SciMLOperators
-import SciMLOperators: AbstractSciMLOperator
+import SciMLOperators: AbstractSciMLOperator, WOperator, update_coefficients!
 # Load-bearing runtime dependency: provides the nonlinear-solver machinery the FIRK
 # integrators dispatch into. The convergence-state names FIRK uses are owned by
 # OrdinaryDiffEqCore (imported above), so this is a module-only import to keep the
@@ -63,6 +64,7 @@ using Reexport: @reexport
 include("algorithms.jl")
 include("alg_utils.jl")
 include("controllers.jl")
+include("firk_operators.jl")
 include("firk_caches.jl")
 include("firk_tableaus.jl")
 include("firk_perform_step.jl")

--- a/lib/OrdinaryDiffEqFIRK/src/firk_addsteps.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_addsteps.jl
@@ -454,10 +454,7 @@ function _ode_addsteps!(integrator, cache::RadauIIA5Cache, repeat_step = false)
     γdt, αdt, βdt = γ / dt, α / dt, β / dt
     new_jac = false
     if (new_W = do_newW(integrator, alg, new_jac, cache.W_γdt))
-        @inbounds for II in CartesianIndices(J)
-            W1[II] = -γdt * mass_matrix[Tuple(II)...] + J[II]
-            W2[II] = -(αdt + βdt * im) * mass_matrix[Tuple(II)...] + J[II]
-        end
+        firk_update_W!(W1, W2, J, mass_matrix, γdt, αdt, βdt, uprev, p, t)
         integrator.stats.nw += 1
     end
 

--- a/lib/OrdinaryDiffEqFIRK/src/firk_caches.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_caches.jl
@@ -107,6 +107,9 @@ function alg_cache(
     jac_config = build_jac_config(alg, f, uf, du1, uprev, u, tmp, dw12)
 
     J, W1 = build_J_W(alg, u, uprev, p, t, dt, f, jac_config, uEltypeNoUnits, Val(true))
+    if J isa AbstractSciMLOperator || W1 isa WOperator
+        firk_matrixfree_unsupported("RadauIIA3")
+    end
     W1 = similar(J, Complex{eltype(W1)})
     recursivefill!(W1, false)
 
@@ -258,11 +261,14 @@ function alg_cache(
     jac_config = build_jac_config(alg, f, uf, du1, uprev, u, tmp, dw1)
 
     J, W1 = build_J_W(alg, u, uprev, p, t, dt, f, jac_config, uEltypeNoUnits, Val(true))
-    if J isa AbstractSciMLOperator
-        error("Non-concrete Jacobian not yet supported by RadauIIA5.")
+    if W1 isa WOperator
+        W2 = ComplexShiftOperator(
+            f.mass_matrix, complex(inv(dt)), matrixfree_jacobian(W1), u
+        )
+    else
+        W2 = similar(J, Complex{eltype(W1)})
+        recursivefill!(W2, false)
     end
-    W2 = similar(J, Complex{eltype(W1)})
-    recursivefill!(W2, false)
 
     linprob = LinearProblem(W1, _vec(ubuff), (nothing, u, p, t); u0 = _vec(dw1))
     linsolve1 = init(
@@ -462,8 +468,8 @@ function alg_cache(
     jac_config = build_jac_config(alg, f, uf, du1, uprev, u, tmp, dw1)
 
     J, W1 = build_J_W(alg, u, uprev, p, t, dt, f, jac_config, uEltypeNoUnits, Val(true))
-    if J isa AbstractSciMLOperator
-        error("Non-concrete Jacobian not yet supported by RadauIIA5.")
+    if J isa AbstractSciMLOperator || W1 isa WOperator
+        firk_matrixfree_unsupported("RadauIIA9")
     end
     W2 = similar(J, Complex{eltype(W1)})
     W3 = similar(J, Complex{eltype(W1)})
@@ -685,8 +691,8 @@ function alg_cache(
     jac_config = build_jac_config(alg, f, uf, du1, uprev, u, zero(u), dw1)
 
     J, W1 = build_J_W(alg, u, uprev, p, t, dt, f, jac_config, uEltypeNoUnits, Val(true))
-    if J isa AbstractSciMLOperator
-        error("Non-concrete Jacobian not yet supported by AdaptiveRadau.")
+    if J isa AbstractSciMLOperator || W1 isa WOperator
+        firk_matrixfree_unsupported("AdaptiveRadau")
     end
 
     W2 = [similar(J, Complex{eltype(W1)}) for _ in 1:((max_stages - 1) ÷ 2)]
@@ -842,7 +848,7 @@ function alg_cache(
 
     J, _ = build_J_W(alg, u, uprev, p, t, dt, f, jac_config, uEltypeNoUnits, Val(true))
     if J isa AbstractSciMLOperator
-        error("Non-concrete Jacobian not yet supported by GaussLegendre.")
+        firk_matrixfree_unsupported("GaussLegendre")
     end
 
     W = similar(J, num_stages * n, num_stages * n)

--- a/lib/OrdinaryDiffEqFIRK/src/firk_operators.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_operators.jl
@@ -1,0 +1,99 @@
+"""
+    ComplexShiftOperator{T} <: AbstractSciMLOperator{T}
+
+Lazy operator representing `J - c * M`, where `J` is a Jacobian (or a matrix-free
+Jacobian-vector-product operator such as `JVPCache`), `M` is the mass matrix and `c` is a
+complex shift.
+
+FIRK methods decouple the stage system through the W-transform into one real-shifted and
+`(s - 1) ÷ 2` complex-shifted linear systems. The real-shifted system is handled by
+`SciMLOperators.WOperator`; this operator covers the complex-shifted ones. Since `J` is
+real, it is applied separately to the real and imaginary parts of the argument, so a real
+matrix-free Jacobian can back a complex linear solve.
+"""
+mutable struct ComplexShiftOperator{T, MMType, CType, JType, VType} <:
+    AbstractSciMLOperator{T}
+    mass_matrix::MMType
+    shift::CType
+    J::JType
+    vr::VType
+    vi::VType
+    Jvr::VType
+    Jvi::VType
+end
+
+function ComplexShiftOperator(mass_matrix, shift, J, u)
+    v = similar(_vec(u), eltype(J))
+    fill!(v, zero(eltype(v)))
+    T = Complex{real(eltype(J))}
+    return ComplexShiftOperator{
+        T, typeof(mass_matrix), typeof(shift), typeof(J), typeof(v),
+    }(
+        mass_matrix, shift, J, v, similar(v), similar(v), similar(v)
+    )
+end
+
+Base.size(W::ComplexShiftOperator) = size(W.J)
+Base.size(W::ComplexShiftOperator, d::Integer) = d <= 2 ? size(W)[d] : 1
+SciMLBase.isinplace(::ComplexShiftOperator) = true
+SciMLOperators.isconvertible(::ComplexShiftOperator) = false
+SciMLOperators.has_ldiv(::ComplexShiftOperator) = false
+SciMLOperators.has_ldiv!(::ComplexShiftOperator) = false
+
+function SciMLOperators.update_coefficients!(
+        W::ComplexShiftOperator, u = nothing, p = nothing, t = nothing; shift = nothing
+    )
+    if (u !== nothing) && (p !== nothing) && (t !== nothing)
+        SciMLOperators.update_coefficients!(W.J, u, p, t)
+        SciMLOperators.update_coefficients!(W.mass_matrix, u, p, t)
+    end
+    shift !== nothing && (W.shift = shift)
+    return W
+end
+
+function LinearAlgebra.mul!(
+        Y::AbstractVector, W::ComplexShiftOperator, B::AbstractVector
+    )
+    (; vr, vi, Jvr, Jvi, mass_matrix, shift) = W
+    @.. vr = real(B)
+    @.. vi = imag(B)
+    mul!(Jvr, W.J, vr)
+    mul!(Jvi, W.J, vi)
+    if mass_matrix isa UniformScaling
+        c = shift * mass_matrix.λ
+        @.. Y = Jvr + im * Jvi - c * B
+    else
+        mul!(Y, mass_matrix, B)
+        @.. Y = Jvr + im * Jvi - shift * Y
+    end
+    return Y
+end
+
+matrixfree_jacobian(W::WOperator) = W.jacvec === nothing ? W.J : W.jacvec
+
+function firk_update_W!(
+        W1::WOperator, W2::ComplexShiftOperator, J, mass_matrix, γdt, αdt, βdt, uprev, p, t
+    )
+    update_coefficients!(W1, uprev, p, t; gamma = inv(γdt))
+    update_coefficients!(W2, uprev, p, t; shift = αdt + βdt * im)
+    return nothing
+end
+
+function firk_update_W!(W1, W2, J, mass_matrix, γdt, αdt, βdt, uprev, p, t)
+    @inbounds for II in CartesianIndices(J)
+        W1[II] = -γdt * mass_matrix[Tuple(II)...] + J[II]
+        W2[II] = -(αdt + βdt * im) * mass_matrix[Tuple(II)...] + J[II]
+    end
+    return nothing
+end
+
+function firk_matrixfree_unsupported(algname)
+    return error(
+        "Non-concrete (matrix-free) Jacobians are not yet supported by $algname. " *
+            "Matrix-free `linsolve` choices such as `KrylovJL_GMRES()` are currently " *
+            "supported by `RadauIIA5` only; use `RadauIIA5(linsolve = KrylovJL_GMRES())` " *
+            "for a matrix-free FIRK method, or pass a factorization-based `linsolve` " *
+            "(the default, or e.g. `LUFactorization()`/`KLUFactorization()` with a " *
+            "`jac_prototype`) to $algname."
+    )
+end

--- a/lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
@@ -696,13 +696,12 @@ end
     c2m1 = c2 - 1
     c1mc2 = c1 - c2
     γdt, αdt, βdt = γ / dt, α / dt, β / dt
-    (new_jac = do_newJ(integrator, alg, cache, repeat_step)) &&
-        (calc_J!(J, integrator, cache); cache.W_γdt = dt)
+    if (new_jac = do_newJ(integrator, alg, cache, repeat_step))
+        J isa AbstractSciMLOperator || calc_J!(J, integrator, cache)
+        cache.W_γdt = dt
+    end
     if (new_W = do_newW(integrator, alg, new_jac, cache.W_γdt))
-        @inbounds for II in CartesianIndices(J)
-            W1[II] = -γdt * mass_matrix[Tuple(II)...] + J[II]
-            W2[II] = -(αdt + βdt * im) * mass_matrix[Tuple(II)...] + J[II]
-        end
+        firk_update_W!(W1, W2, J, mass_matrix, γdt, αdt, βdt, uprev, p, t)
         integrator.stats.nw += 1
     end
 

--- a/lib/OrdinaryDiffEqFIRK/test/ode_firk_krylov_tests.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/ode_firk_krylov_tests.jl
@@ -1,0 +1,103 @@
+using OrdinaryDiffEqFIRK, LinearSolve, LinearAlgebra, Test
+using SciMLOperators: AbstractSciMLOperator
+
+const N_brus = 8
+const xyd_brus = range(0, stop = 1, length = N_brus)
+
+brusselator_f(x, y, t) = (((x - 0.3)^2 + (y - 0.6)^2) <= 0.1^2) * (t >= 1.1) * 5.0
+limit_brus(a, N) = a == N + 1 ? 1 : a == 0 ? N : a
+
+function brusselator_2d_loop!(du, u, p, t)
+    A, B, alpha, dx = p
+    alpha = alpha / dx^2
+    @inbounds for I in CartesianIndices((N_brus, N_brus))
+        i, j = Tuple(I)
+        x, y = xyd_brus[i], xyd_brus[j]
+        ip1 = limit_brus(i + 1, N_brus)
+        im1 = limit_brus(i - 1, N_brus)
+        jp1 = limit_brus(j + 1, N_brus)
+        jm1 = limit_brus(j - 1, N_brus)
+        du[i, j, 1] = alpha *
+            (u[im1, j, 1] + u[ip1, j, 1] + u[i, jp1, 1] + u[i, jm1, 1] - 4u[i, j, 1]) +
+            B + u[i, j, 1]^2 * u[i, j, 2] - (A + 1) * u[i, j, 1] +
+            brusselator_f(x, y, t)
+        du[i, j, 2] = alpha *
+            (u[im1, j, 2] + u[ip1, j, 2] + u[i, jp1, 2] + u[i, jm1, 2] - 4u[i, j, 2]) +
+            A * u[i, j, 1] - u[i, j, 1]^2 * u[i, j, 2]
+    end
+    return nothing
+end
+
+function init_brusselator_2d(xyd)
+    N = length(xyd)
+    u = zeros(N, N, 2)
+    for I in CartesianIndices((N, N))
+        x = xyd[I[1]]
+        y = xyd[I[2]]
+        u[I, 1] = 22 * (y * (1 - y))^(3 / 2)
+        u[I, 2] = 27 * (x * (1 - x))^(3 / 2)
+    end
+    return u
+end
+
+brus_prob = ODEProblem(
+    brusselator_2d_loop!, init_brusselator_2d(xyd_brus), (0.0, 1.0),
+    (3.4, 1.0, 10.0, step(xyd_brus))
+)
+
+@testset "RadauIIA5 matrix-free Krylov" begin
+    integ = init(brus_prob, RadauIIA5(linsolve = KrylovJL_GMRES()))
+    @test integ.cache.J isa AbstractSciMLOperator
+    @test integ.cache.W2 isa OrdinaryDiffEqFIRK.ComplexShiftOperator
+
+    ref = solve(brus_prob, RadauIIA5(), abstol = 1.0e-12, reltol = 1.0e-12)
+    sol = solve(
+        brus_prob, RadauIIA5(linsolve = KrylovJL_GMRES()),
+        abstol = 1.0e-10, reltol = 1.0e-10
+    )
+    @test SciMLBase.successful_retcode(sol)
+    @test sol.u[end] ≈ ref.u[end] rtol = 1.0e-7
+
+    sol_bicg = solve(
+        brus_prob, RadauIIA5(linsolve = KrylovJL_BICGSTAB()),
+        abstol = 1.0e-10, reltol = 1.0e-10
+    )
+    @test SciMLBase.successful_retcode(sol_bicg)
+    @test sol_bicg.u[end] ≈ ref.u[end] rtol = 1.0e-7
+end
+
+@testset "RadauIIA5 matrix-free Krylov with mass matrix" begin
+    n_heat = 24
+    function heat_nonlinear!(du, u, p, t)
+        dx2 = inv((1 / (length(u) + 1))^2)
+        @inbounds for i in eachindex(u)
+            um = i == 1 ? zero(eltype(u)) : u[i - 1]
+            up = i == length(u) ? zero(eltype(u)) : u[i + 1]
+            du[i] = dx2 * (um - 2u[i] + up) - u[i]^2
+        end
+        return nothing
+    end
+    u0 = [sinpi(i / (n_heat + 1)) for i in 1:n_heat]
+    mm = Diagonal(range(1.0, 2.0, length = n_heat))
+    prob = ODEProblem(
+        ODEFunction(heat_nonlinear!, mass_matrix = mm), u0, (0.0, 1.0)
+    )
+
+    ref = solve(prob, RadauIIA5(), abstol = 1.0e-12, reltol = 1.0e-12)
+    sol = solve(
+        prob, RadauIIA5(linsolve = KrylovJL_GMRES()), abstol = 1.0e-10, reltol = 1.0e-10
+    )
+    @test SciMLBase.successful_retcode(sol)
+    @test sol.u[end] ≈ ref.u[end] rtol = 1.0e-7
+end
+
+@testset "Unsupported FIRK methods report what is supported" begin
+    for alg in (
+            RadauIIA3(linsolve = KrylovJL_GMRES()),
+            RadauIIA9(linsolve = KrylovJL_GMRES()),
+            AdaptiveRadau(linsolve = KrylovJL_GMRES()),
+            GaussLegendre(linsolve = KrylovJL_GMRES()),
+        )
+        @test_throws "RadauIIA5" init(brus_prob, alg)
+    end
+end

--- a/lib/OrdinaryDiffEqFIRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/runtests.jl
@@ -10,6 +10,7 @@ end
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "FIRK Tests" include("ode_firk_tests.jl")
+    @time @safetestset "FIRK Krylov Tests" include("ode_firk_krylov_tests.jl")
 end
 
 # Run QA tests (AllocCheck, JET, Aqua) - skip on pre-release Julia


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Part of https://github.com/SciML/OrdinaryDiffEq.jl/issues/4156.

## What changed and why

`RadauIIA5(linsolve = KrylovJL_GMRES())` errored in `alg_cache` with `Non-concrete Jacobian not yet supported by RadauIIA5.`, so the one FIRK/Krylov combination people actually want for large stiff systems at tight tolerances was unavailable. The real-shifted stage system now reuses `SciMLOperators.WOperator` (the same object `build_J_W` already returns on the matrix-free path, exactly as BDF/Rosenbrock use it), and a new internal `ComplexShiftOperator` backs the complex-shifted system `J - (α + βi)/h·M` by applying the real matrix-free Jacobian-vector product separately to the real and imaginary parts of the argument. The W-form update in `perform_step!`/`_ode_addsteps!` is now a two-method `firk_update_W!` so the operator and dense paths dispatch instead of branching inline.

**Scope was cut deliberately: this is `RadauIIA5` only.** `RadauIIA3`, `RadauIIA9`, `AdaptiveRadau` and `GaussLegendre` still require a materializable Jacobian. Extending to them is mechanical for `RadauIIA9` (one more complex pair) and less so for `AdaptiveRadau` (a stage-count-dependent vector of complex operators plus the threaded stage loop), and `AdaptiveRadau` cache construction is currently under separate investigation, so I kept it out. Their error message now names what *is* supported rather than only refusing, and the duplicated `"…not yet supported by RadauIIA5."` message that actually guarded the `RadauIIA9` cache is corrected.

`ComplexShiftOperator` is internal (not exported, not `public`), so no public API is added; the version bump to 2.7.0 is a minor bump for the new capability.

## Verification

Julia 1.12.6, branch based on `c11ff74bb4`.

**New test failing before the fix** (`git stash push -- lib/OrdinaryDiffEqFIRK/src`, then run the new test file against unpatched sources):

```
RadauIIA5 matrix-free Krylov: Error During Test at .../test/ode_firk_krylov_tests.jl:48
  Non-concrete Jacobian not yet supported by RadauIIA5.
RadauIIA5 matrix-free Krylov with mass matrix: Error During Test at .../test/ode_firk_krylov_tests.jl:69
  Non-concrete Jacobian not yet supported by RadauIIA5.
Unsupported FIRK methods report what is supported: Test Failed at .../test/ode_firk_krylov_tests.jl:101
     Message: "Non-concrete Jacobian not yet supported by AdaptiveRadau."
Unsupported FIRK methods report what is supported: Test Failed at .../test/ode_firk_krylov_tests.jl:101
     Message: "Non-concrete Jacobian not yet supported by GaussLegendre."
Test Summary:                                       | Pass  Fail  Error  Total     Time
FIRK Krylov                                         |    1     3      2      6  1m02.1s
  RadauIIA5 matrix-free Krylov                      |                 1      1     3.3s
  RadauIIA5 matrix-free Krylov with mass matrix     |                 1      1    17.4s
  Unsupported FIRK methods report what is supported |    1     3             4     5.6s
ERROR: Some tests did not pass: 1 passed, 3 failed, 2 errored, 0 broken.
```

**FIRK test group with the fix** — `cd lib/OrdinaryDiffEqFIRK && GROUP=Core julia --project -e 'using Pkg; Pkg.test()'`:

```
Test Summary: | Pass  Total     Time
FIRK Tests    |  105    105  4m07.5s
Test Summary:     | Pass  Total     Time
FIRK Krylov Tests |   12     12  1m09.0s
     Testing OrdinaryDiffEqFIRK tests passed
```

**Accuracy** — the new tests solve a 2D Brusselator (8x8x2 = 128 unknowns) and a mass-matrix nonlinear heat problem with `KrylovJL_GMRES` / `KrylovJL_BICGSTAB` at `abstol = reltol = 1e-10` and compare against `RadauIIA5()` with the default dense `linsolve` at `1e-12`, `rtol = 1e-7`. They also assert `cache.J isa AbstractSciMLOperator` and `cache.W2 isa ComplexShiftOperator`, so a regression that silently fell back to a dense Jacobian would fail rather than pass. Additional manual spot checks (not in the suite) on a 32-point nonlinear heat problem:

```
RadauIIA5 KrylovJL concrete_jac=true    ad=AutoForwardDiff retcode=Success err=1.32e-10
RadauIIA5 KrylovJL concrete_jac=nothing ad=AutoForwardDiff retcode=Success err=1.08e-10
RadauIIA5 KrylovJL concrete_jac=nothing ad=AutoFiniteDiff  retcode=Success err=1.15e-10
```

**Formatting / spelling** — `Runic` v1.5.1 `--check` over the touched files exits 0; `typos` over `lib/OrdinaryDiffEqFIRK` and `docs/src/implicit/FIRK.md` exits 0.

## Pre-existing failures I did NOT introduce (verified on the unmodified base)

Two checks fail identically with and without this change, on a clean `c11ff74bb4` tree:

1. `GROUP=QA` — `public API has docstrings: Evaluated: isempty([:SciMLBase])`. Reproduced with my changes stashed, and it is red on master's own CI. Root cause is a SciMLTesting regression, not this PR: SciML/SciMLTesting.jl#41 (v2.6.2, registered 2026-08-05) rewrote `_has_docstring` from a `occursin("No documentation found", ...)` string match to `Base.Docs.hasdoc`. The old check silently passed *every* undocumented module binding, because an undocumented module renders as `"No docstring found for public module …"`. A module self-exports its own name, so `@reexport using SciMLBase` pulls `:SciMLBase` into the public-API set. `run_api_docs`'s *rendered* check already exempts external reexports (SciML/SciMLTesting.jl#30); its *docstrings* check does not. Pinning SciMLTesting 2.6.1 or adding `ignore = (:SciMLBase,)` both make it green. 11 sublibrary QA lanes are red on master for this reason.
2. `julia --project=docs docs/make.jl` — `Error: Cannot resolve @ref for md"[`DummyControllerCache`](@ref)" in docs/src/devtools/internals/public_api.md` → `makedocs encountered an error [:cross_references]`. Reproduced with my changes stashed; both builds emit exactly one `Error`, and my `docs/src/implicit/FIRK.md` addition produces no new Documenter messages. Introduced by #4118, which rendered `DummyController`'s docstring; that docstring `@ref`s `DummyControllerCache`, whose `@docs` entry was removed in #3832. `DummyControllerCache` is deliberately non-public, so the fix is to drop the `@ref` in `lib/OrdinaryDiffEqCore/src/integrators/controllers.jl:498`.

Both belong in their own PRs rather than being smuggled in here.

## What I did NOT verify

- GPU paths, downstream packages, and the allow-failure CI jobs (`julia pre`, GPU, Downstream) — not run locally.
- Julia 1.10/1.11; only 1.12.6 was exercised.
- Out-of-place (`Val{false}`) FIRK caches — those still `lu` a dense matrix and are unchanged; matrix-free out-of-place is unsupported before and after.
- Preconditioners with the complex operator. `ComplexShiftOperator` supports `mul!` only; a left/right preconditioner supplied through `linsolve` is untested here.

## Things a reviewer should push back on

- **`nf` accounting for the complex solve is incomplete.** `OrdinaryDiffEqDifferentiation.dolinsolve` increments `stats.nf` by the Krylov iteration count only when `linsolve.A isa WOperator`, so the real solve is counted and the complex one is not. Fixing it properly belongs in that helper rather than here, so `stats.nf` under-reports on this path. Say the word and I will do it in a follow-up (or here).
- **The Jacobian is not truly frozen across a W-reuse step.** `JVPCache` holds a reference to `uprev`, so on a step where `do_newW` returns `false` the JVP silently tracks the current `uprev` rather than the one from when W was built. This matches the existing BDF/Rosenbrock matrix-free behaviour and only affects Newton convergence rate, not the fixed point, but it is worth a second opinion.
- **`ComplexShiftOperator` lives in `OrdinaryDiffEqFIRK` rather than `OrdinaryDiffEqDifferentiation`** next to `WOperator`/`JVPCache`. I kept it local to avoid a cross-package version bump for a single-consumer type; if you would rather it be shared infrastructure it should move.
- The `firk_update_W!` dispatch pair changes `_ode_addsteps!` for `RadauIIA5Cache` as well as `perform_step!`. The dense branch is byte-identical to what was inlined there before, but it is a behaviour-adjacent refactor in a path the new tests do not reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F75XsVeZ94QH3PmCuq6QUF