### PR TITLE
Zero-initialize AdaptiveRadau integrator.k to fix nondeterministic results

### DIFF
--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFIRK"
 uuid = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.6.1"
+version = "2.6.2"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
@@ -167,7 +167,7 @@ function initialize!(integrator, cache::AdaptiveRadauCache)
     integrator.k[1] = integrator.fsalfirst
     integrator.k[2] = integrator.fsallast
     for i in 3:(max_stages + 2)
-        integrator.k[i] = similar(integrator.fsallast)
+        integrator.k[i] = zero(integrator.fsallast)
     end
     integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)

--- a/lib/OrdinaryDiffEqFIRK/test/ode_firk_tests.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/ode_firk_tests.jl
@@ -189,3 +189,36 @@ for iip in (true, false)
     @test length(sol.t) < 5000 # the error estimate is not very good
     @test SciMLBase.successful_retcode(sol)
 end
+
+@testset "AdaptiveRadau initializes every integrator.k entry" begin
+    # Entries past the starting stage count are first read only after an upward order
+    # change. `n` is above the small-object pool and the matching frees below dirty the
+    # heap, so uninitialized entries show up as nonzero instead of incidentally zero.
+    n = 300
+    decay!(du, u, p, t) = (@. du = -u; nothing)
+    prob_decay = ODEProblem(decay!, ones(n), (0.0, 1.0))
+    let junk = [fill(NaN, n) for _ in 1:64]
+        junk[end][1] = NaN
+    end
+    GC.gc()
+    integ = init(prob_decay, AdaptiveRadau(); abstol = 1.0e-9, reltol = 1.0e-9)
+    @test all(i -> all(iszero, integ.k[i]), 3:(integ.kshortsize))
+end
+
+@testset "AdaptiveRadau is deterministic across repeated solves" begin
+    function rober_firk!(du, u, p, t)
+        y1, y2, y3 = u
+        du[1] = -0.04y1 + 1.0e4 * y2 * y3
+        du[2] = 0.04y1 - 1.0e4 * y2 * y3 - 3.0e7 * y2^2
+        du[3] = 3.0e7 * y2^2
+        return nothing
+    end
+    prob_rober = ODEProblem(rober_firk!, [1.0, 0.0, 0.0], (0.0, 1.0e5))
+    sols = [
+        solve(prob_rober, AdaptiveRadau(); abstol = 1.0e-9, reltol = 1.0e-9)
+            for _ in 1:25
+    ]
+    @test all(SciMLBase.successful_retcode, sols)
+    @test allequal(sol.u[end] for sol in sols)
+    @test allequal(sol.stats.naccept for sol in sols)
+end


### PR DESCRIPTION
## What changed and why

`initialize!(integrator, cache::AdaptiveRadauCache)` allocated `integrator.k[3:max_stages+2]` with `similar(integrator.fsallast)`. Only the first `min_stages` of those entries are ever written before use; the remainder are first *read* (as `z[i] = integrator.k[i+2]`, the collocation extrapolant that seeds the Newton iteration) after the order-adaptation logic raises `num_stages`. So uninitialized heap contents entered the initial guess, making `AdaptiveRadau` return run-to-run different answers on a fixed deterministic problem, and occasionally `Unstable`. The out-of-place `AdaptiveRadauConstantCache` path already used `zero(...)`; this makes the in-place path match. One-word change plus a regression test.

Reported symptom: 200 repeated ROBER solves at `abstol = reltol = 1e-9` gave 33 distinct endpoints and 6 `Unstable` returns, while `RadauIIA5`, `RadauIIA9`, `Rodas5P` and `FBDF` were bit-identical under the same harness.

## Evidence that the buffers really are read uninitialized

Temporarily filling those exact buffers with `NaN` at allocation (`fill!(similar(integrator.fsallast), NaN)`) turns every ROBER solve into a failure, while the fixed-order FIRK methods are untouched:

```
AdaptiveRadau    nthreads=1 unique=1 maxrelspread=0.0 retcodes=[(:Unstable, 20)] naccept_uniq=1
RadauIIA5        nthreads=1 unique=1 maxrelspread=0.0 retcodes=[(:Success, 20)] naccept_uniq=1
RadauIIA9        nthreads=1 unique=1 maxrelspread=0.0 retcodes=[(:Success, 20)] naccept_uniq=1
```

Applying the same `NaN` instrument to the `similar` calls in `initialize!` for `RadauIIA9Cache` and `GaussLegendreCache` changes nothing (both solve fine), because their stage count is fixed and every entry is written on the first step. The bug is specific to `AdaptiveRadau`.

## Reproduction on `master` (`c11ff74`, Julia 1.12.6, `BLAS.set_num_threads(1)`, `-t 1`)

200 ROBER solves per algorithm per process, three fresh processes:

```
--- process 1
AdaptiveRadau    nthreads=1 unique=1 maxrelspread=0.0 retcodes=[(:Success, 200)] naccept_uniq=1
--- process 2
AdaptiveRadau    nthreads=1 unique=7 maxrelspread=449.78 retcodes=[(:Success, 189), (:Unstable, 11)] naccept_uniq=6
--- process 3
AdaptiveRadau    nthreads=1 unique=2 maxrelspread=449.78 retcodes=[(:Success, 199), (:Unstable, 1)] naccept_uniq=2
```

`RadauIIA5` and `RadauIIA9` reported `unique=1` in all three processes. Whether a given process is affected at all depends on what the allocator hands back, which is why two processes can disagree on whether the method is deterministic.

After the fix, four fresh processes (`-t 1`) and one with `-t 8`, 200/200 and 100/100 solves respectively:

```
AdaptiveRadau    nthreads=1 unique=1 maxrelspread=0.0 retcodes=[(:Success, 200)] naccept_uniq=1
AdaptiveRadau    nthreads=1 unique=1 maxrelspread=0.0 retcodes=[(:Success, 200)] naccept_uniq=1
AdaptiveRadau    nthreads=1 unique=1 maxrelspread=0.0 retcodes=[(:Success, 200)] naccept_uniq=1
AdaptiveRadau    nthreads=1 unique=1 maxrelspread=0.0 retcodes=[(:Success, 200)] naccept_uniq=1
AdaptiveRadau    nthreads=8 unique=1 maxrelspread=0.0 retcodes=[(:Success, 100)] naccept_uniq=1
```

Accuracy against a `RadauIIA9` reference at `1e-13`, all at `abstol = reltol = 1e-9`:

```
AdaptiveRadau  Success relerr=2.90e-7 naccept=59  nreject=1
RadauIIA5      Success relerr=3.18e-7 naccept=166 nreject=1
RadauIIA9      Success relerr=2.12e-7 naccept=53  nreject=0
Rodas5P        Success relerr=2.03e-8 naccept=278 nreject=1
FBDF           Success relerr=4.14e-8 naccept=764 nreject=5
```

## Failing before / passing after

`GROUP=Core julia --project -e 'using Pkg; Pkg.test()'` in `lib/OrdinaryDiffEqFIRK`, with the test added and the one-line source change stashed:

```
AdaptiveRadau initializes every integrator.k entry: Test Failed at .../test/ode_firk_tests.jl:205
  Expression: all((i->begin
            all(iszero, integ.k[i])
        end), 3:integ.kshortsize)

AdaptiveRadau is deterministic across repeated solves: Test Failed at .../test/ode_firk_tests.jl:221
  Expression: all(SciMLBase.successful_retcode, sols)

AdaptiveRadau is deterministic across repeated solves: Test Failed at .../test/ode_firk_tests.jl:222
  Expression: allequal((sol.u[end] for sol = sols))

AdaptiveRadau is deterministic across repeated solves: Test Failed at .../test/ode_firk_tests.jl:223
  Expression: allequal((sol.stats.naccept for sol = sols))

Test Summary:                                                  | Pass  Fail  Total     Time
FIRK Tests                                                     |  105     4    109  4m08.9s
  AdaptiveRadau initializes every integrator.k entry           |          1      1    13.1s
  AdaptiveRadau is deterministic across repeated solves        |          3      3    10.3s
ERROR: Package OrdinaryDiffEqFIRK errored during testing
```

Same command with the fix applied:

```
Test Summary: | Pass  Total     Time
FIRK Tests    |  109    109  4m31.8s
     Testing OrdinaryDiffEqFIRK tests passed
```

The `iszero` test is the reliable discriminator: the repeated-solve test observes the user-visible symptom but can pass on unfixed code when the allocator happens to hand back zeroed pages (see process 1 above), so it is a guard rather than the proof.

## Also run

- `Runic.main(["--check", ...])` on both changed files: exit 0.
- `typos` on both changed files: exit 0.
- `GROUP=QA` in `lib/OrdinaryDiffEqFIRK`: one failure, `public API has docstrings` / `isempty([:SciMLBase])`. I re-ran `GROUP=QA` with my source change stashed and got the identical failure, so it is pre-existing on `master` and unrelated to this PR. AllocCheck and JET pass.

## Not verified

- Only the FIRK sublibrary test groups were run; the root `OrdinaryDiffEq` suite, downstream packages, GPU and allowed-to-fail jobs were not.
- Julia 1.12.6 x86_64 Linux only; not 1.10/1.11, not `julia pre`.
- No benchmark run, so the step-count effect of a now-consistently-zero extrapolant on problems that previously read nonzero garbage is unmeasured beyond the ROBER numbers above.

## Worth pushing back on

Zeroing removes the undefined behavior but does not make the extrapolant *correct* across an order change. When `num_stages` goes from 5 to 7, `z[6]` and `z[7]` are seeded from entries that no previous step ever wrote, and the divided-difference table is built with the *new* tableau's `c` nodes against values collocated at the *old* nodes. That is a separate, deterministic quality-of-initial-guess issue affecting Newton iteration counts, not the answer; I left it alone to keep this diff to the memory bug. Happy to open a follow-up if you want the order-change step to fall back to the constant extrapolant.

Please ignore until reviewed by @ChrisRackauckas.
