### PR TITLE
Fix docs build: unlink the unresolvable DummyControllerCache @ref

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
@@ -495,7 +495,7 @@ end
 
 Placeholder controller for algorithms that manage step-size selection
 themselves (BDF, Nordsieck, Leaping, …). Selecting it makes
-[`setup_controller_cache`](@ref) hand back a [`DummyControllerCache`](@ref)
+[`setup_controller_cache`](@ref) hand back a `DummyControllerCache`
 whose dispatch methods fall through to the algorithm-level
 `stepsize_controller!` / `step_accept_controller!` / `step_reject_controller!`
 methods that own the actual logic. The per-knob accessors


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## What changed and why

The `DummyController` docstring contains `[`DummyControllerCache`](@ref)`. That
docstring became rendered by #4118 (it is listed in
`docs/src/devtools/internals/public_api.md`), but `DummyControllerCache` has no
`@docs` entry — its entry was dropped in #3832 — so Documenter cannot resolve the
cross-reference and `makedocs` aborts with `[:cross_references]`.

`DummyControllerCache` is deliberately internal: it is not `export`ed and not
declared `public` anywhere in the repo (`grep -rn "export.*DummyController\|public.*DummyController" --include=*.jl .` returns nothing), and the
Developer Extension API page it would live on states outright that "Concrete
per-algorithm caches ... remain internal unless listed below". Adding a `@docs`
entry would therefore publish a name the repo intends to keep private, so the fix
is to keep the prose and drop the link.

## Evidence this fails on unmodified master

Base commit: `c11ff74bb404216d03ad68b971438047097609e2` ("Sync package versions with the General registry (#4152)"), clean checkout, no local modifications.

### Before (unmodified master)

```
$ julia --project=docs docs/make.jl    # julia 1.12.6
...
[ Info: CrossReferences: building cross-references.
┌ Error: Cannot resolve @ref for md"[`DummyControllerCache`](@ref)" in docs/src/devtools/internals/public_api.md.
│ - No docstring found in doc for binding `OrdinaryDiffEqCore.DummyControllerCache`.
│ - No docstring found in doc for binding `Main.DummyControllerCache`.
└ @ Documenter ~/.julia/packages/Documenter/AXNMp/src/utilities/utilities.jl:47
[ Info: CheckDocument: running document checks.
...
[ Info: Populate: populating indices.
ERROR: LoadError: `makedocs` encountered an error [:cross_references] -- terminating build before rendering.
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:44
  [2] runner(::Type{Documenter.Builder.RenderDocument}, doc::Documenter.Document)
    @ Documenter ~/.julia/packages/Documenter/AXNMp/src/builder_pipeline.jl:259
...
in expression starting at .../docs/make.jl:92

MAKE_EXIT=1
```

### After (this branch)

```
$ julia --project=docs docs/make.jl    # julia 1.12.6
...
[ Info: Automatic `version="7.3.1"` for inventory from ../Project.toml
┌ Warning: Documenter could not auto-detect the building environment. Skipping deployment.
└ @ Documenter ~/.julia/packages/Documenter/AXNMp/src/deployconfig.jl:93

MAKE_EXIT=0
```

`grep -n "^ERROR\|┌ Error:"` over the post-fix build log returns no matches. Only
pre-existing size-threshold / missing-docstring warnings remain, which the build
already tolerated before this change.

## Also run locally

- `Runic.main(["--check", "--diff", "lib/OrdinaryDiffEqCore/src/integrators/controllers.jl"])` — exit 0.
- `typos` over the diff — exit 0, no findings.

## Not verified

- No test group was run; this is a docstring-only change with no runtime effect.
- Allowed-to-fail lanes (`julia pre`, GPU, downstream) were not run.
- The unrelated `Warning: 772 docstrings not included in the manual` remains, as it did before this change.
