### PR TITLE
Render DummyControllerCache so its @ref resolves (fixes the master docs build)

### DIFF
--- a/docs/src/devtools/internals/public_api.md
+++ b/docs/src/devtools/internals/public_api.md
@@ -314,6 +314,7 @@ OrdinaryDiffEqCore.resolve_stage_step_limiters
 OrdinaryDiffEqCore.trivial_limiter!
 OrdinaryDiffEqCore.DEOptions
 OrdinaryDiffEqCore.DummyController
+OrdinaryDiffEqCore.DummyControllerCache
 ```
 
 ### Time-stop and saving queues


### PR DESCRIPTION
## What changed

One line: `OrdinaryDiffEqCore.DummyControllerCache` added to the `@docs` block in `docs/src/devtools/internals/public_api.md`, next to `DummyController` which is already there.

`DummyController`'s docstring says

> Selecting it makes [`setup_controller_cache`](@ref) hand back a [`DummyControllerCache`](@ref) …

but the cache type had no `@docs` entry anywhere, so Documenter could not resolve that reference and aborted the build.

## Why it matters

**The Documentation workflow is currently failing on master for this reason**, so no PR gets a docs preview. From the most recent master run (https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/31198061733):

```
┌ Error: Cannot resolve @ref for md"[`DummyControllerCache`](@ref)" in docs/src/devtools/internals/public_api.md.
...
ERROR: LoadError: `makedocs` encountered an error [:cross_references] -- terminating build before rendering.
```

## Verification

Full `docs/make.jl` build at `c11ff74bb4` (current master), unmodified — reproduces the CI failure exactly:

```
$ julia --project=docs docs/make.jl
┌ Error: Cannot resolve @ref for md"[`DummyControllerCache`](@ref)" in docs/src/devtools/internals/public_api.md.
ERROR: LoadError: `makedocs` encountered an error [:cross_references] -- terminating build before rendering.
exit=1
```

Same build with this one-line change:

```
$ julia --project=docs docs/make.jl
[ Info: Automatic `version="7.3.1"` for inventory from ../Project.toml
┌ Warning: Documenter could not auto-detect the building environment. Skipping deployment.
exit=0
$ grep -c "Cannot resolve @ref" build.log
0
$ du -sh docs/build
7.0M    docs/build
```

The remaining `undefined binding` / `Invalid type of object in @eval` warnings in the build are pre-existing and non-fatal (they are covered by `warnonly`); only the `:cross_references` stage was hard-failing.

## Not verified

Nothing else — this touches one markdown line and no code. Test suites not run; they cannot be affected.

## For the reviewer

If `DummyControllerCache` is deliberately meant to stay unrendered, the alternative fix is to drop the `@ref` from `DummyController`'s docstring and leave it as plain code formatting. I picked rendering it because `DummyController` itself is already on that internals page and the two are described together.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gstik9KAfxtNAz53ejBPwN
