### PR TITLE
Matrix-free Jacobians / Krylov linsolve for the Radau FIRK methods

### DIFF
--- a/docs/src/implicit/FIRK.md
+++ b/docs/src/implicit/FIRK.md
@@ -63,7 +63,25 @@ Gauss–Legendre methods use the roots of the Legendre polynomial directly as co
 ### System size considerations
 
   - **Systems < 200**: FIRK methods are competitive due to better multithreading
-  - **Systems > 200**: Consider SDIRK or BDF methods instead
+  - **Systems > 200**: Consider SDIRK or BDF methods instead, or keep a Radau method and
+    switch to a matrix-free linear solver (see below)
+
+## Matrix-free (Newton-Krylov) usage
+
+The RadauIIA methods and `AdaptiveRadau` accept a matrix-free `linsolve`, which avoids
+forming a Jacobian at all:
+
+```julia
+solve(prob, RadauIIA5(linsolve = KrylovJL_GMRES()))
+```
+
+The W-transform decouples each step into one real shifted solve and one shifted solve per
+complex-conjugate stage pair, and every one of them is applied through the same real
+Jacobian-vector product. `concrete_jac = true` keeps a concrete Jacobian alongside the
+matrix-free application, which is what a preconditioner needs.
+
+`GaussLegendre` has no matrix-free path: it solves a single coupled
+`num_stages * length(u)` block system rather than decoupled shifted systems.
 
 ## Performance Guidelines
 

--- a/lib/OrdinaryDiffEqFIRK/src/OrdinaryDiffEqFIRK.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/OrdinaryDiffEqFIRK.jl
@@ -25,6 +25,7 @@ import DiffEqBase: initialize!, calculate_residuals, calculate_residuals!
 using MuladdMacro: @muladd
 using RecursiveArrayTools: recursivefill!
 import Polyester
+import LinearAlgebra
 using LinearAlgebra: I, UniformScaling, mul!, lu, dot
 import LinearSolve
 import FastBroadcast: @..
@@ -35,6 +36,7 @@ import FastPower: fastpower
 using OrdinaryDiffEqDifferentiation: build_J_W, build_jac_config,
     calc_J!, dolinsolve, calc_J,
     islinearfunction
+import ADTypes
 import ADTypes: AutoForwardDiff
 import SciMLOperators
 import SciMLOperators: AbstractSciMLOperator
@@ -64,6 +66,7 @@ include("algorithms.jl")
 include("alg_utils.jl")
 include("controllers.jl")
 include("firk_caches.jl")
+include("firk_operators.jl")
 include("firk_tableaus.jl")
 include("firk_perform_step.jl")
 include("firk_interpolants.jl")

--- a/lib/OrdinaryDiffEqFIRK/src/firk_caches.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_caches.jl
@@ -107,8 +107,8 @@ function alg_cache(
     jac_config = build_jac_config(alg, f, uf, du1, uprev, u, tmp, dw12)
 
     J, W1 = build_J_W(alg, u, uprev, p, t, dt, f, jac_config, uEltypeNoUnits, Val(true))
-    W1 = similar(J, Complex{eltype(W1)})
-    recursivefill!(W1, false)
+    W1 = firk_real_W(alg, J, W1)
+    W1 = build_complex_W(alg, f, u, J, W1)
 
     linprob = LinearProblem(W1, _vec(cubuff), (nothing, u, p, t); u0 = _vec(dw12))
     linsolve = init(
@@ -258,11 +258,8 @@ function alg_cache(
     jac_config = build_jac_config(alg, f, uf, du1, uprev, u, tmp, dw1)
 
     J, W1 = build_J_W(alg, u, uprev, p, t, dt, f, jac_config, uEltypeNoUnits, Val(true))
-    if J isa AbstractSciMLOperator
-        error("Non-concrete Jacobian not yet supported by RadauIIA5.")
-    end
-    W2 = similar(J, Complex{eltype(W1)})
-    recursivefill!(W2, false)
+    W1 = firk_real_W(alg, J, W1)
+    W2 = build_complex_W(alg, f, u, J, W1)
 
     linprob = LinearProblem(W1, _vec(ubuff), (nothing, u, p, t); u0 = _vec(dw1))
     linsolve1 = init(
@@ -462,13 +459,9 @@ function alg_cache(
     jac_config = build_jac_config(alg, f, uf, du1, uprev, u, tmp, dw1)
 
     J, W1 = build_J_W(alg, u, uprev, p, t, dt, f, jac_config, uEltypeNoUnits, Val(true))
-    if J isa AbstractSciMLOperator
-        error("Non-concrete Jacobian not yet supported by RadauIIA5.")
-    end
-    W2 = similar(J, Complex{eltype(W1)})
-    W3 = similar(J, Complex{eltype(W1)})
-    recursivefill!(W2, false)
-    recursivefill!(W3, false)
+    W1 = firk_real_W(alg, J, W1)
+    W2 = build_complex_W(alg, f, u, J, W1)
+    W3 = build_complex_W(alg, f, u, J, W1)
 
     linprob = LinearProblem(W1, _vec(ubuff), (nothing, u, p, t); u0 = _vec(dw1))
     linsolve1 = init(
@@ -685,12 +678,8 @@ function alg_cache(
     jac_config = build_jac_config(alg, f, uf, du1, uprev, u, zero(u), dw1)
 
     J, W1 = build_J_W(alg, u, uprev, p, t, dt, f, jac_config, uEltypeNoUnits, Val(true))
-    if J isa AbstractSciMLOperator
-        error("Non-concrete Jacobian not yet supported by AdaptiveRadau.")
-    end
-
-    W2 = [similar(J, Complex{eltype(W1)}) for _ in 1:((max_stages - 1) ÷ 2)]
-    recursivefill!.(W2, false)
+    W1 = firk_real_W(alg, J, W1)
+    W2 = [build_complex_W(alg, f, u, J, W1) for _ in 1:((max_stages - 1) ÷ 2)]
 
     linprob = LinearProblem(W1, _vec(ubuff), (nothing, u, p, t); u0 = _vec(dw1))
     linsolve1 = init(
@@ -842,7 +831,14 @@ function alg_cache(
 
     J, _ = build_J_W(alg, u, uprev, p, t, dt, f, jac_config, uEltypeNoUnits, Val(true))
     if J isa AbstractSciMLOperator
-        error("Non-concrete Jacobian not yet supported by GaussLegendre.")
+        error(
+            "GaussLegendre does not support a matrix-free Jacobian: unlike the Radau " *
+                "methods it solves a single coupled $(num_stages * n)-by-$(num_stages * n) " *
+                "system rather than decoupled shifted systems, and no operator form of that " *
+                "system is implemented. Use `RadauIIA3`, `RadauIIA5`, `RadauIIA9` or " *
+                "`AdaptiveRadau` with a Krylov `linsolve`, or set `concrete_jac = true` " *
+                "together with a factorization `linsolve`."
+        )
     end
 
     W = similar(J, num_stages * n, num_stages * n)

--- a/lib/OrdinaryDiffEqFIRK/src/firk_operators.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_operators.jl
@@ -1,0 +1,203 @@
+"""
+    ComplexWOperator{T, MMType, GType, JType, JVType, VType} <: AbstractSciMLOperator{T}
+
+Lazy representation of the complex-shifted FIRK stage matrix
+
+```math
+W = -\\frac{MM}{\\gamma} + J
+```
+
+with complex `gamma` but a *real* mass matrix `MM` and a *real* Jacobian `J`. It is the
+complex counterpart of `SciMLOperators.WOperator` and follows the same `gamma` convention,
+so `-γ_c MM + J` is obtained with `gamma = inv(γ_c)`.
+
+Because `J` is real, the complex product is assembled from two real Jacobian-vector
+products, `J (a + bi) = Ja + i Jb`. That is what allows a matrix-free `J` — a real
+Jacobian-vector-product operator, which cannot be applied to a complex vector — to back
+the complex-conjugate stage pairs of the FIRK W-transform.
+
+# Arguments
+
+  - `mass_matrix`: `UniformScaling` or real matrix `MM`.
+  - `gamma`: complex scalar; the prototype value fixes the operator's element type.
+  - `J`: real Jacobian, either a matrix or an `AbstractSciMLOperator`.
+  - `u`: prototype state, used to allocate the real work buffers.
+  - `jacvec`: optional real Jacobian-vector-product operator applied in place of `J`.
+"""
+mutable struct ComplexWOperator{T, MMType, GType, JType, JVType, VType} <:
+    AbstractSciMLOperator{T}
+    mass_matrix::MMType
+    gamma::GType
+    J::JType
+    jacvec::JVType
+    _rev::VType
+    _imv::VType
+    _reJv::VType
+    _imJv::VType
+    jvps::Int
+end
+
+function ComplexWOperator(mass_matrix, gamma::Number, J, u, jacvec = nothing)
+    v = _vec(u)
+    T = complex(promote_type(eltype(v), real(typeof(gamma))))
+    return ComplexWOperator{
+        T, typeof(mass_matrix), T, typeof(J), typeof(jacvec), typeof(v),
+    }(
+        mass_matrix, convert(T, gamma), J, jacvec,
+        zero(v), zero(v), zero(v), zero(v), 0
+    )
+end
+
+Base.eltype(::ComplexWOperator{T}) where {T} = T
+Base.size(W::ComplexWOperator) = size(W.J)
+Base.size(W::ComplexWOperator, d::Integer) = d <= 2 ? size(W)[d] : 1
+SciMLBase.isinplace(::ComplexWOperator) = true
+SciMLOperators.isconvertible(::ComplexWOperator) = false
+
+_jacobian_operator(W::ComplexWOperator) = W.jacvec === nothing ? W.J : W.jacvec
+
+function SciMLOperators.update_coefficients!(
+        W::ComplexWOperator, u = nothing, p = nothing, t = nothing; gamma = nothing
+    )
+    if u !== nothing && p !== nothing && t !== nothing
+        SciMLOperators.update_coefficients!(W.J, u, p, t)
+        W.jacvec === nothing || SciMLOperators.update_coefficients!(W.jacvec, u, p, t)
+    end
+    gamma === nothing || (W.gamma = gamma)
+    return W
+end
+
+function LinearAlgebra.mul!(Y::AbstractVector, W::ComplexWOperator, B::AbstractVector)
+    (; _rev, _imv, _reJv, _imJv) = W
+    Jop = _jacobian_operator(W)
+    @. _rev = real(B)
+    @. _imv = imag(B)
+    mul!(_reJv, Jop, _rev)
+    mul!(_imJv, Jop, _imv)
+    W.jvps += 2
+    @. Y = complex(_reJv, _imJv)
+    a = -inv(W.gamma)
+    if W.mass_matrix isa UniformScaling
+        @. Y += (a * W.mass_matrix.λ) * B
+    else
+        mul!(_reJv, W.mass_matrix, _rev)
+        mul!(_imJv, W.mass_matrix, _imv)
+        @. Y += a * complex(_reJv, _imJv)
+    end
+    return Y
+end
+
+function LinearAlgebra.mul!(Y::AbstractArray, W::ComplexWOperator, B::AbstractArray)
+    mul!(vec(Y), W, vec(B))
+    return Y
+end
+
+function Base.:*(W::ComplexWOperator, x::AbstractVector)
+    return mul!(similar(x, promote_type(eltype(W), eltype(x))), W, x)
+end
+
+const LazyW = Union{SciMLOperators.WOperator, ComplexWOperator}
+
+"""
+    is_lazy_W(W) -> Bool
+
+Whether the FIRK stage matrix `W` is applied lazily rather than stored as a concrete
+matrix assembled entrywise from `J`.
+"""
+is_lazy_W(W) = W isa LazyW
+
+"""
+    set_W_gamma!(W, γ)
+
+Point the lazily-applied FIRK stage matrix `W` at `-γ MM + J` for the current step. Both
+`SciMLOperators.WOperator` (real stage) and [`ComplexWOperator`](@ref) store the reciprocal
+shift, hence the `inv`.
+
+This is O(1) and no factorization follows it, so the callers re-form a lazy `W` on every
+step rather than reusing a stale shift the way the concrete path does — there is nothing
+to amortize, and a current `W` is a better Newton matrix.
+"""
+set_W_gamma!(W::LazyW, γ) = (W.gamma = inv(γ); W)
+
+"""
+    firk_real_W(alg, J, W) -> W
+
+Stage matrix for the real FIRK stage. `build_J_W` returns a `WOperator` whenever a
+Jacobian-vector product is available, which includes `concrete_jac = true` with a
+factorization `linsolve`. FIRK assembles its own shifted matrices entrywise, so a lazy `W`
+over a concrete `J` is only useful when the linear solver is itself matrix-free; otherwise
+fall back to a concrete matrix.
+"""
+function firk_real_W(alg, J, W)
+    (is_lazy_W(W) && !(J isa AbstractSciMLOperator)) || return W
+    (alg.linsolve === nothing || LinearSolve.needs_concrete_A(alg.linsolve)) || return W
+    return recursivefill!(similar(J), false)
+end
+
+"""
+    build_complex_W(alg, f, u, J, W1) -> W
+
+Stage matrix for a complex-conjugate FIRK stage pair: a concrete complex matrix when the
+real stage matrix `W1` is concrete, and a lazily-applied [`ComplexWOperator`](@ref) when
+`W1` is itself an operator (matrix-free Jacobian and/or Krylov `linsolve`).
+"""
+function build_complex_W(alg, f, u, J, W1)
+    is_lazy_W(W1) || return recursivefill!(similar(J, Complex{eltype(W1)}), false)
+    if alg.linsolve === nothing || LinearSolve.needs_concrete_A(alg.linsolve)
+        error(
+            "$(nameof(typeof(alg))) got a non-concrete (operator) Jacobian, which can only " *
+                "be used with a matrix-free linear solver, but `linsolve = $(alg.linsolve)` " *
+                "requires a concrete matrix. Either pass a Krylov solver (e.g. " *
+                "`linsolve = KrylovJL_GMRES()`), or give the problem a concrete " *
+                "`jac_prototype` so that `W` can be assembled and factorized."
+        )
+    end
+    jacvec = W1 isa SciMLOperators.WOperator ? W1.jacvec : nothing
+    return ComplexWOperator(f.mass_matrix, complex(one(eltype(W1))), J, u, jacvec)
+end
+
+"""
+    firk_new_J!(J, W, integrator, cache)
+
+Refresh the Jacobian for a new step: recompute a concrete `J` in place, or move a
+matrix-free Jacobian's linearization point to `(uprev, p, t)`. `W` carries the
+Jacobian-vector-product operator when one exists alongside a concrete `J`.
+"""
+function firk_new_J!(J, W, integrator, cache)
+    (; uprev, p, t) = integrator
+    if J isa AbstractSciMLOperator
+        SciMLOperators.update_coefficients!(J, uprev, p, t)
+    else
+        calc_J!(J, integrator, cache)
+    end
+    jacvec = W isa LazyW ? W.jacvec : nothing
+    if jacvec !== nothing && jacvec !== J
+        SciMLOperators.update_coefficients!(jacvec, uprev, p, t)
+    end
+    return nothing
+end
+
+"""
+    drain_jvp_count!(integrator, alg, W)
+
+Move the Jacobian-vector products a matrix-free complex stage solve has accumulated into
+the solver stats, and reset the operator's counter. `dolinsolve` only accounts for
+`WOperator`s, so the [`ComplexWOperator`](@ref) products go uncounted otherwise. The
+counter lives on the operator rather than being inferred from the Krylov iteration count
+so that `AdaptiveRadau`'s threaded stage solves each tally into their own operator.
+
+Only a genuinely matrix-free Jacobian costs RHS evaluations; a concretizable operator such
+as a user-supplied `MatrixOperator` does not.
+"""
+function drain_jvp_count!(integrator, alg, W::ComplexWOperator)
+    n = W.jvps
+    W.jvps = 0
+    (n == 0 || !(integrator isa SciMLBase.DEIntegrator)) && return nothing
+    Jop = _jacobian_operator(W)
+    (Jop isa AbstractSciMLOperator && !SciMLOperators.isconvertible(Jop)) || return nothing
+    ad = alg.autodiff isa ADTypes.AutoSparse ? ADTypes.dense_ad(alg.autodiff) : alg.autodiff
+    per_jvp = (ad isa ADTypes.AutoFiniteDiff || ad isa ADTypes.AutoFiniteDifferences) ? 2 : 1
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, per_jvp * n)
+    return nothing
+end
+drain_jvp_count!(integrator, alg, W) = nothing

--- a/lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
@@ -166,8 +166,11 @@ function initialize!(integrator, cache::AdaptiveRadauCache)
     resize!(integrator.k, integrator.kshortsize)
     integrator.k[1] = integrator.fsalfirst
     integrator.k[2] = integrator.fsallast
+    # zero, not `similar`: the stage-value slots above the starting `num_stages` are read
+    # by the extrapolated initial guess as soon as the controller raises the stage count,
+    # before anything has written them
     for i in 3:(max_stages + 2)
-        integrator.k[i] = similar(integrator.fsallast)
+        integrator.k[i] = zero(integrator.fsallast)
     end
     integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)

--- a/lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
@@ -329,8 +329,12 @@ end
     # precalculations
     αdt, βdt = α / dt, β / dt
     (new_jac = do_newJ(integrator, alg, cache, repeat_step)) &&
-        (calc_J!(J, integrator, cache); cache.W_γdt = dt)
-    if (new_W = do_newW(integrator, alg, new_jac, cache.W_γdt))
+        (firk_new_J!(J, W1, integrator, cache); cache.W_γdt = dt)
+    new_W = do_newW(integrator, alg, new_jac, cache.W_γdt)
+    if is_lazy_W(W1)
+        set_W_gamma!(W1, αdt + βdt * im)
+        integrator.stats.nw += 1
+    elseif new_W
         @inbounds for II in CartesianIndices(J)
             W1[II] = -(αdt + βdt * im) * mass_matrix[Tuple(II)...] + J[II]
         end
@@ -409,6 +413,7 @@ end
             )
         end
 
+        drain_jvp_count!(integrator, alg, W1)
         integrator.stats.nsolve += 1
         dw1 = real(dw12)
         dw2 = imag(dw12)
@@ -700,8 +705,13 @@ end
     c1mc2 = c1 - c2
     γdt, αdt, βdt = γ / dt, α / dt, β / dt
     (new_jac = do_newJ(integrator, alg, cache, repeat_step)) &&
-        (calc_J!(J, integrator, cache); cache.W_γdt = dt)
-    if (new_W = do_newW(integrator, alg, new_jac, cache.W_γdt))
+        (firk_new_J!(J, W1, integrator, cache); cache.W_γdt = dt)
+    new_W = do_newW(integrator, alg, new_jac, cache.W_γdt)
+    if is_lazy_W(W1)
+        set_W_gamma!(W1, γdt)
+        set_W_gamma!(W2, αdt + βdt * im)
+        integrator.stats.nw += 1
+    elseif new_W
         @inbounds for II in CartesianIndices(J)
             W1[II] = -γdt * mass_matrix[Tuple(II)...] + J[II]
             W2[II] = -(αdt + βdt * im) * mass_matrix[Tuple(II)...] + J[II]
@@ -830,6 +840,7 @@ end
             )
         end
 
+        drain_jvp_count!(integrator, alg, W2)
         integrator.stats.nsolve += 2
         dw2 = z2
         dw3 = z3
@@ -1274,8 +1285,14 @@ end
 
     γdt, α1dt, β1dt, α2dt, β2dt = γ / dt, α1 / dt, β1 / dt, α2 / dt, β2 / dt
     (new_jac = do_newJ(integrator, alg, cache, repeat_step)) &&
-        (calc_J!(J, integrator, cache); cache.W_γdt = dt)
-    if (new_W = do_newW(integrator, alg, new_jac, cache.W_γdt))
+        (firk_new_J!(J, W1, integrator, cache); cache.W_γdt = dt)
+    new_W = do_newW(integrator, alg, new_jac, cache.W_γdt)
+    if is_lazy_W(W1)
+        set_W_gamma!(W1, γdt)
+        set_W_gamma!(W2, α1dt + β1dt * im)
+        set_W_gamma!(W3, α2dt + β2dt * im)
+        integrator.stats.nw += 1
+    elseif new_W
         @inbounds for II in CartesianIndices(J)
             W1[II] = -γdt * mass_matrix[Tuple(II)...] + J[II]
             W2[II] = -(α1dt + β1dt * im) * mass_matrix[Tuple(II)...] + J[II]
@@ -1493,6 +1510,8 @@ end
                 integrator, linsolve3; A = nothing, b = _vec(cubuff2), linu = _vec(dw45)
             )
         end
+        drain_jvp_count!(integrator, alg, W2)
+        drain_jvp_count!(integrator, alg, W3)
         integrator.stats.nsolve += 3
         dw2 = z2
         dw3 = z3
@@ -1910,8 +1929,15 @@ end
     end
 
     (new_jac = do_newJ(integrator, alg, cache, repeat_step)) &&
-        (calc_J!(J, integrator, cache); cache.W_γdt = dt)
-    if (new_W = do_newW(integrator, alg, new_jac, cache.W_γdt))
+        (firk_new_J!(J, W1, integrator, cache); cache.W_γdt = dt)
+    new_W = do_newW(integrator, alg, new_jac, cache.W_γdt)
+    if is_lazy_W(W1)
+        set_W_gamma!(W1, γdt)
+        for i in 1:((num_stages - 1) ÷ 2)
+            set_W_gamma!(W2[i], αdt[i] + βdt[i] * im)
+        end
+        integrator.stats.nw += 1
+    elseif new_W
         @inbounds for II in CartesianIndices(J)
             W1[II] = -γdt * mass_matrix[Tuple(II)...] + J[II]
         end
@@ -2082,6 +2108,9 @@ end
             end
         end
 
+        for i in 1:((num_stages - 1) ÷ 2)
+            drain_jvp_count!(integrator, alg, W2[i])
+        end
         integrator.stats.nsolve += (num_stages + 1) / 2
 
         for i in 1:((num_stages - 1) ÷ 2)

--- a/lib/OrdinaryDiffEqFIRK/test/firk_krylov_tests.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/firk_krylov_tests.jl
@@ -1,0 +1,142 @@
+using OrdinaryDiffEqFIRK, LinearSolve, LinearAlgebra, SciMLOperators, Test
+using SciMLOperators: AbstractSciMLOperator
+using ADTypes: AutoForwardDiff, AutoFiniteDiff
+using OrdinaryDiffEqFIRK: ComplexWOperator, set_W_gamma!
+
+# 1D Brusselator: the diffusion coupling gives GMRES a system worth iterating on
+const N_KRYLOV = 20
+
+function brusselator_1d!(du, u, p, t)
+    α = p[1]
+    n = length(u) ÷ 2
+    for i in 1:n
+        x = u[i]
+        y = u[n + i]
+        xm = u[i == 1 ? n : i - 1]
+        xp = u[i == n ? 1 : i + 1]
+        ym = u[i == 1 ? 2n : n + i - 1]
+        yp = u[i == n ? n + 1 : n + i + 1]
+        du[i] = 1 + x^2 * y - 4x + α * (xm - 2x + xp)
+        du[n + i] = 3x - x^2 * y + α * (ym - 2y + yp)
+    end
+    return nothing
+end
+
+u0_krylov = vcat(
+    [1 + 0.5sinpi(2i / N_KRYLOV) for i in 1:N_KRYLOV],
+    [3 + 0.3cospi(2i / N_KRYLOV) for i in 1:N_KRYLOV]
+)
+mm_krylov = Matrix(Diagonal(vcat(fill(1.0, N_KRYLOV), fill(2.0, N_KRYLOV))))
+prob_krylov = ODEProblem(brusselator_1d!, u0_krylov, (0.0, 1.0), (10.0,))
+prob_krylov_mm = ODEProblem(
+    ODEFunction(brusselator_1d!; mass_matrix = mm_krylov), u0_krylov, (0.0, 1.0), (10.0,)
+)
+ref_krylov = solve(prob_krylov, RadauIIA5(), reltol = 1.0e-14, abstol = 1.0e-14).u[end]
+ref_krylov_mm = solve(prob_krylov_mm, RadauIIA5(), reltol = 1.0e-14, abstol = 1.0e-14).u[end]
+
+firk_algs = (RadauIIA3, RadauIIA5, RadauIIA9, AdaptiveRadau)
+
+@testset "ComplexWOperator agrees with its dense form" begin
+    n = 7
+    J = randn(n, n)
+    x = randn(ComplexF64, n)
+    γ = 0.3 - 1.7im
+    for mass_matrix in (I, 2.5I, Matrix(Diagonal(rand(n) .+ 1)), randn(n, n))
+        W = ComplexWOperator(mass_matrix, complex(1.0), J, zeros(n))
+        set_W_gamma!(W, γ)
+        dense = -γ * (mass_matrix isa UniformScaling ? Matrix(mass_matrix, n, n) : mass_matrix) + J
+        @test size(W) == (n, n)
+        @test eltype(W) == ComplexF64
+        @test W * x ≈ dense * x
+        @test mul!(similar(x), W, x) ≈ dense * x
+    end
+end
+
+@testset "$alg with a matrix-free linsolve" for alg in firk_algs
+    integ = init(prob_krylov, alg(linsolve = KrylovJL_GMRES()))
+    @test integ.cache.J isa AbstractSciMLOperator
+    # RadauIIA3's single stage pair makes W1 itself the complex operator
+    complex_W = if alg === RadauIIA3
+        integ.cache.W1
+    elseif alg === AdaptiveRadau
+        integ.cache.W2[1]
+    else
+        integ.cache.W2
+    end
+    @test complex_W isa ComplexWOperator
+
+    kry = solve(prob_krylov, alg(linsolve = KrylovJL_GMRES()), reltol = 1.0e-10, abstol = 1.0e-10)
+    @test SciMLBase.successful_retcode(kry)
+    # measured worst case over these methods is 4.8e-9; the margin is for CI variation
+    @test norm(kry.u[end] - ref_krylov, Inf) < 1.0e-6
+
+    mm = solve(
+        prob_krylov_mm, alg(linsolve = KrylovJL_GMRES()), reltol = 1.0e-10, abstol = 1.0e-10
+    )
+    @test SciMLBase.successful_retcode(mm)
+    @test norm(mm.u[end] - ref_krylov_mm, Inf) < 1.0e-5
+end
+
+@testset "$alg with concrete_jac" for alg in firk_algs
+    # concrete J behind a Krylov solve: products go through the JVP, J is kept for preconditioning
+    kry = solve(
+        prob_krylov, alg(linsolve = KrylovJL_GMRES(), concrete_jac = true),
+        reltol = 1.0e-10, abstol = 1.0e-10
+    )
+    @test SciMLBase.successful_retcode(kry)
+    @test norm(kry.u[end] - ref_krylov, Inf) < 1.0e-6
+
+    # concrete J behind a factorization: FIRK assembles and factorizes its own W
+    lu = solve(prob_krylov, alg(concrete_jac = true), reltol = 1.0e-10, abstol = 1.0e-10)
+    @test SciMLBase.successful_retcode(lu)
+    @test norm(lu.u[end] - ref_krylov, Inf) < 1.0e-6
+end
+
+@testset "$alg with an operator jac_prototype" for alg in firk_algs
+    n = 12
+    A = -50 * Matrix(SymTridiagonal(fill(2.0, n), fill(-1.0, n - 1)))
+    linear!(du, u, p, t) = mul!(du, A, u)
+    prob = ODEProblem(
+        ODEFunction(linear!; jac_prototype = MatrixOperator(copy(A))), ones(n), (0.0, 0.5)
+    )
+    sol = solve(prob, alg(linsolve = KrylovJL_GMRES()), reltol = 1.0e-10, abstol = 1.0e-10)
+    @test SciMLBase.successful_retcode(sol)
+    @test norm(sol.u[end] - exp(A * 0.5) * ones(n), Inf) < 1.0e-8
+
+    @test_throws "requires a concrete matrix" solve(prob, alg())
+end
+
+@testset "GaussLegendre reports that it has no matrix-free path" begin
+    @test_throws "does not support a matrix-free Jacobian" solve(
+        prob_krylov, GaussLegendre(num_stages = 3, linsolve = KrylovJL_GMRES())
+    )
+end
+
+@testset "$alg counts matrix-free Jacobian-vector products" for alg in firk_algs
+    nf = Ref(0)
+    counted!(du, u, p, t) = (nf[] += 1; brusselator_1d!(du, u, p, t))
+    prob = ODEProblem(counted!, u0_krylov, (0.0, 1.0), (10.0,))
+    for ad in (AutoForwardDiff(), AutoFiniteDiff())
+        nf[] = 0
+        sol = solve(
+            prob, alg(linsolve = KrylovJL_GMRES(), autodiff = ad),
+            reltol = 1.0e-8, abstol = 1.0e-8
+        )
+        @test SciMLBase.successful_retcode(sol)
+        @test sol.stats.nf == nf[]
+    end
+end
+
+@testset "$alg with a matrix-shaped state" for alg in firk_algs
+    A = [-30.0 1.0; 2.0 -40.0]
+    function matstate!(du, u, p, t)
+        mul!(du, A, u)
+        du .-= 0.1 .* u .^ 2
+        return nothing
+    end
+    prob = ODEProblem(matstate!, [1.0 2.0 3.0; 4.0 5.0 6.0], (0.0, 0.2))
+    ref = solve(prob, RadauIIA5(), reltol = 1.0e-13, abstol = 1.0e-13).u[end]
+    sol = solve(prob, alg(linsolve = KrylovJL_GMRES()), reltol = 1.0e-10, abstol = 1.0e-10)
+    @test SciMLBase.successful_retcode(sol)
+    @test maximum(abs, sol.u[end] - ref) < 1.0e-8
+end

--- a/lib/OrdinaryDiffEqFIRK/test/ode_firk_tests.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/ode_firk_tests.jl
@@ -189,3 +189,16 @@ for iip in (true, false)
     @test length(sol.t) < 5000 # the error estimate is not very good
     @test SciMLBase.successful_retcode(sol)
 end
+
+@testset "AdaptiveRadau initializes every stage-value slot" begin
+    # `integrator.k[3:end]` holds one stage value per possible stage; the extrapolated
+    # initial guess reads all `num_stages` of them, so the slots above the starting stage
+    # count are read as soon as the controller raises the order. Leave dirty blocks in the
+    # allocator's free lists first, or an uninitialized slot can come back zeroed by luck.
+    poison() = sum(sum, [fill(NaN, 2) for _ in 1:50_000])
+    @test isnan(poison())
+    GC.gc(false)
+    vanstiff = ODEProblem(vanderpol_firk, [sqrt(3), 0.0], (0.0, 1.0), [1.0e6])
+    integ = init(vanstiff, AdaptiveRadau())
+    @test all(x -> all(iszero, x), integ.k[3:(integ.kshortsize)])
+end

--- a/lib/OrdinaryDiffEqFIRK/test/qa/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/test/qa/Project.toml
@@ -2,21 +2,22 @@
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 OrdinaryDiffEqFIRK = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources.OrdinaryDiffEqCore]
-path = "../../../OrdinaryDiffEqCore"
+[sources]
+OrdinaryDiffEqCore = {path = "../../../OrdinaryDiffEqCore"}
 
 [compat]
 AllocCheck = "0.2"
 Aqua = "0.8.11"
 JET = "0.9, 0.11"
-SciMLTesting = "2.1"
-julia = "1.10"
 OrdinaryDiffEqCore = "4"
 OrdinaryDiffEqFIRK = "2"
 SciMLBase = "3"
+SciMLTesting = "2.1"
+julia = "1.10"

--- a/lib/OrdinaryDiffEqFIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/qa/qa.jl
@@ -27,5 +27,15 @@ run_qa(
                 :AbstractSciMLOperator,   # SciMLOperators
             ),
         ),
+        all_qualified_accesses_are_public = (;
+            ignore = (
+                # LinearSolve internal, and the only way to ask whether a linear solver
+                # can consume an operator `A`. `build_J_W` in
+                # OrdinaryDiffEqDifferentiation reaches for the same name and ignores it
+                # the same way; FIRK has to make the matching decision for its own
+                # shifted stage matrices. Make-public candidate upstream.
+                :needs_concrete_A,
+            ),
+        ),
     ),
 )

--- a/lib/OrdinaryDiffEqFIRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/runtests.jl
@@ -10,6 +10,7 @@ end
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "FIRK Tests" include("ode_firk_tests.jl")
+    @time @safetestset "FIRK Krylov Tests" include("firk_krylov_tests.jl")
 end
 
 # Run QA tests (AllocCheck, JET, Aqua) - skip on pre-release Julia


### PR DESCRIPTION
Closes https://github.com/SciML/OrdinaryDiffEq.jl/issues/4156.

> **Stacked on https://github.com/SciML/OrdinaryDiffEq.jl/pull/4160** (`AdaptiveRadau` reads uninitialized stage-value slots). That fix has to land first or the `AdaptiveRadau` cases here are intermittently unstable for reasons unrelated to this change. Review only the second commit; the diff against master will shrink once #4160 merges.

## What changed

`RadauIIA3`, `RadauIIA5`, `RadauIIA9` and `AdaptiveRadau` now work with a matrix-free `linsolve`. The W-transform already decouples a step into one real shifted solve plus one shifted solve per complex-conjugate stage pair; each is `-γ M + J` for a different `γ`, so each can be applied lazily through the same real Jacobian-vector product instead of being assembled entrywise.

The real stage is `SciMLOperators.WOperator`, which already exists and already does this. The new piece is the complex stage: `ComplexWOperator` in `lib/OrdinaryDiffEqFIRK/src/firk_operators.jl`, a complex-`gamma` counterpart of `WOperator` that assembles the complex product from two real Jacobian-vector products (`J(a + bi) = Ja + i Jb`). That is what lets a real JVP operator — which cannot be applied to a complex vector at all — back the complex-conjugate pairs.

Everything else is plumbing at the four `alg_cache`/`perform_step!` sites: pick the lazy or the concrete stage matrix, and set `γ` on the lazy one instead of writing `n²` entries.

Two combinations that were broken independently of Krylov also start working, because `build_J_W` hands back a `WOperator` whenever a JVP exists and FIRK could not index into it:

  - `RadauIIA5(concrete_jac = true)` (and the other three) — previously `MethodError: no method matching setindex!(::WOperator, ...)`. `firk_real_W` now falls back to a concrete matrix when the linear solver wants one.
  - `RadauIIA3(linsolve = KrylovJL_GMRES())` — previously `MethodError: no method matching similar(::JVPCache, ::Type{ComplexF64})`; `RadauIIA3` had no guard at all.

`GaussLegendre` is unchanged: it solves a single coupled `num_stages * length(u)` system rather than decoupled shifted ones, so there is nothing to apply lazily without a new block operator. Its error message now says that, and says what to use instead.

## Failing before, passing after

The issue's reproducer, extended to the neighbouring combinations, on a 40-state 1D Brusselator at `reltol = abstol = 1e-10`.

Before (at the parent commit):

```
RadauIIA3(linsolve = KrylovJL_GMRES())                         ERROR: MethodError: no method matching similar(::OrdinaryDiffEqDifferentiation.JVPCache{Float64}, ::Type{ComplexF64})
RadauIIA5(linsolve = KrylovJL_GMRES())                         ERROR: Non-concrete Jacobian not yet supported by RadauIIA5.
RadauIIA9(linsolve = KrylovJL_GMRES())                         ERROR: Non-concrete Jacobian not yet supported by RadauIIA5.
AdaptiveRadau(linsolve = KrylovJL_GMRES())                     ERROR: Non-concrete Jacobian not yet supported by AdaptiveRadau.
RadauIIA5(linsolve = KrylovJL_GMRES(), concrete_jac = true)    ERROR: MethodError: no method matching setindex!(::SciMLOperators.WOperator{true, Float64, ...
RadauIIA5(concrete_jac = true)                                 ERROR: MethodError: no method matching setindex!(::SciMLOperators.WOperator{true, Float64, ...
GaussLegendre(num_stages = 3, linsolve = KrylovJL_GMRES())     ERROR: Non-concrete Jacobian not yet supported by GaussLegendre.
```

After:

```
RadauIIA3(linsolve = KrylovJL_GMRES())                         Success  nf=14149
RadauIIA5(linsolve = KrylovJL_GMRES())                         Success  nf=830
RadauIIA9(linsolve = KrylovJL_GMRES())                         Success  nf=588
AdaptiveRadau(linsolve = KrylovJL_GMRES())                     Success  nf=781
RadauIIA5(linsolve = KrylovJL_GMRES(), concrete_jac = true)    Success  nf=585
RadauIIA5(concrete_jac = true)                                 Success  nf=289
GaussLegendre(num_stages = 3, linsolve = KrylovJL_GMRES())     ERROR: GaussLegendre does not support a matrix-free Jacobian: unlike the Radau methods it solves a single coupled 120-by-120 system rather than decoupled shifted systems, ...
```

The new test file cannot run at all before this commit — it references `ComplexWOperator`, which does not exist there — so the reproducer above is the before/after evidence rather than the test suite.

## Accuracy against a tight reference

Same problem, `reltol = abstol = 1e-10`, reference from `RadauIIA5` at `1e-14`. `cj-kry` is `concrete_jac = true` with GMRES, `cj-lu` is `concrete_jac = true` with the default factorization. `massmat` repeats it with a non-identity diagonal mass matrix.

```
plain    RadauIIA3      dense 8.44e-12 | krylov 8.44e-12 | cj-kry 8.44e-12 | cj-lu 8.44e-12
plain    RadauIIA5      dense 5.10e-09 | krylov 2.15e-10 | cj-kry 2.15e-10 | cj-lu 5.10e-09
plain    RadauIIA9      dense 1.34e-09 | krylov 4.76e-09 | cj-kry 4.76e-09 | cj-lu 1.34e-09
plain    AdaptiveRadau  dense 1.99e-09 | krylov 4.75e-09 | cj-kry 4.75e-09 | cj-lu 1.99e-09
massmat  RadauIIA3      dense 2.54e-11 | krylov 2.54e-11 | cj-kry 2.54e-11 | cj-lu 2.54e-11
massmat  RadauIIA5      dense 1.45e-08 | krylov 5.42e-09 | cj-kry 5.42e-09 | cj-lu 1.45e-08
massmat  RadauIIA9      dense 4.42e-08 | krylov 4.44e-07 | cj-kry 4.44e-07 | cj-lu 4.42e-08
massmat  AdaptiveRadau  dense 1.08e-08 | krylov 6.12e-08 | cj-kry 6.12e-08 | cj-lu 1.08e-08
```

`cj-lu` reproduces the dense-Jacobian result exactly, as it should — that path assembles and factorizes the same `W`. The matrix-free results sit within an order of magnitude of the dense ones, in both directions; the residual difference is the usual inexact-Newton effect of solving each stage system to `reltol` instead of exactly, and it shrinks with the tolerance (`massmat RadauIIA9` goes 4.4e-7 → 2.4e-7 on tightening `1e-9 → 1e-11`).

Separately, `ComplexWOperator` is unit-tested against its dense form for `I`, `λI`, a diagonal, and a full mass matrix.

## `nf` accounting

Each complex stage solve spends two real Jacobian-vector products per Krylov iteration, and `dolinsolve` cannot see them — it only accounts for `WOperator`. The operator counts its own products and drains them into the stats after each Newton iteration (a counter on the operator rather than one inferred from `linres.iters`, so `AdaptiveRadau`'s threaded stage solves each tally into their own operator instead of racing on `integrator.stats`).

Counting the RHS calls directly and comparing against `sol.stats.nf`, on a 12-state linear stiff problem at `1e-9`:

```
RadauIIA3      dense   actual nf  39827   reported  39827   ratio 1.000
RadauIIA3      krylov  actual nf  18669   reported  18669   ratio 1.000
RadauIIA3      kry+cj  actual nf  50505   reported  50505   ratio 1.000
RadauIIA3      fd-kry  actual nf  29335   reported  29335   ratio 1.000
RadauIIA5      dense   actual nf    414   reported    414   ratio 1.000
RadauIIA5      krylov  actual nf   1407   reported   1407   ratio 1.000
RadauIIA5      kry+cj  actual nf   1419   reported    900   ratio 0.634
RadauIIA5      fd-kry  actual nf   2492   reported   2492   ratio 1.000
RadauIIA9      dense   actual nf    143   reported    143   ratio 1.000
RadauIIA9      krylov  actual nf    779   reported    779   ratio 1.000
RadauIIA9      kry+cj  actual nf    791   reported    596   ratio 0.753
RadauIIA9      fd-kry  actual nf   1432   reported   1432   ratio 1.000
AdaptiveRadau  dense   actual nf    181   reported    181   ratio 1.000
AdaptiveRadau  krylov  actual nf    881   reported    881   ratio 1.000
AdaptiveRadau  kry+cj  actual nf    893   reported    665   ratio 0.745
AdaptiveRadau  fd-kry  actual nf   1641   reported   1641   ratio 1.000
```

Exact for the fully matrix-free path with both AD backends; the test suite asserts `sol.stats.nf == actual` for all four methods × `AutoForwardDiff`/`AutoFiniteDiff`.

The `kry+cj` undercount is **pre-existing and not FIRK-specific**: `dolinsolve` gates its accounting on `linsolve.A isa WOperator && linsolve.A.J isa AbstractSciMLOperator`, and with `concrete_jac = true` the `J` is a concrete matrix even though the products go through `jacvec`. That affects every Newton-Krylov integrator (SDIRK, BDF, Rosenbrock) and belongs in a separate PR against `OrdinaryDiffEqDifferentiation`. `RadauIIA3` reads 1.000 there only because it has no real stage solve, so all of its products go through the new operator.

## Verification

```
$ GROUP=Core julia --project=lib/OrdinaryDiffEqFIRK -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
FIRK Tests    |  107    107  3m45.4s
Test Summary:     | Pass  Total     Time
FIRK Krylov Tests |   93     93  5m43.2s
core exit=0
```

```
$ GROUP=QA julia --project=lib/OrdinaryDiffEqFIRK -e 'using Pkg; Pkg.test()'
Test Summary:                                  | Pass  Fail  Total     Time
Aqua                                           |   19     1     20  1m17.1s
    ExplicitImports                            |    6            6    29.3s
    Public API documentation                   |          1      1     2.8s
      public API has docstrings                |          1      1     2.8s   <-- isempty([:SciMLBase])
```


The single QA failure is **pre-existing**. The same run on this branch's parent gives the identical `19 passed, 1 failed` with the same `:SciMLBase` docstring check, and `lib/OrdinaryDiffEqFIRK [QA]` is already red on master upstream: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/31198062683.

An earlier revision of this PR did add three real `ExplicitImports` failures (`alg_autodiff` imported from a non-owner, `SciMLOperators.getops`, `LinearSolve.needs_concrete_A`). Two are gone — `alg_autodiff` is replaced by the algorithm's own public `autodiff` field, and the speculative `getops` method is dropped. `needs_concrete_A` is allow-listed in `test/qa/qa.jl` with a comment: it is the only way to ask whether a linear solver can consume an operator `A`, `build_J_W` in `OrdinaryDiffEqDifferentiation` reaches for the same name and ignores it the same way, and it is a make-public candidate upstream in LinearSolve.

```
$ julia -e 'using Runic; exit(Runic.main(["--check","--diff","lib/OrdinaryDiffEqFIRK/"]))'   # clean
$ typos lib/OrdinaryDiffEqFIRK/ docs/src/implicit/FIRK.md                                    # clean
```


## What I did not verify

- **Docs build fails on this branch and on its parent, identically** — `Cannot resolve @ref for md"[`DummyControllerCache`](@ref)"`, then `makedocs encountered an error [:cross_references]`. Already red on master upstream for the same reason (https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/31198061733). Not introduced here; https://github.com/SciML/OrdinaryDiffEq.jl/pull/4165 fixes it, and with that one-line change applied the full build succeeds, so the `docs/src/implicit/FIRK.md` addition here does render.
- Preconditioners. `wrapprecs` is commented out in the FIRK caches and stays that way; `concrete_jac = true` gives you the concrete `J` to build one from, but nothing wires it up.
- GPU and downstream lanes.
- Out-of-place (`Val{false}`) caches. They build a dense `J` directly and are untouched.
- `lib/OrdinaryDiffEqFIRK/src/firk_addsteps.jl` carries a near-duplicate of the same W assembly and is **not** updated. Those methods take `(integrator, cache[, repeat_step])`, while every `_ode_addsteps!` call site in `OrdinaryDiffEqCore` passes 11 arguments — I checked every call site's arity and none is ≤ 4, so they are unreachable. Rather than ship an untestable parallel change I left them; if they are ever wired up they will need the same treatment (or, better, to stop being a copy of `perform_step!`).

## Things worth pushing back on

1. **The lazy `W` is re-formed every step, ignoring the `do_newW` reuse heuristic.** Setting `γ` on an operator is O(1) and no factorization follows it, so there is nothing to amortize and a current `W` is a strictly better Newton matrix. It also sidesteps a staleness hazard specific to `AdaptiveRadau`: `do_newW` looks only at `dt`, so when the controller raises `num_stages` the newly used `W2[i]` would otherwise still hold whatever shift it was last given — for a slot never used before, that is the construction-time placeholder. The concrete path keeps the original behaviour untouched.
2. **`integrator.stats.nw` therefore increments every step on the matrix-free path**, where the concrete path increments only when `do_newW` says so. That is accurate — `W` really is re-formed each step — but it does make `nw` mean something slightly different between the two paths.
3. **`ComplexWOperator` is internal**, not exported and not `public`. It is reachable only through `alg_cache`, and I would rather not commit to it as API before someone has used FIRK+Krylov in anger.
4. **The `massmat RadauIIA9` accuracy gap (4.4e-7 vs 4.4e-8 dense)** is the largest divergence in the table. I attribute it to inexact Newton and checked that it converges with tolerance, but a reviewer who wants the linear solves driven tighter than `integrator.opts.reltol` should say so.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gstik9KAfxtNAz53ejBPwN
