### PR TITLE
Access full_cache and AutoDePSpecialize from SciMLBase in OrdinaryDiffEqBDF

### DIFF
--- a/lib/OrdinaryDiffEqBDF/src/OrdinaryDiffEqBDF.jl
+++ b/lib/OrdinaryDiffEqBDF/src/OrdinaryDiffEqBDF.jl
@@ -8,7 +8,7 @@ import OrdinaryDiffEqCore: perform_step!, unwrap_alg,
     OrdinaryDiffEqNewtonAlgorithm,
     AbstractController,
     alg_cache, @cache,
-    isfsal, full_cache,
+    isfsal,
     constvalue, error_constant,
     has_special_newton_error,
     trivial_limiter!,
@@ -28,7 +28,7 @@ import OrdinaryDiffEqCore: perform_step!, unwrap_alg,
     _ode_addsteps!, DerivativeOrderNotPossibleError, set_discontinuity,
     DIRK, COEFFICIENT_MULTISTEP, isnewton, set_new_W!,
     find_algebraic_vars_eqs
-import SciMLBase: alg_order, isadaptive, _unwrap_val
+import SciMLBase: alg_order, isadaptive, _unwrap_val, full_cache
 import DiffEqBase: calculate_residuals, calculate_residuals!, initialize!
 using OrdinaryDiffEqSDIRK: ESDIRKIMEXConstantCache, ESDIRKIMEXCache,
     ImplicitEulerESDIRKIMEXTableau
@@ -127,14 +127,14 @@ PrecompileTools.@compile_workload begin
     if Preferences.@load_preference("PrecompileAutoDePSpecialize", false)
         push!(
             prob_list,
-            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
+            ODEProblem{true, SciMLBase.AutoDePSpecialize}(
                 OrdinaryDiffEqCore.lorenz_p, [1.0; 0.0; 0.0],
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_p_params
             )
         )
         push!(
             prob_list,
-            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
+            ODEProblem{true, SciMLBase.AutoDePSpecialize}(
                 OrdinaryDiffEqCore.lorenz_pref, [1.0; 0.0; 0.0],
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_pref_params
             )


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## What changed and why

`OrdinaryDiffEqBDF` imported `full_cache` and reached for `AutoDePSpecialize`
through `OrdinaryDiffEqCore`, which only forwards them. Both names are owned by
`SciMLBase` and are public there, so this switches to the owning module, per the
project rule "access a name through the module that actually declares it public,
not through a re-exporter that merely forwards it". No ExplicitImports
ignore/allow-list entry was added.

Ownership verified in SciMLBase v3.43.0 (`~/.julia/packages/SciMLBase/YjW4D`):

```
src/SciMLBase.jl:2123:export addat!, get_tmp_cache,
src/SciMLBase.jl:2124:    full_cache, user_cache, u_cache, du_cache,
src/SciMLBase.jl:2297:@public FullSpecialize, NoSpecialize, FunctionWrapperSpecialize, AutoDePSpecialize
```

`AutoDePSpecialize` first became `@public` in SciMLBase v3.39.0, and
`lib/OrdinaryDiffEqBDF/Project.toml` already pins `SciMLBase = "3.39"`, so no
compat bump is needed.

## This is not BDF-only

The same non-owner access exists in 13 sibling sublibraries on master. Scanning
`lib/*/src/<Pkg>.jl` for `full_cache` inside an `import OrdinaryDiffEqCore:` block
and for `OrdinaryDiffEqCore.AutoDePSpecialize`:

```
OrdinaryDiffEqAdamsBashforthMoulton     full_cache<-Core
OrdinaryDiffEqExponentialRK             full_cache<-Core
OrdinaryDiffEqHighOrderRK               full_cache<-Core
OrdinaryDiffEqLinear                    full_cache<-Core
OrdinaryDiffEqLowStorageRK              full_cache<-Core, AutoDePSpecialize<-Core
OrdinaryDiffEqMultirate                 full_cache<-Core
OrdinaryDiffEqNewmark                   full_cache<-Core
OrdinaryDiffEqRKN                       full_cache<-Core
OrdinaryDiffEqRosenbrock                full_cache<-Core, AutoDePSpecialize<-Core
OrdinaryDiffEqSDIRK                     full_cache<-Core, AutoDePSpecialize<-Core
OrdinaryDiffEqSSPRK                     full_cache<-Core, AutoDePSpecialize<-Core
OrdinaryDiffEqStabilizedRK              full_cache<-Core
OrdinaryDiffEqTsit5                     full_cache<-Core, AutoDePSpecialize<-Core
OrdinaryDiffEqVerner                    full_cache<-Core, AutoDePSpecialize<-Core
```

11 of those have a QA lane with `explicit_imports = true` and no ignore for these
names (Multirate and Newmark have no `test/qa/qa.jl`), so their lanes fail the same
way. Confirmed by running one of them unmodified — `GROUP=QA` in
`lib/OrdinaryDiffEqTsit5` produces the identical four errors:

```
- `full_cache` has owner `SciMLBase` but it was imported from `OrdinaryDiffEqCore` at .../lib/OrdinaryDiffEqTsit5/src/OrdinaryDiffEqTsit5.jl:12:5
- `AutoDePSpecialize` has owner `SciMLBase` but it was accessed from `OrdinaryDiffEqCore` at .../lib/OrdinaryDiffEqTsit5/src/OrdinaryDiffEqTsit5.jl:72:49
- `AutoDePSpecialize` is not public in `OrdinaryDiffEqCore` but it was imported from `OrdinaryDiffEqCore` at .../lib/OrdinaryDiffEqTsit5/src/OrdinaryDiffEqTsit5.jl:72:49
- `full_cache` is not public in `OrdinaryDiffEqCore` but it was imported from `OrdinaryDiffEqCore` at .../lib/OrdinaryDiffEqTsit5/src/OrdinaryDiffEqTsit5.jl:12:5
```

This PR fixes BDF only, so it stays small and reviewable. The other 13 want the
same one-line-per-file treatment; happy to follow up with a stacked PR once the
approach here is agreed.

## Evidence this fails on unmodified master

Base commit: `c11ff74bb404216d03ad68b971438047097609e2` ("Sync package versions with the General registry (#4152)"), clean checkout, no local modifications. Julia 1.12.6, ExplicitImports v1.15.0, SciMLTesting v2.6.2.

### Before (unmodified master)

```
$ cd lib/OrdinaryDiffEqBDF && GROUP=QA julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.test()'

all_explicit_imports_via_owners: Error During Test
  ExplicitImportsFromNonOwnerException
  Module `OrdinaryDiffEqBDF` has explicit imports of names from modules other than their owner as determined via `Base.which`:
  - `full_cache` has owner `SciMLBase` but it was imported from `OrdinaryDiffEqCore` at `.../lib/OrdinaryDiffEqBDF/src/OrdinaryDiffEqBDF.jl:11:13`

all_qualified_accesses_via_owners: Error During Test
  QualifiedAccessesFromNonOwnerException
  Module `OrdinaryDiffEqBDF` has qualified accesses to names via modules other than their owner as determined via `Base.which`:
  - `AutoDePSpecialize` has owner `SciMLBase` but it was accessed from `OrdinaryDiffEqCore` at `.../lib/OrdinaryDiffEqBDF/src/OrdinaryDiffEqBDF.jl:130:49`

all_qualified_accesses_are_public: Error During Test
  NonPublicQualifiedAccessException
  - `AutoDePSpecialize` is not public in `OrdinaryDiffEqCore` but it was imported from `OrdinaryDiffEqCore` at `.../lib/OrdinaryDiffEqBDF/src/OrdinaryDiffEqBDF.jl:130:49`

all_explicit_imports_are_public: Error During Test
  NonPublicExplicitImportsException
  - `full_cache` is not public in `OrdinaryDiffEqCore` but it was imported from `OrdinaryDiffEqCore` at `.../lib/OrdinaryDiffEqBDF/src/OrdinaryDiffEqBDF.jl:11:13`

Test Summary:                                  | Pass  Fail  Error  Total     Time
Aqua                                           |   15     1      4     20  1m27.3s
  Quality Assurance                            |   15     1      4     20  1m22.7s
    ...
    ExplicitImports                            |    2            4      6    32.4s
      no_implicit_imports                      |    1                   1    19.3s
      no_stale_explicit_imports                |    1                   1     3.0s
      all_explicit_imports_via_owners          |                 1      1     3.4s
      all_qualified_accesses_via_owners        |                 1      1     3.0s
      all_qualified_accesses_are_public        |                 1      1     1.8s
      all_explicit_imports_are_public          |                 1      1     2.0s
    Public API documentation                   |          1             1     2.7s
      public API has docstrings                |          1             1     2.7s
    No unapproved public reexports             |    1                   1     0.0s
ERROR: Package OrdinaryDiffEqBDF errored during testing

EXIT=1
```

### After (this branch)

```
$ cd lib/OrdinaryDiffEqBDF && GROUP=QA julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.test()'

Test Summary:    | Pass  Broken  Total     Time
Allocation Tests |    2      18     20  4m49.5s
Test Summary: | Pass  Broken  Total     Time
JET Tests     |   18      23     41  1m20.0s

Test Summary:                                  | Pass  Fail  Total     Time
Aqua                                           |   19     1     20  1m19.6s
  Quality Assurance                            |   19     1     20  1m16.2s
    Method ambiguity                           |    1            1     8.2s
    Unbound type parameters                    |    1            1     0.1s
    Undefined exports                          |    1            1     0.0s
    Compare Project.toml and test/Project.toml |    1            1     0.0s
    Stale dependencies                         |    1            1     7.8s
    Compat bounds                              |    4            4     0.3s
    Piracy                                     |    1            1     0.2s
    Persistent tasks                           |    1            1    16.4s
    ExplicitImports                            |    6            6    29.8s
    Public API documentation                   |          1      1     3.0s
      public API has docstrings                |          1      1     3.0s
    No unapproved public reexports             |    1            1     0.0s
ERROR: Package OrdinaryDiffEqBDF errored during testing

EXIT=1
```

All six ExplicitImports checks now pass (was `2 Pass / 4 Error`, now `6 Pass`).
`Allocation Tests` (2 Pass / 18 Broken) and `JET Tests` (18 Pass / 23 Broken) are
byte-for-byte identical before and after.

### The lane is still red, for an unrelated reason

`Public API documentation > public API has docstrings` fails on both master and
this branch with `isempty([:SciMLBase])`:

```
public API has docstrings: Test Failed at .../SciMLTesting/v2jEQ/src/SciMLTesting.jl:1205
  Expression: isempty(undocumented)
   Evaluated: isempty([:SciMLBase])
```

That is the separate `@reexport using SciMLBase` re-exports-its-own-module-name
failure affecting many sublibrary QA lanes; it is being handled in SciMLTesting.jl
and is out of scope here. This PR does not change it, which is why the after-run
still exits 1.

### Functional group

```
$ cd lib/OrdinaryDiffEqBDF && GROUP=Core julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.test()'

DAE Convergence Tests               |   50     50  1m42.0s
DAE AD Tests                        |   16     16  10m47.2s
DAE Event Tests                     |    4      4  10.5s
DAE derivative_discontinuity! Tests |    5      5  23.0s
DAE Initialization Tests            |   38  (2 Broken)  40  1m38.8s
BDF Inference Tests                 |    1      1  1.9s
BDF Convergence Tests               |   84     84  3m55.6s
BDF Regression Tests                |   35     35  3m54.4s
Nordsieck BDF Tests                 |  101    101  3m54.7s

EXIT=0
```

## Also run locally

- `Runic.main(["--check", "--diff", "lib/OrdinaryDiffEqBDF/src/OrdinaryDiffEqBDF.jl"])` — exit 0.
- `typos` over the diff — exit 0, no findings.

## Not verified

- Only the BDF `QA` and `Core` groups were run. Other sublibraries' test groups, the umbrella `OrdinaryDiffEq` suite, and the docs build were not run for this change.
- GPU group, downstream, and allowed-to-fail lanes (`julia pre`) were not run.
- The 13 sibling sublibraries listed above are **not** fixed here.

## Worth pushing back on

- Whether to fix all 14 sublibraries in one sweep instead of BDF-first. I kept it to BDF because mechanical sweeps are easier to review on their own, but a reviewer may prefer the single sweep.
- `full_cache` is not referenced anywhere else in `OrdinaryDiffEqBDF`'s sources; the `@cache` macro emits `SciMLBase.full_cache(...)` via a `GlobalRef`. Deleting the import outright is an equally valid fix. I kept it, importing from SciMLBase, to match the existing convention in `OrdinaryDiffEqLowOrderRK` and `OrdinaryDiffEqSymplecticRK` (which already do `import SciMLBase: ... full_cache`) and because `no_stale_explicit_imports` stays green either way.
