### PR TITLE
Access full_cache, resize_non_user_cache!, AutoDePSpecialize and SciMLOperators from their owners

### DIFF
--- a/lib/OrdinaryDiffEqAdamsBashforthMoulton/src/OrdinaryDiffEqAdamsBashforthMoulton.jl
+++ b/lib/OrdinaryDiffEqAdamsBashforthMoulton/src/OrdinaryDiffEqAdamsBashforthMoulton.jl
@@ -8,9 +8,8 @@ import OrdinaryDiffEqCore: OrdinaryDiffEqMutableCache, OrdinaryDiffEqConstantCac
     OrdinaryDiffEqAdamsVarOrderVarStepAlgorithm,
     constvalue,
     trivial_limiter!, get_fsalfirstlast,
-    generic_solver_docstring,
-    full_cache
-import SciMLBase: alg_order
+    generic_solver_docstring
+import SciMLBase: alg_order, full_cache
 import DiffEqBase: initialize!, calculate_residuals, calculate_residuals!
 import OrdinaryDiffEqLowOrderRK: BS3ConstantCache, BS3Cache, RK4ConstantCache, RK4Cache
 import RecursiveArrayTools: recursivefill!

--- a/lib/OrdinaryDiffEqExponentialRK/src/OrdinaryDiffEqExponentialRK.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/OrdinaryDiffEqExponentialRK.jl
@@ -8,7 +8,7 @@ import OrdinaryDiffEqCore: alg_adaptive_order, ismultistep,
     perform_step!, unwrap_alg,
     OrdinaryDiffEqAdaptiveExponentialAlgorithm,
     ExponentialAlgorithm, fsal_typeof, isdtchangeable,
-    full_cache, get_fsalfirstlast,
+    get_fsalfirstlast,
     generic_solver_docstring, _fixup_ad, trivial_limiter!
 import OrdinaryDiffEqCore
 using RecursiveArrayTools: RecursiveArrayTools
@@ -23,7 +23,8 @@ using ExponentialUtilities: ExponentialUtilities, ExpvCache, KrylovSubspace,
     phiv, phiv!, phiv_timestep, phiv_timestep!
 # alg_order / _unwrap_val are owned by SciMLBase (re-exported through OrdinaryDiffEqCore);
 # import from the owner to satisfy ExplicitImports' via-owners check.
-import SciMLBase: alg_order, _unwrap_val, UJacobianWrapper, UDerivativeWrapper
+import SciMLBase: alg_order, _unwrap_val, UJacobianWrapper, UDerivativeWrapper,
+    full_cache
 using OrdinaryDiffEqDifferentiation: build_jac_config, calc_J, calc_J!
 import ADTypes: AutoForwardDiff
 

--- a/lib/OrdinaryDiffEqHighOrderRK/src/OrdinaryDiffEqHighOrderRK.jl
+++ b/lib/OrdinaryDiffEqHighOrderRK/src/OrdinaryDiffEqHighOrderRK.jl
@@ -11,14 +11,14 @@ import OrdinaryDiffEqCore: qmax_default, qmin_default, beta2_default,
     CompiledFloats,
     get_fsalfirstlast,
     unwrap_alg, _ode_interpolant, _ode_interpolant!,
-    DerivativeOrderNotPossibleError, full_cache, isdp8
+    DerivativeOrderNotPossibleError, isdp8
 using FastBroadcast: Serial
 import MuladdMacro: @muladd
 import FastBroadcast: @..
 import RecursiveArrayTools: recursivefill!, copyat_or_push!
 import DiffEqBase: @tight_loop_macros, calculate_residuals, calculate_residuals!,
     initialize!
-import SciMLBase: alg_order
+import SciMLBase: alg_order, full_cache
 import OrdinaryDiffEqCore
 
 using Reexport

--- a/lib/OrdinaryDiffEqLinear/src/OrdinaryDiffEqLinear.jl
+++ b/lib/OrdinaryDiffEqLinear/src/OrdinaryDiffEqLinear.jl
@@ -7,10 +7,11 @@ import OrdinaryDiffEqCore: alg_extrapolates, dt_required,
     OrdinaryDiffEqConstantCache,
     perform_step!, unwrap_alg,
     get_fsalfirstlast,
-    isdtchangeable, full_cache,
+    isdtchangeable,
     generic_solver_docstring
 using LinearAlgebra: mul!, I
-using SciMLOperators: AbstractSciMLOperator, update_coefficients, update_coefficients!
+using SciMLOperators: SciMLOperators, AbstractSciMLOperator, update_coefficients,
+    update_coefficients!
 using ExponentialUtilities: ExponentialUtilities, ExpMethodGeneric, ExpvCache,
     KrylovSubspace, PhivCache, arnoldi!, exponential!,
     expv, expv!, expv_timestep, expv_timestep!
@@ -18,11 +19,11 @@ using RecursiveArrayTools: recursivefill!
 import OrdinaryDiffEqCore
 import DiffEqBase
 import DiffEqBase: calculate_residuals!, initialize!
-import SciMLBase: alg_order, _vec
+import SciMLBase: alg_order, _vec, full_cache
 
 using Reexport: Reexport, @reexport
 @reexport using SciMLBase
-using SciMLBase: SciMLBase, SciMLOperators, SplitFunction
+using SciMLBase: SciMLBase, SplitFunction
 
 include("algorithms.jl")
 include("alg_utils.jl")

--- a/lib/OrdinaryDiffEqLowStorageRK/src/OrdinaryDiffEqLowStorageRK.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/src/OrdinaryDiffEqLowStorageRK.jl
@@ -5,7 +5,7 @@ import OrdinaryDiffEqCore: perform_step!,
     OrdinaryDiffEqMutableCache, OrdinaryDiffEqConstantCache,
     OrdinaryDiffEqAdaptiveAlgorithm, uses_uprev,
     PIDController,
-    alg_cache, @cache, isfsal, full_cache,
+    alg_cache, @cache, isfsal,
     constvalue,
     trivial_limiter!,
     explicit_rk_docstring, get_fsalfirstlast,
@@ -13,7 +13,7 @@ import OrdinaryDiffEqCore: perform_step!,
 import OrdinaryDiffEqCore
 # `alg_order` is owned by and public in SciMLBase; `initialize!` is owned by and
 # public in DiffEqBase. Import from the true public owners (not re-exporters).
-import SciMLBase: alg_order
+import SciMLBase: alg_order, full_cache
 import DiffEqBase: initialize!, calculate_residuals, calculate_residuals!
 using FastBroadcast: FastBroadcast, @.., Serial
 using MuladdMacro: MuladdMacro, @muladd
@@ -78,14 +78,14 @@ PrecompileTools.@compile_workload begin
     if Preferences.@load_preference("PrecompileAutoDePSpecialize", false)
         push!(
             prob_list,
-            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
+            ODEProblem{true, SciMLBase.AutoDePSpecialize}(
                 OrdinaryDiffEqCore.lorenz_p, [1.0; 0.0; 0.0],
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_p_params
             )
         )
         push!(
             prob_list,
-            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
+            ODEProblem{true, SciMLBase.AutoDePSpecialize}(
                 OrdinaryDiffEqCore.lorenz_pref, [1.0; 0.0; 0.0],
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_pref_params
             )

--- a/lib/OrdinaryDiffEqMultirate/src/OrdinaryDiffEqMultirate.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/OrdinaryDiffEqMultirate.jl
@@ -6,7 +6,7 @@ import OrdinaryDiffEqCore: alg_order, isfsal,
     unwrap_alg, initialize!, perform_step!,
     calculate_residuals, calculate_residuals!,
     OrdinaryDiffEqMutableCache, OrdinaryDiffEqConstantCache,
-    @cache, alg_cache, full_cache, get_fsalfirstlast,
+    @cache, alg_cache, get_fsalfirstlast,
     nlsolve_f, issplit, _fixup_ad, _unwrap_val
 import OrdinaryDiffEqCore
 import FastBroadcast: @..
@@ -14,6 +14,7 @@ import MuladdMacro: @muladd
 import RecursiveArrayTools: recursivefill!
 import DiffEqBase: prepare_alg
 import LinearAlgebra
+import SciMLBase: full_cache
 using SciMLBase: SplitFunction
 using OrdinaryDiffEqNonlinearSolve: build_nlsolver, nlsolve!, nlsolvefail,
     markfirststage!, isnewton, set_new_W!, NLNewton

--- a/lib/OrdinaryDiffEqNewmark/src/OrdinaryDiffEqNewmark.jl
+++ b/lib/OrdinaryDiffEqNewmark/src/OrdinaryDiffEqNewmark.jl
@@ -8,13 +8,14 @@ import OrdinaryDiffEqCore: initialize!, perform_step!, unwrap_alg,
     OrdinaryDiffEqImplicitSecondOrderAlgorithm,
     OrdinaryDiffEqAdaptiveImplicitSecondOrderAlgorithm,
     OrdinaryDiffEqAdaptiveAlgorithm, CompiledFloats, uses_uprev,
-    alg_cache, _vec, _reshape, @cache, isfsal, full_cache,
+    alg_cache, _vec, _reshape, @cache, isfsal,
     constvalue, _unwrap_val, _ode_interpolant,
     trivial_limiter!, _ode_interpolant!,
     get_fsalfirstlast, generic_solver_docstring,
     OrdinaryDiffEqCore
 import PreallocationTools: DiffCache, get_tmp
 using TruncatedStacktraces, MuladdMacro, MacroTools, FastBroadcast, RecursiveArrayTools
+import SciMLBase: full_cache
 using SciMLBase: DynamicalODEFunction
 using LinearAlgebra: mul!, lmul!, I
 import FastBroadcast: @..

--- a/lib/OrdinaryDiffEqRKN/src/OrdinaryDiffEqRKN.jl
+++ b/lib/OrdinaryDiffEqRKN/src/OrdinaryDiffEqRKN.jl
@@ -7,12 +7,12 @@ import OrdinaryDiffEqCore: perform_step!,
     OrdinaryDiffEqAdaptivePartitionedAlgorithm,
     OrdinaryDiffEqPartitionedAlgorithm,
     CompiledFloats,
-    alg_cache, @cache, full_cache,
+    alg_cache, @cache,
     constvalue, _ode_interpolant,
     get_fsalfirstlast,
     _ode_interpolant!,
     generic_solver_docstring
-import SciMLBase: alg_order, @def
+import SciMLBase: alg_order, @def, full_cache
 using SciMLBase: SciMLBase
 import DiffEqBase: initialize!, calculate_residuals, calculate_residuals!,
     @tight_loop_macros

--- a/lib/OrdinaryDiffEqRosenbrock/src/OrdinaryDiffEqRosenbrock.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/OrdinaryDiffEqRosenbrock.jl
@@ -11,7 +11,7 @@ import OrdinaryDiffEqCore: alg_adaptive_order, isWmethod, isfsal, _unwrap_val,
     initialize!, perform_step!, get_fsalfirstlast,
     constvalue, only_diagonal_mass_matrix,
     calculate_residuals, has_stiff_interpolation, ODEIntegrator,
-    resize_non_user_cache!, _ode_addsteps!, full_cache,
+    _ode_addsteps!,
     DerivativeOrderNotPossibleError, _fixup_ad,
     copyat_or_push!, DifferentialVarsUndefined, resize_J_W!,
     find_algebraic_vars_eqs
@@ -55,7 +55,7 @@ using Reexport: Reexport, @reexport
 using SciMLBase: SciMLBase, LinearProblem, ODEProblem, init, solve,
     TimeDerivativeWrapper, TimeGradientWrapper, UDerivativeWrapper, UJacobianWrapper
 # alg_order is owned by and public in SciMLBase; import (not using) so methods can be extended
-import SciMLBase: alg_order
+import SciMLBase: alg_order, full_cache, resize_non_user_cache!
 
 import OrdinaryDiffEqCore: alg_autodiff
 import OrdinaryDiffEqCore
@@ -177,14 +177,14 @@ PrecompileTools.@compile_workload begin
     if Preferences.@load_preference("PrecompileAutoDePSpecialize", true)
         push!(
             prob_list,
-            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
+            ODEProblem{true, SciMLBase.AutoDePSpecialize}(
                 OrdinaryDiffEqCore.lorenz_p, [1.0; 0.0; 0.0],
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_p_params
             )
         )
         push!(
             prob_list,
-            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
+            ODEProblem{true, SciMLBase.AutoDePSpecialize}(
                 OrdinaryDiffEqCore.lorenz_pref, [1.0; 0.0; 0.0],
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_pref_params
             )

--- a/lib/OrdinaryDiffEqSDIRK/src/OrdinaryDiffEqSDIRK.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/OrdinaryDiffEqSDIRK.jl
@@ -4,7 +4,7 @@ module OrdinaryDiffEqSDIRK
 # they must be brought in with `import` (not `using`) to allow method definitions.
 import OrdinaryDiffEqCore: perform_step!,
     alg_extrapolates,
-    alg_cache, full_cache,
+    alg_cache,
     isesdirk, issplit,
     ssp_coefficient, get_fsalfirstlast
 # OrdinaryDiffEqCore names used (called/referenced) but not extended here.
@@ -26,7 +26,7 @@ using MacroTools: MacroTools
 using FastBroadcast: FastBroadcast, @..
 using RecursiveArrayTools: RecursiveArrayTools, recursivefill!
 # `alg_order` is owned by SciMLBase and extended here, so it needs `import`.
-import SciMLBase: alg_order
+import SciMLBase: alg_order, full_cache
 using SciMLBase: SciMLBase, SplitFunction, ODEProblem, _vec, _reshape, _unwrap_val
 # `initialize!` is owned by DiffEqBase and extended here, so it needs `import`;
 # `calculate_residuals`/`calculate_residuals!` are only called.
@@ -99,14 +99,14 @@ PrecompileTools.@compile_workload begin
     if Preferences.@load_preference("PrecompileAutoDePSpecialize", false)
         push!(
             prob_list,
-            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
+            ODEProblem{true, SciMLBase.AutoDePSpecialize}(
                 OrdinaryDiffEqCore.lorenz_p, [1.0; 0.0; 0.0],
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_p_params
             )
         )
         push!(
             prob_list,
-            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
+            ODEProblem{true, SciMLBase.AutoDePSpecialize}(
                 OrdinaryDiffEqCore.lorenz_pref, [1.0; 0.0; 0.0],
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_pref_params
             )

--- a/lib/OrdinaryDiffEqSSPRK/src/OrdinaryDiffEqSSPRK.jl
+++ b/lib/OrdinaryDiffEqSSPRK/src/OrdinaryDiffEqSSPRK.jl
@@ -4,13 +4,13 @@ import OrdinaryDiffEqCore: perform_step!, ssp_coefficient,
     OrdinaryDiffEqAlgorithm,
     OrdinaryDiffEqMutableCache, OrdinaryDiffEqConstantCache,
     OrdinaryDiffEqAdaptiveAlgorithm,
-    alg_cache, @cache, isfsal, full_cache,
+    alg_cache, @cache, isfsal,
     constvalue,
     explicit_rk_docstring, trivial_limiter!,
     _ode_interpolant, _ode_interpolant!,
     _ode_addsteps!, get_fsalfirstlast
 import OrdinaryDiffEqCore
-import SciMLBase: alg_order
+import SciMLBase: alg_order, full_cache
 import DiffEqBase: initialize!, calculate_residuals, calculate_residuals!
 using RecursiveArrayTools: RecursiveArrayTools, copyat_or_push!, recursivefill!
 using FastBroadcast: FastBroadcast, @.., Serial
@@ -75,14 +75,14 @@ PrecompileTools.@compile_workload begin
     if Preferences.@load_preference("PrecompileAutoDePSpecialize", false)
         push!(
             prob_list,
-            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
+            ODEProblem{true, SciMLBase.AutoDePSpecialize}(
                 OrdinaryDiffEqCore.lorenz_p, [1.0; 0.0; 0.0],
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_p_params
             )
         )
         push!(
             prob_list,
-            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
+            ODEProblem{true, SciMLBase.AutoDePSpecialize}(
                 OrdinaryDiffEqCore.lorenz_pref, [1.0; 0.0; 0.0],
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_pref_params
             )

--- a/lib/OrdinaryDiffEqStabilizedRK/src/OrdinaryDiffEqStabilizedRK.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/OrdinaryDiffEqStabilizedRK.jl
@@ -8,7 +8,7 @@ import OrdinaryDiffEqCore: alg_adaptive_order,
     OrdinaryDiffEqMutableCache, OrdinaryDiffEqConstantCache,
     OrdinaryDiffEqAdaptiveAlgorithm,
     alg_cache, @cache,
-    constvalue, full_cache, get_fsalfirstlast,
+    constvalue, get_fsalfirstlast,
     generic_solver_docstring
 import OrdinaryDiffEqCore
 using FastBroadcast: FastBroadcast, @..
@@ -21,7 +21,7 @@ import DiffEqBase: initialize!
 using DiffEqBase: calculate_residuals, calculate_residuals!
 
 using SciMLBase: SciMLBase
-import SciMLBase: alg_order, _vec, value
+import SciMLBase: alg_order, _vec, value, full_cache
 using Reexport: Reexport, @reexport
 @reexport using SciMLBase
 

--- a/lib/OrdinaryDiffEqTsit5/src/OrdinaryDiffEqTsit5.jl
+++ b/lib/OrdinaryDiffEqTsit5/src/OrdinaryDiffEqTsit5.jl
@@ -9,7 +9,7 @@ import OrdinaryDiffEqCore: alg_stability_size, explicit_rk_docstring,
     CompiledFloats, @OnDemandTableauExtract,
     CompositeAlgorithm, _ode_addsteps!,
     AutoAlgSwitch, get_fsalfirstlast,
-    full_cache, DerivativeOrderNotPossibleError
+    DerivativeOrderNotPossibleError
 using FastBroadcast: Serial
 import MuladdMacro: @muladd
 import FastBroadcast: @..
@@ -17,7 +17,7 @@ import RecursiveArrayTools: recursivefill!, recursive_unitless_bottom_eltype,
     copyat_or_push!
 import LinearAlgebra: norm
 using TruncatedStacktraces: @truncate_stacktrace
-import SciMLBase: alg_order, @def
+import SciMLBase: alg_order, @def, full_cache
 using DiffEqBase: calculate_residuals, calculate_residuals!
 import DiffEqBase: initialize!
 import OrdinaryDiffEqCore
@@ -69,14 +69,14 @@ PrecompileTools.@compile_workload begin
     if Preferences.@load_preference("PrecompileAutoDePSpecialize", true)
         push!(
             prob_list,
-            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
+            ODEProblem{true, SciMLBase.AutoDePSpecialize}(
                 OrdinaryDiffEqCore.lorenz_p, [1.0; 0.0; 0.0],
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_p_params
             )
         )
         push!(
             prob_list,
-            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
+            ODEProblem{true, SciMLBase.AutoDePSpecialize}(
                 OrdinaryDiffEqCore.lorenz_pref, [1.0; 0.0; 0.0],
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_pref_params
             )

--- a/lib/OrdinaryDiffEqVerner/src/OrdinaryDiffEqVerner.jl
+++ b/lib/OrdinaryDiffEqVerner/src/OrdinaryDiffEqVerner.jl
@@ -5,7 +5,7 @@ import OrdinaryDiffEqCore: perform_step!, unwrap_alg,
     CompositeAlgorithm, accept_step_controller,
     OrdinaryDiffEqMutableCache, OrdinaryDiffEqConstantCache,
     OrdinaryDiffEqAdaptiveAlgorithm, CompiledFloats,
-    alg_cache, @cache, isfsal, full_cache,
+    alg_cache, @cache, isfsal,
     constvalue,
     explicit_rk_docstring, trivial_limiter!, _ode_interpolant,
     _ode_interpolant!, _ode_addsteps!, @fold,
@@ -13,7 +13,7 @@ import OrdinaryDiffEqCore: perform_step!, unwrap_alg,
     DerivativeOrderNotPossibleError,
     get_fsalfirstlast
 import DiffEqBase: calculate_residuals!, calculate_residuals, initialize!
-import SciMLBase: alg_order, _unwrap_val, @def
+import SciMLBase: alg_order, _unwrap_val, @def, full_cache
 using FastBroadcast: @.., Serial
 using MuladdMacro: @muladd
 using RecursiveArrayTools: recursive_unitless_bottom_eltype, recursivecopy,
@@ -67,14 +67,14 @@ PrecompileTools.@compile_workload begin
     if Preferences.@load_preference("PrecompileAutoDePSpecialize", false)
         push!(
             prob_list,
-            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
+            ODEProblem{true, SciMLBase.AutoDePSpecialize}(
                 OrdinaryDiffEqCore.lorenz_p, [1.0; 0.0; 0.0],
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_p_params
             )
         )
         push!(
             prob_list,
-            ODEProblem{true, OrdinaryDiffEqCore.AutoDePSpecialize}(
+            ODEProblem{true, SciMLBase.AutoDePSpecialize}(
                 OrdinaryDiffEqCore.lorenz_pref, [1.0; 0.0; 0.0],
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_pref_params
             )


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## What changed and why

`full_cache` and `resize_non_user_cache!` are defined in and `export`ed by SciMLBase (`src/integrator_interface.jl:147` / `:162`; `export` block at `src/SciMLBase.jl:2077`/`:2079`); `AutoDePSpecialize` is defined in SciMLBase and declared `public` there (`src/SciMLBase.jl:2234`, public since 3.39.0); the `SciMLOperators` module name is owned by SciMLOperators. `OrdinaryDiffEqCore` — and, for `SciMLOperators`, SciMLBase — merely re-exports these. 14 sublibraries reached them through the re-exporter, which fails ExplicitImports' owner/public checks in every QA lane that runs them.

This applies the same transformation #4167 did for `OrdinaryDiffEqBDF`: move the name into the `import SciMLBase:` list, and change `OrdinaryDiffEqCore.AutoDePSpecialize` to `SciMLBase.AutoDePSpecialize`. **Import lines only — no behaviour change, no new dependency, no compat bump.** 44 added lines, 41 removed, 0 comment lines, 14 files.

Branched off `master`, not off #4167 — the two touch disjoint files, so there is no ordering requirement and either can merge first.

## Affected sublibraries (re-derived, not inherited)

I re-derived the list by parsing every `lib/OrdinaryDiffEq*/src/<Name>.jl` import block rather than trusting a handed-down list, then cross-checked each name's owner and publicness against SciMLBase 3.39.0's sources. Result: **14** siblings besides BDF, and **12** of them have a QA lane with `explicit_imports = true`.

| sublibrary | `full_cache` | `AutoDePSpecialize` | other | EI lane |
|---|---|---|---|---|
| AdamsBashforthMoulton | yes | – | – | yes |
| ExponentialRK | yes | – | – | yes |
| HighOrderRK | yes | – | – | yes |
| Linear | yes | – | `SciMLOperators` | yes |
| LowStorageRK | yes | yes | – | yes |
| Multirate | yes | – | – | **no** |
| Newmark | yes | – | – | **no** |
| RKN | yes | – | – | yes |
| Rosenbrock | yes | yes | `resize_non_user_cache!` | yes |
| SDIRK | yes | yes | – | yes |
| SSPRK | yes | yes | – | yes |
| StabilizedRK | yes | – | – | yes |
| Tsit5 | yes | yes | – | yes |
| Verner | yes | yes | – | yes |

Two names beyond `full_cache`/`AutoDePSpecialize` turned up, and both are included because without them the affected lane cannot go green:

- **`resize_non_user_cache!` in Rosenbrock** — SciMLBase-owned, `export`ed, imported from `OrdinaryDiffEqCore`, and absent from Rosenbrock's ignore list. Confirmed by the baseline lane, which names it alongside `full_cache`.
- **`SciMLOperators` in Linear** — owned by SciMLOperators, reached via `using SciMLBase: SciMLBase, SciMLOperators, SplitFunction`. Routed through the existing `using SciMLOperators:` line instead. This one is worth flagging: SciMLBase **3.40.0** deliberately dropped `@reexport using SciMLOperators` in SciML/SciMLBase#1472 ("Make strict QA owner-contract clean"), so this PR moves OrdinaryDiffEqLinear in the same direction SciMLBase itself went.

`Multirate` and `Newmark` have a `test/qa/` directory containing only `allocation_tests.jl` — no `qa.jl`, hence no ExplicitImports checks. They are fixed at the source level; there is no lane to show a before/after on, so their evidence is a clean `GROUP=ALL` run instead.

## Compat and dependency verification

All 14 already have `SciMLBase` in `[deps]` and already pin `SciMLBase = "3.39"`, so `AutoDePSpecialize` is public at the pinned floor everywhere. **No compat bump and no new dependency were needed.** Checked mechanically:

```
sublib                   SciMLBase in [deps]  SciMLBase compat   >=3.39?
AdamsBashforthMoulton    True                 3.39               True
ExponentialRK            True                 3.39               True
HighOrderRK              True                 3.39               True
Linear                   True                 3.39               True
LowStorageRK             True                 3.39               True
Multirate                True                 3.39               True
Newmark                  True                 3.39               True
RKN                      True                 3.39               True
Rosenbrock               True                 3.39               True
SDIRK                    True                 3.39               True
SSPRK                    True                 3.39               True
StabilizedRK             True                 3.39               True
Tsit5                    True                 3.39               True
Verner                   True                 3.39               True
```

## Verification

Julia 1.12.6. Baselines were run against a **separate clean checkout of unmodified `master`** (`7b1ad0368`), so before/after are independent trees rather than a stash.

### ExplicitImports before → after — all 12 lanes run

`rollup` is the `ExplicitImports` testset line (`pass [fail] [error] total`). "target" counts the four checks this PR addresses: `all_explicit_imports_via_owners`, `all_explicit_imports_are_public`, `all_qualified_accesses_via_owners`, `all_qualified_accesses_are_public`.

| sublibrary | before rollup | before target | names flagged before | after rollup | after target |
|---|---|---|---|---|---|
| AdamsBashforthMoulton | `4 2 6` | 2/4 pass, 2 ERROR | `full_cache` | `6 6` | **4/4 pass** |
| ExponentialRK | `4 2 6` | 2/4 pass, 2 ERROR | `full_cache` | `6 6` | **4/4 pass** |
| HighOrderRK | `4 2 6` | 2/4 pass, 2 ERROR | `full_cache` | `6 6` | **4/4 pass** |
| Linear | `4 2 6` | 2/4 pass, 2 ERROR | `SciMLOperators`, `full_cache` | `6 6` | **4/4 pass** |
| LowStorageRK | `2 4 6` | 0/4 pass, 4 ERROR | `AutoDePSpecialize`, `full_cache` | `6 6` | **4/4 pass** |
| RKN | `4 2 6` | 2/4 pass, 2 ERROR | `full_cache` | `6 6` | **4/4 pass** |
| SSPRK | `2 4 6` | 0/4 pass, 4 ERROR | `AutoDePSpecialize`, `full_cache` | `6 6` | **4/4 pass** |
| StabilizedRK | `4 2 6` | 2/4 pass, 2 ERROR | `full_cache` | `6 6` | **4/4 pass** |
| Tsit5 | `2 4 6` | 0/4 pass, 4 ERROR | `AutoDePSpecialize`, `full_cache` | `6 6` | **4/4 pass** |
| Verner | `2 4 6` | 0/4 pass, 4 ERROR | `AutoDePSpecialize`, `full_cache` | `6 6` | **4/4 pass** |
| Rosenbrock | `1 5 6` | 0/4 pass, 4 ERROR | `AutoDePSpecialize`, `full_cache`, `resize_non_user_cache!`, + `Cartesian`, `lorenz_pref`, `lorenz_pref_params` | `4 2 6` | **3/4 pass**, 1 ERROR |
| SDIRK | `2 4 6` | 0/4 pass, 4 ERROR | `AutoDePSpecialize`, `full_cache`, + `lorenz_pref`, `lorenz_pref_params`, `strip_cache` | `5 1 6` | **3/4 pass**, 1 ERROR |

**Ten of twelve reach 4/4. Rosenbrock and SDIRK reach 3/4, not 4/4** — read that carefully rather than assuming a clean sweep. In both, `all_qualified_accesses_are_public` stays red on names this PR does not touch and which are simply missing from those two packages' own ignore lists: `lorenz_pref` / `lorenz_pref_params` (OrdinaryDiffEqCore precompile-workload internals — note Tsit5's `qa.jl` *does* ignore them), plus `Cartesian` (a `Base` internal, in Rosenbrock) and `strip_cache` (in SDIRK). Rosenbrock additionally keeps a pre-existing `no_stale_explicit_imports` error on `WOperator` and `_reshape`. Per the brief I did **not** add ignore entries to paper over any of these; they want their own PR (either make the name public at the owner, or add a documented ignore).

The exact baseline diagnostic, e.g. for Tsit5:

```
all_explicit_imports_via_owners: Error During Test
  ExplicitImportsFromNonOwnerException
  - `full_cache` has owner `SciMLBase` but it was imported from `OrdinaryDiffEqCore`
    at lib/OrdinaryDiffEqTsit5/src/OrdinaryDiffEqTsit5.jl:12:5
all_qualified_accesses_via_owners: Error During Test
  QualifiedAccessesFromNonOwnerException
  - `AutoDePSpecialize` has owner `SciMLBase` but it was accessed from `OrdinaryDiffEqCore`
    at lib/OrdinaryDiffEqTsit5/src/OrdinaryDiffEqTsit5.jl:72:49
```

### Aqua totals, and nothing else moved

Whole-Aqua counts, showing the errors clearing while Allocation and JET stay byte-identical:

| sublibrary | Aqua before | Aqua after | Allocation before → after | JET before → after |
|---|---|---|---|---|
| Tsit5 | 15 pass, 1 fail, **4 error** | 19 pass, 1 fail, **0 error** | `1 1` → `1 1` | `1 pass 2 broken` → `1 pass 2 broken` |
| HighOrderRK | 17 pass, 1 fail, **2 error** | 19 pass, 1 fail, **0 error** | `4 4` → `4 4` | `1 1` → `1 1` |
| LowStorageRK | 15 pass, 1 fail, **4 error** | 19 pass, 1 fail, **0 error** | `38 38` → `38 38` | `1 1` → `1 1` |
| RKN | 17 pass, 1 fail, **2 error** | 19 pass, 1 fail, **0 error** | `17 broken` → `17 broken` | `1 1` → `1 1` |
| SSPRK | 15 pass, 1 fail, **4 error** | 19 pass, 1 fail, **0 error** | `16 pass 2 broken` → `16 pass 2 broken` | `1 pass 22 broken` → `1 pass 22 broken` |
| StabilizedRK | 17 pass, 1 fail, **2 error** | 19 pass, 1 fail, **0 error** | `13 broken` → `13 broken` | `27 27` → `27 27` |
| Verner | 15 pass, 1 fail, **4 error** | 19 pass, 1 fail, **0 error** | `8 8` → `8 8` | `1 1` → `1 1` |

Every row's total is 20. The surviving `1 fail` in all of them is the docstring issue described below.

### The QA lanes remain RED overall — for reasons that are not this PR

1. **`public API has docstrings`, `Evaluated: isempty([:SciMLBase])`** fails in every one of these lanes, identically before and after. Known `master` failure, fixed in https://github.com/SciML/SciMLTesting.jl/pull/45. **Do not read a red QA lane on this PR as a regression** — the signal is the ExplicitImports subtree and the Aqua error column.

2. **AllocCheck aborts** stopped the QA lane before Aqua in AdamsBashforthMoulton, ExponentialRK and Linear when I ran it. A parallel investigation established the root cause and it is *not* a code regression: a bare `Pkg.test()` uses `--check-bounds=yes`, while SciML's Sublibrary CI passes `--check-bounds=auto`, and the AB3 allocation sites only survive under `=yes`. CI has never seen these. See https://github.com/SciML/OrdinaryDiffEq.jl/issues/4172 and the fix in https://github.com/SciML/OrdinaryDiffEq.jl/pull/4171.

3. **`UndefVarError: MatrixOperator`** fails `GROUP=Core` in Linear and ExponentialRK, on clean master too. Cause: SciMLBase 3.40.0 dropped `@reexport using SciMLOperators` (SciML/SciMLBase#1472); those test files use `MatrixOperator` without importing it. Fix in https://github.com/SciML/OrdinaryDiffEq.jl/pull/4170.

Where an abort hid the Aqua testset, I obtained the ExplicitImports result by running that sublibrary's own `test/qa/qa.jl` directly in its QA env — the same `run_qa` call with the same `ei_kwargs`, just without the two preceding testsets. **This harness was cross-validated against the full lane on four sublibraries where both reached Aqua** (HighOrderRK `4 2 6`, LowStorageRK `2 4 6`, RKN `4 2 6`, SSPRK `2 4 6`) and agreed exactly.

### Main test groups

`GROUP=ALL` (Core + QA) on the branch:

- **Multirate — exit 0, fully green.** MREEF, MRAB 16/16, MRI-GARK 57/57, MIS 7/7; Allocation `2 broken`.
- **Newmark — exit 0, fully green.** All functional testsets pass; Allocation `2 broken`; JET `1 1`.
- **AdamsBashforthMoulton** — ABM Convergence 24/24, Adams Variable Coefficients 16/16, ABM Discontinuity Restart 211/211. Allocation `1 fail, 12 broken`, byte-identical to master (issue #4172 above).
- **HighOrderRK** — High Order ERK Convergence 2/2; Allocation 4/4; JET 1/1.
- **Tsit5** — Allocation 1/1; JET 1 pass, 2 broken.
- **SDIRK** — `Convergence` 102 pass / 2 broken on the master baseline (49 minutes); the branch's own SDIRK convergence run did not finish before I stopped the batch, see below.

Multirate and Newmark are precisely the two sublibraries with no ExplicitImports lane, so their clean exit 0 is the evidence that their import move is sound.

### Formatting / spelling

`Runic.main(["--check", "--diff", <the 14 files>])` → exit 0 locally (Runic 1.7.0). `typos <the 14 files>` → exit 0 locally (typos-cli 1.47.0, honouring the repo `.typos.toml`).

CI agrees on the rebased head: **`format-check` success, `Runic Suggestions` success, `Spell Check` success, `Downgrade` success, `Documentation` success.** The remaining test matrices were still running when I wrote this.

## What I did NOT verify

- **Full `GROUP=ALL` functional runs for Rosenbrock and SDIRK on the branch.** Their convergence suites run ~50 minutes each and I stopped the batch before they completed; their ExplicitImports numbers above come from the `qa.jl` harness. RKN, SSPRK, StabilizedRK, Verner, LowStorageRK completed their `GROUP=ALL` lanes (Aqua table above), but I have not tabulated their functional testset counts here.
- **GPU groups** — Linear, LowStorageRK, Rosenbrock and StabilizedRK have a `GROUP=GPU`; not run, no GPU on this machine.
- **Downstream packages** — not run.
- ~~**Docs build**~~ — now covered: CI's `Documentation` workflow passes on the rebased head. (The pre-rebase run failed on `Cannot resolve @ref for DummyControllerCache` in `docs/src/devtools/internals/public_api.md`, which is the pre-existing failure #4164 fixed on master; the rebase picked that fix up.)
- **`julia pre`** — the QA lanes are gated on `isempty(VERSION.prerelease)` anyway — and the other allowed-to-fail jobs.

## Worth pushing back on

- `full_cache` is imported but never *used* outside the module header in 11 of the 14 (only Rosenbrock and SDIRK define methods on it). Deleting the import would arguably be cleaner than moving it; I moved it to stay consistent with the merged BDF change in #4167. Say the word and I will delete instead.
- `SciMLOperators` (Linear) and `resize_non_user_cache!` (Rosenbrock) are scope beyond the two names in the original report. Same defect class, and the affected lanes cannot go green without them, but it is a judgement call.
- Multirate, Newmark, RKIP and SIMDRK have **further** non-owner imports of public names that I deliberately left alone (`alg_order`, `isadaptive`, `initialize!`, `SplitFunction` reached via `OrdinaryDiffEqCore`). None of those four has an ExplicitImports lane, so a fix there is unverifiable by CI and belongs in its own PR.
- Rosenbrock's and SDIRK's residual `all_qualified_accesses_are_public` failures (`lorenz_pref`, `lorenz_pref_params`, `Cartesian`, `strip_cache`) are left red on purpose rather than silenced with ignore entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F75XsVeZ94QH3PmCuq6QUF
