### PR TITLE
Import DiscreteProblem from SciMLBase in the InterfaceII enum test

### DIFF
--- a/test/InterfaceII/enums.jl
+++ b/test/InterfaceII/enums.jl
@@ -1,5 +1,6 @@
 using OrdinaryDiffEq, Random
 using OrdinaryDiffEqFunctionMap
+using SciMLBase: DiscreteProblem
 
 # Simple Poisson random number generator using Knuth's algorithm
 function pois_rand(λ::Float64)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## What changed and why

`test/InterfaceII/enums.jl` used `DiscreteProblem` while importing only `OrdinaryDiffEq`, `Random` and `OrdinaryDiffEqFunctionMap`. OrdinaryDiffEq v7 intentionally dropped the blanket `@reexport using SciMLBase` (`src/OrdinaryDiffEq.jl`: "Load packages (no blanket @reexport)"), and `OrdinaryDiffEqFunctionMap` exports only `FunctionMap`, so the name became unreachable and the whole `InterfaceII` group aborted. This adds `using SciMLBase: DiscreteProblem`, matching the migration pattern the repo already uses elsewhere (`test/InterfaceI/public_api_package_split.jl`, `lib/OrdinaryDiffEqFunctionMap/test/discrete_algorithm_test.jl`). No `src/` change — the reexport removal is the intended v7 behavior.

## Failing before

Base commit: `7b1ad0368280061076d10db82b37ff747486efce` ("Zero AdaptiveRadau's stage-value slots at initialization (#4160)"), clean clone of `master`, no local modifications.

```
$ GROUP=InterfaceII julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
```

```
Test Summary:              | Pass  Total     Time
AutoSparse Detection Tests |    4      4  2m26.9s
Enum Tests: Error During Test at .../SafeTestsets.jl:30
  Got exception outside of a @test
  LoadError: UndefVarError: `DiscreteProblem` not defined in `Main.var"##Enum Tests#305"`
  Suggestion: check for spelling errors or missing imports.
  Hint: a global variable of this name also exists in SciMLBase.
  Stacktrace:
    [1] top-level scope
      @ ~/wt-interfaceii/test/InterfaceII/enums.jl:81
  ...
Test Summary: | Error  Total  Time
Enum Tests    |     1      1  2.6s
ERROR: Package OrdinaryDiffEq errored during testing
```

The group aborted at `Enum Tests`, so `Get du Tests` never ran.

## Passing after

Same command, same environment, only this commit applied:

```
$ GROUP=InterfaceII julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
```

```
Test Summary:              | Pass  Total     Time
AutoSparse Detection Tests |    4      4  2m19.7s
Test Summary: | Total  Time
Enum Tests    |     0  3.2s
Test Summary: | Pass  Total     Time
Get du Tests  |   34     34  9m46.4s
731.662224 seconds (358.92 M allocations: 18.721 GiB, 2.47% gc time, 98.70% compilation time: <1% of which was recompilation)
     Testing OrdinaryDiffEq tests passed
```

The group now runs to completion, including `Get du Tests` which the abort previously skipped. `Enum Tests` reports 0 assertions because `enums.jl` contains no `@test` — it is a smoke test that fails by throwing, which is exactly what regressed. I did not add assertions to it in this PR.

Formatting/spelling: `Runic.main(["--check", "--diff", "test/InterfaceII/enums.jl"])` exits 0; `typos test/InterfaceII/enums.jl` exits 0.

## Scope: is this the only affected test file?

I scanned every `test/` directory in the repo (root `test/` and all `lib/*/test/`) with an AST-based check: for each file, parse it, collect the modules and names its own `using`/`import` statements actually make available (loading each module and taking `names(m)`, so blanket re-exports count), then report SciMLBase-exported names referenced bare that those imports cannot supply. Qualified `Mod.name` accesses, keyword-argument names, comments and strings do not register. The check was validated against the pre-fix file: run on `git show HEAD:test/InterfaceII/enums.jl` it reports `enums.jl => DiscreteProblem`, and it reports nothing for the fixed file.

Only four files in the whole repo have unreachable SciMLBase names, and `test/InterfaceII/enums.jl` was the only one in a group that runs:

| File | Names | Status |
|---|---|---|
| `test/InterfaceII/enums.jl` | `DiscreteProblem` | fixed here |
| `test/multithreading/ode_extrapolation_tests.jl` | `ODEFunction`, `ODEProblem`, `solve` | not run — `test/multithreading/` is referenced by no group in `test/runtests.jl` and by nothing in `.github/`, so it never executes |
| `lib/OrdinaryDiffEqSIMDRK/test/adaptivity_tests.jl` | `ODEProblem`, `solve` | separate sublibrary, and its `src/` does not precompile at all (see below) |
| `lib/OrdinaryDiffEqSIMDRK/test/convergence_tests.jl` | `ODEFunction`, `ODEProblem` | ditto |
| `lib/OrdinaryDiffEqSIMDRK/test/qa/allocation_tests.jl` | `ODEProblem`, `init`, `step!` | ditto |

Notably `test/InterfaceI/interpolation_output_types.jl:30` also calls `DiscreteProblem` with no explicit import, but it loads `OrdinaryDiffEqRKN`, which still does `@reexport using SciMLBase`, so the name is reachable and that file does not fail. I left it alone rather than widen this PR.

## Related breakage found but not fixed here

`lib/OrdinaryDiffEqSIMDRK` does not precompile on master, for the same root cause one level up: it does `@reexport using OrdinaryDiffEqCore`, but `OrdinaryDiffEqCore` no longer re-exports SciMLBase, so `ODEFunction` in `lib/OrdinaryDiffEqSIMDRK/src/perform_step.jl:45` is undefined.

```
$ julia +1.12 --project=lib/OrdinaryDiffEqSIMDRK -e 'using Pkg; Pkg.instantiate(); using OrdinaryDiffEqSIMDRK'
ERROR: LoadError: UndefVarError: `ODEFunction` not defined in `OrdinaryDiffEqSIMDRK`
in expression starting at .../lib/OrdinaryDiffEqSIMDRK/src/OrdinaryDiffEqSIMDRK.jl:1
```

That is a `src/` fix in a different package plus three of its test files, so it is deliberately out of scope here rather than mixed into this one-line test-import change.

## Not verified

- Only the `InterfaceII` group was run. No other group, no QA, no docs build, no downstream, no GPU. The change is a single added `using` line in one test file that no other file includes, so it cannot affect them, but I did not run them.
- Julia 1.12.6 only; not run on LTS or `pre`, both of which `test_groups.toml` lists for `InterfaceII`.
- The `OrdinaryDiffEqSIMDRK` breakage above is reported, not fixed or CI-verified.
