### PR TITLE
Keep AB3's history-slot updates allocation-free (fixes the local ABM GROUP=QA failure)

### DIFF
--- a/lib/OrdinaryDiffEqAdamsBashforthMoulton/src/adams_bashforth_moulton_perform_step.jl
+++ b/lib/OrdinaryDiffEqAdamsBashforthMoulton/src/adams_bashforth_moulton_perform_step.jl
@@ -90,14 +90,14 @@ end
         OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
         @.. broadcast = false thread = thread u = uprev + (dt / 4) * (k1 + 3 * ralk2)        #Ralston Method
         if cnt == 1
-            cache.k3 .= k1
+            @.. broadcast = false thread = thread cache.k3 = k1
         else
-            cache.k2 .= k1
+            @.. broadcast = false thread = thread cache.k2 = k1
         end
     else
         @.. broadcast = false thread = thread u = uprev + (dt / 12) * (23 * k1 - 16 * k2 + 5 * k3)
         cache.k2, cache.k3 = k3, k2
-        cache.k2 .= k1
+        @.. broadcast = false thread = thread cache.k2 = k1
     end
     f(k, u, p, t + dt)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## What changed and why

`perform_step!(integrator, cache::AB3Cache)` saves the previous derivative into its history slots with plain `Base` broadcast, `cache.k3 .= k1` / `cache.k2 .= k1`. `Base`'s `.=` routes through `Base.unalias`, whose `unaliascopy` branch allocates. The history slots are separate arrays from `integrator.fsalfirst`, so that branch can never fire. Switching the three assignments to the `@.. broadcast = false thread = thread` form already used by every other assignment in the same method skips the aliasing check, and with it the allocation.

This makes the sublibrary's own AllocCheck assertion — that `AB3`'s `perform_step!` is allocation-free — hold in both bounds-checking modes instead of only one.

## The failure, and why CI does not show it

Running the documented local command on unmodified master (HEAD `7b1ad0368`), Julia 1.12.6:

```
$ cd lib/OrdinaryDiffEqAdamsBashforthMoulton
$ GROUP=QA julia --project -e 'using Pkg; Pkg.test()'
...
OrdinaryDiffEqAdamsBashforthMoulton.AB3{FastBroadcast.Serial} perform_step! allocation check: Test Failed at .../test/qa/allocation_tests.jl:49
  Expression: length(allocs) == 0
   Evaluated: 6 == 0
Test Summary:                                            | Fail  Broken  Total     Time
Allocation Tests                                         |    1      12     13  1m30.5s
ERROR: LoadError: Some tests did not pass: 0 passed, 1 failed, 0 errored, 12 broken.
```

That aborts the first QA `@safetestset`, so the JET and Aqua/ExplicitImports testsets in the lane never run locally at all.

**CI does not see this.** SciML's Sublibrary CI runs the sublibrary tests as

```
import Pkg; Pkg.test(;coverage=true, julia_args=["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"], ...)
```

(from the job log of run 31198062683, `lib/OrdinaryDiffEqAdamsBashforthMoulton [QA] / Julia 1`, master `c11ff74bb`), and in that run AB3 reports `appears allocation-free with AllocCheck`, `Allocation Tests | 1 Pass 12 Broken`. A bare `Pkg.test()` uses `--check-bounds=yes`, which is what surfaces the sites. So this is a bounds-check-mode-dependent assertion: green on CI, hard failure for anyone running the suite locally the documented way.

## Where the 6 sites come from

All 6 are the three broadcast assignments, 2 sites each (the `Memory{Float64}` and the `Vector{Float64}` of `unaliascopy`):

```
SITE>>> Allocation of Memory{Float64} in ./boot.jl:588
Stacktrace:
  [1] GenericMemory        @ ./boot.jl:588 [inlined]
  [2] copy                 @ ./array.jl:354 [inlined]
  [3] unaliascopy          @ ./abstractarray.jl:1546 [inlined]
  [4] unalias              @ ./abstractarray.jl:1530 [inlined]
  [5] broadcast_unalias    @ ./broadcast.jl:968 [inlined]
  ...
 [13] perform_step!(...)   @ .../adams_bashforth_moulton_perform_step.jl:93
```

Source lines: 93 (`cache.k3 .= k1`), 95 and 100 (`cache.k2 .= k1`) — 2 sites each.

Reduced, with no SciML package involved, the pattern is not AllocCheck-clean at all:

```julia
using AllocCheck
f_dotassign!(a, b) = (a .= b; nothing)
f_copyto!(a, b)    = (copyto!(a, b); nothing)
length(check_allocs(f_dotassign!, (Vector{Float64}, Vector{Float64})))  # 2, in every --check-bounds mode
length(check_allocs(f_copyto!,    (Vector{Float64}, Vector{Float64})))  # 0
```

Inside `perform_step!` the branch is eliminated under `--check-bounds=auto`/`no` and survives under `--check-bounds=yes`, which is the whole of the CI/local discrepancy.

## What I ruled out

`check_allocs(perform_step!, (AB3 integrator, AB3Cache))` on unmodified master, `AllocCheck v0.2.6`, this machine (AMD `znver2`):

| configuration | sites |
| --- | --- |
| Julia 1.12.6, `--check-bounds=yes` | **6** |
| Julia 1.12.6, `--check-bounds=auto` (default) | 0 |
| Julia 1.12.6, `--check-bounds=no` | 0 |
| Julia 1.12.6, `--check-bounds=yes` + `--code-coverage=@lib/OrdinaryDiffEqAdamsBashforthMoulton` | 6 |
| Julia 1.12.6, `--check-bounds=yes`, `-C generic` | 6 |
| Julia 1.12.6, `--check-bounds=yes`, `-C skylake-avx512` | 6 |
| Julia 1.11.9, `--check-bounds=yes` | 6 |
| Julia 1.10.11, `--check-bounds=yes` | 2 |

So it is neither coverage instrumentation (which CI also enables), nor the CPU target, nor the Julia version — only `--check-bounds`. Package versions in the CI run and locally are the same set (AllocCheck 0.2.6, LLVM 9.11.0, GPUCompiler 1.23.0, FastBroadcast 1.3.6, ArrayInterface 7.28.1, SciMLBase 3.43.0, SciMLOperators 1.26.1); FastBroadcast 1.3.5 and 1.3.6 are byte-identical apart from the version field, so the recent bump is not involved either.

I did not find a repo commit that introduced this: at `c3fbd4226`, the last master commit whose ABM QA CI job was green, the same probe still reports 6 locally today. Consistent with the assertion having been bounds-check-mode-dependent since it was added in `a7f30efb9`.

## Verification

Julia 1.12.6, `~/.juliaup/bin/julia +1.12`, run from `lib/OrdinaryDiffEqAdamsBashforthMoulton`.

### `GROUP=QA` — before (clean master)

```
Test Summary:                                                                                         | Fail  Broken  Total     Time
Allocation Tests                                                                                      |    1      12     13  1m30.5s
  AdamsBashforthMoulton Allocation Tests                                                              |    1      12     13  1m28.7s
    ABM perform_step! Static Analysis                                                                 |    1      12     13  1m28.2s
```

### `GROUP=QA` — after

```
AB3{FastBroadcast.Serial} perform_step! appears allocation-free with AllocCheck
AllocCheck found 10 allocation sites in AB4{FastBroadcast.Serial} perform_step!
...
Test Summary:    | Pass  Broken  Total     Time
Allocation Tests |    1      12     13  1m18.4s
Test Summary: | Pass  Total   Time
JET Tests     |    1      1  27.8s
```

Broken count is unchanged at 12 — no `@test_broken` flipped to an unexpected pass. `ABM32` drops from 14 sites to 8 because `perform_step!(::ABM32Cache)` delegates into the `AB3Cache` method; it stays broken.

Direct probe, both bounds-check modes and both the release and LTS Julia:

```
after fix, Julia 1.12.6, --check-bounds=yes  -> NALLOCS=0
after fix, Julia 1.10.11, --check-bounds=yes -> NALLOCS=0
```

### `GROUP=Core` — after

```
Test Summary:         | Pass  Total     Time
ABM Convergence Tests |   24     24  1m48.1s
Test Summary:                     | Pass  Total  Time
Adams Variable Coefficients Tests |   16     16  3.1s
Test Summary:                   | Pass  Total     Time
ABM Discontinuity Restart Tests |  211    211  1m16.5s
     Testing OrdinaryDiffEqAdamsBashforthMoulton tests passed
```

### Formatting / spelling

```
$ julia --project=<runicenv> -e 'using Runic; exit(Runic.main(ARGS))' -- --check --diff lib/OrdinaryDiffEqAdamsBashforthMoulton/src/adams_bashforth_moulton_perform_step.jl
$ echo $?
0
$ typos lib/OrdinaryDiffEqAdamsBashforthMoulton/src/adams_bashforth_moulton_perform_step.jl
$ echo $?
0
```

## What this does NOT fix

The ABM `GROUP=QA` lane is red on CI today for unrelated reasons, and stays red after this PR. Locally the allocation abort hid them; with the abort gone, the local run reproduces exactly what CI already reports:

- `all_explicit_imports_via_owners` — `full_cache` imported from `OrdinaryDiffEqCore` instead of its owner `SciMLBase` (`OrdinaryDiffEqAdamsBashforthMoulton.jl:12:5`). Same class as #4167.
- `all_explicit_imports_are_public`
- `public API has docstrings` — `isempty(undocumented)` evaluating to `isempty([:SciMLBase])`.

## Not verified

- The `Threaded` group (needs Polyester) was not run. The change keeps the method's existing `thread = thread` argument, so `FastBroadcast.Threaded()` behaves as it does for every other assignment in the same method, but that path is untested here.
- The same `cache_field .= src` pattern is present in `AB4`/`AB5`/`ABM32`/`ABM43`/`ABM54` and the `VCAB*`/`VCABM*` methods, which is part of why they are recorded `@test_broken`. This PR does not touch them; converting them is a separate change with its own allocation evidence.
- Whether CI *should* be running sublibrary tests with `--check-bounds=auto` while `Pkg.test()` defaults to `yes` is a separate question this PR does not address. It is the reason the failure is invisible to CI, and the same divergence will hide any future allocation regression of this shape.

## For a reviewer to push back on

- The claim that `cache.k2`/`cache.k3` can never alias `integrator.fsalfirst`. They are separate arrays from `alg_cache`, and `perform_step!(::ABM32Cache)` constructs its `AB3Cache` with `fsalfirst` and `k2`/`k3` as distinct fields, so dropping `Base.unalias` is a no-op at runtime — but it is the one behavioural assumption in the diff.
- `@..` with `broadcast = false` requires matching sizes, where `.=` would broadcast a length-1 right-hand side. Both sides here are the state vector, so this is not a behaviour change for any supported `u`.
- Whether it is worth changing solver source for an assertion CI currently reports as passing. The counter-argument is that the assertion is real, the allocation path is real, and the local `Pkg.test()` run — the documented developer workflow — currently fails hard on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F75XsVeZ94QH3PmCuq6QUF