### PR TITLE
Make the ABM Threaded group test the working tree (fixes its precompile failure)

### DIFF
--- a/lib/OrdinaryDiffEqAdamsBashforthMoulton/test/runtests.jl
+++ b/lib/OrdinaryDiffEqAdamsBashforthMoulton/test/runtests.jl
@@ -9,8 +9,7 @@ function activate_qa_env()
 end
 
 function activate_threaded_env()
-    Pkg.activate(joinpath(@__DIR__, "threaded"))
-    return Pkg.instantiate()
+    return activate_group_env(joinpath(@__DIR__, "threaded"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])
 end
 
 # Run functional tests


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## What changed and why

`OrdinaryDiffEqAdamsBashforthMoulton`'s `GROUP=Threaded` environment was activated with a bare `Pkg.activate` + `Pkg.instantiate`, and `test/threaded/Project.toml` declares a `[sources]` entry for `OrdinaryDiffEqCore` only. The group therefore resolved `OrdinaryDiffEqAdamsBashforthMoulton` **from the registry** while `OrdinaryDiffEqCore` came from the working tree — it was never testing the code in the repo, and the half-registry/half-path mix stopped precompiling.

`activate_threaded_env` now uses `activate_group_env` with the same parents as `activate_qa_env`, so the group resolves the whole monorepo from path like every other group does.

## The failure on master

Unmodified master (HEAD `7b1ad0368`), Julia 1.12.6:

```
$ cd lib/OrdinaryDiffEqAdamsBashforthMoulton
$ GROUP=Threaded julia --project -e 'using Pkg; Pkg.test()'
...
WARNING: Imported binding OrdinaryDiffEqCore.du_cache was undeclared at import time during import to OrdinaryDiffEqLowOrderRK.
WARNING: Imported binding OrdinaryDiffEqCore.u_cache was undeclared at import time during import to OrdinaryDiffEqLowOrderRK.
ERROR: LoadError: invalid method definition in OrdinaryDiffEqLowOrderRK: exported function OrdinaryDiffEqCore.u_cache does not exist
   [1] top-level scope
     @ ~/.julia/packages/OrdinaryDiffEqLowOrderRK/lrGen/src/low_order_rk_caches.jl:695
ERROR: LoadError: Failed to precompile OrdinaryDiffEqLowOrderRK [1344f307-1e59-4825-a18e-ace9aa3fa4c6]
```

Same failure in CI: run 31198062683, `sublibrary-ci / lib/OrdinaryDiffEqAdamsBashforthMoulton [Threaded] / Julia 1` (job 92971605465), byte-identical error.

## Root cause

The threaded environment resolved to:

```
  [89bda076] + OrdinaryDiffEqAdamsBashforthMoulton v2.1.2            <- registry
  [bbf590c4] + OrdinaryDiffEqCore v4.14.0 `../../../OrdinaryDiffEqCore`  <- working tree
```

and therefore pulled registered `OrdinaryDiffEqLowOrderRK` v2.2.2, whose module header is

```julia
import OrdinaryDiffEqCore: ..., du_cache, u_cache, get_fsalfirstlast
```

`9af4fde58` ("Fix clean-master solver package test regressions (#4144)", 2026-08-07) dropped `u_cache`/`du_cache` from `OrdinaryDiffEqCore`'s `import SciMLBase: addat!, full_cache, user_cache, u_cache, du_cache, ...` line and moved the in-repo `OrdinaryDiffEqLowOrderRK` to take them from `SciMLBase` — correct for the monorepo, but the *registered* v2.2.2 still reaches for them through `OrdinaryDiffEqCore`. On Julia 1.12 the missing binding is a hard precompile error; on 1.10 it is only a warning, which is why the `Core` group (which runs on lts as well) is unaffected.

`585e5e919` (#4136, 2026-08-06) removed the same import first and `7b9e7448b` (#4147, same day) restored it; `9af4fde58` removed it again and that is the one that stuck.

CI history for the `[Threaded]` job on master:

| run head | date | Threaded |
| --- | --- | --- |
| `280bd5b46` | 2026-08-04 | success |
| `c3fbd4226` | 2026-08-05 | success |
| `fc8d88895` | 2026-08-05 | success |
| `7b9e7448b` | 2026-08-06 | failure (GitHub infra: "Failed to resolve action download info", unrelated) |
| `c11ff74bb` | 2026-08-07 | failure (this error) |

## Verification

Julia 1.12.6, `~/.juliaup/bin/julia +1.12`, run from `lib/OrdinaryDiffEqAdamsBashforthMoulton`.

### Before (clean master `7b1ad0368`)

`GROUP=Threaded julia --project -e 'using Pkg; Pkg.test()'` exits 1. The threaded environment resolves

```
  [89bda076] + OrdinaryDiffEqAdamsBashforthMoulton v2.1.2
  [bbf590c4] + OrdinaryDiffEqCore v4.14.0 `../../../OrdinaryDiffEqCore`
```

(note: no path for the package under test) and then

```
WARNING: Imported binding OrdinaryDiffEqCore.du_cache was undeclared at import time during import to OrdinaryDiffEqLowOrderRK.
WARNING: Imported binding OrdinaryDiffEqCore.u_cache was undeclared at import time during import to OrdinaryDiffEqLowOrderRK.
ERROR: LoadError: invalid method definition in OrdinaryDiffEqLowOrderRK: exported function OrdinaryDiffEqCore.u_cache does not exist
   [1] top-level scope
     @ ~/.julia/packages/OrdinaryDiffEqLowOrderRK/lrGen/src/low_order_rk_caches.jl:695
Test Summary:                  | Error  Total   Time
ABM Threaded Convergence Tests |     1      1  12.5s
```

### After

The environment now resolves everything from the working tree — `test/threaded/Manifest.toml`:

```toml
[[deps.OrdinaryDiffEqAdamsBashforthMoulton]]
path = "/.../wt-alloc-before/lib/OrdinaryDiffEqAdamsBashforthMoulton"
version = "2.1.2"

[[deps.OrdinaryDiffEqLowOrderRK]]
path = "../../../OrdinaryDiffEqLowOrderRK"
version = "2.2.3"
```

`v2.2.3` is the in-repo `OrdinaryDiffEqLowOrderRK`, which imports `du_cache`/`u_cache` from `SciMLBase`, so the binding that the precompile error complained about is no longer looked up on `OrdinaryDiffEqCore`.

And the group runs clean (`EXIT=0`):

```
Precompiling packages...
   2029.3 ms  ✓ RecursiveArrayTools → RecursiveArrayToolsFastBroadcastPolyesterExt
Test Summary:                  | Pass  Total   Time
ABM Threaded Convergence Tests |    6      6  39.5s
Test Summary:                                                    | Pass  Total   Time
Regression test for threading versions vs non threading versions |   13     13  54.2s
     Testing OrdinaryDiffEqAdamsBashforthMoulton tests passed
```

This is the first time these testsets have run against the code in the repo rather than the registered release, and they pass.

### Formatting / spelling

```
$ julia --project=<runicenv> -e 'using Runic; exit(Runic.main(ARGS))' -- --check --diff lib/OrdinaryDiffEqAdamsBashforthMoulton/test/runtests.jl
$ echo $?
0
$ typos lib/OrdinaryDiffEqAdamsBashforthMoulton/test/runtests.jl
$ echo $?
0
```


## Not verified

- Julia LTS. `test_groups.toml` schedules `Threaded` on `versions = ["1"]` only, and on 1.10 `[sources]` is ignored by Pkg anyway (`activate_group_env` compensates by developing the source paths explicitly).
- Whether the threaded tests actually exercise `FastBroadcast.Threaded()` meaningfully — they were running against the registered package until now, so this is the first time they have run against the working tree at all.

## For a reviewer to push back on

- This makes the `Threaded` job precompile the whole monorepo, because developing the repo root pulls its full `[sources]` graph. That is the same cost the `QA` jobs already pay and the same pattern `OrdinaryDiffEqDifferentiation`'s `Sparse`/`ModelingToolkit` groups use, but it does lengthen the job.
- The alternative fix — deleting the `[sources] OrdinaryDiffEqCore` entry so the environment is fully registry-resolved — would also make it precompile, but it would keep `GROUP=Threaded` testing a released package instead of the branch under test. That seems clearly worse.
- Every other non-QA group environment in the monorepo (`gpu`, `static`, `nopre`, `OrdinaryDiffEqNonlinearSolve/modelingtoolkit`) has the same "does not source its own sublibrary" shape. They do not currently break, because they source nothing by path and so are internally consistent; ABM's `threaded` was the only half-wired one. Worth a separate sweep, not this PR.

## Related

The same `9af4fde58` change means registered `OrdinaryDiffEqLowOrderRK` v2.2.2 (compat `OrdinaryDiffEqCore = "4.10"`) cannot precompile against an `OrdinaryDiffEqCore` released from current master on Julia 1.12. That is a registration-ordering hazard rather than a test-environment bug; filed separately as #4175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F75XsVeZ94QH3PmCuq6QUF