### PR TITLE
Test DDE discontinuity handling at tspan[1]

### DIFF
--- a/lib/DelayDiffEq/test/interface/discontinuities.jl
+++ b/lib/DelayDiffEq/test/interface/discontinuities.jl
@@ -104,6 +104,26 @@ end
         [Discontinuity(0.3, 4), Discontinuity(0.6, 5)]
 end
 
+@testset "discontinuity at tspan[1]" begin
+    history(p, t) = zeros(1)
+    function f(du, u, h, p, t)
+        du[1] = t > 0.0 ? 1.0 : 0.0
+        return nothing
+    end
+    prob = DDEProblem(f, [0.0], history, (0.0, 2.0); constant_lags = (1.0,))
+    integrator = init(
+        prob, MethodOfSteps(Tsit5()); d_discontinuities = [prob.tspan[1]]
+    )
+
+    @test integrator.t == nextfloat(prob.tspan[1])
+    @test integrator.fsalfirst == [1.0]
+
+    sol = solve!(integrator)
+    @test sol.retcode == ReturnCode.Success
+    @test sol.t[end] == prob.tspan[2]
+    @test sol.u[end] ≈ [2.0]
+end
+
 # discontinuities induced by callbacks
 @testset "#190" begin
     cb = ContinuousCallback((u, t, integrator) -> 1, integrator -> nothing)


### PR DESCRIPTION
> Ignore this PR until reviewed by @ChrisRackauckas.

## What changed and why

This adds a DelayDiffEq regression test for a user derivative discontinuity exactly at `tspan[1]` with a constant lag. The test verifies that initialization handles the discontinuity instead of filtering it: the integrator advances to the post-discontinuity side, Tsit5's FSAL derivative is restarted there, and the propagated discontinuity no longer stalls the solve.

The behavior is already implemented on `master` by the starting-time handler merged in https://github.com/SciML/OrdinaryDiffEq.jl/pull/3394; this PR adds the missing DDE coverage requested in https://github.com/SciML/OrdinaryDiffEq.jl/issues/4180.

Closes https://github.com/SciML/OrdinaryDiffEq.jl/issues/4180

## Verification

### Failing before

I temporarily removed the existing `OrdinaryDiffEqCore.handle_starting_time_discontinuity!(integrator)` call from DelayDiffEq initialization and ran the new test in isolation:

```sh
julia --project=lib/DelayDiffEq -e 'push!(LOAD_PATH, abspath("lib/OrdinaryDiffEqTsit5")); using DelayDiffEq, OrdinaryDiffEqTsit5, SciMLBase, Test; @testset "discontinuity at tspan[1]" begin history(p,t)=zeros(1); function f(du,u,h,p,t); du[1]=t>0.0 ? 1.0 : 0.0; nothing; end; prob=DDEProblem(f,[0.0],history,(0.0,2.0);constant_lags=(1.0,)); integrator=init(prob,MethodOfSteps(Tsit5());d_discontinuities=[prob.tspan[1]]); @test integrator.t == nextfloat(prob.tspan[1]); @test integrator.fsalfirst == [1.0]; sol=solve!(integrator); @test sol.retcode == ReturnCode.Success; @test sol.t[end] == prob.tspan[2]; @test sol.u[end] ≈ [2.0]; end'
```

```text
integrator.t: 0.0 == 5.0e-324 failed
integrator.fsalfirst: [0.0] == [1.0] failed
dt(0.0) <= dtmin(...) at t=1.0
sol.t[end]: 1.0 == 2.0 failed
Test Summary:             | Fail  Total  Time
discontinuity at tspan[1] |    5      5  7.1s
```

### Passing after

After restoring the handler, the same command produced:

```text
Test Summary:             | Pass  Total  Time
discontinuity at tspan[1] |    5      5  4.4s
```

The full relevant group passed:

```sh
GROUP=Interface julia --project=lib/DelayDiffEq -e 'using Pkg; Pkg.test()'
```

```text
Test Summary:       | Pass  Total   Time
Discontinuity Tests |   53     53  24.8s
Test Summary:         | Pass  Total     Time
Multi-Algorithm Tests |   28     28  4m01.9s
Testing DelayDiffEq tests passed
```

Formatting and spelling passed:

```sh
julia --project=@runic -m Runic --check lib/DelayDiffEq/test/interface/discontinuities.jl
git diff --unified=0 -- lib/DelayDiffEq/test/interface/discontinuities.jl | typos -
```

Both commands exited 0 with no output.

The QA command was also run:

```sh
GROUP=QA julia --project=lib/DelayDiffEq -e 'using Pkg; Pkg.test()'
```

It exposed unrelated failures already present on the synced base: three `has_tstop`/`first_tstop`/`pop_tstop!` qualified accesses through `OrdinaryDiffEqCore` instead of their `SciMLBase` owner, plus the `SciMLBase` public API documentation check. A clean `upstream/master` reproduction with `GROUP=DelayDiffEq_QA ~/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'` confirmed the same ExplicitImports failures (QA summary: 14 passed, 2 failed, 1 errored). The separate investigation at https://github.com/SciML/OrdinaryDiffEq.jl/issues/4182 traces the wrong qualifiers to commit `e0fb409ab96`; the later `run_qa` conversion exposed them.

## Not verified

I did not run `GROUP=Everything`, GPU jobs, downstream jobs, or a docs build. This change touches only a test and adds no dependency or public API. The direct `integrator.fsalfirst` assertion is intentional: it ensures initialization actually restarts FSAL rather than only removing the queue entry.
