### PR TITLE
Bump OrdinaryDiffEqSIMDRK to 2.1.2 so the #4174 import fix is releasable

### DIFF
--- a/lib/OrdinaryDiffEqSIMDRK/Project.toml
+++ b/lib/OrdinaryDiffEqSIMDRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSIMDRK"
 uuid = "dc97f408-7a72-40e4-9b0d-228a53b292f8"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Elrod <elrodc@gmail.com>"]
-version = "2.1.1"
+version = "2.1.2"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"


### PR DESCRIPTION
## What and why

`OrdinaryDiffEqSIMDRK` 2.1.1 is **registered**, and its master source has since been fixed by #4174 — but the version was never bumped. The fix is therefore not releasable, and registered 2.1.1 declares `OrdinaryDiffEqCore = "4"`, which admits the unreleased Core 4.14.0.

Registered 2.1.1 does:

```julia
@reexport using OrdinaryDiffEqCore
```

and uses `ODEFunction` unqualified. #4119 removed Core's blanket `@reexport using SciMLBase`, dropping 152 names (including `ODEFunction`) from Core's export surface. So registered 2.1.1 + Core 4.14.0 resolves fine and then fails to precompile.

This is one line: `2.1.1 -> 2.1.2`. It is a prerequisite for releasing OrdinaryDiffEqCore 4.14.0 — see #4175, where I posted the full audit.

## Verification (local, Julia 1.12.6)

Each run: temp env, `Pkg.develop(path=lib/OrdinaryDiffEqCore)` (master, 4.14.0), then load.

**Registered 2.1.1 against Core master — fails:**

```
$ julia +1.12 pctest.jl <core-master-path> OrdinaryDiffEqSIMDRK 2.1.1
OrdinaryDiffEqSIMDRK	2.1.1	LOAD_FAIL
Failed to precompile OrdinaryDiffEqSIMDRK [dc97f408-7a72-40e4-9b0d-228a53b292f8]
ERROR: LoadError: UndefVarError: `ODEFunction` not defined in `OrdinaryDiffEqSIMDRK`
Suggestion: check for spelling errors or missing imports.
```

**Master source (this branch) against Core master — passes:**

```
$ julia +1.12 -e 'Pkg.develop(path="lib/OrdinaryDiffEqCore"); Pkg.develop(path="lib/OrdinaryDiffEqSIMDRK");
                  Pkg.precompile(); using OrdinaryDiffEqSIMDRK'
MASTER SIMDRK + MASTER CORE: OK
```

The source fix is #4174's; this PR only makes it shippable.

## What this does NOT fix

Registered 2.1.1 stays in the registry and stays resolvable against Core 4.14.0 for anyone with an old manifest or a constrained resolve. Closing that needs a retroactive `Compat.toml` cap on 2.1.1 in JuliaRegistries/General (precedent: JuliaRegistries/General#159026, #160741, #162878). I have not opened that PR — it is bundled with the Core release decision in #4175.

`OrdinaryDiffEqLowOrderRK` has the same shape but is already bumped on master (2.2.2 registered, 2.2.3 on master), so it needs no source PR.

## Not verified

No CI run yet. I did not run the SIMDRK test suite, only the precompile/load check above, since the diff is a version string.

**Please ignore until reviewed by @ChrisRackauckas.** In particular: do **not** register this until the OrdinaryDiffEqCore 4.14.0-vs-5.x decision in #4175 is made — the ordering matters.
