### PR TITLE
Default threaded implicit extrapolation to GenericLUFactorization instead of RFLUFactorization

### DIFF
--- a/lib/OrdinaryDiffEqExtrapolation/src/OrdinaryDiffEqExtrapolation.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/OrdinaryDiffEqExtrapolation.jl
@@ -30,7 +30,7 @@ import DiffEqBase: initialize!, calculate_residuals, calculate_residuals!, timed
 using FastBroadcast: FastBroadcast, @..
 using MuladdMacro: MuladdMacro, @muladd
 using RecursiveArrayTools: RecursiveArrayTools, recursivefill!
-using LinearSolve: LinearSolve, RFLUFactorization
+using LinearSolve: LinearSolve, GenericLUFactorization
 using FastPower: fastpower
 using SciMLOperators: SciMLOperators, WOperator
 import SciMLLogging: @SciMLMessage

--- a/lib/OrdinaryDiffEqExtrapolation/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/algorithms.jl
@@ -116,7 +116,7 @@ function ImplicitEulerExtrapolation(;
             linsolve === nothing &&
             (threading == true || threading isa PolyesterThreads)
         ) ?
-        RFLUFactorization(; thread = Val(false)) : linsolve
+        GenericLUFactorization() : linsolve
 
     min_order = max(3, min_order)
     init_order = max(min_order + 1, init_order)
@@ -327,7 +327,7 @@ function ImplicitDeuflhardExtrapolation(;
             linsolve === nothing &&
             (threading == true || threading isa PolyesterThreads)
         ) ?
-        RFLUFactorization(; thread = Val(false)) : linsolve
+        GenericLUFactorization() : linsolve
 
     # Warn user if orders have been changed
     if (min_order, init_order, max_order) != (min_order, init_order, max_order)
@@ -539,7 +539,7 @@ function ImplicitHairerWannerExtrapolation(;
             linsolve === nothing &&
             (threading == true || threading isa PolyesterThreads)
         ) ?
-        RFLUFactorization(; thread = Val(false)) : linsolve
+        GenericLUFactorization() : linsolve
 
     # Warn user if orders have been changed
     if (min_order, init_order, max_order) != (min_order, init_order, max_order)
@@ -655,7 +655,7 @@ function ImplicitEulerBarycentricExtrapolation(;
             linsolve === nothing &&
             (threading == true || threading isa PolyesterThreads)
         ) ?
-        RFLUFactorization(; thread = Val(false)) : linsolve
+        GenericLUFactorization() : linsolve
 
     # Warn user if orders have been changed
     if (min_order, init_order, max_order) != (min_order, init_order, max_order)

--- a/lib/OrdinaryDiffEqExtrapolation/test/runtests.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/runtests.jl
@@ -11,6 +11,7 @@ end
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "Extrapolation Utility Tests" include("utils_tests.jl")
     @time @safetestset "Extrapolation Tests" include("ode_extrapolation_tests.jl")
+    @time @safetestset "Threading Linear Solver Tests" include("threading_linsolve_tests.jl")
 end
 
 if TEST_GROUP == "Multithreading"

--- a/lib/OrdinaryDiffEqExtrapolation/test/threading_linsolve_tests.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/threading_linsolve_tests.jl
@@ -1,0 +1,36 @@
+# This file must not load RecursiveFactorization: the regression it guards
+# (issue #4154) is only visible when RecursiveFactorization is absent.
+using OrdinaryDiffEqExtrapolation, Polyester, Test
+using CommonSolve: solve
+using SciMLBase: SciMLBase, ODEProblem
+using LinearSolve: GenericLUFactorization
+using OrdinaryDiffEqCore: PolyesterThreads
+
+function vanderpol!(du, u, p, t)
+    du[1] = u[2]
+    du[2] = p * (1 - u[1]^2) * u[2] - u[1]
+    return nothing
+end
+prob = ODEProblem(vanderpol!, [2.0, 0.0], (0.0, 1.0), 100.0)
+
+algs = [
+    ImplicitEulerExtrapolation, ImplicitDeuflhardExtrapolation,
+    ImplicitHairerWannerExtrapolation, ImplicitEulerBarycentricExtrapolation,
+]
+
+@testset "Threaded implicit extrapolation defaults to a single-threaded factorization" begin
+    @testset "$Alg" for Alg in algs
+        serial = Alg(threading = false)
+        @test serial.linsolve === nothing
+        reference = solve(prob, serial; abstol = 1.0e-9, reltol = 1.0e-9)
+        @test SciMLBase.successful_retcode(reference)
+
+        @testset "threading = $threading" for threading in (true, PolyesterThreads())
+            alg = Alg(threading = threading)
+            @test alg.linsolve isa GenericLUFactorization
+            sol = solve(prob, alg; abstol = 1.0e-9, reltol = 1.0e-9)
+            @test SciMLBase.successful_retcode(sol)
+            @test sol.u[end] ≈ reference.u[end] rtol = 1.0e-5
+        end
+    end
+end


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Closes #4154

## What changed and why

The four implicit extrapolation constructors (`ImplicitEulerExtrapolation`, `ImplicitDeuflhardExtrapolation`, `ImplicitHairerWannerExtrapolation`, `ImplicitEulerBarycentricExtrapolation`) replaced a `nothing` `linsolve` with `RFLUFactorization(; thread = Val(false))` whenever `threading` was enabled. The *intent* was right — pin a known single-threaded factorization so the inner linear solve does not nest threads inside the outer extrapolation threading, which is why it passed `thread = Val(false)`. The *choice* was wrong: `RecursiveFactorization` is only in this sublibrary's `[extras]`, never `[deps]`, so `RFLUFactorization` lives behind a LinearSolve extension that never loads in a user environment and the call threw at construction. The documented `threading` option was unusable.

This swaps the factorization for `GenericLUFactorization()`, which keeps the original intent: single-threaded by construction and behind no extension. The non-threaded path is unchanged — `linsolve` stays `nothing` and LinearSolve does its own default selection.

Leaving `linsolve = nothing` in the threaded case was considered and rejected: it discards the intent, since LinearSolve's default selection can pick a BLAS-threaded LU and reintroduce the nested-threading clash the original code avoided.

`GenericLUFactorization` needs no extension — verified rather than assumed, in an environment with `RecursiveFactorization` **not** loaded:

```
exported: true
ispublic: true
owner module: LinearSolve
constructed: LinearSolve.GenericLUFactorization{LinearAlgebra.RowMaximum}(LinearAlgebra.RowMaximum(), false)
solved: [0.09090909090909091, 0.6363636363636364]  resid=0.0
RecursiveFactorization loaded? false
```

It is `export`ed *and* `Base.ispublic` from LinearSolve, and `parentmodule` is LinearSolve itself, so this is LinearSolve's own public API rather than a re-export. The `using LinearSolve:` line changes from `RFLUFactorization` to `GenericLUFactorization` accordingly.

## New test

`lib/OrdinaryDiffEqExtrapolation/test/threading_linsolve_tests.jl`, wired into the `Core` group. It deliberately does **not** `using RecursiveFactorization` — the existing `test/multithreading/ode_extrapolation_tests.jl` does, which is why CI never caught this. For each of the four algorithms it asserts `linsolve === nothing` for `threading = false` and `linsolve isa GenericLUFactorization` for `threading = true` and `PolyesterThreads()`, then solves stiff van der Pol (`mu = 100`) at `abstol = reltol = 1e-9` and compares each threaded endpoint against the serial one, so a wrong-answer regression fails and not just a type change.

## Failing before / passing after

Environment: the dev'd sublibrary plus `Polyester`/`LinearSolve`, with `RecursiveFactorization` absent — what a user actually gets. Base commit `b9889d3ae234f527ba00856b90d6fc9dd674298b`.

Before (`git checkout HEAD~1 -- lib/OrdinaryDiffEqExtrapolation/src`, new test kept):

```
$ julia +1.12 --project=userenv lib/OrdinaryDiffEqExtrapolation/test/threading_linsolve_tests.jl
threading = true: Error During Test at .../threading_linsolve_tests.jl:28
  Got exception outside of a @test
  RFLUFactorization requires that RecursiveFactorization.jl is loaded, i.e. `using RecursiveFactorization`
threading = PolyesterThreads(): Error During Test at .../threading_linsolve_tests.jl:28
  Got exception outside of a @test
  RFLUFactorization requires that RecursiveFactorization.jl is loaded, i.e. `using RecursiveFactorization`
[... same pair for the other three algorithms; 8 errors total ...]
Test Summary:                                                               | Pass  Error  Total   Time
Threaded implicit extrapolation defaults to a single-threaded factorization |    8      8     16  35.2s
  ImplicitEulerExtrapolation                                                |    2      2      4  18.0s
    threading = true                                                        |           1      1   2.0s
    threading = PolyesterThreads()                                          |           1      1   0.0s
  ImplicitDeuflhardExtrapolation                                            |    2      2      4   6.3s
    threading = true                                                        |           1      1   0.0s
    threading = PolyesterThreads()                                          |           1      1   0.0s
  ImplicitHairerWannerExtrapolation                                         |    2      2      4   5.6s
    threading = true                                                        |           1      1   0.0s
    threading = PolyesterThreads()                                          |           1      1   0.0s
  ImplicitEulerBarycentricExtrapolation                                     |    2      2      4   5.2s
    threading = true                                                        |           1      1   0.0s
    threading = PolyesterThreads()                                          |           1      1   0.0s
ERROR: LoadError: Some tests did not pass: 8 passed, 0 failed, 8 errored, 0 broken.
$ echo $?
1
```

After:

```
$ julia +1.12 --project=userenv lib/OrdinaryDiffEqExtrapolation/test/threading_linsolve_tests.jl
Test Summary:                                                               | Pass  Total     Time
Threaded implicit extrapolation defaults to a single-threaded factorization |   32     32  1m08.4s
$ echo $?
0
```

The test also discriminates under the *CI* condition, where `RecursiveFactorization` is in the manifest via `[extras]` but never `using`-ed, so the LinearSolve extension does not load. Same environment with `RecursiveFactorization` installed:

```
before:  8 passed, 0 failed, 8 errored   (exit 1)
after:  32 passed                        (exit 0)
```

It also rejects the weaker "just delete the override" variant. With `linsolve` left as `nothing` in the threaded branch the test fails on the assertion rather than erroring, which is the point of asserting the type:

```
threading = true: Test Failed at .../threading_linsolve_tests.jl:30
  Expression: alg.linsolve isa GenericLUFactorization
   Evaluated: nothing isa GenericLUFactorization
[...]
ERROR: LoadError: Some tests did not pass: 24 passed, 8 failed, 0 errored, 0 broken.
```

## Local test runs (`julia +1.12`, from `lib/OrdinaryDiffEqExtrapolation`)

`GROUP=Core julia --project -e 'using Pkg; Pkg.test()'`:

```
Test Summary:               | Pass  Total  Time
Extrapolation Utility Tests |   14     14  3.3s
Test Summary:       | Pass  Total     Time
Extrapolation Tests |  284    284  6m34.8s
Test Summary:                 | Pass  Total     Time
Threading Linear Solver Tests |   32     32  1m38.8s
     Testing OrdinaryDiffEqExtrapolation tests passed
```

`GROUP=Multithreading JULIA_NUM_THREADS=2 julia --project -e 'using Pkg; Pkg.test()'`:

```
Test Summary:                     | Pass  Total      Time
Multithreaded Extrapolation Tests |  620    620  10m09.5s
     Testing OrdinaryDiffEqExtrapolation tests passed
```

`GROUP=QA julia --project -e 'using Pkg; Pkg.test()'`:

```
Test Summary:    | Broken  Total     Time
Allocation Tests |      7      7  2m27.1s
Test Summary: | Pass  Total   Time
JET Tests     |    1      1  36.6s
Test Summary: | Pass  Total     Time
Aqua          |   21     21  1m21.6s
     Testing OrdinaryDiffEqExtrapolation tests passed
```

(The 7 `Broken` allocation tests are pre-existing on master and untouched here.)

Formatting and spelling over the four touched files:

```
$ julia -e 'using Runic; exit(Runic.main(["--check","--diff", ...]))'; echo $?
0
$ typos ...; echo $?
0
```

## Timing sanity check (not a benchmark)

`ImplicitHairerWannerExtrapolation(threading = true)` on a 1D reaction-diffusion problem with a dense `N x N` Jacobian, 4 Julia threads, `abstol = reltol = 1e-8`, best of 5:

```
N=50   GenericLU  min=1.7 ms   |  LinearSolve default  min=1.6 ms
N=100  GenericLU  min=2.8 ms   |  LinearSolve default  min=3.1 ms
```

Endpoints agreed to all printed digits in both cases. This is a sanity check only and **not** a performance claim: it is two problem sizes on a machine that was under load average ~165 at the time, so the differences are within noise. It does not establish that `GenericLUFactorization` is faster or slower than the default in general, and it says nothing about large `N` where a BLAS-threaded LU would be expected to win on a quiet machine.

## Not verified

- No GPU, `julia pre`, downstream, or docs-build lanes were run locally. Docs are unaffected (no docstring or public API text changed).
- All groups were run on Julia 1.12 only, not `lts`.
- No measurement of whether pinning a single-threaded factorization actually beats a BLAS-threaded one under the outer extrapolation threading. That premise is inherited from the original code, not established here, and is the main thing a reviewer may want to push back on.

## Note for the reviewer

`RecursiveFactorization` is still referenced by `test/multithreading/ode_extrapolation_tests.jl` line 2 (`using RecursiveFactorization`), so the `[extras]`/`[targets]` entry is not dead. With `RFLUFactorization` gone from `src/`, that `using` no longer serves a purpose, but removing it plus the `[extras]` entry is a mechanical change and is left for a separate PR.
