### PR TITLE
Fix red QA lane: ignore re-exported module bindings in the public-API docstring check

### DIFF
--- a/test/qa/qa_tests.jl
+++ b/test/qa/qa_tests.jl
@@ -52,6 +52,11 @@ run_qa(
     explicit_imports = true,
     check_reexports = true,
     reexports_allow = ORDINARYDIFFEQ_REEXPORTS,
+    # Julia resolves `Docs.Binding(OrdinaryDiffEq, :SciMLBase)` to `SciMLBase.SciMLBase`, so a
+    # docstring written here would be stored in SciMLBase's registry rather than this package's.
+    # Only a module docstring in SciMLBase.jl/SciMLLogging.jl can document these re-exports.
+    # Remove once SciML/SciMLTesting.jl#47 exempts foreign module bindings.
+    api_docs_kwargs = (; ignore = (:SciMLBase, :SciMLLogging)),
     ei_kwargs = (;
         no_implicit_imports = (; skip = (Base, Core, SciMLBase)),
     ),


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## What changed and why

`GROUP=QA` fails on unmodified master: `SciMLTesting.run_api_docs`'s docstring check flags the re-exported module bindings `SciMLBase` and `SciMLLogging` (exported from `src/OrdinaryDiffEq.jl:58`) as public API without a docstring. This adds `api_docs_kwargs = (; ignore = (:SciMLBase, :SciMLLogging))` to the `run_qa` call in `test/qa/qa_tests.jl`.

The check cannot be satisfied from this package. Julia resolves `Docs.Binding(OrdinaryDiffEq, :SciMLBase)` to `SciMLBase.SciMLBase`, so a docstring written in `src/OrdinaryDiffEq.jl` is stored in **SciMLBase's** doc registry, not ours — it is docstring piracy performed at package load time. Neither SciMLBase nor SciMLLogging has a module docstring in any released version, so there is nothing for the check's "a re-exported name documented in its defining package counts as documented" path to follow.

Standalone demonstration (Julia 1.12.6):

```julia
using SciMLLogging: SciMLLogging

module Facade
    using SciMLLogging: SciMLLogging
    export SciMLLogging
end

println("hasdoc(Facade, :SciMLLogging) before      = ", Base.Docs.hasdoc(Facade, :SciMLLogging))
println("Docs.Binding(Facade, :SciMLLogging)       = ", Base.Docs.Binding(Facade, :SciMLLogging))
Core.eval(Facade, :(Base.@doc "Re-export of `SciMLLogging`." SciMLLogging))
println("hasdoc(Facade, :SciMLLogging) after       = ", Base.Docs.hasdoc(Facade, :SciMLLogging))
println("keys(Docs.meta(Facade))                   = ", collect(keys(Base.Docs.meta(Facade))))
println("SciMLLogging.SciMLLogging in meta(SciMLLogging)? = ",
    Base.Docs.Binding(SciMLLogging, :SciMLLogging) in keys(Base.Docs.meta(SciMLLogging)))
```

```
hasdoc(Facade, :SciMLLogging) before      = false
Docs.Binding(Facade, :SciMLLogging)       = SciMLLogging.SciMLLogging
hasdoc(Facade, :SciMLLogging) after       = true
keys(Docs.meta(Facade))                   = Any[]
SciMLLogging.SciMLLogging in meta(SciMLLogging)? = true
```

`docs/make.jl` already works around this with `@eval SciMLBase @doc "..." SciMLBase` (and the same for `SciMLLogging`). That runs only during the docs build, which is why the Documentation lane is green while the QA lane is red; moving those lines into `src/` would make OrdinaryDiffEq mutate a dependency's doc registry on every `using`.

`ignore` is the escape hatch `run_api_docs` documents for exactly this ("a re-export you cannot document at the source, with a comment pointing at the tracking issue"). SciMLTesting's *rendered* check already exempts re-exported modules via `_requires_local_rendering`; the docstrings check has no analogous exemption, which is filed as SciML/SciMLTesting.jl#47. The `ignore` should be dropped once that lands, or once SciMLBase.jl and SciMLLogging.jl grow real module docstrings.

## When this started

History search, not bisect — the shallow CI-era logs for the relevant window have expired, and the three preconditions pin the date exactly:

* `export SciMLBase, SciMLLogging` landed 2026-06-04 in d0daf7a81ce8d0a2c9e5c4125d301318f197898b (#3710).
* SciMLTesting 2.1.0 introduced `run_api_docs` with `api_docs::Bool = true` on by default. The docstring-check body is byte-identical across 2.1.0 through the resolved 2.6.2 (`undocumented = sort!(filter(n -> !(n in skip) && !_has_docstring(pkg, n), api))`), so no later SciMLTesting release tightened it.
* No released SciMLBase 3.x or SciMLLogging 1.x/2.x has a module docstring (`src/SciMLBase.jl` line 1 is a bare `module SciMLBase`).

So the QA lane went red when the SciMLTesting compat floor moved `1.7 -> 2.1` in 12b6996e27ea4ea589a30cd4858cb8ecdd3ef446 (#3867, 2026-07-11), which turned the check on without touching `test/qa/qa_tests.jl`. The QA job has been failing on master since; e.g. `tests / QA (julia 1, ubuntu-latest)` is `failure` on 9d23061 (run 31277347420).

## Verification

`GROUP=QA ~/.juliaup/bin/julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`, Julia 1.12.6, SciMLTesting 2.6.2, SciMLBase 3.43.0, SciMLLogging 2.0.4.

**Before** — clean checkout of master at 9d23061, unmodified (exit 1):

```
┌ Info: run_api_docs: public API names missing a docstring
│   pkg = OrdinaryDiffEq
│   undocumented =
│    2-element Vector{Symbol}:
│     :SciMLBase
└     :SciMLLogging
ERROR: LoadError: Some tests did not pass: 87 passed, 1 failed, 0 errored, 0 broken.
public API has docstrings: Test Failed at /home/crackauc/.julia/packages/SciMLTesting/v2jEQ/src/SciMLTesting.jl:1205
  Expression: isempty(undocumented)
   Evaluated: isempty([:SciMLBase, :SciMLLogging])

Test Summary:                           | Pass  Fail  Total   Time
Quality Assurance Tests                 |   87     1     88  15.3s
  PureKLU-compatible MuladdMacro floors |   79           79   0.1s
  Quality Assurance                     |    8     1      9   7.3s
    ExplicitImports                     |    6            6   4.8s
    Public API documentation            |    1     1      2   2.5s
      public API has docstrings         |          1      1   2.5s
      public API is rendered in docs    |    1            1   0.0s
    No unapproved public reexports      |    1            1   0.0s
```

**After** — same checkout with this commit applied (exit 0):

```
     Testing Running tests...
Test Summary:           | Pass  Total   Time
Quality Assurance Tests |   88     88  13.5s
 13.646965 seconds (8.89 M allocations: 514.320 MiB, 9.62% gc time, 69.92% compilation time: 1% of which was recompilation)
 15.551414 seconds (12.84 M allocations: 712.830 MiB, 11.03% gc time, 73.60% compilation time: 1% of which was recompilation)
     Testing OrdinaryDiffEq tests passed 
```

Formatting and spelling on the changed file:

```
$ julia +1.12 -e 'using Runic; exit(Runic.main(["--check","--diff","test/qa/qa_tests.jl"]))'   # exit 0
$ typos test/qa/qa_tests.jl                                                                    # exit 0
```

## What I did not verify

* No other test group was run — this touches only `test/qa/qa_tests.jl`, but Downgrade, IntegrationTest and the sublibrary lanes were not exercised locally. Note the `Downgrade` and `IntegrationTest` lanes are already red on master independently of this change.
* The docs build was not re-run; this PR does not touch `docs/`. The two `@eval SciMLBase @doc ...` lines in `docs/make.jl` are deliberately left in place — removing them is a separate change that belongs with the upstream fix.
* GPU lanes: not run (no GPU available here).

## For a reviewer to push back on

* This is an `ignore`, not a docstring. It is deliberate: as shown above, the package cannot supply the docstring, and the alternative (moving `docs/make.jl`'s `@eval SciMLBase @doc ...` into `src/`) would make loading OrdinaryDiffEq write into a dependency's doc registry. If you would rather fix it at the root, the two ways are SciML/SciMLTesting.jl#47 (exempt foreign module bindings from the docstring check) or adding module docstrings to SciMLBase.jl and SciMLLogging.jl — the latter would also let `docs/make.jl` drop the two `@eval` lines. Either makes this `ignore` removable.
* No compat floor was changed. A floor bump on SciMLBase for a docstring would not be justifiable, which is part of why the `ignore` is the right layer for this.

## Links

* SciMLTesting tracking issue: https://github.com/SciML/SciMLTesting.jl/issues/47
* Export commit: https://github.com/SciML/OrdinaryDiffEq.jl/commit/d0daf7a81ce8d0a2c9e5c4125d301318f197898b (#3710)
* Commit that turned the check on: https://github.com/SciML/OrdinaryDiffEq.jl/commit/12b6996e27ea4ea589a30cd4858cb8ecdd3ef446 (#3867)
* Failing QA job on master: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/31277347420
