### PR TITLE
Count Krylov Jacobian-vector products on the operator that performs them

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "3.7.1"
+version = "3.8.0"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 

--- a/lib/OrdinaryDiffEqDifferentiation/src/OrdinaryDiffEqDifferentiation.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/OrdinaryDiffEqDifferentiation.jl
@@ -106,7 +106,8 @@ include("operators.jl")
             :calc_rosenbrock_differentiation, :calc_rosenbrock_differentiation!,
             :jacobian!, :jacobian2W!, :update_W!,
             :resize_grad_config!, :resize_jac_config!,
-            :dolinsolve, :wrapprecs, :is_always_new, :islinearfunction, :issuccess_W
+            :dolinsolve, :wrapprecs, :is_always_new, :islinearfunction, :issuccess_W,
+            :drain_jvp_count!, :jvp_counter
         )
     )
 end

--- a/lib/OrdinaryDiffEqDifferentiation/src/linsolve_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/linsolve_utils.jl
@@ -14,8 +14,8 @@ issuccess_W(::Any) = true
 
 Solve the linear system with the LinearSolve.jl cache `linsolve`, optionally
 resetting its matrix `A`, unknown `linu`, right-hand side `b`, and tolerance
-`reltol`. Updates the RHS-evaluation count for matrix-free/iterative solvers and
-returns the LinearSolve result.
+`reltol`. Charges `stats.nf` for the Jacobian-vector products the solve applied
+(see `drain_jvp_count!`) and returns the LinearSolve result.
 """
 function dolinsolve(
         integrator, linsolve; A = nothing, linu = nothing, b = nothing,
@@ -37,17 +37,7 @@ function dolinsolve(
     linres = solve!(linsolve; reltol)
 
     # TODO: this ignores the add of the `f` count for add_steps!
-    if integrator isa SciMLBase.DEIntegrator && _alg.linsolve !== nothing &&
-            !LinearSolve.needs_concrete_A(_alg.linsolve) &&
-            linsolve.A isa WOperator && linsolve.A.J isa AbstractSciMLOperator
-        ad = alg_autodiff(_alg) isa ADTypes.AutoSparse ? ADTypes.dense_ad(alg_autodiff(_alg)) :
-            alg_autodiff(_alg)
-        if ad isa ADTypes.AutoFiniteDiff || ad isa ADTypes.AutoFiniteDifferences
-            OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2 * linres.iters)
-        else
-            OrdinaryDiffEqCore.increment_nf!(integrator.stats, linres.iters)
-        end
-    end
+    drain_jvp_count!(integrator, _alg, linsolve.A)
 
     return linres
 end

--- a/lib/OrdinaryDiffEqDifferentiation/src/operators.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/operators.jl
@@ -15,6 +15,15 @@ when applying the operator.
 ### Computing the JVP
 
 Computing the JVP is done with the DifferentiationInterface function `pushforward!`, which takes advantage of the preparation done upon construction.
+
+### Counting
+
+`njvps` tallies the products applied since the count was last drained by
+`drain_jvp_count!`, which turns them into the `stats.nf` they cost. The tally
+lives here, on the operator that performs the products, because that is the only place
+that sees all of them: a Krylov solve applies the operator more times than its reported
+iteration count (a warm start and the initial residual each cost one), and one operator
+can be shared by several `W`s.
 """
 @concrete mutable struct JVPCache{T} <: SciMLOperators.AbstractSciMLOperator{T}
     jvp_op::Any
@@ -23,6 +32,7 @@ Computing the JVP is done with the DifferentiationInterface function `pushforwar
     u::Any
     p::Any
     t::Any
+    njvps::Int
 end
 
 SciMLBase.isinplace(::JVPCache) = true
@@ -45,11 +55,12 @@ Base.size(J::JVPCache) = (length(J.u), length(J.u))
 
 function JVPCache(f::SciMLBase.AbstractDiffEqFunction, du, u, p, t; autodiff)
     jvp_op = prepare_jvp(f, du, u, p, t, autodiff)
-    return JVPCache{eltype(du)}(jvp_op, f, du, u, p, t)
+    return JVPCache{eltype(du)}(jvp_op, f, du, u, p, t, 0)
 end
 
 function (op::JVPCache)(Jv, v, u, p, t)
     op.jvp_op(Jv, v, u, p, t)
+    op.njvps += 1
     return Jv
 end
 
@@ -57,8 +68,66 @@ function LinearAlgebra.mul!(
         Jv::AbstractArray, J::JVPCache, v::AbstractArray
     )
     J.jvp_op(Jv, v, J.u, J.p, J.t)
+    J.njvps += 1
     return Jv
 end
+
+"""
+    rhs_evals_per_jvp(ad) -> Int
+
+Right-hand-side evaluations one matrix-free Jacobian-vector product costs under autodiff
+backend `ad`.
+
+`stats.nf` counts calls to `f`, not cost-equivalent work. A finite-difference JVP calls
+`f` twice — once at the linearization point and once at the perturbed point — while a
+dual-number JVP calls it once, on a dual input that costs more per call but is still one
+call. Reporting the finite-difference product as one evaluation to make the two look
+comparable would put a cost model into a counter that nothing else in the solver treats
+as one.
+
+The finite-difference count drops to one if the base evaluation is ever cached across the
+products of a single linear solve (`FiniteDiff.finite_difference_jvp!` takes an `f_in`
+argument for exactly that, which DifferentiationInterface's `pushforward!` does not
+currently supply).
+"""
+function rhs_evals_per_jvp(ad)
+    ad = ad isa AutoSparse ? ADTypes.dense_ad(ad) : ad
+    return (ad isa AutoFiniteDiff || ad isa ADTypes.AutoFiniteDifferences) ? 2 : 1
+end
+
+"""
+    drain_jvp_count!(integrator, alg, W) -> nothing
+
+Add the Jacobian-vector products accumulated in `W`'s JVP operator to `integrator.stats.nf`
+and reset the tally, so each product is counted once no matter how many `W`s share the
+operator.
+
+Nothing is counted when no `JVPCache` is involved: a `W` whose Jacobian is a concrete
+matrix or a user-supplied `MatrixOperator` applies a stored matrix and evaluates `f` zero
+times.
+"""
+function drain_jvp_count!(integrator, alg, W)
+    J = jvp_counter(W)
+    (J === nothing || !(integrator isa SciMLBase.DEIntegrator)) && return nothing
+    n = J.njvps
+    J.njvps = 0
+    n == 0 && return nothing
+    OrdinaryDiffEqCore.increment_nf!(
+        integrator.stats, rhs_evals_per_jvp(alg_autodiff(alg)) * n
+    )
+    return nothing
+end
+
+"""
+    jvp_counter(W) -> JVPCache or nothing
+
+The `JVPCache` whose products `W` applies, or `nothing` when `W` costs no RHS evaluations
+per product. A `WOperator` uses its `jacvec` when it has one and its `J` otherwise, which
+is what `LinearAlgebra.mul!` does with it.
+"""
+jvp_counter(J::JVPCache) = J
+jvp_counter(W::WOperator) = jvp_counter(W.jacvec === nothing ? W.J : W.jacvec)
+jvp_counter(::Any) = nothing
 
 # helper functions
 

--- a/lib/OrdinaryDiffEqDifferentiation/test/nf_accounting_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/nf_accounting_tests.jl
@@ -1,0 +1,76 @@
+using OrdinaryDiffEqDifferentiation: rhs_evals_per_jvp
+using OrdinaryDiffEqBDF, LinearSolve, LinearAlgebra, ADTypes, SciMLBase, Test
+using SciMLOperators: MatrixOperator
+
+# `stats.nf` counts calls to `f`. Every configuration below counts them for real and
+# checks the solver reported exactly that many.
+const N = 24
+const dx = 1 / (N + 1)
+const NCALLS = Ref(0)
+function allencahn!(du, u, p, t)
+    NCALLS[] += 1
+    for i in 1:N
+        um = i == 1 ? -one(eltype(u)) : u[i - 1]
+        up = i == N ? one(eltype(u)) : u[i + 1]
+        du[i] = 1.0e-3 * (um - 2u[i] + up) / dx^2 + u[i] - u[i]^3
+    end
+    return nothing
+end
+function allencahn_jac!(J, u, p, t)
+    fill!(J, 0)
+    for i in 1:N
+        J[i, i] = -2.0e-3 / dx^2 + 1 - 3u[i]^2
+        i > 1 && (J[i, i - 1] = 1.0e-3 / dx^2)
+        i < N && (J[i, i + 1] = 1.0e-3 / dx^2)
+    end
+    return J
+end
+u0 = [tanh((i * dx - 0.5) / 0.1) for i in 1:N]
+tspan = (0.0, 1.0)
+
+matrix_free = ODEProblem(allencahn!, u0, tspan)
+operator_jac = ODEProblem(
+    ODEFunction(
+        allencahn!; jac = allencahn_jac!,
+        jac_prototype = MatrixOperator(zeros(N, N); update_func! = allencahn_jac!)
+    ), u0, tspan
+)
+
+function counted_nf(prob, alg)
+    solve(prob, alg; reltol = 1.0e-6, abstol = 1.0e-6, save_everystep = false)
+    NCALLS[] = 0
+    sol = solve(prob, alg; reltol = 1.0e-6, abstol = 1.0e-6, save_everystep = false)
+    @test SciMLBase.successful_retcode(sol)
+    return NCALLS[], sol.stats.nf
+end
+
+@testset "stats.nf counts every RHS evaluation the Krylov solve costs" begin
+    @testset "$adname" for (adname, ad) in
+        (("AutoForwardDiff", AutoForwardDiff()), ("AutoFiniteDiff", AutoFiniteDiff()))
+        # Fully matrix-free: the JVP operator performs every product.
+        real_f, nf = counted_nf(matrix_free, FBDF(linsolve = KrylovJL_GMRES(), autodiff = ad))
+        @test nf == real_f
+
+        # Concrete J kept for the preconditioner, products still done by the JVP operator.
+        real_f, nf = counted_nf(
+            matrix_free, FBDF(linsolve = KrylovJL_GMRES(), concrete_jac = true, autodiff = ad)
+        )
+        @test nf == real_f
+
+        # A user-supplied `MatrixOperator` Jacobian applies a stored matrix: no `f` calls.
+        real_f, nf = counted_nf(operator_jac, FBDF(linsolve = KrylovJL_GMRES(), autodiff = ad))
+        @test nf == real_f
+
+        # Direct solver, no products at all.
+        real_f, nf = counted_nf(matrix_free, FBDF(autodiff = ad))
+        @test nf == real_f
+    end
+end
+
+@testset "rhs_evals_per_jvp" begin
+    @test rhs_evals_per_jvp(AutoForwardDiff()) == 1
+    @test rhs_evals_per_jvp(AutoFiniteDiff()) == 2
+    @test rhs_evals_per_jvp(AutoFiniteDiff(fdjtype = Val(:central))) == 2
+    @test rhs_evals_per_jvp(AutoSparse(AutoFiniteDiff())) == 2
+    @test rhs_evals_per_jvp(AutoSparse(AutoForwardDiff())) == 1
+end

--- a/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
@@ -40,6 +40,7 @@ if TEST_GROUP ∉ ("QA", "Sparse", "ModelingToolkit")
     @time @safetestset "No Jac Tests" include("nojac_tests.jl")
     @time @safetestset "Stale W Linear Operator Tests" include("stale_w_linear_operator_tests.jl")
     @time @safetestset "Krylov warm_start default" include("warm_start_default_tests.jl")
+    @time @safetestset "Krylov nf accounting" include("nf_accounting_tests.jl")
 end
 
 # Run sparse tests (separate environment due to ComponentArrays dep conflicts)

--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFIRK"
 uuid = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.6.1"
+version = "2.6.2"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -46,7 +46,7 @@ FastGaussQuadrature = "1.2"
 MuladdMacro = "0.2.4"
 LinearSolve = "5.1"
 LinearAlgebra = "1.10"
-OrdinaryDiffEqDifferentiation = "3.3"
+OrdinaryDiffEqDifferentiation = "3.8"
 SciMLBase = "3.39"
 OrdinaryDiffEqCore = "4.12"
 GenericSchur = "0.5"

--- a/lib/OrdinaryDiffEqFIRK/src/OrdinaryDiffEqFIRK.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/OrdinaryDiffEqFIRK.jl
@@ -35,8 +35,8 @@ import OrdinaryDiffEqCore: _ode_interpolant, _ode_interpolant!, _ode_addsteps!,
 import FastPower: fastpower
 using OrdinaryDiffEqDifferentiation: build_J_W, build_jac_config,
     calc_J!, dolinsolve, calc_J,
-    islinearfunction
-import ADTypes
+    islinearfunction, drain_jvp_count!
+import OrdinaryDiffEqDifferentiation: jvp_counter
 import ADTypes: AutoForwardDiff
 import SciMLOperators
 import SciMLOperators: AbstractSciMLOperator

--- a/lib/OrdinaryDiffEqFIRK/src/firk_operators.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_operators.jl
@@ -34,7 +34,6 @@ mutable struct ComplexWOperator{T, MMType, GType, JType, JVType, VType} <:
     _imv::VType
     _reJv::VType
     _imJv::VType
-    jvps::Int
 end
 
 function ComplexWOperator(mass_matrix, gamma::Number, J, u, jacvec = nothing)
@@ -44,7 +43,7 @@ function ComplexWOperator(mass_matrix, gamma::Number, J, u, jacvec = nothing)
         T, typeof(mass_matrix), T, typeof(J), typeof(jacvec), typeof(v),
     }(
         mass_matrix, convert(T, gamma), J, jacvec,
-        zero(v), zero(v), zero(v), zero(v), 0
+        zero(v), zero(v), zero(v), zero(v)
     )
 end
 
@@ -74,7 +73,6 @@ function LinearAlgebra.mul!(Y::AbstractVector, W::ComplexWOperator, B::AbstractV
     @. _imv = imag(B)
     mul!(_reJv, Jop, _rev)
     mul!(_imJv, Jop, _imv)
-    W.jvps += 2
     @. Y = complex(_reJv, _imJv)
     a = -inv(W.gamma)
     if W.mass_matrix isa UniformScaling
@@ -177,27 +175,6 @@ function firk_new_J!(J, W, integrator, cache)
     return nothing
 end
 
-"""
-    drain_jvp_count!(integrator, alg, W)
-
-Move the Jacobian-vector products a matrix-free complex stage solve has accumulated into
-the solver stats, and reset the operator's counter. `dolinsolve` only accounts for
-`WOperator`s, so the [`ComplexWOperator`](@ref) products go uncounted otherwise. The
-counter lives on the operator rather than being inferred from the Krylov iteration count
-so that `AdaptiveRadau`'s threaded stage solves each tally into their own operator.
-
-Only a genuinely matrix-free Jacobian costs RHS evaluations; a concretizable operator such
-as a user-supplied `MatrixOperator` does not.
-"""
-function drain_jvp_count!(integrator, alg, W::ComplexWOperator)
-    n = W.jvps
-    W.jvps = 0
-    (n == 0 || !(integrator isa SciMLBase.DEIntegrator)) && return nothing
-    Jop = _jacobian_operator(W)
-    (Jop isa AbstractSciMLOperator && !SciMLOperators.isconvertible(Jop)) || return nothing
-    ad = alg.autodiff isa ADTypes.AutoSparse ? ADTypes.dense_ad(alg.autodiff) : alg.autodiff
-    per_jvp = (ad isa ADTypes.AutoFiniteDiff || ad isa ADTypes.AutoFiniteDifferences) ? 2 : 1
-    OrdinaryDiffEqCore.increment_nf!(integrator.stats, per_jvp * n)
-    return nothing
-end
-drain_jvp_count!(integrator, alg, W) = nothing
+# A `ComplexWOperator` applies the same real JVP operator its `W` does, so the products it
+# performs are already on that operator's tally and `drain_jvp_count!` needs nothing else.
+jvp_counter(W::ComplexWOperator) = jvp_counter(_jacobian_operator(W))


### PR DESCRIPTION
Closes #4162.

**Please ignore until reviewed by @ChrisRackauckas.**

## What `nf` means

`nf` counts calls to `f`. That is what `increment_nf!`'s docstring says ("the RHS-evaluation counter"), what SciMLBase prints it as ("Number of function 1 evaluations"), and what every other increment site in the solver does — `increment_nf!(stats, num_stages)` after `num_stages` calls, and so on. It is not a cost model. This PR keeps that definition and makes the Krylov path obey it; the alternative, rescaling the finite-difference product to one "cost-equivalent" evaluation so it compares evenly with a dual-number product, would put a cost model into a counter nothing else treats as one, and would make `nf` disagree with a user counting their own `f` calls. The choice is written down in the new `rhs_evals_per_jvp` docstring.

Under that definition the 2-vs-1 split the issue points at is **correct**: `FiniteDiff.finite_difference_jvp!` really does call `f` twice per product (at `x` and at the perturbed point — verified in FiniteDiff 2.33.0, both `:forward` and `:central`), and a `ForwardDiff` product really is one call on a dual input. The measurement in the issue (24.96 µs vs 27.67 µs) says the finite-difference product is *cheaper per unit of work*, which is a real and useful fact, but it is not a statement about how many times `f` ran.

## What was actually wrong

The accounting was wrong in three other ways, all of which made `nf` disagree with the true call count. Counting real `f` calls on a 24-state Allen-Cahn problem with `FBDF(linsolve = KrylovJL_GMRES())`, on master (`9d23061ef8a2b155ca2b6ff78670f6e320967940`):

| configuration | real `f` calls | `stats.nf` on master | `stats.nf` with this PR |
|---|---|---|---|
| matrix-free, `AutoForwardDiff` | 219 | 151 | 219 |
| matrix-free, `AutoFiniteDiff` | 402 | 266 | 402 |
| `concrete_jac = true`, `AutoForwardDiff` | 243 | 62 | 243 |
| `concrete_jac = true`, `AutoFiniteDiff` | 427 | 63 | 427 |
| `MatrixOperator` `jac_prototype`, `AutoForwardDiff` | 38 | 151 | 38 |
| `MatrixOperator` `jac_prototype`, `AutoFiniteDiff` | 38 | 264 | 38 |
| direct solver (control) | 58 | 58 | 58 |

1. **`linres.iters` is not the number of products.** A Krylov solve applies the operator more times than it reports iterations. The matrix-free rows under-count by 31% and 34%, which works out to about two extra products per solve over the 35 solves here: one is the Hegedűs warm start, which does an explicit `mul!(similar(cache.b), cache.A, u)` in `LinearSolve/src/iterative_wrappers.jl` before handing off to Krylov, and the rest is the initial residual.
2. **The `jacvec` path was invisible.** The gate was `linsolve.A.J isa AbstractSciMLOperator`, but `WOperator`'s `mul!` uses `W.jacvec` whenever it has one. With `concrete_jac = true` the Krylov solver keeps a concrete `J` for the preconditioner and does its products through `W.jacvec`, so the gate was false and *none* of the products were counted: 62 reported against 243 real.
3. **A concretizable operator was charged for products it does not pay for.** A user-supplied `MatrixOperator` Jacobian applies a stored matrix and calls `f` zero times, but it satisfied the gate and was billed per iteration: 151 and 264 reported against 38 real.

## The fix

Count the products on the operator that performs them, which is the only place that sees all of them and is already the approach `drain_jvp_count!` took for FIRK's `ComplexWOperator` in #4166 ("the counter lives on the operator rather than being inferred from the Krylov iteration count"). `JVPCache` gains an `njvps` tally; `dolinsolve` drains it through a `drain_jvp_count!` that is now shared with FIRK rather than duplicated. All three defects fall out: a `MatrixOperator` has no tally, a `jacvec` has one wherever it sits in the `W`, and the tally counts the products the solver never reported.

This also answers the `#4166` follow-up noted in the issue. FIRK's separate `ComplexWOperator.jvps` field goes away — a `ComplexWOperator` applies the same real JVP operator its `W` does, so those products are already on that operator's tally and one `jvp_counter` method is all FIRK needs. FIRK's existing `stats.nf == nf[]` assertions in `firk_krylov_tests.jl` cover the migration.

Step counts are untouched in every configuration above (`naccept = 27`, `nsolve = 35` before and after): this changes reporting only.

## Failing before / passing after

New test asserts `stats.nf == ` the counted number of `f` calls across the four configurations × two AD backends. On unmodified master, with the `rhs_evals_per_jvp` unit testset removed since the helper does not exist there:

```
AutoForwardDiff: Test Failed
  Expression: nf == real_f
   Evaluated: 151 == 219
AutoForwardDiff: Test Failed
  Expression: nf == real_f
   Evaluated: 62 == 243
AutoForwardDiff: Test Failed
  Expression: nf == real_f
   Evaluated: 151 == 38
AutoFiniteDiff: Test Failed
  Expression: nf == real_f
   Evaluated: 266 == 402
AutoFiniteDiff: Test Failed
  Expression: nf == real_f
   Evaluated: 63 == 427
AutoFiniteDiff: Test Failed
  Expression: nf == real_f
   Evaluated: 264 == 38

Test Summary:                                               | Pass  Fail  Total   Time
stats.nf counts every RHS evaluation the Krylov solve costs |   10     6     16  36.7s
ERROR: LoadError: Some tests did not pass: 10 passed, 6 failed, 0 errored, 0 broken.
```

The 10 passes are the direct-solver control and the `successful_retcode` checks. With the change:

```
Test Summary:                                               | Pass  Total   Time
stats.nf counts every RHS evaluation the Krylov solve costs |   16     16  36.0s
Test Summary:     | Pass  Total  Time
rhs_evals_per_jvp |    5      5  0.0s
```

## Related context, not fixed here

The larger half of #4162 is upstream and is **not** touched. `FiniteDiff.finite_difference_jvp!` takes an `f_in` argument so a caller can hand it a cached `f(x)`, but DifferentiationInterface's `pushforward!` does not pass it — confirmed still true in DifferentiationInterface 0.7.20, `ext/DifferentiationInterfaceFiniteDiffExt/twoarg.jl`, which calls `finite_difference_jvp!(dy, fc!, x, dx, prep.cache; relstep, absstep, dir)` with no `f_in`. So the base evaluation is recomputed on every matvec even though `x` is fixed for the whole linear solve, worth about 1.2× on that path. That fix belongs in DifferentiationInterface. When it lands, `rhs_evals_per_jvp` for `AutoFiniteDiff` becomes 1 and this is the one line that has to change; the docstring says so.

DifferentiationInterface is not a repo I have standing to file in, so this is reported here rather than opened there.

## Verification

Julia 1.12.6. Resolved: LinearSolve 5.6.0, SciMLBase 3.43.0, SciMLOperators 1.26.1, ADTypes 1.22.4, FiniteDiff 2.33.0, DifferentiationInterface 0.7.20, Krylov 0.10.9.

`GROUP=Core julia --project -e 'using Pkg; Pkg.test()'` in `lib/OrdinaryDiffEqDifferentiation`:

```
DAE jacobian2W sparse |    4      4  50.9s
prepare_user_sparsity mass matrix |    9      9  3.3s
ScalarOperator mass matrix |    9      9  9m44.8s
nzval helpers |   26     26  40.9s
prepare_sparse_jac! |    9      9  0.5s
OOP J_t Tracking |    5      5  16.3s
Differentiation Trait Tests |    5      5  13.0s
Autodiff Error Tests |    4      4  3m32.8s
No Jac Tests  |    7      7  19.1s
Stale W Linear Operator Tests |   12     12  5m48.3s
Krylov warm_start default |    7      7  0.1s
Krylov nf accounting |   21     21  1m06.0s
     Testing OrdinaryDiffEqDifferentiation tests passed
```

`GROUP=Core` in `lib/OrdinaryDiffEqFIRK`, which carries the pre-existing `stats.nf == nf[]` assertions the `ComplexWOperator` counter migration has to keep passing:

```
FIRK Tests    |  107    107  4m48.6s
FIRK Krylov Tests |   93     93  8m11.8s
     Testing OrdinaryDiffEqFIRK tests passed
```

`GROUP=QA` in `lib/OrdinaryDiffEqDifferentiation` (JET + Aqua, which is where the ExplicitImports checks live and so where the new `public` declarations are exercised):

```
JET Tests     |    1      1  35.0s
Aqua          |   18     18  41.3s
     Testing OrdinaryDiffEqDifferentiation tests passed
```

`GROUP=QA` in `lib/OrdinaryDiffEqFIRK` **fails**, but it fails identically on unmodified master — `run_api_docs` reports `:SciMLBase` as an undocumented public name, which comes from the pre-existing `@reexport using SciMLBase` in `OrdinaryDiffEqFIRK.jl` and has nothing to do with this diff (`Allocation Tests` 5/5 and `JET Tests` 1/1 in the same group pass):

```
public API has docstrings: Test Failed at SciMLTesting.jl:1205
  Expression: isempty(undocumented)
   Evaluated: isempty([:SciMLBase])
Aqua | 19  1  20
```

I am confirming the master reproduction separately and will report it; it is not something this PR should carry a fix for.

Runic and `typos` are clean over the diff and the new test file.

Both PRs bump `lib/OrdinaryDiffEqDifferentiation` to 3.8.0 (each adds public API), so whichever merges second will conflict on that one line in `Project.toml` and on the `public` block; the rest of the two diffs is disjoint apart from `dolinsolve` itself.

## Not verified

- GPU, Downstream, and Documentation CI. The docs build was not run: no `docs/` file, rendered API entry, or public name is touched (`JVPCache` is documented but internal, and the change to it is additive).
- Test groups other than the ones listed above; in particular the Rosenbrock, SDIRK and StochasticDiffEq suites, which share `dolinsolve` but whose matrix-free paths are the same code as the ones exercised above.
- `AutoFiniteDifferences`, which `rhs_evals_per_jvp` still maps to 2. It is unreachable through this path — `prepare_jvp` asserts `DI.check_inplace(autodiff)` and DifferentiationInterface declares `inplace_support(::AutoFiniteDifferences) = InPlaceNotSupported()` — so the branch is dead rather than tested. I kept it rather than deleting it because deleting a dead branch is a separate question from fixing the accounting; note that 2 would be wrong for it anyway, since `central_fdm(5, 1)` costs five evaluations per product.

## Worth pushing back on

- `njvps` is a plain `Int` incremented in `mul!`. That is safe today because nothing in this repo applies a shared `JVPCache` from more than one thread (FIRK's `AdaptiveRadau` stage operators all share the `W1.jacvec` and run sequentially), but it is a counter in a hot path with no synchronisation, and if a threaded stage solve ever lands it becomes a race. The pre-existing `ComplexWOperator.jvps` had the same property.
- Draining in `dolinsolve` attributes any products applied outside a linear solve to the next solve. The total stays right; the per-step attribution can be off by one solve.
