### PR TITLE
Stop rendering DummyControllerCache as public API

### DIFF
--- a/docs/src/devtools/internals/public_api.md
+++ b/docs/src/devtools/internals/public_api.md
@@ -314,7 +314,6 @@ OrdinaryDiffEqCore.resolve_stage_step_limiters
 OrdinaryDiffEqCore.trivial_limiter!
 OrdinaryDiffEqCore.DEOptions
 OrdinaryDiffEqCore.DummyController
-OrdinaryDiffEqCore.DummyControllerCache
 ```
 
 ### Time-stop and saving queues


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## What changed and why

Two PRs merged on 2026-08-08 fixed the same broken docs build with **opposite** intents, so the state on master is an accident of merge order:

- https://github.com/SciML/OrdinaryDiffEq.jl/pull/4164 (merged 11:59) **unlinked** the `[`DummyControllerCache`](@ref)` in `DummyController`'s docstring, on the grounds that the type is deliberately internal — not exported, no `public` declaration, and `docs/src/devtools/internals/public_api.md` states that concrete per-algorithm caches remain internal unless listed.
- https://github.com/SciML/OrdinaryDiffEq.jl/pull/4165 (merged 13:51) instead **published** the type by adding a `@docs` entry for it, so the `@ref` would resolve.

Chris has ruled that `DummyControllerCache` is not public API. This PR restores the #4164 resolution by reverting #4165's one-line `@docs` addition.

State found on master (`b9889d3`) before this change:

- The `@ref` is **not** back — #4165 touched only `public_api.md`, so #4164's unlinking survived. `controllers.jl:498` reads `hand back a `DummyControllerCache``.
- The `@docs` entry from #4165 **is** present at `public_api.md:317`.
- The docs build **passes** in that state (exit 0) — it just renders an internal type.

So the tree had a docs build that was green for the wrong reason. Removing the `@docs` entry is safe precisely because no live `@ref` points at it: `grep -rn DummyControllerCache docs/` finds only the `@docs` line, and `makedocs` has `warnonly = [:docs_block, :missing_docs, :eval_block]`, so `:cross_references` remains a hard error and would have caught a dangling reference.

The explanatory prose in `DummyController`'s docstring is untouched — a reader still learns the cache type exists, it is just not a link.

## Verification

`julia --project=docs docs/make.jl` on Julia 1.12.6, with the repo and all `lib/` subpackages `Pkg.develop`ed into the docs environment.

Before (unmodified master, `b9889d3ae`):

```
[ Info: Automatic `version="7.4.0"` for inventory from ../Project.toml
┌ Warning: Documenter could not auto-detect the building environment. Skipping deployment.
└ @ Documenter ~/.julia/packages/Documenter/AXNMp/src/deployconfig.jl:93
DOCS_EXIT=0
```

After (this branch):

```
DOCS_EXIT=0
```

Both runs exit 0. Confirming the change had the intended effect on the rendered output:

```
$ grep -o 'id="[^"]*DummyControllerCache[^"]*"' -r docs/build/ | wc -l
0
$ grep -o DummyControllerCache docs/build/devtools/internals/public_api/index.html | wc -l
1
```

No docstring anchor for the type anywhere in the build; the single remaining occurrence is the plain `<code>` span inside `DummyController`'s docstring, which is the prose #4164 kept. The type now appears in Documenter's `:missing_docs` warning list alongside the other intentionally-internal names (`OrdinaryDiffEqDifferentiation.JVPCache`, `OrdinaryDiffEqLowOrderRK.BS5ConstantCache`, `OrdinaryDiffEqVerner.RKV76IIaTableau`, …), which is the correct place for it.

`typos docs/src/devtools/internals/public_api.md` → exit 0. Runic is a no-op: the diff contains no `.jl` files.

## Possible follow-up, deliberately not done here

`public_api.md` still renders `OrdinaryDiffEqCore.DefaultCache` (`lib/OrdinaryDiffEqCore/src/caches/basic_caches.jl:75`), which is the concrete cache for `DefaultODEAlgorithm` and arguably falls under the same "concrete per-algorithm caches remain internal" sentence. It is less clear-cut than this case — the page's own preamble explicitly sanctions "the listed automatic-switch caches", and `DefaultCache` plausibly belongs to that family along with `AutoSwitchCache`. Worth a separate decision; this PR does one thing.

## Not verified

- No test suite was run — the diff is one deleted line in a Markdown `@docs` block and touches no Julia source.
- Only the local docs build was exercised; the deploy path (`deploydocs`) is not reachable locally and was skipped by Documenter.
- Building the docs required `Pkg.develop`ing every `lib/` subpackage into the docs environment, which adds entries to `docs/Project.toml`. Those were reverted and are not part of this diff — meaning the committed `docs/Project.toml` is unchanged from master but was not itself the file the local build resolved against.
