### PR TITLE
Treat `DiffEqBase.promote_f` as an opaque Mooncake primitive

### DIFF
--- a/lib/DiffEqBase/ext/DiffEqBaseMooncakeExt.jl
+++ b/lib/DiffEqBase/ext/DiffEqBaseMooncakeExt.jl
@@ -3,9 +3,10 @@ module DiffEqBaseMooncakeExt
 using DiffEqBase, Mooncake
 using DiffEqBase: SciMLBase
 using SciMLBase: ADOriginator, ChainRulesOriginator, MooncakeOriginator
-import Mooncake: rrule!!, CoDual, zero_fcodual, @is_primitive,
+import Mooncake: rrule!!, frule!!, CoDual, Dual, zero_fcodual, @is_primitive,
     @from_rrule, @zero_adjoint, @mooncake_overlay, MinimalCtx,
-    NoPullback
+    NoPullback, NoRData, primal, tangent, fdata,
+    zero_tangent, instantiate, lazy_zero_rdata
 
 @from_rrule(
     MinimalCtx,
@@ -32,5 +33,101 @@ import Mooncake: rrule!!, CoDual, zero_fcodual, @is_primitive,
     },
     true,
 )
+
+# `promote_f`'s "simple" method (used when the algorithm does not need ForwardDiff
+# internally, e.g. Tsit5/Verner): either returns `(f, p)` unchanged (no wrapping needed),
+# or wraps `f` in a `FunctionWrappersWrapper` for performance (type-erasing dynamic
+# dispatch), passing `p` straight through in the common case, or (only in the rare
+# `AutoDePSpecialize` "opaque" branch) repacking it via `RespecializeParams.pack_auto`.
+# None of this can be traced through directly in forward mode: constructing a
+# `FunctionWrappersWrapper` internally hits raw `:cfunction` IR that Mooncake's
+# forward-mode interpreter does not support (SciML/SciMLSensitivity.jl#1427). This treats
+# the whole call as an opaque primitive with a hand-derived tangent instead: `f`'s own
+# tangent/fdata is forwarded when it's returned unchanged, `NoTangent`/`NoFData` when it's
+# wrapped (matching `FunctionWrappersWrapper`'s own declared `NoTangent` tangent type), and
+# `p`'s tangent/fdata is forwarded unchanged in the identity case. The
+# `AutoDePSpecialize`/opaque-p case isn't handled -- it fails loudly with a clear error
+# instead of silently returning a wrong gradient.
+@is_primitive MinimalCtx Tuple{
+    typeof(DiffEqBase.promote_f), Any, Val, Any, Any, Any, Val{false}, Val,
+}
+
+function _unsupported_promote_f_opaque_p()
+    return error(
+        "Mooncake differentiation through DiffEqBase.promote_f's AutoDePSpecialize/" *
+        "opaque-p branch is not yet supported: `p` is repacked via " *
+        "RespecializeParams.pack_auto, which has no derivative rule here.",
+    )
+end
+
+function rrule!!(
+        pf::CoDual{typeof(DiffEqBase.promote_f)},
+        f::CoDual, specialize::CoDual{<:Val}, u0::CoDual, p::CoDual, t::CoDual,
+        wrapdiff::CoDual{Val{false}}, cs::CoDual{<:Val},
+    )
+    f_primal, p_primal = primal(f), primal(p)
+    f_out, p_out = DiffEqBase.promote_f(
+        f_primal, primal(specialize), primal(u0), p_primal, primal(t), Val(false),
+        primal(cs),
+    )
+    p_out === p_primal || _unsupported_promote_f_opaque_p()
+    f_out_is_identity = f_out === f_primal
+    f_out_fdata = f_out_is_identity ? f.dx : fdata(zero_tangent(f_out))
+    y = CoDual((f_out, p_out), (f_out_fdata, p.dx))
+
+    # Zero rdata for every argument slot that never participates in the two real
+    # outputs (`f_out`/`p_out`): the callee itself, `specialize`/`wrapdiff`/`cs` (all
+    # `Val`s), and `u0`/`t` (only their *types*, not values, matter here -- they're
+    # solely used to build the wrapped function's dispatch signature). Computed lazily
+    # via `lazy_zero_rdata`/`instantiate` rather than a hardcoded `NoRData()`: several of
+    # these (e.g. `t::Float64`) have a genuinely non-trivial rdata type even though their
+    # *value* has zero contribution here, and returning the wrong type for those would
+    # break accumulation at the call site.
+    lazy_pf, lazy_specialize, lazy_u0, lazy_t, lazy_wrapdiff, lazy_cs = map(
+        lazy_zero_rdata,
+        (primal(pf), primal(specialize), primal(u0), primal(t), primal(wrapdiff), primal(cs)),
+    )
+    lazy_f = f_out_is_identity ? nothing : lazy_zero_rdata(f_primal)
+
+    # `dy`'s shape depends on how Mooncake collapses `(rdata_type(f_out),
+    # rdata_type(p_out))`: mutable types (e.g. array `p_out`) carry their real gradient
+    # via `fdata` mutation, not `rdata`, so their rdata contribution is trivial
+    # (`NoRData`). When one or both slots are trivial, the incoming `dy` isn't a 2-tuple:
+    # it's the single remaining non-trivial rdata, or a bare `NoRData()` if both are.
+    RDf = Mooncake.rdata_type(Mooncake.tangent_type(typeof(f_out)))
+    RDp = Mooncake.rdata_type(Mooncake.tangent_type(typeof(p_out)))
+    function promote_f_pb!!(dy)
+        df_out, dp_out = if RDf === NoRData && RDp === NoRData
+            NoRData(), NoRData()
+        elseif RDf === NoRData
+            NoRData(), dy
+        elseif RDp === NoRData
+            dy, NoRData()
+        else
+            dy
+        end
+        df = f_out_is_identity ? df_out : instantiate(lazy_f)
+        return (
+            instantiate(lazy_pf), df, instantiate(lazy_specialize), instantiate(lazy_u0),
+            dp_out, instantiate(lazy_t), instantiate(lazy_wrapdiff), instantiate(lazy_cs),
+        )
+    end
+    return y, promote_f_pb!!
+end
+
+function frule!!(
+        ::Dual{typeof(DiffEqBase.promote_f)},
+        f::Dual, specialize::Dual{<:Val}, u0::Dual, p::Dual, t::Dual,
+        ::Dual{Val{false}}, cs::Dual{<:Val},
+    )
+    f_primal, p_primal = primal(f), primal(p)
+    f_out, p_out = DiffEqBase.promote_f(
+        f_primal, primal(specialize), primal(u0), p_primal, primal(t), Val(false),
+        primal(cs),
+    )
+    p_out === p_primal || _unsupported_promote_f_opaque_p()
+    f_out_tangent = f_out === f_primal ? tangent(f) : zero_tangent(f_out)
+    return Dual((f_out, p_out), (f_out_tangent, tangent(p)))
+end
 
 end

--- a/lib/DiffEqBase/ext/DiffEqBaseMooncakeExt.jl
+++ b/lib/DiffEqBase/ext/DiffEqBaseMooncakeExt.jl
@@ -55,8 +55,8 @@ import Mooncake: rrule!!, frule!!, CoDual, Dual, zero_fcodual, @is_primitive,
 function _unsupported_promote_f_opaque_p()
     return error(
         "Mooncake differentiation through DiffEqBase.promote_f's AutoDePSpecialize/" *
-        "opaque-p branch is not yet supported: `p` is repacked via " *
-        "RespecializeParams.pack_auto, which has no derivative rule here.",
+            "opaque-p branch is not yet supported: `p` is repacked via " *
+            "RespecializeParams.pack_auto, which has no derivative rule here.",
     )
 end
 

--- a/lib/DiffEqBase/ext/DiffEqBaseMooncakeExt.jl
+++ b/lib/DiffEqBase/ext/DiffEqBaseMooncakeExt.jl
@@ -34,20 +34,16 @@ import Mooncake: rrule!!, frule!!, CoDual, Dual, zero_fcodual, @is_primitive,
     true,
 )
 
-# `promote_f`'s "simple" method (used when the algorithm does not need ForwardDiff
-# internally, e.g. Tsit5/Verner): either returns `(f, p)` unchanged (no wrapping needed),
-# or wraps `f` in a `FunctionWrappersWrapper` for performance (type-erasing dynamic
-# dispatch), passing `p` straight through in the common case, or (only in the rare
-# `AutoDePSpecialize` "opaque" branch) repacking it via `RespecializeParams.pack_auto`.
-# None of this can be traced through directly in forward mode: constructing a
-# `FunctionWrappersWrapper` internally hits raw `:cfunction` IR that Mooncake's
-# forward-mode interpreter does not support (SciML/SciMLSensitivity.jl#1427). This treats
-# the whole call as an opaque primitive with a hand-derived tangent instead: `f`'s own
-# tangent/fdata is forwarded when it's returned unchanged, `NoTangent`/`NoFData` when it's
-# wrapped (matching `FunctionWrappersWrapper`'s own declared `NoTangent` tangent type), and
-# `p`'s tangent/fdata is forwarded unchanged in the identity case. The
-# `AutoDePSpecialize`/opaque-p case isn't handled -- it fails loudly with a clear error
-# instead of silently returning a wrong gradient.
+# promote_f can wrap f in a FunctionWrappersWrapper for performance. Constructing that
+# wrapper hits raw :cfunction IR that Mooncake's forward-mode interpreter can't handle
+# (SciML/SciMLSensitivity.jl#1427), so this treats the whole call as an opaque primitive
+# instead: f/p's tangent is forwarded when returned unchanged, zeroed when f gets wrapped.
+# The rare AutoDePSpecialize opaque-p branch isn't handled and errors loudly instead of
+# silently returning a wrong gradient.
+#
+# Only covers the Val{false} method (algorithms that don't need ForwardDiff internally,
+# e.g. Tsit5/Verner). The Val{true} method used by algorithms like Rosenbrock/BDF wraps
+# jac/tgrad/f separately and is not covered here.
 @is_primitive MinimalCtx Tuple{
     typeof(DiffEqBase.promote_f), Any, Val, Any, Any, Any, Val{false}, Val,
 }
@@ -57,6 +53,21 @@ function _unsupported_promote_f_opaque_p()
         "Mooncake differentiation through DiffEqBase.promote_f's AutoDePSpecialize/" *
             "opaque-p branch is not yet supported: `p` is repacked via " *
             "RespecializeParams.pack_auto, which has no derivative rule here.",
+    )
+end
+
+# `f_out === f_primal` is not just "did promote_f wrap f": promote_f also rebuilds f via
+# `@set f.jac_prototype = similar(...)` whenever jac_prototype is set, regardless of
+# whether wrapping happens, so f_out can be a fresh (non-identical) but still-unwrapped
+# object. Either way, zeroing f_out's tangent below is only exact if f_primal itself had
+# nothing to differentiate; otherwise fail loud rather than silently drop a real gradient.
+function _check_promote_f_input_has_no_tangent(f_primal)
+    Mooncake.tangent_type(typeof(f_primal)) === Mooncake.NoTangent && return nothing
+    return error(
+        "Mooncake differentiation through DiffEqBase.promote_f is not supported when " *
+            "the input `f` (tangent_type = $(Mooncake.tangent_type(typeof(f_primal)))) " *
+            "carries its own differentiable state and promote_f returns a new object " *
+            "for it (e.g. via wrapping, or via the jac_prototype eltype-promotion path).",
     )
 end
 
@@ -72,28 +83,22 @@ function rrule!!(
     )
     p_out === p_primal || _unsupported_promote_f_opaque_p()
     f_out_is_identity = f_out === f_primal
+    f_out_is_identity || _check_promote_f_input_has_no_tangent(f_primal)
     f_out_fdata = f_out_is_identity ? f.dx : fdata(zero_tangent(f_out))
     y = CoDual((f_out, p_out), (f_out_fdata, p.dx))
 
-    # Zero rdata for every argument slot that never participates in the two real
-    # outputs (`f_out`/`p_out`): the callee itself, `specialize`/`wrapdiff`/`cs` (all
-    # `Val`s), and `u0`/`t` (only their *types*, not values, matter here -- they're
-    # solely used to build the wrapped function's dispatch signature). Computed lazily
-    # via `lazy_zero_rdata`/`instantiate` rather than a hardcoded `NoRData()`: several of
-    # these (e.g. `t::Float64`) have a genuinely non-trivial rdata type even though their
-    # *value* has zero contribution here, and returning the wrong type for those would
-    # break accumulation at the call site.
+    # Zero rdata for the argument slots that never reach the outputs (callee, the Val
+    # args, and u0/t, whose types but not values matter here). Uses lazy_zero_rdata
+    # instead of a hardcoded NoRData() since e.g. t::Float64 has real rdata of its own.
     lazy_pf, lazy_specialize, lazy_u0, lazy_t, lazy_wrapdiff, lazy_cs = map(
         lazy_zero_rdata,
         (primal(pf), primal(specialize), primal(u0), primal(t), primal(wrapdiff), primal(cs)),
     )
     lazy_f = f_out_is_identity ? nothing : lazy_zero_rdata(f_primal)
 
-    # `dy`'s shape depends on how Mooncake collapses `(rdata_type(f_out),
-    # rdata_type(p_out))`: mutable types (e.g. array `p_out`) carry their real gradient
-    # via `fdata` mutation, not `rdata`, so their rdata contribution is trivial
-    # (`NoRData`). When one or both slots are trivial, the incoming `dy` isn't a 2-tuple:
-    # it's the single remaining non-trivial rdata, or a bare `NoRData()` if both are.
+    # dy's shape depends on whether f_out/p_out carry real rdata: mutable outputs (e.g.
+    # array p_out) get their gradient via fdata mutation instead, so dy collapses from a
+    # 2-tuple down to a single rdata, or a bare NoRData() if both sides are trivial.
     RDf = Mooncake.rdata_type(Mooncake.tangent_type(typeof(f_out)))
     RDp = Mooncake.rdata_type(Mooncake.tangent_type(typeof(p_out)))
     function promote_f_pb!!(dy)
@@ -126,7 +131,9 @@ function frule!!(
         primal(cs),
     )
     p_out === p_primal || _unsupported_promote_f_opaque_p()
-    f_out_tangent = f_out === f_primal ? tangent(f) : zero_tangent(f_out)
+    f_out_is_identity = f_out === f_primal
+    f_out_is_identity || _check_promote_f_input_has_no_tangent(f_primal)
+    f_out_tangent = f_out_is_identity ? tangent(f) : zero_tangent(f_out)
     return Dual((f_out, p_out), (f_out_tangent, tangent(p)))
 end
 


### PR DESCRIPTION
promote_f can wrap f in a FunctionWrappersWrapper for performance. Constructing that wrapper involves raw cfunction IR, which Mooncake's forward mode interpreter does not support, so forward mode differentiation through a real solve (for example, Tsit5) crashes with "Expressions of type :cfunction are not yet supported in forward mode".

This marks promote_f itself as a Mooncake primitive with a hand written rrule!!/frule!! pair, so Mooncake never traces into the FunctionWrappersWrapper construction. The rare AutoDePSpecialize opaque-p branch is not handled, it errors clearly instead of silently returning a wrong gradient.

promote_f can also return a new (non-identical) f object even when nothing gets wrapped, for example when it rebuilds f to promote a jac_prototype's element type. Zeroing f's tangent is only correct if f itself has nothing to differentiate, so that case is guarded the same way and errors clearly instead of silently dropping a real gradient.

Only covers the Val{false} method (algorithms that do not need ForwardDiff internally, e.g. Tsit5/Verner). The Val{true} method used by algorithms like Rosenbrock/BDF wraps jac/tgrad/f separately and is not covered here.

Fixes the promote_f part of SciML/SciMLSensitivity.jl#1427.