### PR TITLE
Fix umbrella QA project count after multirate split

### DIFF
--- a/test/qa/qa_tests.jl
+++ b/test/qa/qa_tests.jl
@@ -17,7 +17,7 @@ using Test
             occursin(r"(?m)^OrdinaryDiffEqCore = ", project)
         has_muladdmacro && uses_core
     end
-    @test length(projects) == 39
+    @test length(projects) == 40
     for package in projects
         project = read(joinpath(lib_dir, package, "Project.toml"), String)
         floor_match = match(r"(?m)^MuladdMacro = \"([0-9]+\.[0-9]+\.[0-9]+)", project)


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Update the umbrella QA guard from 39 to 40 projects. `OrdinaryDiffEqMultirateImplicit`, added by https://github.com/SciML/OrdinaryDiffEq.jl/pull/4115, depends on `OrdinaryDiffEqCore` and declares a `MuladdMacro` compat floor, so it is intentionally included by this check.

A scripted bisect identified https://github.com/SciML/OrdinaryDiffEq.jl/commit/4bf7627b75e881a14613f1b708f106e4243a882c as the first failing commit. Its parent produces 39 matching projects; that commit adds `OrdinaryDiffEqMultirateImplicit` as the 40th.

## Verification

Failing before the fix on clean `upstream/master` at `ca6e75f5554727003190c6759b47739fc6669d9c`:

```text
$ GROUP=QA ~/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test()'
PureKLU-compatible MuladdMacro floors: Test Failed at test/qa/qa_tests.jl:20
  Expression: length(projects) == 39
   Evaluated: 40 == 39
Test Summary:           | Pass  Fail  Total
Quality Assurance Tests |   89     1     90
ERROR: Package OrdinaryDiffEq errored during testing
```

The same failure occurred in the introducing PR's Actions job: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/31338186806/job/93308671126.

Passing after the fix:

```text
$ GROUP=QA ~/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test()'
Test Summary:           | Pass  Total   Time
Quality Assurance Tests |   90     90  14.5s
     Testing OrdinaryDiffEq tests passed
```

Formatting and spelling:

```text
$ julia -m Runic --check test/qa/qa_tests.jl
$ typos test/qa/qa_tests.jl
$ git diff --check
```

All three exited successfully with no output.

## Not verified

I did not run `GROUP=Everything`, GPU tests, or downstream groups. This changes only the expected size of the project set already exercised by the QA group. No docs or public API were changed, so the docs build was not run.
