### PR TITLE
Document ODENLStepData in the common interface

### DIFF
--- a/docs/src/api/common_interface.md
+++ b/docs/src/api/common_interface.md
@@ -49,6 +49,7 @@ OrdinaryDiffEq.VectorContinuousCallback
 ```@docs
 OrdinaryDiffEq.ReturnCode
 OrdinaryDiffEq.ODEAliasSpecifier
+SciMLBase.ODENLStepData
 OrdinaryDiffEq.add_tstop!
 OrdinaryDiffEq.derivative_discontinuity!
 OrdinaryDiffEq.reinit!


### PR DESCRIPTION
## What changed

Add `SciMLBase.ODENLStepData` to the rendered common-interface API block. SciMLBase moved this public type into its nonlinear-step interface, but OrdinaryDiffEq's existing cross-reference had no local documentation anchor and made the docs build fail.

Draft: please ignore until reviewed by @ChrisRackauckas.

## Verification

### Failing before

On clean OrdinaryDiffEq master `ca6e75f5554727003190c6759b47739fc6669d9c`:

```console
$ /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=docs docs/make.jl
ERROR: LoadError: makedocs encountered errors [:cross_references]
Cannot resolve @ref for md"[`ODENLStepData`](@ref SciMLBase.ODENLStepData)" in docs/src/api/common_interface.md.
```

The failure bisects to SciMLBase commit `2b711f36b1cd93d5da098997081a416bcec1e07b`, which introduced the nonlinear-step interface in https://github.com/SciML/SciMLBase.jl/pull/1509. Its parent builds these OrdinaryDiffEq docs without the cross-reference error.

### Passing after

On current OrdinaryDiffEq master `9b5ea0b3b4a16b7417b2857efd5a94927c7de193` plus this commit:

```console
$ /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=docs docs/make.jl
[ Info: Populate
[ Info: RenderDocument
[ Info: HTMLWriter
[ Info: Automatic `version="7.5.0"` for inventory from ../Project.toml
```

The command exited 0. It emitted only existing HTML-size and deployment-environment warnings; there were no cross-reference or other Documenter errors.

```console
$ GROUP=QA /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Test Summary:           | Pass  Total   Time
Quality Assurance Tests |   90     90  13.8s
     Testing OrdinaryDiffEq tests passed
```

Also passed:

```console
$ /home/crackauc/.juliaup/bin/julia +release -m Runic --check .
$ git diff --check
$ git diff --unified=0 | sed -n '/^+++ /d; /^+[^+]/s/^+//p' | typos --format brief -
```

I did not run GPU, downstream, Julia pre, or the full `GROUP=Everything` matrix; this is a one-line documentation-only change.

## Links

- Introducing SciMLBase commit: https://github.com/SciML/SciMLBase.jl/commit/2b711f36b1cd93d5da098997081a416bcec1e07b
- Introducing SciMLBase PR: https://github.com/SciML/SciMLBase.jl/pull/1509
