### PR TITLE
Render AutoRespecialize in the API docs

### DIFF
--- a/docs/src/api/common_interface.md
+++ b/docs/src/api/common_interface.md
@@ -49,6 +49,7 @@ OrdinaryDiffEq.VectorContinuousCallback
 ```@docs
 OrdinaryDiffEq.ReturnCode
 OrdinaryDiffEq.ODEAliasSpecifier
+SciMLBase.ODENLStepData
 OrdinaryDiffEq.add_tstop!
 OrdinaryDiffEq.derivative_discontinuity!
 OrdinaryDiffEq.reinit!

--- a/docs/src/api/diffeqbase.md
+++ b/docs/src/api/diffeqbase.md
@@ -17,6 +17,7 @@ across all parameter struct types; recover the original payload from
 `sol.prob.p` with `RespecializeParams.unpack(sol.prob.p, typeof(p))`.
 
 ```@docs
+SciMLBase.AutoRespecialize
 OrdinaryDiffEq.AutoDePSpecialize
 ```
 


### PR DESCRIPTION
## What changed and why

Render `SciMLBase.AutoRespecialize` beside the deprecated `OrdinaryDiffEq.AutoDePSpecialize` alias. SciMLBase 3.45 changed the alias docstring to link the canonical binding, but OrdinaryDiffEq did not include that binding in its manual, so Documenter treats the embedded cross-reference as unresolved.

This is stacked on https://github.com/SciML/OrdinaryDiffEq.jl/pull/4210 because clean master currently has a second independent unresolved `ODENLStepData` reference. Once that PR merges, this PR's effective diff is one added documentation line.

Draft: please ignore until reviewed by @ChrisRackauckas.

## Verification

The reproducer used Julia 1.12.6 and the exact SciMLBase 3.45.0 registered tree (`b96feb0185ce8ba3586193f37dafcbe40f58788c`, commit `83df03139d036025b223da2b43aa682a437182ca`) in an isolated depot.

### Failing before

With https://github.com/SciML/OrdinaryDiffEq.jl/pull/4210 applied but without this line:

```console
$ JULIA_DEPOT_PATH=/tmp/ode-autorespecialize-docs julia +release --startup-file=no --project=docs --code-coverage=user docs/make.jl
┌ Error: Cannot resolve @ref for md"[`AutoRespecialize`](@ref)" in docs/src/api/diffeqbase.md.
│ - No docstring found in doc for binding `SciMLBase.AutoRespecialize`.
│ - No docstring found in doc for binding `Main.AutoRespecialize`.
ERROR: LoadError: `makedocs` encountered an error [:cross_references] -- terminating build before rendering.
```

The same environment resolves SciMLBase 3.44.0 and builds successfully before developing the 3.45.0 tree, isolating the boundary to the 3.45 rename commit: https://github.com/SciML/SciMLBase.jl/commit/5e773ba55bfb77c619f8a9fa35e1454c185fa14f.

### Passing after

The same full docs command with this line exits 0:

```console
[ Info: Populate: populating indices.
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
[ Info: Automatic `version="7.5.0"` for inventory from ../Project.toml
```

No `AutoRespecialize` cross-reference or other Documenter error remains. Existing non-fatal missing-doc and HTML-size warnings are unchanged.

QA also passes:

```console
$ GROUP=QA JULIA_DEPOT_PATH=/tmp/ode-autorespecialize-docs:$HOME/.julia julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Test Summary:           | Pass  Total   Time
Quality Assurance Tests |   90     90  14.4s
     Testing OrdinaryDiffEq tests passed
```

Also passed:

```console
$ julia +release --startup-file=no -m Runic --check .
$ git diff --check
$ git diff --unified=0 ... | typos --format brief -
```

I did not run GPU, downstream, Julia pre, or `GROUP=Everything`; this is a one-line documentation-only change.

## Links

- Stacked prerequisite: https://github.com/SciML/OrdinaryDiffEq.jl/pull/4210
- Introducing SciMLBase commit: https://github.com/SciML/SciMLBase.jl/commit/5e773ba55bfb77c619f8a9fa35e1454c185fa14f
- Clean-master failing docs job: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/31478955896/job/93739210698
- Prerequisite branch failing only this reference: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/31483418260/job/93753273286
