### PR TITLE
Floor DelayDiffEq test compat at DiffEqDevTools 3.1.3

### DIFF
--- a/lib/DelayDiffEq/Project.toml
+++ b/lib/DelayDiffEq/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.1.3"
+version = "6.1.4"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -64,7 +64,7 @@ DDEProblemLibrary = "0.1"
 BinaryHeaps = "1"
 DiffEqBase = "7"
 DiffEqCallbacks = "4.17.0"
-DiffEqDevTools = "3"
+DiffEqDevTools = "3.1.3"
 DiffEqNoiseProcess = "5.30.0"
 FastBroadcast = "1.3"
 FiniteDiff = "2.27"


### PR DESCRIPTION
## What changed and why

Floor DelayDiffEq's test-only `DiffEqDevTools` compatibility at 3.1.3 and bump the package patch version. DiffEqDevTools 3.1.2 permits RootedTrees 2.6.2, which fails to load with OrderedCollections 2 because it references the removed bare `RungeKuttaMethod`; DiffEqDevTools 3.1.3 raised the RootedTrees floor and is the first compatible release.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

Failing before, in a clean Julia 1.10 environment:

```console
$ JULIA_PKG_PRECOMPILE_AUTO=0 julia +1.10 --startup-file=no -e 'using Pkg; Pkg.activate(".repro-check-before"); Pkg.add([PackageSpec(name="DiffEqDevTools", version=v"3.1.2"), PackageSpec(name="RootedTrees", version=v"2.6.2"), PackageSpec(name="OrderedCollections", version=v"2.0.1")]); using DiffEqDevTools'
DiffEqDevTools v3.1.2
OrderedCollections v2.0.1
RootedTrees v2.6.2
ERROR: LoadError: UndefVarError: `RungeKuttaMethod` not defined
```

Passing with the new floor, using the same Julia version and OrderedCollections version:

```console
$ JULIA_PKG_PRECOMPILE_AUTO=0 julia +1.10 --startup-file=no -e 'using Pkg; Pkg.activate(".repro-check-after"); Pkg.add([PackageSpec(name="DiffEqDevTools", version=v"3.1.3"), PackageSpec(name="OrderedCollections", version=v"2.0.1")]); using DiffEqDevTools; println("DiffEqDevTools load: PASS")'
DiffEqDevTools v3.1.3
OrderedCollections v2.0.1
RootedTrees v2.23.1
DiffEqDevTools load: PASS
```

Relevant package groups:

```console
$ GROUP=DelayDiffEq_Interface julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Testing DelayDiffEq tests passed
Testing OrdinaryDiffEq tests passed
1011.369509 seconds

$ GROUP=DelayDiffEq_Integrators julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Verner Tests | 16  16  1m02.8s
Initialization | 2  2  3.7s
Testing DelayDiffEq tests passed
Testing OrdinaryDiffEq tests passed
1320.398867 seconds
```

QA reached the separately reproducible clean-master ExplicitImports failure and reported no stale-dependency or compatibility failure from this patch:

```console
$ GROUP=QA julia +1.11 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
QA Tests | 17 pass, 2 errors, 19 total
```

Both errors concern the pre-existing accesses to `has_tstop`, `first_tstop`, and `pop_tstop!` through `OrdinaryDiffEqCore` although `Base.which` reports `SciMLBase` as owner. That independent owner-access failure is not silenced or mixed into this mechanical compat PR.

Additional checks:

```console
$ typos lib/DelayDiffEq/Project.toml
$ git diff --check
```

Both exited 0. Runic is not applicable to this TOML-only change. Documentation was not built because no public API, docstring, or docs file changed.

The Interface and Integrators runs preceded the upstream `SciMLTesting = "2.8"` merge. After rebasing, General still offers only SciMLTesting 2.7.0, so those long groups were not repeated; that independent registry blocker is tracked at https://github.com/SciML/SciMLTesting.jl/issues/49.
