### PR TITLE
Fix Rosenbrock strict QA imports

### DIFF
--- a/lib/OrdinaryDiffEqRosenbrock/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrock/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqRosenbrock"
 uuid = "43230ef6-c299-4910-a778-202eb28ce4ce"
-version = "2.6.5"
+version = "2.6.6"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 
 [deps]

--- a/lib/OrdinaryDiffEqRosenbrock/src/OrdinaryDiffEqRosenbrock.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/OrdinaryDiffEqRosenbrock.jl
@@ -5,7 +5,7 @@ import OrdinaryDiffEqCore: alg_adaptive_order, isWmethod, isfsal, _unwrap_val,
     alg_cache, initialize!,
     calculate_residuals!, OrdinaryDiffEqMutableCache,
     OrdinaryDiffEqConstantCache, _ode_interpolant, _ode_interpolant!,
-    _vec, _reshape, perform_step!, trivial_limiter!,
+    _vec, perform_step!, trivial_limiter!,
     OrdinaryDiffEqRosenbrockAdaptiveAlgorithm,
     OrdinaryDiffEqRosenbrockAlgorithm, generic_solver_docstring,
     initialize!, perform_step!, get_fsalfirstlast,
@@ -23,21 +23,20 @@ using ArrayInterface: ArrayInterface
 # Map flat linear-solve results onto the state container (ArrayPartition-safe).
 @inline _restructure_state(template, x) = ArrayInterface.restructure(template, x)
 @inline _restructure_state(template::Number, x) = oftype(template, x)
-using DiffEqBase: @def
 import DifferentiationInterface as DI
 import LinearSolve
 import ForwardDiff
 using FiniteDiff: FiniteDiff
 using LinearAlgebra: mul!, I, norm, lu, UniformScaling
 using ADTypes: ADTypes, AutoFiniteDiff, AutoForwardDiff
-using SciMLBase: LinearAliasSpecifier
+using SciMLBase: @def, LinearAliasSpecifier
 import OrdinaryDiffEqCore, OrdinaryDiffEqDifferentiation
 
 using OrdinaryDiffEqDifferentiation: wrapprecs, calc_tderivative, build_grad_config,
     build_jac_config, issuccess_W, jacobian2W!,
     resize_jac_config!, resize_grad_config!,
     calc_rosenbrock_differentiation!, build_J_W,
-    dolinsolve, WOperator
+    dolinsolve
 
 using OrdinaryDiffEqDifferentiation: calc_rosenbrock_differentiation
 
@@ -147,8 +146,28 @@ include("integrator_interface.jl")
 import PrecompileTools
 import Preferences
 PrecompileTools.@compile_workload begin
-    lorenz = OrdinaryDiffEqCore.lorenz
-    lorenz_oop = OrdinaryDiffEqCore.lorenz_oop
+    function lorenz(du, u, p, t)
+        du[1] = 10.0(u[2] - u[1])
+        du[2] = u[1] * (28.0 - u[3]) - u[2]
+        return du[3] = u[1] * u[2] - (8 / 3) * u[3]
+    end
+    lorenz_oop(u, p, t) = [
+        10.0(u[2] - u[1]),
+        u[1] * (28.0 - u[3]) - u[2],
+        u[1] * u[2] - (8 / 3) * u[3],
+    ]
+    function lorenz_p(du, u, p, t)
+        du[1] = p.σ * (u[2] - u[1])
+        du[2] = u[1] * (p.ρ - u[3]) - u[2]
+        return du[3] = u[1] * u[2] - p.β * u[3]
+    end
+    lorenz_p_params = (σ = 10.0, ρ = 28.0, β = 8 / 3)
+    function lorenz_pref(du, u, p, t)
+        du[1] = p[1] * (u[2] - u[1])
+        du[2] = u[1] * (p[2] - u[3]) - u[2]
+        return du[3] = u[1] * u[2] - p[3] * u[3]
+    end
+    lorenz_pref_params = [10.0, 28.0, 8 / 3]
     solver_list = [Rosenbrock23(), Rodas5P()]
     prob_list = []
 
@@ -178,8 +197,8 @@ PrecompileTools.@compile_workload begin
         push!(
             prob_list,
             ODEProblem{true, SciMLBase.AutoDespecialize}(
-                OrdinaryDiffEqCore.lorenz_p, [1.0; 0.0; 0.0],
-                (0.0, 1.0), OrdinaryDiffEqCore.lorenz_p_params
+                lorenz_p, [1.0; 0.0; 0.0],
+                (0.0, 1.0), lorenz_p_params
             )
         )
     end
@@ -188,15 +207,15 @@ PrecompileTools.@compile_workload begin
         push!(
             prob_list,
             ODEProblem{true, SciMLBase.AutoDePSpecialize}(
-                OrdinaryDiffEqCore.lorenz_p, [1.0; 0.0; 0.0],
-                (0.0, 1.0), OrdinaryDiffEqCore.lorenz_p_params
+                lorenz_p, [1.0; 0.0; 0.0],
+                (0.0, 1.0), lorenz_p_params
             )
         )
         push!(
             prob_list,
             ODEProblem{true, SciMLBase.AutoDePSpecialize}(
-                OrdinaryDiffEqCore.lorenz_pref, [1.0; 0.0; 0.0],
-                (0.0, 1.0), OrdinaryDiffEqCore.lorenz_pref_params
+                lorenz_pref, [1.0; 0.0; 0.0],
+                (0.0, 1.0), lorenz_pref_params
             )
         )
     end

--- a/lib/OrdinaryDiffEqRosenbrock/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/qa/qa.jl
@@ -11,11 +11,9 @@ using SciMLTesting, OrdinaryDiffEqRosenbrock, Test
 # Explicitly-imported names that are non-public in (and/or owned outside) the
 # module they are imported from.
 const ROSENBROCK_INTERNAL_EXPLICIT_IMPORTS = (
-    Symbol("@def"),                          # owner SciMLBase (MacroTools codegen macro), non-public
-    :_reshape, :_unwrap_val, :_vec,          # owner SciMLBase, non-public internals
+    :_unwrap_val, :_vec,                     # owner SciMLBase, non-public internals
     :calculate_residuals, :calculate_residuals!, :initialize!,  # owner DiffEqBase, non-public
     :copyat_or_push!,                        # owner RecursiveArrayTools, non-public
-    :WOperator,                              # owner SciMLOperators, non-public
     :trivial_limiter!,                       # OrdinaryDiffEqCore owner-internal, non-public
 )
 
@@ -23,7 +21,7 @@ const ROSENBROCK_INTERNAL_EXPLICIT_IMPORTS = (
 # module they are accessed through.
 const ROSENBROCK_INTERNAL_QUALIFIED_ACCESSES = (
     Symbol("@set"),        # owner Accessors, accessed via SciMLBase.@set, non-public
-    :lorenz, :lorenz_oop, :lorenz_p, :lorenz_p_params,  # OrdinaryDiffEqCore precompile-workload helpers, non-public
+    :Cartesian,            # Base's bounded unroll macro is required by the fused kernels.
     :setindex,             # Base internal, non-public
 )
 
@@ -33,6 +31,9 @@ run_qa(
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (
+        # `@reexport using SciMLBase` makes this explicitly imported public macro
+        # appear implicit to ExplicitImports.
+        no_implicit_imports = (; ignore = (Symbol("@def"),)),
         all_explicit_imports_via_owners = (; ignore = ROSENBROCK_INTERNAL_EXPLICIT_IMPORTS),
         all_explicit_imports_are_public = (; ignore = ROSENBROCK_INTERNAL_EXPLICIT_IMPORTS),
         all_qualified_accesses_via_owners = (; ignore = ROSENBROCK_INTERNAL_QUALIFIED_ACCESSES),


### PR DESCRIPTION
## What changed and why

Current master fails the Rosenbrock strict-QA group for two stale imports and three non-public qualified accesses. This revision removes the stale imports, imports `@def` from its public owner (`SciMLBase`), and defines the small Lorenz precompile workload locally instead of accessing `OrdinaryDiffEqCore` internals. `Base.Cartesian` remains a documented, narrowly scoped allow-list entry: its bounded unroll macro is required by the fused Rosenbrock kernels and is not public API.

The package patch version is bumped to 2.6.6. This changes no user-facing public API, docstring, or documentation page.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

Clean current master, `9d92d1c72`, fails the exact strict QA group:

```console
$ GROUP=OrdinaryDiffEqRosenbrock_QA julia +1.12 --project=. --startup-file=no -e 'using Pkg; Pkg.test(; coverage = false)'
Aqua | 19 pass, 2 errors
```

The failures report stale `_reshape` and `WOperator` imports, and non-public accesses to `Base.Cartesian`, `OrdinaryDiffEqCore.lorenz_pref`, and `OrdinaryDiffEqCore.lorenz_pref_params`.

The rebased change passes:

```console
$ GROUP=OrdinaryDiffEqRosenbrock_QA julia +1.12 --project=. --startup-file=no -e 'using Pkg; Pkg.test(; coverage = false)'
Allocation Tests | 20 broken, 20 total
Inference Tests  | 40 pass, 40 total
JET Tests        |  1 pass,  1 total
Aqua             | 21 pass, 21 total
Testing OrdinaryDiffEqRosenbrock tests passed
Testing OrdinaryDiffEq tests passed
```

The relevant functional group also passes:

```console
$ GROUP=OrdinaryDiffEqRosenbrock_Core julia +1.12 --project=. --startup-file=no -e 'using Pkg; Pkg.test(; coverage = false)'
DAE Rosenbrock AD Tests |  16 pass,  16 total
Rosenbrock AD Tests     |  64 pass,  64 total
Rosenbrock Convergence Tests | 191 pass, 191 total
Testing OrdinaryDiffEqRosenbrock tests passed
Testing OrdinaryDiffEq tests passed
```

Runic, `typos`, and `git diff --check` all exited 0. Documentation was not built because no public API or documentation changed.

Fresh CI was triggered by this update.