### PR TITLE
Retain Polyester as an Extrapolation test extra

### DIFF
--- a/lib/OrdinaryDiffEqExtrapolation/Project.toml
+++ b/lib/OrdinaryDiffEqExtrapolation/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExtrapolation"
 uuid = "becaefa8-8ca2-5cf9-886d-c06f3d2bd2c4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.5.0"
+version = "2.5.1"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
@@ -20,6 +20,7 @@ SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"


### PR DESCRIPTION
## What changed and why

Keep Polyester in OrdinaryDiffEqExtrapolation's test extras as well as its weak dependencies, and bump the package patch version. The downgrade action promotes test-target weak dependencies to hard dependencies and removes their weak-dependency entry to preserve the locked floor; without a matching extras entry, Julia's test sandbox rejects the still-declared test target before any tests run.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

Failing before, from clean master https://github.com/SciML/OrdinaryDiffEq.jl/commit/9b5ea0b3b4a16b7417b2857efd5a94927c7de193, after running `julia-actions/julia-downgrade-compat@v2` commit https://github.com/julia-actions/julia-downgrade-compat/commit/30b83cf94e89744fcbd7ea5496be4967d6fbe540 in `alldeps` mode for this sublibrary:

```console
$ GROUP=Core JULIA_DEPOT_PATH="$PWD/.extrapolation-before-depot" JULIA_PKG_PRECOMPILE_AUTO=0 julia +1.11 --startup-file=no --project=lib/OrdinaryDiffEqExtrapolation -e 'using Pkg; Pkg.test(; force_latest_compatible_version=false, allow_reresolve=false)'
ERROR: `Polyester` declared as a `test` dependency, but no such entry in `extras` or `weakdeps`
```

The action's output immediately before the failure confirmed that it promoted `Polyester` into `[deps]`, deleted it from `[weakdeps]`, and updated the locked manifest.

Passing after, using the same clean-master commit, action commit, generated floor graph, Julia version, and locked test command:

```console
$ GROUP=Core JULIA_DEPOT_PATH="$PWD/.extrapolation-after-depot" JULIA_PKG_PRECOMPILE_AUTO=0 julia +1.11 --startup-file=no --project=lib/OrdinaryDiffEqExtrapolation -e 'using Pkg; Pkg.test(; force_latest_compatible_version=false, allow_reresolve=false)'
Extrapolation Utility Tests |  14 pass,  14 total, 6m06.2s
Extrapolation Tests         | 284 pass, 284 total, 13m57.6s
Threading Linear Solver Tests | 32 pass, 32 total, 4m12.4s
Testing OrdinaryDiffEqExtrapolation tests passed
```

Current-master QA reached one separate pre-existing ExplicitImports failure and reported no metadata failure from this patch:

```console
$ GROUP=QA JULIA_DEPOT_PATH="$PWD/.extrap-current-depot" julia +1.11 --startup-file=no --project=lib/OrdinaryDiffEqExtrapolation -e 'using Pkg; Pkg.test()'
Allocation Tests | 7 broken, 7 total, 9m22.4s
JET Tests        | 1 pass, 1 total, 1m51.1s
Aqua             | 20 pass, 1 error, 21 total, 2m34.1s
```

The Aqua error is the independent clean-master access to non-public `Base.Threads.threadpoolsize` at `src/utils.jl:58`. It is not silenced or mixed into this mechanical metadata PR.

Additional checks:

```console
$ typos lib/OrdinaryDiffEqExtrapolation/Project.toml
$ git diff --check
```

Both exited 0. Runic is not applicable to this TOML-only change. Documentation was not built because no public API, docstring, or docs file changed.
