### PR TITLE
Require SciMLPublic 1.1 for downgrade compatibility

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -84,7 +84,7 @@ PreallocationTools = "1.1.2"
 DiffEqBase = "7.10"
 SafeTestsets = "0.1.0"
 SciMLOperators = "1.24.4"
-SciMLPublic = "1"
+SciMLPublic = "1.1.0"
 SparseConnectivityTracer = "1"
 ConstructionBase = "1.5.8"
 


### PR DESCRIPTION
Require the first SciMLPublic release containing the public macro support used by the downgrade matrix.

Verification:
- Minimal downgraded resolver selected SciMLBase 3.43.0 and SciMLPublic 1.1.0.
- GROUP=InterfaceI downgrade test passed locally in 3643 seconds on the identical one-line change before rebasing onto current master.
- Current master root test is separately blocked by its unreleased SciMLBase 3.46+ floor; an independent clean-master investigation is in progress.
- git diff --check passed; no source or [sources]/path changes.

Ignore until reviewed by @ChrisRackauckas.