### PR TITLE
Use public thread-count APIs in Extrapolation

### DIFF
--- a/lib/OrdinaryDiffEqExtrapolation/Project.toml
+++ b/lib/OrdinaryDiffEqExtrapolation/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExtrapolation"
 uuid = "becaefa8-8ca2-5cf9-886d-c06f3d2bd2c4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.5.1"
+version = "2.5.2"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/OrdinaryDiffEqExtrapolation/src/utils.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/utils.jl
@@ -55,5 +55,5 @@ macro threaded(option, ex)
 end
 
 @inline function _thread_storage_size()
-    return Threads.threadpoolsize(:default) + Threads.threadpoolsize(:interactive)
+    return Threads.nthreads(:default) + Threads.nthreads(:interactive)
 end

--- a/lib/OrdinaryDiffEqExtrapolation/test/utils_tests.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/utils_tests.jl
@@ -27,5 +27,5 @@ const ODEX = OrdinaryDiffEqExtrapolation
     @test ODEX._controller_scalar_type((; qmax = Float32(2))) === Float32
 
     @test ODEX._thread_storage_size() ==
-        Threads.threadpoolsize(:default) + Threads.threadpoolsize(:interactive)
+        Threads.nthreads(:default) + Threads.nthreads(:interactive)
 end


### PR DESCRIPTION
## What changed

Use the public `Threads.nthreads(pool)` API instead of `Threads.threadpoolsize(pool)` when sizing Extrapolation's per-thread storage. The two APIs report the same pool sizes on supported Julia releases, while `threadpoolsize` is not public on Julia 1.11 and therefore fails strict ExplicitImports QA. The package patch version is bumped from 2.5.1 to 2.5.2.

This PR should be ignored until reviewed by @ChrisRackauckas.

## Failing before

From `lib/OrdinaryDiffEqExtrapolation` on the unfixed code:

    GROUP=QA JULIA_NUM_THREADS=2 timeout 3600 julia +1.12 --project=. -e 'using Pkg; Pkg.test()'

The allocation checks reported the seven existing broken tests and JET passed 1/1, then Aqua failed strict ExplicitImports:

    all_qualified_accesses_are_public: Error During Test
    Base.Threads.threadpoolsize is not public
    Aqua | 20 passed, 1 errored

The access was introduced in https://github.com/SciML/OrdinaryDiffEq.jl/commit/14d67d07a9fd78d66063c77077cad65c90206907; its parent https://github.com/SciML/OrdinaryDiffEq.jl/commit/4ad7676112b5570e00fdd76e571e0dbbcdcefa99 does not contain the access.

## Passing after

The identical QA command against the patched package completed:

    Allocation Tests | 7 broken
    JET Tests | 1 passed
    Aqua | 21 passed
    Testing OrdinaryDiffEqExtrapolation tests passed

The full relevant group also passed:

    GROUP=Core JULIA_NUM_THREADS=2 timeout 3600 julia +1.12 --project=. -e 'using Pkg; Pkg.test()'

    Utility Tests | 14 passed
    Extrapolation Tests | 284 passed
    Threading Tests | 32 passed
    Testing OrdinaryDiffEqExtrapolation tests passed

Direct controls with `--threads=2,1` showed `nthreads(:default) + nthreads(:interactive)` equals the previous `threadpoolsize` expression on Julia 1.10, 1.11, and 1.12 (2 with two threads and 1 with one thread). On Julia 1.11, `Base.ispublic(Base.Threads, :nthreads)` is true and `Base.ispublic(Base.Threads, :threadpoolsize)` is false.

After rebasing onto the merged Polyester metadata fix, the following checks passed again:

    julia +1.12 --project=.runic-env -e 'using Runic; exit(Runic.main(["--check", "lib/OrdinaryDiffEqExtrapolation/src/utils.jl", "lib/OrdinaryDiffEqExtrapolation/test/utils_tests.jl"]))'
    typos lib/OrdinaryDiffEqExtrapolation/Project.toml lib/OrdinaryDiffEqExtrapolation/src/utils.jl lib/OrdinaryDiffEqExtrapolation/test/utils_tests.jl
    git diff --check upstream/master...HEAD

## Not verified

No GPU tests were run. No documentation build was run because this changes neither public API nor documentation.
