### PR TITLE
Test: import PDIRK allocation APIs from owners

### DIFF
--- a/lib/OrdinaryDiffEqPDIRK/test/qa/Project.toml
+++ b/lib/OrdinaryDiffEqPDIRK/test/qa/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 OrdinaryDiffEqPDIRK = "5dd0a6cf-3d4b-4314-aa06-06d4e299bc89"
@@ -11,6 +12,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 AllocCheck = "0.2"
 Aqua = "0.8.11"
+CommonSolve = "0.2.6"
 JET = "0.9, 0.11"
 SciMLTesting = "2.8"
 julia = "1.10"

--- a/lib/OrdinaryDiffEqPDIRK/test/qa/allocation_tests.jl
+++ b/lib/OrdinaryDiffEqPDIRK/test/qa/allocation_tests.jl
@@ -1,6 +1,7 @@
 using OrdinaryDiffEqPDIRK
 using OrdinaryDiffEqCore
-using SciMLBase: FullSpecialize
+using CommonSolve: init, step!
+using SciMLBase: FullSpecialize, ODEProblem
 using AllocCheck
 using Test
 


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Import the allocation test's interface names from their declaration owners: `ODEProblem` and `FullSpecialize` from SciMLBase, and `init` and `step!` from CommonSolve. Add CommonSolve 0.2.6 to the isolated PDIRK QA environment.

CommonSolve is MIT licensed, matching OrdinaryDiffEq.jl.

PDIRK stopped blanket-reexporting SciMLBase in https://github.com/SciML/OrdinaryDiffEq.jl/commit/bf4e4c9179d6946b52033984638602e78d0141ed. That correctly tightened the package API, but this allocation test still depended on those incidental exports and now fails before exercising PDIRK.

The failure is visible in https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/31499890955/job/93815903443.

## Verification

All local commands used Julia 1.12.6, one Julia thread, an isolated depot, the eager General registry flavor used by CI, and the current compatible graph including SciMLBase 3.46.0 and SciMLTesting 2.8.0.

### Failing before

On unmodified master `bb08eb9e9d451b830a610489c2cf7c8f416937ee`:

```sh
GROUP=QA JULIA_PKG_SERVER_REGISTRY_PREFERENCE=eager JULIA_DEPOT_PATH="$PWD/../../../.pdirk-eager-depot" JULIA_PKG_PRECOMPILE_AUTO=0 JULIA_NUM_THREADS=1 timeout 3600 ~/.juliaup/bin/julia +1.12 --project=. -e 'using Pkg; Pkg.test(; coverage=false, julia_args=["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version=false, allow_reresolve=true)'
```

```text
PDIRK Allocation Tests: Error During Test at test/qa/allocation_tests.jl:7
UndefVarError: `ODEProblem` not defined
Test Summary:            | Error  Total     Time
Allocation Tests         |     1      1  6m56.0s
  PDIRK Allocation Tests |     1      1     3.9s
ERROR: Package OrdinaryDiffEqPDIRK errored during testing
```

### Passing after

The identical `GROUP=QA` command exits 0:

```text
Test Summary:    | Broken  Total   Time
Allocation Tests |      1      1  49.1s
Test Summary: | Pass  Total     Time
JET Tests     |    1      1  3m36.5s
Test Summary: | Pass  Total     Time
Aqua          |   21     21  2m23.7s
Test Summary:     | Pass  Total     Time
Convergence Tests |    4      4  3m43.1s
Testing OrdinaryDiffEqPDIRK tests passed
```

The pre-existing allocation assertion remains intentionally marked broken; this change does not suppress or loosen it.

After rebasing onto master `ac9271faf78f478aeb9eb582c9d5a355a3699cd6`, the focused allocation file also exits 0:

```text
Test Summary:          | Broken  Total   Time
PDIRK Allocation Tests |      1      1  48.6s
```

The Core-only route:

```sh
GROUP=Core JULIA_PKG_SERVER_REGISTRY_PREFERENCE=eager JULIA_DEPOT_PATH="$PWD/../../../.pdirk-eager-depot" JULIA_PKG_PRECOMPILE_AUTO=0 JULIA_NUM_THREADS=1 timeout 3600 ~/.juliaup/bin/julia +1.12 --project=. -e 'using Pkg; Pkg.test(; coverage=false, julia_args=["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version=false, allow_reresolve=true)'
# Test Summary:     | Pass  Total     Time
# Convergence Tests |    4      4  5m18.7s
# Testing OrdinaryDiffEqPDIRK tests passed
```

Static checks:

```sh
~/.juliaup/bin/julia +1.12 --startup-file=no -m Runic --check lib/OrdinaryDiffEqPDIRK/test/qa/allocation_tests.jl
# exited 0

typos lib/OrdinaryDiffEqPDIRK/test/qa/allocation_tests.jl lib/OrdinaryDiffEqPDIRK/test/qa/Project.toml
# exited 0

git diff --check
# exited 0
```

### Introducing boundary

The unchanged allocation file passes on parent https://github.com/SciML/OrdinaryDiffEq.jl/commit/b526d569ae4dcd80b8a311b9c713f9b197dd8fe0:

```text
Test Summary:          | Broken  Total   Time
PDIRK Allocation Tests |      1      1  47.2s
```

It fails on https://github.com/SciML/OrdinaryDiffEq.jl/commit/bf4e4c9179d6946b52033984638602e78d0141ed:

```text
UndefVarError: `ODEProblem` not defined in `Main`
Test Summary:          | Error  Total  Time
PDIRK Allocation Tests |     1      1  2.8s
```

Runtime binding checks confirm `SciMLBase.ODEProblem` is owned by SciMLBase, while both `CommonSolve.init` and `CommonSolve.step!` are owned by CommonSolve. SciMLBase's `init` and `step!` bindings also resolve to CommonSolve, so importing them through SciMLBase would rely on a reexport.

Docs were not built because this changes only tests and their isolated environment; it does not touch documentation, docstrings, or public API. GPU and unrelated sublibrary groups were not run.
