### PR TITLE
Fix Delay tstop extension ownership

### DIFF
--- a/lib/DelayDiffEq/Project.toml
+++ b/lib/DelayDiffEq/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.1.4"
+version = "6.1.5"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/DelayDiffEq/src/integrators/utils.jl
+++ b/lib/DelayDiffEq/src/integrators/utils.jl
@@ -303,13 +303,13 @@ function add_next_discontinuities!(integrator, order, t = integrator.t)
 end
 
 # Interface for accessing and removing next time stops and discontinuities
-function OrdinaryDiffEqCore.has_tstop(integrator::DDEIntegrator)
+function SciMLBase.has_tstop(integrator::DDEIntegrator)
     return _has(integrator.opts.tstops, integrator.tstops_propagated)
 end
-function OrdinaryDiffEqCore.first_tstop(integrator::DDEIntegrator)
+function SciMLBase.first_tstop(integrator::DDEIntegrator)
     return _first(integrator.opts.tstops, integrator.tstops_propagated)
 end
-function OrdinaryDiffEqCore.pop_tstop!(integrator::DDEIntegrator)
+function SciMLBase.pop_tstop!(integrator::DDEIntegrator)
     return _pop!(integrator.opts.tstops, integrator.tstops_propagated)
 end
 


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Define DelayDiffEq's `has_tstop`, `first_tstop`, and `pop_tstop!` methods through `SciMLBase`, which owns, exports, and documents those integrator interfaces. Defining the methods through the OrdinaryDiffEqCore reexport made both ExplicitImports ownership checks fail. The DelayDiffEq patch version is bumped to 6.1.5.

Closes https://github.com/SciML/OrdinaryDiffEq.jl/issues/4182.

## Failing before

On unmodified current master, with the current SciMLBase and SciMLTesting owner checkouts routed into the DelayDiffEq test environment:

```sh
GROUP=QA JULIA_NUM_THREADS=2 JULIA_PKG_PRECOMPILE_AUTO=0 timeout 3600 julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
```

```text
Test Summary: | Pass  Error  Total
QA Tests      |   18      2     20

QualifiedAccessesFromNonOwnerException:
has_tstop   has owner SciMLBase but was accessed from OrdinaryDiffEqCore
first_tstop has owner SciMLBase but was accessed from OrdinaryDiffEqCore
pop_tstop!  has owner SciMLBase but was accessed from OrdinaryDiffEqCore
```

The owner mismatch entered with the initial DelayDiffEq monorepo import:
https://github.com/SciML/OrdinaryDiffEq.jl/commit/e0fb409ab96b5c5f27da86075205af4b2a8eed4a. Its parent does not contain `lib/DelayDiffEq`.

## Passing after

The identical QA command after the fix, rerun after rebasing onto current master:

```text
Test Summary: | Pass  Total      Time
QA Tests      |   20     20  14m01.6s
Testing DelayDiffEq tests passed
```

The full relevant group also passed:

```sh
GROUP=Integrators JULIA_NUM_THREADS=2 JULIA_PKG_PRECOMPILE_AUTO=0 timeout 3600 julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
```

```text
Cache Tests              | 44 pass
Event Tests              | 20 pass
Iterator Tests           | 12 pass
Reinitialization Tests   | 24 pass
Residual Control Tests   | 18 pass
Return Code Tests        |  6 pass
Rosenbrock Tests         | 42 pass
SDIRK Tests              | 45 pass, 36 existing broken
Unique Timepoints Tests  |  2 pass
Verner Tests             | 16 pass
Initialization           |  2 pass
Testing DelayDiffEq tests passed
```

Additional local checks:

```text
Runic --check: exit 0
typos: exit 0
git diff --check: exit 0
```

## Not verified

The documentation build was not run because this changes dispatch ownership to an existing documented SciMLBase public API; it adds no public name or docstring.
