### PR TITLE
Render StochasticDiffEqCore.DiffCache in developer API docs

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -88,6 +88,7 @@ OrdinaryDiffEqStabilizedRK = {path = "../lib/OrdinaryDiffEqStabilizedRK"}
 OrdinaryDiffEqSymplecticRK = {path = "../lib/OrdinaryDiffEqSymplecticRK"}
 OrdinaryDiffEqTsit5 = {path = "../lib/OrdinaryDiffEqTsit5"}
 OrdinaryDiffEqVerner = {path = "../lib/OrdinaryDiffEqVerner"}
+StochasticDiffEqCore = {path = "../lib/StochasticDiffEqCore"}
 StochasticDiffEqLevyArea = {path = "../lib/StochasticDiffEqLevyArea"}
 StochasticDiffEqWeak = {path = "../lib/StochasticDiffEqWeak"}
 

--- a/docs/src/devtools/internals/public_api.md
+++ b/docs/src/devtools/internals/public_api.md
@@ -391,6 +391,7 @@ algorithm pages to select methods for `solve`.
 StochasticDiffEqCore.AbstractJ
 StochasticDiffEqCore.AbstractJCommute
 StochasticDiffEqCore.AbstractJDiagonal
+StochasticDiffEqCore.DiffCache
 StochasticDiffEqCore.DiffEqNLSolveTag
 StochasticDiffEqCore.IICommutative
 StochasticDiffEqCore.IIFNLSolveFunc


### PR DESCRIPTION
## What changed

- Render `StochasticDiffEqCore.DiffCache` in the existing stochastic solver extension API block.
- Make the docs environment load `StochasticDiffEqCore` from the checked-out monorepo source, matching the other locally documented sublibraries.

This restores the strict rendered-public-API QA lane without an ignore or test suppression. Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Root cause

https://github.com/SciML/OrdinaryDiffEq.jl/commit/da6a633b4f991cae8f518c37e0329b587991f104 enabled rendered-doc checking for `StochasticDiffEqCore` and created its umbrella `@docs` block, but omitted the already-public and documented `DiffCache`. Its parent, https://github.com/SciML/OrdinaryDiffEq.jl/commit/9b5ea0b3b4a16b7417b2857efd5a94927c7de193, configured `rendered = false`; the parent public-doc test therefore passes 1/1 (the full parent QA run has three unrelated ExplicitImports errors fixed by the introducing commit).

Adding only the `@docs` entry exposed a docs-environment version skew: `docs/Project.toml` resolved registered `StochasticDiffEqCore` v2.0.5, whose `DiffCache` docstring still contains an unresolved ``[`get_du`](@ref)``. The local v2.0.6 source already uses the corrected plain `SciMLBase.get_du` wording. The source mapping makes the manual render the code at the checked-out revision.

## Verification

Failing before the fix on clean master `c29f1147ffd59e1c4fa6b305a50d33215fd9070a`:

```console
$ GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test(; coverage=false, julia_args=["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"])'
public API is rendered in docs: Test Failed
  Expression: isempty(unrendered)
   Evaluated: isempty([:DiffCache])
Test Summary:     | Pass  Fail  Total
QA (Aqua and JET) |   20     1     21
```

Passing after the complete fix:

```console
$ GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test(; coverage=false, julia_args=["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"])'
Test Summary:     | Pass  Total     Time
QA (Aqua and JET) |   21     21  1m39.0s
     Testing StochasticDiffEqCore tests passed

$ GROUP=Core julia +1.12 --project=. -e 'using Pkg; Pkg.test(; coverage=false, julia_args=["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"])'
Test Summary:          | Pass  Total  Time
Module loads and types |   13     13  2.7s
     Testing StochasticDiffEqCore tests passed

$ julia +1.12 --project=docs -e 'using Pkg; Pkg.instantiate()'
$ julia +1.12 --project=docs docs/make.jl
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
[ Info: Automatic `version="7.6.0"` for inventory from ../Project.toml
```

The docs command initially failed after the `@docs` addition and before the source mapping with:

```console
ERROR: Cannot resolve @ref for md"[`get_du`](@ref)" in docs/src/devtools/internals/public_api.md.
- No docstring found in doc for binding `SciMLBase.get_du`.
ERROR: `makedocs` encountered an error [:cross_references]
```

Additional checks:

```console
$ julia +1.12 -m Runic --check .
# exit 0
$ typos docs/Project.toml docs/src/devtools/internals/public_api.md
# exit 0
$ git diff --check
# exit 0
```

Not run locally: `GROUP=Everything`, GPU jobs, downstream jobs, or Julia-version matrix lanes.

## Links

- Failing CI job: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/31499890955/job/93815902505
- Introducing commit: https://github.com/SciML/OrdinaryDiffEq.jl/commit/da6a633b4f991cae8f518c37e0329b587991f104
- Passing parent control for the rendered-doc configuration: https://github.com/SciML/OrdinaryDiffEq.jl/commit/9b5ea0b3b4a16b7417b2857efd5a94927c7de193
