### PR TITLE
Stabilize sparse isdiag complexity timing

### DIFF
--- a/lib/OrdinaryDiffEqCore/test/sparse_isdiag_tests.jl
+++ b/lib/OrdinaryDiffEqCore/test/sparse_isdiag_tests.jl
@@ -3,6 +3,19 @@ using Test
 using SparseArrays
 using OrdinaryDiffEqCore: _isdiag
 
+function median_isdiag_runtime(A; samples = 5, evaluations = 10)
+    times = map(1:samples) do _
+        is_diagonal = true
+        elapsed = @elapsed for _ in 1:evaluations
+            is_diagonal &= _isdiag(A)
+        end
+        @assert is_diagonal
+        elapsed
+    end
+    sort!(times)
+    return times[cld(samples, 2)]
+end
+
 @testset "Sparse isdiag Performance" begin
     # Test 1: Correctness - _isdiag should correctly identify diagonal matrices
     @testset "Correctness" begin
@@ -46,14 +59,8 @@ using OrdinaryDiffEqCore: _isdiag
         _isdiag(M_small)
         _isdiag(M_large)
 
-        # Measure
-        t_small = @elapsed for _ in 1:10
-            _isdiag(M_small)
-        end
-
-        t_large = @elapsed for _ in 1:10
-            _isdiag(M_large)
-        end
+        t_small = median_isdiag_runtime(M_small)
+        t_large = median_isdiag_runtime(M_large)
 
         ratio = t_large / t_small
         size_ratio = n_large / n_small  # 4x size increase
@@ -64,7 +71,7 @@ using OrdinaryDiffEqCore: _isdiag
         @test ratio < size_ratio * 2  # Should be closer to linear than quadratic
 
         # Absolute sanity check: processing 40k diagonal shouldn't take > 100ms
-        t_single = @elapsed _isdiag(M_large)
+        t_single = median_isdiag_runtime(M_large; evaluations = 1)
         @test t_single < 0.1  # Should be < 100ms, typically < 1ms
     end
 


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

The sparse `_isdiag` complexity test currently relies on one timing batch. Under the coverage instrumentation used by CI, a scheduler interruption can inflate the large-matrix batch enough to make the linear implementation appear superlinear. This uses the median of five batches for both timing assertions while preserving the existing `8×` scaling limit and `0.1` second absolute limit.

The failure was introduced with the sparse implementation and its performance test in https://github.com/SciML/OrdinaryDiffEq.jl/commit/f2237e66be9fd0457de6375d6c961c2af653c5d0. A file-introduction `git bisect run` from current master to its passing parent identified that commit as the first bad commit.

## Verification

### Failing before

On Julia 1.10.11 with one thread and `--code-coverage=user`, I repeated the existing one-batch measurement 500 times:

```julia
using SparseArrays, Statistics, OrdinaryDiffEqCore
using OrdinaryDiffEqCore: _isdiag

n_small, n_large = 10_000, 40_000
M_small = sparse(1:n_small, 1:n_small, ones(n_small), n_small, n_small)
M_large = sparse(1:n_large, 1:n_large, ones(n_large), n_large, n_large)
_isdiag(M_small); _isdiag(M_large)

ratios = Float64[]
for _ in 1:500
    t_small = @elapsed for _ in 1:10
        @assert _isdiag(M_small)
    end
    t_large = @elapsed for _ in 1:10
        @assert _isdiag(M_large)
    end
    push!(ratios, t_large / t_small)
end
println("ratio min/q25/median/q75/max=", minimum(ratios), "/", quantile(ratios, 0.25), "/", median(ratios), "/", quantile(ratios, 0.75), "/", maximum(ratios))
println("ratio_ge_8=", count(>=(8), ratios), "/", length(ratios))
```

I ran the program above through Julia's `-e` option with:

```text
JULIA_NUM_THREADS=1 julia +1.10 --code-coverage=user --project=. -e '<program above>'
```

Output:

```text
ratio min/q25/median/q75/max=3.0969039694204374/3.9994936045325638/4.005892300046126/4.015246214092482/12.115939203276966
ratio_ge_8=1/500
```

This is the same signature as https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/31516193816/job/93864623026, where `8.259137864077669 < 8.0` failed.

### Passing after

Repeating 2,000 median-of-five measurements under the same coverage configuration gave:

```text
robust_ratio min/median/p99/max=3.224278024942271/4.008372461193241/4.284103418777201/5.83813559021057
robust_ratio_ge_8=0/2000
```

The exact fixed test passed with coverage:

```text
JULIA_NUM_THREADS=1 julia +1.10 --code-coverage=user --project=. -e 'include("test/sparse_isdiag_tests.jl")'
Test Summary:             | Pass  Total  Time
Sparse isdiag Performance |   10     10  2.8s
```

The full Core group passed using the CI package-test options:

```text
GROUP=Core julia +1.10 --project=. -e 'using Pkg; Pkg.test(; coverage=true, julia_args=["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version=false, allow_reresolve=true)'
Test Summary:             | Pass  Total  Time
Sparse isdiag Performance |   10     10  1.7s
...
Testing OrdinaryDiffEqCore tests passed
```

Mechanical checks passed:

```text
julia +1.12 -m Runic --check lib/OrdinaryDiffEqCore/test/sparse_isdiag_tests.jl
typos lib/OrdinaryDiffEqCore/test/sparse_isdiag_tests.jl
git diff --check
```

`GROUP=QA julia +1.10 --project=. -e 'using Pkg; Pkg.test()'` reached AllocCheck (1/1) and JET (30 pass, 1 pre-existing broken), then hit an unrelated current-master Aqua error: ExplicitImports reports the existing `AutoDespecialize` import as stale. This patch does not touch imports. GPU, downstream, and `GROUP=Everything` were not run.
