### PR TITLE
Use DiffCache accessor in resize test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -66,6 +66,7 @@ OrdinaryDiffEqDefault = "2"
 OrdinaryDiffEqRosenbrock = "2.6.3"
 OrdinaryDiffEqTsit5 = "2"
 OrdinaryDiffEqVerner = "2"
+PreallocationTools = "1.1.2"
 RecursiveArrayTools = "4.2.0"
 SciMLBase = "3.46"
 SciMLLogging = "2.0.0"
@@ -118,6 +119,7 @@ OrdinaryDiffEqStabilizedIRK = "e3e12d00-db14-5390-b879-ac3dd2ef6296"
 OrdinaryDiffEqStabilizedRK = "358294b1-0aab-51c3-aafe-ad5ab194a2ad"
 OrdinaryDiffEqSymplecticRK = "fa646aed-7ef9-47eb-84c4-9443fc8cbfa8"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+PreallocationTools = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 RecursiveFactorization = "f2c3362d-daeb-58d1-803e-2bc74f2840b4"
@@ -136,4 +138,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["ADTypes", "ArrayInterface", "ComponentArrays", "AlgebraicMultigrid", "DiffEqCallbacks", "DifferentiationInterface", "DiffEqDevTools", "ExplicitImports",  "ForwardDiff", "IncompleteLU", "InteractiveUtils", "LinearAlgebra", "LinearSolve", "ODEProblemLibrary", "OrdinaryDiffEqAdamsBashforthMoulton", "OrdinaryDiffEqDifferentiation", "OrdinaryDiffEqExplicitRK", "OrdinaryDiffEqExplicitTableaus", "OrdinaryDiffEqExponentialRK", "OrdinaryDiffEqExtrapolation", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqFeagin", "OrdinaryDiffEqFunctionMap", "OrdinaryDiffEqHighOrderRK", "OrdinaryDiffEqIMEXMultistep", "OrdinaryDiffEqLinear", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqLowStorageRK", "NonlinearSolve", "OrdinaryDiffEqNonlinearSolve", "OrdinaryDiffEqNordsieck", "OrdinaryDiffEqPDIRK", "OrdinaryDiffEqPRK", "OrdinaryDiffEqQPRK", "OrdinaryDiffEqRKN", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqSSPRK", "OrdinaryDiffEqStabilizedIRK", "OrdinaryDiffEqStabilizedRK", "OrdinaryDiffEqSymplecticRK", "ElasticArrays", "JLArrays", "Random", "SafeTestsets", "SciMLOperators", "SciMLTesting", "StableRNGs", "StructArrays", "Test", "Unitful", "Pkg", "RecursiveArrayTools", "RecursiveFactorization", "SparseArrays", "SparseConnectivityTracer", "SparseMatrixColorings", "StaticArrays", "Statistics"]
+test = ["ADTypes", "ArrayInterface", "ComponentArrays", "AlgebraicMultigrid", "DiffEqCallbacks", "DifferentiationInterface", "DiffEqDevTools", "ExplicitImports",  "ForwardDiff", "IncompleteLU", "InteractiveUtils", "LinearAlgebra", "LinearSolve", "ODEProblemLibrary", "OrdinaryDiffEqAdamsBashforthMoulton", "OrdinaryDiffEqDifferentiation", "OrdinaryDiffEqExplicitRK", "OrdinaryDiffEqExplicitTableaus", "OrdinaryDiffEqExponentialRK", "OrdinaryDiffEqExtrapolation", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqFeagin", "OrdinaryDiffEqFunctionMap", "OrdinaryDiffEqHighOrderRK", "OrdinaryDiffEqIMEXMultistep", "OrdinaryDiffEqLinear", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqLowStorageRK", "NonlinearSolve", "OrdinaryDiffEqNonlinearSolve", "OrdinaryDiffEqNordsieck", "OrdinaryDiffEqPDIRK", "OrdinaryDiffEqPRK", "OrdinaryDiffEqQPRK", "OrdinaryDiffEqRKN", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqSSPRK", "OrdinaryDiffEqStabilizedIRK", "OrdinaryDiffEqStabilizedRK", "OrdinaryDiffEqSymplecticRK", "ElasticArrays", "JLArrays", "Random", "SafeTestsets", "SciMLOperators", "SciMLTesting", "StableRNGs", "StructArrays", "Test", "Unitful", "Pkg", "PreallocationTools", "RecursiveArrayTools", "RecursiveFactorization", "SparseArrays", "SparseConnectivityTracer", "SparseMatrixColorings", "StaticArrays", "Statistics"]

--- a/test/Integrators_II/resize_tests.jl
+++ b/test/Integrators_II/resize_tests.jl
@@ -1,5 +1,6 @@
 using OrdinaryDiffEq, Test, ADTypes, SparseMatrixColorings, DiffEqBase, ForwardDiff, SciMLBase, LinearSolve
 using OrdinaryDiffEqLowOrderRK, OrdinaryDiffEqSDIRK, OrdinaryDiffEqRosenbrock
+using PreallocationTools: get_tmp
 import OrdinaryDiffEqDifferentiation.DI
 
 f(du, u, p, t) = du .= u
@@ -242,7 +243,7 @@ runSim(Rosenbrock23(autodiff = AutoFiniteDiff()))
     @test_nowarn resize!(integrator, 2)
     # #1990: SplitFunction scratch buffer must grow with the state
     @test length(integrator.u) == 2
-    @test length(integrator.f._func_cache) == 2
+    @test length(get_tmp(integrator.f._func_cache, integrator.u)) == 2
     # Julia's resize! leaves new entries undefined. Tsit5's next step reads
     # uprev (and fsalfirst), so undef/NaN garbage can collapse dt and make the
     # following @test_nowarn flake. Initialize the new component (same pattern


### PR DESCRIPTION
## What changed

The Integrators II resize test now inspects the `PreallocationTools.DiffCache` through its exported, documented `get_tmp` accessor instead of calling `length` on the cache wrapper. `PreallocationTools` is declared explicitly as a test dependency with a `1.1.2` compat floor. Its MIT license matches this repository's MIT license.

Fixes https://github.com/SciML/OrdinaryDiffEq.jl/issues/4188.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Failing before

On unmodified master, this exact group command failed deterministically:

```sh
GROUP=Integrators_II ~/.juliaup/bin/julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
```

```text
resize! with SplitODEProblem: Error During Test
Expression: length(integrator.f._func_cache) == 2
MethodError: no method matching length(::PreallocationTools.DiffCache{Vector{Float64}, Vector{Float64}})

Test Summary: | Pass Error Total
Resize Tests  |   89     1    90
```

The assertion was introduced by https://github.com/SciML/OrdinaryDiffEq.jl/commit/6bc9d9a7081b49869441b97499129fd5fc98606e; its parent https://github.com/SciML/OrdinaryDiffEq.jl/commit/9af4fde5856eb05103950e692b77a67be1a06b71 does not contain it.

## Passing after

The same command now passes the discriminating suite twice:

```text
Test Summary: | Pass Total    Time
Resize Tests  |   90    90 4m03.2s
```

The first full-group run continued through `Cache Tests` (`214` pass, `4` existing broken) but reached the one-hour shell timeout in a later `ode_add_steps_tests.jl` test without a test failure. I restarted the exact command with the warm cache and a two-hour shell timeout; its final tail was:

```text
Test Summary:   | Pass Total    Time
Add Steps Tests |    1     1 7m33.8s

Test Summary:             | Pass Broken Total     Time
IMEX Split Function Tests |   15      1    16 12m17.9s

5135.211344 seconds
Testing OrdinaryDiffEq tests passed
```

QA on the patched checkout:

```sh
GROUP=QA ~/.juliaup/bin/julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
```

```text
Test Summary:     | Pass Total
Quality Assurance |   90    90
Testing OrdinaryDiffEq tests passed
```

Mechanical checks passed:

```text
Runic: clean
typos over the diff: clean
git diff --check: clean
```

## Not verified locally

I did not run the LTS or Julia-pre matrices locally. The exact current-Julia group and QA were run locally as above.
