### PR TITLE
Floor DelayDiffEq Unitful test compat for Julia pre

### DIFF
--- a/lib/DelayDiffEq/Project.toml
+++ b/lib/DelayDiffEq/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.1.4"
+version = "6.1.5"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -103,7 +103,7 @@ SciMLLogging = "1.10.1, 2"
 SimpleNonlinearSolve = "2.11.1"
 SymbolicIndexingInterface = "0.3.43"
 Test = "<0.0.1, 1"
-Unitful = "1"
+Unitful = "1.25.1"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
## What changed

Raise DelayDiffEq's Unitful test compat floor from `1` to `1.25.1` and bump DelayDiffEq from `6.1.4` to `6.1.5`. Unitful 1.25.1 is the first registered release whose source parses on Julia 1.13; the prior compat allowed the Julia-pre test environment to preserve Unitful 1.24.0 and fail before the units tests could run.

This changes only a test-extra compat bound. It does not add Unitful as a runtime dependency or change public API.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Root cause and boundary

The failing job resolved Unitful 1.24.0 on Julia 1.13.0-rc2 and rejected `Base. *(::MixedUnits, ::MixedUnits) =` at `src/logarithm.jl:127`. A standalone environment importing no SciML package reproduces the parse error with Unitful 1.24.0 and 1.25.0; Unitful 1.25.1 and 1.26.0 load successfully. The owner fix is JuliaPhysics/Unitful.jl@00daf8a44e1e02e5decf5bafda065016843d993d, released in Unitful 1.25.1.

The OrdinaryDiffEq exposure boundary is e0fb409ab96b5c5f27da86075205af4b2a8eed4a, which added DelayDiffEq as a sublibrary with `Unitful = "1"` in its test compat.

## Failing before

Using Julia 1.13.0-rc2, current General commit `576c81254044aedd421ebcc56b26dca361ffcccd`, and a local ignored Manifest pinning Unitful 1.24.0 to model the preserved resolution from CI:

```sh
GROUP=Interface julia +1.13 --project=. -e 'using Pkg; Pkg.test(; coverage=true, julia_args=["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version=false, allow_reresolve=true)'
```

preserved `Unitful v1.24.0`, passed every earlier Interface testset, and failed at the units group:

```text
Base. *(::MixedUnits, ::MixedUnits) =
#   └───────────────────────────────┘ ── extra tokens after end of expression
Test Summary: | Error  Total  Time
Units Tests   |     1      1  4.6s
ERROR: Package DelayDiffEq errored during testing
```

## Passing after

The same command, General commit, depot, and pinned Manifest with this compat floor re-resolved Unitful to 1.28.0 and completed successfully:

```text
Test Summary: | Pass  Total   Time
Units Tests   |   21     21  27.6s
Test Summary:         | Pass  Total     Time
Multi-Algorithm Tests |   28     28  1m44.0s
Testing DelayDiffEq tests passed
```

The full patched Interface run also passed independently in the feature worktree with Unitful 1.28.0:

```text
Test Summary: | Pass  Total   Time
Units Tests   |   21     21  55.6s
Test Summary:         | Pass  Total     Time
Multi-Algorithm Tests |   28     28  1m46.4s
Testing DelayDiffEq tests passed
```

## Other verification

```sh
julia +1.12 --project=@runic -e 'using Runic; exit(Runic.main(["--check", "lib/DelayDiffEq"]))'
typos lib/DelayDiffEq/Project.toml
git diff --check
```

All three exited successfully with no output.

`GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test(; allow_reresolve=true)'` ran locally. Its summary was 18 passed and 2 errors; both are the independent clean-master Delay tstop owner/public-access failure (`has_tstop`, `first_tstop`, and `pop_tstop!`) already addressed by draft PR https://github.com/SciML/OrdinaryDiffEq.jl/pull/4226. This PR does not mix that owner fix. Because both PRs follow the package-version convention, they currently have an expected one-line `6.1.5` version conflict if either lands first.

Docs were not built because this test-only compat change touches no docs, docstrings, or public API. `GROUP=Everything` was not run.

## Links

- Failing CI job: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/31520713874/job/93878511263
- Unitful 1.25.1 release: https://github.com/JuliaPhysics/Unitful.jl/releases/tag/v1.25.1
- Unitful parser fix: https://github.com/JuliaPhysics/Unitful.jl/commit/00daf8a44e1e02e5decf5bafda065016843d993d
- OrdinaryDiffEq exposure commit: https://github.com/SciML/OrdinaryDiffEq.jl/commit/e0fb409ab96b5c5f27da86075205af4b2a8eed4a
- Independent Delay tstop fix: https://github.com/SciML/OrdinaryDiffEq.jl/pull/4226
