### PR TITLE
Fix the adaptive error estimates of MRIGARKERK22a and MIS

### DIFF
--- a/lib/OrdinaryDiffEqMultirate/Project.toml
+++ b/lib/OrdinaryDiffEqMultirate/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqMultirate"
 uuid = "d4b830b4-ac80-426b-8507-16693d424963"
 authors = ["singhharsh1708 <hs1663531@gmail.com>"]
-version = "3.0.2"
+version = "3.0.3"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/OrdinaryDiffEqMultirate/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/algorithms.jl
@@ -189,7 +189,7 @@ step advances through the tableau's outer stages; each stage solves a small
 modified fast ODE on `τ ∈ [0, d_i · dt]` whose right-hand side is the original
 fast rate `f1` plus a constant offset built from prior stages' slow tendencies
 and α/γ corrections. The inner ODE is approximated with `m · d_i` explicit
-midpoint (RK2) micro-steps. Embedded error estimate is `Y_s − Y_{s-1}`.
+midpoint (RK2) micro-steps. The embedded error estimate is `dt * sum(bhat_j * f2(Y_j))` with `bhat = b - btilde`, a first-order embedded solution.
 
 Currently provides the 2nd-order, 4-stage MIS2(4,2) tableau of
 Wensch–Knoth–Galant (BIT 2009).",

--- a/lib/OrdinaryDiffEqMultirate/src/multirate_perform_step.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/multirate_perform_step.jl
@@ -622,7 +622,7 @@ end
 function perform_step!(integrator, cache::MISCache, repeat_step = false)
     (; t, dt, uprev, u, f, p) = integrator
     (; tmp, atmp, v, offset, k_fast, Y, fS, tab) = cache
-    (; α, β, γ, d, c, ctilde) = tab
+    (; α, β, γ, d, c, ctilde, bhat) = tab
 
     f.f1(integrator.fsalfirst, uprev, p, t)
     f.f2(k_fast, uprev, p, t)
@@ -681,7 +681,11 @@ function perform_step!(integrator, cache::MISCache, repeat_step = false)
     @.. broadcast = false u = Y[s]
 
     if integrator.opts.adaptive
-        @.. broadcast = false tmp = Y[s] - Y[s - 1]
+        @.. broadcast = false tmp = (dt * bhat[1]) * fS[1]
+        for j in 2:s
+            iszero(bhat[j]) && continue
+            @.. broadcast = false tmp = tmp + (dt * bhat[j]) * fS[j]
+        end
         calculate_residuals!(
             atmp, tmp, uprev, u,
             integrator.opts.abstol, integrator.opts.reltol,
@@ -700,7 +704,7 @@ end
 
 @muladd function perform_step!(integrator, cache::MISConstantCache, repeat_step = false)
     (; t, dt, uprev, f, p) = integrator
-    (; α, β, γ, d, c, ctilde) = cache.tab
+    (; α, β, γ, d, c, ctilde, bhat) = cache.tab
 
     integrator.fsalfirst = f.f1(uprev, p, t) + f.f2(uprev, p, t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
@@ -760,7 +764,11 @@ end
     integrator.u = Y[s]
 
     if integrator.opts.adaptive
-        utilde = @.. broadcast = false Y[s] - Y[s - 1]
+        utilde = @.. broadcast = false (dt * bhat[1]) * fS[1]
+        for j in 2:s
+            iszero(bhat[j]) && continue
+            utilde = @.. broadcast = false utilde + (dt * bhat[j]) * fS[j]
+        end
         atmp = calculate_residuals(
             utilde, uprev, integrator.u,
             integrator.opts.abstol, integrator.opts.reltol,

--- a/lib/OrdinaryDiffEqMultirate/src/multirate_tableaus.jl
+++ b/lib/OrdinaryDiffEqMultirate/src/multirate_tableaus.jl
@@ -37,7 +37,8 @@ function MRIGARKERK22aTableau(::Type{T}) where {T}
     Δc = T[1 // 2, 1 // 2]
     W0 = T[1 // 2 0; -1 // 2 1]
     W1 = zeros(T, 2, 2)
-    return MRIGARKTableau{T}(Δc, W0, W1, T[], T[], zeros(T, 2), 2)
+    Wemb0 = T[1 // 2, 0]
+    return MRIGARKTableau{T}(Δc, W0, W1, Wemb0, T[], zeros(T, 2), 2)
 end
 
 function MRIGARKERK22bTableau(::Type{T}) where {T}
@@ -96,6 +97,14 @@ struct MISTableau{T}
     d::Vector{T}   # inner-interval lengths, d_i = Σ_j β[i,j]
     c::Vector{T}   # stage abscissae, (I − α − γ)⁻¹ d
     ctilde::Vector{T}  # inner start abscissae, α c
+    bhat::Vector{T}    # b − b̃, slow-quadrature weights of the error estimate
+end
+
+function mis_bhat(α, β, γ, ::Type{T}) where {T}
+    A = (LinearAlgebra.I(size(β, 1)) - α - γ) \ β
+    bhat = Vector{T}(A[end, :])
+    bhat[1] -= one(T)
+    return bhat
 end
 
 function MIS2Tableau(::Type{T}) where {T}
@@ -120,5 +129,5 @@ function MIS2Tableau(::Type{T}) where {T}
     d = T[sum(@view β[i, :]) for i in axes(β, 1)]
     c = (LinearAlgebra.I(length(d)) - α - γ) \ d
     ctilde = α * c
-    return MISTableau{T}(α, β, γ, d, c, ctilde)
+    return MISTableau{T}(α, β, γ, d, c, ctilde, mis_bhat(α, β, γ, T))
 end

--- a/lib/OrdinaryDiffEqMultirate/test/mis_tests.jl
+++ b/lib/OrdinaryDiffEqMultirate/test/mis_tests.jl
@@ -42,4 +42,20 @@ using OrdinaryDiffEqMultirate, DiffEqDevTools, Test, LinearAlgebra
         sim = test_convergence(dts, prob, MIS(m = 4))
         @test sim.𝒪est[:l∞] ≈ 2 atol = 0.3
     end
+
+    @testset "Embedded estimate drives a usable step size" begin
+        prob = SplitODEProblem(
+            (u, p, t) -> -0.9 * u, (u, p, t) -> -0.1 * u, 1.0, (0.0, 1.0)
+        )
+        sol = solve(prob, MIS(m = 10), reltol = 1.0e-6, abstol = 1.0e-6)
+        @test sol.retcode == ReturnCode.Success
+        @test sol.stats.naccept < 2000
+        @test abs(sol.u[end] - exp(-1.0)) < 1.0e-5
+    end
+
+    @testset "Embedded weights are consistent" begin
+        tab = OrdinaryDiffEqMultirate.MIS2Tableau(Float64)
+        @test sum(tab.bhat) ≈ 0 atol = 1.0e-10
+        @test tab.c[end] ≈ 1
+    end
 end

--- a/lib/OrdinaryDiffEqMultirate/test/mri_gark_tests.jl
+++ b/lib/OrdinaryDiffEqMultirate/test/mri_gark_tests.jl
@@ -43,6 +43,16 @@ using OrdinaryDiffEqMultirate, DiffEqDevTools, Test, LinearAlgebra
             sim = test_convergence(dts, prob, MRIGARKERK22a(m = 8))
             @test sim.𝒪est[:l∞] ≈ 2 atol = 0.3
         end
+
+        @testset "Embedded estimate drives a usable step size" begin
+            prob = SplitODEProblem(
+                (u, p, t) -> -0.9 * u, (u, p, t) -> -0.1 * u, 1.0, (0.0, 1.0)
+            )
+            sol = solve(prob, MRIGARKERK22a(m = 10), reltol = 1.0e-6, abstol = 1.0e-6)
+            @test sol.retcode == ReturnCode.Success
+            @test sol.stats.naccept < 2000
+            @test abs(sol.u[end] - exp(-1.0)) < 1.0e-5
+        end
     end
 
     @testset "MRIGARKERK22b" begin


### PR DESCRIPTION
`MRIGARKERK22a` and `MIS` had no real embedded pair, so their error estimate was a stage difference, O(dt) rather than O(dt^2), and the controller drove the step size to nothing; both now difference against a genuine lower-order solution.

The embedded weights come from the equivalent explicit RK form, `A = (I - alpha - gamma)^-1 beta` with `b = A[s,:]`; for MIS2 that `b` has `sum(b) = 1`, `b.c = 1/2` and `b.c^2 = 0.3019`, confirming order 2 and no more, and differencing it against the order-1 weights gives `sum(b - b~) = 0`.

On the split test problem at `reltol = abstol` of 1e-6, 1e-8 and 1e-10 the step counts are 1578, 15766 and 157640 with errors 3.46e-5, 3.45e-7 and 3.44e-9, the expected order-2 scaling.

AI Disclosure: Claude assisted with this change.
