### PR TITLE
Despecialize DAE residual functions

### DIFF
--- a/lib/DiffEqBase/ext/DiffEqBaseForwardDiffExt.jl
+++ b/lib/DiffEqBase/ext/DiffEqBaseForwardDiffExt.jl
@@ -5,7 +5,8 @@ using DiffEqBase.ArrayInterface
 using DiffEqBase: Void, FunctionWrappersWrappers, OrdinaryDiffEqTag,
     AbstractTimeseriesSolution,
     RecursiveArrayTools, _promote_tspan, has_continuous_callback
-import DiffEqBase: hasdualpromote, wrapfun_oop, wrapfun_iip, wrapfun_iip_opaque,
+import DiffEqBase: hasdualpromote, wrapfun_oop, wrapfun_iip, wrapfun_dae_iip,
+    wrapfun_iip_opaque,
     prob2dtmin, promote_tspan, ODE_DEFAULT_NORM
 import SciMLBase: isdualtype, DualEltypeChecker, sse, __sum
 import RespecializeParams
@@ -78,10 +79,36 @@ function _make_fww(
         FW{Nothing, A1}(vff), FW{Nothing, A2}(vff),
         FW{Nothing, A3}(vff), FW{Nothing, A4}(vff),
     )
+    return _make_fww(fwt)
+end
+
+function _make_fww(@nospecialize(vff), ::Type{A1}, ::Type{A2}) where {A1, A2}
+    FW = FunctionWrappersWrappers.FunctionWrappers.FunctionWrapper
+    fwt = (FW{Nothing, A1}(vff), FW{Nothing, A2}(vff))
+    return _make_fww(fwt)
+end
+
+function _make_fww(fwt::Tuple)
     cs = FunctionWrappersWrappers.SingleCacheStorage()
     return FunctionWrappersWrappers.FunctionWrappersWrapper{
         typeof(fwt), FunctionWrappersWrappers.AllowNonIsBits, typeof(cs),
     }(fwt, cs)
+end
+
+function wrapfun_dae_iip(
+        ff,
+        inputs::Tuple{T1, T2, T3, T4, T5},
+        ::Val{CS}
+    ) where {T1, T2, T3, T4, T5, CS}
+    dualT = dualgen(eltype(T3), Val(CS))
+    dualT1 = ArrayInterface.promote_eltype(T1, dualT)
+    dualT2 = ArrayInterface.promote_eltype(T2, dualT)
+    dualT3 = ArrayInterface.promote_eltype(T3, dualT)
+    return _make_fww(
+        Void(ff),
+        Tuple{T1, T2, T3, T4, T5},
+        Tuple{dualT1, dualT2, dualT3, T4, T5}
+    )
 end
 
 function wrapfun_iip(

--- a/lib/DiffEqBase/src/norecompile.jl
+++ b/lib/DiffEqBase/src/norecompile.jl
@@ -37,6 +37,14 @@ end
 # 3-arg fallback: when ForwardDiff extension is not loaded, ignore chunk size
 wrapfun_iip(ff, inputs, ::Val) = wrapfun_iip(ff, inputs)
 
+function wrapfun_dae_iip(ff, inputs)
+    return FunctionWrappersWrappers.FunctionWrappersWrapper(
+        Void(ff), (typeof(inputs),), (Nothing,)
+    )
+end
+
+wrapfun_dae_iip(ff, inputs, ::Val) = wrapfun_dae_iip(ff, inputs)
+
 function wrapfun_oop(ff, inputs)
     return FunctionWrappersWrappers.FunctionWrappersWrapper(
         ff, (typeof(inputs),), (typeof(inputs[1]),)

--- a/lib/DiffEqBase/src/solve.jl
+++ b/lib/DiffEqBase/src/solve.jl
@@ -855,6 +855,29 @@ function _despecialize_auxiliary_functions(f)
     return f
 end
 
+function _replace_dae_residual(f::DAEFunction{iip, specialize}, residual) where {iip, specialize}
+    return DAEFunction{iip, specialize}(
+        residual;
+        analytic = f.analytic,
+        tgrad = f.tgrad,
+        jac = f.jac,
+        jac_u = f.jac_u,
+        jac_du = f.jac_du,
+        jvp = f.jvp,
+        vjp = f.vjp,
+        jac_prototype = f.jac_prototype,
+        sparsity = f.sparsity,
+        Wfact = f.Wfact,
+        Wfact_t = f.Wfact_t,
+        paramjac = f.paramjac,
+        observed = f.observed,
+        colorvec = f.colorvec,
+        sys = f.sys,
+        initialization_data = f.initialization_data,
+        nlstep_data = f.nlstep_data
+    )
+end
+
 _promote_parameters(::Val{SciMLBase.AutoDespecialize}, p) =
     SciMLBase.DespecializedParameters(p)
 _promote_parameters(::Val, p) = p
@@ -873,6 +896,18 @@ function promote_f(
         f = @set f.jac_prototype = similar(f.jac_prototype, uElType)
     end
     despecialize && (f = _despecialize_auxiliary_functions(f))
+
+    dae_wrap_path = despecialize && f isa DAEFunction && isinplace(f) &&
+        !(f.f isa AbstractSciMLOperator) &&
+        !(f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper) &&
+        !(u0 isa SubArray) && eltype(u0) !== Any &&
+        RecursiveArrayTools.recursive_unitless_eltype(u0) === eltype(u0) &&
+        one(t) === oneunit(t) && hasdualpromote(u0, t)
+    if dae_wrap_path
+        residual = ParameterDespecializationWrapper(f.f)
+        wrapped = wrapfun_dae_iip(residual, (u0, u0, u0, p_out, t), Val(CS))
+        return (_replace_dae_residual(f, wrapped), p_out)
+    end
 
     wrap_path = f isa ODEFunction && isinplace(f) && !(f.f isa AbstractSciMLOperator) &&
         # Opt-out SubArrays since they would create type mismatches with the integrator's internal Arrays
@@ -1002,6 +1037,18 @@ function promote_f(
         f = @set f.jac_prototype = similar(f.jac_prototype, uElType)
     end
     despecialize && (f = _despecialize_auxiliary_functions(f))
+
+    dae_wrap_path = despecialize && f isa DAEFunction && isinplace(f) &&
+        !(f.f isa AbstractSciMLOperator) &&
+        !(f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper) &&
+        !(u0 isa SubArray) && eltype(u0) !== Any &&
+        RecursiveArrayTools.recursive_unitless_eltype(u0) === eltype(u0) &&
+        one(t) === oneunit(t)
+    if dae_wrap_path
+        residual = ParameterDespecializationWrapper(f.f)
+        wrapped = wrapfun_dae_iip(residual, (u0, u0, u0, p_out, t))
+        return (_replace_dae_residual(f, wrapped), p_out)
+    end
 
     wrap_path = f isa ODEFunction && isinplace(f) && !(f.f isa AbstractSciMLOperator) &&
         f.mass_matrix isa UniformScaling &&

--- a/lib/DiffEqBase/src/solve.jl
+++ b/lib/DiffEqBase/src/solve.jl
@@ -852,11 +852,30 @@ function _despecialize_auxiliary_functions(f)
             !(f.g isa ParameterDespecializationWrapper)
         f = @set f.g = ParameterDespecializationWrapper(f.g)
     end
-    return f
+    f = SciMLBase.widen_bounded_type_params(f)
+    return _widen_type_parameter(f, Val(:ID))
+end
+
+@generated function _widen_type_parameter(f::F, ::Val{name}) where {F, name}
+    wrapper = F.name.wrapper
+    typevars = TypeVar[]
+    body = wrapper
+    while body isa UnionAll
+        push!(typevars, body.var)
+        body = body.body
+    end
+    index = findfirst(typevar -> typevar.name === name, typevars)
+    index === nothing && return :(f)
+    typevars[index].ub === Any || return :(f)
+    params = collect(F.parameters)
+    params[index] = Any
+    NewType = wrapper{params...}
+    fields = [:(getfield(f, $i)) for i in 1:fieldcount(NewType)]
+    return :($NewType($(fields...)))
 end
 
 function _replace_dae_residual(f::DAEFunction{iip, specialize}, residual) where {iip, specialize}
-    return DAEFunction{iip, specialize}(
+    replaced = DAEFunction{iip, specialize}(
         residual;
         analytic = f.analytic,
         tgrad = f.tgrad,
@@ -876,6 +895,8 @@ function _replace_dae_residual(f::DAEFunction{iip, specialize}, residual) where 
         initialization_data = f.initialization_data,
         nlstep_data = f.nlstep_data
     )
+    replaced = SciMLBase.widen_bounded_type_params(replaced)
+    return _widen_type_parameter(replaced, Val(:ID))
 end
 
 _promote_parameters(::Val{SciMLBase.AutoDespecialize}, p) =

--- a/lib/DiffEqBase/test/despecialized_p_test.jl
+++ b/lib/DiffEqBase/test/despecialized_p_test.jl
@@ -17,6 +17,14 @@ struct DynamicSDEParameters
     sigma::Float64
 end
 
+struct DynamicDAEResidual{ID} end
+
+function (::DynamicDAEResidual)(resid, du, u, p, t)
+    seen_dae_parameter[] = typeof(p)
+    resid[1] = du[1] + p.rate * u[1]
+    return nothing
+end
+
 const seen_rhs_parameter = Ref{DataType}()
 const seen_jac_parameter = Ref{DataType}()
 const seen_tgrad_parameter = Ref{DataType}()
@@ -140,15 +148,18 @@ end
 @testset "other differential equation functions use the dynamic path" begin
     p = DynamicP(0.5)
 
-    function dae_rhs!(resid, du, u, p, t)
-        seen_dae_parameter[] = typeof(p)
-        resid[1] = du[1] + p.rate * u[1]
-        return nothing
-    end
-    dae_f = DAEFunction{true, SciMLBase.AutoDespecialize}(dae_rhs!)
+    dae_f = DAEFunction{true, SciMLBase.AutoDespecialize}(DynamicDAEResidual{1}())
     dae_prob = DAEProblem(dae_f, [0.0], [1.0], (0.0, 1.0), p)
     dae_concrete = concretize(dae_prob)
+    other_dae_f = DAEFunction{true, SciMLBase.AutoDespecialize}(DynamicDAEResidual{2}())
+    other_dae_prob = DAEProblem(
+        other_dae_f, [0.0], [1.0], (0.0, 1.0), OtherDynamicP(1.5, 1)
+    )
+    other_dae_concrete = concretize(other_dae_prob)
     @test dae_concrete.p isa SciMLBase.DespecializedParameters
+    @test typeof(dae_concrete.f) === typeof(other_dae_concrete.f)
+    @test typeof(dae_concrete) === typeof(other_dae_concrete)
+    @test SciMLBase.unwrapped_f(dae_concrete.f.f) isa DynamicDAEResidual{1}
     resid = zeros(1)
     dae_concrete.f(resid, [0.0], [1.0], dae_concrete.p, 0.0)
     @test resid == [0.5]

--- a/lib/DiffEqBase/test/despecialized_p_test.jl
+++ b/lib/DiffEqBase/test/despecialized_p_test.jl
@@ -18,11 +18,22 @@ struct DynamicSDEParameters
 end
 
 struct DynamicDAEResidual{ID} end
+struct DynamicInitializationResidual{ID} end
 
 function (::DynamicDAEResidual)(resid, du, u, p, t)
     seen_dae_parameter[] = typeof(p)
     resid[1] = du[1] + p.rate * u[1]
     return nothing
+end
+
+function (::DynamicInitializationResidual)(resid, u, p)
+    resid[1] = u[1]
+    return nothing
+end
+
+function dynamic_initialization_data(::Val{ID}, p) where {ID}
+    initprob = NonlinearProblem{true}(DynamicInitializationResidual{ID}(), [0.0], p)
+    return SciMLBase.OverrideInitData(initprob, nothing, nothing, nothing)
 end
 
 const seen_rhs_parameter = Ref{DataType}()
@@ -148,17 +159,26 @@ end
 @testset "other differential equation functions use the dynamic path" begin
     p = DynamicP(0.5)
 
-    dae_f = DAEFunction{true, SciMLBase.AutoDespecialize}(DynamicDAEResidual{1}())
+    dae_initdata = dynamic_initialization_data(Val(1), p)
+    dae_f = DAEFunction{true, SciMLBase.AutoDespecialize}(
+        DynamicDAEResidual{1}(); initialization_data = dae_initdata
+    )
     dae_prob = DAEProblem(dae_f, [0.0], [1.0], (0.0, 1.0), p)
     dae_concrete = concretize(dae_prob)
-    other_dae_f = DAEFunction{true, SciMLBase.AutoDespecialize}(DynamicDAEResidual{2}())
+    other_p = OtherDynamicP(1.5, 1)
+    other_dae_initdata = dynamic_initialization_data(Val(2), other_p)
+    other_dae_f = DAEFunction{true, SciMLBase.AutoDespecialize}(
+        DynamicDAEResidual{2}(); initialization_data = other_dae_initdata
+    )
     other_dae_prob = DAEProblem(
-        other_dae_f, [0.0], [1.0], (0.0, 1.0), OtherDynamicP(1.5, 1)
+        other_dae_f, [0.0], [1.0], (0.0, 1.0), other_p
     )
     other_dae_concrete = concretize(other_dae_prob)
     @test dae_concrete.p isa SciMLBase.DespecializedParameters
     @test typeof(dae_concrete.f) === typeof(other_dae_concrete.f)
     @test typeof(dae_concrete) === typeof(other_dae_concrete)
+    @test dae_concrete.f.initialization_data === dae_initdata
+    @test other_dae_concrete.f.initialization_data === other_dae_initdata
     @test SciMLBase.unwrapped_f(dae_concrete.f.f) isa DynamicDAEResidual{1}
     resid = zeros(1)
     dae_concrete.f(resid, [0.0], [1.0], dae_concrete.p, 0.0)


### PR DESCRIPTION
## What changed

`AutoDespecialize` now wraps in-place `DAEFunction` residuals behind the same parameter-unwrapping barrier used for ODE functions. The ForwardDiff-aware wrapper accepts the five-argument DAE residual signature `(resid, du, u, p, t)`, so `DFBDF` can reuse one concrete problem and nonlinear-cache type across different residual and parameter types.

The generic AutoDespecialize path also widens model-specific SciMLFunction metadata. It uses SciMLBase's public `widen_bounded_type_params` interface and erases an unbounded `ID` parameter while retaining the original metadata value. This contains ModelingToolkit initialization data behind the same function barrier instead of allowing each compiled system to specialize the solver-facing function type. `AutoSpecialize`, `AutoRespecialize`, and `FullSpecialize` are unchanged.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Failing before

With the final regression test applied to unmodified DiffEqBase:

    julia +release --startup-file=no --project=lib/DiffEqBase -e 'include("lib/DiffEqBase/test/despecialized_p_test.jl")'

The DAE test failed its concrete `DAEFunction` and `DAEProblem` type-equality assertions. Applying only the residual wrapper still failed the same two assertions because the two `OverrideInitData` values remained encoded in the `ID` type parameter:

    other differential equation functions use the dynamic path | 21 pass / 2 fail / 23 total

The focused ModelingToolkit integration then compiled two different DAE systems. With the residual wrapper but before metadata widening, both ForwardDiff and FiniteDiff cases failed their problem-type and DFBDF-cache-type equality assertions:

    MTK DAE AutoDespecialize | 16 pass / 4 fail / 20 total

## Passing after

The identical DiffEqBase focused command passed:

    other differential equation functions use the dynamic path | 23 pass / 23 total

The identical ModelingToolkit integration passed. It asserted different source `MTKParameters` and generated-function types, followed by identical solver-facing problem and DFBDF cache types after `init`, successful solves, and the analytic endpoint for both AD choices:

    MTK DAE AutoDespecialize | 20 pass / 20 total

A separate OrdinaryDiffEqBDF integration exercised two handwritten residual types and two parameter types under `AutoForwardDiff()` and `AutoFiniteDiff()`:

    DFBDF despecializes DAE residuals | 12 pass / 12 total

Full local DiffEqBase groups:

    GROUP=Core julia +release --startup-file=no --project=lib/DiffEqBase -e 'using Pkg; Pkg.test(coverage=false)'
    Testing DiffEqBase tests passed

    GROUP=QA julia +release --startup-file=no --project=lib/DiffEqBase -e 'using Pkg; Pkg.test(coverage=false)'
    Aqua | 9 pass / 9 total
    Testing DiffEqBase tests passed

Julia Runic check, `typos --diff`, and `git diff --check` all exited 0. No public API or documentation changed, so a docs build was not required.

## Compile/runtime measurement

Before adding the separate `DFBDF` precompile workload, fresh-process `init` measurements on the one-state DAE were:

    AutoDespecialize first: 2.35 s compile
    AutoDespecialize second distinct model: 0.382 s compile
    FullSpecialize first: 1.56 s compile
    FullSpecialize second distinct model: 1.15 s compile

The second-model comparison shows the stable solver cache removing about 0.77 s (67%) of compilation. Warm solve time over 100 samples was 69.5 μs for `AutoDespecialize` versus 66.0 μs for `FullSpecialize`, about 5% overhead on this deliberately tiny problem. A stacked follow-up precompiles the stable `DFBDF` DAE path to remove the remaining first-use solver-cache compilation.

## Not verified

GPU and Julia prerelease paths were not run locally. The full ModelingToolkit suite was not run locally; the discriminating two-system integration was run against the ModelingToolkit AutoDespecialize branch.
