### PR TITLE
Precompile AutoDespecialize DAE defaults and BDF algorithms

### DIFF
--- a/lib/DiffEqBase/src/solve.jl
+++ b/lib/DiffEqBase/src/solve.jl
@@ -123,6 +123,9 @@ end
 
 Base.@constprop :aggressive function init_up(prob::AbstractDEProblem, sensealg, u0, p, args...; kwargs...)
     alg = extract_alg(args, kwargs, has_kwargs(prob) ? prob.kwargs : kwargs)
+    if isnothing(alg)
+        alg = prepare_alg(alg, u0, p, prob)
+    end
     return if isnothing(alg) || !(alg isa AbstractDEAlgorithm) # Default algorithm handling
         _prob = get_concrete_problem(
             prob, !(prob isa DiscreteProblem); alg = alg, u0 = u0,
@@ -637,6 +640,9 @@ Base.@constprop :aggressive function solve_up(
         kwargs...
     )
     alg = extract_alg(args, kwargs, has_kwargs(prob) ? prob.kwargs : kwargs)
+    if isnothing(alg)
+        alg = prepare_alg(alg, u0, p, prob)
+    end
     return if isnothing(alg) || !(alg isa AbstractDEAlgorithm) # Default algorithm handling
         _prob = get_concrete_problem(
             prob, !(prob isa DiscreteProblem); alg = alg, u0 = u0,

--- a/lib/DiffEqBase/test/high_level_solve.jl
+++ b/lib/DiffEqBase/test/high_level_solve.jl
@@ -1,5 +1,6 @@
 using DiffEqBase, Test
 using Distributions
+import SciMLBase
 
 @test DiffEqBase.promote_tspan((0.0, 1.0)) == (0.0, 1.0)
 @test DiffEqBase.promote_tspan((0, 1.0)) == (0.0, 1.0)
@@ -46,3 +47,22 @@ prob2 = DiffEqBase.get_concrete_problem(prob, true)
 @test prob2.u0 == 2.0
 @test prob2.tspan == (0.0, 3.0)
 @test prob2.constant_lags == [1.0]
+
+struct PreparedDefaultAlgorithm <: SciMLBase.AbstractODEAlgorithm end
+
+prepared_default_problem = ODEProblem((u, p, t) -> p * u, 1.0, (0.0, 1.0), 2.0)
+const PreparedDefaultProblem = typeof(prepared_default_problem)
+
+DiffEqBase.prepare_alg(::Nothing, u0, p, ::PreparedDefaultProblem) =
+    PreparedDefaultAlgorithm()
+SciMLBase.__solve(prob::PreparedDefaultProblem, ::PreparedDefaultAlgorithm; kwargs...) =
+    (prob, :solve)
+SciMLBase.__init(prob::PreparedDefaultProblem, ::PreparedDefaultAlgorithm; kwargs...) =
+    (prob, :init)
+
+solved_problem, solve_stage = solve(prepared_default_problem; wrap = Val(false))
+initialized_problem, init_stage = init(prepared_default_problem)
+@test solved_problem === prepared_default_problem
+@test initialized_problem === prepared_default_problem
+@test solve_stage === :solve
+@test init_stage === :init

--- a/lib/OrdinaryDiffEqBDF/src/OrdinaryDiffEqBDF.jl
+++ b/lib/OrdinaryDiffEqBDF/src/OrdinaryDiffEqBDF.jl
@@ -59,7 +59,8 @@ import ADTypes: AutoForwardDiff
 
 using Reexport: Reexport, @reexport
 import SciMLBase
-using SciMLBase: ODEProblem, ODEFunction, derivative_discontinuity!, solve
+using SciMLBase: DAEFunction, DAEProblem, ODEProblem, ODEFunction,
+    derivative_discontinuity!, solve
 @reexport using SciMLBase
 
 include("algorithms.jl")
@@ -86,6 +87,11 @@ function precompile_mm_dae(du, u, p, t)
     du[1] = -0.04u[1] + 1.0e4 * u[2] * u[3]
     du[2] = 0.04u[1] - 3.0e7 * u[2]^2 - 1.0e4 * u[2] * u[3]
     return du[3] = u[1] + u[2] + u[3] - 1.0
+end
+
+function precompile_dae(resid, du, u, p, t)
+    resid[1] = du[1] + p.rate * u[1]
+    return nothing
 end
 
 PrecompileTools.@compile_workload begin
@@ -139,6 +145,14 @@ PrecompileTools.@compile_workload begin
                 (0.0, 1.0), OrdinaryDiffEqCore.lorenz_pref_params
             )
         )
+    end
+
+    if Preferences.@load_preference("PrecompileAutoDespecialize", true)
+        dae_f = DAEFunction{true, SciMLBase.AutoDespecialize}(precompile_dae)
+        dae_prob = DAEProblem(
+            dae_f, [-0.5], [1.0], (0.0, 0.1), (rate = 0.5,)
+        )
+        solve(dae_prob, DFBDF())
     end
 
     if Preferences.@load_preference("PrecompileFunctionWrapperSpecialize", false)

--- a/lib/OrdinaryDiffEqBDF/src/OrdinaryDiffEqBDF.jl
+++ b/lib/OrdinaryDiffEqBDF/src/OrdinaryDiffEqBDF.jl
@@ -153,6 +153,7 @@ PrecompileTools.@compile_workload begin
             dae_f, [-0.5], [1.0], (0.0, 0.1), (rate = 0.5,)
         )
         solve(dae_prob, DFBDF())
+        solve(dae_prob, DNordsieckBDF())
     end
 
     if Preferences.@load_preference("PrecompileFunctionWrapperSpecialize", false)

--- a/lib/OrdinaryDiffEqBDF/test/dae_ad_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/dae_ad_tests.jl
@@ -18,7 +18,7 @@ function despecialized_dae_problem(model, p)
     return DAEProblem(f, [-p.rate], [1.0], (0.0, 0.1), p)
 end
 
-@testset "AutoDespecialize reuses DFBDF caches" begin
+@testset "AutoDespecialize reuses DAE solver caches" begin
     problems = (
         despecialized_dae_problem(
             DespecializedDAEResidual{1}(), (rate = 0.5,)
@@ -28,16 +28,18 @@ end
         ),
     )
 
-    for autodiff in (AutoForwardDiff(), AutoFiniteDiff())
-        alg = DFBDF(; autodiff)
-        integrators = map(prob -> init(prob, alg), problems)
-        @test typeof(integrators[1].sol.prob) === typeof(integrators[2].sol.prob)
-        @test typeof(integrators[1].cache) === typeof(integrators[2].cache)
+    for Alg in (DFBDF, DNordsieckBDF)
+        for autodiff in (AutoForwardDiff(), AutoFiniteDiff())
+            alg = Alg(; autodiff)
+            integrators = map(prob -> init(prob, alg), problems)
+            @test typeof(integrators[1].sol.prob) === typeof(integrators[2].sol.prob)
+            @test typeof(integrators[1].cache) === typeof(integrators[2].cache)
 
-        for prob in problems
-            sol = solve(prob, alg)
-            @test successful_retcode(sol)
-            @test sol.u[end][1] ≈ exp(-0.05) rtol = 1.0e-3
+            for prob in problems
+                sol = solve(prob, alg)
+                @test successful_retcode(sol)
+                @test sol.u[end][1] ≈ exp(-0.05) rtol = 1.0e-3
+            end
         end
     end
 end

--- a/lib/OrdinaryDiffEqBDF/test/dae_ad_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/dae_ad_tests.jl
@@ -1,9 +1,46 @@
 using OrdinaryDiffEqBDF, LinearAlgebra, Test
 using OrdinaryDiffEqNonlinearSolve: BrownFullBasicInit, ShampineCollocationInit
 using ADTypes: AutoForwardDiff, AutoFiniteDiff
+using SciMLBase: AutoDespecialize, DAEFunction, DAEProblem, successful_retcode
 import DifferentiationInterface as DI
 
 afd_cs3 = AutoForwardDiff(chunksize = 3)
+
+struct DespecializedDAEResidual{ID} end
+
+function (::DespecializedDAEResidual)(resid, du, u, p, t)
+    resid[1] = du[1] + p.rate * u[1]
+    return nothing
+end
+
+function despecialized_dae_problem(model, p)
+    f = DAEFunction{true, AutoDespecialize}(model)
+    return DAEProblem(f, [-p.rate], [1.0], (0.0, 0.1), p)
+end
+
+@testset "AutoDespecialize reuses DFBDF caches" begin
+    problems = (
+        despecialized_dae_problem(
+            DespecializedDAEResidual{1}(), (rate = 0.5,)
+        ),
+        despecialized_dae_problem(
+            DespecializedDAEResidual{2}(), (rate = 0.5, unused = 1)
+        ),
+    )
+
+    for autodiff in (AutoForwardDiff(), AutoFiniteDiff())
+        alg = DFBDF(; autodiff)
+        integrators = map(prob -> init(prob, alg), problems)
+        @test typeof(integrators[1].sol.prob) === typeof(integrators[2].sol.prob)
+        @test typeof(integrators[1].cache) === typeof(integrators[2].cache)
+
+        for prob in problems
+            sol = solve(prob, alg)
+            @test successful_retcode(sol)
+            @test sol.u[end][1] ≈ exp(-0.05) rtol = 1.0e-3
+        end
+    end
+end
 
 function f(out, du, u, p, t)
     out[1] = -p[1] * u[1] + p[3] * u[2] * u[3] - du[1]

--- a/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
+++ b/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
@@ -9,6 +9,7 @@ using OrdinaryDiffEqBDF: FBDF, DFBDF
 
 import OrdinaryDiffEqCore: is_mass_matrix_alg, default_autoswitch, isdefaultalg
 import ADTypes: AutoFiniteDiff
+import DiffEqBase
 import LinearSolve
 using LinearAlgebra: I
 using EnumX: EnumX

--- a/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
+++ b/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
@@ -15,7 +15,7 @@ using LinearAlgebra: I
 using EnumX: EnumX
 
 import SciMLBase
-using SciMLBase: ODEProblem, DAEProblem, solve
+using SciMLBase: ODEProblem, DAEProblem, DAEFunction, solve
 
 include("default_alg.jl")
 
@@ -40,6 +40,11 @@ function _lorenz_pref!(du, u, p, t)
 end
 
 const _lorenz_pref_params = [10.0, 28.0, 8 / 3]
+
+function _dae_p!(resid, du, u, p, t)
+    resid[1] = du[1] + p.rate * u[1]
+    return nothing
+end
 
 import PrecompileTools
 import Preferences
@@ -96,6 +101,10 @@ PrecompileTools.@compile_workload begin
             (0.0, 1.0), _lorenz_p_params
         )
         push!(parameter_generic_prob_list, prob)
+
+        dae_f = DAEFunction{true, SciMLBase.AutoDespecialize}(_dae_p!)
+        dae_prob = DAEProblem(dae_f, [-0.5], [1.0], (0.0, 0.1), (rate = 0.5,))
+        solve(dae_prob)
     end
 
     if Preferences.@load_preference("PrecompileAutoDePSpecialize", true)

--- a/lib/OrdinaryDiffEqDefault/src/default_alg.jl
+++ b/lib/OrdinaryDiffEqDefault/src/default_alg.jl
@@ -81,6 +81,11 @@ end
 SciMLBase.supports_solve_rng(::SciMLBase.AbstractODEProblem, ::Nothing) = true
 SciMLBase.supports_solve_rng(::SciMLBase.AbstractDAEProblem, ::Nothing) = true
 
+DiffEqBase.prepare_alg(::Nothing, u0, p, ::ODEProblem) =
+    DefaultODEAlgorithm(autodiff = AutoFiniteDiff())
+DiffEqBase.prepare_alg(::Nothing, u0, p, ::DAEProblem) =
+    DFBDF(autodiff = AutoFiniteDiff())
+
 function SciMLBase.__init(prob::ODEProblem, ::Nothing, args...; kwargs...)
     return SciMLBase.__init(
         prob, DefaultODEAlgorithm(autodiff = AutoFiniteDiff()),

--- a/lib/OrdinaryDiffEqDefault/test/default_solver_tests.jl
+++ b/lib/OrdinaryDiffEqDefault/test/default_solver_tests.jl
@@ -1,6 +1,7 @@
 using OrdinaryDiffEqDefault, OrdinaryDiffEqTsit5, OrdinaryDiffEqVerner,
     OrdinaryDiffEqRosenbrock, OrdinaryDiffEqBDF, ADTypes
 using Test, LinearSolve, LinearAlgebra, SparseArrays, StaticArrays
+import SciMLBase
 
 f_2dlinear = (du, u, p, t) -> (@. du = p * u)
 
@@ -191,11 +192,17 @@ function dae_rober!(out, du, u, p, t)
 end
 u0_dae = [1.0, 0.0, 0.0]
 du0_dae = [-0.04, 0.04, 0.0]
+dae_rober_despecialized = DAEFunction{true, SciMLBase.AutoDespecialize}(dae_rober!)
 prob_dae = DAEProblem(
-    dae_rober!, du0_dae, u0_dae, (0.0, 1.0e3); differential_vars = [true, true, false]
+    dae_rober_despecialized, du0_dae, u0_dae, (0.0, 1.0e3), (unused = 1,);
+    differential_vars = [true, true, false]
 )
 sol_dae_default = solve(prob_dae)
 sol_dae_dfbdf = solve(prob_dae, DFBDF(autodiff = AutoFiniteDiff()))
+init_dae_default = init(prob_dae)
+init_dae_dfbdf = init(prob_dae, DFBDF(autodiff = AutoFiniteDiff()))
 @test sol_dae_default.retcode == ReturnCode.Success
 @test sol_dae_default.t == sol_dae_dfbdf.t
 @test sol_dae_default.u == sol_dae_dfbdf.u
+@test typeof(init_dae_default.sol.prob) === typeof(init_dae_dfbdf.sol.prob)
+@test typeof(init_dae_default.cache) === typeof(init_dae_dfbdf.cache)


### PR DESCRIPTION
## What changed

This precompiles all three `AutoDespecialize` DAE entry points requested here:

- explicit `DFBDF()` initialization and solve;
- explicit `DNordsieckBDF()` initialization and solve;
- the no-algorithm `solve(dae_prob)` default, which resolves to `DFBDF(AutoFiniteDiff())`.

`OrdinaryDiffEqDefault` now extends the public `DiffEqBase.prepare_alg` hook for its ODE and DAE defaults. That lets DiffEqBase concretize an `AutoDespecialize` problem using the algorithm that will actually run, before the late default-solver handoff. The BDF regression test covers different residual types and parameter layouts under both ForwardDiff and FiniteDiff, and requires identical concrete problem/cache types for both BDF algorithms.

This is stacked on the generic default-algorithm handoff in https://github.com/SciML/OrdinaryDiffEq.jl/pull/4247. The DAE residual wrapping prerequisite has merged as https://github.com/SciML/OrdinaryDiffEq.jl/pull/4239 and was removed from this branch during the rebase.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Failing before

Without the early `prepare_alg(nothing, u0, p, prob)` handoff, the focused DiffEqBase regression test reached:

    High Level solve Interface | 17 pass / 1 error
    Error: Default algorithm choices require DifferentialEquations.jl.

The existing OrdinaryDiffEqDefault discriminator also showed that the implicit default was concretized differently from the equivalent explicit algorithm:

    Default Solver Tests | 46 pass / 2 fail
    naccept: 48 != 54
    nf:      182 != 241

With the precompile preference disabled, median first-initialization times from three fresh Julia processes were:

    DFBDF()             2.411 s
    DNordsieckBDF()     2.608 s
    default DAE solve   2.598 s

## Passing after

The generic handoff regression passes 21/21 and full DiffEqBase Core passes in https://github.com/SciML/OrdinaryDiffEq.jl/pull/4247.

The exact monorepo BDF group passed:

    GROUP=OrdinaryDiffEqBDF_Core julia +release --startup-file=no --project=. \
        -e 'using Pkg; Pkg.test(coverage=false)'

    AutoDespecialize reuses DAE solver caches | 24 pass / 24 total
    DAE Convergence Tests                     | 50 pass / 50 total
    DAE AD Tests                              | 40 pass / 40 total
    DAE Event Tests                           | 4 pass / 4 total
    DAE derivative_discontinuity Tests        | 11 pass / 11 total
    DAE Initialization Tests                  | 38 pass / 2 broken / 40 total
    DAE Nonlinear Solve Path                  | 16 pass / 16 total
    BDF Inference Tests                       | 1 pass / 1 total
    BDF Convergence Tests                     | 84 pass / 84 total
    BDF Regression Tests                      | 35 pass / 35 total
    Nordsieck BDF Tests                       | 101 pass / 101 total
    Testing OrdinaryDiffEqBDF tests passed

An isolated environment developed the local DiffEqBase, OrdinaryDiffEqBDF, and OrdinaryDiffEqDefault stack. The official Default test suite then passed:

    Pkg.test("OrdinaryDiffEqDefault"; allow_reresolve=false)

    Default Solver Tests | 48 pass / 48 total
    Testing OrdinaryDiffEqDefault tests passed

The default `init(prob)` and explicit `init(prob, DFBDF(autodiff=AutoFiniteDiff()))` produced identical concrete problem/cache types and identical trajectories. Explicit `DFBDF` and `DNordsieckBDF` both solved successfully.

Both required sublibrary QA groups passed:

    OrdinaryDiffEqDefault: JET 1/1, Aqua 20/20
    OrdinaryDiffEqBDF:     Allocation 2 pass/18 broken,
                           JET 18 pass/23 broken, Aqua 21/21

Julia Runic, typos over the diff, and `git diff --check` exited 0. No public API, docstring, or documentation changed, so a docs build was not required.

## Compile-time measurement

With `PrecompileAutoDespecialize=true`, the same benchmark in three fresh Julia processes produced these medians:

    DFBDF()             0.577 s  (76.1% reduction)
    DNordsieckBDF()     0.570 s  (78.2% reduction)
    default DAE solve   0.531 s  (79.6% reduction)

The benchmark used a distinct residual type and a parameter layout not present in the workload. Each measurement was the elapsed time of `init` in a new Julia process after separately precompiling isolated preference-on and preference-off environments.

## Not verified

GPU, Julia prerelease, and downstream package suites were not run locally.
