### PR TITLE
Normalize Mooncake promote_f tuple tangents

### DIFF
--- a/lib/DiffEqBase/ext/DiffEqBaseMooncakeExt.jl
+++ b/lib/DiffEqBase/ext/DiffEqBaseMooncakeExt.jl
@@ -71,6 +71,12 @@ function _check_promote_f_input_has_no_tangent(f_primal)
     )
 end
 
+_tuple_fdata(::Mooncake.NoFData, ::Mooncake.NoFData) = Mooncake.NoFData()
+_tuple_fdata(a, b) = (a, b)
+
+_tuple_tangent(::Mooncake.NoTangent, ::Mooncake.NoTangent) = Mooncake.NoTangent()
+_tuple_tangent(a, b) = (a, b)
+
 function rrule!!(
         pf::CoDual{typeof(DiffEqBase.promote_f)},
         f::CoDual, specialize::CoDual{<:Val}, u0::CoDual, p::CoDual, t::CoDual,
@@ -85,7 +91,7 @@ function rrule!!(
     f_out_is_identity = f_out === f_primal
     f_out_is_identity || _check_promote_f_input_has_no_tangent(f_primal)
     f_out_fdata = f_out_is_identity ? f.dx : fdata(zero_tangent(f_out))
-    y = CoDual((f_out, p_out), (f_out_fdata, p.dx))
+    y = CoDual((f_out, p_out), _tuple_fdata(f_out_fdata, p.dx))
 
     # Zero rdata for the argument slots that never reach the outputs (callee, the Val
     # args, and u0/t, whose types but not values matter here). Uses lazy_zero_rdata
@@ -134,7 +140,7 @@ function frule!!(
     f_out_is_identity = f_out === f_primal
     f_out_is_identity || _check_promote_f_input_has_no_tangent(f_primal)
     f_out_tangent = f_out_is_identity ? tangent(f) : zero_tangent(f_out)
-    return Dual((f_out, p_out), (f_out_tangent, tangent(p)))
+    return Dual((f_out, p_out), _tuple_tangent(f_out_tangent, tangent(p)))
 end
 
 end

--- a/test/AD/discrete_adjoints.jl
+++ b/test/AD/discrete_adjoints.jl
@@ -41,11 +41,14 @@ function f_dt_sum(u0)
     return sum(sol[1, :])
 end
 
+f_dt_sum_scalar(x) = f_dt_sum([x, 0.0, 0.0])
+
 u0 = [1.0; 0.0; 0.0]
 
 # Reference jacobian and gradient using ForwardDiff
 fdj = DI.jacobian(f_dt, AutoForwardDiff(), u0)
 fdg = DI.gradient(f_dt_sum, AutoForwardDiff(), u0)
+fdd = DI.derivative(f_dt_sum_scalar, AutoForwardDiff(), 1.0)
 @testset "Discrete Adjoints" begin
     # Enzyme tests skipped - Enzyme segfaults on ODE solves which crashes the process
     # before @test_broken can catch it. See https://github.com/EnzymeAD/Enzyme.jl/issues/2699
@@ -54,7 +57,13 @@ fdg = DI.gradient(f_dt_sum, AutoForwardDiff(), u0)
     @testset "Mooncake" begin
         @testset "Gradient via SensitivityADPassThrough" begin
             mkg = DI.gradient(f_dt_sum, AutoMooncake(; config = nothing), u0)
+            @test mkg isa typeof(fdg)
             @test mkg ≈ fdg rtol = 1.0e-6
+        end
+        @testset "Derivative via SensitivityADPassThrough" begin
+            mkd = DI.derivative(f_dt_sum_scalar, AutoMooncake(; config = nothing), 1.0)
+            @test mkd isa typeof(fdd)
+            @test mkd ≈ fdd rtol = 1.0e-6
         end
     end
 end


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

Mooncake represents the tangent and forward data for a tuple whose fields are both nondifferentiable as a single `NoTangent` / `NoFData`, not as a two-element tuple. The `promote_f` rules added in https://github.com/SciML/OrdinaryDiffEq.jl/pull/4201 always constructed the latter, so FullSpecialize solves failed a generated type assertion before integration.

This normalizes the two nondifferentiable fields to Mooncake's collapsed representation in both the reverse and forward rules, while preserving tuple representation when either field carries data. The regression test covers both Mooncake gradient and scalar derivative paths through a FullSpecialize solve.

## Verification

Julia 1.12.6, current upstream `master` `293f1195207aa66a9416be563297f05f13a53c61`.

Failing before, clean master:

```sh
GROUP=AD julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test(coverage=false)'
```

The first phases passed, then the existing discrete-adjoint gradient errored:

```text
AD Tests              | 28299 passed
Autodiff Events Tests | 5 passed, 1 existing broken
TypeError: expected CoDual{Tuple{ODEFunction{FullSpecialize...}, NullParameters}, NoFData},
got CoDual{Tuple{ODEFunction{FullSpecialize...}, NullParameters}, Tuple{NoFData, NoFData}}
Discrete Adjoint Tests | 1 error / 1 total
```

Passing after:

```sh
GROUP=AD julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test(coverage=false)'
```

```text
AD Tests               | 28299/28299 passed
Autodiff Events Tests  | 5 passed, 1 existing broken
Discrete Adjoint Tests | 4/4 passed
Testing OrdinaryDiffEq tests passed
```

```sh
GROUP=QA julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test(coverage=false)'
```

```text
Quality Assurance Tests | 90/90 passed
Testing OrdinaryDiffEq tests passed
```

DiffEqBase QA also passed `9/9`. Runic, typos over the diff, and `git diff --check` passed.

No public API or documentation changed, so I did not run the docs build.

## Not verified

I did not run Julia LTS/pre-release, GPU, or downstream package groups locally.
