### PR TITLE
Raise IMEXMultistep DiffEqBase compat to 7.5.7

### DIFF
--- a/lib/OrdinaryDiffEqIMEXMultistep/Project.toml
+++ b/lib/OrdinaryDiffEqIMEXMultistep/Project.toml
@@ -33,7 +33,7 @@ OrdinaryDiffEqCore = "4"
 julia = "1.10"
 ADTypes = "1.22.0"
 OrdinaryDiffEqNonlinearSolve = "2"
-DiffEqBase = "7"
+DiffEqBase = "7.5.7"
 SafeTestsets = "0.1.0"
 
 [targets]


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Raise `OrdinaryDiffEqIMEXMultistep`'s `DiffEqBase` compatibility floor from 7 to 7.5.7. The discontinuity-restart behavior added in https://github.com/SciML/OrdinaryDiffEq.jl/pull/4106 depends on callback modification reporting that is not correct in DiffEqBase 7.0.0, which is what the sublibrary downgrade job currently resolves.

DiffEqBase 7.5.6 contains the first callback-reporting repair, but it accesses `integrator.user_set_discontinuity`; the downgraded `OrdinaryDiffEqCore` 4.0.0 integrator does not have that field. DiffEqBase 7.5.7 is the first boundary that both reports the discontinuity and supports that older integrator.

## Verification

### Failing before

On unmodified `upstream/master` (`293f1195207aa66a9416be563297f05f13a53c61`), I reproduced the sublibrary job locally with Julia 1.11 and the exact `julia-actions/julia-downgrade-compat@v2` script. `EFFECTIVE_SKIP` was computed verbatim by the reusable workflow's standard-library, in-repo-sublibrary, and caller-skip steps:

```sh
GROUP=Core julia +1.11 --startup-file=no ../julia-downgrade-compat-v2/downgrade.jl "$EFFECTIVE_SKIP" lib/OrdinaryDiffEqIMEXMultistep alldeps 1.11 ''
julia +1.11 --startup-file=no --project=lib/OrdinaryDiffEqIMEXMultistep -e 'using Pkg; Pkg.build()'
GROUP=Core julia +1.11 --startup-file=no --project=lib/OrdinaryDiffEqIMEXMultistep -e 'using Pkg; Pkg.test(coverage=false)'
```

The action resolved DiffEqBase 7.0.0, OrdinaryDiffEqCore 4.0.0, SciMLBase 3.39.0, OrdinaryDiffEqDifferentiation 3.3.0, and OrdinaryDiffEqNonlinearSolve 2.0.0. Result:

```text
Discontinuity restart | 38 pass | 34 fail | 72 total
  CNAB2                 | 20 pass | 16 fail
  CNLF2                 | 18 pass | 18 fail
ERROR: Some tests did not pass: 38 passed, 34 failed
```

This is the same assertion count as the clean-master CI failure.

### Passing after

Running the same fresh downgrade/build/test sequence with this compat change resolved DiffEqBase 7.5.7 while retaining OrdinaryDiffEqCore 4.0.0 and the other minimum dependencies:

```text
Discontinuity restart | 72 pass | 72 total | 22.3s
Testing OrdinaryDiffEqIMEXMultistep tests passed
```

Holding the other downgraded dependencies fixed established the boundary:

```text
DiffEqBase 7.5.6: type ODEIntegrator has no field user_set_discontinuity
DiffEqBase 7.5.7: CNAB2 36/36, CNLF2 36/36
```

Additional local validation:

```sh
GROUP=OrdinaryDiffEqIMEXMultistep julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test(coverage=false)'
GROUP=OrdinaryDiffEqIMEXMultistep_QA julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test(coverage=false)'
julia +release --startup-file=no -m Runic --check --diff lib/OrdinaryDiffEqIMEXMultistep/Project.toml
typos lib/OrdinaryDiffEqIMEXMultistep/Project.toml
git diff --check
```

Results: the standard group passed, including 72/72 restart assertions. QA passed with JET 1/1 and Aqua 21/21; its two pre-existing allocation expectations remained `Broken`. Runic, typos, and `git diff --check` returned zero. I did not run docs because this changes no docs, docstrings, or public API. I did not run GPU, `julia pre`, or every monorepo sublibrary.

## Links

- Clean-master failure: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/31642714570/job/94269019245
- Same failure on the active PR: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/31689545530/job/94413491491
- IMEX restart change: https://github.com/SciML/OrdinaryDiffEq.jl/commit/06f871e215eceb6c831b1aaed887341185e2a293
- First callback-reporting repair (DiffEqBase 7.5.6): https://github.com/SciML/OrdinaryDiffEq.jl/commit/8862e1e3233ea778689d8e255a7d2bb875e8c1a3
- Old-integrator compatibility repair (DiffEqBase 7.5.7): https://github.com/SciML/OrdinaryDiffEq.jl/commit/91b090f24a15bf46a8fdc1d0f1a4ffd00abc4159
