### PR TITLE
Handle operator-backed instability diagnostics

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.15.0"
+version = "4.15.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqCore/src/misc_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/misc_utils.jl
@@ -336,6 +336,10 @@ function _find_large_jac_entries!(rows::Set{Int}, cols::Set{Int}, entries::Vecto
     end
     return
 end
+
+function _find_large_jac_entries!(rows::Set{Int}, cols::Set{Int}, entries::Vector, jac::MatrixOperator)
+    return _find_large_jac_entries!(rows, cols, entries, jac.A)
+end
 """
     find_algebraic_vars_eqs(M)
 

--- a/lib/OrdinaryDiffEqCore/test/sparse_isdiag_tests.jl
+++ b/lib/OrdinaryDiffEqCore/test/sparse_isdiag_tests.jl
@@ -1,7 +1,19 @@
 using Test
 # Load SparseArrays first to trigger the extension
 using SparseArrays
-using OrdinaryDiffEqCore: _isdiag
+using SciMLOperators: MatrixOperator
+using OrdinaryDiffEqCore: _find_large_jac_entries!, _isdiag
+
+@testset "MatrixOperator numerical instability entries" begin
+    jac = MatrixOperator(sparse([1, 2], [1, 2], [1.0e7, Inf]))
+    rows = Set{Int}()
+    cols = Set{Int}()
+    entries = Tuple{Int, Int, Float64}[]
+    _find_large_jac_entries!(rows, cols, entries, jac)
+    @test rows == Set([1, 2])
+    @test cols == Set([1, 2])
+    @test entries == [(1, 1, 1.0e7), (2, 2, Inf)]
+end
 
 @testset "Sparse isdiag Performance" begin
     # Test 1: Correctness - _isdiag should correctly identify diagonal matrices

--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "3.9.0"
+version = "3.9.1"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -359,6 +359,7 @@ function get_fresh_jacobian(integrator, cache::OrdinaryDiffEqCache)
     njacs, nf = stats.njacs, stats.nf
     J = if SciMLBase.isinplace(integrator.sol.prob)
         Jfresh = zero(cache.J)
+        Jfresh isa AbstractSciMLOperator && return cache.J
         calc_J!(Jfresh, integrator, cache)
         Jfresh
     else


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## What changed and why

This fixes two failures in the numerical-instability diagnostic for operator-backed Jacobians:

- unwrap `SciMLOperators.MatrixOperator` before scanning its entries;
- if `zero(cache.J)` produces an `AbstractSciMLOperator` sentinel such as `NullOperator`, retain the stored Jacobian instead of calling `jacobian!` on that sentinel.

These paths run while reporting an existing solver failure; the patch prevents the diagnostic itself from throwing a second exception. OrdinaryDiffEqCore is bumped to 4.15.1 and OrdinaryDiffEqDifferentiation to 3.9.1.

## Failing before / passing after

The MatrixOperator scanner regression test fails without the first fix:

```text
MatrixOperator numerical instability entries: Error During Test
MethodError: no method matching _find_large_jac_entries!(..., ::MatrixOperator{..., SparseMatrixCSC{...}, ...})
Test Summary:                                 | Error  Total
MatrixOperator numerical instability entries |     1      1
```

The same official test passes after the fix:

```text
MatrixOperator numerical instability entries | 3 pass, 3 total
Sparse isdiag Performance                    | 10 pass, 10 total
```

The `NullOperator` regression begins exactly at https://github.com/SciML/OrdinaryDiffEq.jl/commit/0ed2615804a38c915846358d39987f689f2511e6. A standalone Rosenbrock23 + KLU + MatrixOperator reproducer behaves as follows:

```text
parent 9d92d1c7220ab2fbb2a8f141a27ddd95db904789:
(retcode = ReturnCode.Unstable, njacs = 0, nw = 1)

introducing commit 0ed2615804a38c915846358d39987f689f2511e6:
MethodError: no method matching jacobian!(::NullOperator, ::SciMLBase.UJacobianWrapper, ...)

patched:
(retcode = ReturnCode.Unstable, njacs = 0, nw = 1)
```

The existing `OrdinaryDiffEqNonlinearSolve/test/linear_solver_tests.jl` is the exact regression detector and passes after the combined fix:

```text
Hires MatrixOperator tests         | 36 pass, 36 total
Float32 MatrixOperator tests       | 36 pass, 36 total
```

## Local verification

```text
OrdinaryDiffEqCore GROUP=Core
  Developer Time Queue API 10/10; Developer Codegen API 2/2;
  Sparse isdiag 8/8; Algebraic Vars 22/22; interpolation 49/49;
  Testing OrdinaryDiffEqCore tests passed

OrdinaryDiffEqCore GROUP=QA
  JET 30 pass, 1 existing broken; Aqua 26 pass

OrdinaryDiffEqDifferentiation GROUP=Core
  includes DAE sparse 4/4, sparsity 9/9, ScalarOperator 9/9,
  stale-W 12/12, Krylov nf 21/21, tolerance 7/7;
  Testing OrdinaryDiffEqDifferentiation tests passed

OrdinaryDiffEqDifferentiation GROUP=QA
  JET 1/1; Aqua 19/19
```

Runic over every changed Julia file, typos over the diff, and `git diff --check` passed.

## Not verified

GPU and version-matrix jobs were not run locally. No docs build was run because this changes no public API, docstring, or documentation.