### PR TITLE
Give MRIGARKESDIRK34a a proper embedded pair

### DIFF
--- a/lib/OrdinaryDiffEqMultirateImplicit/src/multirate_implicit_tableaus.jl
+++ b/lib/OrdinaryDiffEqMultirateImplicit/src/multirate_implicit_tableaus.jl
@@ -22,7 +22,16 @@ function MRIGARKESDIRK34aTableau(::Type{T}) where {T}
     W0[6, 1] = -β
     W1 = zeros(T, 6, 6)
     γ0 = T[0, β, 0, β, 0, β]
-    return MRIGARKTableau{T}(Δc, W0, W1, T[], T[], γ0, 3)
+    # Order-2 embedding. With f1 = 0 the method collapses to an implicit RK on the slow
+    # term whose weights are the running sums of W0 plus γ0 on the diagonal; that b
+    # satisfies the order conditions through b·c² = 1/3 and misses b·c³, i.e. order 3
+    # exactly. The last stage has Δc = 0, so the embedded substage is a pure slow
+    # quadrature and the embedded weights are b₅ + Wemb0, where b₅ is everything before
+    # the last stage. Putting the correction on fS₁ and fS₄ (c = 0 and c = 2/3) and
+    # solving the two order conditions gives ∓3β/2; the obvious support on c = 0 and
+    # c = 1 is degenerate, reproducing the real last stage so the difference vanishes.
+    Wemb0 = T[-3 * β / 2, 0, 0, 3 * β / 2, 0, 0]
+    return MRIGARKTableau{T}(Δc, W0, W1, Wemb0, T[], γ0, 3)
 end
 
 # Stage 11 carries an all-zero coupling row: the method is stiffly accurate, so the

--- a/lib/OrdinaryDiffEqMultirateImplicit/test/mri_gark_implicit_tests.jl
+++ b/lib/OrdinaryDiffEqMultirateImplicit/test/mri_gark_implicit_tests.jl
@@ -47,6 +47,23 @@ import DiffEqBase
             ReturnCode.Success
     end
 
+    # Without an embedded coupling the estimate fell back to `u - z[s]`, which for this
+    # tableau is the last stage's slow correction: O(dt^2) for an order-3 method, so the
+    # controller was two orders too pessimistic and overshot the requested accuracy by
+    # three. This solve used to take 15892 steps and land at 8.9e-11 for a 1e-8 request.
+    @testset "Embedded estimate tracks the tolerance" begin
+        w, e = 50.0, 0.1
+        f1!(du, u, p, t) = (du[1] = -w * u[2]; du[2] = w * u[1]; nothing)
+        f2!(du, u, p, t) = (du .= -e .* u; nothing)
+        prob = SplitODEProblem(f1!, f2!, [1.0, 0.0], (0.0, 1.0))
+        exact = exp(-e) * [cos(w), sin(w)]
+
+        sol = solve(prob, MRIGARKESDIRK34a(m = 8); abstol = 1.0e-8, reltol = 1.0e-8)
+        @test sol.retcode == ReturnCode.Success
+        @test sol.stats.naccept < 4000
+        @test norm(sol.u[end] - exact) / norm(exact) < 1.0e-6
+    end
+
     @testset "Convergence" begin
         analytic(u0, p, t) = u0 * exp(-3t)
         prob = SplitODEProblem(


### PR DESCRIPTION
Follow-up to #4232, which fixed the two multirate methods whose adaptive mode was unusable and
noted this one as the remaining case.

`MRIGARKESDIRK34a` ships with no embedded coupling, so the estimate falls back to `u - z[s]`.
Because its last stage has `Δc = 0`, that fallback is the stage's slow correction, which is
O(dt^2) rather than the O(dt) that made `MRIGARKERK22a` and `MIS` hit `maxiters`. It is not
broken, just two orders too pessimistic for an order-3 method, so the controller crawls and
overshoots the requested accuracy by orders of magnitude.

Fast rotation plus slow decay, `m = 8`, same environment, only the tableau differing:

| tol | steps, master | steps, this branch | error, master | error, this branch |
| --- | --- | --- | --- | --- |
| 1e-6 | 1593 | 268 | 3.16e-8 | 7.43e-6 |
| 1e-8 | 15892 | 1224 | 8.87e-11 | 6.71e-8 |
| 1e-10 | 158884 | 5654 | 3.92e-11 | 4.03e-10 |

6x to 28x fewer steps, and the error now tracks the tolerance. On master it does not: tightening
from 1e-8 to 1e-10 moves the error only from 8.9e-11 to 3.9e-11, because the estimate has driven
the step size down to where roundoff dominates. For scale, `MRIGARKERK33a`, the other order-3
member and the one that already has an embedding, takes 915 steps at 1e-8.

## Deriving the coupling

With `f1 = 0` the inner IVP of each stage integrates a constant, so the method collapses to an
implicit Runge-Kutta on the slow term whose weights are the running sums of `W0` with `γ0` added
on the diagonal. That `b` satisfies

```
sum(b) = 1        b·c = 1/2        b·c² = 1/3        b·c³ = 0.3191 ≠ 1/4
```

i.e. order 3 exactly, which is a useful check on the reconstruction itself.

The embedded solution replaces only the last stage's coupling, and since `Δc[6] = 0` that
substage is a pure slow quadrature with no implicit term, so the embedded weights are
`b₅ + Wemb0` where `b₅` is everything accumulated before the last stage. Requiring order 1 and 2
of the embedded companion, and *not* order 3, gives two equations for the correction.

Putting the correction on `fS₁` and `fS₄` (`c = 0` and `c = 2/3`) solves them at `∓3β/2`:

```julia
Wemb0 = T[-3 * β / 2, 0, 0, 3 * β / 2, 0, 0]
```

which yields `sum(b̃) = 1`, `b̃·c = 1/2`, and `b̃·c² = 0.1880 ≠ 1/3`, so the pair is genuinely
3(2) and the difference is O(dt^3).

Worth recording: the obvious support on `c = 0` and `c = 1`, mirroring where the real last stage
puts its weight, is degenerate. Those two order conditions have a unique solution there and it
reproduces the real last stage exactly, leaving `‖b − b̃‖ = 1.8e-16` and no estimate at all.
Moving one node off `c = 1` is what breaks the degeneracy.

## Testing

Fixed-step convergence is unchanged at order 3 (2.995, 2.997 measured before and after), so this
only changes the estimate, not the solution. Added a regression test that the solve completes,
stays under 4000 steps and lands within 1e-6 at `tol = 1e-8`; on master it takes 15892 steps.
`mri_gark_implicit_tests.jl` 38/38 and `mreil_tests.jl` 151/151 pass.

## AI Disclosure

Claude assisted with this work.
