### PR TITLE
Prepare default algorithms before AutoDespecialize concretization

### DIFF
--- a/lib/DiffEqBase/src/solve.jl
+++ b/lib/DiffEqBase/src/solve.jl
@@ -123,6 +123,9 @@ end
 
 Base.@constprop :aggressive function init_up(prob::AbstractDEProblem, sensealg, u0, p, args...; kwargs...)
     alg = extract_alg(args, kwargs, has_kwargs(prob) ? prob.kwargs : kwargs)
+    if isnothing(alg)
+        alg = prepare_alg(alg, u0, p, prob)
+    end
     return if isnothing(alg) || !(alg isa AbstractDEAlgorithm) # Default algorithm handling
         _prob = get_concrete_problem(
             prob, !(prob isa DiscreteProblem); alg = alg, u0 = u0,
@@ -637,6 +640,9 @@ Base.@constprop :aggressive function solve_up(
         kwargs...
     )
     alg = extract_alg(args, kwargs, has_kwargs(prob) ? prob.kwargs : kwargs)
+    if isnothing(alg)
+        alg = prepare_alg(alg, u0, p, prob)
+    end
     return if isnothing(alg) || !(alg isa AbstractDEAlgorithm) # Default algorithm handling
         _prob = get_concrete_problem(
             prob, !(prob isa DiscreteProblem); alg = alg, u0 = u0,

--- a/lib/DiffEqBase/test/high_level_solve.jl
+++ b/lib/DiffEqBase/test/high_level_solve.jl
@@ -1,5 +1,6 @@
 using DiffEqBase, Test
 using Distributions
+import SciMLBase
 
 @test DiffEqBase.promote_tspan((0.0, 1.0)) == (0.0, 1.0)
 @test DiffEqBase.promote_tspan((0, 1.0)) == (0.0, 1.0)
@@ -46,3 +47,22 @@ prob2 = DiffEqBase.get_concrete_problem(prob, true)
 @test prob2.u0 == 2.0
 @test prob2.tspan == (0.0, 3.0)
 @test prob2.constant_lags == [1.0]
+
+struct PreparedDefaultAlgorithm <: SciMLBase.AbstractODEAlgorithm end
+
+prepared_default_problem = ODEProblem((u, p, t) -> p * u, 1.0, (0.0, 1.0), 2.0)
+const PreparedDefaultProblem = typeof(prepared_default_problem)
+
+DiffEqBase.prepare_alg(::Nothing, u0, p, ::PreparedDefaultProblem) =
+    PreparedDefaultAlgorithm()
+SciMLBase.__solve(prob::PreparedDefaultProblem, ::PreparedDefaultAlgorithm; kwargs...) =
+    (prob, :solve)
+SciMLBase.__init(prob::PreparedDefaultProblem, ::PreparedDefaultAlgorithm; kwargs...) =
+    (prob, :init)
+
+solved_problem, solve_stage = solve(prepared_default_problem; wrap = Val(false))
+initialized_problem, init_stage = init(prepared_default_problem)
+@test solved_problem === prepared_default_problem
+@test initialized_problem === prepared_default_problem
+@test solve_stage === :solve
+@test init_stage === :init

--- a/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
+++ b/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
@@ -9,6 +9,7 @@ using OrdinaryDiffEqBDF: FBDF, DFBDF
 
 import OrdinaryDiffEqCore: is_mass_matrix_alg, default_autoswitch, isdefaultalg
 import ADTypes: AutoFiniteDiff
+import DiffEqBase
 import LinearSolve
 using LinearAlgebra: I
 using EnumX: EnumX

--- a/lib/OrdinaryDiffEqDefault/src/default_alg.jl
+++ b/lib/OrdinaryDiffEqDefault/src/default_alg.jl
@@ -81,6 +81,11 @@ end
 SciMLBase.supports_solve_rng(::SciMLBase.AbstractODEProblem, ::Nothing) = true
 SciMLBase.supports_solve_rng(::SciMLBase.AbstractDAEProblem, ::Nothing) = true
 
+DiffEqBase.prepare_alg(::Nothing, u0, p, ::ODEProblem) =
+    DefaultODEAlgorithm(autodiff = AutoFiniteDiff())
+DiffEqBase.prepare_alg(::Nothing, u0, p, ::DAEProblem) =
+    DFBDF(autodiff = AutoFiniteDiff())
+
 function SciMLBase.__init(prob::ODEProblem, ::Nothing, args...; kwargs...)
     return SciMLBase.__init(
         prob, DefaultODEAlgorithm(autodiff = AutoFiniteDiff()),

--- a/lib/OrdinaryDiffEqDefault/test/default_solver_tests.jl
+++ b/lib/OrdinaryDiffEqDefault/test/default_solver_tests.jl
@@ -1,6 +1,7 @@
 using OrdinaryDiffEqDefault, OrdinaryDiffEqTsit5, OrdinaryDiffEqVerner,
     OrdinaryDiffEqRosenbrock, OrdinaryDiffEqBDF, ADTypes
 using Test, LinearSolve, LinearAlgebra, SparseArrays, StaticArrays
+import SciMLBase
 
 f_2dlinear = (du, u, p, t) -> (@. du = p * u)
 
@@ -191,11 +192,17 @@ function dae_rober!(out, du, u, p, t)
 end
 u0_dae = [1.0, 0.0, 0.0]
 du0_dae = [-0.04, 0.04, 0.0]
+dae_rober_despecialized = DAEFunction{true, SciMLBase.AutoDespecialize}(dae_rober!)
 prob_dae = DAEProblem(
-    dae_rober!, du0_dae, u0_dae, (0.0, 1.0e3); differential_vars = [true, true, false]
+    dae_rober_despecialized, du0_dae, u0_dae, (0.0, 1.0e3), (unused = 1,);
+    differential_vars = [true, true, false]
 )
 sol_dae_default = solve(prob_dae)
 sol_dae_dfbdf = solve(prob_dae, DFBDF(autodiff = AutoFiniteDiff()))
+init_dae_default = init(prob_dae)
+init_dae_dfbdf = init(prob_dae, DFBDF(autodiff = AutoFiniteDiff()))
 @test sol_dae_default.retcode == ReturnCode.Success
 @test sol_dae_default.t == sol_dae_dfbdf.t
 @test sol_dae_default.u == sol_dae_dfbdf.u
+@test typeof(init_dae_default.sol.prob) === typeof(init_dae_dfbdf.sol.prob)
+@test typeof(init_dae_default.cache) === typeof(init_dae_dfbdf.cache)


### PR DESCRIPTION
## What changed

DiffEqBase now asks the public `prepare_alg` hook for a default algorithm before concretizing an `AutoDespecialize` problem. If a downstream package supplies one, the existing explicit-algorithm path uses it for autodiff/Jacobian preparation and wrapper construction before `__solve` or `__init` runs.

OrdinaryDiffEqDefault supplies its existing defaults through that hook:

- `ODEProblem` → `DefaultODEAlgorithm(autodiff=AutoFiniteDiff())`;
- `DAEProblem` → `DFBDF(autodiff=AutoFiniteDiff())`.

The DAE default-solver regression uses `AutoDespecialize`, verifies that implicit and explicit DFBDF initialization produce identical concrete problem/cache types, and retains the exact trajectory comparison. This is the generic handoff required by the DAE precompile workloads in https://github.com/SciML/OrdinaryDiffEq.jl/pull/4241.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Failing before

I removed only the new early `prepare_alg` call and ran the focused DiffEqBase Core regression. It failed:

    High Level solve Interface | 17 pass / 1 error
    Error: Default algorithm choices require DifferentialEquations.jl.

The existing OrdinaryDiffEqDefault discriminator also showed the incorrect late handoff when run against the generic change without the OrdinaryDiffEqDefault hook:

    Default Solver Tests | 46 pass / 2 fail
    naccept: 48 != 54
    nf:      182 != 241

The implicit default concretized a generic four-signature function wrapper while the explicit default selected the algorithm-dependent autodiff/Jacobian path.

## Passing after

The identical DiffEqBase regression passed 21/21, and the full DiffEqBase Core group passed.

An isolated environment developed this branch's local DiffEqBase, OrdinaryDiffEqBDF, and OrdinaryDiffEqDefault. The official Default test suite then passed:

    Pkg.test("OrdinaryDiffEqDefault"; allow_reresolve=false)

    Default Solver Tests | 48 pass / 48 total
    Testing OrdinaryDiffEqDefault tests passed

The default `init(prob)` and explicit `init(prob, DFBDF(autodiff=AutoFiniteDiff()))` produced identical concrete problem/cache types, trajectories, and solver statistics.

Required QA passed:

    DiffEqBase:             Aqua 9/9
    OrdinaryDiffEqDefault: JET 1/1, Aqua 20/20

Julia Runic, typos over the diff, and `git diff --check` exited 0. No public API, docstring, or documentation changed, so a docs build was not required.

## Not verified

GPU, Julia prerelease, and downstream package suites were not run locally.
