### PR TITLE
Bump DiffEqBase to 7.15.1

### DIFF
--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.15.0"
+version = "7.15.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"


### PR DESCRIPTION
## What changed

Bump DiffEqBase from 7.15.0 to 7.15.1 so the DiffEqBase portion of the merged AutoDespecialize DAE and default-algorithm work can be released.

This is a version-only change. The implementation was merged in https://github.com/SciML/OrdinaryDiffEq.jl/pull/4241.

## Verification

I validated the exact current DiffEqBase source against SciMLBase PR https://github.com/SciML/SciMLBase.jl/pull/1504 at commit `71e1a412f70f45d818f21752545f7912ac4dd624`, because current master requires SciMLBase 3.46.2 and that version is not registered yet.

```text
GROUP=Core julia +release --project=lib/DiffEqBase -e 'using Pkg; Pkg.test(coverage=false, allow_reresolve=false)'
ForwardDiff Dual Detection | 355 passed, 9 broken
Opaque-p Hook              | 30 passed
Despecialized-p Hook       | 44 passed
Problem Kwargs Merging     | 23 passed
Verbose Inference          | 2 passed
Testing DiffEqBase tests passed

GROUP=QA julia +release --project=lib/DiffEqBase -e 'using Pkg; Pkg.test(coverage=false, allow_reresolve=false)'
Aqua | 9 passed
Testing DiffEqBase tests passed
```

`Runic --check lib/DiffEqBase/src`, typos over the diff, and `git diff --check` all exited 0.

## Release-order dependency

The ordinary registered graph cannot resolve this source yet: SciMLBase 3.46.2 is required by the preceding DiffEqBase 7.15.0 change, but only exists on https://github.com/SciML/SciMLBase.jl/pull/1504. The exact clean-master boundary and passing parent are documented at https://github.com/SciML/OrdinaryDiffEq.jl/issues/4249. This package should be registered after SciMLBase 3.46.2.

I did not run GPU, prerelease Julia, downstream, or the full monorepo suite locally.

Ignore this draft until reviewed by @ChrisRackauckas.
