### PR TITLE
Bump OrdinaryDiffEqDefault to 2.4.5

### DIFF
--- a/lib/OrdinaryDiffEqDefault/Project.toml
+++ b/lib/OrdinaryDiffEqDefault/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqDefault"
 uuid = "50262376-6c5a-4cf5-baba-aaf4f84d72d7"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.4.4"
+version = "2.4.5"
 
 [deps]
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"


### PR DESCRIPTION
## What changed

Bump OrdinaryDiffEqDefault from 2.4.4 to 2.4.5 so the default DAE AutoDespecialize precompile path merged in https://github.com/SciML/OrdinaryDiffEq.jl/pull/4241 can be released.

This is a version-only change.

## Verification

I validated the exact current OrdinaryDiffEqDefault source with a locally pinned manifest containing the current monorepo DiffEqBase and OrdinaryDiffEqBDF sources plus SciMLBase PR https://github.com/SciML/SciMLBase.jl/pull/1504 at commit `71e1a412f70f45d818f21752545f7912ac4dd624`.

```text
GROUP=Core julia +release --project=lib/OrdinaryDiffEqDefault -e 'using Pkg; Pkg.test(coverage=false, allow_reresolve=false)'
Default Solver Tests | 48 passed
Testing OrdinaryDiffEqDefault tests passed

GROUP=QA julia +release --project=lib/OrdinaryDiffEqDefault -e 'using Pkg; Pkg.test(coverage=false, allow_reresolve=false)'
JET Tests | 1 passed
Aqua      | 20 passed
Testing OrdinaryDiffEqDefault tests passed
```

`Runic --check lib/OrdinaryDiffEqDefault/src`, typos over the diff, and `git diff --check` all exited 0.

## Release-order dependency

The ordinary registered graph cannot resolve current master yet: SciMLBase 3.46.2 is required, but only exists on https://github.com/SciML/SciMLBase.jl/pull/1504. The exact clean-master boundary and passing parent are documented at https://github.com/SciML/OrdinaryDiffEq.jl/issues/4249. Release order should be SciMLBase 3.46.2, DiffEqBase 7.15.1, OrdinaryDiffEqBDF 2.4.3, then OrdinaryDiffEqDefault 2.4.5.

I did not run GPU, prerelease Julia, downstream, or the full monorepo suite locally.

Ignore this draft until reviewed by @ChrisRackauckas.
