### PR TITLE
Bump OrdinaryDiffEqBDF to 2.4.3

### DIFF
--- a/lib/OrdinaryDiffEqBDF/Project.toml
+++ b/lib/OrdinaryDiffEqBDF/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqBDF"
 uuid = "6ad6398a-0878-4a85-9266-38940aa047c8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.4.2"
+version = "2.4.3"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"


### PR DESCRIPTION
## What changed

Bump OrdinaryDiffEqBDF from 2.4.2 to 2.4.3 so the DFBDF and DNordsieckBDF AutoDespecialize precompile work merged in https://github.com/SciML/OrdinaryDiffEq.jl/pull/4241 can be released.

This is a version-only change.

## Verification

I validated the exact current OrdinaryDiffEqBDF source with current monorepo dependencies and SciMLBase PR https://github.com/SciML/SciMLBase.jl/pull/1504 at commit `71e1a412f70f45d818f21752545f7912ac4dd624`.

```text
GROUP=Core julia +release --project=lib/OrdinaryDiffEqBDF -e 'using Pkg; Pkg.test(coverage=false, allow_reresolve=false)'
DAE Convergence Tests           | 50 passed
DAE AD Tests                    | 40 passed
DAE Event Tests                 | 4 passed
DAE derivative_discontinuity!   | 11 passed
DAE Initialization Tests        | 38 passed, 2 broken
DAE Nonlinear Solve Path Tests  | 16 passed
BDF Inference Tests             | 1 passed
BDF Convergence Tests           | 84 passed
BDF Regression Tests            | 35 passed
Nordsieck BDF Tests             | 101 passed
Testing OrdinaryDiffEqBDF tests passed
```

The ordinary `Pkg.test` QA route reproduced the clean-master release-order failure `report_integrator_failure not defined in SciMLBase`. After pinning the unchanged QA group environment to SciMLBase PR 1504, the official QA runner passed:

```text
Allocation Tests | 2 passed, 18 broken
JET Tests        | 18 passed, 23 broken
Aqua             | 21 passed
```

`Runic --check lib/OrdinaryDiffEqBDF/src`, typos over the diff, and `git diff --check` all exited 0.

## Release-order dependency

SciMLBase 3.46.2 is required by current master but is not registered; it only exists on https://github.com/SciML/SciMLBase.jl/pull/1504. The exact clean-master boundary and passing parent are documented at https://github.com/SciML/OrdinaryDiffEq.jl/issues/4249. Release order should be SciMLBase 3.46.2, DiffEqBase 7.15.1, this OrdinaryDiffEqBDF 2.4.3 release, then OrdinaryDiffEqDefault 2.4.5.

I did not run GPU, prerelease Julia, downstream, or the full monorepo suite locally.

Ignore this draft until reviewed by @ChrisRackauckas.
