### PR TITLE
Clamp initial dt probe to first tstop

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
@@ -642,9 +642,13 @@ Convenience wrapper that calls [`ode_determine_initdt`](@ref) with the fields of
 `integrator` (state, tolerances, norm, problem).
 """
 function _determine_initdt(integrator)
+    tdir = integrator.tdir
+    dtmax = tdir * min(
+        abs(integrator.opts.dtmax), abs(first_tstop(integrator) - tdir * integrator.t)
+    )
     return ode_determine_initdt(
         integrator.u, integrator.t,
-        integrator.tdir, integrator.opts.dtmax,
+        tdir, dtmax,
         integrator.opts.abstol, integrator.opts.reltol,
         integrator.opts.internalnorm, integrator.sol.prob,
         integrator

--- a/test/InterfaceI/ode_initdt_tests.jl
+++ b/test/InterfaceI/ode_initdt_tests.jl
@@ -130,3 +130,23 @@ end
     sol_ok = solve(ODEProblem(f_ok, [1.0], (0.0, 1.0)), Tsit5())
     @test SciMLBase.successful_retcode(sol_ok)
 end
+
+@testset "Initial dt probe respects the first tstop" begin
+    for (tspan, tstop) in (((0.0, 10.0), 1.0e-3), ((10.0, 0.0), 9.999))
+        tdir = sign(tspan[2] - tspan[1])
+        for stop_keyword in (:tstops, :d_discontinuities)
+            options = NamedTuple{(stop_keyword,)}(([tstop],))
+            for isinplace in (false, true)
+                evaluated = Float64[]
+                f = if isinplace
+                    (du, u, p, t) -> (push!(p, t); du .= -u)
+                else
+                    (u, p, t) -> (push!(p, t); -u)
+                end
+                prob = ODEProblem(f, [1.0], tspan, evaluated)
+                init(prob, Tsit5(); options...)
+                @test maximum(tdir .* (evaluated .- tstop)) <= 0
+            end
+        end
+    end
+end


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## What changed and why

Bound the `dtmax` passed to `ode_determine_initdt` by the directional distance from the integrator's current time to its first `tstop`. This prevents the initial step-size probe from evaluating the RHS after a user `tstop` or `d_discontinuity`; the existing stop heap also makes the bound apply correctly to backward integration.

Added a looped regression test covering forward and backward integration, in-place and out-of-place RHS functions, and independent `tstops` and `d_discontinuities` inputs.

Fixes https://github.com/SciML/OrdinaryDiffEq.jl/issues/4240

## Root cause

`_determine_initdt` passed the configured `dtmax` directly to `ode_determine_initdt`. The default is the full signed `tspan` width, while `modify_dt_for_tstops!` only clamps the actual step afterward, so the estimator's second RHS evaluation could already have crossed the first stop.

## Verification

Failing before the implementation change:

```text
$ GROUP=InterfaceI julia +1.12 --project -e 'using Pkg; Pkg.test()'
Test Summary:                                | Pass  Fail  Total     Time
Initdt Tests                                 |   29     8     37  1m55.4s
  Initial dt probe respects the first tstop  |          8      8     7.6s
ERROR: Some tests did not pass: 29 passed, 8 failed, 0 errored, 0 broken.
```

Passing with the implementation change:

```text
$ GROUP=InterfaceI julia +1.12 --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
Initdt Tests  |   37     37  1m54.7s
...
Testing OrdinaryDiffEq tests passed
```

The final regression assertion was rerun after formatting:

```text
Test Summary:                             | Pass  Total  Time
Initial dt probe respects the first tstop |    8      8  4.4s
```

Additional checks:

```text
$ GROUP=QA julia +1.12 --project -e 'using Pkg; Pkg.test()'
Test Summary:           | Pass  Total   Time
Quality Assurance Tests |   90     90  15.3s
Testing OrdinaryDiffEq tests passed

$ julia +1.12 -m Runic --check lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl test/InterfaceI/ode_initdt_tests.jl
# exit 0, no output

$ typos lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl test/InterfaceI/ode_initdt_tests.jl
# exit 0, no output
```

The issue reproducer now reports probes at the stop and bounded initial steps:

```text
oop-forward: dt=0.001, evaluated=[0.0, 0.0, 0.001]
iip-forward: dt=0.001, evaluated=[0.0, 0.0, 0.001]
oop-backward: dt=-0.0009999999999994458, evaluated=[10.0, 10.0, 9.999]
iip-backward: dt=-0.0009999999999994458, evaluated=[10.0, 10.0, 9.999]
```

The registered SciMLBase 3.47.0 did not yet contain `report_integrator_failure`, which current OrdinaryDiffEq `master` expects. Local tests therefore used the pending SciMLBase source containing that hook through an ignored Manifest entry; this workaround is not part of the diff.

## Not verified

- `GROUP=Everything`, downstream, GPU, Julia pre-release, and Julia LTS lanes were not run locally.
- Docs were not built because the change does not touch docstrings, rendered docs, or public API.
