### PR TITLE
Restore the upcrossing callback expectation

### DIFF
--- a/lib/DiffEqBase/test/downstream/community_callback_tests.jl
+++ b/lib/DiffEqBase/test/downstream/community_callback_tests.jl
@@ -232,7 +232,7 @@ cb = VectorContinuousCallback(cond!, terminate_affect!, 1)
 u0 = [0.0, 0.0, 1.0]
 prob = ODEProblem(f!, u0, (0.0, 10.0); callback = cb)
 soln = solve(prob, Tsit5())
-@test soln.t[end] ≈ pi / 2 atol = 1.0e-4
+@test soln.t[end] ≈ 3pi / 2 atol = 1.0e-4
 
 odefun = ODEFunction((u, p, t) -> [u[2], u[2] - p]; mass_matrix = [1 0; 0 0])
 callback = PresetTimeCallback(0.5, integ -> (integ.p = -integ.p))


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.**

## What changed

Restore the community callback regression's expected termination time to `3pi / 2`. The callback deliberately terminates only for a `+1` signed event (an upcrossing); since its condition is `u[3] = cos(t)`, the first qualifying event is the upcrossing at `3pi / 2`, not the downcrossing at `pi / 2`.

## Root cause

https://github.com/SciML/OrdinaryDiffEq.jl/pull/3914 deliberately preserved the test's upcrossing-only behavior with `any(isone, events)` and verified termination near `3pi / 2`. Later, https://github.com/SciML/OrdinaryDiffEq.jl/commit/a351aa2a6b7d64459731f4e8b415ce043a3168ba changed only the expected time to `pi / 2`, based on the incompatible assumption that the affect ran for every crossing. A source/test bisect from current master to its parent `bde2e13420670b588950d5507ce32d6ecf8af41c` identified `a351aa2a6b7d64459731f4e8b415ce043a3168ba` as the first bad commit. Direct current-master and `9d92d1c7220ab2fbb2a8f141a27ddd95db904789` controls both produced the same termination time, confirming this is a stale expectation rather than a solver change between those commits.

This was exposed in https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/31772115802/job/94680127903.

## Failing before / passing after

Before:

```text
soln.t[end] = 4.712335206969428
pi / 2 = 1.5707963267948966
Test Failed
  Evaluated: 4.712335206969428 ≈ 1.5707963267948966 (atol=0.0001)
```

After, with the same tight tolerance:

```text
soln.t[end] = 4.712335206969428
(3pi) / 2 = 4.71238898038469
```

The full group then reported:

```text
Test Summary:            | Pass  Total      Time
Community Callback Tests |   16     16  10m36.4s
Test Summary:              | Pass  Total   Time
Distributed Ensemble Tests |    4      4  53.1s
Testing DiffEqBase tests passed
```

## Local verification

- `GROUP=Downstream2 julia +1.12 --project=lib/DiffEqBase -e 'using Pkg; Pkg.test()'`: passed in 1239.92 s; Community Callback 16/16 and Distributed Ensemble 4/4.
- `GROUP=QA julia +1.12 --project=lib/DiffEqBase -e 'using Pkg; Pkg.test()'`: Aqua 9/9; final output `Testing DiffEqBase tests passed`.
- `julia +1.12 --startup-file=no -m Runic --check lib/DiffEqBase/test/downstream/community_callback_tests.jl`: passed.
- `typos lib/DiffEqBase/test/downstream/community_callback_tests.jl`: passed.
- `git diff --check`: passed.

Current master has the independent SciMLBase hook load failure addressed by https://github.com/SciML/OrdinaryDiffEq.jl/pull/4253. Local runtime and group validation temporarily included only its guard commit https://github.com/SciML/OrdinaryDiffEq.jl/commit/399453a90c7f6b664e1ec875f4a2aec77eda9f05; that prerequisite commit was removed before this focused branch was committed and pushed.

Docs, GPU, and prerelease Julia jobs were not run because this is a test-only correction for the Julia 1.12 DiffEqBase Downstream2 job.
