### PR TITLE
Preserve invalid positional solver errors after default preparation

### DIFF
--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.18.0"
+version = "7.18.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/DiffEqBase/src/solve.jl
+++ b/lib/DiffEqBase/src/solve.jl
@@ -123,7 +123,7 @@ end
 
 Base.@constprop :aggressive function init_up(prob::AbstractDEProblem, sensealg, u0, p, args...; kwargs...)
     alg = extract_alg(args, kwargs, has_kwargs(prob) ? prob.kwargs : kwargs)
-    if isnothing(alg)
+    if isnothing(alg) && (isempty(args) || first(args) === nothing)
         alg = prepare_alg(alg, u0, p, prob)
     end
     return if isnothing(alg) || !(alg isa AbstractDEAlgorithm) # Default algorithm handling
@@ -640,7 +640,7 @@ Base.@constprop :aggressive function solve_up(
         kwargs...
     )
     alg = extract_alg(args, kwargs, has_kwargs(prob) ? prob.kwargs : kwargs)
-    if isnothing(alg)
+    if isnothing(alg) && (isempty(args) || first(args) === nothing)
         alg = prepare_alg(alg, u0, p, prob)
     end
     return if isnothing(alg) || !(alg isa AbstractDEAlgorithm) # Default algorithm handling

--- a/lib/DiffEqBase/test/downstream/solve_error_handling.jl
+++ b/lib/DiffEqBase/test/downstream/solve_error_handling.jl
@@ -18,6 +18,7 @@ sol = solve(prob, nothing, alg = Tsit5())
 sol = init(prob, nothing, alg = Tsit5())
 
 @test_throws SciMLBase.NonSolverError solve(prob, 5.0)
+@test_throws SciMLBase.NonSolverError init(prob, 5.0)
 
 prob = ODEProblem{false}(f_oop, u0, (nothing, nothing))
 @test_throws SciMLBase.NoTspanError solve(prob, Tsit5())


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.**

## What changed and why

Prepare a problem-dependent default algorithm only when the caller omitted the positional algorithm or explicitly passed `nothing`. Invalid positional values now continue through the normal fallback and raise `NonSolverError` instead of being silently replaced and dropped. The matching `init(prob, 5.0)` regression is covered alongside `solve(prob, 5.0)`, and DiffEqBase is bumped to 7.18.1.

An independent runtime bisect from current master https://github.com/SciML/OrdinaryDiffEq.jl/commit/3c20997bb9aaf93d5c7bebcdd63810eb63416e6b to good https://github.com/SciML/OrdinaryDiffEq.jl/commit/9d92d1c7220ab2fbb2a8f141a27ddd95db904789 identified https://github.com/SciML/OrdinaryDiffEq.jl/commit/27faa3ad384c655109e7fd9a99af8abfc0ac556c as the first bad commit. That commit made `prepare_alg` unconditional whenever `extract_alg` returned `nothing`; for an invalid positional `5.0`, this installed `DefaultODEAlgorithm`, entered the valid-algorithm branch, and discarded the invalid argument.

## Failing before / passing after

On unfixed current master, both calls fail to throw:

```text
Test Failed at none:1
  Expression: solve(prob, 5.0)
    Expected: SciMLBase.NonSolverError
  No exception thrown

Test Failed at none:1
  Expression: init(prob, 5.0)
    Expected: SciMLBase.NonSolverError
  No exception thrown
```

With this patch, the complete error-handling testset and DiffEqBase downstream group pass:

```text
Test Summary:        | Pass  Total   Time
Solve Error Handling |   14     14  33.2s

1998.991675 seconds
Testing DiffEqBase tests passed
```

## Local verification

- `GROUP=Downstream julia +1.12 --project=lib/DiffEqBase -e 'using Pkg; Pkg.test()'`: passed in 1998.99 seconds. Error handling 14/14; Enzyme 5/5; Unitful 4/4; FlexUnits 3/3; all other downstream testsets completed.
- `GROUP=QA julia +1.12 --project=lib/DiffEqBase -e 'using Pkg; Pkg.test()'`: Aqua 9/9; package tests passed.
- A compiled-modules-disabled focused run of `solve(prob, 5.0)` and `init(prob, 5.0)` passed after failing on the unfixed source; the complete `solve_error_handling.jl` file passed 14/14.
- Runic on the changed Julia files, `typos` on all three changed files, and `git diff upstream/master --check`: passed.

The DiffEqBase change intentionally triggers the broad CI matrix requested for this master-failure audit. Docs, GPU, and prerelease-Julia jobs were not run locally because this changes no public API or documentation and the local target is DiffEqBase downstream/error handling.
