### PR TITLE
Filter derivative discontinuities before the initial time

### DIFF
--- a/lib/DelayDiffEq/test/interface/discontinuities.jl
+++ b/lib/DelayDiffEq/test/interface/discontinuities.jl
@@ -124,6 +124,20 @@ end
     @test sol.u[end] ≈ [2.0]
 end
 
+@testset "discontinuity before tspan[1]" begin
+    history(p, t) = ones(1)
+    function f(du, u, h, p, t)
+        du[1] = -h(p, t - 10.0)[1]
+        return nothing
+    end
+    prob = DDEProblem(f, [1.0], history, (0.0, 50.0); constant_lags = (10.0,))
+
+    sol = solve(prob, MethodOfSteps(Tsit5()); d_discontinuities = [-3.0])
+
+    @test sol.retcode == ReturnCode.Success
+    @test sol.t[end] == prob.tspan[2]
+end
+
 # discontinuities induced by callbacks
 @testset "#190" begin
     cb = ContinuousCallback((u, t, integrator) -> 1, integrator -> nothing)

--- a/lib/OrdinaryDiffEqCore/src/solve.jl
+++ b/lib/OrdinaryDiffEqCore/src/solve.jl
@@ -1157,11 +1157,13 @@ Build the internal directional queue of derivative-discontinuity times.
 
 # Returns
 
-- `BinaryHeap{T}`: All requested discontinuities stored in integration direction.
+- `BinaryHeap{T}`: Requested discontinuities at or after the initial time in the
+  integration direction, stored directionally.
 
 # Rules
 
-- Unlike `initialize_tstops`, this helper does not filter times against `tspan`.
+- Entries before the initial time in the integration direction are discarded. Entries
+  at the initial time and beyond the final time are retained.
 - Solver authors use this queue only when their initialization path supports the
   `d_discontinuities` solve keyword.
 
@@ -1176,14 +1178,7 @@ discontinuities = initialize_d_discontinuities(Float64, (0.5,), (0.0, 1.0))
 function initialize_d_discontinuities(::Type{T}, d_discontinuities, tspan) where {T}
     d_discontinuities_internal = BinaryHeap{T}(FasterForward())
     sizehint!(d_discontinuities_internal, length(d_discontinuities))
-
-    t0, tf = tspan
-    tdir = sign(tf - t0)
-
-    for t in d_discontinuities
-        push!(d_discontinuities_internal, tdir * t)
-    end
-
+    reinit_d_discontinuities!(T, d_discontinuities_internal, d_discontinuities, tspan)
     return d_discontinuities_internal
 end
 
@@ -1192,9 +1187,11 @@ function reinit_d_discontinuities!(::Type{T}, d_discontinuities_internal, d_disc
 
     t0, tf = tspan
     tdir = sign(tf - t0)
+    tdir_t0 = tdir * t0
 
     for t in d_discontinuities
-        push!(d_discontinuities_internal, tdir * t)
+        tdir_t = tdir * t
+        tdir_t0 ≤ tdir_t && push!(d_discontinuities_internal, tdir_t)
     end
     return
 end

--- a/lib/OrdinaryDiffEqCore/test/developer_time_queue_api_tests.jl
+++ b/lib/OrdinaryDiffEqCore/test/developer_time_queue_api_tests.jl
@@ -28,8 +28,23 @@ end
     ) == [-0.25]
 
     @test popall!(
-        OrdinaryDiffEqCore.initialize_d_discontinuities(Float64, (0.25, 0.75), (1.0, 0.0))
-    ) == [-0.75, -0.25]
+        OrdinaryDiffEqCore.initialize_d_discontinuities(
+            Float64, (-1.0, 0.0, 0.25, 1.0, 2.0), (0.0, 1.0)
+        )
+    ) == [0.0, 0.25, 1.0, 2.0]
+    @test popall!(
+        OrdinaryDiffEqCore.initialize_d_discontinuities(
+            Float64, (2.0, 1.0, 0.75, 0.0, -1.0), (1.0, 0.0)
+        )
+    ) == [-1.0, -0.75, 0.0, 1.0]
+
+    discontinuities = OrdinaryDiffEqCore.initialize_d_discontinuities(
+        Float64, (-1.0,), (0.0, 1.0)
+    )
+    OrdinaryDiffEqCore.reinit_d_discontinuities!(
+        Float64, discontinuities, (-1.0, 0.0, 2.0), (0.0, 1.0)
+    )
+    @test popall!(discontinuities) == [0.0, 2.0]
 
     float32_tstops = OrdinaryDiffEqCore.initialize_tstops(
         Float32, (Float32(0.5),), (), (Float32(0), Float32(1))


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Filter derivative-discontinuity entries that lie before the initial time in the integration direction when initializing or reinitializing the internal queue. Entries at the initial time and beyond the final time remain unchanged, and the same rule is applied for forward and reverse integration.

A stale pre-`t0` entry otherwise remains permanently at the head of the queue. For DDEs, that blocks later propagated discontinuities from being handled, leaves a propagated `tstop` at zero distance, and terminates the solve with `DtLessThanMin`.

This follows the resolution chosen in https://github.com/SciML/OrdinaryDiffEq.jl/issues/4199#issuecomment-5238111435: discard entries before `t0` instead of propagating history discontinuities.

Closes https://github.com/SciML/OrdinaryDiffEq.jl/issues/4199

## Failing before

I retained the new regression tests, temporarily restored the unfixed queue initialization, and ran:

```sh
GROUP=DelayDiffEq_Interface /home/crackauc/.juliaup/bin/julia +1.12 --project --color=no -e 'using Pkg; Pkg.test()'
```

The pre-`t0` DDE stopped at its first propagated discontinuity:

```text
Expression: sol.retcode == ReturnCode.Success
Evaluated: DtLessThanMin == Success

Expression: sol.t[end] == prob.tspan[2]
Evaluated: 10.0 == 50.0

Test Summary:       | Pass  Fail  Total
Discontinuity Tests |   53     2     55
```

## Passing after

On final commit `a5c928b269b506f48df065b4aa085adfbfa82dda`:

```sh
GROUP=DelayDiffEq_Interface /home/crackauc/.juliaup/bin/julia +1.12 --project --color=no -e 'using Pkg; Pkg.test()'
```

```text
Test Summary:       | Pass  Total   Time
Discontinuity Tests |   55     55  16.6s
Test Summary:         | Pass  Total     Time
Multi-Algorithm Tests |   28     28  1m47.2s
Testing DelayDiffEq tests passed
Testing OrdinaryDiffEq tests passed
```

The Core group covers forward filtering, reverse filtering, preservation of `t0` and post-`tf` entries, and reinitialization:

```sh
GROUP=OrdinaryDiffEqCore_Core /home/crackauc/.juliaup/bin/julia +1.12 --project --color=no -e 'using Pkg; Pkg.test()'
```

```text
Test Summary:            | Pass  Total  Time
Developer Time Queue API |    8      8  1.6s
Testing OrdinaryDiffEqCore tests passed
Testing OrdinaryDiffEq tests passed
```

QA also passed:

```sh
GROUP=QA /home/crackauc/.juliaup/bin/julia +1.12 --project --color=no -e 'using Pkg; Pkg.test()'
```

```text
Test Summary:           | Pass  Total   Time
Quality Assurance Tests |   90     90  15.2s
Testing OrdinaryDiffEq tests passed
```

Runic over all three changed Julia files, `typos` over the diff, and `git diff --check` all exited 0.

The full documentation command also exited 0 through cross-references and HTML rendering:

```sh
/home/crackauc/.juliaup/bin/julia +1.12 --project=docs --color=no --startup-file=no docs/make.jl
```

That docs validation used the local SciMLBase documentation-fix stack for the independently reproduced `ODENLStepData`, `AutoRespecialize`, and dead `Problem_Traits` links. It did not disable or downgrade any Documenter checks.

## Not verified

I did not run `GROUP=Everything`, GPU jobs, or downstream-package jobs. No dependency or public name was added.