### PR TITLE
Correct derivative discontinuity tstop expectation

### DIFF
--- a/test/InterfaceI/ode_tstops_tests.jl
+++ b/test/InterfaceI/ode_tstops_tests.jl
@@ -18,7 +18,7 @@ Random.seed!(100)
         prob, RK4(), dt = 1 // 3, tstops = [1 / 2],
         d_discontinuities = [-1 / 2, 1 / 2, 3 / 2], adaptive = false
     )
-    @test sol.t == [0, 1 / 3, 1 / 2, 1 / 3 + 1 / 2, 1]
+    @test sol.t == [0, 1 / 3, 1 / 2, nextfloat(1 / 2) + 1 / 3, 1]
 
     # TODO
     integrator = init(


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Keep exact equality in the fixed-step `d_discontinuities` test, but calculate the first post-discontinuity time from `nextfloat(1 / 2)`. The active derivative discontinuity advances the integrator one ULP before the following `1 / 3` step, as documented by `shift_past_discontinuity!`; the previous expression described the no-discontinuity case.

This surfaced after https://github.com/SciML/OrdinaryDiffEq.jl/pull/4258 correctly filtered the stale pre-`t0` discontinuity which had blocked the real `1 / 2` entry.

## Failing before

On clean current OrdinaryDiffEq master `080fa945ba2a01cb1c3654aa24a56cf97fe4919d`, Julia 1.12.6:

```sh
GROUP=InterfaceI JULIA_NUM_THREADS=2 julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test(; coverage=false)'
```

```text
Expression: sol.t == [0, 1 / 3, 1 / 2, 1 / 3 + 1 / 2, 1]
Evaluated: [0.0, 0.3333333333333333, 0.5, 0.8333333333333335, 1.0] == [0.0, 0.3333333333333333, 0.5, 0.8333333333333333, 1.0]
Test Summary: | Pass Fail Total
Tstops Tests  |   61    1    62
```

An isolated current/parent source control used the same RK4 solve and printed the exact Float64 bit patterns. Current master produced a two-ULP delta only with `d_discontinuities`; parent `8c7968fa` produced the old exact value because the stale `-1 / 2` entry still blocked the active discontinuity.

## Passing after

```sh
GROUP=InterfaceI JULIA_NUM_THREADS=2 julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test(; coverage=false)'
```

```text
Test Summary:                 | Pass Total     Time
Algebraic Interpolation Tests |   52    52  2m29.0s
Test Summary:                           | Pass Total Time
Interpolation and Cache Stripping Tests |   16    16 3.6s
Test Summary:             | Pass Total  Time
Public API Package Splits |   15    15 40.0s
Test Summary:  | Pass Total Time
Aliasing Tests |    1     1 0.2s
Test Summary:           | Pass Total Time
Solution Memory Release |    1     1 0.3s
Testing OrdinaryDiffEq tests passed
```

```sh
GROUP=QA JULIA_NUM_THREADS=2 julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test(; coverage=false)'
```

```text
Test Summary:           | Pass Total     Time
Quality Assurance Tests |   90    90  8m25.1s
Testing OrdinaryDiffEq tests passed
```

Julia Runic `--check` on the changed file, `typos` on the changed file, and `git diff --check` all exited 0.

## Not verified

I did not run `GROUP=Everything`, GPU jobs, or the other Julia-version matrices locally. This test-only change does not touch public API or documentation.
