### PR TITLE
Support nlstep_data on the DAE and multistep stage paths

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -111,13 +111,31 @@ function initialize!(
         integrator.stats.nsolve += cache.cache.stats.nsolve
     end
 
-    nlstep_data = f.nlstep_data
+    nlstep_data = get_nlstep_data(f)
     if nlstep_data !== nothing
         atmp .= 0
-        if method === COEFFICIENT_MULTISTEP
-            nlstep_data.set_γ_c(nlstep_data.nlprob, (one(t), one(t), α * invγdt, tstep))
+        if f isa DAEFunction
+            # Fully implicit: `_compute_rhs!` states the stage residual as `F(du, u, p, t)`
+            # at `du = (tmp + α z) * invγdt` and `u = get_dae_uprev(integrator, uprev) + z`,
+            # so the coefficient lands on the derivative argument and the state argument
+            # carries the predictor base -- `cache.u₀` for a multistep method, not `uprev`.
+            # There is no `M z` term, so `γ₃` stays 1.
+            @.. broadcast = false ustep = tmp * invγdt
+            nlstep_data.set_γ_c(nlstep_data.nlprob, (α * invγdt, one(t), one(t), tstep))
+            nlstep_data.set_inner_tmp(nlstep_data.nlprob, get_dae_uprev(integrator, uprev))
+            nlstep_data.set_outer_tmp(nlstep_data.nlprob, ustep)
+        elseif method === COEFFICIENT_MULTISTEP
+            # The multistep residual `tmp + f(z) - (α * invγdt) * M * z` is `O(z / dt)`, but
+            # the convergence check measures this residual against the solution scale, so at
+            # small `dt` it reads as divergence and the step is rejected -- which shrinks
+            # `dt`, inflates it further, and walks the solver to `dtmin`. Scale the stage
+            # system so the `M z` coefficient is 1, as in the branch below. The root is
+            # unchanged.
+            s = inv(α * invγdt)
+            @.. broadcast = false ustep = tmp * s
+            nlstep_data.set_γ_c(nlstep_data.nlprob, (s, one(t), one(t), tstep))
             nlstep_data.set_inner_tmp(nlstep_data.nlprob, atmp)
-            nlstep_data.set_outer_tmp(nlstep_data.nlprob, tmp)
+            nlstep_data.set_outer_tmp(nlstep_data.nlprob, ustep)
         else
             nlstep_data.set_γ_c(nlstep_data.nlprob, (dt, γ, one(t), tstep))
             nlstep_data.set_inner_tmp(nlstep_data.nlprob, tmp)
@@ -488,7 +506,7 @@ end
     (; z, tmp, ztmp, γ, α, cache, method) = nlsolver
     (; tstep, invγdt, atmp, ustep) = cache
 
-    nlstep_data = integrator.f.nlstep_data
+    nlstep_data = get_nlstep_data(integrator.f)
     nlcache = nlsolver.cache.cache
     if nlcache isa NonlinearSolveNoInitCache
         # A no-init cache holds no iteration state, so it cannot be driven one `step!` at a

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -2,6 +2,12 @@
 # This allows nlsolver to work with DiscreteFunction which lacks mass_matrix
 get_mass_matrix(f) = hasproperty(f, :mass_matrix) ? f.mass_matrix : I
 
+# Not every `AbstractSciMLFunction` has an `nlstep_data` field: a `DynamicalODEFunction`
+# has none, so reading it outright threw before the first step. Mirrors the field check
+# `get_mass_matrix` already uses for `DiscreteFunction`; it constant-folds on a concrete
+# `f`, so the branch selecting `prob` stays resolved at compile time.
+get_nlstep_data(f) = hasfield(typeof(f), :nlstep_data) ? f.nlstep_data : nothing
+
 # Map a flat linear-solve result back onto the state container. Delegates to
 # ArrayInterface.restructure (which preserves ArrayPartition / other wrappers that
 # plain reshape collapses); Number states need a convert because restructure
@@ -828,7 +834,8 @@ function build_nlsolver(
             # `W` is the Jacobian of the *raw* stage residual, so handing it to the inner
             # solver as the Jacobian of a preconditioned one would be a lie; let the inner
             # solver differentiate the composition it actually solves.
-            use_w_reuse = !isdae && f.nlstep_data === nothing &&
+            nlstep_data = get_nlstep_data(f)
+            use_w_reuse = !isdae && nlstep_data === nothing &&
                 precondition === nothing &&
                 (
                 (
@@ -836,8 +843,8 @@ function build_nlsolver(
                         !(W_for_reuse isa AbstractSciMLOperator)
                 ) || matrixfree_W
             )
-            prob = if f.nlstep_data !== nothing
-                f.nlstep_data.nlprob
+            prob = if nlstep_data !== nothing
+                nlstep_data.nlprob
             else
                 nlf = isdae ? daenlf : odenlf
                 nlp_params = if isdae

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_nlstep_data_field_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_nlstep_data_field_tests.jl
@@ -1,0 +1,120 @@
+using OrdinaryDiffEqBDF, OrdinaryDiffEqSDIRK
+using OrdinaryDiffEqNonlinearSolve: NonlinearSolveAlg
+using NonlinearSolve: NewtonRaphson
+using ADTypes, SciMLBase
+using Test
+
+# `nlstep_data` is a field of `ODEFunction`/`SplitFunction` only, so `build_nlsolver` and
+# the `NonlinearSolveAlg` step have to look it up by field: reading it outright threw on
+# every other `AbstractSciMLFunction` before the first step.
+
+@testset "DynamicalODEFunction carries no nlstep_data" begin
+    # A `SecondOrderODEProblem` builds a `DynamicalODEFunction`; `u'' = -u` has
+    # `u = cos(t)`, `v = -sin(t)`.
+    ff(dv, v, u, p, t) = (dv .= -u)
+    prob = SecondOrderODEProblem(ff, [0.0], [1.0], (0.0, 1.0))
+
+    alg = ImplicitEuler(
+        nlsolve = NonlinearSolveAlg(NewtonRaphson(; autodiff = AutoFiniteDiff()))
+    )
+    sol = solve(prob, alg; reltol = 1.0e-8, abstol = 1.0e-8)
+    @test SciMLBase.successful_retcode(sol)
+    @test sol.u[end].x[1][1] ≈ -sin(1.0) rtol = 1.0e-3
+    @test sol.u[end].x[2][1] ≈ cos(1.0) rtol = 1.0e-3
+end
+
+# The `nlstep_data` stage systems below are hand-rolled stand-ins for what ModelingToolkit
+# generates, so this sublibrary can test the contract without depending on it. Each holds
+# its stage coefficients in a mutable parameter object that the six hooks write into.
+mutable struct StageParams
+    γ₁::Float64
+    γ₂::Float64
+    γ₃::Float64
+    c::Float64
+    inner::Vector{Float64}
+    outer::Vector{Float64}
+end
+
+set_γ_c!(prob, γc) = ((prob.p.γ₁, prob.p.γ₂, prob.p.γ₃, prob.p.c) = γc; nothing)
+set_outer!(prob, tmp) = (copyto!(prob.p.outer, tmp); nothing)
+set_inner!(prob, tmp) = (copyto!(prob.p.inner, tmp); nothing)
+
+# `0 = du[1] + u[1] - u[2]`, `0 = u[1] + u[2] - 1` is index-1 with the closed form
+# `u[1] = 1/2 + exp(-2t)/2`, `u[2] = 1 - u[1]`.
+function dae_f!(out, du, u, p, t)
+    out[1] = du[1] + u[1] - u[2]
+    out[2] = u[1] + u[2] - 1
+    return nothing
+end
+
+# The fully implicit stage system: `F(γ₁ z + outer_tmp, γ₂ z + inner_tmp, p, c)`.
+function dae_stage!(res, z, p)
+    du = p.γ₁ .* z .+ p.outer
+    u = p.γ₂ .* z .+ p.inner
+    dae_f!(res, du, u, nothing, p.c)
+    return nothing
+end
+
+@testset "DAEProblem with nlstep_data solves the fully implicit stage system" begin
+    # `DAEFunction` only gained the field in SciMLBase 3.44.
+    if :nlstep_data in fieldnames(DAEFunction)
+        nlstep = SciMLBase.ODENLStepData(
+            NonlinearProblem(
+                NonlinearFunction{true}(dae_stage!), zeros(2),
+                StageParams(1.0, 1.0, 1.0, 0.0, zeros(2), zeros(2))
+            ),
+            1:2, set_γ_c!, set_outer!, set_inner!, (ztmp, sol) -> (ztmp .= sol.u)
+        )
+        u0, du0, tspan = [1.0, 0.0], [-1.0, 0.0], (0.0, 1.0)
+        dvars = [true, false]
+        prob = DAEProblem(
+            DAEFunction(dae_f!; nlstep_data = nlstep), du0, u0, tspan;
+            differential_vars = dvars
+        )
+        alg = DFBDF(nlsolve = NonlinearSolveAlg(NewtonRaphson(; autodiff = AutoFiniteDiff())))
+        sol = solve(prob, alg; reltol = 1.0e-10, abstol = 1.0e-10)
+
+        # Before the stage assignment existed, both `initialize!` arms stated the stage
+        # system in mass-matrix ODE conventions, and this returned `Success` sitting at the
+        # initial condition.
+        @test SciMLBase.successful_retcode(sol)
+        @test sol.u[end][1] ≈ 0.5 + exp(-2.0) / 2 rtol = 1.0e-6
+        @test sol.u[end][2] ≈ 0.5 - exp(-2.0) / 2 rtol = 1.0e-6
+        @test sol.u[end] ≉ u0
+    end
+end
+
+odef!(du, u, p, t) = (du .= .-u .^ 3 .- u)
+
+# The mass-matrix stage system: `outer_tmp + γ₁ f(γ₂ z + inner_tmp, p, c) - γ₃ M z`.
+function ode_stage!(res, z, p)
+    u = p.γ₂ .* z .+ p.inner
+    k = similar(u)
+    odef!(k, u, nothing, p.c)
+    @. res = p.outer + p.γ₁ * k - p.γ₃ * z
+    return nothing
+end
+
+@testset "COEFFICIENT_MULTISTEP nlstep stage residual is on the solution's scale" begin
+    # `FBDF` drives the stage system through the `COEFFICIENT_MULTISTEP` arm, whose raw
+    # residual carries an `α * invγdt` factor. The `nlstep_data` branch measures that
+    # residual for convergence, so leaving it unscaled read as divergence at small `dt`
+    # and walked the solver to `dtmin`: `Unstable`, sitting at `u0`.
+    u0, tspan = [1.0], (0.0, 1.0)
+    ref = solve(ODEProblem(odef!, u0, tspan), FBDF(); reltol = 1.0e-10, abstol = 1.0e-10)
+
+    nlstep = SciMLBase.ODENLStepData(
+        NonlinearProblem(
+            NonlinearFunction{true}(ode_stage!), zeros(1),
+            StageParams(1.0, 1.0, 1.0, 0.0, zeros(1), zeros(1))
+        ),
+        1:1, set_γ_c!, set_outer!, set_inner!, (ztmp, sol) -> (ztmp .= sol.u)
+    )
+    prob = ODEProblem(ODEFunction(odef!; nlstep_data = nlstep), u0, tspan)
+    alg = FBDF(nlsolve = NonlinearSolveAlg(NewtonRaphson(; autodiff = AutoFiniteDiff())))
+    sol = solve(prob, alg; reltol = 1.0e-10, abstol = 1.0e-10)
+
+    @test SciMLBase.successful_retcode(sol)
+    @test sol.u[end] ≈ ref.u[end] rtol = 1.0e-6
+    @test sol.u[end] ≉ u0
+end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
@@ -58,6 +58,7 @@ if TEST_GROUP ∉ ("QA", "ModelingToolkit")
     @time @safetestset "NonlinearSolveAlg Preconditioning Tests" include("nsa_conditioning_tests.jl")
     @time @safetestset "NonlinearSolveAlg Residual Convergence Tests" include("nsa_residual_convergence_tests.jl")
     @time @safetestset "NonlinearSolveAlg DAEProblem Tests" include("nsa_dae_tests.jl")
+    @time @safetestset "NonlinearSolveAlg nlstep_data Field Tests" include("nsa_nlstep_data_field_tests.jl")
 end
 
 # Run QA tests (JET, Aqua)


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.** It is a draft and should not be merged before then.

Rebased onto `3d2933057` (#4279). That PR made `NonlinearSolveAlg` solve `DAEProblem`s and independently fixed four defects this branch previously carried — the `daenlf`/`oopdaenlf` argument mismatches, the unallocated `dz`, and the `initialize!` parameter tuple. Those are dropped here. **#4127 is fixed by #4279, not by this PR**; an earlier revision of this description claimed the issue stayed open, which is no longer true.

What remains is the part #4279 did not touch: `nlstep_data` on the DAE and multistep stage paths. It adds zero lines mentioning `nlstep_data`, and master's branch still has only the multistep and `DIRK` arms.

## The three defects

**1. `nlstep_data` is read as a field off any `AbstractSciMLFunction`.** Only `ODEFunction`, `SplitFunction` and (since SciMLBase 3.44) `DAEFunction` have it, so a `DynamicalODEFunction` threw before the first step:

```
FieldError: type DynamicalODEFunction has no field `nlstep_data`
  build_nlsolver(...) @ utils.jl:839
```

Looked up the way `get_mass_matrix` already does for `DiscreteFunction`. The check constant-folds on a concrete `f`, so the branch selecting `prob` stays resolved at compile time.

**2. A `DAEFunction` carrying `nlstep_data` had no stage assignment.** Both arms state the stage system in mass-matrix ODE conventions, so a fully implicit problem took the `DIRK` arm and solved the wrong system. `_compute_rhs!` states the fully implicit stage as `F(du, u, p, t)` at `du = (tmp + α z) * invγdt` and `u = get_dae_uprev(integrator, uprev) + z`, so the coefficient belongs on the *derivative* argument and the state argument carries the predictor base. There is no `M z` term, so `γ₃` stays 1.

**3. The multistep stage residual is inflated by `α * invγdt`.** `tmp + f(z) - (α * invγdt) * M * z` is `O(z / dt)`, but this branch feeds the raw residual to `calculate_residuals!` as its convergence measure. At small `dt` it reads as divergence, the step is rejected, `dt` shrinks, the residual grows, and the solver walks to `dtmin`. Scaled so the `M z` coefficient is 1, matching the `DIRK` arm — which only escaped this because its assignment omits the `invγdt` factor. The root is unchanged.

## The bit to review hardest

Defect 2's predictor base does not announce itself. `get_dae_uprev(integrator, uprev)` returns `cache.u₀` when the cache defines one — as BDF's does, since a multistep predictor is not `uprev`. Using `uprev` **still converges**: it does not error, it solves a slightly wrong stage system and reports `Success`.

Robertson index-1, `tspan = (0, 1e2)`, `abstol = reltol = 1e-10`:

```
no DAE arm at all (master):  Success  [0.0, 1.0]     ← the initial condition
with uprev:                  Success  [6.153424605628343e-6, 0.6172329005992305]
with the predictor base:     Success  [6.153591276834092e-6, 0.6172348824868119]
plain DFBDF (reference):     Success  [6.153591274602223e-6, 0.6172348823018348]
```

Four orders of accuracy between the middle two, with the same retcode either way.

## Verification

Julia 1.12.4, SciMLBase 3.47.0, on `3d2933057`.

**Multistep**, `D(y) ~ -y^3 - y` from `y = 1.0`, `tspan = (0, 1)`:

```
FBDF()                                    Success  0.2694046833972673       (reference)
FBDF(nlsolve=NonlinearSolveAlg())         Success  0.2694046833972673       (no nlstep: unaffected)
FBDF(nlsolve=NonlinearSolveAlg()) nlstep  Success  0.26940468363541614
  before this PR:                         Unstable 0.9999999999500001       ← the initial condition
```

**End to end**, all four `NonlinearSolveAlg` DAE/ODE configurations on this branch:

```
#4127's own reproducer (raw DAEFunction)  Success  [0.617234888799185, 6.153591429556399e-6, ...]
MTK DAEProblem, no nlstep                 Success  [6.153591276836758e-6, 0.6172348824869219]
MTK DAEProblem, nlstep = true             Success  [6.153591276834092e-6, 0.6172348824868119]
ODE nlstep regression                     Success  maxdiff vs plain FBDF 2.38e-10
```

**Tests** — new `lib/OrdinaryDiffEqNonlinearSolve/test/nsa_nlstep_data_field_tests.jl`, registered in that sublibrary's `runtests.jl`. The stage systems are hand-rolled so this does not add a ModelingToolkit dependency. Run as `julia --project=env <file> > log 2>&1; echo "EXIT=$?"` — exit `0`, 10 tests, no failures:

```
Test Summary:                               | Pass  Total     Time
DynamicalODEFunction carries no nlstep_data |    3      3  2m29.6s
Test Summary:                                                      | Pass  Total  Time
DAEProblem with nlstep_data solves the fully implicit stage system |    4      4   7.1s
Test Summary:                                                          | Pass  Total  Time
COEFFICIENT_MULTISTEP nlstep stage residual is on the solution's scale |    3      3   4.5s
```

Each assertion has a demonstrated failing-before state. The DAE and multistep testsets both assert `≉ u0`, because "sitting at the initial condition" was the signature of both bugs and a tolerance check alone can miss it; the DAE case is checked against the closed form `u₁ = 1/2 + exp(-2t)/2` rather than a reference solve.

## This changes ODE behaviour, deliberately

Fixing defect 3 is the point, and it turns an `Unstable` result into a correct one. `NonlinearSolveAlg` **without** `nlstep_data` is unaffected — verified byte-identical to plain `FBDF` above.

## Not verified

- The full `OrdinaryDiffEqNonlinearSolve` suite was not run to completion locally; only the `NonlinearSolveAlg` paths above.
- No GPU or downstream jobs.
- Only `DFBDF`, `FBDF` and `ImplicitEuler` were exercised. Other algorithms reach the same branch but are untested here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
