### PR TITLE
Stop paying for the inner residual the stage never reads

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.8.0"
+version = "2.9.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
@@ -51,7 +51,7 @@ SciMLTesting = "2.4"
 CommonSolve = "0.2.6"
 Pkg = "1"
 NonlinearSolve = "4.25"
-NonlinearSolveBase = "2.41"
+NonlinearSolveBase = "2.45"
 ForwardDiff = "1.3.3"
 Test = "<0.0.1, 1"
 FastBroadcast = "1.3"

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -252,8 +252,12 @@ current step needs, the Newton direction it produces is off by that ratio.
 `NLNewton` scales the increment it just computed. `NonlinearSolveAlg` cannot: the inner
 solver computes *and* applies the increment inside `step!`. Scaling the right-hand side
 beforehand is equivalent for the Newton descent `δu = -W \\ fu`, and unlike rewriting
-`nlcache.u` afterwards it leaves the inner cache's `u`/`fu` pair mutually consistent — the
-inner solver re-evaluates `fu` at the end of `step!`, so the scaling does not persist.
+`nlcache.u` afterwards it leaves the inner cache's `u`/`fu` pair mutually consistent.
+
+The scaled residual belongs to the iterate the step starts from, so it must not outlive that
+step. Every reader calls `sync_inner_residual!` first, which re-evaluates at the current
+iterate whenever the step deferred its own evaluation, and the next `initialize!`
+reinitializes the cache in any case.
 """
 function rescale_stale_W_rhs!(nlcache, nlsolver, integrator, nlstep_data)
     cache = nlsolver.cache
@@ -266,6 +270,56 @@ function rescale_stale_W_rhs!(nlcache, nlsolver, integrator, nlstep_data)
     γdt = isdae ? nlsolver.α * cache.invγdt : nlsolver.γ * integrator.dt
     W_γdt ≈ γdt && return nothing
     rmul!(get_fu(nlcache), 2 / (1 + γdt / W_γdt))
+    return nothing
+end
+
+"""
+    defers_residual(nlcache) -> Bool
+
+Whether the inner cache can end a `step!` without evaluating the residual at the iterate that
+step landed on.
+
+A stage that converges in `m` Newton iterations needs the residual at the `m` points its steps
+are taken *from*. `step!` evaluates it at the point each step lands *on*, so the last of the
+`m` evaluations has no reader: nothing in this file looks at it, and the next stage's `reinit!`
+overwrites it. Skipping it costs the stage one `f` call less than driving the solver naively.
+"""
+function defers_residual end
+
+"""
+    sync_inner_residual!(nlcache)
+
+Bring the inner cache's residual forward to its current iterate when a `step!` left it behind.
+A no-op unless an evaluation is actually outstanding, so it is cheap to call ahead of any read
+of `get_fu`.
+"""
+function sync_inner_residual! end
+
+# Shims: the `NonlinearSolveBase` API these forward to postdates this package's compat floor,
+# and without it the inner solver evaluates on every step as it always has.
+if isdefined(NonlinearSolveBase, :supports_deferred_residual)
+    defers_residual(nlcache) = NonlinearSolveBase.supports_deferred_residual(nlcache)
+    sync_inner_residual!(nlcache) = NonlinearSolveBase.refresh_residual!(nlcache)
+else
+    defers_residual(nlcache) = false
+    sync_inner_residual!(nlcache) = nothing
+end
+
+"""
+    step_inner!(nlcache, recompute_jacobian, defer_residual)
+
+Advance the inner cache by one Newton iteration, asking it to skip the residual evaluation
+that ends the step when `defer_residual` says [`sync_inner_residual!`](@ref) will supply it.
+
+The keyword only goes where it is understood: an older `NonlinearSolveBase` has no such
+keyword and would reject the call.
+"""
+function step_inner!(nlcache, recompute_jacobian, defer_residual)
+    if defer_residual
+        step!(nlcache; recompute_jacobian, evaluate_residual = false)
+    else
+        step!(nlcache; recompute_jacobian)
+    end
     return nothing
 end
 
@@ -343,6 +397,7 @@ stood before the step.
 """
 function stalled_inner_step(nlcache, ndisp, nz, fnorm_prev, γΔt)
     ndisp > roundoff_level(typeof(ndisp)) * nz && return false
+    sync_inner_residual!(nlcache)
     maxabs(get_fu(nlcache)) < fnorm_prev && return false
     return stage_unsolved(nlcache, γΔt)
 end
@@ -380,17 +435,20 @@ end
     else
         recompute_jacobian = nlsolver.iter == 1 && (cache.W === nothing || cache.new_W)
         inner_solve_failed(nlcache) && return convert(eltype(z), Inf)
+        sync_inner_residual!(nlcache)
         fnorm_prev = maxabs(get_fu(nlcache))
         γΔt = residual_to_z_scale(nlsolver, nlsolve_f(integrator) isa DAEFunction)
-        step!(nlcache; recompute_jacobian)
+        step_inner!(nlcache, recompute_jacobian, defers_residual(nlcache))
         # `step!` can *land* in a terminal state as well as start in one. Checking only on
         # entry defers a failed step to the next call, which never comes: the iterate it
         # leaves behind is unmoved, so the outer displacement test accepts the stage first.
         # An inner solver can also give up *because* there is nothing left to correct — a
         # line search collapses on a stage that is already solved — so the residual, not the
         # retcode alone, has the say.
-        inner_solve_failed(nlcache) && stage_unsolved(nlcache, γΔt) &&
-            return convert(eltype(z), Inf)
+        if inner_solve_failed(nlcache)
+            sync_inner_residual!(nlcache)
+            stage_unsolved(nlcache, γΔt) && return convert(eltype(z), Inf)
+        end
         active_u = get_u(nlcache)
         cache.stalled = stalled_inner_step(
             nlcache, maxabs(z .- active_u), maxabs(z), fnorm_prev, γΔt
@@ -437,21 +495,28 @@ end
     else
         recompute_jacobian = nlsolver.iter == 1 && (cache.W === nothing || cache.new_W)
         inner_solve_failed(nlcache) && return convert(eltype(atmp), Inf)
-        # Read before `rescale_stale_W_rhs!`, which rewrites `fu` in place: the unscaled
-        # residual is the one `step!` will produce again, so it is the like-for-like
-        # comparison.
+        # Both must precede `rescale_stale_W_rhs!`, which rewrites `fu` in place: a deferred
+        # evaluation settled after it would overwrite the rescaled residual, and the unscaled
+        # residual is the one `step!` will produce again, so it is the like-for-like read.
+        sync_inner_residual!(nlcache)
         fnorm_prev = maxabs(get_fu(nlcache))
         γΔt = residual_to_z_scale(nlsolver, nlsolve_f(integrator) isa DAEFunction)
         rescale_stale_W_rhs!(nlcache, nlsolver, integrator, nlstep_data)
-        step!(nlcache; recompute_jacobian)
+        # The `nlstep_data` branch below reads the residual on every iteration, so deferring
+        # there would only move the same evaluation a few lines later.
+        step_inner!(
+            nlcache, recompute_jacobian, nlstep_data === nothing && defers_residual(nlcache)
+        )
         # `step!` can *land* in a terminal state as well as start in one. Checking only on
         # entry defers a failed step to the next call, which never comes: the iterate it
         # leaves behind is unmoved, so the outer displacement test accepts the stage first.
         # An inner solver can also give up *because* there is nothing left to correct — a
         # line search collapses on a stage that is already solved — so the residual, not the
         # retcode alone, has the say.
-        inner_solve_failed(nlcache) && stage_unsolved(nlcache, γΔt) &&
-            return convert(eltype(atmp), Inf)
+        if inner_solve_failed(nlcache)
+            sync_inner_residual!(nlcache)
+            stage_unsolved(nlcache, γΔt) && return convert(eltype(atmp), Inf)
+        end
     end
 
     if nlstep_data !== nothing

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_stats_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_stats_tests.jl
@@ -38,6 +38,19 @@ prob = ODEProblem(
     ODEFunction(rober!; jac = rober_jac!), [1.0, 0.0, 0.0],
     (0.0, 1.0e5), [0.04, 3.0e7, 1.0e4]
 )
+const LINJAC = [-1.5 0.25; 0.0 -0.5]
+
+function lin!(du, u, p, t)
+    FCALLS[] += 1
+    du[1] = LINJAC[1, 1] * u[1] + LINJAC[1, 2] * u[2]
+    du[2] = LINJAC[2, 2] * u[2]
+    return nothing
+end
+
+linprob = ODEProblem(
+    ODEFunction(lin!; jac = (J, u, p, t) -> (J .= LINJAC; nothing)),
+    [1.0, 1.0], (0.0, 20.0)
+)
 nsa = NonlinearSolveAlg(NewtonRaphson(; autodiff = AutoForwardDiff()))
 
 @testset "reported work matches the work actually performed" begin
@@ -55,5 +68,26 @@ nsa = NonlinearSolveAlg(NewtonRaphson(; autodiff = AutoForwardDiff()))
         @test sol.stats.nf <= FCALLS[]
         @test sol.stats.nf >= 0.99 * FCALLS[]
         @test sol.stats.njacs == JCALLS[]
+    end
+end
+
+@testset "no residual evaluation per stage beyond the Newton iterations" begin
+    # A `k`-iteration stage needs the residual at the `k` points its Newton steps are taken
+    # from, but a `NonlinearSolve` cache evaluates it where each step *lands*, so driving it
+    # naively costs `k + 1`. The Jacobians here are analytic, so `NLNewton` measures how many
+    # `f` calls outside the Newton iterations a step legitimately needs.
+    #
+    # `linprob` is the case where deferring buys nothing and so has to cost nothing: its
+    # stage equation is solved exactly by one Newton step. Only one-implicit-stage methods
+    # are compared on it, because the excess below is per step while `NonlinearSolveAlg`
+    # spends one residual per *stage* re-initializing the inner cache.
+    for (p, algs) in ((prob, (KenCarp4, TRBDF2, FBDF)), (linprob, (FBDF, QNDF))), A in algs
+        excess = map((NLNewton(), nsa)) do nl
+            FCALLS[] = 0
+            sol = solve(p, A(nlsolve = nl); reltol = 1.0e-8, abstol = 1.0e-10)
+            @test SciMLBase.successful_retcode(sol)
+            (FCALLS[] - sol.stats.nnonliniter) / sol.stats.naccept
+        end
+        @test excess[2] <= excess[1] + 0.25
     end
 end


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Depends on SciML/NonlinearSolve.jl#1167 — but **degrades gracefully**, so it can merge before that releases (see below).

`NonlinearSolveAlg` pays one more rhs evaluation per implicit stage solve than `NLNewton`. For `m` Newton iterations `NLNewton` evaluates the stage residual `m` times; NSA evaluates it `m + 1`. The extra one is the residual at the **converged** iterate, produced by the `evaluate_f!` that ends `NonlinearSolveFirstOrder`'s `step!` — nothing reads it, and the next stage's `reinit!` discards it. Being per *stage solve* rather than per step, it costs multi-stage SDIRK proportionally more (KenCarp4 has 5 implicit stages).

This became visible only after #4045 fixed a 22–37% undercount in NSA's `stats.nf`.

### Budget

Bruss1D/FBDF at rtol 1e-9, identical trajectories both sides (naccept 1053, nreject 14), attributed by `stacktrace()` at a counted rhs — sums are exact:

| call site | NLNewton | NSA |
|---|---:|---:|
| `_compute_rhs!` in `compute_step!` (1 per Newton iteration) | **1738** | — |
| `evaluate_f!` at the tail of each inner `step!` | — | **1760** |
| `reinit_common!` from `initialize!` (1 per stage solve) | — | **1067** |
| AD Jacobian | 80 | 80 |
| integrator init / FSAL | 3 | 4 |
| **total counted** | **1821** | **2911** |

The excess is 1090 = 1067 stage solves + 22 extra Newton iterations + 1. The `reinit!` evaluation is *necessary* (`F(z₀)` at a new predictor is genuinely unknown — `NLNewton` computes the same thing in its first iteration); the waste is the trailing one.

### Change

`compute_step!` asks the inner cache whether it supports deferral, steps with `evaluate_residual = false` when it does, and calls `sync_inner_residual!` at the three sites that read the residual (the next step's RHS via `fnorm_prev`, `stalled_inner_step`, and the `inner_solve_failed` veto). Everything else keeps the eager path.

**Graceful degradation.** The deferral is gated on `isdefined`, so against a `NonlinearSolveBase` without the new API NSA behaves exactly as today. Verified against registry `NonlinearSolveBase` 2.43.0: `supports_deferred_residual` undefined, `sync_inner_residual!` makes 0 `f` calls, and a 408-row battery is **bit-for-bit identical to master** (total `f` 403,721,198). The `Project.toml` floor is raised to 2.45 in this PR; if that is inconvenient before the upstream release, the floor is the only thing that needs deferring.

### Effect

60 configurations — ROBER/HIRES/POLLU/VdPstiff/Bruss1D × TRBDF2/KenCarp4/FBDF/QNDF × rtol 1e-6/1e-9/1e-12:

```
NSA total nf  10,857,930 -> 6,587,656
per-config ratio: median 0.787  min 0.538  max 0.883
rows differing in trajectory, stats or error: 0 / 120
```

`retcode`, `naccept`, `nreject`, `njacs`, `nw`, `nnonliniter`, `nnonlinconvfail` and the error against a `Rodas5P` reference (reltol 1e-13/abstol 1e-15) are identical on every row — compared row by row, not by summary statistics. NLNewton rows are untouched.

NSA/NLNewton `nf` ratio: median **1.356 → 1.047**, mean 1.453 → 1.100. On some configurations NSA becomes cheaper than `NLNewton` (ROBER/KenCarp4 313,399 → 170,969 against 193,131).

### Tests

`nsa_stats_tests.jl` gains "one residual evaluation per Newton iteration". Negative control on unmodified master — 5 of 15 fail, each excess equal to that method's implicit stage count per step:

```
Evaluated: 1.0335570469798658 <= 0.2862903225806452
Evaluated: 1.1331658291457287 <= 0.25753768844221103
Evaluated: 2.168              <= 1.262
```

All nine `nsa_*.jl` files pass on this branch: 39 + 21 + 13 + 10 + 10 + 14 + 8 + 102 + 70 = **287, 0 failures**. Runic clean. `OrdinaryDiffEqNonlinearSolve` 2.8.0 → 2.9.0.

### What this does not fix

After it, the residual `nf` gap is small for FBDF (ROBER 1.09×, Bruss1D 1.02×). Two unrelated contributors remain on SDIRK, both worth their own investigation:

- NSA takes more steps on some problems — ROBER/TRBDF2@1e-9 is 1.37× the `f` but also 1.36× the accepted steps, i.e. per-step cost is identical at 2.54. Purely step selection.
- NSA hits nonlinear convergence failures where `NLNewton` has none (Bruss1D/TRBDF2@1e-9: 112 vs 0), each forcing a fresh Jacobian — that accounts for the whole remaining 1.73× there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
