### PR TITLE
GLEE: report global error via the SciMLBase interface

### DIFF
--- a/docs/src/globalerrorcontrol/GlobalDiffEq.md
+++ b/docs/src/globalerrorcontrol/GlobalDiffEq.md
@@ -18,9 +18,12 @@ The global-error-estimating solvers [`GLEE24`](@ref), [`GLEE35`](@ref)
 (Constantinescu 2016), and the Dormand-Prince-based [`MM5GEE`](@ref) (Makazaga
 and Murua 2003) carry a running, asymptotically correct estimate of the
 solution's global error at every time point, at the cost of a few extra stages
-per step. Solving with them produces a solution whose states are
-`ArrayPartition`s (`sol.u[i].x[1]` the solution, `sol.u[i].x[2]` the global
-error estimate); [`global_error_estimate`](@ref) extracts the estimates.
+per step. They report it through the standard SciMLBase global-error interface:
+solving returns an ordinary solution (`sol.u` and `sol(t)` are the solution),
+with the estimate in `sol.global_error` — `sol.global_error[i]` is the
+estimated global error of `sol.u[i]` at `sol.t[i]`, and
+[`SciMLBase.has_global_error`](@ref) is `true` for these algorithms.
+[`global_error_estimate`](@ref) returns `sol.global_error`.
 
 [`GlobalRichardson`](@ref) wraps any fixed-step method in global Richardson
 extrapolation over whole solves, interpreting `abstol` and `reltol` as global

--- a/lib/GlobalDiffEq/Project.toml
+++ b/lib/GlobalDiffEq/Project.toml
@@ -1,9 +1,10 @@
 name = "GlobalDiffEq"
 uuid = "1d72d19b-84cc-4cb7-a099-7cbdb9ccc67c"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.3.1"
+version = "1.4.0"
 
 [deps]
+Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -22,6 +23,7 @@ OrdinaryDiffEqCore = {path = "../OrdinaryDiffEqCore"}
 OrdinaryDiffEqTsit5 = {path = "../OrdinaryDiffEqTsit5"}
 
 [compat]
+Accessors = "0.1.42"
 DiffEqBase = "7"
 FastBroadcast = "1.3"
 LinearAlgebra = "1"
@@ -34,7 +36,7 @@ RecursiveArrayTools = "4.2.0"
 Reexport = "0.2, 1.0"
 Richardson = "1.2"
 SafeTestsets = "0.0.1, 0.1"
-SciMLBase = "3"
+SciMLBase = "3.48"
 SciMLTesting = "2.4"
 Test = "1"
 julia = "1.10"

--- a/lib/GlobalDiffEq/src/GlobalDiffEq.jl
+++ b/lib/GlobalDiffEq/src/GlobalDiffEq.jl
@@ -7,6 +7,7 @@ import LinearAlgebra, OrdinaryDiffEqCore, OrdinaryDiffEqTsit5,
     RecursiveArrayTools, Richardson, SciMLBase
 import DiffEqBase: initialize!, calculate_residuals, calculate_residuals!
 import OrdinaryDiffEqCore: perform_step!, @cache
+import Accessors: @set
 using FastBroadcast: FastBroadcast, @..
 using MuladdMacro: MuladdMacro, @muladd
 using PrecompileTools: @setup_workload, @compile_workload

--- a/lib/GlobalDiffEq/src/glee/algorithms.jl
+++ b/lib/GlobalDiffEq/src/glee/algorithms.jl
@@ -6,13 +6,16 @@ OrdinaryDiffEqCore.OrdinaryDiffEqAdaptiveAlgorithm end
 const _GLEE_DOCS_SHARED = """
 GLEE methods propagate the solution `y` together with an asymptotically
 correct estimate `ε` of its global (accumulated) error, at the cost of a few
-extra stages per step. Solving any `ODEProblem` with a GLEE method produces a
-solution whose states are `ArrayPartition`s: `sol.u[i].x[1]` is the solution
-and `sol.u[i].x[2]` is the global error estimate at `sol.t[i]` (see
-[`global_error_estimate`](@ref)). The per-step increment of `ε` is an
-asymptotically correct local error estimate, which drives standard step-size
-adaptivity, so local tolerances behave exactly as for ordinary adaptive
-Runge-Kutta methods while the global error is estimated for free.
+extra stages per step. Solving any `ODEProblem` with a GLEE method returns an
+ordinary solution — `sol.u[i]` is the solution at `sol.t[i]` and `sol(t)`
+interpolates it at full order — with the global error estimate reported through
+the standard SciMLBase interface: [`SciMLBase.has_global_error`](@ref) is
+`true`, and `sol.global_error[i]` is the estimated global error of `sol.u[i]`
+(also available as [`global_error_estimate`](@ref)`(sol)`). The per-step
+increment of `ε` is an asymptotically correct local error estimate, which
+drives standard step-size adaptivity, so local tolerances behave exactly as for
+ordinary adaptive Runge-Kutta methods while the global error is estimated for
+free.
 
 Only explicit, mass-matrix-free ODEs are supported. The reference for the
 methods and their theory is:
@@ -80,6 +83,8 @@ SciMLBase.alg_order(::GLEE23) = 2
 SciMLBase.alg_order(::GLEE24) = 2
 SciMLBase.alg_order(::GLEE35) = 3
 SciMLBase.alg_order(::MM5GEE) = 5
+
+SciMLBase.has_global_error(::AbstractGLEEAlgorithm) = true
 
 OrdinaryDiffEqCore.alg_adaptive_order(alg::AbstractGLEEAlgorithm) =
     SciMLBase.alg_order(alg)

--- a/lib/GlobalDiffEq/src/glee/solve.jl
+++ b/lib/GlobalDiffEq/src/glee/solve.jl
@@ -69,13 +69,66 @@ function SciMLBase.__init(
     )
 end
 
+# Wraps the interpolation of the extended (y, ε) solve and projects it onto the
+# solution partition, so `sol(t)` returns the ordinary solution at full
+# interpolation order while the global error estimate lives in
+# `sol.global_error`.
+struct GLEESolutionInterpolation{I} <: SciMLBase.AbstractDiffEqInterpolation
+    inner::I
+end
+
+_project_y(u::RecursiveArrayTools.ArrayPartition) = u.x[1]
+_project_y(u::AbstractVector) = map(_project_y, u)
+
+function _project_interpolated(full, idxs)
+    if full isa RecursiveArrayTools.AbstractDiffEqArray
+        projected = RecursiveArrayTools.DiffEqArray(map(_project_y, full.u), full.t)
+        return idxs === nothing ? projected : projected[idxs]
+    end
+    y = _project_y(full)
+    return idxs === nothing ? y : y[idxs]
+end
+
+# The extended interpolation is always queried with `idxs = nothing` (whole
+# partitioned state), then projected; user `idxs` index into the projected
+# solution component, never into the raw partition layout.
+function (interp::GLEESolutionInterpolation)(
+        tvals, idxs, deriv, p, continuity::Symbol = :left
+    )
+    full = interp.inner(tvals, nothing, deriv, p, continuity)
+    return _project_interpolated(full, idxs)
+end
+
+function (interp::GLEESolutionInterpolation)(
+        val, tvals, idxs, deriv, p, continuity::Symbol = :left
+    )
+    projected = interp(tvals, idxs, deriv, p, continuity)
+    val isa RecursiveArrayTools.AbstractDiffEqArray ? copyto!(val.u, projected) :
+        copyto!(val, projected)
+    return val
+end
+
 function SciMLBase.__solve(
         prob::SciMLBase.AbstractODEProblem, alg::AbstractGLEEAlgorithm, args...;
         kwargs...
     )
     integrator = SciMLBase.__init(prob, alg, args...; kwargs...)
     SciMLBase.solve!(integrator)
-    return integrator.sol
+    return _split_global_error_solution(integrator.sol, prob)
+end
+
+# Turn the extended (y, ε) ArrayPartition solution into an ordinary solution
+# over the user's problem: `u` holds the solution partition, `global_error`
+# holds the error partition, and the interpolation projects onto the solution.
+function _split_global_error_solution(ext_sol, prob)
+    us = [u.x[1] for u in ext_sol.u]
+    ges = [u.x[2] for u in ext_sol.u]
+    sol = @set ext_sol.interp = GLEESolutionInterpolation(ext_sol.interp)
+    sol = @set sol.prob = prob
+    sol = @set sol.global_error = ges
+    # Set `u` last: `setproperties` recomputes the solution's `T`/`N` type
+    # parameters from the new (unpartitioned) `u`.
+    return @set sol.u = us
 end
 
 """
@@ -83,24 +136,23 @@ end
     global_error_estimate(sol, i)
 
 Extract the global error estimate from a solution computed with a GLEE method
-([`GLEE23`](@ref), [`GLEE24`](@ref), [`GLEE35`](@ref)).
+([`GLEE23`](@ref), [`GLEE24`](@ref), [`GLEE35`](@ref), [`MM5GEE`](@ref)).
 
-GLEE solutions carry the partitioned state `(y, ε)`: `sol.u[i].x[1]` is the
-solution value and `sol.u[i].x[2]` the estimate of its global error at
-`sol.t[i]`. `global_error_estimate(sol, i)` returns the error estimate at the
-`i`-th saved time point and `global_error_estimate(sol)` returns the vector of
-estimates at every saved time point.
+These solvers report the global error through the standard SciMLBase interface:
+`sol.global_error` is a vector matching `sol.u`, with `sol.global_error[i]` the
+estimated global error of `sol.u[i]` at `sol.t[i]` (see
+[`SciMLBase.has_global_error`](@ref)). `global_error_estimate(sol)` returns that
+vector and `global_error_estimate(sol, i)` its `i`-th element.
 """
 function global_error_estimate(sol::SciMLBase.AbstractODESolution)
-    return [global_error_estimate(sol, i) for i in eachindex(sol.u)]
-end
-
-function global_error_estimate(sol::SciMLBase.AbstractODESolution, i::Integer)
-    u = sol.u[i]
-    u isa RecursiveArrayTools.ArrayPartition && length(u.x) == 2 || throw(
+    sol.global_error === nothing && throw(
         ArgumentError(
             "global_error_estimate expects a solution produced by a GLEE method"
         )
     )
-    return u.x[2]
+    return sol.global_error
+end
+
+function global_error_estimate(sol::SciMLBase.AbstractODESolution, i::Integer)
+    return global_error_estimate(sol)[i]
 end

--- a/lib/GlobalDiffEq/test/glee_tests.jl
+++ b/lib/GlobalDiffEq/test/glee_tests.jl
@@ -15,7 +15,7 @@ function glee_convergence(prob, alg, dts)
     est_errs = Float64[]
     for dt in dts
         sol = solve(prob, alg; dt, adaptive = false)
-        err = prince_exact(prince_tspan[2]) - sol.u[end].x[1][1]
+        err = prince_exact(prince_tspan[2]) - sol.u[end][1]
         est = global_error_estimate(sol, length(sol.u))[1]
         push!(errs, abs(err))
         push!(est_errs, abs(est - err))
@@ -48,11 +48,34 @@ end
     end
 end
 
+@testset "GLEE SciMLBase global-error interface" begin
+    prob = ODEProblem(f_prince!, [0.0], prince_tspan)
+    for alg in (GLEE23(), GLEE24(), GLEE35(), MM5GEE())
+        @test SciMLBase.has_global_error(alg)
+        sol = solve(prob, alg; dt = 1 / 64, adaptive = false)
+        # ordinary solution in `u`, global error estimate in `global_error`
+        @test !(sol.u[end] isa ArrayPartition)
+        @test eltype(sol.u) === Vector{Float64}
+        @test sol.global_error !== nothing
+        @test length(sol.global_error) == length(sol.u)
+        @test global_error_estimate(sol) === sol.global_error
+        # dense output projects onto the solution component at full order
+        for t in (0.3, 1.3, 2.0)
+            yt = sol(t)
+            @test !(yt isa ArrayPartition)
+            @test isapprox(yt[1], prince_exact(t); atol = 1.0e-2)
+        end
+        # vector-t dense output too
+        ys = sol([0.5, 1.5])
+        @test length(ys) == 2 && all(!(y isa ArrayPartition) for y in ys)
+    end
+end
+
 @testset "GLEE estimate tracks the true error" begin
     prob = ODEProblem(f_prince!, [0.0], prince_tspan)
     for alg in (GLEE23(), GLEE24(), GLEE35(), MM5GEE())
         sol = solve(prob, alg; dt = 1 / 128, adaptive = false)
-        err = prince_exact(prince_tspan[2]) - sol.u[end].x[1][1]
+        err = prince_exact(prince_tspan[2]) - sol.u[end][1]
         est = global_error_estimate(sol)[end][1]
         @test est / err ≈ 1 rtol = 0.1
     end
@@ -63,7 +86,7 @@ end
     for alg in (GLEE24(), MM5GEE())
         sol = solve(prob, alg; abstol = 1.0e-8, reltol = 1.0e-8)
         @test SciMLBase.successful_retcode(sol)
-        err = prince_exact(prince_tspan[2]) - sol.u[end].x[1][1]
+        err = prince_exact(prince_tspan[2]) - sol.u[end][1]
         est = global_error_estimate(sol)[end][1]
         @test isfinite(est)
         @test est / err ≈ 1 rtol = 0.6
@@ -72,12 +95,16 @@ end
 
 @testset "GLEE integrator interface" begin
     prob = ODEProblem(f_prince!, [0.0], prince_tspan)
+    # The low-level integrator carries the partitioned (y, ε) state internally.
     integrator = init(prob, GLEE24(); dt = 1 / 64, adaptive = false)
     @test integrator.u isa ArrayPartition
     solve!(integrator)
-    sol = integrator.sol
-    @test SciMLBase.successful_retcode(sol)
-    err = prince_exact(prince_tspan[2]) - sol.u[end].x[1][1]
+    @test SciMLBase.successful_retcode(integrator.sol)
+    # `solve` returns the split solution: ordinary `u`, error in `global_error`.
+    sol = solve(prob, GLEE24(); dt = 1 / 64, adaptive = false)
+    @test !(sol.u[end] isa ArrayPartition)
+    @test SciMLBase.has_global_error(GLEE24())
+    err = prince_exact(prince_tspan[2]) - sol.u[end][1]
     @test global_error_estimate(sol)[end][1] / err ≈ 1 rtol = 0.1
 end
 


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

**Independent PR** — a single commit on current `master` (GlobalDiffEq v1.4.0), with no dependency on the other GlobalDiffEq PRs; reviewable and mergeable on its own. Its prerequisites are already on `master`/released — SciMLBase's global-error interface (SciML/SciMLBase.jl#1531, in SciMLBase ≥ 3.48) and the GLEE/MM5GEE methods (#3954) — so it stands alone.

## Summary

Implements the review direction from #3956 — global error as a SciMLBase interface, with the solver splitting its `(y, ε)` partition so the user gets an ordinary solution in `u` and the estimate in the global-error save. Migrates the GLEE/MM5GEE solvers onto the SciMLBase global-error interface (SciML/SciMLBase.jl#1531):

- `SciMLBase.has_global_error(::AbstractGLEEAlgorithm) = true`.
- Solving returns an **ordinary** solution: `sol.u[i]` is the solution and `sol(t)` interpolates it; the estimate lives in `sol.global_error` (`sol.global_error[i]` is the global error of `sol.u[i]`). Users no longer see the internal `(y, ε)` `ArrayPartition`.
- The extended partitioned solve is split in `__solve`, and a small projecting interpolation reuses the **high-order extended dense output**, so `sol(t)`, `sol(t, Val{1})` (derivatives), the vector-`t` form, and the in-place form all return the solution component at full interpolation order.
- `global_error_estimate(sol)` returns `sol.global_error`. SciMLBase compat bumped to `3.48`.

## Validation (run locally, current master, released SciMLBase v3.49.0)

- `ODEDIFFEQ_TEST_GROUP=Core`: **pass** — Basic 1/1, Algorithm traits 3/3, GLEE solvers 91/91 (incl. the new interface testset), BigFloat 2/2.
- `ODEDIFFEQ_TEST_GROUP=QA`: **pass** — 23 passed, 1 pre-existing declared broken.
- Smoke tests on the unstable Prince42 problem for GLEE23/24/35 + MM5GEE: `sol.u` plain, `sol.global_error` matches, `sol(t)`/`sol(t,Val{1})`/in-place all project to the solution at full order (GLEE35/MM5GEE match exact to 5+ digits).

Follow-up (Phase 3): the `GlobalErrorTransport`/`GlobalDefectCorrection`/`GlobalAdjoint` wrappers (#3956/#3957/#3953) will populate the same `sol.global_error`, plus the adjoint every-step mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)