### PR TITLE
Re-export the SciMLBase common interface from leaf solver sublibraries, chosen by a documented rule

### DIFF
--- a/docs/common_imex_first_steps.jl
+++ b/docs/common_imex_first_steps.jl
@@ -18,8 +18,7 @@ function imex_first_steps(name, solver)
         one for stiff (implicit) terms and one for non-stiff (explicit) terms.
 
         ```julia
-        using $name
-        using SciMLBase: SplitODEProblem, solve
+        using $name: SplitODEProblem, solve
 
         # Example: A 1D reaction-diffusion system
         # du/dt = f₁(u,p,t) + f₂(u,p,t)

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -64,6 +64,7 @@ pages = [
     ],
     "APIs" => [
         "api/common_interface.md",
+        "api/reexports.md",
         "api/diffeqbase.md",
         "api/ordinarydiffeqcore.md",
         "api/controllers.md",

--- a/docs/src/api/common_interface.md
+++ b/docs/src/api/common_interface.md
@@ -52,6 +52,8 @@ Filter = x -> x in [
     SciMLBase.DAEProblem,
     SciMLBase.DAEFunction,
     SciMLBase.DAESolution,
+    SciMLBase.DiscreteProblem,
+    SciMLBase.DiscreteFunction,
     SciMLBase.EnsembleProblem,
     SciMLBase.DynamicalODEFunction,
     SciMLBase.EnsembleContext

--- a/docs/src/api/common_interface.md
+++ b/docs/src/api/common_interface.md
@@ -2,7 +2,9 @@
 
 OrdinaryDiffEq re-exports the common problem, callback, solve, and automatic
 differentiation interfaces needed to construct and solve ordinary differential
-equations.
+equations. The exact set of
+re-exported SciMLBase names, and the rule that decides it, are given in
+[Re-exported SciMLBase API](@ref).
 
 ## Solve interface
 

--- a/docs/src/api/reexports.md
+++ b/docs/src/api/reexports.md
@@ -15,11 +15,11 @@ A SciMLBase name is re-exported if and only if it belongs to the **user-facing c
 interface** — the part of SciMLBase a user writes in a script. Concretely, a name is
 re-exported when it falls in one of these five closed categories:
 
-1. **Problem and function types** — every concrete `…Problem` and `…Function` type SciMLBase
-   exports. Membership is mechanical: the name ends in `Problem`/`Function`, the type is not
-   abstract, and it is not a dispatch tag (`Abstract…`, `Standard…`). Every problem that can be
-   *stated* through DifferentialEquations.jl can therefore be stated through any solver
-   sublibrary, whether or not that particular sublibrary can solve it.
+1. **Problem and function types** — the concrete SciMLBase types in the
+   [Common Interface API](@ref). This is the set OrdinaryDiffEq uses for ODEs, split ODEs,
+   second-order and dynamical ODEs, DAEs, discrete maps, and ensembles. Problem domains solved
+   by other libraries, such as optimization, nonlinear equations, SDEs, DDEs, and boundary
+   value problems, are not re-exported.
 2. **Solving and solution inspection** — `solve`, `solve!`, `init`, `step!`, `remake`,
    `ReturnCode`, `successful_retcode`, the statistics types, and the specialization and
    initialization options accepted by problem constructors and `solve`.
@@ -39,20 +39,22 @@ are categories, not case-by-case decisions:
     user calls.
   - **Internal dispatch tags** (`StandardODEProblem`, `…AliasSpecifier` internals, originator
     types).
+  - **Other problem domains** (`OptimizationProblem`, `NonlinearProblem`, `SDEProblem`, …) —
+    their solver packages own those interfaces.
 
 Two consequences worth stating explicitly, because they are the point of having a rule:
 
-  - **The list does not depend on history.** It is not "whatever this package happened to
-    export before"; a name is in or out purely by category. Re-deriving the list from a fresh
-    SciMLBase gives the same answer.
+  - **The list follows real usage.** It is not "whatever this package happened to export
+    before"; the problem and function types come from OrdinaryDiffEq's documented common
+    interface.
   - **The list is uniform.** Every solver sublibrary re-exports the same names. A name is never
     available from one sublibrary and missing from another, so moving a script between solver
     packages never produces an `UndefVarError`.
 
-The rule is enforced, not just described: `test/qa/qa_tests.jl` re-derives categories 1 from a
-live SciMLBase, checks the enumerated names in categories 2–5 are still exported by SciMLBase,
-and asserts that all sublibraries and this page list exactly the same names. Adding a problem
-type to SciMLBase therefore fails CI until the sublibraries re-export it.
+The rule is enforced, not just described: `test/qa/reexport_tests.jl` reads the Common
+Interface API and asserts that its concrete SciMLBase problem and function types exactly match
+this page. It also checks that the enumerated names are exported by SciMLBase and that every
+selective sublibrary uses exactly the same list.
 
 ## Do not rely on `using` for solver names
 
@@ -65,23 +67,9 @@ as `SciMLBase.name`.
 ### Problem and function types
 
 ```julia
-AnalyticalProblem, BVProblem, ConvexOptimizationProblem, DAEProblem,
-DDEProblem, DiscreteProblem, DynamicalDDEProblem, DynamicalODEProblem,
-DynamicalSDEProblem, EigenvalueProblem, EnsembleProblem, HomotopyProblem,
-ImmutableNonlinearProblem, ImmutableODEProblem, ImplicitDiscreteProblem, IncrementingODEProblem,
-IntegralProblem, IntervalNonlinearProblem, LinearProblem, NoiseProblem,
-NonlinearLeastSquaresProblem, NonlinearProblem, ODEProblem, OptimizationProblem,
-PDEProblem, RODEProblem, SCCNonlinearProblem, SDDEProblem,
-SDEProblem, SampledIntegralProblem, SecondOrderBVProblem, SecondOrderDDEProblem,
-SecondOrderODEProblem, SplitODEProblem, SplitSDEProblem, SteadyStateProblem,
-TwoPointBVProblem, TwoPointSecondOrderBVProblem, WeightedEnsembleProblem, BVPFunction,
-BatchIntegralFunction, DAEFunction, DDEFunction, DiscreteFunction,
-DynamicalBVPFunction, DynamicalDDEFunction, DynamicalODEFunction, DynamicalSDEFunction,
-HomotopyNonlinearFunction, ImplicitDiscreteFunction, IncrementingODEFunction, IntegralFunction,
-IntervalNonlinearFunction, MultiObjectiveOptimizationFunction, NonlinearFunction, ODEFunction,
-ODEInputFunction, OptimizationFunction, RODEFunction, SDDEFunction,
-SDEFunction, SplitFunction, SplitSDEFunction, TwoPointBVPFunction,
-TwoPointDynamicalBVPFunction
+DAEProblem, DiscreteProblem, DynamicalODEProblem, EnsembleProblem, ODEProblem,
+SecondOrderODEProblem, SplitODEProblem, DAEFunction, DiscreteFunction,
+DynamicalODEFunction, ODEFunction, SplitFunction
 ```
 
 ### Solving and solution inspection
@@ -118,4 +106,3 @@ set_ut!, terminate!, u_modified!
 EnsembleAnalysis, EnsembleDistributed, EnsembleSerial, EnsembleSplitThreads,
 EnsembleSummary, EnsembleThreads
 ```
-

--- a/docs/src/api/reexports.md
+++ b/docs/src/api/reexports.md
@@ -1,0 +1,121 @@
+# Re-exported SciMLBase API
+
+Every OrdinaryDiffEq solver sublibrary (`OrdinaryDiffEqTsit5`, `OrdinaryDiffEqFeagin`, …)
+re-exports part of [SciMLBase](https://github.com/SciML/SciMLBase.jl), so that
+`using OrdinaryDiffEqFeagin` alone is enough to write and run a solve, exactly as
+`using DifferentialEquations` is. This page defines *which* names that is, and why.
+
+Sublibraries that name their re-exports use exactly the list below. The remaining
+sublibraries still re-export all of SciMLBase, which is a superset of this list, and are
+migrated to it separately so that no release both narrows exports and changes behaviour.
+
+## The rule
+
+A SciMLBase name is re-exported if and only if it belongs to the **user-facing common
+interface** — the part of SciMLBase a user writes in a script. Concretely, a name is
+re-exported when it falls in one of these five closed categories:
+
+1. **Problem and function types** — every concrete `…Problem` and `…Function` type SciMLBase
+   exports. Membership is mechanical: the name ends in `Problem`/`Function`, the type is not
+   abstract, and it is not a dispatch tag (`Abstract…`, `Standard…`). Every problem that can be
+   *stated* through DifferentialEquations.jl can therefore be stated through any solver
+   sublibrary, whether or not that particular sublibrary can solve it.
+2. **Solving and solution inspection** — `solve`, `solve!`, `init`, `step!`, `remake`,
+   `ReturnCode`, `successful_retcode`, the statistics types, and the specialization and
+   initialization options accepted by problem constructors and `solve`.
+3. **Callbacks** — the callback types and their root-finding options.
+4. **Integrator interface** — the mutating and querying verbs documented for use *inside* a
+   callback or an `init`/`step!` loop (`u_modified!`, `add_tstop!`, `set_u!`, `get_du`, …).
+5. **Ensembles** — the ensemble algorithms and `EnsembleAnalysis`.
+
+Everything else SciMLBase exports stays behind the `SciMLBase.` qualifier. Those exclusions
+are categories, not case-by-case decisions:
+
+  - **Abstract types** (`AbstractODEProblem`, `AbstractDEAlgorithm`, …) — dispatch hooks for
+    package authors, not something a user constructs.
+  - **Solver-author API** — trait predicates (`isinplace`, `has_jac`, `allowscomplex`,
+    `requiresgradient`, …), construction helpers (`build_solution`), wrapper and cache types,
+    and macros. These are the interface a *new solver package* implements, not the interface a
+    user calls.
+  - **Internal dispatch tags** (`StandardODEProblem`, `…AliasSpecifier` internals, originator
+    types).
+
+Two consequences worth stating explicitly, because they are the point of having a rule:
+
+  - **The list does not depend on history.** It is not "whatever this package happened to
+    export before"; a name is in or out purely by category. Re-deriving the list from a fresh
+    SciMLBase gives the same answer.
+  - **The list is uniform.** Every solver sublibrary re-exports the same names. A name is never
+    available from one sublibrary and missing from another, so moving a script between solver
+    packages never produces an `UndefVarError`.
+
+The rule is enforced, not just described: `test/qa/qa_tests.jl` re-derives categories 1 from a
+live SciMLBase, checks the enumerated names in categories 2–5 are still exported by SciMLBase,
+and asserts that all sublibraries and this page list exactly the same names. Adding a problem
+type to SciMLBase therefore fails CI until the sublibraries re-export it.
+
+## Do not rely on `using` for solver names
+
+Only the names below come from SciMLBase. Algorithm names (`Tsit5`, `Feagin14`, `FBDF`, …) come
+from the solver sublibrary that defines them, and everything else in SciMLBase remains reachable
+as `SciMLBase.name`.
+
+## The re-exported names
+
+### Problem and function types
+
+```julia
+AnalyticalProblem, BVProblem, ConvexOptimizationProblem, DAEProblem,
+DDEProblem, DiscreteProblem, DynamicalDDEProblem, DynamicalODEProblem,
+DynamicalSDEProblem, EigenvalueProblem, EnsembleProblem, HomotopyProblem,
+ImmutableNonlinearProblem, ImmutableODEProblem, ImplicitDiscreteProblem, IncrementingODEProblem,
+IntegralProblem, IntervalNonlinearProblem, LinearProblem, NoiseProblem,
+NonlinearLeastSquaresProblem, NonlinearProblem, ODEProblem, OptimizationProblem,
+PDEProblem, RODEProblem, SCCNonlinearProblem, SDDEProblem,
+SDEProblem, SampledIntegralProblem, SecondOrderBVProblem, SecondOrderDDEProblem,
+SecondOrderODEProblem, SplitODEProblem, SplitSDEProblem, SteadyStateProblem,
+TwoPointBVProblem, TwoPointSecondOrderBVProblem, WeightedEnsembleProblem, BVPFunction,
+BatchIntegralFunction, DAEFunction, DDEFunction, DiscreteFunction,
+DynamicalBVPFunction, DynamicalDDEFunction, DynamicalODEFunction, DynamicalSDEFunction,
+HomotopyNonlinearFunction, ImplicitDiscreteFunction, IncrementingODEFunction, IntegralFunction,
+IntervalNonlinearFunction, MultiObjectiveOptimizationFunction, NonlinearFunction, ODEFunction,
+ODEInputFunction, OptimizationFunction, RODEFunction, SDDEFunction,
+SDEFunction, SplitFunction, SplitSDEFunction, TwoPointBVPFunction,
+TwoPointDynamicalBVPFunction
+```
+
+### Solving and solution inspection
+
+```julia
+solve, solve!, init, step!,
+remake, ReturnCode, successful_retcode, DEStats,
+NLStats, NullParameters, AutoSpecialize, FullSpecialize,
+NoSpecialize, FunctionWrapperSpecialize, CheckInit, NoInit,
+OverrideInit
+```
+
+### Callbacks
+
+```julia
+CallbackSet, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
+LeftRootFind, RightRootFind, NoRootFind
+```
+
+### Integrator interface
+
+```julia
+add_saveat!, add_tstop!, auto_dt_reset!, change_t_via_interpolation!,
+check_error, check_error!, first_tstop, get_dt,
+get_du, get_du!, get_proposed_dt, get_tmp_cache,
+pop_tstop!, reinit!, savevalues!, set_abstol!,
+set_proposed_dt!, set_reltol!, set_t!, set_u!,
+set_ut!, terminate!, u_modified!
+```
+
+### Ensembles
+
+```julia
+EnsembleAnalysis, EnsembleDistributed, EnsembleSerial, EnsembleSplitThreads,
+EnsembleSummary, EnsembleThreads
+```
+

--- a/docs/src/explicit/QPRK.md
+++ b/docs/src/explicit/QPRK.md
@@ -76,8 +76,9 @@ For ultra-high precision, also consider:
 ## Usage Example
 
 ```julia
-using OrdinaryDiffEqQPRK
-using SciMLBase: ODEProblem, solve
+using OrdinaryDiffEqQPRK: ODEProblem, solve, QPRK98
+
+f(u, p, t) = [u[2], -u[1]]
 # Ensure using Float128 for ultra-high precision
 u0 = Float128[1.0, 0.0]
 tspan = (Float128(0.0), Float128(10.0))

--- a/docs/src/explicit/TaylorSeries.md
+++ b/docs/src/explicit/TaylorSeries.md
@@ -103,10 +103,8 @@ Pkg.add("OrdinaryDiffEqTaylorSeries")
 Then use the methods with:
 
 ```julia
-using OrdinaryDiffEqTaylorSeries: ExplicitTaylor2, ExplicitTaylor,
+using OrdinaryDiffEqTaylorSeries: ODEProblem, solve, ExplicitTaylor2, ExplicitTaylor,
     ExplicitTaylorAdaptiveOrder
-using CommonSolve: solve
-using SciMLBase: ODEProblem
 
 # Example: Second-order Taylor method
 function f(u, p, t)

--- a/lib/OrdinaryDiffEqDefault/Project.toml
+++ b/lib/OrdinaryDiffEqDefault/Project.toml
@@ -4,6 +4,7 @@ authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 version = "2.5.0"
 
 [deps]
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 OrdinaryDiffEqBDF = "6ad6398a-0878-4a85-9266-38940aa047c8"
 OrdinaryDiffEqVerner = "79d7bb75-1356-48c1-b8c0-6832512096c2"
@@ -31,6 +32,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 
 [compat]
+Reexport = "1.2.2"
 Aqua = "0.8.11"
 SciMLTesting = "2.8"
 Pkg = "1"

--- a/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
+++ b/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
@@ -17,35 +17,19 @@ using EnumX: EnumX
 import SciMLBase
 
 using Reexport: Reexport, @reexport
-# Re-exported SciMLBase API. This list is identical in every OrdinaryDiffEq solver
-# sublibrary and is generated from the rule documented in docs/src/api/reexports.md;
-# `test/qa/qa_tests.jl` checks the sublibraries against each other and against that rule.
-@reexport using SciMLBase: AnalyticalProblem, BVProblem, ConvexOptimizationProblem,
-    DAEProblem, DDEProblem, DiscreteProblem, DynamicalDDEProblem, DynamicalODEProblem,
-    DynamicalSDEProblem, EigenvalueProblem, EnsembleProblem, HomotopyProblem,
-    ImmutableNonlinearProblem, ImmutableODEProblem, ImplicitDiscreteProblem,
-    IncrementingODEProblem, IntegralProblem, IntervalNonlinearProblem, LinearProblem,
-    NoiseProblem, NonlinearLeastSquaresProblem, NonlinearProblem, ODEProblem,
-    OptimizationProblem, PDEProblem, RODEProblem, SCCNonlinearProblem, SDDEProblem,
-    SDEProblem, SampledIntegralProblem, SecondOrderBVProblem, SecondOrderDDEProblem,
-    SecondOrderODEProblem, SplitODEProblem, SplitSDEProblem, SteadyStateProblem,
-    TwoPointBVProblem, TwoPointSecondOrderBVProblem, WeightedEnsembleProblem, BVPFunction,
-    BatchIntegralFunction, DAEFunction, DDEFunction, DiscreteFunction, DynamicalBVPFunction,
-    DynamicalDDEFunction, DynamicalODEFunction, DynamicalSDEFunction,
-    HomotopyNonlinearFunction, ImplicitDiscreteFunction, IncrementingODEFunction,
-    IntegralFunction, IntervalNonlinearFunction, MultiObjectiveOptimizationFunction,
-    NonlinearFunction, ODEFunction, ODEInputFunction, OptimizationFunction, RODEFunction,
-    SDDEFunction, SDEFunction, SplitFunction, SplitSDEFunction, TwoPointBVPFunction,
-    TwoPointDynamicalBVPFunction, solve, solve!, init, step!, remake, ReturnCode,
-    successful_retcode, DEStats, NLStats, NullParameters, AutoSpecialize, FullSpecialize,
-    NoSpecialize, FunctionWrapperSpecialize, CheckInit, NoInit, OverrideInit, CallbackSet,
-    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, LeftRootFind,
-    RightRootFind, NoRootFind, add_saveat!, add_tstop!, auto_dt_reset!,
-    change_t_via_interpolation!, check_error, check_error!, first_tstop, get_dt, get_du,
-    get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!, reinit!, savevalues!, set_abstol!,
-    set_proposed_dt!, set_reltol!, set_t!, set_u!, set_ut!, terminate!, u_modified!,
-    EnsembleAnalysis, EnsembleDistributed, EnsembleSerial, EnsembleSplitThreads,
-    EnsembleSummary, EnsembleThreads
+# Kept in sync with docs/src/api/reexports.md by test/qa/reexport_tests.jl.
+@reexport using SciMLBase: DAEProblem, DiscreteProblem, DynamicalODEProblem,
+    EnsembleProblem, ODEProblem, SecondOrderODEProblem, SplitODEProblem, DAEFunction,
+    DiscreteFunction, DynamicalODEFunction, ODEFunction, SplitFunction, solve, solve!, init,
+    step!, remake, ReturnCode, successful_retcode, DEStats, NLStats, NullParameters,
+    AutoSpecialize, FullSpecialize, NoSpecialize, FunctionWrapperSpecialize, CheckInit,
+    NoInit, OverrideInit, CallbackSet, ContinuousCallback, DiscreteCallback,
+    VectorContinuousCallback, LeftRootFind, RightRootFind, NoRootFind, add_saveat!,
+    add_tstop!, auto_dt_reset!, change_t_via_interpolation!, check_error, check_error!,
+    first_tstop, get_dt, get_du, get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!,
+    reinit!, savevalues!, set_abstol!, set_proposed_dt!, set_reltol!, set_t!, set_u!,
+    set_ut!, terminate!, u_modified!, EnsembleAnalysis, EnsembleDistributed, EnsembleSerial,
+    EnsembleSplitThreads, EnsembleSummary, EnsembleThreads
 using SciMLBase: SciMLBase
 
 include("default_alg.jl")

--- a/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
+++ b/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
@@ -15,7 +15,11 @@ using LinearAlgebra: I
 using EnumX: EnumX
 
 import SciMLBase
-using SciMLBase: ODEProblem, DAEProblem, DAEFunction, solve
+
+using Reexport: Reexport, @reexport
+@reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
+    reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
+    CallbackSet, terminate!, DAEProblem, DAEFunction
 
 include("default_alg.jl")
 

--- a/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
+++ b/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
@@ -17,10 +17,11 @@ using EnumX: EnumX
 import SciMLBase
 
 using Reexport: Reexport, @reexport
-@reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
-    reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
-    CallbackSet, terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
+using SciMLBase: ODEFunction, init, solve!, step!, remake, reinit!, ReturnCode,
+    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, CallbackSet,
+    terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
     successful_retcode, ODEAliasSpecifier, DAEProblem, DAEFunction
+@reexport using SciMLBase: ODEProblem, solve
 
 include("default_alg.jl")
 

--- a/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
+++ b/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
@@ -17,10 +17,7 @@ using EnumX: EnumX
 import SciMLBase
 
 using Reexport: Reexport, @reexport
-using SciMLBase: ODEFunction, init, solve!, step!, remake, reinit!, ReturnCode,
-    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, CallbackSet,
-    terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
-    successful_retcode, ODEAliasSpecifier, DAEProblem, DAEFunction
+using SciMLBase: DAEProblem, DAEFunction
 @reexport using SciMLBase: ODEProblem, solve
 
 include("default_alg.jl")

--- a/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
+++ b/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
@@ -19,7 +19,8 @@ import SciMLBase
 using Reexport: Reexport, @reexport
 @reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
     reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
-    CallbackSet, terminate!, DAEProblem, DAEFunction
+    CallbackSet, terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
+    successful_retcode, ODEAliasSpecifier, DAEProblem, DAEFunction
 
 include("default_alg.jl")
 

--- a/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
+++ b/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
@@ -17,8 +17,36 @@ using EnumX: EnumX
 import SciMLBase
 
 using Reexport: Reexport, @reexport
-using SciMLBase: DAEProblem, DAEFunction
-@reexport using SciMLBase: ODEProblem, solve
+# Re-exported SciMLBase API. This list is identical in every OrdinaryDiffEq solver
+# sublibrary and is generated from the rule documented in docs/src/api/reexports.md;
+# `test/qa/qa_tests.jl` checks the sublibraries against each other and against that rule.
+@reexport using SciMLBase: AnalyticalProblem, BVProblem, ConvexOptimizationProblem,
+    DAEProblem, DDEProblem, DiscreteProblem, DynamicalDDEProblem, DynamicalODEProblem,
+    DynamicalSDEProblem, EigenvalueProblem, EnsembleProblem, HomotopyProblem,
+    ImmutableNonlinearProblem, ImmutableODEProblem, ImplicitDiscreteProblem,
+    IncrementingODEProblem, IntegralProblem, IntervalNonlinearProblem, LinearProblem,
+    NoiseProblem, NonlinearLeastSquaresProblem, NonlinearProblem, ODEProblem,
+    OptimizationProblem, PDEProblem, RODEProblem, SCCNonlinearProblem, SDDEProblem,
+    SDEProblem, SampledIntegralProblem, SecondOrderBVProblem, SecondOrderDDEProblem,
+    SecondOrderODEProblem, SplitODEProblem, SplitSDEProblem, SteadyStateProblem,
+    TwoPointBVProblem, TwoPointSecondOrderBVProblem, WeightedEnsembleProblem, BVPFunction,
+    BatchIntegralFunction, DAEFunction, DDEFunction, DiscreteFunction, DynamicalBVPFunction,
+    DynamicalDDEFunction, DynamicalODEFunction, DynamicalSDEFunction,
+    HomotopyNonlinearFunction, ImplicitDiscreteFunction, IncrementingODEFunction,
+    IntegralFunction, IntervalNonlinearFunction, MultiObjectiveOptimizationFunction,
+    NonlinearFunction, ODEFunction, ODEInputFunction, OptimizationFunction, RODEFunction,
+    SDDEFunction, SDEFunction, SplitFunction, SplitSDEFunction, TwoPointBVPFunction,
+    TwoPointDynamicalBVPFunction, solve, solve!, init, step!, remake, ReturnCode,
+    successful_retcode, DEStats, NLStats, NullParameters, AutoSpecialize, FullSpecialize,
+    NoSpecialize, FunctionWrapperSpecialize, CheckInit, NoInit, OverrideInit, CallbackSet,
+    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, LeftRootFind,
+    RightRootFind, NoRootFind, add_saveat!, add_tstop!, auto_dt_reset!,
+    change_t_via_interpolation!, check_error, check_error!, first_tstop, get_dt, get_du,
+    get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!, reinit!, savevalues!, set_abstol!,
+    set_proposed_dt!, set_reltol!, set_t!, set_u!, set_ut!, terminate!, u_modified!,
+    EnsembleAnalysis, EnsembleDistributed, EnsembleSerial, EnsembleSplitThreads,
+    EnsembleSummary, EnsembleThreads
+using SciMLBase: SciMLBase
 
 include("default_alg.jl")
 

--- a/lib/OrdinaryDiffEqDefault/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqDefault/test/qa/qa.jl
@@ -8,12 +8,7 @@ using SciMLTesting, OrdinaryDiffEqDefault, Test
 const ENUM_SUBMODULE = (OrdinaryDiffEqDefault.DefaultSolverChoice,)
 
 # SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
-const SCIMLBASE_REEXPORTS = (
-    :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
-    :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-    :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
-    :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier, :DAEProblem, :DAEFunction,
-)
+const SCIMLBASE_REEXPORTS = (:ODEProblem, :solve)
 
 run_qa(
     OrdinaryDiffEqDefault;

--- a/lib/OrdinaryDiffEqDefault/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqDefault/test/qa/qa.jl
@@ -7,8 +7,16 @@ using SciMLTesting, OrdinaryDiffEqDefault, Test
 # mis-attributes those still-used imports as unused.
 const ENUM_SUBMODULE = (OrdinaryDiffEqDefault.DefaultSolverChoice,)
 
+# SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
+const SCIMLBASE_REEXPORTS = (
+    :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
+    :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+    :CallbackSet, :terminate!, :DAEProblem, :DAEFunction,
+)
+
 run_qa(
     OrdinaryDiffEqDefault;
+    reexports_allow = SCIMLBASE_REEXPORTS,
     aqua_kwargs = (; piracies = false),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqDefault/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqDefault/test/qa/qa.jl
@@ -11,7 +11,8 @@ const ENUM_SUBMODULE = (OrdinaryDiffEqDefault.DefaultSolverChoice,)
 const SCIMLBASE_REEXPORTS = (
     :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
     :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-    :CallbackSet, :terminate!, :DAEProblem, :DAEFunction,
+    :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
+    :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier, :DAEProblem, :DAEFunction,
 )
 
 run_qa(

--- a/lib/OrdinaryDiffEqDefault/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqDefault/test/qa/qa.jl
@@ -1,4 +1,4 @@
-using SciMLTesting, OrdinaryDiffEqDefault, Test
+using SciMLTesting, OrdinaryDiffEqDefault, SciMLBase, Test
 
 # `DefaultSolverChoice` is an `EnumX.@enumx`-generated submodule that
 # ExplicitImports cannot statically analyze. Its members (`Tsit5`, `Vern7`,
@@ -7,12 +7,11 @@ using SciMLTesting, OrdinaryDiffEqDefault, Test
 # mis-attributes those still-used imports as unused.
 const ENUM_SUBMODULE = (OrdinaryDiffEqDefault.DefaultSolverChoice,)
 
-# SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
-const SCIMLBASE_REEXPORTS = (:ODEProblem, :solve)
-
 run_qa(
     OrdinaryDiffEqDefault;
-    reexports_allow = SCIMLBASE_REEXPORTS,
+    # Approve the SciMLBase names this package re-exports. The list itself and the rule
+    # behind it are checked repo-wide by test/qa/qa_tests.jl against docs/src/api/reexports.md.
+    reexports_allow = intersect(names(SciMLBase), names(OrdinaryDiffEqDefault)),
     aqua_kwargs = (; piracies = false),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqDefault/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqDefault/test/qa/qa.jl
@@ -9,8 +9,6 @@ const ENUM_SUBMODULE = (OrdinaryDiffEqDefault.DefaultSolverChoice,)
 
 run_qa(
     OrdinaryDiffEqDefault;
-    # Approve the SciMLBase names this package re-exports. The list itself and the rule
-    # behind it are checked repo-wide by test/qa/qa_tests.jl against docs/src/api/reexports.md.
     reexports_allow = intersect(names(SciMLBase), names(OrdinaryDiffEqDefault)),
     aqua_kwargs = (; piracies = false),
     explicit_imports = true,

--- a/lib/OrdinaryDiffEqDefault/test/runtests.jl
+++ b/lib/OrdinaryDiffEqDefault/test/runtests.jl
@@ -18,20 +18,21 @@ end
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
+        # docs/src/api/reexports.md defines this surface; test/qa/qa_tests.jl checks the
+        # full list repo-wide. Here, spot-check that the common interface is usable and
+        # that solver-author API stayed behind the `SciMLBase.` qualifier.
         using OrdinaryDiffEqDefault, Test
-        expected = (:ODEProblem, :solve)
-        @test all(Base.isexported.(Ref(OrdinaryDiffEqDefault), expected))
-        removed = (
-            :ODEFunction, :init, :solve!, :step!, :remake, :reinit!, :ReturnCode,
-            :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-            :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
-            :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier, :DAEProblem,
-            :DAEFunction,
+        exported = (
+            :ODEProblem, :ODEFunction, :SplitODEProblem, :solve, :init, :step!,
+            :remake, :ReturnCode, :CallbackSet, :ContinuousCallback, :terminate!,
+            :u_modified!, :add_tstop!, :get_du, :EnsembleProblem,
         )
-        @test all(x -> !x, Base.isexported.(Ref(OrdinaryDiffEqDefault), removed))
-        @test !Base.isexported(OrdinaryDiffEqDefault, :EnsembleProblem)
-        @test !Base.isexported(OrdinaryDiffEqDefault, :get_du)
-        @test !Base.isexported(OrdinaryDiffEqDefault, :u_modified!)
+        @test all(Base.isexported.(Ref(OrdinaryDiffEqDefault), exported))
+        internal = (
+            :build_solution, :isinplace, :has_jac, :AbstractODEProblem,
+            :StandardODEProblem, :UJacobianWrapper,
+        )
+        @test !any(Base.isexported.(Ref(OrdinaryDiffEqDefault), internal))
     end
     @time @safetestset "Default Solver Tests" include("default_solver_tests.jl")
 end

--- a/lib/OrdinaryDiffEqDefault/test/runtests.jl
+++ b/lib/OrdinaryDiffEqDefault/test/runtests.jl
@@ -17,6 +17,11 @@ end
 
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
+    @time @safetestset "SciMLBase reexport" begin
+        using OrdinaryDiffEqDefault, Test
+        @test Base.isexported(OrdinaryDiffEqDefault, :ODEProblem)
+        @test Base.isexported(OrdinaryDiffEqDefault, :solve)
+    end
     @time @safetestset "Default Solver Tests" include("default_solver_tests.jl")
 end
 

--- a/lib/OrdinaryDiffEqDefault/test/runtests.jl
+++ b/lib/OrdinaryDiffEqDefault/test/runtests.jl
@@ -19,14 +19,16 @@ end
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
         using OrdinaryDiffEqDefault, Test
-        expected = (
-            :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
-            :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+        expected = (:ODEProblem, :solve)
+        @test all(Base.isexported.(Ref(OrdinaryDiffEqDefault), expected))
+        removed = (
+            :ODEFunction, :init, :solve!, :step!, :remake, :reinit!, :ReturnCode,
+            :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
             :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
             :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier, :DAEProblem,
             :DAEFunction,
         )
-        @test all(Base.isexported.(Ref(OrdinaryDiffEqDefault), expected))
+        @test all(x -> !x, Base.isexported.(Ref(OrdinaryDiffEqDefault), removed))
         @test !Base.isexported(OrdinaryDiffEqDefault, :EnsembleProblem)
         @test !Base.isexported(OrdinaryDiffEqDefault, :get_du)
         @test !Base.isexported(OrdinaryDiffEqDefault, :u_modified!)

--- a/lib/OrdinaryDiffEqDefault/test/runtests.jl
+++ b/lib/OrdinaryDiffEqDefault/test/runtests.jl
@@ -19,8 +19,17 @@ end
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
         using OrdinaryDiffEqDefault, Test
-        @test Base.isexported(OrdinaryDiffEqDefault, :ODEProblem)
-        @test Base.isexported(OrdinaryDiffEqDefault, :solve)
+        expected = (
+            :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
+            :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+            :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
+            :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier, :DAEProblem,
+            :DAEFunction,
+        )
+        @test all(Base.isexported.(Ref(OrdinaryDiffEqDefault), expected))
+        @test !Base.isexported(OrdinaryDiffEqDefault, :EnsembleProblem)
+        @test !Base.isexported(OrdinaryDiffEqDefault, :get_du)
+        @test !Base.isexported(OrdinaryDiffEqDefault, :u_modified!)
     end
     @time @safetestset "Default Solver Tests" include("default_solver_tests.jl")
 end

--- a/lib/OrdinaryDiffEqDefault/test/runtests.jl
+++ b/lib/OrdinaryDiffEqDefault/test/runtests.jl
@@ -18,9 +18,6 @@ end
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
-        # docs/src/api/reexports.md defines this surface; test/qa/qa_tests.jl checks the
-        # full list repo-wide. Here, spot-check that the common interface is usable and
-        # that solver-author API stayed behind the `SciMLBase.` qualifier.
         using OrdinaryDiffEqDefault, Test
         exported = (
             :ODEProblem, :ODEFunction, :SplitODEProblem, :solve, :init, :step!,
@@ -30,7 +27,8 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
         @test all(Base.isexported.(Ref(OrdinaryDiffEqDefault), exported))
         internal = (
             :build_solution, :isinplace, :has_jac, :AbstractODEProblem,
-            :StandardODEProblem, :UJacobianWrapper,
+            :StandardODEProblem, :UJacobianWrapper, :LinearProblem,
+            :ConvexOptimizationProblem,
         )
         @test !any(Base.isexported.(Ref(OrdinaryDiffEqDefault), internal))
     end

--- a/lib/OrdinaryDiffEqExtrapolation/Project.toml
+++ b/lib/OrdinaryDiffEqExtrapolation/Project.toml
@@ -4,6 +4,7 @@ authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <maying
 version = "2.5.0"
 
 [deps]
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
@@ -35,6 +36,7 @@ Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
 OrdinaryDiffEqExtrapolationPolyesterExt = "Polyester"
 
 [compat]
+Reexport = "1.2.2"
 CommonSolve = "0.2.6"
 SciMLTesting = "2.4"
 Pkg = "1"

--- a/lib/OrdinaryDiffEqExtrapolation/src/OrdinaryDiffEqExtrapolation.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/OrdinaryDiffEqExtrapolation.jl
@@ -42,6 +42,11 @@ import ADTypes: AutoForwardDiff
 using CommonSolve: init
 using SciMLBase: SciMLBase, LinearProblem
 
+using Reexport: Reexport, @reexport
+@reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
+    reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
+    CallbackSet, terminate!
+
 include("utils.jl")
 include("algorithms.jl")
 include("alg_utils.jl")

--- a/lib/OrdinaryDiffEqExtrapolation/src/OrdinaryDiffEqExtrapolation.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/OrdinaryDiffEqExtrapolation.jl
@@ -40,39 +40,22 @@ import OrdinaryDiffEqDifferentiation: calc_J,
 import ADTypes: AutoForwardDiff
 
 using CommonSolve: init
-using SciMLBase: SciMLBase
+using SciMLBase: SciMLBase, LinearProblem
 
 using Reexport: Reexport, @reexport
-# Re-exported SciMLBase API. This list is identical in every OrdinaryDiffEq solver
-# sublibrary and is generated from the rule documented in docs/src/api/reexports.md;
-# `test/qa/qa_tests.jl` checks the sublibraries against each other and against that rule.
-@reexport using SciMLBase: AnalyticalProblem, BVProblem, ConvexOptimizationProblem,
-    DAEProblem, DDEProblem, DiscreteProblem, DynamicalDDEProblem, DynamicalODEProblem,
-    DynamicalSDEProblem, EigenvalueProblem, EnsembleProblem, HomotopyProblem,
-    ImmutableNonlinearProblem, ImmutableODEProblem, ImplicitDiscreteProblem,
-    IncrementingODEProblem, IntegralProblem, IntervalNonlinearProblem, LinearProblem,
-    NoiseProblem, NonlinearLeastSquaresProblem, NonlinearProblem, ODEProblem,
-    OptimizationProblem, PDEProblem, RODEProblem, SCCNonlinearProblem, SDDEProblem,
-    SDEProblem, SampledIntegralProblem, SecondOrderBVProblem, SecondOrderDDEProblem,
-    SecondOrderODEProblem, SplitODEProblem, SplitSDEProblem, SteadyStateProblem,
-    TwoPointBVProblem, TwoPointSecondOrderBVProblem, WeightedEnsembleProblem, BVPFunction,
-    BatchIntegralFunction, DAEFunction, DDEFunction, DiscreteFunction, DynamicalBVPFunction,
-    DynamicalDDEFunction, DynamicalODEFunction, DynamicalSDEFunction,
-    HomotopyNonlinearFunction, ImplicitDiscreteFunction, IncrementingODEFunction,
-    IntegralFunction, IntervalNonlinearFunction, MultiObjectiveOptimizationFunction,
-    NonlinearFunction, ODEFunction, ODEInputFunction, OptimizationFunction, RODEFunction,
-    SDDEFunction, SDEFunction, SplitFunction, SplitSDEFunction, TwoPointBVPFunction,
-    TwoPointDynamicalBVPFunction, solve, solve!, init, step!, remake, ReturnCode,
-    successful_retcode, DEStats, NLStats, NullParameters, AutoSpecialize, FullSpecialize,
-    NoSpecialize, FunctionWrapperSpecialize, CheckInit, NoInit, OverrideInit, CallbackSet,
-    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, LeftRootFind,
-    RightRootFind, NoRootFind, add_saveat!, add_tstop!, auto_dt_reset!,
-    change_t_via_interpolation!, check_error, check_error!, first_tstop, get_dt, get_du,
-    get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!, reinit!, savevalues!, set_abstol!,
-    set_proposed_dt!, set_reltol!, set_t!, set_u!, set_ut!, terminate!, u_modified!,
-    EnsembleAnalysis, EnsembleDistributed, EnsembleSerial, EnsembleSplitThreads,
-    EnsembleSummary, EnsembleThreads
-using SciMLBase: SciMLBase
+# Kept in sync with docs/src/api/reexports.md by test/qa/reexport_tests.jl.
+@reexport using SciMLBase: DAEProblem, DiscreteProblem, DynamicalODEProblem,
+    EnsembleProblem, ODEProblem, SecondOrderODEProblem, SplitODEProblem, DAEFunction,
+    DiscreteFunction, DynamicalODEFunction, ODEFunction, SplitFunction, solve, solve!, init,
+    step!, remake, ReturnCode, successful_retcode, DEStats, NLStats, NullParameters,
+    AutoSpecialize, FullSpecialize, NoSpecialize, FunctionWrapperSpecialize, CheckInit,
+    NoInit, OverrideInit, CallbackSet, ContinuousCallback, DiscreteCallback,
+    VectorContinuousCallback, LeftRootFind, RightRootFind, NoRootFind, add_saveat!,
+    add_tstop!, auto_dt_reset!, change_t_via_interpolation!, check_error, check_error!,
+    first_tstop, get_dt, get_du, get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!,
+    reinit!, savevalues!, set_abstol!, set_proposed_dt!, set_reltol!, set_t!, set_u!,
+    set_ut!, terminate!, u_modified!, EnsembleAnalysis, EnsembleDistributed, EnsembleSerial,
+    EnsembleSplitThreads, EnsembleSummary, EnsembleThreads
 
 include("utils.jl")
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqExtrapolation/src/OrdinaryDiffEqExtrapolation.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/OrdinaryDiffEqExtrapolation.jl
@@ -43,10 +43,6 @@ using CommonSolve: init
 using SciMLBase: SciMLBase, LinearProblem
 
 using Reexport: Reexport, @reexport
-using SciMLBase: ODEFunction, init, solve!, step!, remake, reinit!, ReturnCode,
-    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, CallbackSet,
-    terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
-    successful_retcode, ODEAliasSpecifier
 @reexport using SciMLBase: ODEProblem, solve
 
 include("utils.jl")

--- a/lib/OrdinaryDiffEqExtrapolation/src/OrdinaryDiffEqExtrapolation.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/OrdinaryDiffEqExtrapolation.jl
@@ -40,10 +40,39 @@ import OrdinaryDiffEqDifferentiation: calc_J,
 import ADTypes: AutoForwardDiff
 
 using CommonSolve: init
-using SciMLBase: SciMLBase, LinearProblem
+using SciMLBase: SciMLBase
 
 using Reexport: Reexport, @reexport
-@reexport using SciMLBase: ODEProblem, solve
+# Re-exported SciMLBase API. This list is identical in every OrdinaryDiffEq solver
+# sublibrary and is generated from the rule documented in docs/src/api/reexports.md;
+# `test/qa/qa_tests.jl` checks the sublibraries against each other and against that rule.
+@reexport using SciMLBase: AnalyticalProblem, BVProblem, ConvexOptimizationProblem,
+    DAEProblem, DDEProblem, DiscreteProblem, DynamicalDDEProblem, DynamicalODEProblem,
+    DynamicalSDEProblem, EigenvalueProblem, EnsembleProblem, HomotopyProblem,
+    ImmutableNonlinearProblem, ImmutableODEProblem, ImplicitDiscreteProblem,
+    IncrementingODEProblem, IntegralProblem, IntervalNonlinearProblem, LinearProblem,
+    NoiseProblem, NonlinearLeastSquaresProblem, NonlinearProblem, ODEProblem,
+    OptimizationProblem, PDEProblem, RODEProblem, SCCNonlinearProblem, SDDEProblem,
+    SDEProblem, SampledIntegralProblem, SecondOrderBVProblem, SecondOrderDDEProblem,
+    SecondOrderODEProblem, SplitODEProblem, SplitSDEProblem, SteadyStateProblem,
+    TwoPointBVProblem, TwoPointSecondOrderBVProblem, WeightedEnsembleProblem, BVPFunction,
+    BatchIntegralFunction, DAEFunction, DDEFunction, DiscreteFunction, DynamicalBVPFunction,
+    DynamicalDDEFunction, DynamicalODEFunction, DynamicalSDEFunction,
+    HomotopyNonlinearFunction, ImplicitDiscreteFunction, IncrementingODEFunction,
+    IntegralFunction, IntervalNonlinearFunction, MultiObjectiveOptimizationFunction,
+    NonlinearFunction, ODEFunction, ODEInputFunction, OptimizationFunction, RODEFunction,
+    SDDEFunction, SDEFunction, SplitFunction, SplitSDEFunction, TwoPointBVPFunction,
+    TwoPointDynamicalBVPFunction, solve, solve!, init, step!, remake, ReturnCode,
+    successful_retcode, DEStats, NLStats, NullParameters, AutoSpecialize, FullSpecialize,
+    NoSpecialize, FunctionWrapperSpecialize, CheckInit, NoInit, OverrideInit, CallbackSet,
+    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, LeftRootFind,
+    RightRootFind, NoRootFind, add_saveat!, add_tstop!, auto_dt_reset!,
+    change_t_via_interpolation!, check_error, check_error!, first_tstop, get_dt, get_du,
+    get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!, reinit!, savevalues!, set_abstol!,
+    set_proposed_dt!, set_reltol!, set_t!, set_u!, set_ut!, terminate!, u_modified!,
+    EnsembleAnalysis, EnsembleDistributed, EnsembleSerial, EnsembleSplitThreads,
+    EnsembleSummary, EnsembleThreads
+using SciMLBase: SciMLBase
 
 include("utils.jl")
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqExtrapolation/src/OrdinaryDiffEqExtrapolation.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/OrdinaryDiffEqExtrapolation.jl
@@ -45,7 +45,8 @@ using SciMLBase: SciMLBase, LinearProblem
 using Reexport: Reexport, @reexport
 @reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
     reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
-    CallbackSet, terminate!
+    CallbackSet, terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
+    successful_retcode, ODEAliasSpecifier
 
 include("utils.jl")
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqExtrapolation/src/OrdinaryDiffEqExtrapolation.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/OrdinaryDiffEqExtrapolation.jl
@@ -43,10 +43,11 @@ using CommonSolve: init
 using SciMLBase: SciMLBase, LinearProblem
 
 using Reexport: Reexport, @reexport
-@reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
-    reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
-    CallbackSet, terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
+using SciMLBase: ODEFunction, init, solve!, step!, remake, reinit!, ReturnCode,
+    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, CallbackSet,
+    terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
     successful_retcode, ODEAliasSpecifier
+@reexport using SciMLBase: ODEProblem, solve
 
 include("utils.jl")
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqExtrapolation/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/qa/qa.jl
@@ -1,4 +1,4 @@
-using SciMLTesting, OrdinaryDiffEqExtrapolation, Test
+using SciMLTesting, OrdinaryDiffEqExtrapolation, SciMLBase, Test
 # Load Polyester so the extension exists and ExplicitImports analyzes it.
 using Polyester
 
@@ -6,12 +6,11 @@ using Polyester
 # SciMLTesting, so the threading options need approving here too.
 const THREADING_PUBLIC = (:Sequential, :BaseThreads, :PolyesterThreads)
 
-# SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
-const SCIMLBASE_REEXPORTS = (:ODEProblem, :solve)
-
 run_qa(
     OrdinaryDiffEqExtrapolation;
-    reexports_allow = (SCIMLBASE_REEXPORTS..., THREADING_PUBLIC...),
+    # Approve the SciMLBase names this package re-exports. The list itself and the rule
+    # behind it are checked repo-wide by test/qa/qa_tests.jl against docs/src/api/reexports.md.
+    reexports_allow = vcat(intersect(names(SciMLBase), names(OrdinaryDiffEqExtrapolation)), collect(THREADING_PUBLIC)),
     ei_kwargs = (;
         all_explicit_imports_are_public = (;
             # Package-internal hook the Polyester extension implements; deliberately not public.

--- a/lib/OrdinaryDiffEqExtrapolation/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/qa/qa.jl
@@ -8,8 +8,6 @@ const THREADING_PUBLIC = (:Sequential, :BaseThreads, :PolyesterThreads)
 
 run_qa(
     OrdinaryDiffEqExtrapolation;
-    # Approve the SciMLBase names this package re-exports. The list itself and the rule
-    # behind it are checked repo-wide by test/qa/qa_tests.jl against docs/src/api/reexports.md.
     reexports_allow = vcat(intersect(names(SciMLBase), names(OrdinaryDiffEqExtrapolation)), collect(THREADING_PUBLIC)),
     ei_kwargs = (;
         all_explicit_imports_are_public = (;

--- a/lib/OrdinaryDiffEqExtrapolation/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/qa/qa.jl
@@ -7,12 +7,7 @@ using Polyester
 const THREADING_PUBLIC = (:Sequential, :BaseThreads, :PolyesterThreads)
 
 # SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
-const SCIMLBASE_REEXPORTS = (
-    :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
-    :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-    :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
-    :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
-)
+const SCIMLBASE_REEXPORTS = (:ODEProblem, :solve)
 
 run_qa(
     OrdinaryDiffEqExtrapolation;

--- a/lib/OrdinaryDiffEqExtrapolation/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/qa/qa.jl
@@ -10,7 +10,8 @@ const THREADING_PUBLIC = (:Sequential, :BaseThreads, :PolyesterThreads)
 const SCIMLBASE_REEXPORTS = (
     :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
     :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-    :CallbackSet, :terminate!,
+    :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
+    :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
 )
 
 run_qa(

--- a/lib/OrdinaryDiffEqExtrapolation/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/qa/qa.jl
@@ -6,9 +6,16 @@ using Polyester
 # SciMLTesting, so the threading options need approving here too.
 const THREADING_PUBLIC = (:Sequential, :BaseThreads, :PolyesterThreads)
 
+# SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
+const SCIMLBASE_REEXPORTS = (
+    :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
+    :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+    :CallbackSet, :terminate!,
+)
+
 run_qa(
     OrdinaryDiffEqExtrapolation;
-    reexports_allow = THREADING_PUBLIC,
+    reexports_allow = (SCIMLBASE_REEXPORTS..., THREADING_PUBLIC...),
     ei_kwargs = (;
         all_explicit_imports_are_public = (;
             # Package-internal hook the Polyester extension implements; deliberately not public.

--- a/lib/OrdinaryDiffEqExtrapolation/test/runtests.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/runtests.jl
@@ -10,19 +10,21 @@ end
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
+        # docs/src/api/reexports.md defines this surface; test/qa/qa_tests.jl checks the
+        # full list repo-wide. Here, spot-check that the common interface is usable and
+        # that solver-author API stayed behind the `SciMLBase.` qualifier.
         using OrdinaryDiffEqExtrapolation, Test
-        expected = (:ODEProblem, :solve)
-        @test all(Base.isexported.(Ref(OrdinaryDiffEqExtrapolation), expected))
-        removed = (
-            :ODEFunction, :init, :solve!, :step!, :remake, :reinit!, :ReturnCode,
-            :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-            :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
-            :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
+        exported = (
+            :ODEProblem, :ODEFunction, :SplitODEProblem, :solve, :init, :step!,
+            :remake, :ReturnCode, :CallbackSet, :ContinuousCallback, :terminate!,
+            :u_modified!, :add_tstop!, :get_du, :EnsembleProblem,
         )
-        @test all(x -> !x, Base.isexported.(Ref(OrdinaryDiffEqExtrapolation), removed))
-        @test !Base.isexported(OrdinaryDiffEqExtrapolation, :EnsembleProblem)
-        @test !Base.isexported(OrdinaryDiffEqExtrapolation, :get_du)
-        @test !Base.isexported(OrdinaryDiffEqExtrapolation, :u_modified!)
+        @test all(Base.isexported.(Ref(OrdinaryDiffEqExtrapolation), exported))
+        internal = (
+            :build_solution, :isinplace, :has_jac, :AbstractODEProblem,
+            :StandardODEProblem, :UJacobianWrapper,
+        )
+        @test !any(Base.isexported.(Ref(OrdinaryDiffEqExtrapolation), internal))
     end
     @time @safetestset "Extrapolation Utility Tests" include("utils_tests.jl")
     @time @safetestset "Extrapolation Tests" include("ode_extrapolation_tests.jl")

--- a/lib/OrdinaryDiffEqExtrapolation/test/runtests.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/runtests.jl
@@ -11,8 +11,16 @@ end
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
         using OrdinaryDiffEqExtrapolation, Test
-        @test Base.isexported(OrdinaryDiffEqExtrapolation, :ODEProblem)
-        @test Base.isexported(OrdinaryDiffEqExtrapolation, :solve)
+        expected = (
+            :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
+            :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+            :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
+            :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
+        )
+        @test all(Base.isexported.(Ref(OrdinaryDiffEqExtrapolation), expected))
+        @test !Base.isexported(OrdinaryDiffEqExtrapolation, :EnsembleProblem)
+        @test !Base.isexported(OrdinaryDiffEqExtrapolation, :get_du)
+        @test !Base.isexported(OrdinaryDiffEqExtrapolation, :u_modified!)
     end
     @time @safetestset "Extrapolation Utility Tests" include("utils_tests.jl")
     @time @safetestset "Extrapolation Tests" include("ode_extrapolation_tests.jl")

--- a/lib/OrdinaryDiffEqExtrapolation/test/runtests.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/runtests.jl
@@ -9,6 +9,11 @@ end
 
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
+    @time @safetestset "SciMLBase reexport" begin
+        using OrdinaryDiffEqExtrapolation, Test
+        @test Base.isexported(OrdinaryDiffEqExtrapolation, :ODEProblem)
+        @test Base.isexported(OrdinaryDiffEqExtrapolation, :solve)
+    end
     @time @safetestset "Extrapolation Utility Tests" include("utils_tests.jl")
     @time @safetestset "Extrapolation Tests" include("ode_extrapolation_tests.jl")
     @time @safetestset "Threading Linear Solver Tests" include("threading_linsolve_tests.jl")

--- a/lib/OrdinaryDiffEqExtrapolation/test/runtests.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/runtests.jl
@@ -10,9 +10,6 @@ end
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
-        # docs/src/api/reexports.md defines this surface; test/qa/qa_tests.jl checks the
-        # full list repo-wide. Here, spot-check that the common interface is usable and
-        # that solver-author API stayed behind the `SciMLBase.` qualifier.
         using OrdinaryDiffEqExtrapolation, Test
         exported = (
             :ODEProblem, :ODEFunction, :SplitODEProblem, :solve, :init, :step!,
@@ -22,7 +19,8 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
         @test all(Base.isexported.(Ref(OrdinaryDiffEqExtrapolation), exported))
         internal = (
             :build_solution, :isinplace, :has_jac, :AbstractODEProblem,
-            :StandardODEProblem, :UJacobianWrapper,
+            :StandardODEProblem, :UJacobianWrapper, :LinearProblem,
+            :ConvexOptimizationProblem,
         )
         @test !any(Base.isexported.(Ref(OrdinaryDiffEqExtrapolation), internal))
     end

--- a/lib/OrdinaryDiffEqExtrapolation/test/runtests.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/runtests.jl
@@ -11,13 +11,15 @@ end
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
         using OrdinaryDiffEqExtrapolation, Test
-        expected = (
-            :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
-            :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+        expected = (:ODEProblem, :solve)
+        @test all(Base.isexported.(Ref(OrdinaryDiffEqExtrapolation), expected))
+        removed = (
+            :ODEFunction, :init, :solve!, :step!, :remake, :reinit!, :ReturnCode,
+            :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
             :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
             :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
         )
-        @test all(Base.isexported.(Ref(OrdinaryDiffEqExtrapolation), expected))
+        @test all(x -> !x, Base.isexported.(Ref(OrdinaryDiffEqExtrapolation), removed))
         @test !Base.isexported(OrdinaryDiffEqExtrapolation, :EnsembleProblem)
         @test !Base.isexported(OrdinaryDiffEqExtrapolation, :get_du)
         @test !Base.isexported(OrdinaryDiffEqExtrapolation, :u_modified!)

--- a/lib/OrdinaryDiffEqFeagin/Project.toml
+++ b/lib/OrdinaryDiffEqFeagin/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFeagin"
 uuid = "101fe9f7-ebb6-4678-b671-3a81e7194747"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.2"
+version = "2.3.0"
 
 [deps]
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"

--- a/lib/OrdinaryDiffEqFeagin/Project.toml
+++ b/lib/OrdinaryDiffEqFeagin/Project.toml
@@ -1,9 +1,10 @@
 name = "OrdinaryDiffEqFeagin"
 uuid = "101fe9f7-ebb6-4678-b671-3a81e7194747"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.1"
+version = "2.2.2"
 
 [deps]
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
@@ -21,6 +22,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 
 [compat]
+Reexport = "1.2.2"
 SciMLTesting = "2.4"
 Pkg = "1"
 Test = "<0.0.1, 1"

--- a/lib/OrdinaryDiffEqFeagin/src/OrdinaryDiffEqFeagin.jl
+++ b/lib/OrdinaryDiffEqFeagin/src/OrdinaryDiffEqFeagin.jl
@@ -15,36 +15,19 @@ using DiffEqBase: @tight_loop_macros
 import OrdinaryDiffEqCore
 
 using Reexport: Reexport, @reexport
-# Re-exported SciMLBase API. This list is identical in every OrdinaryDiffEq solver
-# sublibrary and is generated from the rule documented in docs/src/api/reexports.md;
-# `test/qa/qa_tests.jl` checks the sublibraries against each other and against that rule.
-@reexport using SciMLBase: AnalyticalProblem, BVProblem, ConvexOptimizationProblem,
-    DAEProblem, DDEProblem, DiscreteProblem, DynamicalDDEProblem, DynamicalODEProblem,
-    DynamicalSDEProblem, EigenvalueProblem, EnsembleProblem, HomotopyProblem,
-    ImmutableNonlinearProblem, ImmutableODEProblem, ImplicitDiscreteProblem,
-    IncrementingODEProblem, IntegralProblem, IntervalNonlinearProblem, LinearProblem,
-    NoiseProblem, NonlinearLeastSquaresProblem, NonlinearProblem, ODEProblem,
-    OptimizationProblem, PDEProblem, RODEProblem, SCCNonlinearProblem, SDDEProblem,
-    SDEProblem, SampledIntegralProblem, SecondOrderBVProblem, SecondOrderDDEProblem,
-    SecondOrderODEProblem, SplitODEProblem, SplitSDEProblem, SteadyStateProblem,
-    TwoPointBVProblem, TwoPointSecondOrderBVProblem, WeightedEnsembleProblem, BVPFunction,
-    BatchIntegralFunction, DAEFunction, DDEFunction, DiscreteFunction, DynamicalBVPFunction,
-    DynamicalDDEFunction, DynamicalODEFunction, DynamicalSDEFunction,
-    HomotopyNonlinearFunction, ImplicitDiscreteFunction, IncrementingODEFunction,
-    IntegralFunction, IntervalNonlinearFunction, MultiObjectiveOptimizationFunction,
-    NonlinearFunction, ODEFunction, ODEInputFunction, OptimizationFunction, RODEFunction,
-    SDDEFunction, SDEFunction, SplitFunction, SplitSDEFunction, TwoPointBVPFunction,
-    TwoPointDynamicalBVPFunction, solve, solve!, init, step!, remake, ReturnCode,
-    successful_retcode, DEStats, NLStats, NullParameters, AutoSpecialize, FullSpecialize,
-    NoSpecialize, FunctionWrapperSpecialize, CheckInit, NoInit, OverrideInit, CallbackSet,
-    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, LeftRootFind,
-    RightRootFind, NoRootFind, add_saveat!, add_tstop!, auto_dt_reset!,
-    change_t_via_interpolation!, check_error, check_error!, first_tstop, get_dt, get_du,
-    get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!, reinit!, savevalues!, set_abstol!,
-    set_proposed_dt!, set_reltol!, set_t!, set_u!, set_ut!, terminate!, u_modified!,
-    EnsembleAnalysis, EnsembleDistributed, EnsembleSerial, EnsembleSplitThreads,
-    EnsembleSummary, EnsembleThreads
-using SciMLBase: SciMLBase
+# Kept in sync with docs/src/api/reexports.md by test/qa/reexport_tests.jl.
+@reexport using SciMLBase: DAEProblem, DiscreteProblem, DynamicalODEProblem,
+    EnsembleProblem, ODEProblem, SecondOrderODEProblem, SplitODEProblem, DAEFunction,
+    DiscreteFunction, DynamicalODEFunction, ODEFunction, SplitFunction, solve, solve!, init,
+    step!, remake, ReturnCode, successful_retcode, DEStats, NLStats, NullParameters,
+    AutoSpecialize, FullSpecialize, NoSpecialize, FunctionWrapperSpecialize, CheckInit,
+    NoInit, OverrideInit, CallbackSet, ContinuousCallback, DiscreteCallback,
+    VectorContinuousCallback, LeftRootFind, RightRootFind, NoRootFind, add_saveat!,
+    add_tstop!, auto_dt_reset!, change_t_via_interpolation!, check_error, check_error!,
+    first_tstop, get_dt, get_du, get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!,
+    reinit!, savevalues!, set_abstol!, set_proposed_dt!, set_reltol!, set_t!, set_u!,
+    set_ut!, terminate!, u_modified!, EnsembleAnalysis, EnsembleDistributed, EnsembleSerial,
+    EnsembleSplitThreads, EnsembleSummary, EnsembleThreads
 using SciMLBase: SciMLBase
 
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqFeagin/src/OrdinaryDiffEqFeagin.jl
+++ b/lib/OrdinaryDiffEqFeagin/src/OrdinaryDiffEqFeagin.jl
@@ -17,7 +17,8 @@ import OrdinaryDiffEqCore
 using Reexport: Reexport, @reexport
 @reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
     reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
-    CallbackSet, terminate!
+    CallbackSet, terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
+    successful_retcode, ODEAliasSpecifier
 using SciMLBase: SciMLBase
 
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqFeagin/src/OrdinaryDiffEqFeagin.jl
+++ b/lib/OrdinaryDiffEqFeagin/src/OrdinaryDiffEqFeagin.jl
@@ -15,10 +15,11 @@ using DiffEqBase: @tight_loop_macros
 import OrdinaryDiffEqCore
 
 using Reexport: Reexport, @reexport
-@reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
-    reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
-    CallbackSet, terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
+using SciMLBase: ODEFunction, init, solve!, step!, remake, reinit!, ReturnCode,
+    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, CallbackSet,
+    terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
     successful_retcode, ODEAliasSpecifier
+@reexport using SciMLBase: ODEProblem, solve
 using SciMLBase: SciMLBase
 
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqFeagin/src/OrdinaryDiffEqFeagin.jl
+++ b/lib/OrdinaryDiffEqFeagin/src/OrdinaryDiffEqFeagin.jl
@@ -14,6 +14,12 @@ import RecursiveArrayTools: recursivefill!
 using DiffEqBase: @tight_loop_macros
 import OrdinaryDiffEqCore
 
+using Reexport: Reexport, @reexport
+@reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
+    reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
+    CallbackSet, terminate!
+using SciMLBase: SciMLBase
+
 include("algorithms.jl")
 include("alg_utils.jl")
 include("feagin_tableaus.jl")

--- a/lib/OrdinaryDiffEqFeagin/src/OrdinaryDiffEqFeagin.jl
+++ b/lib/OrdinaryDiffEqFeagin/src/OrdinaryDiffEqFeagin.jl
@@ -15,7 +15,36 @@ using DiffEqBase: @tight_loop_macros
 import OrdinaryDiffEqCore
 
 using Reexport: Reexport, @reexport
-@reexport using SciMLBase: ODEProblem, solve
+# Re-exported SciMLBase API. This list is identical in every OrdinaryDiffEq solver
+# sublibrary and is generated from the rule documented in docs/src/api/reexports.md;
+# `test/qa/qa_tests.jl` checks the sublibraries against each other and against that rule.
+@reexport using SciMLBase: AnalyticalProblem, BVProblem, ConvexOptimizationProblem,
+    DAEProblem, DDEProblem, DiscreteProblem, DynamicalDDEProblem, DynamicalODEProblem,
+    DynamicalSDEProblem, EigenvalueProblem, EnsembleProblem, HomotopyProblem,
+    ImmutableNonlinearProblem, ImmutableODEProblem, ImplicitDiscreteProblem,
+    IncrementingODEProblem, IntegralProblem, IntervalNonlinearProblem, LinearProblem,
+    NoiseProblem, NonlinearLeastSquaresProblem, NonlinearProblem, ODEProblem,
+    OptimizationProblem, PDEProblem, RODEProblem, SCCNonlinearProblem, SDDEProblem,
+    SDEProblem, SampledIntegralProblem, SecondOrderBVProblem, SecondOrderDDEProblem,
+    SecondOrderODEProblem, SplitODEProblem, SplitSDEProblem, SteadyStateProblem,
+    TwoPointBVProblem, TwoPointSecondOrderBVProblem, WeightedEnsembleProblem, BVPFunction,
+    BatchIntegralFunction, DAEFunction, DDEFunction, DiscreteFunction, DynamicalBVPFunction,
+    DynamicalDDEFunction, DynamicalODEFunction, DynamicalSDEFunction,
+    HomotopyNonlinearFunction, ImplicitDiscreteFunction, IncrementingODEFunction,
+    IntegralFunction, IntervalNonlinearFunction, MultiObjectiveOptimizationFunction,
+    NonlinearFunction, ODEFunction, ODEInputFunction, OptimizationFunction, RODEFunction,
+    SDDEFunction, SDEFunction, SplitFunction, SplitSDEFunction, TwoPointBVPFunction,
+    TwoPointDynamicalBVPFunction, solve, solve!, init, step!, remake, ReturnCode,
+    successful_retcode, DEStats, NLStats, NullParameters, AutoSpecialize, FullSpecialize,
+    NoSpecialize, FunctionWrapperSpecialize, CheckInit, NoInit, OverrideInit, CallbackSet,
+    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, LeftRootFind,
+    RightRootFind, NoRootFind, add_saveat!, add_tstop!, auto_dt_reset!,
+    change_t_via_interpolation!, check_error, check_error!, first_tstop, get_dt, get_du,
+    get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!, reinit!, savevalues!, set_abstol!,
+    set_proposed_dt!, set_reltol!, set_t!, set_u!, set_ut!, terminate!, u_modified!,
+    EnsembleAnalysis, EnsembleDistributed, EnsembleSerial, EnsembleSplitThreads,
+    EnsembleSummary, EnsembleThreads
+using SciMLBase: SciMLBase
 using SciMLBase: SciMLBase
 
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqFeagin/src/OrdinaryDiffEqFeagin.jl
+++ b/lib/OrdinaryDiffEqFeagin/src/OrdinaryDiffEqFeagin.jl
@@ -15,10 +15,6 @@ using DiffEqBase: @tight_loop_macros
 import OrdinaryDiffEqCore
 
 using Reexport: Reexport, @reexport
-using SciMLBase: ODEFunction, init, solve!, step!, remake, reinit!, ReturnCode,
-    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, CallbackSet,
-    terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
-    successful_retcode, ODEAliasSpecifier
 @reexport using SciMLBase: ODEProblem, solve
 using SciMLBase: SciMLBase
 

--- a/lib/OrdinaryDiffEqFeagin/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFeagin/test/qa/qa.jl
@@ -4,7 +4,8 @@ using SciMLTesting, OrdinaryDiffEqFeagin, Test
 const SCIMLBASE_REEXPORTS = (
     :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
     :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-    :CallbackSet, :terminate!,
+    :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
+    :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
 )
 
 run_qa(

--- a/lib/OrdinaryDiffEqFeagin/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFeagin/test/qa/qa.jl
@@ -2,8 +2,6 @@ using SciMLTesting, OrdinaryDiffEqFeagin, SciMLBase, Test
 
 run_qa(
     OrdinaryDiffEqFeagin;
-    # Approve the SciMLBase names this package re-exports. The list itself and the rule
-    # behind it are checked repo-wide by test/qa/qa_tests.jl against docs/src/api/reexports.md.
     reexports_allow = intersect(names(SciMLBase), names(OrdinaryDiffEqFeagin)),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqFeagin/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFeagin/test/qa/qa.jl
@@ -1,12 +1,7 @@
 using SciMLTesting, OrdinaryDiffEqFeagin, Test
 
 # SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
-const SCIMLBASE_REEXPORTS = (
-    :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
-    :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-    :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
-    :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
-)
+const SCIMLBASE_REEXPORTS = (:ODEProblem, :solve)
 
 run_qa(
     OrdinaryDiffEqFeagin;

--- a/lib/OrdinaryDiffEqFeagin/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFeagin/test/qa/qa.jl
@@ -1,7 +1,15 @@
 using SciMLTesting, OrdinaryDiffEqFeagin, Test
 
+# SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
+const SCIMLBASE_REEXPORTS = (
+    :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
+    :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+    :CallbackSet, :terminate!,
+)
+
 run_qa(
     OrdinaryDiffEqFeagin;
+    reexports_allow = SCIMLBASE_REEXPORTS,
     explicit_imports = true,
     ei_kwargs = (;
         all_explicit_imports_are_public = (;

--- a/lib/OrdinaryDiffEqFeagin/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFeagin/test/qa/qa.jl
@@ -1,11 +1,10 @@
-using SciMLTesting, OrdinaryDiffEqFeagin, Test
-
-# SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
-const SCIMLBASE_REEXPORTS = (:ODEProblem, :solve)
+using SciMLTesting, OrdinaryDiffEqFeagin, SciMLBase, Test
 
 run_qa(
     OrdinaryDiffEqFeagin;
-    reexports_allow = SCIMLBASE_REEXPORTS,
+    # Approve the SciMLBase names this package re-exports. The list itself and the rule
+    # behind it are checked repo-wide by test/qa/qa_tests.jl against docs/src/api/reexports.md.
+    reexports_allow = intersect(names(SciMLBase), names(OrdinaryDiffEqFeagin)),
     explicit_imports = true,
     ei_kwargs = (;
         all_explicit_imports_are_public = (;

--- a/lib/OrdinaryDiffEqFeagin/test/runtests.jl
+++ b/lib/OrdinaryDiffEqFeagin/test/runtests.jl
@@ -11,8 +11,16 @@ end
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
         using OrdinaryDiffEqFeagin, Test
-        @test Base.isexported(OrdinaryDiffEqFeagin, :ODEProblem)
-        @test Base.isexported(OrdinaryDiffEqFeagin, :solve)
+        expected = (
+            :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
+            :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+            :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
+            :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
+        )
+        @test all(Base.isexported.(Ref(OrdinaryDiffEqFeagin), expected))
+        @test !Base.isexported(OrdinaryDiffEqFeagin, :EnsembleProblem)
+        @test !Base.isexported(OrdinaryDiffEqFeagin, :get_du)
+        @test !Base.isexported(OrdinaryDiffEqFeagin, :u_modified!)
     end
     @time @safetestset "Feagin Tests" include("ode_feagin_tests.jl")
 end

--- a/lib/OrdinaryDiffEqFeagin/test/runtests.jl
+++ b/lib/OrdinaryDiffEqFeagin/test/runtests.jl
@@ -9,6 +9,11 @@ end
 
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
+    @time @safetestset "SciMLBase reexport" begin
+        using OrdinaryDiffEqFeagin, Test
+        @test Base.isexported(OrdinaryDiffEqFeagin, :ODEProblem)
+        @test Base.isexported(OrdinaryDiffEqFeagin, :solve)
+    end
     @time @safetestset "Feagin Tests" include("ode_feagin_tests.jl")
 end
 

--- a/lib/OrdinaryDiffEqFeagin/test/runtests.jl
+++ b/lib/OrdinaryDiffEqFeagin/test/runtests.jl
@@ -11,13 +11,15 @@ end
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
         using OrdinaryDiffEqFeagin, Test
-        expected = (
-            :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
-            :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+        expected = (:ODEProblem, :solve)
+        @test all(Base.isexported.(Ref(OrdinaryDiffEqFeagin), expected))
+        removed = (
+            :ODEFunction, :init, :solve!, :step!, :remake, :reinit!, :ReturnCode,
+            :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
             :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
             :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
         )
-        @test all(Base.isexported.(Ref(OrdinaryDiffEqFeagin), expected))
+        @test all(x -> !x, Base.isexported.(Ref(OrdinaryDiffEqFeagin), removed))
         @test !Base.isexported(OrdinaryDiffEqFeagin, :EnsembleProblem)
         @test !Base.isexported(OrdinaryDiffEqFeagin, :get_du)
         @test !Base.isexported(OrdinaryDiffEqFeagin, :u_modified!)

--- a/lib/OrdinaryDiffEqFeagin/test/runtests.jl
+++ b/lib/OrdinaryDiffEqFeagin/test/runtests.jl
@@ -10,9 +10,6 @@ end
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
-        # docs/src/api/reexports.md defines this surface; test/qa/qa_tests.jl checks the
-        # full list repo-wide. Here, spot-check that the common interface is usable and
-        # that solver-author API stayed behind the `SciMLBase.` qualifier.
         using OrdinaryDiffEqFeagin, Test
         exported = (
             :ODEProblem, :ODEFunction, :SplitODEProblem, :solve, :init, :step!,
@@ -22,7 +19,8 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
         @test all(Base.isexported.(Ref(OrdinaryDiffEqFeagin), exported))
         internal = (
             :build_solution, :isinplace, :has_jac, :AbstractODEProblem,
-            :StandardODEProblem, :UJacobianWrapper,
+            :StandardODEProblem, :UJacobianWrapper, :LinearProblem,
+            :ConvexOptimizationProblem,
         )
         @test !any(Base.isexported.(Ref(OrdinaryDiffEqFeagin), internal))
     end

--- a/lib/OrdinaryDiffEqFeagin/test/runtests.jl
+++ b/lib/OrdinaryDiffEqFeagin/test/runtests.jl
@@ -10,19 +10,21 @@ end
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
+        # docs/src/api/reexports.md defines this surface; test/qa/qa_tests.jl checks the
+        # full list repo-wide. Here, spot-check that the common interface is usable and
+        # that solver-author API stayed behind the `SciMLBase.` qualifier.
         using OrdinaryDiffEqFeagin, Test
-        expected = (:ODEProblem, :solve)
-        @test all(Base.isexported.(Ref(OrdinaryDiffEqFeagin), expected))
-        removed = (
-            :ODEFunction, :init, :solve!, :step!, :remake, :reinit!, :ReturnCode,
-            :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-            :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
-            :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
+        exported = (
+            :ODEProblem, :ODEFunction, :SplitODEProblem, :solve, :init, :step!,
+            :remake, :ReturnCode, :CallbackSet, :ContinuousCallback, :terminate!,
+            :u_modified!, :add_tstop!, :get_du, :EnsembleProblem,
         )
-        @test all(x -> !x, Base.isexported.(Ref(OrdinaryDiffEqFeagin), removed))
-        @test !Base.isexported(OrdinaryDiffEqFeagin, :EnsembleProblem)
-        @test !Base.isexported(OrdinaryDiffEqFeagin, :get_du)
-        @test !Base.isexported(OrdinaryDiffEqFeagin, :u_modified!)
+        @test all(Base.isexported.(Ref(OrdinaryDiffEqFeagin), exported))
+        internal = (
+            :build_solution, :isinplace, :has_jac, :AbstractODEProblem,
+            :StandardODEProblem, :UJacobianWrapper,
+        )
+        @test !any(Base.isexported.(Ref(OrdinaryDiffEqFeagin), internal))
     end
     @time @safetestset "Feagin Tests" include("ode_feagin_tests.jl")
 end

--- a/lib/OrdinaryDiffEqFunctionMap/Project.toml
+++ b/lib/OrdinaryDiffEqFunctionMap/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFunctionMap"
 uuid = "d3585ca7-f5d3-4ba6-8057-292ed1abd90f"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.2"
+version = "2.3.0"
 
 [deps]
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"

--- a/lib/OrdinaryDiffEqFunctionMap/Project.toml
+++ b/lib/OrdinaryDiffEqFunctionMap/Project.toml
@@ -1,9 +1,10 @@
 name = "OrdinaryDiffEqFunctionMap"
 uuid = "d3585ca7-f5d3-4ba6-8057-292ed1abd90f"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.1"
+version = "2.2.2"
 
 [deps]
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
@@ -28,6 +29,7 @@ DiffEqDevTools = {path = "../DiffEqDevTools"}
 OrdinaryDiffEqLowOrderRK = {path = "../OrdinaryDiffEqLowOrderRK"}
 
 [compat]
+Reexport = "1.2.2"
 SciMLTesting = "2.8"
 Pkg = "1"
 Test = "<0.0.1, 1"

--- a/lib/OrdinaryDiffEqFunctionMap/src/OrdinaryDiffEqFunctionMap.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/src/OrdinaryDiffEqFunctionMap.jl
@@ -19,35 +19,19 @@ import SciMLBase
 import SciMLBase: alg_order
 
 using Reexport: Reexport, @reexport
-# Re-exported SciMLBase API. This list is identical in every OrdinaryDiffEq solver
-# sublibrary and is generated from the rule documented in docs/src/api/reexports.md;
-# `test/qa/qa_tests.jl` checks the sublibraries against each other and against that rule.
-@reexport using SciMLBase: AnalyticalProblem, BVProblem, ConvexOptimizationProblem,
-    DAEProblem, DDEProblem, DiscreteProblem, DynamicalDDEProblem, DynamicalODEProblem,
-    DynamicalSDEProblem, EigenvalueProblem, EnsembleProblem, HomotopyProblem,
-    ImmutableNonlinearProblem, ImmutableODEProblem, ImplicitDiscreteProblem,
-    IncrementingODEProblem, IntegralProblem, IntervalNonlinearProblem, LinearProblem,
-    NoiseProblem, NonlinearLeastSquaresProblem, NonlinearProblem, ODEProblem,
-    OptimizationProblem, PDEProblem, RODEProblem, SCCNonlinearProblem, SDDEProblem,
-    SDEProblem, SampledIntegralProblem, SecondOrderBVProblem, SecondOrderDDEProblem,
-    SecondOrderODEProblem, SplitODEProblem, SplitSDEProblem, SteadyStateProblem,
-    TwoPointBVProblem, TwoPointSecondOrderBVProblem, WeightedEnsembleProblem, BVPFunction,
-    BatchIntegralFunction, DAEFunction, DDEFunction, DiscreteFunction, DynamicalBVPFunction,
-    DynamicalDDEFunction, DynamicalODEFunction, DynamicalSDEFunction,
-    HomotopyNonlinearFunction, ImplicitDiscreteFunction, IncrementingODEFunction,
-    IntegralFunction, IntervalNonlinearFunction, MultiObjectiveOptimizationFunction,
-    NonlinearFunction, ODEFunction, ODEInputFunction, OptimizationFunction, RODEFunction,
-    SDDEFunction, SDEFunction, SplitFunction, SplitSDEFunction, TwoPointBVPFunction,
-    TwoPointDynamicalBVPFunction, solve, solve!, init, step!, remake, ReturnCode,
-    successful_retcode, DEStats, NLStats, NullParameters, AutoSpecialize, FullSpecialize,
-    NoSpecialize, FunctionWrapperSpecialize, CheckInit, NoInit, OverrideInit, CallbackSet,
-    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, LeftRootFind,
-    RightRootFind, NoRootFind, add_saveat!, add_tstop!, auto_dt_reset!,
-    change_t_via_interpolation!, check_error, check_error!, first_tstop, get_dt, get_du,
-    get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!, reinit!, savevalues!, set_abstol!,
-    set_proposed_dt!, set_reltol!, set_t!, set_u!, set_ut!, terminate!, u_modified!,
-    EnsembleAnalysis, EnsembleDistributed, EnsembleSerial, EnsembleSplitThreads,
-    EnsembleSummary, EnsembleThreads
+# Kept in sync with docs/src/api/reexports.md by test/qa/reexport_tests.jl.
+@reexport using SciMLBase: DAEProblem, DiscreteProblem, DynamicalODEProblem,
+    EnsembleProblem, ODEProblem, SecondOrderODEProblem, SplitODEProblem, DAEFunction,
+    DiscreteFunction, DynamicalODEFunction, ODEFunction, SplitFunction, solve, solve!, init,
+    step!, remake, ReturnCode, successful_retcode, DEStats, NLStats, NullParameters,
+    AutoSpecialize, FullSpecialize, NoSpecialize, FunctionWrapperSpecialize, CheckInit,
+    NoInit, OverrideInit, CallbackSet, ContinuousCallback, DiscreteCallback,
+    VectorContinuousCallback, LeftRootFind, RightRootFind, NoRootFind, add_saveat!,
+    add_tstop!, auto_dt_reset!, change_t_via_interpolation!, check_error, check_error!,
+    first_tstop, get_dt, get_du, get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!,
+    reinit!, savevalues!, set_abstol!, set_proposed_dt!, set_reltol!, set_t!, set_u!,
+    set_ut!, terminate!, u_modified!, EnsembleAnalysis, EnsembleDistributed, EnsembleSerial,
+    EnsembleSplitThreads, EnsembleSummary, EnsembleThreads
 using SciMLBase: SciMLBase
 
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqFunctionMap/src/OrdinaryDiffEqFunctionMap.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/src/OrdinaryDiffEqFunctionMap.jl
@@ -19,10 +19,6 @@ import SciMLBase
 import SciMLBase: alg_order
 
 using Reexport: Reexport, @reexport
-using SciMLBase: ODEProblem, ODEFunction, init, solve!, step!, remake, reinit!, ReturnCode,
-    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, CallbackSet,
-    terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
-    successful_retcode, ODEAliasSpecifier, DiscreteFunction
 @reexport using SciMLBase: DiscreteProblem, solve
 
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqFunctionMap/src/OrdinaryDiffEqFunctionMap.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/src/OrdinaryDiffEqFunctionMap.jl
@@ -19,7 +19,36 @@ import SciMLBase
 import SciMLBase: alg_order
 
 using Reexport: Reexport, @reexport
-@reexport using SciMLBase: DiscreteProblem, solve
+# Re-exported SciMLBase API. This list is identical in every OrdinaryDiffEq solver
+# sublibrary and is generated from the rule documented in docs/src/api/reexports.md;
+# `test/qa/qa_tests.jl` checks the sublibraries against each other and against that rule.
+@reexport using SciMLBase: AnalyticalProblem, BVProblem, ConvexOptimizationProblem,
+    DAEProblem, DDEProblem, DiscreteProblem, DynamicalDDEProblem, DynamicalODEProblem,
+    DynamicalSDEProblem, EigenvalueProblem, EnsembleProblem, HomotopyProblem,
+    ImmutableNonlinearProblem, ImmutableODEProblem, ImplicitDiscreteProblem,
+    IncrementingODEProblem, IntegralProblem, IntervalNonlinearProblem, LinearProblem,
+    NoiseProblem, NonlinearLeastSquaresProblem, NonlinearProblem, ODEProblem,
+    OptimizationProblem, PDEProblem, RODEProblem, SCCNonlinearProblem, SDDEProblem,
+    SDEProblem, SampledIntegralProblem, SecondOrderBVProblem, SecondOrderDDEProblem,
+    SecondOrderODEProblem, SplitODEProblem, SplitSDEProblem, SteadyStateProblem,
+    TwoPointBVProblem, TwoPointSecondOrderBVProblem, WeightedEnsembleProblem, BVPFunction,
+    BatchIntegralFunction, DAEFunction, DDEFunction, DiscreteFunction, DynamicalBVPFunction,
+    DynamicalDDEFunction, DynamicalODEFunction, DynamicalSDEFunction,
+    HomotopyNonlinearFunction, ImplicitDiscreteFunction, IncrementingODEFunction,
+    IntegralFunction, IntervalNonlinearFunction, MultiObjectiveOptimizationFunction,
+    NonlinearFunction, ODEFunction, ODEInputFunction, OptimizationFunction, RODEFunction,
+    SDDEFunction, SDEFunction, SplitFunction, SplitSDEFunction, TwoPointBVPFunction,
+    TwoPointDynamicalBVPFunction, solve, solve!, init, step!, remake, ReturnCode,
+    successful_retcode, DEStats, NLStats, NullParameters, AutoSpecialize, FullSpecialize,
+    NoSpecialize, FunctionWrapperSpecialize, CheckInit, NoInit, OverrideInit, CallbackSet,
+    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, LeftRootFind,
+    RightRootFind, NoRootFind, add_saveat!, add_tstop!, auto_dt_reset!,
+    change_t_via_interpolation!, check_error, check_error!, first_tstop, get_dt, get_du,
+    get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!, reinit!, savevalues!, set_abstol!,
+    set_proposed_dt!, set_reltol!, set_t!, set_u!, set_ut!, terminate!, u_modified!,
+    EnsembleAnalysis, EnsembleDistributed, EnsembleSerial, EnsembleSplitThreads,
+    EnsembleSummary, EnsembleThreads
+using SciMLBase: SciMLBase
 
 include("algorithms.jl")
 include("alg_utils.jl")

--- a/lib/OrdinaryDiffEqFunctionMap/src/OrdinaryDiffEqFunctionMap.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/src/OrdinaryDiffEqFunctionMap.jl
@@ -21,7 +21,8 @@ import SciMLBase: alg_order
 using Reexport: Reexport, @reexport
 @reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
     reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
-    CallbackSet, terminate!, DiscreteProblem, DiscreteFunction
+    CallbackSet, terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
+    successful_retcode, ODEAliasSpecifier, DiscreteProblem, DiscreteFunction
 
 include("algorithms.jl")
 include("alg_utils.jl")

--- a/lib/OrdinaryDiffEqFunctionMap/src/OrdinaryDiffEqFunctionMap.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/src/OrdinaryDiffEqFunctionMap.jl
@@ -18,6 +18,11 @@ import OrdinaryDiffEqCore
 import SciMLBase
 import SciMLBase: alg_order
 
+using Reexport: Reexport, @reexport
+@reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
+    reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
+    CallbackSet, terminate!, DiscreteProblem, DiscreteFunction
+
 include("algorithms.jl")
 include("alg_utils.jl")
 include("functionmap_caches.jl")

--- a/lib/OrdinaryDiffEqFunctionMap/src/OrdinaryDiffEqFunctionMap.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/src/OrdinaryDiffEqFunctionMap.jl
@@ -19,10 +19,11 @@ import SciMLBase
 import SciMLBase: alg_order
 
 using Reexport: Reexport, @reexport
-@reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
-    reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
-    CallbackSet, terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
-    successful_retcode, ODEAliasSpecifier, DiscreteProblem, DiscreteFunction
+using SciMLBase: ODEProblem, ODEFunction, init, solve!, step!, remake, reinit!, ReturnCode,
+    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, CallbackSet,
+    terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
+    successful_retcode, ODEAliasSpecifier, DiscreteFunction
+@reexport using SciMLBase: DiscreteProblem, solve
 
 include("algorithms.jl")
 include("alg_utils.jl")

--- a/lib/OrdinaryDiffEqFunctionMap/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/test/qa/qa.jl
@@ -1,13 +1,7 @@
 using SciMLTesting, OrdinaryDiffEqFunctionMap, Test
 
 # SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
-const SCIMLBASE_REEXPORTS = (
-    :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
-    :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-    :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
-    :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
-    :DiscreteProblem, :DiscreteFunction,
-)
+const SCIMLBASE_REEXPORTS = (:DiscreteProblem, :solve)
 
 run_qa(
     OrdinaryDiffEqFunctionMap;

--- a/lib/OrdinaryDiffEqFunctionMap/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/test/qa/qa.jl
@@ -2,8 +2,6 @@ using SciMLTesting, OrdinaryDiffEqFunctionMap, SciMLBase, Test
 
 run_qa(
     OrdinaryDiffEqFunctionMap;
-    # Approve the SciMLBase names this package re-exports. The list itself and the rule
-    # behind it are checked repo-wide by test/qa/qa_tests.jl against docs/src/api/reexports.md.
     reexports_allow = intersect(names(SciMLBase), names(OrdinaryDiffEqFunctionMap)),
     aqua_kwargs = (; piracies = false),  # piracy is needed for default-algorithm dispatch
     explicit_imports = true,

--- a/lib/OrdinaryDiffEqFunctionMap/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/test/qa/qa.jl
@@ -1,7 +1,15 @@
 using SciMLTesting, OrdinaryDiffEqFunctionMap, Test
 
+# SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
+const SCIMLBASE_REEXPORTS = (
+    :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
+    :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+    :CallbackSet, :terminate!, :DiscreteProblem, :DiscreteFunction,
+)
+
 run_qa(
     OrdinaryDiffEqFunctionMap;
+    reexports_allow = SCIMLBASE_REEXPORTS,
     aqua_kwargs = (; piracies = false),  # piracy is needed for default-algorithm dispatch
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqFunctionMap/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/test/qa/qa.jl
@@ -1,11 +1,10 @@
-using SciMLTesting, OrdinaryDiffEqFunctionMap, Test
-
-# SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
-const SCIMLBASE_REEXPORTS = (:DiscreteProblem, :solve)
+using SciMLTesting, OrdinaryDiffEqFunctionMap, SciMLBase, Test
 
 run_qa(
     OrdinaryDiffEqFunctionMap;
-    reexports_allow = SCIMLBASE_REEXPORTS,
+    # Approve the SciMLBase names this package re-exports. The list itself and the rule
+    # behind it are checked repo-wide by test/qa/qa_tests.jl against docs/src/api/reexports.md.
+    reexports_allow = intersect(names(SciMLBase), names(OrdinaryDiffEqFunctionMap)),
     aqua_kwargs = (; piracies = false),  # piracy is needed for default-algorithm dispatch
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqFunctionMap/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/test/qa/qa.jl
@@ -4,7 +4,9 @@ using SciMLTesting, OrdinaryDiffEqFunctionMap, Test
 const SCIMLBASE_REEXPORTS = (
     :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
     :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-    :CallbackSet, :terminate!, :DiscreteProblem, :DiscreteFunction,
+    :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
+    :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
+    :DiscreteProblem, :DiscreteFunction,
 )
 
 run_qa(

--- a/lib/OrdinaryDiffEqFunctionMap/test/runtests.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/test/runtests.jl
@@ -11,14 +11,16 @@ end
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
         using OrdinaryDiffEqFunctionMap, Test
-        expected = (
-            :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
-            :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-            :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
-            :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
-            :DiscreteProblem, :DiscreteFunction,
-        )
+        expected = (:DiscreteProblem, :solve)
         @test all(Base.isexported.(Ref(OrdinaryDiffEqFunctionMap), expected))
+        removed = (
+            :ODEProblem, :ODEFunction, :init, :solve!, :step!, :remake, :reinit!,
+            :ReturnCode, :ContinuousCallback, :DiscreteCallback,
+            :VectorContinuousCallback, :CallbackSet, :terminate!, :add_tstop!,
+            :derivative_discontinuity!, :set_proposed_dt!, :successful_retcode,
+            :ODEAliasSpecifier, :DiscreteFunction,
+        )
+        @test all(x -> !x, Base.isexported.(Ref(OrdinaryDiffEqFunctionMap), removed))
         @test !Base.isexported(OrdinaryDiffEqFunctionMap, :EnsembleProblem)
         @test !Base.isexported(OrdinaryDiffEqFunctionMap, :get_du)
         @test !Base.isexported(OrdinaryDiffEqFunctionMap, :u_modified!)

--- a/lib/OrdinaryDiffEqFunctionMap/test/runtests.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/test/runtests.jl
@@ -10,20 +10,21 @@ end
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
+        # docs/src/api/reexports.md defines this surface; test/qa/qa_tests.jl checks the
+        # full list repo-wide. Here, spot-check that the common interface is usable and
+        # that solver-author API stayed behind the `SciMLBase.` qualifier.
         using OrdinaryDiffEqFunctionMap, Test
-        expected = (:DiscreteProblem, :solve)
-        @test all(Base.isexported.(Ref(OrdinaryDiffEqFunctionMap), expected))
-        removed = (
-            :ODEProblem, :ODEFunction, :init, :solve!, :step!, :remake, :reinit!,
-            :ReturnCode, :ContinuousCallback, :DiscreteCallback,
-            :VectorContinuousCallback, :CallbackSet, :terminate!, :add_tstop!,
-            :derivative_discontinuity!, :set_proposed_dt!, :successful_retcode,
-            :ODEAliasSpecifier, :DiscreteFunction,
+        exported = (
+            :ODEProblem, :ODEFunction, :SplitODEProblem, :solve, :init, :step!,
+            :remake, :ReturnCode, :CallbackSet, :ContinuousCallback, :terminate!,
+            :u_modified!, :add_tstop!, :get_du, :EnsembleProblem,
         )
-        @test all(x -> !x, Base.isexported.(Ref(OrdinaryDiffEqFunctionMap), removed))
-        @test !Base.isexported(OrdinaryDiffEqFunctionMap, :EnsembleProblem)
-        @test !Base.isexported(OrdinaryDiffEqFunctionMap, :get_du)
-        @test !Base.isexported(OrdinaryDiffEqFunctionMap, :u_modified!)
+        @test all(Base.isexported.(Ref(OrdinaryDiffEqFunctionMap), exported))
+        internal = (
+            :build_solution, :isinplace, :has_jac, :AbstractODEProblem,
+            :StandardODEProblem, :UJacobianWrapper,
+        )
+        @test !any(Base.isexported.(Ref(OrdinaryDiffEqFunctionMap), internal))
     end
     @time @safetestset "DiscreteProblem Defaults" include("discrete_problem_defaults.jl")
     @time @safetestset "Discrete Algorithm Tests" include("discrete_algorithm_test.jl")

--- a/lib/OrdinaryDiffEqFunctionMap/test/runtests.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/test/runtests.jl
@@ -9,6 +9,11 @@ end
 
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
+    @time @safetestset "SciMLBase reexport" begin
+        using OrdinaryDiffEqFunctionMap, Test
+        @test Base.isexported(OrdinaryDiffEqFunctionMap, :ODEProblem)
+        @test Base.isexported(OrdinaryDiffEqFunctionMap, :solve)
+    end
     @time @safetestset "DiscreteProblem Defaults" include("discrete_problem_defaults.jl")
     @time @safetestset "Discrete Algorithm Tests" include("discrete_algorithm_test.jl")
 end

--- a/lib/OrdinaryDiffEqFunctionMap/test/runtests.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/test/runtests.jl
@@ -10,9 +10,6 @@ end
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
-        # docs/src/api/reexports.md defines this surface; test/qa/qa_tests.jl checks the
-        # full list repo-wide. Here, spot-check that the common interface is usable and
-        # that solver-author API stayed behind the `SciMLBase.` qualifier.
         using OrdinaryDiffEqFunctionMap, Test
         exported = (
             :ODEProblem, :ODEFunction, :SplitODEProblem, :solve, :init, :step!,
@@ -22,7 +19,8 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
         @test all(Base.isexported.(Ref(OrdinaryDiffEqFunctionMap), exported))
         internal = (
             :build_solution, :isinplace, :has_jac, :AbstractODEProblem,
-            :StandardODEProblem, :UJacobianWrapper,
+            :StandardODEProblem, :UJacobianWrapper, :LinearProblem,
+            :ConvexOptimizationProblem,
         )
         @test !any(Base.isexported.(Ref(OrdinaryDiffEqFunctionMap), internal))
     end

--- a/lib/OrdinaryDiffEqFunctionMap/test/runtests.jl
+++ b/lib/OrdinaryDiffEqFunctionMap/test/runtests.jl
@@ -11,8 +11,17 @@ end
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
         using OrdinaryDiffEqFunctionMap, Test
-        @test Base.isexported(OrdinaryDiffEqFunctionMap, :ODEProblem)
-        @test Base.isexported(OrdinaryDiffEqFunctionMap, :solve)
+        expected = (
+            :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
+            :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+            :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
+            :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
+            :DiscreteProblem, :DiscreteFunction,
+        )
+        @test all(Base.isexported.(Ref(OrdinaryDiffEqFunctionMap), expected))
+        @test !Base.isexported(OrdinaryDiffEqFunctionMap, :EnsembleProblem)
+        @test !Base.isexported(OrdinaryDiffEqFunctionMap, :get_du)
+        @test !Base.isexported(OrdinaryDiffEqFunctionMap, :u_modified!)
     end
     @time @safetestset "DiscreteProblem Defaults" include("discrete_problem_defaults.jl")
     @time @safetestset "Discrete Algorithm Tests" include("discrete_algorithm_test.jl")

--- a/lib/OrdinaryDiffEqIMEXMultistep/Project.toml
+++ b/lib/OrdinaryDiffEqIMEXMultistep/Project.toml
@@ -4,6 +4,7 @@ authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 version = "2.2.0"
 
 [deps]
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 OrdinaryDiffEqDifferentiation = "4302a76b-040a-498a-8c04-15b101fed76b"
@@ -21,6 +22,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 
 [compat]
+Reexport = "1.2.2"
 SciMLTesting = "2.4"
 Pkg = "1"
 Test = "<0.0.1, 1"

--- a/lib/OrdinaryDiffEqIMEXMultistep/src/OrdinaryDiffEqIMEXMultistep.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/src/OrdinaryDiffEqIMEXMultistep.jl
@@ -17,7 +17,8 @@ import ADTypes: AutoForwardDiff
 using Reexport: Reexport, @reexport
 @reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
     reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
-    CallbackSet, terminate!, SplitODEProblem, SplitFunction
+    CallbackSet, terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
+    successful_retcode, ODEAliasSpecifier, SplitODEProblem, SplitFunction
 using SciMLBase: SciMLBase
 
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqIMEXMultistep/src/OrdinaryDiffEqIMEXMultistep.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/src/OrdinaryDiffEqIMEXMultistep.jl
@@ -15,10 +15,11 @@ using OrdinaryDiffEqNonlinearSolve: NLNewton, build_nlsolver, markfirststage!, n
 import ADTypes: AutoForwardDiff
 
 using Reexport: Reexport, @reexport
-@reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
-    reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
-    CallbackSet, terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
-    successful_retcode, ODEAliasSpecifier, SplitODEProblem, SplitFunction
+using SciMLBase: ODEProblem, ODEFunction, init, solve!, step!, remake, reinit!, ReturnCode,
+    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, CallbackSet,
+    terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
+    successful_retcode, ODEAliasSpecifier, SplitFunction
+@reexport using SciMLBase: SplitODEProblem, solve
 using SciMLBase: SciMLBase
 
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqIMEXMultistep/src/OrdinaryDiffEqIMEXMultistep.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/src/OrdinaryDiffEqIMEXMultistep.jl
@@ -15,7 +15,36 @@ using OrdinaryDiffEqNonlinearSolve: NLNewton, build_nlsolver, markfirststage!, n
 import ADTypes: AutoForwardDiff
 
 using Reexport: Reexport, @reexport
-@reexport using SciMLBase: SplitODEProblem, solve
+# Re-exported SciMLBase API. This list is identical in every OrdinaryDiffEq solver
+# sublibrary and is generated from the rule documented in docs/src/api/reexports.md;
+# `test/qa/qa_tests.jl` checks the sublibraries against each other and against that rule.
+@reexport using SciMLBase: AnalyticalProblem, BVProblem, ConvexOptimizationProblem,
+    DAEProblem, DDEProblem, DiscreteProblem, DynamicalDDEProblem, DynamicalODEProblem,
+    DynamicalSDEProblem, EigenvalueProblem, EnsembleProblem, HomotopyProblem,
+    ImmutableNonlinearProblem, ImmutableODEProblem, ImplicitDiscreteProblem,
+    IncrementingODEProblem, IntegralProblem, IntervalNonlinearProblem, LinearProblem,
+    NoiseProblem, NonlinearLeastSquaresProblem, NonlinearProblem, ODEProblem,
+    OptimizationProblem, PDEProblem, RODEProblem, SCCNonlinearProblem, SDDEProblem,
+    SDEProblem, SampledIntegralProblem, SecondOrderBVProblem, SecondOrderDDEProblem,
+    SecondOrderODEProblem, SplitODEProblem, SplitSDEProblem, SteadyStateProblem,
+    TwoPointBVProblem, TwoPointSecondOrderBVProblem, WeightedEnsembleProblem, BVPFunction,
+    BatchIntegralFunction, DAEFunction, DDEFunction, DiscreteFunction, DynamicalBVPFunction,
+    DynamicalDDEFunction, DynamicalODEFunction, DynamicalSDEFunction,
+    HomotopyNonlinearFunction, ImplicitDiscreteFunction, IncrementingODEFunction,
+    IntegralFunction, IntervalNonlinearFunction, MultiObjectiveOptimizationFunction,
+    NonlinearFunction, ODEFunction, ODEInputFunction, OptimizationFunction, RODEFunction,
+    SDDEFunction, SDEFunction, SplitFunction, SplitSDEFunction, TwoPointBVPFunction,
+    TwoPointDynamicalBVPFunction, solve, solve!, init, step!, remake, ReturnCode,
+    successful_retcode, DEStats, NLStats, NullParameters, AutoSpecialize, FullSpecialize,
+    NoSpecialize, FunctionWrapperSpecialize, CheckInit, NoInit, OverrideInit, CallbackSet,
+    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, LeftRootFind,
+    RightRootFind, NoRootFind, add_saveat!, add_tstop!, auto_dt_reset!,
+    change_t_via_interpolation!, check_error, check_error!, first_tstop, get_dt, get_du,
+    get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!, reinit!, savevalues!, set_abstol!,
+    set_proposed_dt!, set_reltol!, set_t!, set_u!, set_ut!, terminate!, u_modified!,
+    EnsembleAnalysis, EnsembleDistributed, EnsembleSerial, EnsembleSplitThreads,
+    EnsembleSummary, EnsembleThreads
+using SciMLBase: SciMLBase
 using SciMLBase: SciMLBase
 
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqIMEXMultistep/src/OrdinaryDiffEqIMEXMultistep.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/src/OrdinaryDiffEqIMEXMultistep.jl
@@ -15,10 +15,6 @@ using OrdinaryDiffEqNonlinearSolve: NLNewton, build_nlsolver, markfirststage!, n
 import ADTypes: AutoForwardDiff
 
 using Reexport: Reexport, @reexport
-using SciMLBase: ODEProblem, ODEFunction, init, solve!, step!, remake, reinit!, ReturnCode,
-    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, CallbackSet,
-    terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
-    successful_retcode, ODEAliasSpecifier, SplitFunction
 @reexport using SciMLBase: SplitODEProblem, solve
 using SciMLBase: SciMLBase
 

--- a/lib/OrdinaryDiffEqIMEXMultistep/src/OrdinaryDiffEqIMEXMultistep.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/src/OrdinaryDiffEqIMEXMultistep.jl
@@ -14,6 +14,12 @@ using OrdinaryDiffEqNonlinearSolve: NLNewton, build_nlsolver, markfirststage!, n
     nlsolvefail, du_alias_or_new
 import ADTypes: AutoForwardDiff
 
+using Reexport: Reexport, @reexport
+@reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
+    reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
+    CallbackSet, terminate!, SplitODEProblem, SplitFunction
+using SciMLBase: SciMLBase
+
 include("algorithms.jl")
 include("alg_utils.jl")
 include("imex_multistep_caches.jl")

--- a/lib/OrdinaryDiffEqIMEXMultistep/src/OrdinaryDiffEqIMEXMultistep.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/src/OrdinaryDiffEqIMEXMultistep.jl
@@ -15,36 +15,19 @@ using OrdinaryDiffEqNonlinearSolve: NLNewton, build_nlsolver, markfirststage!, n
 import ADTypes: AutoForwardDiff
 
 using Reexport: Reexport, @reexport
-# Re-exported SciMLBase API. This list is identical in every OrdinaryDiffEq solver
-# sublibrary and is generated from the rule documented in docs/src/api/reexports.md;
-# `test/qa/qa_tests.jl` checks the sublibraries against each other and against that rule.
-@reexport using SciMLBase: AnalyticalProblem, BVProblem, ConvexOptimizationProblem,
-    DAEProblem, DDEProblem, DiscreteProblem, DynamicalDDEProblem, DynamicalODEProblem,
-    DynamicalSDEProblem, EigenvalueProblem, EnsembleProblem, HomotopyProblem,
-    ImmutableNonlinearProblem, ImmutableODEProblem, ImplicitDiscreteProblem,
-    IncrementingODEProblem, IntegralProblem, IntervalNonlinearProblem, LinearProblem,
-    NoiseProblem, NonlinearLeastSquaresProblem, NonlinearProblem, ODEProblem,
-    OptimizationProblem, PDEProblem, RODEProblem, SCCNonlinearProblem, SDDEProblem,
-    SDEProblem, SampledIntegralProblem, SecondOrderBVProblem, SecondOrderDDEProblem,
-    SecondOrderODEProblem, SplitODEProblem, SplitSDEProblem, SteadyStateProblem,
-    TwoPointBVProblem, TwoPointSecondOrderBVProblem, WeightedEnsembleProblem, BVPFunction,
-    BatchIntegralFunction, DAEFunction, DDEFunction, DiscreteFunction, DynamicalBVPFunction,
-    DynamicalDDEFunction, DynamicalODEFunction, DynamicalSDEFunction,
-    HomotopyNonlinearFunction, ImplicitDiscreteFunction, IncrementingODEFunction,
-    IntegralFunction, IntervalNonlinearFunction, MultiObjectiveOptimizationFunction,
-    NonlinearFunction, ODEFunction, ODEInputFunction, OptimizationFunction, RODEFunction,
-    SDDEFunction, SDEFunction, SplitFunction, SplitSDEFunction, TwoPointBVPFunction,
-    TwoPointDynamicalBVPFunction, solve, solve!, init, step!, remake, ReturnCode,
-    successful_retcode, DEStats, NLStats, NullParameters, AutoSpecialize, FullSpecialize,
-    NoSpecialize, FunctionWrapperSpecialize, CheckInit, NoInit, OverrideInit, CallbackSet,
-    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, LeftRootFind,
-    RightRootFind, NoRootFind, add_saveat!, add_tstop!, auto_dt_reset!,
-    change_t_via_interpolation!, check_error, check_error!, first_tstop, get_dt, get_du,
-    get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!, reinit!, savevalues!, set_abstol!,
-    set_proposed_dt!, set_reltol!, set_t!, set_u!, set_ut!, terminate!, u_modified!,
-    EnsembleAnalysis, EnsembleDistributed, EnsembleSerial, EnsembleSplitThreads,
-    EnsembleSummary, EnsembleThreads
-using SciMLBase: SciMLBase
+# Kept in sync with docs/src/api/reexports.md by test/qa/reexport_tests.jl.
+@reexport using SciMLBase: DAEProblem, DiscreteProblem, DynamicalODEProblem,
+    EnsembleProblem, ODEProblem, SecondOrderODEProblem, SplitODEProblem, DAEFunction,
+    DiscreteFunction, DynamicalODEFunction, ODEFunction, SplitFunction, solve, solve!, init,
+    step!, remake, ReturnCode, successful_retcode, DEStats, NLStats, NullParameters,
+    AutoSpecialize, FullSpecialize, NoSpecialize, FunctionWrapperSpecialize, CheckInit,
+    NoInit, OverrideInit, CallbackSet, ContinuousCallback, DiscreteCallback,
+    VectorContinuousCallback, LeftRootFind, RightRootFind, NoRootFind, add_saveat!,
+    add_tstop!, auto_dt_reset!, change_t_via_interpolation!, check_error, check_error!,
+    first_tstop, get_dt, get_du, get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!,
+    reinit!, savevalues!, set_abstol!, set_proposed_dt!, set_reltol!, set_t!, set_u!,
+    set_ut!, terminate!, u_modified!, EnsembleAnalysis, EnsembleDistributed, EnsembleSerial,
+    EnsembleSplitThreads, EnsembleSummary, EnsembleThreads
 using SciMLBase: SciMLBase
 
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqIMEXMultistep/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/test/qa/qa.jl
@@ -4,7 +4,9 @@ using SciMLTesting, OrdinaryDiffEqIMEXMultistep, Test
 const SCIMLBASE_REEXPORTS = (
     :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
     :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-    :CallbackSet, :terminate!, :SplitODEProblem, :SplitFunction,
+    :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
+    :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
+    :SplitODEProblem, :SplitFunction,
 )
 
 run_qa(

--- a/lib/OrdinaryDiffEqIMEXMultistep/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/test/qa/qa.jl
@@ -1,7 +1,15 @@
 using SciMLTesting, OrdinaryDiffEqIMEXMultistep, Test
 
+# SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
+const SCIMLBASE_REEXPORTS = (
+    :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
+    :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+    :CallbackSet, :terminate!, :SplitODEProblem, :SplitFunction,
+)
+
 run_qa(
     OrdinaryDiffEqIMEXMultistep;
+    reexports_allow = SCIMLBASE_REEXPORTS,
     explicit_imports = true,
     ei_kwargs = (;
         all_explicit_imports_are_public = (;

--- a/lib/OrdinaryDiffEqIMEXMultistep/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/test/qa/qa.jl
@@ -1,13 +1,7 @@
 using SciMLTesting, OrdinaryDiffEqIMEXMultistep, Test
 
 # SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
-const SCIMLBASE_REEXPORTS = (
-    :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
-    :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-    :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
-    :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
-    :SplitODEProblem, :SplitFunction,
-)
+const SCIMLBASE_REEXPORTS = (:SplitODEProblem, :solve)
 
 run_qa(
     OrdinaryDiffEqIMEXMultistep;

--- a/lib/OrdinaryDiffEqIMEXMultistep/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/test/qa/qa.jl
@@ -2,8 +2,6 @@ using SciMLTesting, OrdinaryDiffEqIMEXMultistep, SciMLBase, Test
 
 run_qa(
     OrdinaryDiffEqIMEXMultistep;
-    # Approve the SciMLBase names this package re-exports. The list itself and the rule
-    # behind it are checked repo-wide by test/qa/qa_tests.jl against docs/src/api/reexports.md.
     reexports_allow = intersect(names(SciMLBase), names(OrdinaryDiffEqIMEXMultistep)),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqIMEXMultistep/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/test/qa/qa.jl
@@ -1,11 +1,10 @@
-using SciMLTesting, OrdinaryDiffEqIMEXMultistep, Test
-
-# SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
-const SCIMLBASE_REEXPORTS = (:SplitODEProblem, :solve)
+using SciMLTesting, OrdinaryDiffEqIMEXMultistep, SciMLBase, Test
 
 run_qa(
     OrdinaryDiffEqIMEXMultistep;
-    reexports_allow = SCIMLBASE_REEXPORTS,
+    # Approve the SciMLBase names this package re-exports. The list itself and the rule
+    # behind it are checked repo-wide by test/qa/qa_tests.jl against docs/src/api/reexports.md.
+    reexports_allow = intersect(names(SciMLBase), names(OrdinaryDiffEqIMEXMultistep)),
     explicit_imports = true,
     ei_kwargs = (;
         all_explicit_imports_are_public = (;

--- a/lib/OrdinaryDiffEqIMEXMultistep/test/runtests.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/test/runtests.jl
@@ -9,6 +9,12 @@ end
 
 @time @safetestset "Discontinuity restart" include("imex_discontinuity_restart_tests.jl")
 
+@time @safetestset "SciMLBase reexport" begin
+    using OrdinaryDiffEqIMEXMultistep, Test
+    @test Base.isexported(OrdinaryDiffEqIMEXMultistep, :ODEProblem)
+    @test Base.isexported(OrdinaryDiffEqIMEXMultistep, :solve)
+end
+
 # Run QA tests (AllocCheck, JET, Aqua) - skip on pre-release Julia
 # Allocation tests must run before JET because JET's static analysis
 # invalidates compiled code and causes spurious runtime allocations.

--- a/lib/OrdinaryDiffEqIMEXMultistep/test/runtests.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/test/runtests.jl
@@ -10,20 +10,21 @@ end
 @time @safetestset "Discontinuity restart" include("imex_discontinuity_restart_tests.jl")
 
 @time @safetestset "SciMLBase reexport" begin
+    # docs/src/api/reexports.md defines this surface; test/qa/qa_tests.jl checks the
+    # full list repo-wide. Here, spot-check that the common interface is usable and
+    # that solver-author API stayed behind the `SciMLBase.` qualifier.
     using OrdinaryDiffEqIMEXMultistep, Test
-    expected = (:SplitODEProblem, :solve)
-    @test all(Base.isexported.(Ref(OrdinaryDiffEqIMEXMultistep), expected))
-    removed = (
-        :ODEProblem, :ODEFunction, :init, :solve!, :step!, :remake, :reinit!,
-        :ReturnCode, :ContinuousCallback, :DiscreteCallback,
-        :VectorContinuousCallback, :CallbackSet, :terminate!, :add_tstop!,
-        :derivative_discontinuity!, :set_proposed_dt!, :successful_retcode,
-        :ODEAliasSpecifier, :SplitFunction,
+    exported = (
+        :ODEProblem, :ODEFunction, :SplitODEProblem, :solve, :init, :step!,
+        :remake, :ReturnCode, :CallbackSet, :ContinuousCallback, :terminate!,
+        :u_modified!, :add_tstop!, :get_du, :EnsembleProblem,
     )
-    @test all(x -> !x, Base.isexported.(Ref(OrdinaryDiffEqIMEXMultistep), removed))
-    @test !Base.isexported(OrdinaryDiffEqIMEXMultistep, :EnsembleProblem)
-    @test !Base.isexported(OrdinaryDiffEqIMEXMultistep, :get_du)
-    @test !Base.isexported(OrdinaryDiffEqIMEXMultistep, :u_modified!)
+    @test all(Base.isexported.(Ref(OrdinaryDiffEqIMEXMultistep), exported))
+    internal = (
+        :build_solution, :isinplace, :has_jac, :AbstractODEProblem,
+        :StandardODEProblem, :UJacobianWrapper,
+    )
+    @test !any(Base.isexported.(Ref(OrdinaryDiffEqIMEXMultistep), internal))
 end
 
 # Run QA tests (AllocCheck, JET, Aqua) - skip on pre-release Julia

--- a/lib/OrdinaryDiffEqIMEXMultistep/test/runtests.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/test/runtests.jl
@@ -11,8 +11,17 @@ end
 
 @time @safetestset "SciMLBase reexport" begin
     using OrdinaryDiffEqIMEXMultistep, Test
-    @test Base.isexported(OrdinaryDiffEqIMEXMultistep, :ODEProblem)
-    @test Base.isexported(OrdinaryDiffEqIMEXMultistep, :solve)
+    expected = (
+        :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
+        :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+        :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
+        :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
+        :SplitODEProblem, :SplitFunction,
+    )
+    @test all(Base.isexported.(Ref(OrdinaryDiffEqIMEXMultistep), expected))
+    @test !Base.isexported(OrdinaryDiffEqIMEXMultistep, :EnsembleProblem)
+    @test !Base.isexported(OrdinaryDiffEqIMEXMultistep, :get_du)
+    @test !Base.isexported(OrdinaryDiffEqIMEXMultistep, :u_modified!)
 end
 
 # Run QA tests (AllocCheck, JET, Aqua) - skip on pre-release Julia

--- a/lib/OrdinaryDiffEqIMEXMultistep/test/runtests.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/test/runtests.jl
@@ -10,9 +10,6 @@ end
 @time @safetestset "Discontinuity restart" include("imex_discontinuity_restart_tests.jl")
 
 @time @safetestset "SciMLBase reexport" begin
-    # docs/src/api/reexports.md defines this surface; test/qa/qa_tests.jl checks the
-    # full list repo-wide. Here, spot-check that the common interface is usable and
-    # that solver-author API stayed behind the `SciMLBase.` qualifier.
     using OrdinaryDiffEqIMEXMultistep, Test
     exported = (
         :ODEProblem, :ODEFunction, :SplitODEProblem, :solve, :init, :step!,
@@ -22,7 +19,8 @@ end
     @test all(Base.isexported.(Ref(OrdinaryDiffEqIMEXMultistep), exported))
     internal = (
         :build_solution, :isinplace, :has_jac, :AbstractODEProblem,
-        :StandardODEProblem, :UJacobianWrapper,
+        :StandardODEProblem, :UJacobianWrapper, :LinearProblem,
+        :ConvexOptimizationProblem,
     )
     @test !any(Base.isexported.(Ref(OrdinaryDiffEqIMEXMultistep), internal))
 end

--- a/lib/OrdinaryDiffEqIMEXMultistep/test/runtests.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/test/runtests.jl
@@ -11,14 +11,16 @@ end
 
 @time @safetestset "SciMLBase reexport" begin
     using OrdinaryDiffEqIMEXMultistep, Test
-    expected = (
-        :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
-        :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-        :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
-        :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
-        :SplitODEProblem, :SplitFunction,
-    )
+    expected = (:SplitODEProblem, :solve)
     @test all(Base.isexported.(Ref(OrdinaryDiffEqIMEXMultistep), expected))
+    removed = (
+        :ODEProblem, :ODEFunction, :init, :solve!, :step!, :remake, :reinit!,
+        :ReturnCode, :ContinuousCallback, :DiscreteCallback,
+        :VectorContinuousCallback, :CallbackSet, :terminate!, :add_tstop!,
+        :derivative_discontinuity!, :set_proposed_dt!, :successful_retcode,
+        :ODEAliasSpecifier, :SplitFunction,
+    )
+    @test all(x -> !x, Base.isexported.(Ref(OrdinaryDiffEqIMEXMultistep), removed))
     @test !Base.isexported(OrdinaryDiffEqIMEXMultistep, :EnsembleProblem)
     @test !Base.isexported(OrdinaryDiffEqIMEXMultistep, :get_du)
     @test !Base.isexported(OrdinaryDiffEqIMEXMultistep, :u_modified!)

--- a/lib/OrdinaryDiffEqPDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqPDIRK/Project.toml
@@ -4,6 +4,7 @@ authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 version = "2.4.1"
 
 [deps]
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
 OrdinaryDiffEqDifferentiation = "4302a76b-040a-498a-8c04-15b101fed76b"
@@ -23,6 +24,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 
 [compat]
+Reexport = "1.2.2"
 SciMLTesting = "2.8"
 ADTypes = "1.22.0"
 DiffEqBase = "7"

--- a/lib/OrdinaryDiffEqPDIRK/src/OrdinaryDiffEqPDIRK.jl
+++ b/lib/OrdinaryDiffEqPDIRK/src/OrdinaryDiffEqPDIRK.jl
@@ -22,10 +22,6 @@ using OrdinaryDiffEqNonlinearSolve: NLNewton, build_nlsolver, nlsolve!, nlsolvef
 import ADTypes: AutoForwardDiff
 
 using Reexport: Reexport, @reexport
-using SciMLBase: ODEFunction, init, solve!, step!, remake, reinit!, ReturnCode,
-    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, CallbackSet,
-    terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
-    successful_retcode, ODEAliasSpecifier
 @reexport using SciMLBase: ODEProblem, solve
 
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqPDIRK/src/OrdinaryDiffEqPDIRK.jl
+++ b/lib/OrdinaryDiffEqPDIRK/src/OrdinaryDiffEqPDIRK.jl
@@ -24,7 +24,8 @@ import ADTypes: AutoForwardDiff
 using Reexport: Reexport, @reexport
 @reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
     reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
-    CallbackSet, terminate!
+    CallbackSet, terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
+    successful_retcode, ODEAliasSpecifier
 
 include("algorithms.jl")
 include("alg_utils.jl")

--- a/lib/OrdinaryDiffEqPDIRK/src/OrdinaryDiffEqPDIRK.jl
+++ b/lib/OrdinaryDiffEqPDIRK/src/OrdinaryDiffEqPDIRK.jl
@@ -21,6 +21,11 @@ using OrdinaryDiffEqNonlinearSolve: NLNewton, build_nlsolver, nlsolve!, nlsolvef
 
 import ADTypes: AutoForwardDiff
 
+using Reexport: Reexport, @reexport
+@reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
+    reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
+    CallbackSet, terminate!
+
 include("algorithms.jl")
 include("alg_utils.jl")
 include("pdirk_caches.jl")

--- a/lib/OrdinaryDiffEqPDIRK/src/OrdinaryDiffEqPDIRK.jl
+++ b/lib/OrdinaryDiffEqPDIRK/src/OrdinaryDiffEqPDIRK.jl
@@ -22,10 +22,11 @@ using OrdinaryDiffEqNonlinearSolve: NLNewton, build_nlsolver, nlsolve!, nlsolvef
 import ADTypes: AutoForwardDiff
 
 using Reexport: Reexport, @reexport
-@reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
-    reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
-    CallbackSet, terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
+using SciMLBase: ODEFunction, init, solve!, step!, remake, reinit!, ReturnCode,
+    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, CallbackSet,
+    terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
     successful_retcode, ODEAliasSpecifier
+@reexport using SciMLBase: ODEProblem, solve
 
 include("algorithms.jl")
 include("alg_utils.jl")

--- a/lib/OrdinaryDiffEqPDIRK/src/OrdinaryDiffEqPDIRK.jl
+++ b/lib/OrdinaryDiffEqPDIRK/src/OrdinaryDiffEqPDIRK.jl
@@ -22,7 +22,36 @@ using OrdinaryDiffEqNonlinearSolve: NLNewton, build_nlsolver, nlsolve!, nlsolvef
 import ADTypes: AutoForwardDiff
 
 using Reexport: Reexport, @reexport
-@reexport using SciMLBase: ODEProblem, solve
+# Re-exported SciMLBase API. This list is identical in every OrdinaryDiffEq solver
+# sublibrary and is generated from the rule documented in docs/src/api/reexports.md;
+# `test/qa/qa_tests.jl` checks the sublibraries against each other and against that rule.
+@reexport using SciMLBase: AnalyticalProblem, BVProblem, ConvexOptimizationProblem,
+    DAEProblem, DDEProblem, DiscreteProblem, DynamicalDDEProblem, DynamicalODEProblem,
+    DynamicalSDEProblem, EigenvalueProblem, EnsembleProblem, HomotopyProblem,
+    ImmutableNonlinearProblem, ImmutableODEProblem, ImplicitDiscreteProblem,
+    IncrementingODEProblem, IntegralProblem, IntervalNonlinearProblem, LinearProblem,
+    NoiseProblem, NonlinearLeastSquaresProblem, NonlinearProblem, ODEProblem,
+    OptimizationProblem, PDEProblem, RODEProblem, SCCNonlinearProblem, SDDEProblem,
+    SDEProblem, SampledIntegralProblem, SecondOrderBVProblem, SecondOrderDDEProblem,
+    SecondOrderODEProblem, SplitODEProblem, SplitSDEProblem, SteadyStateProblem,
+    TwoPointBVProblem, TwoPointSecondOrderBVProblem, WeightedEnsembleProblem, BVPFunction,
+    BatchIntegralFunction, DAEFunction, DDEFunction, DiscreteFunction, DynamicalBVPFunction,
+    DynamicalDDEFunction, DynamicalODEFunction, DynamicalSDEFunction,
+    HomotopyNonlinearFunction, ImplicitDiscreteFunction, IncrementingODEFunction,
+    IntegralFunction, IntervalNonlinearFunction, MultiObjectiveOptimizationFunction,
+    NonlinearFunction, ODEFunction, ODEInputFunction, OptimizationFunction, RODEFunction,
+    SDDEFunction, SDEFunction, SplitFunction, SplitSDEFunction, TwoPointBVPFunction,
+    TwoPointDynamicalBVPFunction, solve, solve!, init, step!, remake, ReturnCode,
+    successful_retcode, DEStats, NLStats, NullParameters, AutoSpecialize, FullSpecialize,
+    NoSpecialize, FunctionWrapperSpecialize, CheckInit, NoInit, OverrideInit, CallbackSet,
+    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, LeftRootFind,
+    RightRootFind, NoRootFind, add_saveat!, add_tstop!, auto_dt_reset!,
+    change_t_via_interpolation!, check_error, check_error!, first_tstop, get_dt, get_du,
+    get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!, reinit!, savevalues!, set_abstol!,
+    set_proposed_dt!, set_reltol!, set_t!, set_u!, set_ut!, terminate!, u_modified!,
+    EnsembleAnalysis, EnsembleDistributed, EnsembleSerial, EnsembleSplitThreads,
+    EnsembleSummary, EnsembleThreads
+using SciMLBase: SciMLBase
 
 include("algorithms.jl")
 include("alg_utils.jl")

--- a/lib/OrdinaryDiffEqPDIRK/src/OrdinaryDiffEqPDIRK.jl
+++ b/lib/OrdinaryDiffEqPDIRK/src/OrdinaryDiffEqPDIRK.jl
@@ -22,35 +22,19 @@ using OrdinaryDiffEqNonlinearSolve: NLNewton, build_nlsolver, nlsolve!, nlsolvef
 import ADTypes: AutoForwardDiff
 
 using Reexport: Reexport, @reexport
-# Re-exported SciMLBase API. This list is identical in every OrdinaryDiffEq solver
-# sublibrary and is generated from the rule documented in docs/src/api/reexports.md;
-# `test/qa/qa_tests.jl` checks the sublibraries against each other and against that rule.
-@reexport using SciMLBase: AnalyticalProblem, BVProblem, ConvexOptimizationProblem,
-    DAEProblem, DDEProblem, DiscreteProblem, DynamicalDDEProblem, DynamicalODEProblem,
-    DynamicalSDEProblem, EigenvalueProblem, EnsembleProblem, HomotopyProblem,
-    ImmutableNonlinearProblem, ImmutableODEProblem, ImplicitDiscreteProblem,
-    IncrementingODEProblem, IntegralProblem, IntervalNonlinearProblem, LinearProblem,
-    NoiseProblem, NonlinearLeastSquaresProblem, NonlinearProblem, ODEProblem,
-    OptimizationProblem, PDEProblem, RODEProblem, SCCNonlinearProblem, SDDEProblem,
-    SDEProblem, SampledIntegralProblem, SecondOrderBVProblem, SecondOrderDDEProblem,
-    SecondOrderODEProblem, SplitODEProblem, SplitSDEProblem, SteadyStateProblem,
-    TwoPointBVProblem, TwoPointSecondOrderBVProblem, WeightedEnsembleProblem, BVPFunction,
-    BatchIntegralFunction, DAEFunction, DDEFunction, DiscreteFunction, DynamicalBVPFunction,
-    DynamicalDDEFunction, DynamicalODEFunction, DynamicalSDEFunction,
-    HomotopyNonlinearFunction, ImplicitDiscreteFunction, IncrementingODEFunction,
-    IntegralFunction, IntervalNonlinearFunction, MultiObjectiveOptimizationFunction,
-    NonlinearFunction, ODEFunction, ODEInputFunction, OptimizationFunction, RODEFunction,
-    SDDEFunction, SDEFunction, SplitFunction, SplitSDEFunction, TwoPointBVPFunction,
-    TwoPointDynamicalBVPFunction, solve, solve!, init, step!, remake, ReturnCode,
-    successful_retcode, DEStats, NLStats, NullParameters, AutoSpecialize, FullSpecialize,
-    NoSpecialize, FunctionWrapperSpecialize, CheckInit, NoInit, OverrideInit, CallbackSet,
-    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, LeftRootFind,
-    RightRootFind, NoRootFind, add_saveat!, add_tstop!, auto_dt_reset!,
-    change_t_via_interpolation!, check_error, check_error!, first_tstop, get_dt, get_du,
-    get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!, reinit!, savevalues!, set_abstol!,
-    set_proposed_dt!, set_reltol!, set_t!, set_u!, set_ut!, terminate!, u_modified!,
-    EnsembleAnalysis, EnsembleDistributed, EnsembleSerial, EnsembleSplitThreads,
-    EnsembleSummary, EnsembleThreads
+# Kept in sync with docs/src/api/reexports.md by test/qa/reexport_tests.jl.
+@reexport using SciMLBase: DAEProblem, DiscreteProblem, DynamicalODEProblem,
+    EnsembleProblem, ODEProblem, SecondOrderODEProblem, SplitODEProblem, DAEFunction,
+    DiscreteFunction, DynamicalODEFunction, ODEFunction, SplitFunction, solve, solve!, init,
+    step!, remake, ReturnCode, successful_retcode, DEStats, NLStats, NullParameters,
+    AutoSpecialize, FullSpecialize, NoSpecialize, FunctionWrapperSpecialize, CheckInit,
+    NoInit, OverrideInit, CallbackSet, ContinuousCallback, DiscreteCallback,
+    VectorContinuousCallback, LeftRootFind, RightRootFind, NoRootFind, add_saveat!,
+    add_tstop!, auto_dt_reset!, change_t_via_interpolation!, check_error, check_error!,
+    first_tstop, get_dt, get_du, get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!,
+    reinit!, savevalues!, set_abstol!, set_proposed_dt!, set_reltol!, set_t!, set_u!,
+    set_ut!, terminate!, u_modified!, EnsembleAnalysis, EnsembleDistributed, EnsembleSerial,
+    EnsembleSplitThreads, EnsembleSummary, EnsembleThreads
 using SciMLBase: SciMLBase
 
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqPDIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqPDIRK/test/qa/qa.jl
@@ -5,12 +5,7 @@ using SciMLTesting, OrdinaryDiffEqPDIRK, Test
 const THREADING_PUBLIC = (:Sequential, :BaseThreads, :PolyesterThreads)
 
 # SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
-const SCIMLBASE_REEXPORTS = (
-    :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
-    :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-    :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
-    :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
-)
+const SCIMLBASE_REEXPORTS = (:ODEProblem, :solve)
 
 run_qa(
     OrdinaryDiffEqPDIRK;

--- a/lib/OrdinaryDiffEqPDIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqPDIRK/test/qa/qa.jl
@@ -1,15 +1,14 @@
-using SciMLTesting, OrdinaryDiffEqPDIRK, Test
+using SciMLTesting, OrdinaryDiffEqPDIRK, SciMLBase, Test
 
 # `public` on a name another package owns counts as a public reexport to
 # SciMLTesting, so the threading options need approving here too.
 const THREADING_PUBLIC = (:Sequential, :BaseThreads, :PolyesterThreads)
 
-# SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
-const SCIMLBASE_REEXPORTS = (:ODEProblem, :solve)
-
 run_qa(
     OrdinaryDiffEqPDIRK;
-    reexports_allow = (SCIMLBASE_REEXPORTS..., THREADING_PUBLIC...),
+    # Approve the SciMLBase names this package re-exports. The list itself and the rule
+    # behind it are checked repo-wide by test/qa/qa_tests.jl against docs/src/api/reexports.md.
+    reexports_allow = vcat(intersect(names(SciMLBase), names(OrdinaryDiffEqPDIRK)), collect(THREADING_PUBLIC)),
     explicit_imports = true,
     ei_kwargs = (;
         all_explicit_imports_are_public = (;

--- a/lib/OrdinaryDiffEqPDIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqPDIRK/test/qa/qa.jl
@@ -6,8 +6,6 @@ const THREADING_PUBLIC = (:Sequential, :BaseThreads, :PolyesterThreads)
 
 run_qa(
     OrdinaryDiffEqPDIRK;
-    # Approve the SciMLBase names this package re-exports. The list itself and the rule
-    # behind it are checked repo-wide by test/qa/qa_tests.jl against docs/src/api/reexports.md.
     reexports_allow = vcat(intersect(names(SciMLBase), names(OrdinaryDiffEqPDIRK)), collect(THREADING_PUBLIC)),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqPDIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqPDIRK/test/qa/qa.jl
@@ -8,7 +8,8 @@ const THREADING_PUBLIC = (:Sequential, :BaseThreads, :PolyesterThreads)
 const SCIMLBASE_REEXPORTS = (
     :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
     :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-    :CallbackSet, :terminate!,
+    :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
+    :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
 )
 
 run_qa(

--- a/lib/OrdinaryDiffEqPDIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqPDIRK/test/qa/qa.jl
@@ -4,9 +4,16 @@ using SciMLTesting, OrdinaryDiffEqPDIRK, Test
 # SciMLTesting, so the threading options need approving here too.
 const THREADING_PUBLIC = (:Sequential, :BaseThreads, :PolyesterThreads)
 
+# SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
+const SCIMLBASE_REEXPORTS = (
+    :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
+    :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+    :CallbackSet, :terminate!,
+)
+
 run_qa(
     OrdinaryDiffEqPDIRK;
-    reexports_allow = THREADING_PUBLIC,
+    reexports_allow = (SCIMLBASE_REEXPORTS..., THREADING_PUBLIC...),
     explicit_imports = true,
     ei_kwargs = (;
         all_explicit_imports_are_public = (;

--- a/lib/OrdinaryDiffEqPDIRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqPDIRK/test/runtests.jl
@@ -9,8 +9,16 @@ end
 
 @time @safetestset "SciMLBase reexport" begin
     using OrdinaryDiffEqPDIRK, Test
-    @test Base.isexported(OrdinaryDiffEqPDIRK, :ODEProblem)
-    @test Base.isexported(OrdinaryDiffEqPDIRK, :solve)
+    expected = (
+        :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
+        :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+        :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
+        :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
+    )
+    @test all(Base.isexported.(Ref(OrdinaryDiffEqPDIRK), expected))
+    @test !Base.isexported(OrdinaryDiffEqPDIRK, :EnsembleProblem)
+    @test !Base.isexported(OrdinaryDiffEqPDIRK, :get_du)
+    @test !Base.isexported(OrdinaryDiffEqPDIRK, :u_modified!)
 end
 
 # Run QA tests (AllocCheck, JET) - skip on pre-release Julia

--- a/lib/OrdinaryDiffEqPDIRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqPDIRK/test/runtests.jl
@@ -9,13 +9,15 @@ end
 
 @time @safetestset "SciMLBase reexport" begin
     using OrdinaryDiffEqPDIRK, Test
-    expected = (
-        :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
-        :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+    expected = (:ODEProblem, :solve)
+    @test all(Base.isexported.(Ref(OrdinaryDiffEqPDIRK), expected))
+    removed = (
+        :ODEFunction, :init, :solve!, :step!, :remake, :reinit!, :ReturnCode,
+        :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
         :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
         :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
     )
-    @test all(Base.isexported.(Ref(OrdinaryDiffEqPDIRK), expected))
+    @test all(x -> !x, Base.isexported.(Ref(OrdinaryDiffEqPDIRK), removed))
     @test !Base.isexported(OrdinaryDiffEqPDIRK, :EnsembleProblem)
     @test !Base.isexported(OrdinaryDiffEqPDIRK, :get_du)
     @test !Base.isexported(OrdinaryDiffEqPDIRK, :u_modified!)

--- a/lib/OrdinaryDiffEqPDIRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqPDIRK/test/runtests.jl
@@ -8,19 +8,21 @@ function activate_qa_env()
 end
 
 @time @safetestset "SciMLBase reexport" begin
+    # docs/src/api/reexports.md defines this surface; test/qa/qa_tests.jl checks the
+    # full list repo-wide. Here, spot-check that the common interface is usable and
+    # that solver-author API stayed behind the `SciMLBase.` qualifier.
     using OrdinaryDiffEqPDIRK, Test
-    expected = (:ODEProblem, :solve)
-    @test all(Base.isexported.(Ref(OrdinaryDiffEqPDIRK), expected))
-    removed = (
-        :ODEFunction, :init, :solve!, :step!, :remake, :reinit!, :ReturnCode,
-        :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-        :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
-        :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
+    exported = (
+        :ODEProblem, :ODEFunction, :SplitODEProblem, :solve, :init, :step!,
+        :remake, :ReturnCode, :CallbackSet, :ContinuousCallback, :terminate!,
+        :u_modified!, :add_tstop!, :get_du, :EnsembleProblem,
     )
-    @test all(x -> !x, Base.isexported.(Ref(OrdinaryDiffEqPDIRK), removed))
-    @test !Base.isexported(OrdinaryDiffEqPDIRK, :EnsembleProblem)
-    @test !Base.isexported(OrdinaryDiffEqPDIRK, :get_du)
-    @test !Base.isexported(OrdinaryDiffEqPDIRK, :u_modified!)
+    @test all(Base.isexported.(Ref(OrdinaryDiffEqPDIRK), exported))
+    internal = (
+        :build_solution, :isinplace, :has_jac, :AbstractODEProblem,
+        :StandardODEProblem, :UJacobianWrapper,
+    )
+    @test !any(Base.isexported.(Ref(OrdinaryDiffEqPDIRK), internal))
 end
 
 # Run QA tests (AllocCheck, JET) - skip on pre-release Julia

--- a/lib/OrdinaryDiffEqPDIRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqPDIRK/test/runtests.jl
@@ -7,6 +7,12 @@ function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])
 end
 
+@time @safetestset "SciMLBase reexport" begin
+    using OrdinaryDiffEqPDIRK, Test
+    @test Base.isexported(OrdinaryDiffEqPDIRK, :ODEProblem)
+    @test Base.isexported(OrdinaryDiffEqPDIRK, :solve)
+end
+
 # Run QA tests (AllocCheck, JET) - skip on pre-release Julia
 # Allocation tests must run before JET because JET's static analysis
 # invalidates compiled code and causes spurious runtime allocations.

--- a/lib/OrdinaryDiffEqPDIRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqPDIRK/test/runtests.jl
@@ -8,9 +8,6 @@ function activate_qa_env()
 end
 
 @time @safetestset "SciMLBase reexport" begin
-    # docs/src/api/reexports.md defines this surface; test/qa/qa_tests.jl checks the
-    # full list repo-wide. Here, spot-check that the common interface is usable and
-    # that solver-author API stayed behind the `SciMLBase.` qualifier.
     using OrdinaryDiffEqPDIRK, Test
     exported = (
         :ODEProblem, :ODEFunction, :SplitODEProblem, :solve, :init, :step!,
@@ -20,7 +17,8 @@ end
     @test all(Base.isexported.(Ref(OrdinaryDiffEqPDIRK), exported))
     internal = (
         :build_solution, :isinplace, :has_jac, :AbstractODEProblem,
-        :StandardODEProblem, :UJacobianWrapper,
+        :StandardODEProblem, :UJacobianWrapper, :LinearProblem,
+        :ConvexOptimizationProblem,
     )
     @test !any(Base.isexported.(Ref(OrdinaryDiffEqPDIRK), internal))
 end

--- a/lib/OrdinaryDiffEqPRK/Project.toml
+++ b/lib/OrdinaryDiffEqPRK/Project.toml
@@ -1,9 +1,10 @@
 name = "OrdinaryDiffEqPRK"
 uuid = "5b33eab2-c0f1-4480-b2c3-94bc1e80bda1"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.3.0"
+version = "2.3.1"
 
 [deps]
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -23,6 +24,7 @@ DiffEqBase = {path = "../DiffEqBase"}
 DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
+Reexport = "1.2.2"
 SciMLTesting = "2.8"
 Pkg = "1"
 Test = "<0.0.1, 1"

--- a/lib/OrdinaryDiffEqPRK/Project.toml
+++ b/lib/OrdinaryDiffEqPRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqPRK"
 uuid = "5b33eab2-c0f1-4480-b2c3-94bc1e80bda1"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.3.1"
+version = "2.4.0"
 
 [deps]
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"

--- a/lib/OrdinaryDiffEqPRK/src/OrdinaryDiffEqPRK.jl
+++ b/lib/OrdinaryDiffEqPRK/src/OrdinaryDiffEqPRK.jl
@@ -11,7 +11,36 @@ import MuladdMacro: @muladd
 import FastBroadcast: @..
 
 using Reexport: Reexport, @reexport
-@reexport using SciMLBase: ODEProblem, solve
+# Re-exported SciMLBase API. This list is identical in every OrdinaryDiffEq solver
+# sublibrary and is generated from the rule documented in docs/src/api/reexports.md;
+# `test/qa/qa_tests.jl` checks the sublibraries against each other and against that rule.
+@reexport using SciMLBase: AnalyticalProblem, BVProblem, ConvexOptimizationProblem,
+    DAEProblem, DDEProblem, DiscreteProblem, DynamicalDDEProblem, DynamicalODEProblem,
+    DynamicalSDEProblem, EigenvalueProblem, EnsembleProblem, HomotopyProblem,
+    ImmutableNonlinearProblem, ImmutableODEProblem, ImplicitDiscreteProblem,
+    IncrementingODEProblem, IntegralProblem, IntervalNonlinearProblem, LinearProblem,
+    NoiseProblem, NonlinearLeastSquaresProblem, NonlinearProblem, ODEProblem,
+    OptimizationProblem, PDEProblem, RODEProblem, SCCNonlinearProblem, SDDEProblem,
+    SDEProblem, SampledIntegralProblem, SecondOrderBVProblem, SecondOrderDDEProblem,
+    SecondOrderODEProblem, SplitODEProblem, SplitSDEProblem, SteadyStateProblem,
+    TwoPointBVProblem, TwoPointSecondOrderBVProblem, WeightedEnsembleProblem, BVPFunction,
+    BatchIntegralFunction, DAEFunction, DDEFunction, DiscreteFunction, DynamicalBVPFunction,
+    DynamicalDDEFunction, DynamicalODEFunction, DynamicalSDEFunction,
+    HomotopyNonlinearFunction, ImplicitDiscreteFunction, IncrementingODEFunction,
+    IntegralFunction, IntervalNonlinearFunction, MultiObjectiveOptimizationFunction,
+    NonlinearFunction, ODEFunction, ODEInputFunction, OptimizationFunction, RODEFunction,
+    SDDEFunction, SDEFunction, SplitFunction, SplitSDEFunction, TwoPointBVPFunction,
+    TwoPointDynamicalBVPFunction, solve, solve!, init, step!, remake, ReturnCode,
+    successful_retcode, DEStats, NLStats, NullParameters, AutoSpecialize, FullSpecialize,
+    NoSpecialize, FunctionWrapperSpecialize, CheckInit, NoInit, OverrideInit, CallbackSet,
+    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, LeftRootFind,
+    RightRootFind, NoRootFind, add_saveat!, add_tstop!, auto_dt_reset!,
+    change_t_via_interpolation!, check_error, check_error!, first_tstop, get_dt, get_du,
+    get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!, reinit!, savevalues!, set_abstol!,
+    set_proposed_dt!, set_reltol!, set_t!, set_u!, set_ut!, terminate!, u_modified!,
+    EnsembleAnalysis, EnsembleDistributed, EnsembleSerial, EnsembleSplitThreads,
+    EnsembleSummary, EnsembleThreads
+using SciMLBase: SciMLBase
 using SciMLBase: SciMLBase
 
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqPRK/src/OrdinaryDiffEqPRK.jl
+++ b/lib/OrdinaryDiffEqPRK/src/OrdinaryDiffEqPRK.jl
@@ -11,10 +11,6 @@ import MuladdMacro: @muladd
 import FastBroadcast: @..
 
 using Reexport: Reexport, @reexport
-using SciMLBase: ODEFunction, init, solve!, step!, remake, reinit!, ReturnCode,
-    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, CallbackSet,
-    terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
-    successful_retcode, ODEAliasSpecifier
 @reexport using SciMLBase: ODEProblem, solve
 using SciMLBase: SciMLBase
 

--- a/lib/OrdinaryDiffEqPRK/src/OrdinaryDiffEqPRK.jl
+++ b/lib/OrdinaryDiffEqPRK/src/OrdinaryDiffEqPRK.jl
@@ -10,6 +10,12 @@ import DiffEqBase: initialize!
 import MuladdMacro: @muladd
 import FastBroadcast: @..
 
+using Reexport: Reexport, @reexport
+@reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
+    reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
+    CallbackSet, terminate!
+using SciMLBase: SciMLBase
+
 include("algorithms.jl")
 include("alg_utils.jl")
 include("prk_caches.jl")

--- a/lib/OrdinaryDiffEqPRK/src/OrdinaryDiffEqPRK.jl
+++ b/lib/OrdinaryDiffEqPRK/src/OrdinaryDiffEqPRK.jl
@@ -11,10 +11,11 @@ import MuladdMacro: @muladd
 import FastBroadcast: @..
 
 using Reexport: Reexport, @reexport
-@reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
-    reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
-    CallbackSet, terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
+using SciMLBase: ODEFunction, init, solve!, step!, remake, reinit!, ReturnCode,
+    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, CallbackSet,
+    terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
     successful_retcode, ODEAliasSpecifier
+@reexport using SciMLBase: ODEProblem, solve
 using SciMLBase: SciMLBase
 
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqPRK/src/OrdinaryDiffEqPRK.jl
+++ b/lib/OrdinaryDiffEqPRK/src/OrdinaryDiffEqPRK.jl
@@ -13,7 +13,8 @@ import FastBroadcast: @..
 using Reexport: Reexport, @reexport
 @reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
     reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
-    CallbackSet, terminate!
+    CallbackSet, terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
+    successful_retcode, ODEAliasSpecifier
 using SciMLBase: SciMLBase
 
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqPRK/src/OrdinaryDiffEqPRK.jl
+++ b/lib/OrdinaryDiffEqPRK/src/OrdinaryDiffEqPRK.jl
@@ -11,36 +11,19 @@ import MuladdMacro: @muladd
 import FastBroadcast: @..
 
 using Reexport: Reexport, @reexport
-# Re-exported SciMLBase API. This list is identical in every OrdinaryDiffEq solver
-# sublibrary and is generated from the rule documented in docs/src/api/reexports.md;
-# `test/qa/qa_tests.jl` checks the sublibraries against each other and against that rule.
-@reexport using SciMLBase: AnalyticalProblem, BVProblem, ConvexOptimizationProblem,
-    DAEProblem, DDEProblem, DiscreteProblem, DynamicalDDEProblem, DynamicalODEProblem,
-    DynamicalSDEProblem, EigenvalueProblem, EnsembleProblem, HomotopyProblem,
-    ImmutableNonlinearProblem, ImmutableODEProblem, ImplicitDiscreteProblem,
-    IncrementingODEProblem, IntegralProblem, IntervalNonlinearProblem, LinearProblem,
-    NoiseProblem, NonlinearLeastSquaresProblem, NonlinearProblem, ODEProblem,
-    OptimizationProblem, PDEProblem, RODEProblem, SCCNonlinearProblem, SDDEProblem,
-    SDEProblem, SampledIntegralProblem, SecondOrderBVProblem, SecondOrderDDEProblem,
-    SecondOrderODEProblem, SplitODEProblem, SplitSDEProblem, SteadyStateProblem,
-    TwoPointBVProblem, TwoPointSecondOrderBVProblem, WeightedEnsembleProblem, BVPFunction,
-    BatchIntegralFunction, DAEFunction, DDEFunction, DiscreteFunction, DynamicalBVPFunction,
-    DynamicalDDEFunction, DynamicalODEFunction, DynamicalSDEFunction,
-    HomotopyNonlinearFunction, ImplicitDiscreteFunction, IncrementingODEFunction,
-    IntegralFunction, IntervalNonlinearFunction, MultiObjectiveOptimizationFunction,
-    NonlinearFunction, ODEFunction, ODEInputFunction, OptimizationFunction, RODEFunction,
-    SDDEFunction, SDEFunction, SplitFunction, SplitSDEFunction, TwoPointBVPFunction,
-    TwoPointDynamicalBVPFunction, solve, solve!, init, step!, remake, ReturnCode,
-    successful_retcode, DEStats, NLStats, NullParameters, AutoSpecialize, FullSpecialize,
-    NoSpecialize, FunctionWrapperSpecialize, CheckInit, NoInit, OverrideInit, CallbackSet,
-    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, LeftRootFind,
-    RightRootFind, NoRootFind, add_saveat!, add_tstop!, auto_dt_reset!,
-    change_t_via_interpolation!, check_error, check_error!, first_tstop, get_dt, get_du,
-    get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!, reinit!, savevalues!, set_abstol!,
-    set_proposed_dt!, set_reltol!, set_t!, set_u!, set_ut!, terminate!, u_modified!,
-    EnsembleAnalysis, EnsembleDistributed, EnsembleSerial, EnsembleSplitThreads,
-    EnsembleSummary, EnsembleThreads
-using SciMLBase: SciMLBase
+# Kept in sync with docs/src/api/reexports.md by test/qa/reexport_tests.jl.
+@reexport using SciMLBase: DAEProblem, DiscreteProblem, DynamicalODEProblem,
+    EnsembleProblem, ODEProblem, SecondOrderODEProblem, SplitODEProblem, DAEFunction,
+    DiscreteFunction, DynamicalODEFunction, ODEFunction, SplitFunction, solve, solve!, init,
+    step!, remake, ReturnCode, successful_retcode, DEStats, NLStats, NullParameters,
+    AutoSpecialize, FullSpecialize, NoSpecialize, FunctionWrapperSpecialize, CheckInit,
+    NoInit, OverrideInit, CallbackSet, ContinuousCallback, DiscreteCallback,
+    VectorContinuousCallback, LeftRootFind, RightRootFind, NoRootFind, add_saveat!,
+    add_tstop!, auto_dt_reset!, change_t_via_interpolation!, check_error, check_error!,
+    first_tstop, get_dt, get_du, get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!,
+    reinit!, savevalues!, set_abstol!, set_proposed_dt!, set_reltol!, set_t!, set_u!,
+    set_ut!, terminate!, u_modified!, EnsembleAnalysis, EnsembleDistributed, EnsembleSerial,
+    EnsembleSplitThreads, EnsembleSummary, EnsembleThreads
 using SciMLBase: SciMLBase
 
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqPRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqPRK/test/qa/qa.jl
@@ -4,9 +4,16 @@ using SciMLTesting, OrdinaryDiffEqPRK, Test
 # SciMLTesting, so the threading options need approving here too.
 const THREADING_PUBLIC = (:Sequential, :BaseThreads, :PolyesterThreads)
 
+# SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
+const SCIMLBASE_REEXPORTS = (
+    :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
+    :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+    :CallbackSet, :terminate!,
+)
+
 run_qa(
     OrdinaryDiffEqPRK;
-    reexports_allow = THREADING_PUBLIC,
+    reexports_allow = (SCIMLBASE_REEXPORTS..., THREADING_PUBLIC...),
     explicit_imports = true,
     ei_kwargs = (;
         all_explicit_imports_are_public = (;

--- a/lib/OrdinaryDiffEqPRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqPRK/test/qa/qa.jl
@@ -5,12 +5,7 @@ using SciMLTesting, OrdinaryDiffEqPRK, Test
 const THREADING_PUBLIC = (:Sequential, :BaseThreads, :PolyesterThreads)
 
 # SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
-const SCIMLBASE_REEXPORTS = (
-    :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
-    :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-    :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
-    :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
-)
+const SCIMLBASE_REEXPORTS = (:ODEProblem, :solve)
 
 run_qa(
     OrdinaryDiffEqPRK;

--- a/lib/OrdinaryDiffEqPRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqPRK/test/qa/qa.jl
@@ -6,8 +6,6 @@ const THREADING_PUBLIC = (:Sequential, :BaseThreads, :PolyesterThreads)
 
 run_qa(
     OrdinaryDiffEqPRK;
-    # Approve the SciMLBase names this package re-exports. The list itself and the rule
-    # behind it are checked repo-wide by test/qa/qa_tests.jl against docs/src/api/reexports.md.
     reexports_allow = vcat(intersect(names(SciMLBase), names(OrdinaryDiffEqPRK)), collect(THREADING_PUBLIC)),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqPRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqPRK/test/qa/qa.jl
@@ -1,15 +1,14 @@
-using SciMLTesting, OrdinaryDiffEqPRK, Test
+using SciMLTesting, OrdinaryDiffEqPRK, SciMLBase, Test
 
 # `public` on a name another package owns counts as a public reexport to
 # SciMLTesting, so the threading options need approving here too.
 const THREADING_PUBLIC = (:Sequential, :BaseThreads, :PolyesterThreads)
 
-# SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
-const SCIMLBASE_REEXPORTS = (:ODEProblem, :solve)
-
 run_qa(
     OrdinaryDiffEqPRK;
-    reexports_allow = (SCIMLBASE_REEXPORTS..., THREADING_PUBLIC...),
+    # Approve the SciMLBase names this package re-exports. The list itself and the rule
+    # behind it are checked repo-wide by test/qa/qa_tests.jl against docs/src/api/reexports.md.
+    reexports_allow = vcat(intersect(names(SciMLBase), names(OrdinaryDiffEqPRK)), collect(THREADING_PUBLIC)),
     explicit_imports = true,
     ei_kwargs = (;
         all_explicit_imports_are_public = (;

--- a/lib/OrdinaryDiffEqPRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqPRK/test/qa/qa.jl
@@ -8,7 +8,8 @@ const THREADING_PUBLIC = (:Sequential, :BaseThreads, :PolyesterThreads)
 const SCIMLBASE_REEXPORTS = (
     :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
     :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-    :CallbackSet, :terminate!,
+    :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
+    :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
 )
 
 run_qa(

--- a/lib/OrdinaryDiffEqPRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqPRK/test/runtests.jl
@@ -8,9 +8,6 @@ function activate_qa_env()
 end
 
 @time @safetestset "SciMLBase reexport" begin
-    # docs/src/api/reexports.md defines this surface; test/qa/qa_tests.jl checks the
-    # full list repo-wide. Here, spot-check that the common interface is usable and
-    # that solver-author API stayed behind the `SciMLBase.` qualifier.
     using OrdinaryDiffEqPRK, Test
     exported = (
         :ODEProblem, :ODEFunction, :SplitODEProblem, :solve, :init, :step!,
@@ -20,7 +17,8 @@ end
     @test all(Base.isexported.(Ref(OrdinaryDiffEqPRK), exported))
     internal = (
         :build_solution, :isinplace, :has_jac, :AbstractODEProblem,
-        :StandardODEProblem, :UJacobianWrapper,
+        :StandardODEProblem, :UJacobianWrapper, :LinearProblem,
+        :ConvexOptimizationProblem,
     )
     @test !any(Base.isexported.(Ref(OrdinaryDiffEqPRK), internal))
 end

--- a/lib/OrdinaryDiffEqPRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqPRK/test/runtests.jl
@@ -9,8 +9,16 @@ end
 
 @time @safetestset "SciMLBase reexport" begin
     using OrdinaryDiffEqPRK, Test
-    @test Base.isexported(OrdinaryDiffEqPRK, :ODEProblem)
-    @test Base.isexported(OrdinaryDiffEqPRK, :solve)
+    expected = (
+        :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
+        :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+        :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
+        :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
+    )
+    @test all(Base.isexported.(Ref(OrdinaryDiffEqPRK), expected))
+    @test !Base.isexported(OrdinaryDiffEqPRK, :EnsembleProblem)
+    @test !Base.isexported(OrdinaryDiffEqPRK, :get_du)
+    @test !Base.isexported(OrdinaryDiffEqPRK, :u_modified!)
 end
 
 # Run QA tests (AllocCheck, JET, Aqua) - skip on pre-release Julia

--- a/lib/OrdinaryDiffEqPRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqPRK/test/runtests.jl
@@ -7,6 +7,12 @@ function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])
 end
 
+@time @safetestset "SciMLBase reexport" begin
+    using OrdinaryDiffEqPRK, Test
+    @test Base.isexported(OrdinaryDiffEqPRK, :ODEProblem)
+    @test Base.isexported(OrdinaryDiffEqPRK, :solve)
+end
+
 # Run QA tests (AllocCheck, JET, Aqua) - skip on pre-release Julia
 # Allocation tests must run before JET because JET's static analysis
 # invalidates compiled code and causes spurious runtime allocations.

--- a/lib/OrdinaryDiffEqPRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqPRK/test/runtests.jl
@@ -9,13 +9,15 @@ end
 
 @time @safetestset "SciMLBase reexport" begin
     using OrdinaryDiffEqPRK, Test
-    expected = (
-        :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
-        :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+    expected = (:ODEProblem, :solve)
+    @test all(Base.isexported.(Ref(OrdinaryDiffEqPRK), expected))
+    removed = (
+        :ODEFunction, :init, :solve!, :step!, :remake, :reinit!, :ReturnCode,
+        :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
         :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
         :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
     )
-    @test all(Base.isexported.(Ref(OrdinaryDiffEqPRK), expected))
+    @test all(x -> !x, Base.isexported.(Ref(OrdinaryDiffEqPRK), removed))
     @test !Base.isexported(OrdinaryDiffEqPRK, :EnsembleProblem)
     @test !Base.isexported(OrdinaryDiffEqPRK, :get_du)
     @test !Base.isexported(OrdinaryDiffEqPRK, :u_modified!)

--- a/lib/OrdinaryDiffEqPRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqPRK/test/runtests.jl
@@ -8,19 +8,21 @@ function activate_qa_env()
 end
 
 @time @safetestset "SciMLBase reexport" begin
+    # docs/src/api/reexports.md defines this surface; test/qa/qa_tests.jl checks the
+    # full list repo-wide. Here, spot-check that the common interface is usable and
+    # that solver-author API stayed behind the `SciMLBase.` qualifier.
     using OrdinaryDiffEqPRK, Test
-    expected = (:ODEProblem, :solve)
-    @test all(Base.isexported.(Ref(OrdinaryDiffEqPRK), expected))
-    removed = (
-        :ODEFunction, :init, :solve!, :step!, :remake, :reinit!, :ReturnCode,
-        :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-        :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
-        :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
+    exported = (
+        :ODEProblem, :ODEFunction, :SplitODEProblem, :solve, :init, :step!,
+        :remake, :ReturnCode, :CallbackSet, :ContinuousCallback, :terminate!,
+        :u_modified!, :add_tstop!, :get_du, :EnsembleProblem,
     )
-    @test all(x -> !x, Base.isexported.(Ref(OrdinaryDiffEqPRK), removed))
-    @test !Base.isexported(OrdinaryDiffEqPRK, :EnsembleProblem)
-    @test !Base.isexported(OrdinaryDiffEqPRK, :get_du)
-    @test !Base.isexported(OrdinaryDiffEqPRK, :u_modified!)
+    @test all(Base.isexported.(Ref(OrdinaryDiffEqPRK), exported))
+    internal = (
+        :build_solution, :isinplace, :has_jac, :AbstractODEProblem,
+        :StandardODEProblem, :UJacobianWrapper,
+    )
+    @test !any(Base.isexported.(Ref(OrdinaryDiffEqPRK), internal))
 end
 
 # Run QA tests (AllocCheck, JET, Aqua) - skip on pre-release Julia

--- a/lib/OrdinaryDiffEqQPRK/Project.toml
+++ b/lib/OrdinaryDiffEqQPRK/Project.toml
@@ -4,6 +4,7 @@ authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 version = "2.2.1"
 
 [deps]
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
@@ -25,6 +26,7 @@ DiffEqBase = {path = "../DiffEqBase"}
 DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
+Reexport = "1.2.2"
 SciMLTesting = "2.8"
 Pkg = "1"
 Test = "<0.0.1, 1"

--- a/lib/OrdinaryDiffEqQPRK/src/OrdinaryDiffEqQPRK.jl
+++ b/lib/OrdinaryDiffEqQPRK/src/OrdinaryDiffEqQPRK.jl
@@ -17,7 +17,8 @@ import OrdinaryDiffEqCore
 using Reexport: Reexport, @reexport
 @reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
     reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
-    CallbackSet, terminate!
+    CallbackSet, terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
+    successful_retcode, ODEAliasSpecifier
 using SciMLBase: SciMLBase
 
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqQPRK/src/OrdinaryDiffEqQPRK.jl
+++ b/lib/OrdinaryDiffEqQPRK/src/OrdinaryDiffEqQPRK.jl
@@ -15,7 +15,36 @@ using RecursiveArrayTools: recursive_unitless_bottom_eltype, recursivefill!
 import OrdinaryDiffEqCore
 
 using Reexport: Reexport, @reexport
-@reexport using SciMLBase: ODEProblem, solve
+# Re-exported SciMLBase API. This list is identical in every OrdinaryDiffEq solver
+# sublibrary and is generated from the rule documented in docs/src/api/reexports.md;
+# `test/qa/qa_tests.jl` checks the sublibraries against each other and against that rule.
+@reexport using SciMLBase: AnalyticalProblem, BVProblem, ConvexOptimizationProblem,
+    DAEProblem, DDEProblem, DiscreteProblem, DynamicalDDEProblem, DynamicalODEProblem,
+    DynamicalSDEProblem, EigenvalueProblem, EnsembleProblem, HomotopyProblem,
+    ImmutableNonlinearProblem, ImmutableODEProblem, ImplicitDiscreteProblem,
+    IncrementingODEProblem, IntegralProblem, IntervalNonlinearProblem, LinearProblem,
+    NoiseProblem, NonlinearLeastSquaresProblem, NonlinearProblem, ODEProblem,
+    OptimizationProblem, PDEProblem, RODEProblem, SCCNonlinearProblem, SDDEProblem,
+    SDEProblem, SampledIntegralProblem, SecondOrderBVProblem, SecondOrderDDEProblem,
+    SecondOrderODEProblem, SplitODEProblem, SplitSDEProblem, SteadyStateProblem,
+    TwoPointBVProblem, TwoPointSecondOrderBVProblem, WeightedEnsembleProblem, BVPFunction,
+    BatchIntegralFunction, DAEFunction, DDEFunction, DiscreteFunction, DynamicalBVPFunction,
+    DynamicalDDEFunction, DynamicalODEFunction, DynamicalSDEFunction,
+    HomotopyNonlinearFunction, ImplicitDiscreteFunction, IncrementingODEFunction,
+    IntegralFunction, IntervalNonlinearFunction, MultiObjectiveOptimizationFunction,
+    NonlinearFunction, ODEFunction, ODEInputFunction, OptimizationFunction, RODEFunction,
+    SDDEFunction, SDEFunction, SplitFunction, SplitSDEFunction, TwoPointBVPFunction,
+    TwoPointDynamicalBVPFunction, solve, solve!, init, step!, remake, ReturnCode,
+    successful_retcode, DEStats, NLStats, NullParameters, AutoSpecialize, FullSpecialize,
+    NoSpecialize, FunctionWrapperSpecialize, CheckInit, NoInit, OverrideInit, CallbackSet,
+    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, LeftRootFind,
+    RightRootFind, NoRootFind, add_saveat!, add_tstop!, auto_dt_reset!,
+    change_t_via_interpolation!, check_error, check_error!, first_tstop, get_dt, get_du,
+    get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!, reinit!, savevalues!, set_abstol!,
+    set_proposed_dt!, set_reltol!, set_t!, set_u!, set_ut!, terminate!, u_modified!,
+    EnsembleAnalysis, EnsembleDistributed, EnsembleSerial, EnsembleSplitThreads,
+    EnsembleSummary, EnsembleThreads
+using SciMLBase: SciMLBase
 using SciMLBase: SciMLBase
 
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqQPRK/src/OrdinaryDiffEqQPRK.jl
+++ b/lib/OrdinaryDiffEqQPRK/src/OrdinaryDiffEqQPRK.jl
@@ -15,10 +15,6 @@ using RecursiveArrayTools: recursive_unitless_bottom_eltype, recursivefill!
 import OrdinaryDiffEqCore
 
 using Reexport: Reexport, @reexport
-using SciMLBase: ODEFunction, init, solve!, step!, remake, reinit!, ReturnCode,
-    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, CallbackSet,
-    terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
-    successful_retcode, ODEAliasSpecifier
 @reexport using SciMLBase: ODEProblem, solve
 using SciMLBase: SciMLBase
 

--- a/lib/OrdinaryDiffEqQPRK/src/OrdinaryDiffEqQPRK.jl
+++ b/lib/OrdinaryDiffEqQPRK/src/OrdinaryDiffEqQPRK.jl
@@ -15,36 +15,19 @@ using RecursiveArrayTools: recursive_unitless_bottom_eltype, recursivefill!
 import OrdinaryDiffEqCore
 
 using Reexport: Reexport, @reexport
-# Re-exported SciMLBase API. This list is identical in every OrdinaryDiffEq solver
-# sublibrary and is generated from the rule documented in docs/src/api/reexports.md;
-# `test/qa/qa_tests.jl` checks the sublibraries against each other and against that rule.
-@reexport using SciMLBase: AnalyticalProblem, BVProblem, ConvexOptimizationProblem,
-    DAEProblem, DDEProblem, DiscreteProblem, DynamicalDDEProblem, DynamicalODEProblem,
-    DynamicalSDEProblem, EigenvalueProblem, EnsembleProblem, HomotopyProblem,
-    ImmutableNonlinearProblem, ImmutableODEProblem, ImplicitDiscreteProblem,
-    IncrementingODEProblem, IntegralProblem, IntervalNonlinearProblem, LinearProblem,
-    NoiseProblem, NonlinearLeastSquaresProblem, NonlinearProblem, ODEProblem,
-    OptimizationProblem, PDEProblem, RODEProblem, SCCNonlinearProblem, SDDEProblem,
-    SDEProblem, SampledIntegralProblem, SecondOrderBVProblem, SecondOrderDDEProblem,
-    SecondOrderODEProblem, SplitODEProblem, SplitSDEProblem, SteadyStateProblem,
-    TwoPointBVProblem, TwoPointSecondOrderBVProblem, WeightedEnsembleProblem, BVPFunction,
-    BatchIntegralFunction, DAEFunction, DDEFunction, DiscreteFunction, DynamicalBVPFunction,
-    DynamicalDDEFunction, DynamicalODEFunction, DynamicalSDEFunction,
-    HomotopyNonlinearFunction, ImplicitDiscreteFunction, IncrementingODEFunction,
-    IntegralFunction, IntervalNonlinearFunction, MultiObjectiveOptimizationFunction,
-    NonlinearFunction, ODEFunction, ODEInputFunction, OptimizationFunction, RODEFunction,
-    SDDEFunction, SDEFunction, SplitFunction, SplitSDEFunction, TwoPointBVPFunction,
-    TwoPointDynamicalBVPFunction, solve, solve!, init, step!, remake, ReturnCode,
-    successful_retcode, DEStats, NLStats, NullParameters, AutoSpecialize, FullSpecialize,
-    NoSpecialize, FunctionWrapperSpecialize, CheckInit, NoInit, OverrideInit, CallbackSet,
-    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, LeftRootFind,
-    RightRootFind, NoRootFind, add_saveat!, add_tstop!, auto_dt_reset!,
-    change_t_via_interpolation!, check_error, check_error!, first_tstop, get_dt, get_du,
-    get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!, reinit!, savevalues!, set_abstol!,
-    set_proposed_dt!, set_reltol!, set_t!, set_u!, set_ut!, terminate!, u_modified!,
-    EnsembleAnalysis, EnsembleDistributed, EnsembleSerial, EnsembleSplitThreads,
-    EnsembleSummary, EnsembleThreads
-using SciMLBase: SciMLBase
+# Kept in sync with docs/src/api/reexports.md by test/qa/reexport_tests.jl.
+@reexport using SciMLBase: DAEProblem, DiscreteProblem, DynamicalODEProblem,
+    EnsembleProblem, ODEProblem, SecondOrderODEProblem, SplitODEProblem, DAEFunction,
+    DiscreteFunction, DynamicalODEFunction, ODEFunction, SplitFunction, solve, solve!, init,
+    step!, remake, ReturnCode, successful_retcode, DEStats, NLStats, NullParameters,
+    AutoSpecialize, FullSpecialize, NoSpecialize, FunctionWrapperSpecialize, CheckInit,
+    NoInit, OverrideInit, CallbackSet, ContinuousCallback, DiscreteCallback,
+    VectorContinuousCallback, LeftRootFind, RightRootFind, NoRootFind, add_saveat!,
+    add_tstop!, auto_dt_reset!, change_t_via_interpolation!, check_error, check_error!,
+    first_tstop, get_dt, get_du, get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!,
+    reinit!, savevalues!, set_abstol!, set_proposed_dt!, set_reltol!, set_t!, set_u!,
+    set_ut!, terminate!, u_modified!, EnsembleAnalysis, EnsembleDistributed, EnsembleSerial,
+    EnsembleSplitThreads, EnsembleSummary, EnsembleThreads
 using SciMLBase: SciMLBase
 
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqQPRK/src/OrdinaryDiffEqQPRK.jl
+++ b/lib/OrdinaryDiffEqQPRK/src/OrdinaryDiffEqQPRK.jl
@@ -14,6 +14,12 @@ using MuladdMacro: MuladdMacro, @muladd
 using RecursiveArrayTools: recursive_unitless_bottom_eltype, recursivefill!
 import OrdinaryDiffEqCore
 
+using Reexport: Reexport, @reexport
+@reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
+    reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
+    CallbackSet, terminate!
+using SciMLBase: SciMLBase
+
 include("algorithms.jl")
 include("alg_utils.jl")
 include("qprk_caches.jl")

--- a/lib/OrdinaryDiffEqQPRK/src/OrdinaryDiffEqQPRK.jl
+++ b/lib/OrdinaryDiffEqQPRK/src/OrdinaryDiffEqQPRK.jl
@@ -15,10 +15,11 @@ using RecursiveArrayTools: recursive_unitless_bottom_eltype, recursivefill!
 import OrdinaryDiffEqCore
 
 using Reexport: Reexport, @reexport
-@reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
-    reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
-    CallbackSet, terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
+using SciMLBase: ODEFunction, init, solve!, step!, remake, reinit!, ReturnCode,
+    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, CallbackSet,
+    terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
     successful_retcode, ODEAliasSpecifier
+@reexport using SciMLBase: ODEProblem, solve
 using SciMLBase: SciMLBase
 
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqQPRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqQPRK/test/qa/qa.jl
@@ -2,8 +2,6 @@ using SciMLTesting, OrdinaryDiffEqQPRK, SciMLBase, Test
 
 run_qa(
     OrdinaryDiffEqQPRK;
-    # Approve the SciMLBase names this package re-exports. The list itself and the rule
-    # behind it are checked repo-wide by test/qa/qa_tests.jl against docs/src/api/reexports.md.
     reexports_allow = intersect(names(SciMLBase), names(OrdinaryDiffEqQPRK)),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/OrdinaryDiffEqQPRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqQPRK/test/qa/qa.jl
@@ -4,7 +4,8 @@ using SciMLTesting, OrdinaryDiffEqQPRK, Test
 const SCIMLBASE_REEXPORTS = (
     :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
     :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-    :CallbackSet, :terminate!,
+    :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
+    :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
 )
 
 run_qa(

--- a/lib/OrdinaryDiffEqQPRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqQPRK/test/qa/qa.jl
@@ -1,12 +1,7 @@
 using SciMLTesting, OrdinaryDiffEqQPRK, Test
 
 # SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
-const SCIMLBASE_REEXPORTS = (
-    :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
-    :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-    :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
-    :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
-)
+const SCIMLBASE_REEXPORTS = (:ODEProblem, :solve)
 
 run_qa(
     OrdinaryDiffEqQPRK;

--- a/lib/OrdinaryDiffEqQPRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqQPRK/test/qa/qa.jl
@@ -1,7 +1,15 @@
 using SciMLTesting, OrdinaryDiffEqQPRK, Test
 
+# SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
+const SCIMLBASE_REEXPORTS = (
+    :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
+    :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+    :CallbackSet, :terminate!,
+)
+
 run_qa(
     OrdinaryDiffEqQPRK;
+    reexports_allow = SCIMLBASE_REEXPORTS,
     explicit_imports = true,
     ei_kwargs = (
         all_explicit_imports_are_public = (

--- a/lib/OrdinaryDiffEqQPRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqQPRK/test/qa/qa.jl
@@ -1,11 +1,10 @@
-using SciMLTesting, OrdinaryDiffEqQPRK, Test
-
-# SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
-const SCIMLBASE_REEXPORTS = (:ODEProblem, :solve)
+using SciMLTesting, OrdinaryDiffEqQPRK, SciMLBase, Test
 
 run_qa(
     OrdinaryDiffEqQPRK;
-    reexports_allow = SCIMLBASE_REEXPORTS,
+    # Approve the SciMLBase names this package re-exports. The list itself and the rule
+    # behind it are checked repo-wide by test/qa/qa_tests.jl against docs/src/api/reexports.md.
+    reexports_allow = intersect(names(SciMLBase), names(OrdinaryDiffEqQPRK)),
     explicit_imports = true,
     ei_kwargs = (
         all_explicit_imports_are_public = (

--- a/lib/OrdinaryDiffEqQPRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqQPRK/test/runtests.jl
@@ -11,8 +11,16 @@ end
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
         using OrdinaryDiffEqQPRK, Test
-        @test Base.isexported(OrdinaryDiffEqQPRK, :ODEProblem)
-        @test Base.isexported(OrdinaryDiffEqQPRK, :solve)
+        expected = (
+            :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
+            :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+            :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
+            :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
+        )
+        @test all(Base.isexported.(Ref(OrdinaryDiffEqQPRK), expected))
+        @test !Base.isexported(OrdinaryDiffEqQPRK, :EnsembleProblem)
+        @test !Base.isexported(OrdinaryDiffEqQPRK, :get_du)
+        @test !Base.isexported(OrdinaryDiffEqQPRK, :u_modified!)
     end
     @time @safetestset "Quadruple Precision Tests" include("ode_quadruple_precision_tests.jl")
 end

--- a/lib/OrdinaryDiffEqQPRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqQPRK/test/runtests.jl
@@ -10,9 +10,6 @@ end
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
-        # docs/src/api/reexports.md defines this surface; test/qa/qa_tests.jl checks the
-        # full list repo-wide. Here, spot-check that the common interface is usable and
-        # that solver-author API stayed behind the `SciMLBase.` qualifier.
         using OrdinaryDiffEqQPRK, Test
         exported = (
             :ODEProblem, :ODEFunction, :SplitODEProblem, :solve, :init, :step!,
@@ -22,7 +19,8 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
         @test all(Base.isexported.(Ref(OrdinaryDiffEqQPRK), exported))
         internal = (
             :build_solution, :isinplace, :has_jac, :AbstractODEProblem,
-            :StandardODEProblem, :UJacobianWrapper,
+            :StandardODEProblem, :UJacobianWrapper, :LinearProblem,
+            :ConvexOptimizationProblem,
         )
         @test !any(Base.isexported.(Ref(OrdinaryDiffEqQPRK), internal))
     end

--- a/lib/OrdinaryDiffEqQPRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqQPRK/test/runtests.jl
@@ -10,19 +10,21 @@ end
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
+        # docs/src/api/reexports.md defines this surface; test/qa/qa_tests.jl checks the
+        # full list repo-wide. Here, spot-check that the common interface is usable and
+        # that solver-author API stayed behind the `SciMLBase.` qualifier.
         using OrdinaryDiffEqQPRK, Test
-        expected = (:ODEProblem, :solve)
-        @test all(Base.isexported.(Ref(OrdinaryDiffEqQPRK), expected))
-        removed = (
-            :ODEFunction, :init, :solve!, :step!, :remake, :reinit!, :ReturnCode,
-            :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-            :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
-            :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
+        exported = (
+            :ODEProblem, :ODEFunction, :SplitODEProblem, :solve, :init, :step!,
+            :remake, :ReturnCode, :CallbackSet, :ContinuousCallback, :terminate!,
+            :u_modified!, :add_tstop!, :get_du, :EnsembleProblem,
         )
-        @test all(x -> !x, Base.isexported.(Ref(OrdinaryDiffEqQPRK), removed))
-        @test !Base.isexported(OrdinaryDiffEqQPRK, :EnsembleProblem)
-        @test !Base.isexported(OrdinaryDiffEqQPRK, :get_du)
-        @test !Base.isexported(OrdinaryDiffEqQPRK, :u_modified!)
+        @test all(Base.isexported.(Ref(OrdinaryDiffEqQPRK), exported))
+        internal = (
+            :build_solution, :isinplace, :has_jac, :AbstractODEProblem,
+            :StandardODEProblem, :UJacobianWrapper,
+        )
+        @test !any(Base.isexported.(Ref(OrdinaryDiffEqQPRK), internal))
     end
     @time @safetestset "Quadruple Precision Tests" include("ode_quadruple_precision_tests.jl")
 end

--- a/lib/OrdinaryDiffEqQPRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqQPRK/test/runtests.jl
@@ -9,6 +9,11 @@ end
 
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
+    @time @safetestset "SciMLBase reexport" begin
+        using OrdinaryDiffEqQPRK, Test
+        @test Base.isexported(OrdinaryDiffEqQPRK, :ODEProblem)
+        @test Base.isexported(OrdinaryDiffEqQPRK, :solve)
+    end
     @time @safetestset "Quadruple Precision Tests" include("ode_quadruple_precision_tests.jl")
 end
 

--- a/lib/OrdinaryDiffEqQPRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqQPRK/test/runtests.jl
@@ -11,13 +11,15 @@ end
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
         using OrdinaryDiffEqQPRK, Test
-        expected = (
-            :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
-            :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+        expected = (:ODEProblem, :solve)
+        @test all(Base.isexported.(Ref(OrdinaryDiffEqQPRK), expected))
+        removed = (
+            :ODEFunction, :init, :solve!, :step!, :remake, :reinit!, :ReturnCode,
+            :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
             :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
             :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
         )
-        @test all(Base.isexported.(Ref(OrdinaryDiffEqQPRK), expected))
+        @test all(x -> !x, Base.isexported.(Ref(OrdinaryDiffEqQPRK), removed))
         @test !Base.isexported(OrdinaryDiffEqQPRK, :EnsembleProblem)
         @test !Base.isexported(OrdinaryDiffEqQPRK, :get_du)
         @test !Base.isexported(OrdinaryDiffEqQPRK, :u_modified!)

--- a/lib/OrdinaryDiffEqTaylorSeries/Project.toml
+++ b/lib/OrdinaryDiffEqTaylorSeries/Project.toml
@@ -4,6 +4,7 @@ authors = ["Songchen Tan <i@tansongchen.com>"]
 version = "2.2.1"
 
 [deps]
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -32,6 +33,7 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+Reexport = "1.2.2"
 SciMLTesting = "2.4"
 CommonSolve = "0.2.6"
 DiffEqBase = "7"

--- a/lib/OrdinaryDiffEqTaylorSeries/src/OrdinaryDiffEqTaylorSeries.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/src/OrdinaryDiffEqTaylorSeries.jl
@@ -26,10 +26,7 @@ import OrdinaryDiffEqCore
 import FunctionWrappers: FunctionWrapper
 
 using Reexport: Reexport, @reexport
-using SciMLBase: ODEFunction, init, solve!, step!, remake, reinit!, ReturnCode,
-    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, CallbackSet,
-    terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
-    successful_retcode, ODEAliasSpecifier
+using SciMLBase: ODEFunction
 @reexport using SciMLBase: ODEProblem, solve
 
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqTaylorSeries/src/OrdinaryDiffEqTaylorSeries.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/src/OrdinaryDiffEqTaylorSeries.jl
@@ -28,7 +28,8 @@ import FunctionWrappers: FunctionWrapper
 using Reexport: Reexport, @reexport
 @reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
     reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
-    CallbackSet, terminate!
+    CallbackSet, terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
+    successful_retcode, ODEAliasSpecifier
 
 include("algorithms.jl")
 include("alg_utils.jl")

--- a/lib/OrdinaryDiffEqTaylorSeries/src/OrdinaryDiffEqTaylorSeries.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/src/OrdinaryDiffEqTaylorSeries.jl
@@ -26,10 +26,11 @@ import OrdinaryDiffEqCore
 import FunctionWrappers: FunctionWrapper
 
 using Reexport: Reexport, @reexport
-@reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
-    reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
-    CallbackSet, terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
+using SciMLBase: ODEFunction, init, solve!, step!, remake, reinit!, ReturnCode,
+    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, CallbackSet,
+    terminate!, add_tstop!, derivative_discontinuity!, set_proposed_dt!,
     successful_retcode, ODEAliasSpecifier
+@reexport using SciMLBase: ODEProblem, solve
 
 include("algorithms.jl")
 include("alg_utils.jl")

--- a/lib/OrdinaryDiffEqTaylorSeries/src/OrdinaryDiffEqTaylorSeries.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/src/OrdinaryDiffEqTaylorSeries.jl
@@ -26,8 +26,36 @@ import OrdinaryDiffEqCore
 import FunctionWrappers: FunctionWrapper
 
 using Reexport: Reexport, @reexport
-using SciMLBase: ODEFunction
-@reexport using SciMLBase: ODEProblem, solve
+# Re-exported SciMLBase API. This list is identical in every OrdinaryDiffEq solver
+# sublibrary and is generated from the rule documented in docs/src/api/reexports.md;
+# `test/qa/qa_tests.jl` checks the sublibraries against each other and against that rule.
+@reexport using SciMLBase: AnalyticalProblem, BVProblem, ConvexOptimizationProblem,
+    DAEProblem, DDEProblem, DiscreteProblem, DynamicalDDEProblem, DynamicalODEProblem,
+    DynamicalSDEProblem, EigenvalueProblem, EnsembleProblem, HomotopyProblem,
+    ImmutableNonlinearProblem, ImmutableODEProblem, ImplicitDiscreteProblem,
+    IncrementingODEProblem, IntegralProblem, IntervalNonlinearProblem, LinearProblem,
+    NoiseProblem, NonlinearLeastSquaresProblem, NonlinearProblem, ODEProblem,
+    OptimizationProblem, PDEProblem, RODEProblem, SCCNonlinearProblem, SDDEProblem,
+    SDEProblem, SampledIntegralProblem, SecondOrderBVProblem, SecondOrderDDEProblem,
+    SecondOrderODEProblem, SplitODEProblem, SplitSDEProblem, SteadyStateProblem,
+    TwoPointBVProblem, TwoPointSecondOrderBVProblem, WeightedEnsembleProblem, BVPFunction,
+    BatchIntegralFunction, DAEFunction, DDEFunction, DiscreteFunction, DynamicalBVPFunction,
+    DynamicalDDEFunction, DynamicalODEFunction, DynamicalSDEFunction,
+    HomotopyNonlinearFunction, ImplicitDiscreteFunction, IncrementingODEFunction,
+    IntegralFunction, IntervalNonlinearFunction, MultiObjectiveOptimizationFunction,
+    NonlinearFunction, ODEFunction, ODEInputFunction, OptimizationFunction, RODEFunction,
+    SDDEFunction, SDEFunction, SplitFunction, SplitSDEFunction, TwoPointBVPFunction,
+    TwoPointDynamicalBVPFunction, solve, solve!, init, step!, remake, ReturnCode,
+    successful_retcode, DEStats, NLStats, NullParameters, AutoSpecialize, FullSpecialize,
+    NoSpecialize, FunctionWrapperSpecialize, CheckInit, NoInit, OverrideInit, CallbackSet,
+    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, LeftRootFind,
+    RightRootFind, NoRootFind, add_saveat!, add_tstop!, auto_dt_reset!,
+    change_t_via_interpolation!, check_error, check_error!, first_tstop, get_dt, get_du,
+    get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!, reinit!, savevalues!, set_abstol!,
+    set_proposed_dt!, set_reltol!, set_t!, set_u!, set_ut!, terminate!, u_modified!,
+    EnsembleAnalysis, EnsembleDistributed, EnsembleSerial, EnsembleSplitThreads,
+    EnsembleSummary, EnsembleThreads
+using SciMLBase: SciMLBase
 
 include("algorithms.jl")
 include("alg_utils.jl")

--- a/lib/OrdinaryDiffEqTaylorSeries/src/OrdinaryDiffEqTaylorSeries.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/src/OrdinaryDiffEqTaylorSeries.jl
@@ -26,35 +26,19 @@ import OrdinaryDiffEqCore
 import FunctionWrappers: FunctionWrapper
 
 using Reexport: Reexport, @reexport
-# Re-exported SciMLBase API. This list is identical in every OrdinaryDiffEq solver
-# sublibrary and is generated from the rule documented in docs/src/api/reexports.md;
-# `test/qa/qa_tests.jl` checks the sublibraries against each other and against that rule.
-@reexport using SciMLBase: AnalyticalProblem, BVProblem, ConvexOptimizationProblem,
-    DAEProblem, DDEProblem, DiscreteProblem, DynamicalDDEProblem, DynamicalODEProblem,
-    DynamicalSDEProblem, EigenvalueProblem, EnsembleProblem, HomotopyProblem,
-    ImmutableNonlinearProblem, ImmutableODEProblem, ImplicitDiscreteProblem,
-    IncrementingODEProblem, IntegralProblem, IntervalNonlinearProblem, LinearProblem,
-    NoiseProblem, NonlinearLeastSquaresProblem, NonlinearProblem, ODEProblem,
-    OptimizationProblem, PDEProblem, RODEProblem, SCCNonlinearProblem, SDDEProblem,
-    SDEProblem, SampledIntegralProblem, SecondOrderBVProblem, SecondOrderDDEProblem,
-    SecondOrderODEProblem, SplitODEProblem, SplitSDEProblem, SteadyStateProblem,
-    TwoPointBVProblem, TwoPointSecondOrderBVProblem, WeightedEnsembleProblem, BVPFunction,
-    BatchIntegralFunction, DAEFunction, DDEFunction, DiscreteFunction, DynamicalBVPFunction,
-    DynamicalDDEFunction, DynamicalODEFunction, DynamicalSDEFunction,
-    HomotopyNonlinearFunction, ImplicitDiscreteFunction, IncrementingODEFunction,
-    IntegralFunction, IntervalNonlinearFunction, MultiObjectiveOptimizationFunction,
-    NonlinearFunction, ODEFunction, ODEInputFunction, OptimizationFunction, RODEFunction,
-    SDDEFunction, SDEFunction, SplitFunction, SplitSDEFunction, TwoPointBVPFunction,
-    TwoPointDynamicalBVPFunction, solve, solve!, init, step!, remake, ReturnCode,
-    successful_retcode, DEStats, NLStats, NullParameters, AutoSpecialize, FullSpecialize,
-    NoSpecialize, FunctionWrapperSpecialize, CheckInit, NoInit, OverrideInit, CallbackSet,
-    ContinuousCallback, DiscreteCallback, VectorContinuousCallback, LeftRootFind,
-    RightRootFind, NoRootFind, add_saveat!, add_tstop!, auto_dt_reset!,
-    change_t_via_interpolation!, check_error, check_error!, first_tstop, get_dt, get_du,
-    get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!, reinit!, savevalues!, set_abstol!,
-    set_proposed_dt!, set_reltol!, set_t!, set_u!, set_ut!, terminate!, u_modified!,
-    EnsembleAnalysis, EnsembleDistributed, EnsembleSerial, EnsembleSplitThreads,
-    EnsembleSummary, EnsembleThreads
+# Kept in sync with docs/src/api/reexports.md by test/qa/reexport_tests.jl.
+@reexport using SciMLBase: DAEProblem, DiscreteProblem, DynamicalODEProblem,
+    EnsembleProblem, ODEProblem, SecondOrderODEProblem, SplitODEProblem, DAEFunction,
+    DiscreteFunction, DynamicalODEFunction, ODEFunction, SplitFunction, solve, solve!, init,
+    step!, remake, ReturnCode, successful_retcode, DEStats, NLStats, NullParameters,
+    AutoSpecialize, FullSpecialize, NoSpecialize, FunctionWrapperSpecialize, CheckInit,
+    NoInit, OverrideInit, CallbackSet, ContinuousCallback, DiscreteCallback,
+    VectorContinuousCallback, LeftRootFind, RightRootFind, NoRootFind, add_saveat!,
+    add_tstop!, auto_dt_reset!, change_t_via_interpolation!, check_error, check_error!,
+    first_tstop, get_dt, get_du, get_du!, get_proposed_dt, get_tmp_cache, pop_tstop!,
+    reinit!, savevalues!, set_abstol!, set_proposed_dt!, set_reltol!, set_t!, set_u!,
+    set_ut!, terminate!, u_modified!, EnsembleAnalysis, EnsembleDistributed, EnsembleSerial,
+    EnsembleSplitThreads, EnsembleSummary, EnsembleThreads
 using SciMLBase: SciMLBase
 
 include("algorithms.jl")

--- a/lib/OrdinaryDiffEqTaylorSeries/src/OrdinaryDiffEqTaylorSeries.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/src/OrdinaryDiffEqTaylorSeries.jl
@@ -20,10 +20,15 @@ using TaylorDiff: TaylorDiff, TaylorArray, TaylorScalar
 using Symbolics: Symbolics, @variables, build_function
 using SymbolicUtils: SymbolicUtils
 import CommonSolve: solve
-import SciMLBase: SciMLBase, unwrapped_f, alg_order, ODEFunction, ODEProblem
+import SciMLBase: SciMLBase, unwrapped_f, alg_order
 import DiffEqBase: initialize!, calculate_residuals, calculate_residuals!
 import OrdinaryDiffEqCore
 import FunctionWrappers: FunctionWrapper
+
+using Reexport: Reexport, @reexport
+@reexport using SciMLBase: ODEProblem, ODEFunction, solve, init, solve!, step!, remake,
+    reinit!, ReturnCode, ContinuousCallback, DiscreteCallback, VectorContinuousCallback,
+    CallbackSet, terminate!
 
 include("algorithms.jl")
 include("alg_utils.jl")

--- a/lib/OrdinaryDiffEqTaylorSeries/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/test/qa/qa.jl
@@ -9,7 +9,8 @@ using SciMLTesting, OrdinaryDiffEqTaylorSeries, Test
 const SCIMLBASE_REEXPORTS = (
     :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
     :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-    :CallbackSet, :terminate!,
+    :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
+    :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
 )
 
 run_qa(

--- a/lib/OrdinaryDiffEqTaylorSeries/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/test/qa/qa.jl
@@ -7,8 +7,6 @@ using SciMLTesting, OrdinaryDiffEqTaylorSeries, SciMLBase, Test
 # been dropped; only the genuine residual remains (see SciML/OrdinaryDiffEq.jl#3776).
 run_qa(
     OrdinaryDiffEqTaylorSeries;
-    # Approve the SciMLBase names this package re-exports. The list itself and the rule
-    # behind it are checked repo-wide by test/qa/qa_tests.jl against docs/src/api/reexports.md.
     reexports_allow = intersect(names(SciMLBase), names(OrdinaryDiffEqTaylorSeries)),
     aqua_kwargs = (;
         unbound_args = false, undefined_exports = false, stale_deps = false,

--- a/lib/OrdinaryDiffEqTaylorSeries/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/test/qa/qa.jl
@@ -1,16 +1,15 @@
-using SciMLTesting, OrdinaryDiffEqTaylorSeries, Test
+using SciMLTesting, OrdinaryDiffEqTaylorSeries, SciMLBase, Test
 
 # Every name in the ignore lists below is genuinely internal (not exported and
 # not declared `public`) in its OWNER package, so there is no public name to
 # migrate to. The base solver-author API (perform_step!/alg_cache/controllers/
 # etc.) is now declared `public` in OrdinaryDiffEqCore, so those entries have
 # been dropped; only the genuine residual remains (see SciML/OrdinaryDiffEq.jl#3776).
-# SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
-const SCIMLBASE_REEXPORTS = (:ODEProblem, :solve)
-
 run_qa(
     OrdinaryDiffEqTaylorSeries;
-    reexports_allow = SCIMLBASE_REEXPORTS,
+    # Approve the SciMLBase names this package re-exports. The list itself and the rule
+    # behind it are checked repo-wide by test/qa/qa_tests.jl against docs/src/api/reexports.md.
+    reexports_allow = intersect(names(SciMLBase), names(OrdinaryDiffEqTaylorSeries)),
     aqua_kwargs = (;
         unbound_args = false, undefined_exports = false, stale_deps = false,
         ambiguities = false,

--- a/lib/OrdinaryDiffEqTaylorSeries/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/test/qa/qa.jl
@@ -5,8 +5,16 @@ using SciMLTesting, OrdinaryDiffEqTaylorSeries, Test
 # migrate to. The base solver-author API (perform_step!/alg_cache/controllers/
 # etc.) is now declared `public` in OrdinaryDiffEqCore, so those entries have
 # been dropped; only the genuine residual remains (see SciML/OrdinaryDiffEq.jl#3776).
+# SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
+const SCIMLBASE_REEXPORTS = (
+    :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
+    :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+    :CallbackSet, :terminate!,
+)
+
 run_qa(
     OrdinaryDiffEqTaylorSeries;
+    reexports_allow = SCIMLBASE_REEXPORTS,
     aqua_kwargs = (;
         unbound_args = false, undefined_exports = false, stale_deps = false,
         ambiguities = false,

--- a/lib/OrdinaryDiffEqTaylorSeries/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/test/qa/qa.jl
@@ -6,12 +6,7 @@ using SciMLTesting, OrdinaryDiffEqTaylorSeries, Test
 # etc.) is now declared `public` in OrdinaryDiffEqCore, so those entries have
 # been dropped; only the genuine residual remains (see SciML/OrdinaryDiffEq.jl#3776).
 # SciMLBase names re-exported for ordinary ODE usage; everything else stays behind `SciMLBase.`.
-const SCIMLBASE_REEXPORTS = (
-    :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
-    :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-    :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
-    :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
-)
+const SCIMLBASE_REEXPORTS = (:ODEProblem, :solve)
 
 run_qa(
     OrdinaryDiffEqTaylorSeries;

--- a/lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl
@@ -13,9 +13,6 @@ end
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
-        # docs/src/api/reexports.md defines this surface; test/qa/qa_tests.jl checks the
-        # full list repo-wide. Here, spot-check that the common interface is usable and
-        # that solver-author API stayed behind the `SciMLBase.` qualifier.
         using OrdinaryDiffEqTaylorSeries, Test
         exported = (
             :ODEProblem, :ODEFunction, :SplitODEProblem, :solve, :init, :step!,
@@ -25,7 +22,8 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
         @test all(Base.isexported.(Ref(OrdinaryDiffEqTaylorSeries), exported))
         internal = (
             :build_solution, :isinplace, :has_jac, :AbstractODEProblem,
-            :StandardODEProblem, :UJacobianWrapper,
+            :StandardODEProblem, :UJacobianWrapper, :LinearProblem,
+            :ConvexOptimizationProblem,
         )
         @test !any(Base.isexported.(Ref(OrdinaryDiffEqTaylorSeries), internal))
     end

--- a/lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl
@@ -14,8 +14,16 @@ end
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
         using OrdinaryDiffEqTaylorSeries, Test
-        @test Base.isexported(OrdinaryDiffEqTaylorSeries, :ODEProblem)
-        @test Base.isexported(OrdinaryDiffEqTaylorSeries, :solve)
+        expected = (
+            :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
+            :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+            :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
+            :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
+        )
+        @test all(Base.isexported.(Ref(OrdinaryDiffEqTaylorSeries), expected))
+        @test !Base.isexported(OrdinaryDiffEqTaylorSeries, :EnsembleProblem)
+        @test !Base.isexported(OrdinaryDiffEqTaylorSeries, :get_du)
+        @test !Base.isexported(OrdinaryDiffEqTaylorSeries, :u_modified!)
     end
     @testset "ExplicitTaylor2 Convergence Tests" begin
         # Test convergence

--- a/lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl
@@ -12,6 +12,11 @@ end
 
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
+    @time @safetestset "SciMLBase reexport" begin
+        using OrdinaryDiffEqTaylorSeries, Test
+        @test Base.isexported(OrdinaryDiffEqTaylorSeries, :ODEProblem)
+        @test Base.isexported(OrdinaryDiffEqTaylorSeries, :solve)
+    end
     @testset "ExplicitTaylor2 Convergence Tests" begin
         # Test convergence
         dts = 2.0 .^ (-8:-4)

--- a/lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl
@@ -13,19 +13,21 @@ end
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
+        # docs/src/api/reexports.md defines this surface; test/qa/qa_tests.jl checks the
+        # full list repo-wide. Here, spot-check that the common interface is usable and
+        # that solver-author API stayed behind the `SciMLBase.` qualifier.
         using OrdinaryDiffEqTaylorSeries, Test
-        expected = (:ODEProblem, :solve)
-        @test all(Base.isexported.(Ref(OrdinaryDiffEqTaylorSeries), expected))
-        removed = (
-            :ODEFunction, :init, :solve!, :step!, :remake, :reinit!, :ReturnCode,
-            :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
-            :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
-            :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
+        exported = (
+            :ODEProblem, :ODEFunction, :SplitODEProblem, :solve, :init, :step!,
+            :remake, :ReturnCode, :CallbackSet, :ContinuousCallback, :terminate!,
+            :u_modified!, :add_tstop!, :get_du, :EnsembleProblem,
         )
-        @test all(x -> !x, Base.isexported.(Ref(OrdinaryDiffEqTaylorSeries), removed))
-        @test !Base.isexported(OrdinaryDiffEqTaylorSeries, :EnsembleProblem)
-        @test !Base.isexported(OrdinaryDiffEqTaylorSeries, :get_du)
-        @test !Base.isexported(OrdinaryDiffEqTaylorSeries, :u_modified!)
+        @test all(Base.isexported.(Ref(OrdinaryDiffEqTaylorSeries), exported))
+        internal = (
+            :build_solution, :isinplace, :has_jac, :AbstractODEProblem,
+            :StandardODEProblem, :UJacobianWrapper,
+        )
+        @test !any(Base.isexported.(Ref(OrdinaryDiffEqTaylorSeries), internal))
     end
     @testset "ExplicitTaylor2 Convergence Tests" begin
         # Test convergence

--- a/lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl
@@ -14,13 +14,15 @@ end
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "SciMLBase reexport" begin
         using OrdinaryDiffEqTaylorSeries, Test
-        expected = (
-            :ODEProblem, :ODEFunction, :solve, :init, :solve!, :step!, :remake, :reinit!,
-            :ReturnCode, :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
+        expected = (:ODEProblem, :solve)
+        @test all(Base.isexported.(Ref(OrdinaryDiffEqTaylorSeries), expected))
+        removed = (
+            :ODEFunction, :init, :solve!, :step!, :remake, :reinit!, :ReturnCode,
+            :ContinuousCallback, :DiscreteCallback, :VectorContinuousCallback,
             :CallbackSet, :terminate!, :add_tstop!, :derivative_discontinuity!,
             :set_proposed_dt!, :successful_retcode, :ODEAliasSpecifier,
         )
-        @test all(Base.isexported.(Ref(OrdinaryDiffEqTaylorSeries), expected))
+        @test all(x -> !x, Base.isexported.(Ref(OrdinaryDiffEqTaylorSeries), removed))
         @test !Base.isexported(OrdinaryDiffEqTaylorSeries, :EnsembleProblem)
         @test !Base.isexported(OrdinaryDiffEqTaylorSeries, :get_du)
         @test !Base.isexported(OrdinaryDiffEqTaylorSeries, :u_modified!)

--- a/test/qa/qa_tests.jl
+++ b/test/qa/qa_tests.jl
@@ -51,6 +51,61 @@ const ORDINARYDIFFEQ_REEXPORTS = intersect(
     ),
 )
 
+@testset "Re-exported SciMLBase API is uniform and follows the documented rule" begin
+    # docs/src/api/reexports.md defines which SciMLBase names a solver sublibrary re-exports
+    # (the user-facing common interface: problem/function types, solve, callbacks, integrator
+    # interface, ensembles). That page is the single source of truth; this testset enforces it.
+    repo_dir = joinpath(@__DIR__, "..", "..")
+
+    documented = Symbol[]
+    for line in eachline(joinpath(repo_dir, "docs", "src", "api", "reexports.md"))
+        occursin(r"^[A-Za-z_][A-Za-z0-9_!]*(?:, [A-Za-z_][A-Za-z0-9_!]*)*,?$", line) || continue
+        append!(documented, Symbol.(filter(!isempty, strip.(split(line, ",")))))
+    end
+    @test allunique(documented)
+    @test length(documented) > 100
+
+    exported = setdiff(names(SciMLBase), [:SciMLBase])
+    @test isempty(setdiff(documented, exported))
+
+    # Categories 2-5 are enumerated by hand, but category 1 (problem and function types) is
+    # mechanical, so re-derive it: a concrete, non-dispatch-tag `...Problem`/`...Function`.
+    # A new SciMLBase problem type fails here until the sublibraries re-export it.
+    is_dispatch_tag(name) = startswith(name, "Abstract") || startswith(name, "Standard")
+    function is_concrete_type(name)
+        value = getglobal(SciMLBase, name)
+        return value isa Type && !isabstracttype(Base.unwrap_unionall(value))
+    end
+    required = filter(exported) do name
+        text = String(name)
+        (endswith(text, "Problem") || endswith(text, "Function")) &&
+            !is_dispatch_tag(text) && is_concrete_type(name)
+    end
+    @test isempty(setdiff(required, documented))
+
+    function reexported_names(path)
+        source = read(path, String)
+        m = match(r"@reexport using SciMLBase:((?:[^\n]*\n)(?:    [^\n]*\n)*)", source)
+        m === nothing && return nothing
+        return Symbol.(filter(!isempty, strip.(split(replace(m[1], r"\s+" => " "), ","))))
+    end
+
+    # Sublibraries that still re-export all of SciMLBase are a superset of the rule and are
+    # migrated separately; every sublibrary that names its re-exports must match the page.
+    lib_dir = joinpath(repo_dir, "lib")
+    selective = Dict{String, Vector{Symbol}}()
+    for package in readdir(lib_dir)
+        source = joinpath(lib_dir, package, "src", package * ".jl")
+        isfile(source) || continue
+        found = reexported_names(source)
+        found === nothing || (selective[package] = found)
+    end
+    @test length(selective) == 9
+    for (package, found) in selective
+        @test (package, sort(found)) == (package, sort(documented))
+    end
+end
+
 # The umbrella package's QA lane historically ran only the ExplicitImports checks
 # (no Aqua/JET), so keep `aqua = false` to preserve that scope.
 run_qa(

--- a/test/qa/qa_tests.jl
+++ b/test/qa/qa_tests.jl
@@ -51,60 +51,7 @@ const ORDINARYDIFFEQ_REEXPORTS = intersect(
     ),
 )
 
-@testset "Re-exported SciMLBase API is uniform and follows the documented rule" begin
-    # docs/src/api/reexports.md defines which SciMLBase names a solver sublibrary re-exports
-    # (the user-facing common interface: problem/function types, solve, callbacks, integrator
-    # interface, ensembles). That page is the single source of truth; this testset enforces it.
-    repo_dir = joinpath(@__DIR__, "..", "..")
-
-    documented = Symbol[]
-    for line in eachline(joinpath(repo_dir, "docs", "src", "api", "reexports.md"))
-        occursin(r"^[A-Za-z_][A-Za-z0-9_!]*(?:, [A-Za-z_][A-Za-z0-9_!]*)*,?$", line) || continue
-        append!(documented, Symbol.(filter(!isempty, strip.(split(line, ",")))))
-    end
-    @test allunique(documented)
-    @test length(documented) > 100
-
-    exported = setdiff(names(SciMLBase), [:SciMLBase])
-    @test isempty(setdiff(documented, exported))
-
-    # Categories 2-5 are enumerated by hand, but category 1 (problem and function types) is
-    # mechanical, so re-derive it: a concrete, non-dispatch-tag `...Problem`/`...Function`.
-    # A new SciMLBase problem type fails here until the sublibraries re-export it.
-    is_dispatch_tag(name) = startswith(name, "Abstract") || startswith(name, "Standard")
-    function is_concrete_type(name)
-        value = getglobal(SciMLBase, name)
-        return value isa Type && !isabstracttype(Base.unwrap_unionall(value))
-    end
-    required = filter(exported) do name
-        text = String(name)
-        (endswith(text, "Problem") || endswith(text, "Function")) &&
-            !is_dispatch_tag(text) && is_concrete_type(name)
-    end
-    @test isempty(setdiff(required, documented))
-
-    function reexported_names(path)
-        source = read(path, String)
-        m = match(r"@reexport using SciMLBase:((?:[^\n]*\n)(?:    [^\n]*\n)*)", source)
-        m === nothing && return nothing
-        return Symbol.(filter(!isempty, strip.(split(replace(m[1], r"\s+" => " "), ","))))
-    end
-
-    # Sublibraries that still re-export all of SciMLBase are a superset of the rule and are
-    # migrated separately; every sublibrary that names its re-exports must match the page.
-    lib_dir = joinpath(repo_dir, "lib")
-    selective = Dict{String, Vector{Symbol}}()
-    for package in readdir(lib_dir)
-        source = joinpath(lib_dir, package, "src", package * ".jl")
-        isfile(source) || continue
-        found = reexported_names(source)
-        found === nothing || (selective[package] = found)
-    end
-    @test length(selective) == 9
-    for (package, found) in selective
-        @test (package, sort(found)) == (package, sort(documented))
-    end
-end
+include("reexport_tests.jl")
 
 # The umbrella package's QA lane historically ran only the ExplicitImports checks
 # (no Aqua/JET), so keep `aqua = false` to preserve that scope.

--- a/test/qa/reexport_tests.jl
+++ b/test/qa/reexport_tests.jl
@@ -1,0 +1,55 @@
+using SciMLBase, Test
+
+@testset "Re-exported SciMLBase API follows real OrdinaryDiffEq usage" begin
+    repo_dir = joinpath(@__DIR__, "..", "..")
+
+    documented = Symbol[]
+    for line in eachline(joinpath(repo_dir, "docs", "src", "api", "reexports.md"))
+        occursin(r"^[A-Za-z_][A-Za-z0-9_!]*(?:, [A-Za-z_][A-Za-z0-9_!]*)*,?$", line) || continue
+        append!(documented, Symbol.(filter(!isempty, strip.(split(line, ",")))))
+    end
+    @test allunique(documented)
+    @test length(documented) > 50
+
+    exported = setdiff(names(SciMLBase), [:SciMLBase])
+    @test isempty(setdiff(documented, exported))
+
+    common_interface = read(
+        joinpath(repo_dir, "docs", "src", "api", "common_interface.md"), String
+    )
+    referenced = Set(
+        Symbol(m.captures[1]) for
+            m in eachmatch(r"SciMLBase\.([A-Za-z_][A-Za-z0-9_!]*)", common_interface)
+    )
+    is_concrete_type(name) = begin
+        value = getglobal(SciMLBase, name)
+        value isa Type && !isabstracttype(Base.unwrap_unionall(value))
+    end
+    problem_api = filter(exported) do name
+        text = String(name)
+        (endswith(text, "Problem") || endswith(text, "Function")) &&
+            is_concrete_type(name)
+    end
+    required_problem_api = intersect(problem_api, referenced)
+    @test issetequal(intersect(documented, problem_api), required_problem_api)
+
+    function reexported_names(path)
+        source = read(path, String)
+        m = match(r"@reexport using SciMLBase:((?:[^\n]*\n)(?:    [^\n]*\n)*)", source)
+        m === nothing && return nothing
+        return Symbol.(filter(!isempty, strip.(split(replace(m[1], r"\s+" => " "), ","))))
+    end
+
+    lib_dir = joinpath(repo_dir, "lib")
+    selective = Dict{String, Vector{Symbol}}()
+    for package in readdir(lib_dir)
+        source = joinpath(lib_dir, package, "src", package * ".jl")
+        isfile(source) || continue
+        found = reexported_names(source)
+        found === nothing || (selective[package] = found)
+    end
+    @test length(selective) == 9
+    for (package, found) in selective
+        @test (package, sort(found)) == (package, sort(documented))
+    end
+end


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

Fixes https://github.com/SciML/OrdinaryDiffEq.jl/issues/4269

## What changed and why

Nine leaf solver packages stopped re-exporting SciMLBase's user-facing interface when their imports were hardened, breaking code such as `using OrdinaryDiffEqFeagin; ODEProblem(...)`. This PR restores a uniform, deliberately limited interface across those packages.

The problem/function portion now follows real OrdinaryDiffEq usage: it is exactly the concrete SciMLBase problem and function types rendered in `docs/src/api/common_interface.md`. That leaves 12 relevant names (`ODEProblem`, `SplitODEProblem`, `DAEProblem`, discrete/dynamical/second-order variants, their function types, and `EnsembleProblem`) and removes unrelated optimization, nonlinear-equation, SDE, DDE, BVP, integral, and linear-problem APIs. The remaining reexports are the common solve, callback, integrator, and ensemble interfaces.

`test/qa/reexport_tests.jl` checks the documented list against the Common Interface, the live SciMLBase exports, and all nine selective packages. Extrapolation's implementation genuinely uses `LinearProblem`, so it now imports that public API explicitly without re-exporting it.

The package version bumps remain minor because this adds public API relative to the currently registered leaf releases. Selective reexports remain identical in Default, Extrapolation, Feagin, FunctionMap, IMEXMultistep, PDIRK, PRK, QPRK, and TaylorSeries.

## Failing before / passing after

With the new contract test present and the unfixed broad list still in place:

```text
$ JULIA_DEPOT_PATH=../.julia_depot julia +1.12 --startup-file=no --project=.analysisenv test/qa/reexport_tests.jl
Test Summary:                                               | Pass  Fail  Total
Re-exported SciMLBase API follows real OrdinaryDiffEq usage |   13     1     14
```

On rebased commit `4997b0a669bc74f8932d4609726b4d142b799954`:

```text
$ JULIA_DEPOT_PATH=../.julia_depot julia +1.12 --startup-file=no --project=. test/qa/reexport_tests.jl
Test Summary:                                               | Pass  Total  Time
Re-exported SciMLBase API follows real OrdinaryDiffEq usage |   14     14  1.2s
```

## Verification

```text
$ GROUP=QA julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary:           | Pass  Total   Time
Quality Assurance Tests |  106    106  18.4s
Testing OrdinaryDiffEq tests passed

$ julia +1.12 --startup-file=no --project=docs docs/make.jl
[completed successfully; only existing generated-page/search-size and deployment-environment warnings]

$ julia +1.12 --startup-file=no --project=../formatenv -m Runic --check --diff <changed Julia files>
[Runic 1.9.0: clean]

$ typos <all changed files>
[clean]

$ git diff --check upstream/master
[clean]
```

Targeted `GROUP=Core` suites passed for Default, Extrapolation, Feagin, FunctionMap, IMEXMultistep, PRK, QPRK, and TaylorSeries. The Extrapolation Core suite was rerun in full after making its `LinearProblem` import explicit.

PDIRK Core has an unrelated failure on an unmodified base checkout: the argument-guard test added by https://github.com/SciML/OrdinaryDiffEq.jl/commit/e4f0c5ebbb4ef8a29dfb7e66477df37bfef77390 resolves registered `OrdinaryDiffEqNonlinearSolve` 2.9.0 instead of the monorepo's 2.9.1 because `lib/OrdinaryDiffEqPDIRK/Project.toml` lacks a `[sources]` entry. A clean-base bisect identified that commit; adding the local source mapping makes PDIRK Core pass 10/10. That unrelated fix is intentionally not mixed into this PR.

Leaf QA passed for Default, Extrapolation, and Feagin. The other six leaf QA invocations reached their allocation checks but JET could not start a filesystem monitor because this host had all 128/128 per-user inotify instances occupied (`IOError: FolderMonitor (start): too many open files`). No tests were disabled or silenced.

## Not verified locally

- GPU lanes, `julia pre`, and downstream-package jobs.
- The six leaf JET/Aqua completions blocked by machine-wide inotify saturation; root QA and CI cover the checked-in QA contract.
- Sublibraries outside the nine selective packages; they still blanket-reexport SciMLBase and are unchanged.

## Reviewer note

The judgment call is the Common Interface page as the source of truth for problem/function types. Adding a concrete SciMLBase type to that page makes the contract fail until the nine selective packages and the reexport documentation are updated together.

AI agent continuation: OpenAI Codex
Codex-Session-ID: 01a03a11-47c2-77e0-858b-167004f0b79c

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiHL8AqRSy2VQZF6j68ovM
