### PR TITLE
Remove obsolete SciMLTesting QA overrides

### DIFF
--- a/lib/DelayDiffEq/test/qa/qa_tests.jl
+++ b/lib/DelayDiffEq/test/qa/qa_tests.jl
@@ -45,7 +45,6 @@ const EXPLICIT_INTERNAL = (
 
 run_qa(
     DelayDiffEq;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(DelayDiffEq), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     aqua_kwargs = (;
         ambiguities = (; recursive = false),

--- a/lib/DiffEqDevTools/test/qa/qa.jl
+++ b/lib/DiffEqDevTools/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, DiffEqDevTools, Test
 
 run_qa(
     DiffEqDevTools;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(DiffEqDevTools), "..", "..", "docs", "src")),
     aqua_kwargs = (;
         ambiguities = false, piracies = false, unbound_args = false, stale_deps = false,
         deps_compat = (; check_extras = false),

--- a/lib/GlobalDiffEq/test/qa/qa.jl
+++ b/lib/GlobalDiffEq/test/qa/qa.jl
@@ -2,29 +2,11 @@ using SciMLTesting, GlobalDiffEq, Test
 using JET
 using OrdinaryDiffEqTsit5, OrdinaryDiffEqSSPRK
 
-# `@reexport using DiffEqBase` republishes DiffEqBase's API; those names are
-# documented and rendered at their owning packages, not in the OrdinaryDiffEq
-# manual's GlobalDiffEq page, so only GlobalDiffEq's own names are held to the
-# rendered-docs check.
-reexported_names = Tuple(
-    filter(public_api_names(GlobalDiffEq)) do name
-        object = getfield(GlobalDiffEq, name)
-        !(object isa Union{Function, Type, Module}) ||
-            parentmodule(object) !== GlobalDiffEq
-    end
-)
-
 run_qa(
     GlobalDiffEq;
     reexports_allow = union(public_api_names(DiffEqBase), (:DiffEqBase,)),
     explicit_imports = true,
     # GlobalDiffEq's rendered documentation lives in the monorepo docs, two
-    # directories up from the sublibrary root.
-    api_docs_kwargs = (;
-        rendered = true,
-        docs_src = joinpath(dirname(dirname(pkgdir(GlobalDiffEq))), "docs", "src"),
-        rendered_ignore = reexported_names,
-    ),
     ei_kwargs = (;
         all_qualified_accesses_are_public = (;
             # `SciMLBase.__solve` is SciMLBase's internal solve entry point (not

--- a/lib/ImplicitDiscreteSolve/test/qa/qa.jl
+++ b/lib/ImplicitDiscreteSolve/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, ImplicitDiscreteSolve, Test
 
 run_qa(
     ImplicitDiscreteSolve;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(ImplicitDiscreteSolve), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     aqua_kwargs = (; piracies = false),
     explicit_imports = true,

--- a/lib/OrdinaryDiffEqAdamsBashforthMoulton/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqAdamsBashforthMoulton/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqAdamsBashforthMoulton, Test
 
 run_qa(
     OrdinaryDiffEqAdamsBashforthMoulton;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqAdamsBashforthMoulton), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/OrdinaryDiffEqBDF/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqBDF/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqBDF, Test
 
 run_qa(
     OrdinaryDiffEqBDF;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqBDF), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/OrdinaryDiffEqDifferentiation/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/qa/qa.jl
@@ -8,7 +8,6 @@ using SciMLTesting, OrdinaryDiffEqDifferentiation, Test
 # tracked in SciML/OrdinaryDiffEq.jl#3776).
 run_qa(
     OrdinaryDiffEqDifferentiation;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqDifferentiation), "..", "..", "docs", "src")),
     aqua_kwargs = (; piracies = false, ambiguities = false),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqExplicitRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqExplicitRK/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqExplicitRK, Test
 
 run_qa(
     OrdinaryDiffEqExplicitRK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqExplicitRK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqExplicitTableaus/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqExplicitTableaus/test/qa/qa.jl
@@ -3,7 +3,5 @@ using JET
 
 run_qa(
     OrdinaryDiffEqExplicitTableaus;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqExplicitTableaus), "..", "..", "docs", "src")),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
 )

--- a/lib/OrdinaryDiffEqExponentialRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqExponentialRK, Test
 
 run_qa(
     OrdinaryDiffEqExponentialRK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqExponentialRK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/OrdinaryDiffEqFIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/qa/qa.jl
@@ -12,7 +12,6 @@ const THREADING_PUBLIC = (:Sequential, :BaseThreads, :PolyesterThreads)
 # See SciML/OrdinaryDiffEq.jl#3776.
 run_qa(
     OrdinaryDiffEqFIRK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqFIRK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,), THREADING_PUBLIC),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/OrdinaryDiffEqHighOrderRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqHighOrderRK/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqHighOrderRK, Test
 
 run_qa(
     OrdinaryDiffEqHighOrderRK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqHighOrderRK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/OrdinaryDiffEqImplicitTableaus/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqImplicitTableaus/test/qa/qa.jl
@@ -3,7 +3,5 @@ using JET
 
 run_qa(
     OrdinaryDiffEqImplicitTableaus;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqImplicitTableaus), "..", "..", "docs", "src")),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
 )

--- a/lib/OrdinaryDiffEqLinear/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqLinear/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqLinear, Test
 
 run_qa(
     OrdinaryDiffEqLinear;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqLinear), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqLowOrderRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqLowOrderRK/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqLowOrderRK, Test
 
 run_qa(
     OrdinaryDiffEqLowOrderRK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqLowOrderRK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqLowStorageRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqLowStorageRK, Test
 
 run_qa(
     OrdinaryDiffEqLowStorageRK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqLowStorageRK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/OrdinaryDiffEqNordsieck/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqNordsieck/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqNordsieck, Test
 
 run_qa(
     OrdinaryDiffEqNordsieck;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqNordsieck), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqRKN/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqRKN/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqRKN, Test
 
 run_qa(
     OrdinaryDiffEqRKN;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqRKN), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqRosenbrock/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/qa/qa.jl
@@ -27,7 +27,6 @@ const ROSENBROCK_INTERNAL_QUALIFIED_ACCESSES = (
 
 run_qa(
     OrdinaryDiffEqRosenbrock;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqRosenbrock), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/OrdinaryDiffEqRosenbrockTableaus/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqRosenbrockTableaus/test/qa/qa.jl
@@ -3,7 +3,5 @@ using JET
 
 run_qa(
     OrdinaryDiffEqRosenbrockTableaus;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqRosenbrockTableaus), "..", "..", "docs", "src")),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
 )

--- a/lib/OrdinaryDiffEqSDIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/qa/qa.jl
@@ -12,7 +12,6 @@ using SciMLTesting, OrdinaryDiffEqSDIRK, Test
 #     `@truncate_stacktrace`).
 run_qa(
     OrdinaryDiffEqSDIRK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqSDIRK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:Predictor, :SciMLBase)),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/OrdinaryDiffEqSSPRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqSSPRK/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqSSPRK, Test
 
 run_qa(
     OrdinaryDiffEqSSPRK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqSSPRK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/OrdinaryDiffEqStabilizedIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqStabilizedIRK/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqStabilizedIRK, Test
 
 run_qa(
     OrdinaryDiffEqStabilizedIRK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqStabilizedIRK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqStabilizedRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqStabilizedRK, Test
 
 run_qa(
     OrdinaryDiffEqStabilizedRK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqStabilizedRK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/OrdinaryDiffEqSymplecticRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqSymplecticRK/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqSymplecticRK, Test
 
 run_qa(
     OrdinaryDiffEqSymplecticRK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqSymplecticRK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
 )

--- a/lib/OrdinaryDiffEqTsit5/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqTsit5/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqTsit5, Test
 
 run_qa(
     OrdinaryDiffEqTsit5;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqTsit5), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqVerner/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqVerner/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqVerner, Test
 
 run_qa(
     OrdinaryDiffEqVerner;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqVerner), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/StochasticDiffEqCore/test/qa/qa.jl
+++ b/lib/StochasticDiffEqCore/test/qa/qa.jl
@@ -97,7 +97,6 @@ const SDEC_TYPE_ALIASES = (:SDEIntegrator, :SDEOptions)
 
 run_qa(
     StochasticDiffEqCore;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqCore), "..", "..", "docs", "src")),
     # `@reexport using DiffEqBase` pulls in DiffEqBase's own API plus its SciMLBase
     # re-export. `names(DiffEqBase)` only propagates SciMLBase's *exports*, so SciMLBase's
     # `public`-but-unexported API (`alg_order`, `isadaptive`) needs its own union entry.
@@ -106,7 +105,6 @@ run_qa(
         (:DiffEqBase,), ODEC_PUBLIC_REEXPORTS, SDEC_TYPE_ALIASES,
     ),
     aqua_kwargs = (; piracies = (; treat_as_own = ODEC_STOCHASTIC_SURFACE)),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
     ei_kwargs = (;
         # `@..` reaches StochasticDiffEqCore via DiffEqBase's re-export of

--- a/lib/StochasticDiffEqHighOrder/test/qa/qa.jl
+++ b/lib/StochasticDiffEqHighOrder/test/qa/qa.jl
@@ -3,9 +3,7 @@ using JET
 
 run_qa(
     StochasticDiffEqHighOrder;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqHighOrder), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
     ei_kwargs = (
         # `@..` is owned by FastBroadcast but reexported through DiffEqBase, and

--- a/lib/StochasticDiffEqIIF/test/qa/qa.jl
+++ b/lib/StochasticDiffEqIIF/test/qa/qa.jl
@@ -3,8 +3,6 @@ using JET
 
 run_qa(
     StochasticDiffEqIIF;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqIIF), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
 )

--- a/lib/StochasticDiffEqImplicit/test/qa/qa.jl
+++ b/lib/StochasticDiffEqImplicit/test/qa/qa.jl
@@ -3,15 +3,7 @@ using JET
 
 run_qa(
     StochasticDiffEqImplicit;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqImplicit), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
-    # Scope JET to this package in `:typo` mode, matching the OrdinaryDiffEq* solver
-    # sublibraries. The deprecated `target_defined_modules = true` also reported
-    # `nlsolve!`/`get_W`/`set_new_W!` "no matching method" cross-package false
-    # positives that arise only because `perform_step!` leaves `integrator`
-    # untyped (at runtime it is always an `ODEIntegrator <: DEIntegrator`, so the
-    # functional Core tests exercise these paths without error).
-    jet_kwargs = (; target_modules = (StochasticDiffEqImplicit,), mode = :typo),
     explicit_imports = true,
     ei_kwargs = (;
         # `@..` is owned by FastBroadcast and re-exported through DiffEqBase; FastBroadcast

--- a/lib/StochasticDiffEqLeaping/test/qa/qa.jl
+++ b/lib/StochasticDiffEqLeaping/test/qa/qa.jl
@@ -3,11 +3,7 @@ using JET
 
 run_qa(
     StochasticDiffEqLeaping;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqLeaping), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
-    # Scope JET to this package in `:typo` mode (the OrdinaryDiffEq* solver-sublibrary
-    # convention); `target_defined_modules = true` is deprecated in JET.
-    jet_kwargs = (; target_modules = (StochasticDiffEqLeaping,), mode = :typo),
     explicit_imports = true,
     ei_kwargs = (;
         # `@..` is the SciML fused-broadcast macro, owned by FastBroadcast and

--- a/lib/StochasticDiffEqLevyArea/test/qa/qa.jl
+++ b/lib/StochasticDiffEqLevyArea/test/qa/qa.jl
@@ -3,7 +3,5 @@ using JET
 
 run_qa(
     StochasticDiffEqLevyArea;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqLevyArea), "..", "..", "docs", "src")),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
 )

--- a/lib/StochasticDiffEqLowOrder/test/qa/qa.jl
+++ b/lib/StochasticDiffEqLowOrder/test/qa/qa.jl
@@ -3,9 +3,7 @@ using JET
 
 run_qa(
     StochasticDiffEqLowOrder;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqLowOrder), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
     ei_broken = (:no_implicit_imports, :all_explicit_imports_via_owners, :all_explicit_imports_are_public),  # known-broken; see SciML/OrdinaryDiffEq.jl#3776
 )

--- a/lib/StochasticDiffEqMilstein/test/qa/qa.jl
+++ b/lib/StochasticDiffEqMilstein/test/qa/qa.jl
@@ -3,9 +3,7 @@ using JET
 
 run_qa(
     StochasticDiffEqMilstein;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqMilstein), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
     ei_broken = (:no_implicit_imports, :all_explicit_imports_via_owners, :all_qualified_accesses_are_public, :all_explicit_imports_are_public),  # known-broken; see SciML/OrdinaryDiffEq.jl#3776
 )

--- a/lib/StochasticDiffEqROCK/test/qa/qa.jl
+++ b/lib/StochasticDiffEqROCK/test/qa/qa.jl
@@ -3,9 +3,7 @@ using JET
 
 run_qa(
     StochasticDiffEqROCK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqROCK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
     ei_broken = (:no_implicit_imports, :no_stale_explicit_imports, :all_explicit_imports_via_owners, :all_explicit_imports_are_public),  # known-broken; see SciML/OrdinaryDiffEq.jl#3776
 )

--- a/lib/StochasticDiffEqRODE/test/qa/qa.jl
+++ b/lib/StochasticDiffEqRODE/test/qa/qa.jl
@@ -3,9 +3,7 @@ using JET
 
 run_qa(
     StochasticDiffEqRODE;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqRODE), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
     ei_broken = (:no_implicit_imports, :all_explicit_imports_via_owners, :all_explicit_imports_are_public),  # known-broken; see SciML/OrdinaryDiffEq.jl#3776
 )

--- a/lib/StochasticDiffEqWeak/test/qa/qa.jl
+++ b/lib/StochasticDiffEqWeak/test/qa/qa.jl
@@ -3,9 +3,7 @@ using JET
 
 run_qa(
     StochasticDiffEqWeak;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqWeak), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
     ei_broken = (:no_implicit_imports, :no_stale_explicit_imports, :all_explicit_imports_via_owners, :all_explicit_imports_are_public),  # known-broken; see SciML/OrdinaryDiffEq.jl#3776
 )

--- a/test/qa/qa_tests.jl
+++ b/test/qa/qa_tests.jl
@@ -4,6 +4,20 @@ using ADTypes, CommonSolve, DiffEqBase, OrdinaryDiffEqBDF, OrdinaryDiffEqDefault
     SciMLBase, SciMLLogging
 using Test
 
+@testset "QA JET target configuration" begin
+    lib_dir = joinpath(@__DIR__, "..", "..", "lib")
+    deprecated_overrides = String[]
+    for package in readdir(lib_dir)
+        qa_file = joinpath(lib_dir, package, "test", "qa", "qa.jl")
+        isfile(qa_file) || continue
+        occursin(
+            r"jet_kwargs\s*=\s*\(;\s*target_defined_modules\s*=\s*true\s*\)",
+            read(qa_file, String),
+        ) && push!(deprecated_overrides, qa_file)
+    end
+    @test isempty(deprecated_overrides)
+end
+
 @testset "PureKLU-compatible MuladdMacro floors" begin
     lib_dir = joinpath(@__DIR__, "..", "..", "lib")
     projects = filter(readdir(lib_dir)) do package


### PR DESCRIPTION
## Summary

Remove repository-specific SciMLTesting QA overrides that are redundant with current SciMLTesting behavior:

- Remove docs_src-only api_docs_kwargs from 37 sublibrary QA files.
- Remove GlobalDiffEq rendered_ignore/reexport filtering; ownership-aware public-doc validation handles external reexports.
- Remove legacy target_defined_modules and explicit target_modules JET overrides from sublibrary run_qa calls.
- Add a QA regression test that rejects reintroducing the deprecated target_defined_modules override.

SciMLTesting 2.10 already discovers the repository-level docs/src for lib/<PackageName> subpackages and defaults JET to the package target. No source code, public docs, suppressions, or compat entries were changed.

## Verification

- Combined branch: `GROUP=QA julia --project -e 'using Pkg; Pkg.test()'`: Quality Assurance `91/91`, exit 0.
- Base before cleanup: `GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'` from `lib/OrdinaryDiffEqExplicitTableaus`: Quality Assurance `21/21`, exit 0.
- After cleanup: same affected sublibrary QA lane: Quality Assurance `21/21`, exit 0.
- Runic check: exit 0.
- `git diff --check`: exit 0.
- `typos --diff test/qa/qa_tests.jl`: exit 0.
- Docs build was attempted with `timeout 3600 julia --startup-file=no --project=docs docs/make.jl` and could not start because Documenter is not installed in the local docs environment.

This PR should be ignored until reviewed by @ChrisRackauckas.
