### PR TITLE
Remove redundant JET target module overrides

### DIFF
--- a/lib/OrdinaryDiffEqExplicitTableaus/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqExplicitTableaus/test/qa/qa.jl
@@ -4,6 +4,5 @@ using JET
 run_qa(
     OrdinaryDiffEqExplicitTableaus;
     api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqExplicitTableaus), "..", "..", "docs", "src")),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
 )

--- a/lib/OrdinaryDiffEqImplicitTableaus/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqImplicitTableaus/test/qa/qa.jl
@@ -4,6 +4,5 @@ using JET
 run_qa(
     OrdinaryDiffEqImplicitTableaus;
     api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqImplicitTableaus), "..", "..", "docs", "src")),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
 )

--- a/lib/OrdinaryDiffEqRosenbrockTableaus/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqRosenbrockTableaus/test/qa/qa.jl
@@ -4,6 +4,5 @@ using JET
 run_qa(
     OrdinaryDiffEqRosenbrockTableaus;
     api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqRosenbrockTableaus), "..", "..", "docs", "src")),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
 )

--- a/lib/StochasticDiffEqCore/test/qa/qa.jl
+++ b/lib/StochasticDiffEqCore/test/qa/qa.jl
@@ -106,7 +106,6 @@ run_qa(
         (:DiffEqBase,), ODEC_PUBLIC_REEXPORTS, SDEC_TYPE_ALIASES,
     ),
     aqua_kwargs = (; piracies = (; treat_as_own = ODEC_STOCHASTIC_SURFACE)),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
     ei_kwargs = (;
         # `@..` reaches StochasticDiffEqCore via DiffEqBase's re-export of

--- a/lib/StochasticDiffEqHighOrder/test/qa/qa.jl
+++ b/lib/StochasticDiffEqHighOrder/test/qa/qa.jl
@@ -5,7 +5,6 @@ run_qa(
     StochasticDiffEqHighOrder;
     api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqHighOrder), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
     ei_kwargs = (
         # `@..` is owned by FastBroadcast but reexported through DiffEqBase, and

--- a/lib/StochasticDiffEqIIF/test/qa/qa.jl
+++ b/lib/StochasticDiffEqIIF/test/qa/qa.jl
@@ -5,6 +5,5 @@ run_qa(
     StochasticDiffEqIIF;
     api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqIIF), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
 )

--- a/lib/StochasticDiffEqLevyArea/test/qa/qa.jl
+++ b/lib/StochasticDiffEqLevyArea/test/qa/qa.jl
@@ -4,6 +4,5 @@ using JET
 run_qa(
     StochasticDiffEqLevyArea;
     api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqLevyArea), "..", "..", "docs", "src")),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
 )

--- a/lib/StochasticDiffEqLowOrder/test/qa/qa.jl
+++ b/lib/StochasticDiffEqLowOrder/test/qa/qa.jl
@@ -5,7 +5,6 @@ run_qa(
     StochasticDiffEqLowOrder;
     api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqLowOrder), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
     ei_broken = (:no_implicit_imports, :all_explicit_imports_via_owners, :all_explicit_imports_are_public),  # known-broken; see SciML/OrdinaryDiffEq.jl#3776
 )

--- a/lib/StochasticDiffEqMilstein/test/qa/qa.jl
+++ b/lib/StochasticDiffEqMilstein/test/qa/qa.jl
@@ -5,7 +5,6 @@ run_qa(
     StochasticDiffEqMilstein;
     api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqMilstein), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
     ei_broken = (:no_implicit_imports, :all_explicit_imports_via_owners, :all_qualified_accesses_are_public, :all_explicit_imports_are_public),  # known-broken; see SciML/OrdinaryDiffEq.jl#3776
 )

--- a/lib/StochasticDiffEqROCK/test/qa/qa.jl
+++ b/lib/StochasticDiffEqROCK/test/qa/qa.jl
@@ -5,7 +5,6 @@ run_qa(
     StochasticDiffEqROCK;
     api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqROCK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
     ei_broken = (:no_implicit_imports, :no_stale_explicit_imports, :all_explicit_imports_via_owners, :all_explicit_imports_are_public),  # known-broken; see SciML/OrdinaryDiffEq.jl#3776
 )

--- a/lib/StochasticDiffEqRODE/test/qa/qa.jl
+++ b/lib/StochasticDiffEqRODE/test/qa/qa.jl
@@ -5,7 +5,6 @@ run_qa(
     StochasticDiffEqRODE;
     api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqRODE), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
     ei_broken = (:no_implicit_imports, :all_explicit_imports_via_owners, :all_explicit_imports_are_public),  # known-broken; see SciML/OrdinaryDiffEq.jl#3776
 )

--- a/lib/StochasticDiffEqWeak/test/qa/qa.jl
+++ b/lib/StochasticDiffEqWeak/test/qa/qa.jl
@@ -5,7 +5,6 @@ run_qa(
     StochasticDiffEqWeak;
     api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqWeak), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
-    jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
     ei_broken = (:no_implicit_imports, :no_stale_explicit_imports, :all_explicit_imports_via_owners, :all_explicit_imports_are_public),  # known-broken; see SciML/OrdinaryDiffEq.jl#3776
 )

--- a/test/qa/qa_tests.jl
+++ b/test/qa/qa_tests.jl
@@ -4,6 +4,20 @@ using ADTypes, CommonSolve, DiffEqBase, OrdinaryDiffEqBDF, OrdinaryDiffEqDefault
     SciMLBase, SciMLLogging
 using Test
 
+@testset "QA JET target configuration" begin
+    lib_dir = joinpath(@__DIR__, "..", "..", "lib")
+    deprecated_overrides = String[]
+    for package in readdir(lib_dir)
+        qa_file = joinpath(lib_dir, package, "test", "qa", "qa.jl")
+        isfile(qa_file) || continue
+        occursin(
+            r"jet_kwargs\s*=\s*\(;\s*target_defined_modules\s*=\s*true\s*\)",
+            read(qa_file, String),
+        ) && push!(deprecated_overrides, qa_file)
+    end
+    @test isempty(deprecated_overrides)
+end
+
 @testset "PureKLU-compatible MuladdMacro floors" begin
     lib_dir = joinpath(@__DIR__, "..", "..", "lib")
     projects = filter(readdir(lib_dir)) do package


### PR DESCRIPTION
## Summary

SciMLTesting 2.10 already scopes run_qa JET checks to target_modules = (pkg,) in :typo mode. This removes the deprecated target_defined_modules = true override from all 12 remaining sublibrary QA files and adds a root QA guard against reintroducing that assignment.

No compatibility changes or source-code changes are included.

## Verification

- GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
  - Quality Assurance Tests | 91 91
- Each affected sublibrary QA environment was developed from this branch and run without the override:
  - OrdinaryDiffEqExplicitTableaus: 21/21
  - OrdinaryDiffEqImplicitTableaus: 21/21
  - OrdinaryDiffEqRosenbrockTableaus: 21/21
  - StochasticDiffEqHighOrder: 21/21
  - StochasticDiffEqIIF: 21/21
  - StochasticDiffEqLevyArea: 21/21
  - StochasticDiffEqLowOrder: 18 pass, 3 expected broken ExplicitImports checks, exit 0
  - StochasticDiffEqRODE: 18 pass, 3 expected broken ExplicitImports checks, exit 0
  - StochasticDiffEqWeak: 17 pass, 4 expected broken ExplicitImports checks, exit 0
- The representative before/after comparison for OrdinaryDiffEqExplicitTableaus was 21/21 with the deprecated override and 21/21 with the default.
- typos over the diff: passed.
- Runic --check over changed Julia files: passed.
- git diff --check: passed.

## Findings left visible

Removing the override does not hide these existing QA findings:

- StochasticDiffEqMilstein: JET reports K may be undefined in src/perform_step/rkmilgeneral.jl:316.
- StochasticDiffEqROCK: JET reports 38 possible errors, including undefined locals in src/perform_step/SROCK_perform_step.jl.
- StochasticDiffEqCore: the QA run reports DiffCache as unrendered public API documentation.

These need separate source or documentation fixes. This PR intentionally does not add jet_broken, change JET scope, or alter compat bounds.

Please ignore this draft until reviewed by @ChrisRackauckas.

## Links

- SciMLTesting repository: https://github.com/SciML/SciMLTesting.jl
- Existing ExplicitImports tracking issue: https://github.com/SciML/OrdinaryDiffEq.jl/issues/3776
