### PR TITLE
NonlinearSolveAlg: solve true DAEProblems, and stop the out-of-place stage aliasing its own iterate

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.9.0"
+version = "2.10.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -457,7 +457,12 @@ end
             nlcache, maxabs(z .- active_u), maxabs(z), fnorm_prev, γΔt
         )
     end
-    nlsolver.ztmp = active_u
+    # `active_u` is the inner cache's own iterate and `step!` updates it in place, so storing
+    # it here would leave `apply_step!` aliasing `nlsolver.z` to that buffer: from the next
+    # iteration on, `z .- active_u` below is identically zero however far the inner solver
+    # moved, and `_uninformative_step` reads that as "made no progress" until the stage runs
+    # out of iterations.
+    nlsolver.ztmp = copy(active_u)
 
     ustep = if nlsolve_f(integrator) isa DAEFunction
         get_dae_uprev(integrator, uprev) .+ z

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -60,7 +60,7 @@ function initialize!(
         integrator.stats.nsolve += cache.cache.stats.nsolve
     end
     if f isa DAEFunction
-        nlp_params = (tmp, α, tstep, invγdt, p, dt, uprev, f)
+        nlp_params = (tmp, α, tstep, invγdt, p, get_dae_uprev(integrator, uprev), f)
     else
         nlp_params = (tmp, γ, α, tstep, invγdt, method, p, dt, f)
     end
@@ -150,7 +150,10 @@ function initialize!(
             end
         end
         if f isa DAEFunction
-            nlp_params = (tmp, ztmp, ustep, γ, α, tstep, k, invγdt, p, dt, f)
+            nlp_params = (
+                tmp, ustep, α, tstep, k, invγdt, p,
+                get_dae_uprev(integrator, uprev), f,
+            )
         else
             nlp_params = (tmp, ustep, γ, α, tstep, k, invγdt, method, p, dt, f)
         end
@@ -456,7 +459,11 @@ end
     end
     nlsolver.ztmp = active_u
 
-    ustep = compute_ustep(tmp, γ, z, method)
+    ustep = if nlsolve_f(integrator) isa DAEFunction
+        get_dae_uprev(integrator, uprev) .+ z
+    else
+        compute_ustep(tmp, γ, z, method)
+    end
     atmp = calculate_residuals(
         z .- active_u, uprev, ustep, opts.abstol, opts.reltol,
         opts.internalnorm, t
@@ -558,7 +565,12 @@ end
     else
         active_u = nlcache isa NonlinearSolveNoInitCache ? innersol.u : get_u(nlcache)
         @.. broadcast = false ztmp = active_u
-        ustep = compute_ustep!(ustep, tmp, γ, z, method)
+        ustep = if nlsolve_f(integrator) isa DAEFunction
+            _uprev = get_dae_uprev(integrator, uprev)
+            @.. broadcast = false ustep = _uprev + z
+        else
+            compute_ustep!(ustep, tmp, γ, z, method)
+        end
         @.. broadcast = false atmp = z - ztmp
         if !(nlcache isa NonlinearSolveNoInitCache)
             cache.stalled = stalled_inner_step(

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
@@ -588,9 +588,11 @@ mutable struct NonlinearSolveCache{uType, tType, rateType, tType2, P, C, JType, 
     jac_config::jcType
     du1::du1Type
     weight::weightType
-    # Smoothed error estimate `W \ tmp` for the `smooth_est` option (into buffer `dz`).
-    # `linsolve` is not a second solver: it aliases the inner NonlinearSolve's own W
-    # factorization (`get_linear_cache`), or is `nothing` when none is reusable (→ raw estimate).
+    # `u`-sized scratch. Holds the smoothed error estimate `W \ tmp` for the `smooth_est`
+    # option, and is what `get_tmp_cache` hands DAE initialization, so the in-place cache
+    # allocates it whether or not `W` is reused. `linsolve` is not a second solver: it aliases
+    # the inner NonlinearSolve's own W factorization (`get_linear_cache`), or is `nothing`
+    # when none is reusable (→ raw estimate).
     dz::dzType
     linsolve::lsType
     W_γdt::tType

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -425,9 +425,26 @@ function build_nlsolver(
     )
 end
 
-function daenlf(ztmp, z, p)
-    tmp, ustep, γ, α, tstep, k, invγdt, _p, dt, f = p
-    return _compute_rhs!(tmp, ztmp, ustep, γ, α, tstep, k, invγdt, _p, dt, f, z)[1]
+# A DAE stage never reuses `W`, so the inner solver differentiates this residual itself and a
+# dual-number backend calls it with a dual `z`; the cache's stage buffers hold the problem's
+# own element type and cannot take the duals.
+@inline function dae_stage_buffers(
+        ustep::AbstractArray{T}, dustep::AbstractArray{T}, ::AbstractArray{T}
+    ) where {T}
+    return ustep, dustep
+end
+@inline function dae_stage_buffers(ustep, dustep, resid)
+    R = eltype(resid)
+    return similar(ustep, R), similar(dustep, R)
+end
+
+# The DAE kernel writes `du` at the stage into its second argument and the residual into its
+# sixth, the reverse of the ODE kernel's single output: `dustep` is scratch, and the residual
+# goes to the buffer the inner solver owns.
+function daenlf(resid, z, p)
+    tmp, ustep, α, tstep, dustep, invγdt, _p, uprev, f = p
+    us, dus = dae_stage_buffers(ustep, dustep, resid)
+    return _compute_rhs!(tmp, dus, us, α, tstep, resid, invγdt, _p, uprev, f, z)[1]
 end
 
 function odenlf(ztmp, z, p)
@@ -802,7 +819,7 @@ function build_nlsolver(
             else
                 nlf = isdae ? daenlf : odenlf
                 nlp_params = if isdae
-                    (tmp, ustep, γ, α, tstep, k, invγdt, p, dt, f)
+                    (tmp, ustep, α, tstep, k, invγdt, p, uprev, f)
                 else
                     (tmp, ustep, γ, α, tstep, k, invγdt, DIRK, p, dt, f)
                 end
@@ -866,7 +883,7 @@ function build_nlsolver(
                 use_w_reuse ? jac_config : nothing,
                 (use_w_reuse && uf !== nothing) ? du1 : nothing,
                 weight,
-                use_w_reuse ? dz : nothing,
+                dz,
                 est_linsolve,
                 zero(tstep), true, false, precondition, postcondition
             )
@@ -944,8 +961,8 @@ function build_nlsolver(
 end
 
 function oopdaenlf(z, p)
-    tmp, α, tstep, invγdt, _p, dt, uprev, f = p
-    return _compute_rhs(tmp, α, tstep, invγdt, p, dt, uprev, f, z)[1]
+    tmp, α, tstep, invγdt, _p, uprev, f = p
+    return _compute_rhs(tmp, α, tstep, invγdt, _p, uprev, f, z)[1]
 end
 
 function oopodenlf(z, p)
@@ -1033,7 +1050,7 @@ function build_nlsolver(
             )
             nlf = isdae ? oopdaenlf : oopodenlf
             nlp_params = if isdae
-                (tmp, α, tstep, invγdt, p, dt, uprev, f)
+                (tmp, α, tstep, invγdt, p, uprev, f)
             else
                 (tmp, γ, α, tstep, invγdt, DIRK, p, dt, f)
             end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_dae_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_dae_tests.jl
@@ -1,0 +1,78 @@
+using OrdinaryDiffEqBDF
+using OrdinaryDiffEqRosenbrock
+using OrdinaryDiffEqNonlinearSolve
+using OrdinaryDiffEqNonlinearSolve: NonlinearSolveAlg
+using NonlinearSolve: NewtonRaphson
+using ADTypes, LinearAlgebra, SciMLBase
+using Test
+
+# Robertson in fully implicit residual form, third equation algebraic. The stage residual of
+# a `DAEProblem` goes through `daenlf`/`oopdaenlf`, which are the only callers of the
+# `DAEFunction` methods of `_compute_rhs!`/`_compute_rhs` — a signature the adapters used to
+# disagree with, so every `NonlinearSolveAlg` call on a true DAE raised a `MethodError`.
+function rober_dae!(out, du, u, p, t)
+    k₁, k₂, k₃ = p
+    out[1] = -k₁ * u[1] + k₃ * u[2] * u[3] - du[1]
+    out[2] = k₁ * u[1] - k₂ * u[2]^2 - k₃ * u[2] * u[3] - du[2]
+    out[3] = u[1] + u[2] + u[3] - 1.0
+    return nothing
+end
+
+function rober_dae(du, u, p, t)
+    k₁, k₂, k₃ = p
+    return [
+        -k₁ * u[1] + k₃ * u[2] * u[3] - du[1],
+        k₁ * u[1] - k₂ * u[2]^2 - k₃ * u[2] * u[3] - du[2],
+        u[1] + u[2] + u[3] - 1.0,
+    ]
+end
+
+# Equivalent singular-mass-matrix ODE, for a reference independent of the DAE solvers.
+function rober_mm!(du, u, p, t)
+    k₁, k₂, k₃ = p
+    du[1] = -k₁ * u[1] + k₃ * u[2] * u[3]
+    du[2] = k₁ * u[1] - k₂ * u[2]^2 - k₃ * u[2] * u[3]
+    du[3] = u[1] + u[2] + u[3] - 1.0
+    return nothing
+end
+
+const P = [0.04, 3.0e7, 1.0e4]
+const U0 = [1.0, 0.0, 0.0]
+const DU0 = [-0.04, 0.04, 0.0]
+const TSPAN = (0.0, 1.0e4)
+const DVARS = [true, true, false]
+
+prob_iip = DAEProblem(rober_dae!, DU0, U0, TSPAN, P; differential_vars = DVARS)
+prob_oop = DAEProblem(
+    DAEFunction{false}(rober_dae), DU0, U0, TSPAN, P; differential_vars = DVARS
+)
+prob_mm = ODEProblem(
+    ODEFunction(rober_mm!; mass_matrix = [1.0 0 0; 0 1.0 0; 0 0 0]), U0, TSPAN, P
+)
+uref = solve(prob_mm, Rodas5P(); reltol = 1.0e-12, abstol = 1.0e-12).u[end]
+
+nsa(ad) = NonlinearSolveAlg(NewtonRaphson(; autodiff = ad))
+
+@testset "NonlinearSolveAlg solves a true DAEProblem" begin
+    @testset "$pname / $aname / $adname" for (pname, prob) in
+            (("in-place", prob_iip), ("out-of-place", prob_oop)),
+            (aname, ALG) in (("DFBDF", DFBDF), ("DImplicitEuler", DImplicitEuler)),
+            (adname, ad) in
+            (("AutoFiniteDiff", AutoFiniteDiff()), ("AutoForwardDiff", AutoForwardDiff()))
+
+        sol = solve(prob, ALG(nlsolve = nsa(ad)); reltol = 1.0e-8, abstol = 1.0e-8)
+        @test SciMLBase.successful_retcode(sol)
+
+        ref = solve(prob, ALG(); reltol = 1.0e-8, abstol = 1.0e-8)
+        @test SciMLBase.successful_retcode(ref)
+
+        # Right answer, not merely a successful retcode: within the accuracy `NLNewton`
+        # itself reaches on this problem at this tolerance.
+        tol = 4 * maximum(abs, (ref.u[end] .- uref) ./ max.(abs.(uref), 1.0e-8)) + 1.0e-6
+        @test maximum(abs, (sol.u[end] .- uref) ./ max.(abs.(uref), 1.0e-8)) < tol
+
+        # And it must get there by taking a comparable number of steps: a stage that never
+        # converges still integrates the problem, just with `dt` driven to nothing.
+        @test 0.25 < sol.stats.naccept / ref.stats.naccept < 4
+    end
+end

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/runtests.jl
@@ -56,6 +56,7 @@ if TEST_GROUP ∉ ("QA", "ModelingToolkit")
     @time @safetestset "NonlinearSolveAlg No-Init Inner Solver Tests" include("nsa_noinit_tests.jl")
     @time @safetestset "NonlinearSolveAlg Preconditioning Tests" include("nsa_conditioning_tests.jl")
     @time @safetestset "NonlinearSolveAlg Residual Convergence Tests" include("nsa_residual_convergence_tests.jl")
+    @time @safetestset "NonlinearSolveAlg DAEProblem Tests" include("nsa_dae_tests.jl")
 end
 
 # Run QA tests (JET, Aqua)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Fixes #4127.

`NonlinearSolveAlg` could not solve a true `DAEProblem` at all — every one threw a `MethodError` from `_compute_rhs!` while the inner cache was being constructed, before a step was taken. `NLNewton` solves the same problems.

```julia
prob = DAEProblem(rober_dae!, du0, u0, (0.0, 1e5), p; differential_vars = [true, true, false])
solve(prob, DFBDF(nlsolve = NonlinearSolveAlg(NewtonRaphson())))
# MethodError: no method matching _compute_rhs!(::Vector, ::Vector, ::Vector, ::Float64, ...)
```

### Four defects, three of them hidden behind the first

**1. The DAE residual adapters disagreed with the kernels they call.** The in-place DAE kernel is `_compute_rhs!(tmp, ztmp, ustep, α, tstep, k, invγdt, p, uprev, f, z)` — no `γ`, and `uprev` where the ODE variant has `dt`. `daenlf` forwarded a `γ` anyway and passed `dt` in `uprev`'s slot. `oopdaenlf` passed the whole parameter tuple where the user's ODE parameters belong, plus a stray `dt`. The parameter tuples built in `build_nlsolver` and `initialize!` disagreed with the adapter's arity as well, which would have silently shifted every binding had the throw not come first (Julia drops trailing elements when destructuring a tuple into fewer names). All three now agree, verified at runtime rather than by reading: `length(p)` is 9 at both construction sites and matches the adapter for in-place, 7 for out-of-place.

**2. DAE initialization wrote into `nothing`.** `get_tmp_cache(integrator, ::DAEAlgorithm, cache)` returns `cache.nlsolver.cache.dz`, but the cache stored `use_w_reuse ? dz : nothing`, and `use_w_reuse = !isdae && …` is false for every DAE. Past defect 1 this is `MethodError: no method matching setindex!(::Nothing, ::Float64, ::Int64)` from `_initialize_dae`. The in-place cache now always keeps `dz` — it was already allocated, and `can_smooth_est` keys off `linsolve` rather than `dz`, so smoothing is unaffected.

**3. The out-of-place stage aliased its own iterate — and this is not DAE-specific.** `compute_step!` did `nlsolver.ztmp = active_u`; `apply_step!` then makes `nlsolver.z` that same buffer, which the inner solver updates in place. From the second iteration `z .- active_u` is structurally zero however far the solver actually moved:

```
iter=1 ndz=58.9255  alias_z_u=false
iter=2 ndz=0.0      alias_z_u=true   <- uninformative, forever
iter=3 ndz=0.0      alias_z_u=true
```

so the stage never reports convergence and `dt` collapses to a denormal. Fixed with `nlsolver.ztmp = copy(active_u)`.

**4. `AutoForwardDiff` could not be used on a DAE stage.** A DAE never reuses `W`, so the inner solver differentiates the residual directly and a dual `z` cannot be written into real-valued buffers. `dae_stage_buffers` widens the two stage buffers to the residual's element type.

### Results

Robertson in residual form, error against an independent reference (index-1 elimination to a 2-variable stiff ODE, `Rodas5P` at rtol 1e-14, cross-checked against `RadauIIA5` — the two agree to 4.9e-9), measured at six points across the trajectory:

```
iip DFBDF NLNewton  1e-12  Success nacc=3585 maxrelerr=4.62e-08 |sum(u)-1|=7.77e-15 min(u)=+7.27e-08
iip DFBDF NSA/FD    1e-12  Success nacc=3715 maxrelerr=1.21e-08 |sum(u)-1|=5.55e-16 min(u)=+7.27e-08
iip DFBDF NSA/AD    1e-12  Success nacc=3703 maxrelerr=5.88e-08 |sum(u)-1|=4.44e-16 min(u)=+7.27e-08
oop DFBDF NSA/FD    1e-09  Success nacc= 980 maxrelerr=1.18e-05 |sum(u)-1|=3.33e-16
```

18 configurations (3 tolerances × in-place/out-of-place × `DFBDF`/`DImplicitEuler`/`DABDF2`). Mass balance holds to machine precision, no negative concentrations, every NSA row within ~6% of `NLNewton`'s step count. All 18 throw on master.

**The out-of-place fix (defect 3) repairs ordinary ODEs too.** Over 178 rows (11 problems × 8 algorithms × both nonlinear solvers): all 88 `NLNewton` rows, all 48 in-place rows, and all 32 StaticArray/scalar out-of-place rows are **byte-identical**. 27 out-of-place vector rows change, and **15 of them were wrong on master** (relative errors 55–172), e.g.

```
massmat-sing-oop  TRBDF2         MaxIters 1.09e+02  ->  Success 1.87e-05
massmat-sing-oop  ImplicitEuler  MaxIters 1.72e+02  ->  Success 2.45e-09
rober-oop         QNDF           MaxIters 1.13e+02  ->  Success 2.58e-07
vdp-oop           Trapezoid      Unstable 1.00e+00  ->  Success 7.93e-09
```

No configuration regressed.

Also verified: index-2 pendulum (NSA correct to 5.6e-9 where `NLNewton` returns `Unstable` and is off by 1.99 in position), DAE initialization from inconsistent initial conditions with `BrownFullBasicInit`/`ShampineCollocationInit`, several `differential_vars` settings, and matrix-free/Krylov DAEs.

### Pre-existing, not touched

- `DABDF2` is `Unstable` at `naccept = 0` on Robertson-DAE under **both** nonlinear solvers, in-place and out-of-place, at all tolerances.
- A sparse `jac_prototype` on a `DAEProblem` throws `FieldError: type DAEFunction has no field mass_matrix` for both solvers.
- `NonlinearSolveAlg(TrustRegion())` reaches the right answer on the DAE but in 51390 steps against 634.

### Tests

New `nsa_dae_tests.jl` (32 assertions): 2 problems × 2 algorithms × 2 AD backends, asserting `successful_retcode`, accuracy within 4× of what `NLNewton` achieves against the reference, and step count within 4× of `NLNewton` so a stage that never converges cannot pass by brute force. On unmodified master all 8 sub-testsets error. All ten existing `nsa_*.jl` files are unchanged at 287 assertions; the other 13 files in the package have identical pass counts and exit codes on master and branch.

Runic clean. `OrdinaryDiffEqNonlinearSolve` 2.9.0 → 2.10.0 — a minor bump rather than a patch, because defect 3 changes out-of-place ODE results (from wrong to right, but it is still a behaviour change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
