### PR TITLE
docs: remove obsolete API QA overrides

### DIFF
--- a/lib/DelayDiffEq/test/qa/qa_tests.jl
+++ b/lib/DelayDiffEq/test/qa/qa_tests.jl
@@ -45,7 +45,6 @@ const EXPLICIT_INTERNAL = (
 
 run_qa(
     DelayDiffEq;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(DelayDiffEq), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     aqua_kwargs = (;
         ambiguities = (; recursive = false),

--- a/lib/DiffEqDevTools/test/qa/qa.jl
+++ b/lib/DiffEqDevTools/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, DiffEqDevTools, Test
 
 run_qa(
     DiffEqDevTools;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(DiffEqDevTools), "..", "..", "docs", "src")),
     aqua_kwargs = (;
         ambiguities = false, piracies = false, unbound_args = false, stale_deps = false,
         deps_compat = (; check_extras = false),

--- a/lib/GlobalDiffEq/test/qa/qa.jl
+++ b/lib/GlobalDiffEq/test/qa/qa.jl
@@ -6,11 +6,6 @@ run_qa(
     GlobalDiffEq;
     reexports_allow = union(public_api_names(DiffEqBase), (:DiffEqBase,)),
     explicit_imports = true,
-    # GlobalDiffEq's rendered documentation lives in the monorepo docs, two
-    # directories up from the sublibrary root.
-    api_docs_kwargs = (;
-        docs_src = joinpath(dirname(dirname(pkgdir(GlobalDiffEq))), "docs", "src"),
-    ),
     ei_kwargs = (;
         all_qualified_accesses_are_public = (;
             # `SciMLBase.__solve` is SciMLBase's internal solve entry point (not

--- a/lib/ImplicitDiscreteSolve/test/qa/qa.jl
+++ b/lib/ImplicitDiscreteSolve/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, ImplicitDiscreteSolve, Test
 
 run_qa(
     ImplicitDiscreteSolve;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(ImplicitDiscreteSolve), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     aqua_kwargs = (; piracies = false),
     explicit_imports = true,

--- a/lib/OrdinaryDiffEqAdamsBashforthMoulton/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqAdamsBashforthMoulton/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqAdamsBashforthMoulton, Test
 
 run_qa(
     OrdinaryDiffEqAdamsBashforthMoulton;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqAdamsBashforthMoulton), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/OrdinaryDiffEqBDF/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqBDF/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqBDF, Test
 
 run_qa(
     OrdinaryDiffEqBDF;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqBDF), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/OrdinaryDiffEqDifferentiation/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/qa/qa.jl
@@ -8,7 +8,6 @@ using SciMLTesting, OrdinaryDiffEqDifferentiation, Test
 # tracked in SciML/OrdinaryDiffEq.jl#3776).
 run_qa(
     OrdinaryDiffEqDifferentiation;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqDifferentiation), "..", "..", "docs", "src")),
     aqua_kwargs = (; piracies = false, ambiguities = false),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqExplicitRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqExplicitRK/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqExplicitRK, Test
 
 run_qa(
     OrdinaryDiffEqExplicitRK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqExplicitRK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqExplicitTableaus/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqExplicitTableaus/test/qa/qa.jl
@@ -3,7 +3,6 @@ using JET
 
 run_qa(
     OrdinaryDiffEqExplicitTableaus;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqExplicitTableaus), "..", "..", "docs", "src")),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
 )

--- a/lib/OrdinaryDiffEqExponentialRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqExponentialRK, Test
 
 run_qa(
     OrdinaryDiffEqExponentialRK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqExponentialRK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/OrdinaryDiffEqFIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/qa/qa.jl
@@ -12,7 +12,6 @@ const THREADING_PUBLIC = (:Sequential, :BaseThreads, :PolyesterThreads)
 # See SciML/OrdinaryDiffEq.jl#3776.
 run_qa(
     OrdinaryDiffEqFIRK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqFIRK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,), THREADING_PUBLIC),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/OrdinaryDiffEqHighOrderRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqHighOrderRK/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqHighOrderRK, Test
 
 run_qa(
     OrdinaryDiffEqHighOrderRK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqHighOrderRK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/OrdinaryDiffEqImplicitTableaus/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqImplicitTableaus/test/qa/qa.jl
@@ -3,7 +3,6 @@ using JET
 
 run_qa(
     OrdinaryDiffEqImplicitTableaus;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqImplicitTableaus), "..", "..", "docs", "src")),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
 )

--- a/lib/OrdinaryDiffEqLinear/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqLinear/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqLinear, Test
 
 run_qa(
     OrdinaryDiffEqLinear;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqLinear), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqLowOrderRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqLowOrderRK/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqLowOrderRK, Test
 
 run_qa(
     OrdinaryDiffEqLowOrderRK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqLowOrderRK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqLowStorageRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqLowStorageRK/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqLowStorageRK, Test
 
 run_qa(
     OrdinaryDiffEqLowStorageRK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqLowStorageRK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/OrdinaryDiffEqNordsieck/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqNordsieck/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqNordsieck, Test
 
 run_qa(
     OrdinaryDiffEqNordsieck;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqNordsieck), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqRKN/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqRKN/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqRKN, Test
 
 run_qa(
     OrdinaryDiffEqRKN;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqRKN), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqRosenbrock/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/qa/qa.jl
@@ -27,7 +27,6 @@ const ROSENBROCK_INTERNAL_QUALIFIED_ACCESSES = (
 
 run_qa(
     OrdinaryDiffEqRosenbrock;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqRosenbrock), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/OrdinaryDiffEqRosenbrockTableaus/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqRosenbrockTableaus/test/qa/qa.jl
@@ -3,7 +3,6 @@ using JET
 
 run_qa(
     OrdinaryDiffEqRosenbrockTableaus;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqRosenbrockTableaus), "..", "..", "docs", "src")),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
 )

--- a/lib/OrdinaryDiffEqSDIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/qa/qa.jl
@@ -12,7 +12,6 @@ using SciMLTesting, OrdinaryDiffEqSDIRK, Test
 #     `@truncate_stacktrace`).
 run_qa(
     OrdinaryDiffEqSDIRK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqSDIRK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:Predictor, :SciMLBase)),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/OrdinaryDiffEqSSPRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqSSPRK/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqSSPRK, Test
 
 run_qa(
     OrdinaryDiffEqSSPRK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqSSPRK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/OrdinaryDiffEqStabilizedIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqStabilizedIRK/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqStabilizedIRK, Test
 
 run_qa(
     OrdinaryDiffEqStabilizedIRK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqStabilizedIRK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqStabilizedRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqStabilizedRK, Test
 
 run_qa(
     OrdinaryDiffEqStabilizedRK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqStabilizedRK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/OrdinaryDiffEqSymplecticRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqSymplecticRK/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqSymplecticRK, Test
 
 run_qa(
     OrdinaryDiffEqSymplecticRK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqSymplecticRK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
 )

--- a/lib/OrdinaryDiffEqTsit5/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqTsit5/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqTsit5, Test
 
 run_qa(
     OrdinaryDiffEqTsit5;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqTsit5), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (;

--- a/lib/OrdinaryDiffEqVerner/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqVerner/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, OrdinaryDiffEqVerner, Test
 
 run_qa(
     OrdinaryDiffEqVerner;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(OrdinaryDiffEqVerner), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(SciMLBase), (:SciMLBase,)),
     explicit_imports = true,
     ei_kwargs = (

--- a/lib/StochasticDiffEqCore/test/qa/qa.jl
+++ b/lib/StochasticDiffEqCore/test/qa/qa.jl
@@ -97,7 +97,6 @@ const SDEC_TYPE_ALIASES = (:SDEIntegrator, :SDEOptions)
 
 run_qa(
     StochasticDiffEqCore;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqCore), "..", "..", "docs", "src")),
     # `@reexport using DiffEqBase` pulls in DiffEqBase's own API plus its SciMLBase
     # re-export. `names(DiffEqBase)` only propagates SciMLBase's *exports*, so SciMLBase's
     # `public`-but-unexported API (`alg_order`, `isadaptive`) needs its own union entry.

--- a/lib/StochasticDiffEqHighOrder/test/qa/qa.jl
+++ b/lib/StochasticDiffEqHighOrder/test/qa/qa.jl
@@ -3,7 +3,6 @@ using JET
 
 run_qa(
     StochasticDiffEqHighOrder;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqHighOrder), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,

--- a/lib/StochasticDiffEqIIF/test/qa/qa.jl
+++ b/lib/StochasticDiffEqIIF/test/qa/qa.jl
@@ -3,7 +3,6 @@ using JET
 
 run_qa(
     StochasticDiffEqIIF;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqIIF), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,

--- a/lib/StochasticDiffEqImplicit/test/qa/qa.jl
+++ b/lib/StochasticDiffEqImplicit/test/qa/qa.jl
@@ -3,7 +3,6 @@ using JET
 
 run_qa(
     StochasticDiffEqImplicit;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqImplicit), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
     # Scope JET to this package in `:typo` mode, matching the OrdinaryDiffEq* solver
     # sublibraries. The deprecated `target_defined_modules = true` also reported

--- a/lib/StochasticDiffEqLeaping/test/qa/qa.jl
+++ b/lib/StochasticDiffEqLeaping/test/qa/qa.jl
@@ -3,7 +3,6 @@ using JET
 
 run_qa(
     StochasticDiffEqLeaping;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqLeaping), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
     # Scope JET to this package in `:typo` mode (the OrdinaryDiffEq* solver-sublibrary
     # convention); `target_defined_modules = true` is deprecated in JET.

--- a/lib/StochasticDiffEqLevyArea/test/qa/qa.jl
+++ b/lib/StochasticDiffEqLevyArea/test/qa/qa.jl
@@ -3,7 +3,6 @@ using JET
 
 run_qa(
     StochasticDiffEqLevyArea;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqLevyArea), "..", "..", "docs", "src")),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,
 )

--- a/lib/StochasticDiffEqLowOrder/test/qa/qa.jl
+++ b/lib/StochasticDiffEqLowOrder/test/qa/qa.jl
@@ -3,7 +3,6 @@ using JET
 
 run_qa(
     StochasticDiffEqLowOrder;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqLowOrder), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,

--- a/lib/StochasticDiffEqMilstein/test/qa/qa.jl
+++ b/lib/StochasticDiffEqMilstein/test/qa/qa.jl
@@ -3,7 +3,6 @@ using JET
 
 run_qa(
     StochasticDiffEqMilstein;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqMilstein), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,

--- a/lib/StochasticDiffEqROCK/test/qa/qa.jl
+++ b/lib/StochasticDiffEqROCK/test/qa/qa.jl
@@ -3,7 +3,6 @@ using JET
 
 run_qa(
     StochasticDiffEqROCK;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqROCK), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,

--- a/lib/StochasticDiffEqRODE/test/qa/qa.jl
+++ b/lib/StochasticDiffEqRODE/test/qa/qa.jl
@@ -3,7 +3,6 @@ using JET
 
 run_qa(
     StochasticDiffEqRODE;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqRODE), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,

--- a/lib/StochasticDiffEqWeak/test/qa/qa.jl
+++ b/lib/StochasticDiffEqWeak/test/qa/qa.jl
@@ -3,7 +3,6 @@ using JET
 
 run_qa(
     StochasticDiffEqWeak;
-    api_docs_kwargs = (; docs_src = joinpath(pkgdir(StochasticDiffEqWeak), "..", "..", "docs", "src")),
     reexports_allow = union(public_api_names(StochasticDiffEqCore), (:StochasticDiffEqCore,)),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,


### PR DESCRIPTION
## Summary

- Remove 38 obsolete repository-specific `api_docs_kwargs` overrides.
- Rely on SciMLTesting's standard rendered API-doc and monorepo docs discovery.
- Remove GlobalDiffEq's obsolete rendered/reexport-ignore override.
- Preserve existing JET configuration and intentional reexport allowances.

This is a focused replacement for https://github.com/SciML/OrdinaryDiffEq.jl/pull/4275. It changes only docs QA configuration; no runtime code, public API definitions, or tests were changed.

## Verification

- `git diff --check`: passed.
- Runic check over all changed Julia files: passed.
- `typos` over changed files: passed.
- `GROUP=OrdinaryDiffEqExplicitRK_QA julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: passed; Generic RK 19/19, Allocation 1/1, Aqua 21/21, JET 1 pass + 2 broken.
- `GROUP=GlobalDiffEq_QA julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: passed; QA 23 pass + 1 broken.
- `JULIA_DEPOT_PATH=.odeqa-depot:/home/crackauc/.julia timeout 3600 julia +1.12 --startup-file=no --project=docs docs/make.jl`: exited 0. Documenter emitted existing warnings about duplicate/missing bindings and generated-file size, but the build completed successfully.

Please ignore this draft until reviewed by @ChrisRackauckas.
