### PR TITLE
Fix TaylorIntegration downstream imports from OrdinaryDiffEqCore

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
+++ b/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
@@ -77,10 +77,13 @@ using SciMLBase: NoInit, CheckInit, OverrideInit, AbstractDEProblem, _unwrap_val
     ODEAliasSpecifier
 
 # Names previously relied on implicitly through `@reexport using SciMLBase`.
+# `ODEFunction` and `DynamicalODEProblem` are also imported here for external
+# solver extensions such as TaylorIntegrationDiffEqExt, which intentionally
+# depends on OrdinaryDiffEqCore rather than the umbrella package.
 using SciMLBase: SciMLBase, CallbackSet, ContinuousCallback, DAEProblem,
-    DAESolution, DiscreteProblem, DynamicalODEFunction,
+    DAESolution, DiscreteProblem, DynamicalODEFunction, DynamicalODEProblem,
     IntervalNonlinearProblem, NonlinearLeastSquaresProblem,
-    ODEProblem, ReturnCode, SplitFunction, SplitSDEFunction,
+    ODEFunction, ODEProblem, ReturnCode, SplitFunction, SplitSDEFunction,
     VectorContinuousCallback, auto_dt_reset!, derivative_discontinuity!,
     get_tmp_cache, isinplace, reinit!
 const LinearAliasSpecifier = SciMLBase.LinearAliasSpecifier

--- a/lib/OrdinaryDiffEqCore/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqCore/test/qa/qa.jl
@@ -29,7 +29,8 @@ run_qa(
             ignore = (
                 :BrownFullBasicInit, :ShampineCollocationInit, :DEVerbosity,
                 :Minimal, :_vec, :_reshape, :unwrap_cache, :_unwrap_val,
-                :calculate_residuals, :calculate_residuals!,
+                :calculate_residuals, :calculate_residuals!, :DynamicalODEProblem,
+                :ODEFunction,
             ),
         ),
         # Internal (non-`public`) names of upstream packages that OrdinaryDiffEqCore
@@ -46,7 +47,8 @@ run_qa(
                 :enable_interpolation_sensitivitymode,
                 :forwarddiff_chunksize, :get_root_indp,
                 :get_save_idxs_and_saved_subsystem, :has_initializeprob,
-                :has_lazy_interpolation, :late_binding_update_u0_p, :remaker_of,
+                :has_lazy_interpolation, :has_mtk_sys, :late_binding_update_u0_p,
+                :log_numerical_instability, :remaker_of,
                 :save_discretes_if_enabled!, :save_final_discretes!,
                 :strip_interpolation, :struct_as_namedtuple, :unitfulvalue,
                 :unwrap_cache, :value,

--- a/lib/OrdinaryDiffEqCore/test/runtests.jl
+++ b/lib/OrdinaryDiffEqCore/test/runtests.jl
@@ -32,6 +32,13 @@ end
 
 # Functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
+    @time @safetestset "SciMLBase constructor bindings" begin
+        using OrdinaryDiffEqCore: DynamicalODEProblem, ODEFunction
+        using SciMLBase, Test
+
+        @test ODEFunction === SciMLBase.ODEFunction
+        @test DynamicalODEProblem === SciMLBase.DynamicalODEProblem
+    end
     @time @safetestset "Developer Time Queue API" include("developer_time_queue_api_tests.jl")
     @time @safetestset "Developer Codegen API" include("developer_codegen_api_tests.jl")
     @time @safetestset "Sparse isdiag Performance" include("sparse_isdiag_tests.jl")


### PR DESCRIPTION
## Summary

Restore the `SciMLBase.ODEFunction` and `SciMLBase.DynamicalODEProblem` bindings in `OrdinaryDiffEqCore`. TaylorIntegration intentionally imports these names from OrdinaryDiffEqCore, so removing the former blanket SciMLBase reexport broke the downstream extension. The regression test verifies that the Core bindings are the owner bindings.

No TaylorIntegration files were changed and no upstream issue was opened. The failure was introduced by [`4ca8a4c2c`](https://github.com/SciML/OrdinaryDiffEq.jl/commit/4ca8a4c2c), which removed Core's blanket SciMLBase reexport.

## Before/after evidence

On a clean depot with an unmodified TaylorIntegration checkout and OrdinaryDiffEqCore at the pre-fix revision, the extension failed during precompilation:

```text
TaylorIntegration -> TaylorIntegrationDiffEqExt
ERROR: LoadError: UndefVarError: `ODEFunction` not defined
in TaylorIntegrationDiffEqExt.jl:3
```

With this branch substituted into the same clean-depot setup, the exact reproducer completed successfully:

```text
5 dependencies successfully precompiled
TaylorIntegration extension loaded with fixed OrdinaryDiffEqCore
```

The reproducer also asserts:

```julia
OrdinaryDiffEqCore.ODEFunction === SciMLBase.ODEFunction
OrdinaryDiffEqCore.DynamicalODEProblem === SciMLBase.DynamicalODEProblem
```

## Verification

- `GROUP=Core /home/crackauc/packages/julias/julia-1.12/bin/julia --startup-file=no --project=lib/OrdinaryDiffEqCore -e "using Pkg; Pkg.test()"`: passed; `SciMLBase constructor bindings | 2 | 2`, and the package reported `tests passed`.
- `GROUP=QA /home/crackauc/packages/julias/julia-1.12/bin/julia --startup-file=no --project=lib/OrdinaryDiffEqCore -e "using Pkg; Pkg.test()"`: passed; AllocCheck `1/1`, JET `30 passed, 1 broken, 31 total`, Aqua `26/26`.
- Runic checked all `1,068` Julia files: passed.
- Changed-file `typos`: passed.
- `git diff --check`: passed.

The QA allowlist additions are for the pre-existing Core methods extending SciMLBase's internal `has_mtk_sys` and `log_numerical_instability` hooks; they have no public replacement.

This PR is a draft and should be ignored until reviewed by @ChrisRackauckas.
