### PR TITLE
docs: specify the OrdinaryDiffEq algorithm extension contract

### DIFF
--- a/docs/src/devtools/internals/public_api.md
+++ b/docs/src/devtools/internals/public_api.md
@@ -59,6 +59,37 @@ OrdinaryDiffEqCore.@fold
 
 Every solver subtypes one of these abstract algorithm types.
 
+### Minimal algorithm contract
+
+Solver packages should subtype the narrowest applicable algorithm type, define
+the order, and then implement the cache and stepping hooks. The generic trait
+defaults are intentional: an explicit fixed-step method needs only the methods
+below before adding its cache and stepping implementation.
+
+```julia
+using OrdinaryDiffEqCore: OrdinaryDiffEqAlgorithm
+
+struct MyEuler <: OrdinaryDiffEqAlgorithm end
+OrdinaryDiffEqCore.alg_order(::MyEuler) = 1
+OrdinaryDiffEqCore.isfsal(::MyEuler) = false
+
+@assert !OrdinaryDiffEqCore.isadaptive(MyEuler())
+@assert !OrdinaryDiffEqCore.isimplicit(MyEuler())
+```
+
+The complete solver implementation then supplies:
+
+1. `alg_cache(alg, ...)`, returning an `OrdinaryDiffEqConstantCache` or
+   `OrdinaryDiffEqMutableCache`.
+2. `initialize!(integrator, cache)`, initializing FSAL and cache state.
+3. `perform_step!(integrator, cache, repeat_step = false)`, writing the candidate
+   state to `integrator.u` and the error estimate to `integrator.EEst`.
+
+Adaptive methods subtype `OrdinaryDiffEqAdaptiveAlgorithm` and must provide an
+embedded error estimate suitable for the controller. Implicit methods subtype
+`OrdinaryDiffEqImplicitAlgorithm` and must provide the nonlinear-solver cache
+and stage operations expected by the selected `nlsolve` configuration.
+
 ```@docs
 OrdinaryDiffEqCore.OrdinaryDiffEqAlgorithm
 OrdinaryDiffEqCore.OrdinaryDiffEqAdaptiveAlgorithm

--- a/lib/OrdinaryDiffEqCore/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqCore/src/algorithms.jl
@@ -7,6 +7,25 @@ the more specific abstract types below (adaptive / implicit / exponential / …)
 rather than this root directly. Trait functions such as [`isadaptive`](@ref),
 [`isimplicit`](@ref), [`isfsal`](@ref), and [`alg_order`](@ref) dispatch on this
 hierarchy.
+
+# Extension contract
+
+A solver subtype must provide an `alg_cache` method and matching
+[`initialize!`](@ref) and [`perform_step!`](@ref) methods. It should also define
+[`alg_order`](@ref) and override only the traits whose behavior differs from the
+defaults. The cache type must be either an
+[`OrdinaryDiffEqConstantCache`](@ref) or an
+[`OrdinaryDiffEqMutableCache`](@ref).
+
+# Example
+
+```julia
+using OrdinaryDiffEqCore: OrdinaryDiffEqAlgorithm
+
+struct MyEuler <: OrdinaryDiffEqAlgorithm end
+OrdinaryDiffEqCore.alg_order(::MyEuler) = 1
+OrdinaryDiffEqCore.isfsal(::MyEuler) = false
+```
 """
 abstract type OrdinaryDiffEqAlgorithm <: SciMLBase.AbstractODEAlgorithm end
 """
@@ -15,6 +34,21 @@ abstract type OrdinaryDiffEqAlgorithm <: SciMLBase.AbstractODEAlgorithm end
 Abstract supertype for explicit ODE algorithms that support adaptive step-size
 control (they carry an embedded error estimate). Subtyping this makes
 [`isadaptive`](@ref) return `true`.
+
+An adaptive algorithm must also provide an error estimate in
+[`perform_step!`](@ref) and a controller-compatible [`alg_order`](@ref). Use
+[`OrdinaryDiffEqAdaptiveImplicitAlgorithm`](@ref) instead when each step solves
+a nonlinear system.
+
+# Example
+
+```julia
+using OrdinaryDiffEqCore: OrdinaryDiffEqAdaptiveAlgorithm
+
+struct MyAdaptive <: OrdinaryDiffEqAdaptiveAlgorithm end
+OrdinaryDiffEqCore.alg_order(::MyAdaptive) = 4
+@assert OrdinaryDiffEqCore.isadaptive(MyAdaptive())
+```
 """
 abstract type OrdinaryDiffEqAdaptiveAlgorithm <: OrdinaryDiffEqAlgorithm end
 """
@@ -175,6 +209,22 @@ OrdinaryDiffEqAdaptiveImplicitAlgorithm end
 
 Abstract supertype for implicit ODE algorithms (those that solve a nonlinear
 system each step). Subtyping this makes [`isimplicit`](@ref) return `true`.
+
+An implicit algorithm must provide the nonlinear-solver cache and stage methods
+expected by [`alg_cache`](@ref), [`initialize!`](@ref), and
+[`perform_step!`](@ref). Its package should document the accepted `nlsolve` and
+linear-solver options and whether Jacobian reuse is supported by
+[`alg_can_repeat_jac`](@ref).
+
+# Example
+
+```julia
+using OrdinaryDiffEqCore: OrdinaryDiffEqImplicitAlgorithm
+
+struct MyImplicit <: OrdinaryDiffEqImplicitAlgorithm end
+OrdinaryDiffEqCore.alg_order(::MyImplicit) = 2
+@assert OrdinaryDiffEqCore.isimplicit(MyImplicit())
+```
 """
 abstract type OrdinaryDiffEqImplicitAlgorithm <:
 OrdinaryDiffEqAlgorithm end

--- a/lib/OrdinaryDiffEqCore/test/algorithm_interface_tests.jl
+++ b/lib/OrdinaryDiffEqCore/test/algorithm_interface_tests.jl
@@ -1,0 +1,31 @@
+using OrdinaryDiffEqCore: OrdinaryDiffEqAlgorithm,
+    OrdinaryDiffEqAdaptiveAlgorithm, OrdinaryDiffEqImplicitAlgorithm,
+    isadaptive, isdtchangeable, isimplicit
+import OrdinaryDiffEqCore: alg_order, isfsal
+using Test
+
+struct GenericExplicitAlgorithm <: OrdinaryDiffEqAlgorithm end
+struct GenericAdaptiveAlgorithm <: OrdinaryDiffEqAdaptiveAlgorithm end
+struct GenericImplicitAlgorithm <: OrdinaryDiffEqImplicitAlgorithm end
+
+alg_order(::GenericExplicitAlgorithm) = 1
+alg_order(::GenericAdaptiveAlgorithm) = 4
+alg_order(::GenericImplicitAlgorithm) = 2
+isfsal(::GenericExplicitAlgorithm) = false
+
+@testset "Generic algorithm trait contract" begin
+    explicit = GenericExplicitAlgorithm()
+    adaptive = GenericAdaptiveAlgorithm()
+    implicit = GenericImplicitAlgorithm()
+
+    @test alg_order(explicit) == 1
+    @test alg_order(adaptive) == 4
+    @test alg_order(implicit) == 2
+    @test !isadaptive(explicit)
+    @test isadaptive(adaptive)
+    @test !isimplicit(explicit)
+    @test isimplicit(implicit)
+    @test !isfsal(explicit)
+    @test isfsal(adaptive)
+    @test isdtchangeable(implicit)
+end

--- a/lib/OrdinaryDiffEqCore/test/runtests.jl
+++ b/lib/OrdinaryDiffEqCore/test/runtests.jl
@@ -32,6 +32,7 @@ end
 
 # Functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
+    @time @safetestset "Generic algorithm trait contract" include("algorithm_interface_tests.jl")
     @time @safetestset "SciMLBase constructor bindings" begin
         using OrdinaryDiffEqCore: DynamicalODEProblem, ODEFunction
         using SciMLBase, Test


### PR DESCRIPTION
## Summary

- Expand the original docstrings for `OrdinaryDiffEqAlgorithm`, `OrdinaryDiffEqAdaptiveAlgorithm`, and `OrdinaryDiffEqImplicitAlgorithm` with extension rules and runnable examples.
- Add a developer-facing minimal algorithm contract to the existing Core public API page.
- Add generic trait tests that define only minimal algorithm subtypes and use the generic Core interface.

This is documentation and interface-contract coverage only; it does not change solver behavior or add a new public name. Please ignore this draft until reviewed by @ChrisRackauckas.

## Verification

- `GROUP=OrdinaryDiffEqCore_Core julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` passed; the new Generic algorithm trait contract was 10/10 and the existing Core groups passed.
- `GROUP=OrdinaryDiffEqCore_QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` completed successfully; final reported QA summary was 1/1.
- Julia Runic formatting check passed for all changed Julia files.
- `typos --diff && git diff --check` passed.
- `julia --startup-file=no --project=docs docs/make.jl` was attempted. Documenter stopped on the pre-existing unresolved `SciMLBase.has_global_error` cross-reference in `docs/src/api/common_interface.md`; this branch contains no `has_global_error` source or docs change.