### PR TITLE
Allow transformed calls through the parameter barrier

### DIFF
--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.15.0"
+version = "7.15.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/DiffEqBase/src/solve.jl
+++ b/lib/DiffEqBase/src/solve.jl
@@ -839,8 +839,9 @@ Base.@inline @generated function _invoke_parameter_despecialization(
         f, args::Tuple{Vararg{Any, N}}
     ) where {N}
     parameter_indices = findall(T -> T <: SciMLBase.DespecializedParameters, args.parameters)
-    length(parameter_indices) == 1 ||
-        error("a parameter-despecialization barrier requires exactly one parameter wrapper")
+    length(parameter_indices) <= 1 ||
+        error("a parameter-despecialization barrier accepts at most one parameter wrapper")
+    isempty(parameter_indices) && return :(_invoke_parameter_despecialization(f, args...))
     parameter_index = only(parameter_indices)
     call_args = [
         i == parameter_index ? :(SciMLBase.unwrap_parameters(args[$i])) : :(args[$i])

--- a/lib/DiffEqBase/test/despecialized_p_test.jl
+++ b/lib/DiffEqBase/test/despecialized_p_test.jl
@@ -114,6 +114,11 @@ concretize(prob, alg = nothing) = DiffEqBase.get_concrete_problem(prob, true; al
     @test du == [-0.5]
     @test seen_rhs_parameter[] === DynamicP
 
+    barrier = DiffEqBase.ParameterDespecializationWrapper(dynamic_rhs!)
+    barrier(du, first_prob.u0, SciMLBase.unwrap_parameters(first_prob.p), 0.0)
+    @test du == [-0.5]
+    @test seen_rhs_parameter[] === DynamicP
+
     J = zeros(1, 1)
     first_prob.f.jac(J, first_prob.u0, first_prob.p, 0.0)
     @test J == [-0.5;;]


### PR DESCRIPTION
## What changed

Allow `ParameterDespecializationWrapper` to invoke its noinline call barrier when an AD transform has already unwrapped the parameter argument. The wrapper still unwraps one `DespecializedParameters` argument itself and still rejects calls containing more than one wrapper.

This is required by the Enzyme/Mooncake paths reached by ModelingToolkit's `AutoDespecialize` support in https://github.com/SciML/ModelingToolkit.jl/pull/4919.

Ignore this PR until reviewed by @ChrisRackauckas.

## Failing before / passing after

The focused call used an already-unwrapped parameter vector with `ParameterDespecializationWrapper`.

Before:

```text
ERROR: a parameter-despecialization barrier requires exactly one parameter wrapper
```

After, using the identical call:

```text
unwrapped_barrier_call=pass
```

The owner regression also covers the normal wrapped call. Its four testsets pass with `17 + 3 + 3 + 23 = 46` assertions.

## Verification

```text
GROUP=Core julia +1.12 --startup-file=no --project=lib/DiffEqBase -e 'using Pkg; Pkg.test()'
Despecialized-p Hook | 46 / 46
Testing DiffEqBase tests passed

GROUP=QA julia +1.12 --startup-file=no --project=lib/DiffEqBase -e 'using Pkg; Pkg.test()'
Aqua | 9 / 9
Testing DiffEqBase tests passed
```

The exact SciMLSensitivity `Core8` downstream environment from https://github.com/SciML/ModelingToolkit.jl/pull/4919 was also run with this patch and the matching SciMLSensitivity owner patch:

```text
before: Core 8 | 35 pass | 5 error | 5 broken
after:  Core 8 | 45 pass | 5 broken | 50 total | 108m24.9s
Testing SciMLSensitivity tests passed
```

Runic 1.8, added-line `typos`, and `git diff --check` pass.

## Not verified

GPU and allowed-to-fail prerelease jobs were not run locally. No public API or documentation changed, so no docs build was required.
