### PR TITLE
Run runic on docstrings and markdown

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,9 +50,11 @@ Most of the breaking changes fall into a small set of recurring themes. Keep the
 
   # v7 — a typed object
   Rosenbrock23(autodiff = AutoForwardDiff())
-  solve(prob, alg;
+  solve(
+      prob, alg;
       verbose = DEVerbosity(SciMLLogging.None()),
-      alias = ODEAliasSpecifier(alias_u0 = true))
+      alias = ODEAliasSpecifier(alias_u0 = true)
+  )
   ```
 
   The `Bool` form chose between code paths (e.g. ForwardDiff vs. FiniteDiff for `autodiff`) at runtime, so the choice was invisible to the compiler; the typed object carries that choice in its type, so the solver specializes on it at compile time. The same swap applies to `lazy` (now `Val{true}()` / `Val{false}()`). See the per-keyword before/after sections below ([`autodiff`](#autodiff-bool-no-longer-accepted), [`verbose`](#verbose-bool-no-longer-accepted), [`alias`](#alias-bool-no-longer-accepted), [`lazy`](#lazy-keyword-bool-no-longer-accepted)) for the full migration of each.
@@ -294,12 +296,12 @@ Across all implicit/Rosenbrock/BDF/SDIRK/FIRK/Exponential constructors:
 
 ```julia
 # v6
-Rosenbrock23(autodiff=true)   # worked
-Rosenbrock23(autodiff=false)  # worked
+Rosenbrock23(autodiff = true)   # worked
+Rosenbrock23(autodiff = false)  # worked
 
 # v7 — must use ADTypes
-Rosenbrock23(autodiff=AutoForwardDiff())
-Rosenbrock23(autodiff=AutoFiniteDiff())
+Rosenbrock23(autodiff = AutoForwardDiff())
+Rosenbrock23(autodiff = AutoFiniteDiff())
 ```
 
 **Why:** type stability. `autodiff::Bool` forced a runtime branch between AD backends that the compiler couldn't specialize through; `autodiff::AbstractADType` dispatches at compile time. This is also what enables the "generalizes beyond ForwardDiff" story — you can now pass `AutoEnzyme()`, `AutoZygote()`, `AutoMooncake()`, etc., and the solver specializes correctly.
@@ -308,10 +310,10 @@ Rosenbrock23(autodiff=AutoFiniteDiff())
 
 ```julia
 # v6
-solve(prob, alg, verbose=false)
+solve(prob, alg, verbose = false)
 
 # v7 — must use DEVerbosity
-solve(prob, alg, verbose=DEVerbosity(SciMLLogging.None()))
+solve(prob, alg, verbose = DEVerbosity(SciMLLogging.None()))
 ```
 
 **Why:** same type-stability reason, plus `DEVerbosity` exposes fine-grained control (separate levels for nonlinear solver, linear solver, initialization, etc.) that a single `Bool` can't express.
@@ -322,10 +324,10 @@ solve(prob, alg, verbose=DEVerbosity(SciMLLogging.None()))
 
 ```julia
 # v6
-solve(prob, alg, alias=true)
+solve(prob, alg, alias = true)
 
 # v7 — must use ODEAliasSpecifier
-solve(prob, alg, alias=ODEAliasSpecifier(alias_u0=true))
+solve(prob, alg, alias = ODEAliasSpecifier(alias_u0 = true))
 ```
 
 Deprecated `alias_u0` / `alias_du0` keyword shortcuts also removed — they already printed warnings on v6. Update to `alias = ODEAliasSpecifier(alias_u0=…, alias_du0=…)` on v6 first, then upgrade.
@@ -342,7 +344,7 @@ solve(prob, Rodas5P())
 solve(prob, Rodas5P())  # throws if u0 is inconsistent
 
 # v7 — explicit opt-in to automatic fixing
-solve(prob, Rodas5P(), initializealg=BrownFullBasicInit())
+solve(prob, Rodas5P(), initializealg = BrownFullBasicInit())
 ```
 
 **Why:** silently fixing an inconsistent DAE initial condition produced wrong answers when the user's `u0` was actually correct but a modeling bug elsewhere made the system look inconsistent. The new default errors loudly; users who want the old "just fix it" behavior opt in explicitly via `initializealg=BrownFullBasicInit()`.
@@ -483,6 +485,7 @@ function affect!(integrator, event_index)
     elseif event_index == 2
         # ball 2 hit the ground
     end
+    return
 end
 cb = VectorContinuousCallback(condition, affect!, affect_neg!, 2)
 
@@ -497,6 +500,7 @@ function affect!(integrator, simultaneous_events)
             # ball 2 hit the ground
         end
     end
+    return
 end
 cb = VectorContinuousCallback(condition, affect!, 2)
 ```

--- a/README.md
+++ b/README.md
@@ -39,10 +39,12 @@ f(u, p, t) = 1.01 * u
 u0 = 1 / 2
 tspan = (0.0, 1.0)
 prob = ODEProblem(f, u0, tspan)
-sol = solve(prob, Tsit5(), reltol = 1e-8, abstol = 1e-8)
+sol = solve(prob, Tsit5(), reltol = 1.0e-8, abstol = 1.0e-8)
 using Plots
-plot(sol, linewidth = 5, title = "Solution to the linear ODE with a thick line",
-    xaxis = "Time (t)", yaxis = "u(t) (in μm)", label = "My Thick Line!") # legend=false
+plot(
+    sol, linewidth = 5, title = "Solution to the linear ODE with a thick line",
+    xaxis = "Time (t)", yaxis = "u(t) (in μm)", label = "My Thick Line!", # legend = false
+)
 plot!(sol.t, t -> 0.5 * exp(1.01 * t), lw = 3, ls = :dash, label = "True Solution!")
 ```
 
@@ -54,6 +56,7 @@ function lorenz!(du, u, p, t)
     du[1] = 10.0 * (u[2] - u[1])
     du[2] = u[1] * (28.0 - u[3]) - u[2]
     du[3] = u[1] * u[2] - (8 / 3) * u[3]
+    return
 end
 u0 = [1.0; 0.0; 0.0]
 tspan = (0.0, 100.0)
@@ -66,9 +69,10 @@ plot(sol, idxs = (1, 2, 3))
 Very fast static array versions can be specifically compiled to the size of your model. For example:
 
 ```julia
-using OrdinaryDiffEq, StaticArrays
+using OrdinaryDiffEq
+using StaticArrays: SA
 function lorenz(u, p, t)
-    SA[10.0 * (u[2] - u[1]), u[1] * (28.0 - u[3]) - u[2], u[1] * u[2] - (8 / 3) * u[3]]
+    return SA[10.0 * (u[2] - u[1]), u[1] * (28.0 - u[3]) - u[2], u[1] * u[2] - (8 / 3) * u[3]]
 end
 u0 = SA[1.0; 0.0; 0.0]
 tspan = (0.0, 100.0)
@@ -90,6 +94,7 @@ using OrdinaryDiffEq
 function harmonic_oscillator!(dv, v, u, p, t)
     ω = p[1]
     dv[1] = -ω^2 * u[1]
+    return
 end
 ω = 2.0  # angular frequency
 initial_position = [1.0]
@@ -106,9 +111,9 @@ For more complex dynamical systems, such as the Hénon-Heiles potential, symplec
 ```julia
 function HH_acceleration!(dv, v, u, p, t)
     x, y = u
-    dx, dy = dv
-    dv[1] = -x - 2 * x * y
-    dv[2] = y^2 - y - x^2
+    dv[1] = dx = -x - 2 * x * y
+    dv[2] = dy = y^2 - y - x^2
+    return
 end
 initial_positions = [0.0, 0.1]
 initial_velocities = [0.5, 0.0]

--- a/docs/src/api/controllers.md
+++ b/docs/src/api/controllers.md
@@ -196,11 +196,11 @@ controllers should too so they compose with each other and with
 ```julia
 using OrdinaryDiffEqCore
 using OrdinaryDiffEqCore: AbstractController, AbstractControllerCache,
-                         CommonControllerOptions, resolve_basic,
-                         _resolved_QT, get_EEst, get_current_adaptive_order,
-                         get_current_qmax, fastpower
+    CommonControllerOptions, resolve_basic,
+    _resolved_QT, get_EEst, get_current_adaptive_order,
+    get_current_qmax, fastpower
 import OrdinaryDiffEqCore: setup_controller_cache, stepsize_controller!,
-                          step_accept_controller!, step_reject_controller!
+    step_accept_controller!, step_reject_controller!
 
 # Type-stability trick: `basic` is either a `NamedTuple` of user-supplied
 # overrides (before setup_controller_cache resolves it) or a fully-resolved

--- a/docs/src/devtools/alg_dev/benchmarks.md
+++ b/docs/src/devtools/alg_dev/benchmarks.md
@@ -20,13 +20,15 @@ Then you call `Shootout` on that setup. The code is as follows:
 
 ```julia
 using OrdinaryDiffEq, DiffEqProblemLibrary.ODEProblemLibrary, DiffEqDevTools, ODE,
-      ODEInterface, ODEInterfaceDiffEq
+    ODEInterface, ODEInterfaceDiffEq
 
 ODEProblemLibrary.importodeproblems()
 prob = ODEProblemLibrary.prob_ode_2Dlinear
-setups = [Dict(:alg => DP5())
-          Dict(:abstol => 1e-3, :reltol => 1e-6, :alg => ode45()) # Fix ODE to be normal
-          Dict(:alg => dopri5())]
+setups = [
+    Dict(:alg => DP5())
+    Dict(:abstol => 1.0e-3, :reltol => 1.0e-6, :alg => ode45()) # Fix ODE to be normal
+    Dict(:alg => dopri5())
+]
 names = ["DifferentialEquations"; "ODE"; "ODEInterface"]
 shoot = Shootout(prob, setups; dt = 1 / 2^(10), names = names)
 ```
@@ -70,8 +72,10 @@ into the function as well:
 
 ```julia
 wp_set = WorkPrecisionSet(prob, tspan, abstols, reltols, setups; numruns = 2)
-setups = [Dict(:alg => RK4()); Dict(:alg => Euler()); Dict(:alg => BS3());
-          Dict(:alg => Midpoint()); Dict(:alg => BS5()); Dict(:alg => DP5())]
+setups = [
+    Dict(:alg => RK4()); Dict(:alg => Euler()); Dict(:alg => BS3());
+    Dict(:alg => Midpoint()); Dict(:alg => BS5()); Dict(:alg => DP5())
+]
 wp_set = WorkPrecisionSet(prob, abstols, reltols, setups; dt = 1 / 2^4, numruns = 2)
 ```
 

--- a/docs/src/devtools/contributing/adding_algorithms.md
+++ b/docs/src/devtools/contributing/adding_algorithms.md
@@ -58,11 +58,11 @@ For more details, refer to https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull
 ```julia
 using OrdinaryDiffEq
 import OrdinaryDiffEq:
-                       OrdinaryDiffEqAlgorithm, OrdinaryDiffEqMutableCache,
-                       OrdinaryDiffEqConstantCache,
-                       alg_order, alg_cache, initialize!, perform_step!, trivial_limiter!,
-                       constvalue,
-                       @muladd, @unpack, @cache, @..
+    OrdinaryDiffEqAlgorithm, OrdinaryDiffEqMutableCache,
+    OrdinaryDiffEqConstantCache,
+    alg_order, alg_cache, initialize!, perform_step!, trivial_limiter!,
+    constvalue,
+    @muladd, @unpack, @cache, @..
 
 struct RK_ALG{StageLimiter, StepLimiter} <: OrdinaryDiffEq.OrdinaryDiffEqAlgorithm
     stage_limiter!::StageLimiter
@@ -73,7 +73,7 @@ export RK_ALG
 alg_order(alg::RK_ALG) = 3
 
 @cache struct RK_ALGCache{uType, rateType, StageLimiter, StepLimiter, TabType} <:
-              OrdinaryDiffEqMutableCache
+    OrdinaryDiffEqMutableCache
     u::uType
     uprev::uType
     k::rateType
@@ -107,38 +107,43 @@ end
 function RK_ALGConstantCache(T, T2)
     α40 = T(0.476769811285196)
     α41 = T(0.098511733286064)
-    α43 = T(0.424718455428740)
+    α43 = T(0.42471845542874)
     α62 = T(0.155221702560091)
     α65 = T(0.844778297439909)
     β10 = T(0.284220721334261)
     β21 = T(0.284220721334261)
     β32 = T(0.284220721334261)
-    β43 = T(0.120713785765930)
+    β43 = T(0.12071378576593)
     β54 = T(0.284220721334261)
-    β65 = T(0.240103497065900)
+    β65 = T(0.2401034970659)
     c1 = T2(0.284220721334261)
     c2 = T2(0.568441442668522)
     c3 = T2(0.852662164002783)
     c4 = T2(0.510854218958172)
     c5 = T2(0.795074940292433)
 
-    RK_ALGConstantCache(
-        α40, α41, α43, α62, α65, β10, β21, β32, β43, β54, β65, c1, c2, c3, c4, c5)
+    return RK_ALGConstantCache(
+        α40, α41, α43, α62, α65, β10, β21, β32, β43, β54, β65, c1, c2, c3, c4, c5
+    )
 end
 
-function alg_cache(alg::RK_ALG, u, rate_prototype, uEltypeNoUnits, uBottomEltypeNoUnits,
-        tTypeNoUnits, uprev, uprev2, f, t, dt, reltol, p, calck, ::Val{true})
+function alg_cache(
+        alg::RK_ALG, u, rate_prototype, uEltypeNoUnits, uBottomEltypeNoUnits,
+        tTypeNoUnits, uprev, uprev2, f, t, dt, reltol, p, calck, ::Val{true}
+    )
     tmp = similar(u)
     u₂ = similar(u)
     k = zero(rate_prototype)
     fsalfirst = zero(rate_prototype)
     tab = RK_ALGConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
-    RK_ALGCache(u, uprev, k, tmp, u₂, fsalfirst, alg.stage_limiter!, alg.step_limiter!, tab)
+    return RK_ALGCache(u, uprev, k, tmp, u₂, fsalfirst, alg.stage_limiter!, alg.step_limiter!, tab)
 end
 
-function alg_cache(alg::RK_ALG, u, rate_prototype, uEltypeNoUnits, uBottomEltypeNoUnits,
-        tTypeNoUnits, uprev, uprev2, f, t, dt, reltol, p, calck, ::Val{false})
-    RK_ALGConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
+function alg_cache(
+        alg::RK_ALG, u, rate_prototype, uEltypeNoUnits, uBottomEltypeNoUnits,
+        tTypeNoUnits, uprev, uprev2, f, t, dt, reltol, p, calck, ::Val{false}
+    )
+    return RK_ALGConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
 end
 
 function initialize!(integrator, cache::RK_ALGConstantCache)
@@ -150,12 +155,13 @@ function initialize!(integrator, cache::RK_ALGConstantCache)
     # Avoid undefined entries if k is an array of arrays
     integrator.fsallast = zero(integrator.fsalfirst)
     integrator.k[1] = integrator.fsalfirst
+    return
 end
 
 @muladd function perform_step!(integrator, cache::RK_ALGConstantCache, repeat_step = false)
     @unpack t, dt, uprev, u, f, p = integrator
     @unpack α40, α41, α43, α62, α65, β10, β21, β32, β43, β54, β65, c1, c2, c3, c4,
-    c5 = cache
+        c5 = cache
 
     # u1 -> stored as u
     u = uprev + β10 * dt * integrator.fsalfirst
@@ -190,13 +196,14 @@ function initialize!(integrator, cache::RK_ALGCache)
     integrator.k[1] = integrator.fsalfirst
     integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t) # FSAL for interpolation
     integrator.destats.nf += 1
+    return
 end
 
 @muladd function perform_step!(integrator, cache::RK_ALGCache, repeat_step = false)
     @unpack t, dt, uprev, u, f, p = integrator
     @unpack k, tmp, u₂, fsalfirst, stage_limiter!, step_limiter! = cache
     @unpack α40, α41, α43, α62, α65, β10, β21, β32, β43, β54, β65, c1, c2, c3, c4,
-    c5 = cache.tab
+        c5 = cache.tab
 
     # u1 -> stored as u
     @.. u = uprev + β10 * dt * integrator.fsalfirst
@@ -227,8 +234,10 @@ end
 end
 
 #oop test
-f = ODEFunction((u, p, t) -> 1.01u,
-    analytic = (u0, p, t) -> u0 * exp(1.01t))
+f = ODEFunction(
+    (u, p, t) -> 1.01u,
+    analytic = (u0, p, t) -> u0 * exp(1.01t)
+)
 prob = ODEProblem(f, 1.01, (0.0, 1.0))
 sol = solve(prob, RK_ALG(), dt = 0.1)
 
@@ -248,8 +257,10 @@ sim.𝒪est[:final]
 plot(sim)
 
 #iip test
-f = ODEFunction((du, u, p, t) -> (du .= 1.01 .* u),
-    analytic = (u0, p, t) -> u0 * exp(1.01t))
+f = ODEFunction(
+    (du, u, p, t) -> (du .= 1.01 .* u),
+    analytic = (u0, p, t) -> u0 * exp(1.01t)
+)
 prob = ODEProblem(f, [1.01], (0.0, 1.0))
 sol = solve(prob, RK_ALG(), dt = 0.1)
 

--- a/docs/src/devtools/contributing/adding_packages.md
+++ b/docs/src/devtools/contributing/adding_packages.md
@@ -47,11 +47,12 @@ function DiffEqBase.__solve{uType, duType, tType, isinplace, LinearSolver}(
         alg::DASKRDAEAlgorithm{LinearSolver},
         timeseries = [], ts = [], ks = []; verbose = true,
         callback = nothing, abstol = 1 / 10^6, reltol = 1 / 10^3,
-        saveat = Float64[], adaptive = true, maxiters = Int(1e5),
+        saveat = Float64[], adaptive = true, maxiters = 10^5,
         timeseries_errors = true, save_everystep = isempty(saveat), dense = save_everystep,
         save_start = true, save_timeseries = nothing,
         userdata = nothing,
-        kwargs...)
+        kwargs...
+    )
     # do something
 end
 ```
@@ -68,11 +69,13 @@ In `solve` you do option handling and call your solver. At the end, you return
 the solution via:
 
 ```julia
-build_solution(prob, alg, ts, timeseries,
+build_solution(
+    prob, alg, ts, timeseries,
     du = dures,
     dense = dense,
     timeseries_errors = timeseries_errors,
-    retcode = :Success)
+    retcode = :Success
+)
 ```
 
 Giving `du` is only currently allowed for DAEs and is optional. The errors

--- a/docs/src/devtools/contributing/diffeq_internals.md
+++ b/docs/src/devtools/contributing/diffeq_internals.md
@@ -25,6 +25,7 @@ take a look at the Midpoint method's implementation:
     integrator.k[1] = integrator.fsalfirst
     integrator.k[2] = integrator.fsallast
     @pack integrator = t, dt, u
+    return
 end
 ```
 

--- a/docs/src/dynamicalodeexplicit/Newmark.md
+++ b/docs/src/dynamicalodeexplicit/Newmark.md
@@ -76,10 +76,10 @@ you will need to install some of the other libraries listed in the navigation ba
 ```julia
 using OrdinaryDiffEqNewmark
 function f1!(dv, v, u, p, t)
-    dv .= -u
+    return dv .= -u
 end
 function f2!(du, v, u, p, t)
-    du .= v
+    return du .= v
 end
 v0 = ones(2)
 u0 = zeros(2)

--- a/docs/src/dynamicalodeexplicit/RKN.md
+++ b/docs/src/dynamicalodeexplicit/RKN.md
@@ -103,9 +103,9 @@ you will need to install some of the other libraries listed in the navigation ba
 using OrdinaryDiffEqRKN
 function HH_acceleration!(dv, v, u, p, t)
     x, y = u
-    dx, dy = dv
-    dv[1] = -x - 2 * x * y
-    dv[2] = y^2 - y - x^2
+    dv[1] = dx = -x - 2 * x * y
+    dv[2] = dy = y^2 - y - x^2
+    return
 end
 initial_positions = [0.0, 0.1]
 initial_velocities = [0.5, 0.0]

--- a/docs/src/dynamicalodeexplicit/SymplecticRK.md
+++ b/docs/src/dynamicalodeexplicit/SymplecticRK.md
@@ -99,9 +99,9 @@ you will need to install some of the other libraries listed in the navigation ba
 using OrdinaryDiffEqSymplecticRK
 function HH_acceleration!(dv, v, u, p, t)
     x, y = u
-    dx, dy = dv
-    dv[1] = -x - 2 * x * y
-    dv[2] = y^2 - y - x^2
+    dv[1] = dx = -x - 2 * x * y
+    dv[2] = dy = y^2 - y - x^2
+    return
 end
 initial_positions = [0.0, 0.1]
 initial_velocities = [0.5, 0.0]

--- a/docs/src/explicit/QPRK.md
+++ b/docs/src/explicit/QPRK.md
@@ -82,7 +82,7 @@ using SciMLBase: ODEProblem, solve
 u0 = Float128[1.0, 0.0]
 tspan = (Float128(0.0), Float128(10.0))
 prob = ODEProblem(f, u0, tspan)
-sol = solve(prob, QPRK98(), abstol = 1e-25, reltol = 1e-25)
+sol = solve(prob, QPRK98(), abstol = 1.0e-25, reltol = 1.0e-25)
 ```
 
 ```@eval

--- a/docs/src/explicit/TaylorSeries.md
+++ b/docs/src/explicit/TaylorSeries.md
@@ -114,12 +114,12 @@ function f(u, p, t)
     du1 = σ * (u[2] - u[1])
     du2 = u[1] * (ρ - u[3]) - u[2]
     du3 = u[1] * u[2] - β * u[3]
-    [du1, du2, du3]
+    return [du1, du2, du3]
 end
 
 u0 = [1.0, 0.0, 0.0]
 tspan = (0.0, 10.0)
-p = [10.0, 28.0, 8/3]
+p = [10.0, 28.0, 8 / 3]
 prob = ODEProblem(f, u0, tspan, p)
 
 # Second-order Taylor method

--- a/docs/src/fullyimplicitdae/BDF.md
+++ b/docs/src/fullyimplicitdae/BDF.md
@@ -44,9 +44,10 @@ Use `DAEProblem` with implicit function specification:
 
 ```julia
 function f2(out, du, u, p, t)
-    out[1] = -0.04u[1] + 1e4 * u[2] * u[3] - du[1]
-    out[2] = +0.04u[1] - 3e7 * u[2]^2 - 1e4 * u[2] * u[3] - du[2]
+    out[1] = -0.04u[1] + 1.0e4 * u[2] * u[3] - du[1]
+    out[2] = +0.04u[1] - 3.0e7 * u[2]^2 - 1.0e4 * u[2] * u[3] - du[2]
     out[3] = u[1] + u[2] + u[3] - 1.0
+    return
 end
 u₀ = [1.0, 0, 0]
 du₀ = [-0.04, 0.04, 0.0]

--- a/docs/src/globalerrorcontrol/GlobalDiffEq.md
+++ b/docs/src/globalerrorcontrol/GlobalDiffEq.md
@@ -35,6 +35,7 @@ function lorenz!(du, u, p, t)
     du[1] = 10.0(u[2] - u[1])
     du[2] = u[1] * (28.0 - u[3]) - u[2]
     du[3] = u[1] * u[2] - (8 / 3) * u[3]
+    return
 end
 prob = ODEProblem(lorenz!, [1.0; 0.0; 0.0], (0.0, 10.0))
 sol = solve(prob, GLEE35(); abstol = 1.0e-8, reltol = 1.0e-8)

--- a/docs/src/massmatrixdae/BDF.md
+++ b/docs/src/massmatrixdae/BDF.md
@@ -47,12 +47,12 @@ function rober(du, u, p, t)
     du[1] = -k₁ * y₁ + k₃ * y₂ * y₃
     du[2] = k₁ * y₁ - k₃ * y₂ * y₃ - k₂ * y₂^2
     du[3] = y₁ + y₂ + y₃ - 1
-    nothing
+    return
 end
 M = Diagonal([1.0, 1.0, 0])  # Singular mass matrix
 f = ODEFunction(rober, mass_matrix = M)
-prob_mm = ODEProblem(f, [1.0, 0.0, 0.0], (0.0, 1e5), (0.04, 3e7, 1e4))
-sol = solve(prob_mm, FBDF(), reltol = 1e-8, abstol = 1e-8)
+prob_mm = ODEProblem(f, [1.0, 0.0, 0.0], (0.0, 1.0e5), (0.04, 3.0e7, 1.0e4))
+sol = solve(prob_mm, FBDF(), reltol = 1.0e-8, abstol = 1.0e-8)
 ```
 
 ## Solver Selection Guide

--- a/docs/src/massmatrixdae/Rosenbrock.md
+++ b/docs/src/massmatrixdae/Rosenbrock.md
@@ -109,12 +109,12 @@ function rober(du, u, p, t)
     du[1] = -k₁ * y₁ + k₃ * y₂ * y₃
     du[2] = k₁ * y₁ - k₃ * y₂ * y₃ - k₂ * y₂^2
     du[3] = y₁ + y₂ + y₃ - 1
-    nothing
+    return
 end
 M = Diagonal([1.0, 1.0, 0])  # Singular mass matrix
 f = ODEFunction(rober, mass_matrix = M)
-prob_mm = ODEProblem(f, [1.0, 0.0, 0.0], (0.0, 1e5), (0.04, 3e7, 1e4))
-sol = solve(prob_mm, Rodas5(), reltol = 1e-8, abstol = 1e-8)
+prob_mm = ODEProblem(f, [1.0, 0.0, 0.0], (0.0, 1.0e5), (0.04, 3.0e7, 1.0e4))
+sol = solve(prob_mm, Rodas5(), reltol = 1.0e-8, abstol = 1.0e-8)
 ```
 
 ```@eval

--- a/docs/src/semiimplicit/AMF.md
+++ b/docs/src/semiimplicit/AMF.md
@@ -81,13 +81,13 @@ function setup_fd2d_problem(; A = 0.1, B = 0.1, N = 40, final_t = 1.0)
     h = 1 / (N + 1)
 
     # 1D Laplacian with Dirichlet zero BCs, as a SciMLOperator.
-    D    = (1 / h^2) * Tridiagonal(ones(N - 1), -2 * ones(N), ones(N - 1))
+    D = (1 / h^2) * Tridiagonal(ones(N - 1), -2 * ones(N), ones(N - 1))
     D_op = MatrixOperator(D)
 
     # 2D Jacobian pieces: diffusion in x and in y, via Kronecker products.
     Jx_op = A * Base.kron(D_op, IdentityOperator(N))
     Jy_op = B * Base.kron(IdentityOperator(N), D_op)
-    J_op  = cache_operator(Jx_op + Jy_op, zeros(N^2))
+    J_op = cache_operator(Jx_op + Jy_op, zeros(N^2))
 
     # Nonlinear reaction term.
     g!(du, u, p, t) = (@. du += u^2 * (1 - u) + exp(t); return nothing)
@@ -109,7 +109,7 @@ function setup_fd2d_problem(; A = 0.1, B = 0.1, N = 40, final_t = 1.0)
 end
 
 prob = setup_fd2d_problem()
-sol  = solve(prob, AMF(ROS34PW1a); abstol = 1e-8, reltol = 1e-8)
+sol = solve(prob, AMF(ROS34PW1a); abstol = 1.0e-8, reltol = 1.0e-8)
 ```
 
 For this 1600-unknown problem the AMF stage solve is substantially faster than the dense equivalent, and the speedup grows with `N` because the dense `W` solve is `O(N⁶)` while the two Kronecker-structured AMF solves are `O(N³)` total. A regression test inside the package (`lib/OrdinaryDiffEqAMF/test/test_fd2d.jl`) measures the speedup on the same problem against a baseline `solve(..., ROS34PW1a())` without AMF.
@@ -123,8 +123,8 @@ using SciMLOperators: ScalarOperator
 
 gamma_op = ScalarOperator(
     1.0;
-    update_func       = (old, u, p, t; gamma = 1.0) -> gamma,
-    accepted_kwargs   = Val((:gamma,)),
+    update_func = (old, u, p, t; gamma = 1.0) -> gamma,
+    accepted_kwargs = Val((:gamma,)),
 )
 
 # Each factor is (I − γ Jᵢ), pre-assembled as a Kronecker-structured operator.
@@ -135,12 +135,12 @@ custom_factors = (
 
 amf_func = build_amf_function(
     f!;
-    jac         = J_op,
-    split       = (Jx_op, Jy_op),
+    jac = J_op,
+    split = (Jx_op, Jy_op),
     amf_factors = custom_factors,
 )
 
-sol = solve(ODEProblem(amf_func, u0, (0.0, 1.0)), AMF(ROS34PW1a); reltol = 1e-8)
+sol = solve(ODEProblem(amf_func, u0, (0.0, 1.0)), AMF(ROS34PW1a); reltol = 1.0e-8)
 ```
 
 `split` and `amf_factors` must contain the same number of operators: the split is used to propagate Jacobian updates, and the factors determine the actual `W_prototype` that the linear solver sees.

--- a/docs/src/semilinear/Linear.md
+++ b/docs/src/semilinear/Linear.md
@@ -105,6 +105,7 @@ function update_func!(A, u, p, t)
     A[2, 1] = sin(u[1])
     A[1, 2] = -1
     A[2, 2] = 0
+    return
 end
 A0 = ones(2, 2)
 A = MatrixOperator(A0, update_func! = update_func!)

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -8,10 +8,12 @@ f(u, p, t) = 1.01 * u
 u0 = 1 / 2
 tspan = (0.0, 1.0)
 prob = ODEProblem(f, u0, tspan)
-sol = solve(prob, Tsit5(), reltol = 1e-8, abstol = 1e-8)
+sol = solve(prob, Tsit5(), reltol = 1.0e-8, abstol = 1.0e-8)
 using Plots
-plot(sol, linewidth = 5, title = "Solution to the linear ODE with a thick line",
-    xaxis = "Time (t)", yaxis = "u(t) (in μm)", label = "My Thick Line!") # legend=false
+plot(
+    sol, linewidth = 5, title = "Solution to the linear ODE with a thick line",
+    xaxis = "Time (t)", yaxis = "u(t) (in μm)", label = "My Thick Line!", # legend = false
+)
 plot!(sol.t, t -> 0.5 * exp(1.01 * t), lw = 3, ls = :dash, label = "True Solution!")
 ```
 `Tsit5()` is a good default choice for many non-stiff ODEs. For stiff problems,
@@ -25,6 +27,7 @@ function lorenz!(du, u, p, t)
     du[1] = 10.0 * (u[2] - u[1])
     du[2] = u[1] * (28.0 - u[3]) - u[2]
     du[3] = u[1] * u[2] - (8 / 3) * u[3]
+    return
 end
 u0 = [1.0; 0.0; 0.0]
 tspan = (0.0, 100.0)
@@ -39,7 +42,7 @@ Very fast static array versions can be specifically compiled to the size of your
 ```julia
 using OrdinaryDiffEq, StaticArrays
 function lorenz(u, p, t)
-    SA[10.0 * (u[2] - u[1]), u[1] * (28.0 - u[3]) - u[2], u[1] * u[2] - (8 / 3) * u[3]]
+    return SA[10.0 * (u[2] - u[1]), u[1] * (28.0 - u[3]) - u[2], u[1] * u[2] - (8 / 3) * u[3]]
 end
 u0 = SA[1.0; 0.0; 0.0]
 tspan = (0.0, 100.0)
@@ -52,9 +55,9 @@ For “refined ODEs”, like dynamical equations and `SecondOrderODEProblem`s, r
 ```julia
 function HH_acceleration!(dv, v, u, p, t)
     x, y = u
-    dx, dy = dv
-    dv[1] = -x - 2 * x * y
-    dv[2] = y^2 - y - x^2
+    dv[1] = dx = -x - 2 * x * y
+    dv[2] = dy = y^2 - y - x^2
+    return
 end
 initial_positions = [0.0, 0.1]
 initial_velocities = [0.5, 0.0]

--- a/lib/DiffEqBase/src/calculate_residuals.jl
+++ b/lib/DiffEqBase/src/calculate_residuals.jl
@@ -90,7 +90,7 @@ end
 # Inplace Versions
 
 """
-    DiffEqBase.calculate_residuals!(out, ũ, u₀, u₁, α, ρ, thread=Serial())
+    DiffEqBase.calculate_residuals!(out, ũ, u₀, u₁, α, ρ, thread = Serial())
 
 Save element-wise residuals
 ```math
@@ -125,7 +125,7 @@ end
 end
 
 """
-    calculate_residuals!(out, u₀, u₁, α, ρ, thread=Serial())
+    calculate_residuals!(out, u₀, u₁, α, ρ, thread = Serial())
 
 Save element-wise residuals
 ```math
@@ -147,7 +147,7 @@ with multiple threads.
 end
 
 """
-    calculate_residuals!(out, E₁, E₂, u₀, u₁, α, ρ, δ, scalarnorm, thread=Serial())
+    calculate_residuals!(out, E₁, E₂, u₀, u₁, α, ρ, δ, scalarnorm, thread = Serial())
 
 Calculate element-wise residuals
 ```math

--- a/lib/DiffEqBase/src/callbacks.jl
+++ b/lib/DiffEqBase/src/callbacks.jl
@@ -1,5 +1,5 @@
 """
-    initialize!(cb::CallbackSet,u,t,integrator::DEIntegrator)
+    initialize!(cb::CallbackSet, u, t, integrator::DEIntegrator)
 
 Recursively apply `initialize!` and return whether any modified u
 """
@@ -26,7 +26,7 @@ function initialize!(
 end
 
 """
-    finalize!(cb::CallbackSet,u,t,integrator::DEIntegrator)
+    finalize!(cb::CallbackSet, u, t, integrator::DEIntegrator)
 
 Recursively apply `finalize!` and return whether any modified u
 """

--- a/lib/DiffEqBase/src/opaque_void.jl
+++ b/lib/DiffEqBase/src/opaque_void.jl
@@ -18,7 +18,7 @@
 # original payload with `RespecializeParams.unpack(sol.prob.p, P)`.
 
 """
-    should_opaque_p(p) :: Bool
+    should_opaque_p(p)::Bool
 
 Policy for whether the [`AutoDePSpecialize`](@ref) path de-specializes `p`.
 `isbits` structs are packed into a `RespecializeParams.OpaqueParams` (byte copy)

--- a/lib/DiffEqBase/src/solve.jl
+++ b/lib/DiffEqBase/src/solve.jl
@@ -286,7 +286,7 @@ end
 
 """
 ```julia
-solve(prob::AbstractDEProblem, alg::Union{AbstractDEAlgorithm,Nothing}; kwargs...)
+solve(prob::AbstractDEProblem, alg::Union{AbstractDEAlgorithm, Nothing}; kwargs...)
 ```
 
 ## Arguments

--- a/lib/DiffEqBase/src/verbosity.jl
+++ b/lib/DiffEqBase/src/verbosity.jl
@@ -315,7 +315,7 @@ Create an `DEVerbosity` using a preset configuration:
 - `SciMLLogging.Detailed()`: Comprehensive debugging information
 - `SciMLLogging.All()`: Maximum verbosity
 
-    DEVerbosity(; preset=nothing, error_control=nothing, performance=nothing, numerical=nothing, sde_specific=nothing, dde_specific=nothing, kwargs...)
+    DEVerbosity(; preset = nothing, error_control = nothing, performance = nothing, numerical = nothing, sde_specific = nothing, dde_specific = nothing, kwargs...)
 
 Create an `DEVerbosity` with group-level or individual field control.
 

--- a/lib/DiffEqDevTools/src/benchmark.jl
+++ b/lib/DiffEqDevTools/src/benchmark.jl
@@ -12,8 +12,10 @@ __default_name(alg) = string(nameof(typeof(alg)))
 ## Shootouts
 
 """
-    Shootout(prob, setups; appxsol = nothing, names = nothing,
-        error_estimate = :final, numruns = 20, seconds = 2, kwargs...)
+    Shootout(
+        prob, setups; appxsol = nothing, names = nothing,
+        error_estimate = :final, numruns = 20, seconds = 2, kwargs...
+    )
 
 Benchmark multiple solver configurations on one problem. Each entry of `setups` is a
 dictionary containing an `:alg` and any solver-specific keyword arguments. The result
@@ -37,8 +39,10 @@ mutable struct Shootout
 end
 
 """
-    ShootoutSet(probs, setups; probaux = nothing, names = nothing,
-        print_names = false, kwargs...)
+    ShootoutSet(
+        probs, setups; probaux = nothing, names = nothing,
+        print_names = false, kwargs...
+    )
 
 Run a [`Shootout`](@ref) for every problem in `probs`. `probaux` may contain one
 dictionary of per-problem keyword arguments for each problem; other keyword arguments
@@ -186,9 +190,11 @@ Base.lastindex(shoot::ShootoutSet) = lastindex(shoot.shootouts)
 ## WorkPrecisions
 
 """
-    WorkPrecision(prob, alg, abstols, reltols, dts = nothing;
+    WorkPrecision(
+        prob, alg, abstols, reltols, dts = nothing;
         name = nothing, appxsol = nothing, error_estimate = :final,
-        numruns = 20, seconds = 2, kwargs...)
+        numruns = 20, seconds = 2, kwargs...
+    )
 
 Measure error and execution time for `alg` at corresponding absolute and relative
 tolerances. When `dts` is provided, its entries select a fixed time step for each
@@ -931,9 +937,11 @@ function WorkPrecisionSet(
 end
 
 """
-    get_sample_errors(prob::AbstractRODEProblem, setup, test_dt = nothing;
+    get_sample_errors(
+        prob::AbstractRODEProblem, setup, test_dt = nothing;
         numruns, solution_runs, appxsol_setup = nothing,
-        sample_error_runs = 10^7, parallel_type = :none, kwargs...)
+        sample_error_runs = 10^7, parallel_type = :none, kwargs...
+    )
 
 Estimate an approximate 95% confidence half-width for the sampling error of an RODE
 solver setup. `numruns` may be one sample count or a collection of counts; the return

--- a/lib/DiffEqDevTools/src/convergence.jl
+++ b/lib/DiffEqDevTools/src/convergence.jl
@@ -1,6 +1,8 @@
 """
-    ConvergenceSimulation(solutions, convergence_axis;
-        auxdata = nothing, additional_errors = nothing, expected_value = nothing)
+    ConvergenceSimulation(
+        solutions, convergence_axis;
+        auxdata = nothing, additional_errors = nothing, expected_value = nothing
+    )
 
 Collect solutions and error series from a convergence experiment. The constructor
 combines the error measurements from `solutions` with `additional_errors` and estimates

--- a/lib/DiffEqDevTools/src/tableau_info.jl
+++ b/lib/DiffEqDevTools/src/tableau_info.jl
@@ -45,7 +45,7 @@ the initial value rather than the correct near-zero result. Use inputs where
 julia> stability_region(typemin(Float64), ImplicitEuler())
 ┌ Warning: Newton steps could not converge and algorithm is not adaptive. Use a lower dt.
 
-julia> abs(stability_region(-1e16, ImplicitEuler())) < eps(Float64)
+julia> abs(stability_region(-1.0e16, ImplicitEuler())) < eps(Float64)
 true
 ```
 """
@@ -76,8 +76,10 @@ function stability_region(
 end
 
 """
-    imaginary_stability_interval(tab::ODERKTableau;
-                                 initial_guess = length(tab) - 1)
+    imaginary_stability_interval(
+        tab::ODERKTableau;
+        initial_guess = length(tab) - 1
+    )
 
 Calculates the length of the imaginary stability interval, i.e.,
 the size of the stability region on the imaginary axis.
@@ -95,8 +97,7 @@ function imaginary_stability_interval(
 end
 
 """
-    imaginary_stability_interval(alg::ODERKTableau;
-                                 initial_guess = 20.0)
+    imaginary_stability_interval(alg::ODERKTableau; initial_guess = 20.0)
 
 Calculates the length of the imaginary stability interval, i.e.,
 the size of the stability region on the imaginary axis.

--- a/lib/OrdinaryDiffEqAMF/README.md
+++ b/lib/OrdinaryDiffEqAMF/README.md
@@ -48,14 +48,14 @@ end
 # Per-part Jacobians, expressed as SciMLOperators.
 J1_op = MatrixOperator(UpperTriangular(zeros(N, N)); update_func! = fjac_upper)
 J2_op = MatrixOperator(LowerTriangular(zeros(N, N)); update_func! = fjac_lower)
-J_op  = cache_operator(J1_op + J2_op, zeros(N))
+J_op = cache_operator(J1_op + J2_op, zeros(N))
 
 # Build the ODEFunction with AMF-aware jac_prototype / W_prototype.
 func = build_amf_function(f!; jac = J_op, split = (J1_op, J2_op))
 
-u0    = zeros(N)
+u0 = zeros(N)
 tspan = (0.0, 1.0)
-prob  = ODEProblem(func, u0, tspan)
+prob = ODEProblem(func, u0, tspan)
 
 sol = solve(prob, AMF(ROS34PW1a))
 ```

--- a/lib/OrdinaryDiffEqBDF/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqBDF/src/algorithms.jl
@@ -182,7 +182,7 @@ function SBDF(;
 end
 
 """
-    SBDF2(;kwargs...)
+    SBDF2(; kwargs...)
 
 The two-step version of the IMEX multistep methods of
 
@@ -197,7 +197,7 @@ See also `SBDF`.
 SBDF2(; kwargs...) = SBDF(2; kwargs...)
 
 """
-    SBDF3(;kwargs...)
+    SBDF3(; kwargs...)
 
 The three-step version of the IMEX multistep methods of
 
@@ -212,7 +212,7 @@ See also `SBDF`.
 SBDF3(; kwargs...) = SBDF(3; kwargs...)
 
 """
-    SBDF4(;kwargs...)
+    SBDF4(; kwargs...)
 
 The four-step version of the IMEX multistep methods of
 
@@ -575,7 +575,7 @@ An alias of `QNDF` with κ=0.
 QBDF(; kwargs...) = QNDF(; kappa = tuple(0 // 1, 0 // 1, 0 // 1, 0 // 1, 0 // 1), kwargs...)
 
 """
-    IMEXEuler(;kwargs...)
+    IMEXEuler(; kwargs...)
 
 The one-step version of the IMEX multistep methods of
 
@@ -602,7 +602,7 @@ See also `SBDF`, `IMEXEulerARK`.
 IMEXEuler(; kwargs...) = SBDF(1; kwargs...)
 
 """
-    IMEXEulerARK(;kwargs...)
+    IMEXEulerARK(; kwargs...)
 
 The one-step version of the IMEX multistep methods of
 

--- a/lib/OrdinaryDiffEqBDF/src/controllers.jl
+++ b/lib/OrdinaryDiffEqBDF/src/controllers.jl
@@ -1,6 +1,7 @@
 """
-    BDFController(; qmin, qmax, qsteady_min, qsteady_max, gamma, qmax_first_step,
-                  failfactor)
+    BDFController(;
+        qmin, qmax, qsteady_min, qsteady_max, gamma, qmax_first_step, failfactor
+    )
 
 Step-size controller for the variable-order BDF family (`QNDF`, `FBDF`,
 `DFBDF`). Composes the standard step-size knobs via [`CommonControllerOptions`](@ref);

--- a/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
@@ -855,9 +855,11 @@ end
 
 # PID step size controller
 """
-    PIDController(beta1, beta2, beta3=zero(beta1);
-                  limiter=default_dt_factor_limiter,
-                  accept_safety=0.81)
+    PIDController(
+        beta1, beta2, beta3 = zero(beta1);
+        limiter = default_dt_factor_limiter,
+        accept_safety = 0.81
+    )
 
 The proportional-integral-derivative (PID) controller is a generalization of the
 [`PIController`](@ref) and can have improved stability and efficiency properties.
@@ -1094,9 +1096,11 @@ for algorithms like the (E)SDIRK methods.
 (; qmin, qmax, gamma) = controller
 qmax = get_current_qmax(integrator, qmax)
 niters = integrator.cache.nlsolver.iter
-fac = min(gamma,
+fac = min(
+    gamma,
     (1 + 2 * integrator.cache.nlsolver.maxiters) * gamma /
-    (niters + 2 * integrator.cache.nlsolver.maxiters))
+        (niters + 2 * integrator.cache.nlsolver.maxiters)
+)
 expo = 1 / (get_current_adaptive_order(alg, integrator.cache) + 1)
 qtmp = fastpower(get_EEst(integrator), expo) / fac
 @fastmath q = max(inv(qmax), min(inv(qmin), qtmp))
@@ -1126,7 +1130,7 @@ if qsteady_min <= qacc <= qsteady_max
     qacc = one(qacc)
 end
 cache.dtacc = integrator.dt
-cache.erracc = max(1e-2, get_EEst(integrator))
+cache.erracc = max(1.0e-2, get_EEst(integrator))
 integrator.dt / qacc
 ```
 

--- a/lib/OrdinaryDiffEqCore/src/integrators/type.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/type.jl
@@ -147,7 +147,7 @@ For reference, relevant fields of the `ODEIntegrator` are:
 For example, to modify the absolute tolerance for the future timesteps, one can do:
 
 ```julia
-integrator.opts.abstol = 1e-9
+integrator.opts.abstol = 1.0e-9
 ```
 
 For more info see the linked documentation page.

--- a/lib/OrdinaryDiffEqCore/src/solve.jl
+++ b/lib/OrdinaryDiffEqCore/src/solve.jl
@@ -119,7 +119,7 @@ function resolve_stage_step_limiters(alg, stage_limiter, step_limiter, verbose_s
 end
 
 """
-    _ode_init(prob, alg, timeseries_init=(), ts_init=(), ks_init=(); kwargs...)
+    _ode_init(prob, alg, timeseries_init = (), ts_init = (), ks_init = (); kwargs...)
 
 Internal implementation of `__init` for ODE/DAE/SDE/RODE problems. This is
 separated from `__init` so that SDE packages can call it directly, bypassing

--- a/lib/OrdinaryDiffEqDefault/src/default_alg.jl
+++ b/lib/OrdinaryDiffEqDefault/src/default_alg.jl
@@ -55,6 +55,7 @@ using SciMLBase: ODEProblem, solve
 
 function f!(du, u, p, t)
     du[1] = -u[1]
+    return
 end
 
 prob = ODEProblem(f!, [1.0], (0.0, 1.0))
@@ -237,6 +238,7 @@ using SciMLBase: ODEProblem, solve
 
 function f!(du, u, p, t)
     du[1] = -1000u[1]
+    return
 end
 
 prob = ODEProblem(f!, [1.0], (0.0, 1.0))

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -18,7 +18,7 @@ does not have a `jac_reuse` field.
 end
 
 """
-    _rosenbrock_jac_reuse_decision(integrator, cache, dtgamma) -> NTuple{2,Bool}
+    _rosenbrock_jac_reuse_decision(integrator, cache, dtgamma) -> NTuple{2, Bool}
 
 Decide whether to recompute the Jacobian and/or W matrix for Rosenbrock methods.
 All Rosenbrock/W-method J/W logic lives here — no delegation to `do_newJW`.
@@ -513,14 +513,14 @@ function calc_J_dae(integrator, cache)
 end
 
 """
-    islinearfunction(integrator) -> Tuple{Bool,Bool}
+    islinearfunction(integrator) -> Tuple{Bool, Bool}
 
 return the tuple `(is_linear_wrt_odealg, islinearodefunction)`.
 """
 islinearfunction(integrator) = islinearfunction(integrator.f, integrator.alg)
 
 """
-    islinearfunction(f, alg) -> Tuple{Bool,Bool}
+    islinearfunction(f, alg) -> Tuple{Bool, Bool}
 
 return the tuple `(is_linear_wrt_odealg, islinearodefunction)`.
 """

--- a/lib/OrdinaryDiffEqExplicitRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqExplicitRK/src/algorithms.jl
@@ -93,7 +93,7 @@ end
 construct_tsit5_interp_matrix() = construct_tsit5_interp_matrix(Float64)
 
 """
-    construct_tsit5_interp_matrix(::Type{T}) where T
+    construct_tsit5_interp_matrix(::Type{T}) where {T}
 
 High-precision version for BigFloat and other arbitrary-precision types.
 """

--- a/lib/OrdinaryDiffEqExplicitRK/src/explicit_rk_perform_step.jl
+++ b/lib/OrdinaryDiffEqExplicitRK/src/explicit_rk_perform_step.jl
@@ -351,7 +351,7 @@ coeffs[j] is the coefficient of Θ^(j-1).
 end
 
 """
-    generic_rk_interpolant(Θ, dt, y₀, k, B_interp; idxs=nothing, order=0)
+    generic_rk_interpolant(Θ, dt, y₀, k, B_interp; idxs = nothing, order = 0)
 
 Generic interpolation for Runge-Kutta methods using the B_interp coefficient matrix.
 """

--- a/lib/OrdinaryDiffEqExponentialRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/algorithms.jl
@@ -79,8 +79,10 @@ for (Alg, Description, Ref) in [
 end
 
 """
-    ETD1(; krylov = false, m = 30, iop = 0, autodiff = AutoForwardDiff(),
-           concrete_jac = nothing, step_limiter = trivial_limiter!)
+    ETD1(;
+        krylov = false, m = 30, iop = 0, autodiff = AutoForwardDiff(),
+        concrete_jac = nothing, step_limiter = trivial_limiter!
+    )
 
 **ETD1: First Order Exponential Time Differencing (Semilinear ODE Solver)**
 

--- a/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_caches.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_caches.jl
@@ -6,7 +6,7 @@ get_fsalfirstlast(cache::ExpRKCache, u) = (zero(cache.rtmp), zero(cache.rtmp))
 
 # Precomputation of exponential-like operators
 """
-    expRK_operators(alg,dt,A) -> ops
+    expRK_operators(alg, dt, A) -> ops
 
 Compute operator(s) for an ExpRK algorithm. `dt` is the time step and `A` is
 the matrix form of the linear operator (from either a linear problem or a
@@ -103,7 +103,7 @@ for (Alg, Cache) in [
 end
 
 """
-    alg_cache_expRK(alg,u,uEltypeNoUnits,uprev,f,t,dt,p,du1,tmp,dz,plist)
+    alg_cache_expRK(alg, u, uEltypeNoUnits, uprev, f, t, dt, p, du1, tmp, dz, plist)
 
 Construct the non-standard caches (not uType or rateType) for ExpRK integrators.
 
@@ -823,7 +823,7 @@ end
 
 ## Mutable caches
 """
-    alg_cache_exprb(alg,uEltypeNoUnits,uprev,f,t,p,du1,tmp,dz,plist)
+    alg_cache_exprb(alg, uEltypeNoUnits, uprev, f, t, p, du1, tmp, dz, plist)
 
 Construct the non-standard caches (not uType or rateType) for Exprb integrators.
 

--- a/lib/OrdinaryDiffEqExtrapolation/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/algorithms.jl
@@ -3,8 +3,10 @@ OrdinaryDiffEqAdaptiveAlgorithm end
 abstract type OrdinaryDiffEqImplicitExtrapolationAlgorithm <:
 OrdinaryDiffEqAdaptiveImplicitAlgorithm end
 """
-    AitkenNeville(; max_order = 10, min_order = 1, init_order = 5,
-        threading = false) -> AitkenNeville
+    AitkenNeville(;
+            max_order = 10, min_order = 1, init_order = 5,
+            threading = false
+        ) -> AitkenNeville
 
 Adaptive explicit Euler extrapolation using the Aitken-Neville scheme and a Romberg
 subdivision sequence. The method varies both its step size and extrapolation order and
@@ -47,9 +49,11 @@ Base.@kwdef struct AitkenNeville{TO} <: OrdinaryDiffEqExtrapolationVarOrderVarSt
 end
 
 """
-    ImplicitEulerExtrapolation(; autodiff = AutoForwardDiff(), concrete_jac = nothing,
-        linsolve = nothing, max_order = 12, min_order = 3, init_order = 5,
-        threading = false, sequence = :harmonic) -> ImplicitEulerExtrapolation
+    ImplicitEulerExtrapolation(;
+            autodiff = AutoForwardDiff(), concrete_jac = nothing,
+            linsolve = nothing, max_order = 12, min_order = 3, init_order = 5,
+            threading = false, sequence = :harmonic
+        ) -> ImplicitEulerExtrapolation
 
 Adaptive implicit Euler extrapolation, similar to SEULEX. It is intended for stiff
 problems and varies both its step size and extrapolation order.
@@ -151,9 +155,11 @@ Initial order: " * lpad(init_order, 2, " ") * " --> " * lpad(init_order, 2, " ")
 end
 
 """
-    ExtrapolationMidpointDeuflhard(; min_order = 1, init_order = 5,
-        max_order = 10, sequence = :harmonic, threading = true,
-        sequence_factor = 2) -> ExtrapolationMidpointDeuflhard
+    ExtrapolationMidpointDeuflhard(;
+            min_order = 1, init_order = 5,
+            max_order = 10, sequence = :harmonic, threading = true,
+            sequence_factor = 2
+        ) -> ExtrapolationMidpointDeuflhard
 
 Adaptive explicit midpoint extrapolation with Deuflhard's order and step-size
 selection. Barycentric extrapolation combines the midpoint approximations. The
@@ -250,10 +256,12 @@ Initial order: " * lpad(init_order, 2, " ") * " --> " * lpad(init_order, 2, " ")
 end
 
 """
-    ImplicitDeuflhardExtrapolation(; autodiff = AutoForwardDiff(),
-        concrete_jac = nothing, linsolve = nothing, min_order = 1,
-        init_order = 5, max_order = 10, sequence = :harmonic,
-        threading = false) -> ImplicitDeuflhardExtrapolation
+    ImplicitDeuflhardExtrapolation(;
+            autodiff = AutoForwardDiff(),
+            concrete_jac = nothing, linsolve = nothing, min_order = 1,
+            init_order = 5, max_order = 10, sequence = :harmonic,
+            threading = false
+        ) -> ImplicitDeuflhardExtrapolation
 
 Adaptive implicit midpoint extrapolation with Deuflhard's order and step-size
 selection. It targets stiff problems and uses barycentric extrapolation of the
@@ -360,9 +368,11 @@ Initial order: " * lpad(init_order, 2, " ") * " --> " * lpad(init_order, 2, " ")
 end
 
 """
-    ExtrapolationMidpointHairerWanner(; min_order = 2, init_order = 5,
-        max_order = 10, sequence = :harmonic, threading = true,
-        sequence_factor = 2) -> ExtrapolationMidpointHairerWanner
+    ExtrapolationMidpointHairerWanner(;
+            min_order = 2, init_order = 5,
+            max_order = 10, sequence = :harmonic, threading = true,
+            sequence_factor = 2
+        ) -> ExtrapolationMidpointHairerWanner
 
 Adaptive explicit midpoint extrapolation with the order and step-size controller from
 Hairer and Wanner's ODEX algorithm. Barycentric extrapolation combines the midpoint
@@ -460,10 +470,12 @@ Initial order: " * lpad(init_order, 2, " ") * " --> " * lpad(init_order, 2, " ")
 end
 
 """
-    ImplicitHairerWannerExtrapolation(; autodiff = AutoForwardDiff(),
-        concrete_jac = nothing, linsolve = nothing, min_order = 2,
-        init_order = 5, max_order = 10, sequence = :harmonic,
-        threading = false) -> ImplicitHairerWannerExtrapolation
+    ImplicitHairerWannerExtrapolation(;
+            autodiff = AutoForwardDiff(),
+            concrete_jac = nothing, linsolve = nothing, min_order = 2,
+            init_order = 5, max_order = 10, sequence = :harmonic,
+            threading = false
+        ) -> ImplicitHairerWannerExtrapolation
 
 Adaptive implicit midpoint extrapolation with the order and step-size controller from
 Hairer and Wanner's SODEX algorithm. It is intended for stiff problems and supports
@@ -573,10 +585,12 @@ Initial order: " * lpad(init_order, 2, " ") * " --> " * lpad(init_order, 2, " ")
 end
 
 """
-    ImplicitEulerBarycentricExtrapolation(; autodiff = AutoForwardDiff(),
-        concrete_jac = nothing, linsolve = nothing, min_order = 3,
-        init_order = 5, max_order = 12, sequence = :harmonic,
-        threading = false, sequence_factor = 2) -> ImplicitEulerBarycentricExtrapolation
+    ImplicitEulerBarycentricExtrapolation(;
+            autodiff = AutoForwardDiff(),
+            concrete_jac = nothing, linsolve = nothing, min_order = 3,
+            init_order = 5, max_order = 12, sequence = :harmonic,
+            threading = false, sequence_factor = 2
+        ) -> ImplicitEulerBarycentricExtrapolation
 
 Adaptive implicit Euler extrapolation using barycentric coordinates and the
 Hairer-Wanner order and step-size strategy. It targets stiff problems and can evaluate

--- a/lib/OrdinaryDiffEqIMEXMultistep/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqIMEXMultistep/src/algorithms.jl
@@ -1,8 +1,10 @@
 # IMEX Multistep methods
 
 """
-    CNAB2(; autodiff = AutoForwardDiff(), concrete_jac = nothing, linsolve = nothing,
-        nlsolve = NLNewton(), extrapolant = :linear)
+    CNAB2(;
+        autodiff = AutoForwardDiff(), concrete_jac = nothing, linsolve = nothing,
+        nlsolve = NLNewton(), extrapolant = :linear
+    )
 
 Second-order Crank-Nicolson Adams-Bashforth IMEX multistep method. The first
 component of a `SplitODEProblem` is treated implicitly with Crank-Nicolson, while
@@ -79,8 +81,10 @@ function CNAB2(;
 end
 
 """
-    CNLF2(; autodiff = AutoForwardDiff(), concrete_jac = nothing, linsolve = nothing,
-        nlsolve = NLNewton(), extrapolant = :linear)
+    CNLF2(;
+        autodiff = AutoForwardDiff(), concrete_jac = nothing, linsolve = nothing,
+        nlsolve = NLNewton(), extrapolant = :linear
+    )
 
 Second-order Crank-Nicolson Leapfrog IMEX multistep method. The first component of
 a `SplitODEProblem` is treated implicitly with Crank-Nicolson, while the second

--- a/lib/OrdinaryDiffEqMultirate/README.md
+++ b/lib/OrdinaryDiffEqMultirate/README.md
@@ -43,11 +43,11 @@ using SciMLBase
 f1!(du, u, p, t) = (@. du = -50 * u)    # fast, stiff-ish
 f2!(du, u, p, t) = (@. du = -u)         # slow
 
-u0    = [1.0, 2.0, 3.0]
+u0 = [1.0, 2.0, 3.0]
 tspan = (0.0, 1.0)
 
 prob = SplitODEProblem(f1!, f2!, u0, tspan)
-sol  = solve(prob, MREEF())               # defaults: m=4, order=4, :harmonic
+sol = solve(prob, MREEF())               # defaults: m=4, order=4, :harmonic
 
 # Tune the substep count / extrapolation order explicitly:
 sol = solve(prob, MREEF(m = 8, order = 6, seq = :romberg))

--- a/lib/OrdinaryDiffEqNewmark/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqNewmark/src/algorithms.jl
@@ -83,9 +83,9 @@ The method evaluates the equations of motion at interpolated states:
 
 where:
 
-    aₙ₊αₘ = (1 - αₘ)·aₙ₊₁ + αₘ·aₙ
-    uₙ₊αf = (1 - αf)·uₙ₊₁  + αf·uₙ
-    vₙ₊αf = (1 - αf)·vₙ₊₁  + αf·vₙ
+    aₙ₊αₘ = (1 - αₘ) · aₙ₊₁ + αₘ · aₙ
+    uₙ₊αf = (1 - αf) · uₙ₊₁ + αf · uₙ
+    vₙ₊αf = (1 - αf) · vₙ₊₁ + αf · vₙ
 
 with the standard Newmark update formulas for uₙ₊₁ and vₙ₊₁.
 

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/functional.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/functional.jl
@@ -30,7 +30,7 @@ end
 ## compute_step!
 
 """
-    compute_step!(nlsolver::NLSolver{<:Union{NLFunctional,NLAnderson}}, integrator)
+    compute_step!(nlsolver::NLSolver{<:Union{NLFunctional, NLAnderson}}, integrator)
 
 Compute the next step of the fixed-point iteration
 

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/nlsolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/nlsolve.jl
@@ -51,8 +51,10 @@ this function to participate in the shared [`nlsolve!`](@ref) convergence loop.
 function compute_step! end
 
 """
-    nlsolve!(nlsolver::AbstractNLSolver, integrator, cache = nothing,
-             repeat_step = false)
+    nlsolve!(
+        nlsolver::AbstractNLSolver, integrator, cache = nothing,
+        repeat_step = false
+    )
 
 Solve
 

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/type.jl
@@ -29,7 +29,7 @@ function reject_conditioning(T, precondition, postcondition)
 end
 
 """
-    NLFunctional(; κ = 1//100, max_iter = 10, fast_convergence_cutoff = 1//5)
+    NLFunctional(; κ = 1 // 100, max_iter = 10, fast_convergence_cutoff = 1 // 5)
 
 Functional (fixed-point) iteration solver for the implicit stage equations,
 `z ← g(z)`. No Jacobian/`W` is formed, so it is cheap per iteration but only
@@ -66,8 +66,10 @@ function NLFunctional(;
 end
 
 """
-    NLAnderson(; κ = 1//100, max_iter = 10, max_history = 5, aa_start = 1,
-               droptol = nothing, fast_convergence_cutoff = 1//5)
+    NLAnderson(;
+        κ = 1 // 100, max_iter = 10, max_history = 5, aa_start = 1,
+        droptol = nothing, fast_convergence_cutoff = 1 // 5
+    )
 
 Anderson-accelerated fixed-point iteration for the implicit stage equations. Like
 [`NLFunctional`](@ref) but mixes in `max_history` previous residuals via a
@@ -109,8 +111,10 @@ function NLAnderson(;
 end
 
 """
-    NLNewton(; κ = 1//100, max_iter = 10, fast_convergence_cutoff = 1//5,
-             new_W_dt_cutoff = 1//5, always_new = false, check_div = true, relax = nothing)
+    NLNewton(;
+        κ = 1 // 100, max_iter = 10, fast_convergence_cutoff = 1 // 5,
+        new_W_dt_cutoff = 1 // 5, always_new = false, check_div = true, relax = nothing
+    )
 
 Quasi-Newton nonlinear solver for the implicit stage equations. Uses the
 `W = M/(γΔt) - J` matrix (reused/refactorized across steps and stages when
@@ -164,10 +168,12 @@ function NLNewton(;
 end
 
 """
-    NonlinearSolveAlg(alg = NewtonRaphson(autodiff = AutoFiniteDiff());
-        κ = 1//100, max_iter = 10, fast_convergence_cutoff = 1//5,
-        new_W_dt_cutoff = 1//5, always_new = false, check_div = true,
-        precondition = nothing, postcondition = nothing)
+    NonlinearSolveAlg(
+        alg = NewtonRaphson(autodiff = AutoFiniteDiff());
+        κ = 1 // 100, max_iter = 10, fast_convergence_cutoff = 1 // 5,
+        new_W_dt_cutoff = 1 // 5, always_new = false, check_div = true,
+        precondition = nothing, postcondition = nothing
+    )
 
 Use a NonlinearSolve.jl algorithm for the nonlinear stage equations of an implicit
 OrdinaryDiffEq method. Pass this algorithm as the `nlsolve` keyword to an implicit
@@ -299,9 +305,11 @@ function NonlinearSolveAlg(
 end
 
 """
-    HomotopyNonlinearSolveAlg(alg = HomotopySweep(inner = NewtonRaphson(autodiff = AutoFiniteDiff()));
-        κ = 1//100, max_iter = 10, fast_convergence_cutoff = 1//5,
-        abstol = nothing, reltol = nothing)
+    HomotopyNonlinearSolveAlg(
+        alg = HomotopySweep(inner = NewtonRaphson(autodiff = AutoFiniteDiff()));
+        κ = 1 // 100, max_iter = 10, fast_convergence_cutoff = 1 // 5,
+        abstol = nothing, reltol = nothing
+    )
 
 Solve the implicit stage equations by homotopy continuation in the step size instead of
 a plain Newton iteration. The stage equation

--- a/lib/OrdinaryDiffEqNordsieck/src/controllers.jl
+++ b/lib/OrdinaryDiffEqNordsieck/src/controllers.jl
@@ -1,8 +1,10 @@
 # JVODE
 
 """
-    JVODEController(; qmin, qmax, qsteady_min, qsteady_max, gamma,
-                    qmax_first_step, failfactor)
+    JVODEController(;
+        qmin, qmax, qsteady_min, qsteady_max, gamma,
+        qmax_first_step, failfactor
+    )
 
 Step-size controller for the variable-order Nordsieck-form `JVODE` family.
 Composes the standard step-size knobs via [`CommonControllerOptions`](@ref); the

--- a/lib/OrdinaryDiffEqPDIRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqPDIRK/src/algorithms.jl
@@ -1,6 +1,8 @@
 """
-    PDIRK44(; autodiff = AutoForwardDiff(), concrete_jac = nothing, linsolve = nothing,
-        nlsolve = NLNewton(), extrapolant = :constant, threading = true)
+    PDIRK44(;
+        autodiff = AutoForwardDiff(), concrete_jac = nothing, linsolve = nothing,
+        nlsolve = NLNewton(), extrapolant = :constant, threading = true
+    )
 
 Fourth-order, parallel diagonally implicit Runge-Kutta method. It evaluates the
 independent diagonal stages concurrently when `threading = true`, making it useful

--- a/lib/OrdinaryDiffEqQPRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqQPRK/src/algorithms.jl
@@ -1,6 +1,8 @@
 """
-    QPRK98(; stage_limiter! = trivial_limiter!, step_limiter! = trivial_limiter!,
-        thread = Serial())
+    QPRK98(;
+        stage_limiter! = trivial_limiter!, step_limiter! = trivial_limiter!,
+        thread = Serial()
+    )
 
 Ninth-order explicit embedded Runge-Kutta pair with an eighth-order error estimate,
 designed for quadruple-precision computations. Its parallel tableau is most useful when

--- a/lib/OrdinaryDiffEqRosenbrock/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/algorithms.jl
@@ -344,10 +344,12 @@ end
 ################################################################################
 
 """
-    HybridExplicitImplicitRK(tab; order, autodiff = AutoForwardDiff(),
+    HybridExplicitImplicitRK(
+        tab; order, autodiff = AutoForwardDiff(),
         concrete_jac = nothing, linsolve = nothing,
         step_limiter! = trivial_limiter!, stage_limiter! = trivial_limiter!,
-        max_jac_age = 20, jac_reuse_gamma_tol = 0.03)
+        max_jac_age = 20, jac_reuse_gamma_tol = 0.03
+    )
 
 Generic tableau-based hybrid explicit/linear-implicit Runge-Kutta method for
 semi-explicit index-1 DAEs. Differential variables are advanced with explicit

--- a/lib/OrdinaryDiffEqTaylorSeries/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/src/algorithms.jl
@@ -1,6 +1,8 @@
 """
-    ExplicitTaylor2(; stage_limiter! = trivial_limiter!,
-        step_limiter! = trivial_limiter!, thread = Serial())
+    ExplicitTaylor2(;
+        stage_limiter! = trivial_limiter!,
+        step_limiter! = trivial_limiter!, thread = Serial()
+    )
 
 Second-order explicit Taylor series method. `ExplicitTaylor2` evaluates the first two
 time derivatives of the solution with TaylorDiff.jl and advances with a fixed step size.
@@ -53,8 +55,10 @@ end
 @truncate_stacktrace ExplicitTaylor2 3
 
 """
-    ExplicitTaylor(; order = Val{1}(), stage_limiter! = trivial_limiter!,
-        step_limiter! = trivial_limiter!, thread = Serial())
+    ExplicitTaylor(;
+        order = Val{1}(), stage_limiter! = trivial_limiter!,
+        step_limiter! = trivial_limiter!, thread = Serial()
+    )
 
 Fixed-order explicit Taylor series method with adaptive step-size control. The method
 symbolically constructs a Taylor jet of the requested order and reuses it while solving.
@@ -115,9 +119,11 @@ Base.@kwdef struct ExplicitTaylor{P, StageLimiter, StepLimiter, Thread} <:
 end
 
 """
-    ExplicitTaylorAdaptiveOrder(; min_order = Val{1}(), max_order = Val{10}(),
+    ExplicitTaylorAdaptiveOrder(;
+        min_order = Val{1}(), max_order = Val{10}(),
         stage_limiter! = trivial_limiter!, step_limiter! = trivial_limiter!,
-        thread = Serial())
+        thread = Serial()
+    )
 
 Explicit Taylor series method that adapts both the expansion order and the step size. At
 each accepted step, the controller compares nearby orders and selects the estimated

--- a/lib/StochasticDiffEq/README.md
+++ b/lib/StochasticDiffEq/README.md
@@ -39,11 +39,13 @@ function f!(du, u, p, t)
     du[1] = 10.0 * (u[2] - u[1])
     du[2] = u[1] * (28.0 - u[3]) - u[2]
     du[3] = u[1] * u[2] - (8 / 3) * u[3]
+    return
 end
 function g!(du, u, p, t)
     du[1] = 0.3 * u[1]
     du[2] = 0.3 * u[2]
     du[3] = 0.3 * u[3]
+    return
 end
 u0 = [1.0; 0.0; 0.0]
 tspan = (0.0, 100.0)

--- a/lib/StochasticDiffEq/docs/src/index.md
+++ b/lib/StochasticDiffEq/docs/src/index.md
@@ -21,10 +21,12 @@ using StochasticDiffEq
 # Define the drift and diffusion functions
 function drift!(du, u, p, t)
     du[1] = 1.01 * u[1]
+    return
 end
 
 function diffusion!(du, u, p, t)
     du[1] = 0.87 * u[1]
+    return
 end
 
 # Initial condition and time span

--- a/lib/StochasticDiffEq/docs/src/stiff/implicit_methods.md
+++ b/lib/StochasticDiffEq/docs/src/stiff/implicit_methods.md
@@ -93,7 +93,7 @@ All implicit methods share common configuration parameters:
 # Linear solver options
 ImplicitEM(linsolve = KrylovJL_GMRES())
 
-# Nonlinear solver options  
+# Nonlinear solver options
 ImplicitEM(nlsolve = NLNewton(max_iter = 20))
 
 # Jacobian computation

--- a/lib/StochasticDiffEq/docs/src/usage.md
+++ b/lib/StochasticDiffEq/docs/src/usage.md
@@ -16,7 +16,7 @@ function f(u, p, t)  # drift
     return μ * u
 end
 
-function g(u, p, t)  # diffusion  
+function g(u, p, t)  # diffusion
     return σ * u
 end
 
@@ -24,11 +24,13 @@ end
 function f!(du, u, p, t)
     du[1] = μ * u[1]
     du[2] = -ν * u[2]
+    return
 end
 
 function g!(du, u, p, t)
     du[1] = σ₁ * u[1]
     du[2] = σ₂ * u[2]
+    return
 end
 
 # Create problem
@@ -45,7 +47,7 @@ sol = solve(prob)
 
 # Specify solver explicitly
 sol = solve(prob, SOSRI())          # Recommended for diagonal noise
-sol = solve(prob, SOSRA())          # Optimal for additive noise  
+sol = solve(prob, SOSRA())          # Optimal for additive noise
 sol = solve(prob, SKenCarp())       # For stiff problems
 sol = solve(prob, EM())             # For maximum efficiency
 ```
@@ -70,7 +72,7 @@ sol = solve(prob, SKenCarp(linsolve = KrylovJL_GMRES()))
 Set absolute and relative tolerances:
 
 ```julia
-sol = solve(prob, SOSRI(), abstol = 1e-6, reltol = 1e-3)
+sol = solve(prob, SOSRI(), abstol = 1.0e-6, reltol = 1.0e-3)
 ```
 
 For fixed time stepping:
@@ -89,6 +91,7 @@ Most common case - each component has independent noise:
 function g!(du, u, p, t)
     du[1] = σ₁ * u[1]
     du[2] = σ₂ * u[2]
+    return
 end
 ```
 
@@ -100,6 +103,7 @@ Single noise source affects all components:
 function g!(du, u, p, t)
     du[1] = σ * u[1]
     du[2] = σ * u[2]
+    return
 end
 ```
 
@@ -111,6 +115,7 @@ Multiple noise sources with cross-terms:
 function g!(du, u, p, t)
     du[1] = σ₁₁ * u[1] + σ₁₂ * u[2]
     du[2] = σ₂₁ * u[1] + σ₂₂ * u[2]
+    return
 end
 ```
 
@@ -122,6 +127,7 @@ Noise independent of solution:
 function g!(du, u, p, t)
     du[1] = σ₁
     du[2] = σ₂
+    return
 end
 ```
 
@@ -133,7 +139,7 @@ Specify interpretation when creating problems or choosing solvers:
 # Itô interpretation (default)
 prob = SDEProblem(f!, g!, u0, tspan, interpretation = :Ito)
 
-# Stratonovich interpretation  
+# Stratonovich interpretation
 prob = SDEProblem(f!, g!, u0, tspan, interpretation = :Stratonovich)
 
 # Or at solver level

--- a/lib/StochasticDiffEqCore/src/caches/cache_types.jl
+++ b/lib/StochasticDiffEqCore/src/caches/cache_types.jl
@@ -15,9 +15,11 @@ mutable struct StochasticCompositeCache{T, F} <: StochasticDiffEqCache
 end
 
 """
-    alg_cache(alg, prob, u, ΔW, ΔZ, p, rate_prototype, noise_rate_prototype,
-              jump_rate_prototype, ::Type{uEltypeNoUnits}, ::Type{uBottomEltypeNoUnits},
-              ::Type{tTypeNoUnits}, uprev, f, t, dt, ::Type{Val{iip}}, verbose)
+    alg_cache(
+        alg, prob, u, ΔW, ΔZ, p, rate_prototype, noise_rate_prototype,
+        jump_rate_prototype, ::Type{uEltypeNoUnits}, ::Type{uBottomEltypeNoUnits},
+        ::Type{tTypeNoUnits}, uprev, f, t, dt, ::Type{Val{iip}}, verbose
+    )
 
 Construct the per-algorithm cache used by `perform_step!`.
 

--- a/lib/StochasticDiffEqCore/src/composite_algs.jl
+++ b/lib/StochasticDiffEqCore/src/composite_algs.jl
@@ -14,9 +14,11 @@ mutable struct AutoSwitchCache{nAlg, sAlg, tolType, T}
 end
 
 """
-    AutoSwitch(nonstiffalg, stiffalg; maxstiffstep = 10, maxnonstiffstep = 3,
-               nonstifftol = 9//10, stifftol = 9//10, dtfac = 2,
-               stiffalgfirst = false, switch_max = 5)
+    AutoSwitch(
+        nonstiffalg, stiffalg; maxstiffstep = 10, maxnonstiffstep = 3,
+        nonstifftol = 9 // 10, stifftol = 9 // 10, dtfac = 2,
+        stiffalgfirst = false, switch_max = 5
+    )
 
 Choice function that switches a [`StochasticCompositeAlgorithm`](@ref) between a
 nonstiff and a stiff method based on an online stiffness estimate.

--- a/lib/StochasticDiffEqCore/src/iterated_integrals.jl
+++ b/lib/StochasticDiffEqCore/src/iterated_integrals.jl
@@ -83,7 +83,7 @@ mutable struct JCommute_iip{JType} <: AbstractJCommute
 end
 
 """
-    get_iterated_I(dt, dW, dZ, alg, p = nothing, c = 1, γ = 1//1)
+    get_iterated_I(dt, dW, dZ, alg, p = nothing, c = 1, γ = 1 // 1)
 
 Evaluate and return the Stratonovich iterated stochastic integrals for the step, out
 of place.
@@ -106,7 +106,7 @@ function get_iterated_I(dt, dW, dZ, alg::JDiagonal_oop, p = nothing, c = 1, γ =
 end
 
 """
-    get_iterated_I!(dt, dW, dZ, alg, p = nothing, c = 1, γ = 1//1)
+    get_iterated_I!(dt, dW, dZ, alg, p = nothing, c = 1, γ = 1 // 1)
 
 In-place form of [`get_iterated_I`](@ref): compute the Stratonovich iterated
 stochastic integrals for the step and store them in `alg.J`, returning `nothing`.

--- a/lib/StochasticDiffEqHighOrder/src/algorithms.jl
+++ b/lib/StochasticDiffEqHighOrder/src/algorithms.jl
@@ -1,7 +1,7 @@
 # Rossler
 
 """
-    SRA(;tableau=constructSRA1())
+    SRA(; tableau = constructSRA1())
 
 **SRA: Configurable Stochastic Runge-Kutta for Additive Noise (Nonstiff)**
 
@@ -41,7 +41,7 @@ end
 SRA(; tableau = constructSRA1()) = SRA(tableau)
 
 """
-    SRI(;tableau=constructSRIW1(), error_terms=4)
+    SRI(; tableau = constructSRIW1(), error_terms = 4)
 
 **SRI: Configurable Stochastic Runge-Kutta for Itô SDEs (Nonstiff)**
 

--- a/lib/StochasticDiffEqIIF/src/algorithms.jl
+++ b/lib/StochasticDiffEqIIF/src/algorithms.jl
@@ -1,5 +1,5 @@
 """
-    IIF1M(;nlsolve=NLSOLVEJL_SETUP())
+    IIF1M(; nlsolve = NLSOLVEJL_SETUP())
 
 **IIF1M: Integrating Factor Method 1 (Semi-Linear)**
 
@@ -38,7 +38,7 @@ end
 IIF1M(; nlsolve = NLSOLVEJL_SETUP()) = IIF1M{typeof(nlsolve)}(nlsolve)
 
 """
-    IIF2M(;nlsolve=NLSOLVEJL_SETUP())
+    IIF2M(; nlsolve = NLSOLVEJL_SETUP())
 
 **IIF2M: Integrating Factor Method 2 (Semi-Linear)**
 
@@ -72,7 +72,7 @@ end
 IIF2M(; nlsolve = NLSOLVEJL_SETUP()) = IIF2M{typeof(nlsolve)}(nlsolve)
 
 """
-    IIF1Mil(;nlsolve=NLSOLVEJL_SETUP())
+    IIF1Mil(; nlsolve = NLSOLVEJL_SETUP())
 
 **IIF1Mil: Integrating Factor Milstein Method (Semi-Linear)**
 

--- a/lib/StochasticDiffEqImplicit/src/algorithms.jl
+++ b/lib/StochasticDiffEqImplicit/src/algorithms.jl
@@ -2,10 +2,12 @@ using ADTypes: AutoForwardDiff
 using OrdinaryDiffEqCore: _fixup_ad
 
 """
-    ImplicitEM(; theta = 1, symplectic = false, linsolve = nothing,
-                 nlsolve = NLNewton(), extrapolant = :constant,
-                 new_jac_conv_bound = 1e-3,
-                 autodiff = AutoForwardDiff(), concrete_jac = nothing)
+    ImplicitEM(;
+        theta = 1, symplectic = false, linsolve = nothing,
+        nlsolve = NLNewton(), extrapolant = :constant,
+        new_jac_conv_bound = 1.0e-3,
+        autodiff = AutoForwardDiff(), concrete_jac = nothing
+    )
 
 **ImplicitEM: Drift-Implicit Euler-Maruyama (Stiff)**
 
@@ -160,10 +162,12 @@ that `theta` is fixed to `1/2` and `symplectic` is fixed to `true`.
 SImplicitMidpoint(; kwargs...) = ImplicitEM(; theta = 1 / 2, symplectic = true, kwargs...)
 
 """
-    ImplicitEulerHeun(; theta = 1, symplectic = false, linsolve = nothing,
-                        nlsolve = NLNewton(), extrapolant = :constant,
-                        new_jac_conv_bound = 1e-3,
-                        autodiff = AutoForwardDiff(), concrete_jac = nothing)
+    ImplicitEulerHeun(;
+        theta = 1, symplectic = false, linsolve = nothing,
+        nlsolve = NLNewton(), extrapolant = :constant,
+        new_jac_conv_bound = 1.0e-3,
+        autodiff = AutoForwardDiff(), concrete_jac = nothing
+    )
 
 **ImplicitEulerHeun: Drift-Implicit Euler-Heun (Stiff, Stratonovich)**
 
@@ -239,11 +243,13 @@ function ImplicitEulerHeun(;
 end
 
 """
-    ImplicitRKMil(; theta = 1, symplectic = false, linsolve = nothing,
-                    nlsolve = NLNewton(), extrapolant = :constant,
-                    new_jac_conv_bound = 1e-3,
-                    interpretation = AlgorithmInterpretation.Ito,
-                    autodiff = AutoForwardDiff(), concrete_jac = nothing)
+    ImplicitRKMil(;
+        theta = 1, symplectic = false, linsolve = nothing,
+        nlsolve = NLNewton(), extrapolant = :constant,
+        new_jac_conv_bound = 1.0e-3,
+        interpretation = AlgorithmInterpretation.Ito,
+        autodiff = AutoForwardDiff(), concrete_jac = nothing
+    )
 
 **ImplicitRKMil: Drift-Implicit Runge-Kutta Milstein (Stiff)**
 
@@ -327,10 +333,12 @@ function ImplicitRKMil(;
 end
 
 """
-    ISSEM(; theta = 1, symplectic = false, linsolve = nothing,
-            nlsolve = NLNewton(), extrapolant = :constant,
-            new_jac_conv_bound = 1e-3,
-            autodiff = AutoForwardDiff(), concrete_jac = nothing)
+    ISSEM(;
+        theta = 1, symplectic = false, linsolve = nothing,
+        nlsolve = NLNewton(), extrapolant = :constant,
+        new_jac_conv_bound = 1.0e-3,
+        autodiff = AutoForwardDiff(), concrete_jac = nothing
+    )
 
 **ISSEM: Implicit Split-Step Euler-Maruyama (Fully Stiff)**
 
@@ -419,10 +427,12 @@ function ISSEM(;
 end
 
 """
-    ISSEulerHeun(; theta = 1, symplectic = false, linsolve = nothing,
-                   nlsolve = NLNewton(), extrapolant = :constant,
-                   new_jac_conv_bound = 1e-3,
-                   autodiff = AutoForwardDiff(), concrete_jac = nothing)
+    ISSEulerHeun(;
+        theta = 1, symplectic = false, linsolve = nothing,
+        nlsolve = NLNewton(), extrapolant = :constant,
+        new_jac_conv_bound = 1.0e-3,
+        autodiff = AutoForwardDiff(), concrete_jac = nothing
+    )
 
 **ISSEulerHeun: Implicit Split-Step Euler-Heun (Fully Stiff, Stratonovich)**
 
@@ -497,10 +507,12 @@ function ISSEulerHeun(;
 end
 
 """
-    SKenCarp(; linsolve = nothing, nlsolve = NLNewton(),
-               smooth_est = true, extrapolant = :min_correct,
-               new_jac_conv_bound = 1e-3, ode_error_est = true,
-               autodiff = AutoForwardDiff(), concrete_jac = nothing)
+    SKenCarp(;
+        linsolve = nothing, nlsolve = NLNewton(),
+        smooth_est = true, extrapolant = :min_correct,
+        new_jac_conv_bound = 1.0e-3, ode_error_est = true,
+        autodiff = AutoForwardDiff(), concrete_jac = nothing
+    )
 
 **SKenCarp: Stochastic KenCarp for Additive Noise (Stiff, Recommended)**
 

--- a/lib/StochasticDiffEqLeaping/src/algorithms.jl
+++ b/lib/StochasticDiffEqLeaping/src/algorithms.jl
@@ -82,7 +82,7 @@ Automatically adjusts tau based on:
 end
 
 """
-    ImplicitTauLeaping(; nlsolve=NLFunctional())
+    ImplicitTauLeaping(; nlsolve = NLFunctional())
 
 **ImplicitTauLeaping: First Order Implicit Tau-Leaping Method (Jump-Diffusion)**
 
@@ -129,14 +129,14 @@ This corresponds to `ThetaTrapezoidalTauLeaping` with θ = 1 (fully implicit).
 using StochasticDiffEq, JumpProcesses
 
 # Define rate function and stoichiometry
-rate(out, u, p, t) = (out[1] = 0.1*u[1]; out[2] = 0.05*u[2])
+rate(out, u, p, t) = (out[1] = 0.1 * u[1]; out[2] = 0.05 * u[2])
 c(du, u, p, t, counts, mark) = (du[1] = -counts[1] + counts[2]; du[2] = counts[1] - counts[2])
 
 rj = RegularJump(rate, c, 2)
 prob = DiscreteProblem([100.0, 0.0], (0.0, 10.0))
 jprob = JumpProblem(prob, Direct(), rj)
 
-sol = solve(jprob, ImplicitTauLeaping(); dt=0.1)
+sol = solve(jprob, ImplicitTauLeaping(); dt = 0.1)
 ```
 
 ## References
@@ -153,7 +153,7 @@ function ImplicitTauLeaping(; nlsolve = NLFunctional())
 end
 
 """
-    ThetaTrapezoidalTauLeaping(; theta=0.5, max_iters=10, abstol=1e-8, reltol=1e-6)
+    ThetaTrapezoidalTauLeaping(; theta = 0.5, max_iters = 10, abstol = 1.0e-8, reltol = 1.0e-6)
 
 **ThetaTrapezoidalTauLeaping: Implicit Weak Second Order Tau-Leaping Method (Jump-Diffusion)**
 

--- a/lib/StochasticDiffEqLevyArea/README.md
+++ b/lib/StochasticDiffEqLevyArea/README.md
@@ -42,7 +42,7 @@ W = sqrt(h) * randn(m)
 II = iterated_integrals(W, h)
 
 # With explicit algorithm
-II = iterated_integrals(W, h; alg=MronRoe())
+II = iterated_integrals(W, h; alg = MronRoe())
 
 # With explicit precision
 II = iterated_integrals(W, h, 0.05)
@@ -55,18 +55,18 @@ using Random
 
 # Generate and store Fourier coefficients
 rng = Xoshiro(42)
-n = terms_needed(m, h, h^(3/2), MronRoe(), MaxL2())
+n = terms_needed(m, h, h^(3 / 2), MronRoe(), MaxL2())
 coeffs = generate_coefficients(m, n, MronRoe(), rng)
 
 # Deterministic computation from stored coefficients
 II = levyarea(W / sqrt(h), n, MronRoe(), coeffs)
 
 # Reconstruct the Brownian path at arbitrary times
-t_points = [0.0, h/4, h/2, 3h/4, h]
+t_points = [0.0, h / 4, h / 2, 3h / 4, h]
 W_values = reconstruct_path(W, h, coeffs, t_points)
 
 # Compute iterated integrals over a sub-interval
-II_sub = iterated_integrals_subinterval(W, h, coeffs, 0.0, h/2)
+II_sub = iterated_integrals_subinterval(W, h, coeffs, 0.0, h / 2)
 ```
 
 ## Available Algorithms

--- a/lib/StochasticDiffEqLevyArea/src/alg_utils.jl
+++ b/lib/StochasticDiffEqLevyArea/src/alg_utils.jl
@@ -47,7 +47,7 @@ function effective_cost(dim, q_12, stepsize, eps, alg, norm)
 end
 
 """
-    optimal_algorithm(dim, stepsize, eps=stepsize^(3/2), norm=MaxL2())
+    optimal_algorithm(dim, stepsize, eps = stepsize^(3 / 2), norm = MaxL2())
 
 Returns the optimal algorithm (fewest random numbers) for the given parameters.
 """

--- a/lib/StochasticDiffEqLevyArea/src/fourier.jl
+++ b/lib/StochasticDiffEqLevyArea/src/fourier.jl
@@ -11,7 +11,7 @@ errcoeff(m, h, ::Fourier, ::MaxLp{2}) = h * √3 / (√2 * π)
 norv(m, n, ::Fourier) = 2 * m * n
 
 """
-    levyarea(W, n, alg; rng=default_rng())
+    levyarea(W, n, alg; rng = default_rng())
     levyarea(W, n, alg, coeffs)
 
 Approximate the antisymmetric Lévy-area matrix for the normalized Wiener

--- a/lib/StochasticDiffEqLevyArea/src/generate.jl
+++ b/lib/StochasticDiffEqLevyArea/src/generate.jl
@@ -1,5 +1,5 @@
 """
-    generate_coefficients(m, n, alg, rng=default_rng(); T=Float64)
+    generate_coefficients(m, n, alg, rng = default_rng(); T = Float64)
 
 Generate Fourier coefficients for Lévy area computation. The layout of X and Y
 depends on the algorithm:

--- a/lib/StochasticDiffEqLevyArea/src/iterated_integrals.jl
+++ b/lib/StochasticDiffEqLevyArea/src/iterated_integrals.jl
@@ -1,5 +1,5 @@
 """
-    ito_correction!(I, h=1)
+    ito_correction!(I, h = 1)
 
 Subtract h/2 from every diagonal element of I (Itô correction).
 """

--- a/lib/StochasticDiffEqLevyArea/src/reconstruct.jl
+++ b/lib/StochasticDiffEqLevyArea/src/reconstruct.jl
@@ -39,8 +39,10 @@ function reconstruct_path(
 end
 
 """
-    iterated_integrals_subinterval(dW, h, coeffs, t_start, t_end;
-        n_quadrature=64, ito_correction=true)
+    iterated_integrals_subinterval(
+        dW, h, coeffs, t_start, t_end;
+        n_quadrature = 64, ito_correction = true
+    )
 
 Compute iterated Stratonovich integrals over the sub-interval [t_start, t_end] ⊂ [0, h]
 by reconstructing the Brownian path from Fourier coefficients and computing via

--- a/lib/StochasticDiffEqMilstein/src/algorithms.jl
+++ b/lib/StochasticDiffEqMilstein/src/algorithms.jl
@@ -1,5 +1,5 @@
 """
-    RKMilGeneral(; interpretation=Ito, ii_approx=IILevyArea(), c=1, p=nothing, dt=nothing)
+    RKMilGeneral(; interpretation = Ito, ii_approx = IILevyArea(), c = 1, p = nothing, dt = nothing)
 
 **RKMilGeneral: Generalized Runge-Kutta Milstein Method**
 

--- a/lib/StochasticDiffEqRODE/src/algorithms.jl
+++ b/lib/StochasticDiffEqRODE/src/algorithms.jl
@@ -88,7 +88,7 @@ Applies taming technique to prevent numerical blow-up while maintaining accuracy
 struct RandomTamedEM <: StochasticDiffEqRODEAlgorithm end
 
 """
-    BAOAB(;gamma=1.0, scale_noise=true)
+    BAOAB(; gamma = 1.0, scale_noise = true)
 
 **BAOAB: Langevin Dynamics Integrator (Specialized)**
 

--- a/lib/StochasticDiffEqWeak/src/algorithms.jl
+++ b/lib/StochasticDiffEqWeak/src/algorithms.jl
@@ -715,9 +715,11 @@ struct SMEB <: StochasticDiffEqAlgorithm end
 using ADTypes: AutoForwardDiff
 
 """
-    IRI1(; autodiff=AutoForwardDiff(), concrete_jac=nothing, linsolve=nothing,
-         nlsolve=NLNewton(), extrapolant=:constant, theta=1,
-         new_jac_conv_bound=1e-3)
+    IRI1(;
+        autodiff = AutoForwardDiff(), concrete_jac = nothing, linsolve = nothing,
+        nlsolve = NLNewton(), extrapolant = :constant, theta = 1,
+        new_jac_conv_bound = 1.0e-3
+    )
 
 Adaptive drift-implicit variant of the Rößler `RI1` method for weak
 approximation of Itô SDEs. The nonlinear and linear solves can be customized

--- a/lib/StochasticDiffEqWeak/src/tableaus.jl
+++ b/lib/StochasticDiffEqWeak/src/tableaus.jl
@@ -23,7 +23,7 @@ struct RoesslerRI{T, T2} <: Tableau
 end
 
 """
-    constructDRI1([T=Float64], [T2=Float64])
+    constructDRI1([T = Float64], [T2 = Float64])
 
 Construct the `RoesslerRI` tableau used by `DRI1`, with coefficient element
 type `T` and abscissa element type `T2`.
@@ -79,7 +79,7 @@ function constructDRI1(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
 end
 
 """
-    constructRI1([T=Float64], [T2=Float64])
+    constructRI1([T = Float64], [T2 = Float64])
 
 Construct the `RoesslerRI` tableau used by `RI1`, with coefficient element type
 `T` and abscissa element type `T2`.
@@ -135,7 +135,7 @@ function constructRI1(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
 end
 
 """
-    constructRI3([T=Float64], [T2=Float64])
+    constructRI3([T = Float64], [T2 = Float64])
 
 Construct the `RoesslerRI` tableau used by `RI3`, with coefficient element type
 `T` and abscissa element type `T2`.
@@ -191,7 +191,7 @@ function constructRI3(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
 end
 
 """
-    constructRI5([T=Float64], [T2=Float64])
+    constructRI5([T = Float64], [T2 = Float64])
 
 Construct the `RoesslerRI` tableau used by `RI5`, with coefficient element type
 `T` and abscissa element type `T2`.
@@ -247,7 +247,7 @@ function constructRI5(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
 end
 
 """
-    constructRI6([T=Float64], [T2=Float64])
+    constructRI6([T = Float64], [T2 = Float64])
 
 Construct the `RoesslerRI` tableau used by `RI6`, with coefficient element type
 `T` and abscissa element type `T2`.
@@ -303,7 +303,7 @@ function constructRI6(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
 end
 
 """
-    constructRDI1WM([T=Float64], [T2=Float64])
+    constructRDI1WM([T = Float64], [T2 = Float64])
 
 Construct the `RoesslerRI` tableau used by `RDI1WM`, with coefficient element
 type `T` and abscissa element type `T2`.
@@ -353,7 +353,7 @@ function constructRDI1WM(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2
 end
 
 """
-    constructRDI2WM([T=Float64], [T2=Float64])
+    constructRDI2WM([T = Float64], [T2 = Float64])
 
 Construct the `RoesslerRI` tableau used by `RDI2WM`, with coefficient element
 type `T` and abscissa element type `T2`.
@@ -409,7 +409,7 @@ function constructRDI2WM(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2
 end
 
 """
-    constructRDI3WM([T=Float64], [T2=Float64])
+    constructRDI3WM([T = Float64], [T2 = Float64])
 
 Construct the `RoesslerRI` tableau used by `RDI3WM`, with coefficient element
 type `T` and abscissa element type `T2`.
@@ -465,7 +465,7 @@ function constructRDI3WM(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2
 end
 
 """
-    constructRDI4WM([T=Float64], [T2=Float64])
+    constructRDI4WM([T = Float64], [T2 = Float64])
 
 Construct the `RoesslerRI` tableau used by `RDI4WM`, with coefficient element
 type `T` and abscissa element type `T2`.
@@ -521,7 +521,7 @@ function constructRDI4WM(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2
 end
 
 """
-    checkRIOrder(tableau; tol=1e-6, ps=2)
+    checkRIOrder(tableau; tol = 1.0e-6, ps = 2)
 
 Evaluate the weak order conditions of a `RoesslerRI` tableau through order
 `ps`. Returns one Boolean per condition, using `tol` for coefficient
@@ -628,7 +628,7 @@ struct RoesslerRS{T, T2} <: Tableau
 end
 
 """
-    constructRS1([T=Float64], [T2=Float64])
+    constructRS1([T = Float64], [T2 = Float64])
 
 Construct the `RoesslerRS` tableau used by `RS1`, with coefficient element type
 `T` and abscissa element type `T2`.
@@ -694,7 +694,7 @@ function constructRS1(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
 end
 
 """
-    constructRS2([T=Float64], [T2=Float64])
+    constructRS2([T = Float64], [T2 = Float64])
 
 Construct the `RoesslerRS` tableau used by `RS2`, with coefficient element type
 `T` and abscissa element type `T2`.
@@ -760,7 +760,7 @@ function constructRS2(::Type{T} = Float64, ::Type{T2} = Float64) where {T, T2}
 end
 
 """
-    checkRSOrder(tableau; tol=1e-6, ps=2)
+    checkRSOrder(tableau; tol = 1.0e-6, ps = 2)
 
 Evaluate the weak order conditions of a `RoesslerRS` tableau through order
 `ps`. Returns one Boolean per condition, using `tol` for coefficient
@@ -864,7 +864,7 @@ struct KomoriNON{T} <: Tableau
 end
 
 """
-    constructNON([T=Float64])
+    constructNON([T = Float64])
 
 Construct the `KomoriNON` tableau used by `NON`, with coefficient element type
 `T`.
@@ -933,7 +933,7 @@ function constructNON(::Type{T} = Float64) where {T}
 end
 
 """
-    checkNONOrder(tableau; tol=1e-6)
+    checkNONOrder(tableau; tol = 1.0e-6)
 
 Evaluate the weak and deterministic order conditions of a `KomoriNON` or
 `KomoriNON2` tableau. Returns one Boolean per condition, using `tol` for
@@ -1033,7 +1033,7 @@ struct KomoriNON2{T} <: Tableau
 end
 
 """
-    constructNON2([T=Float64])
+    constructNON2([T = Float64])
 
 Construct the `KomoriNON2` tableau used by `NON2`, with coefficient element
 type `T`.

--- a/test/gpu/dae_tests.jl
+++ b/test/gpu/dae_tests.jl
@@ -419,7 +419,7 @@ end
 # ── Convenience for interactive debugging ────────────────────────────────────
 
 """
-    debug_case(solver; jac="none", mass="diag_cu")
+    debug_case(solver; jac = "none", mass = "diag_cu")
 
 Run a single case interactively. Throws instead of catching so you can inspect
 the stack trace.


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

While taking a look  at other parts of the repo, ran runic formatter with command-line options `--extensions=jl,md --docstrings` and cleaned up some stuff to produce this patch.