### PR TITLE
fix: let the despecialization barrier accept unwrapped parameters

### DIFF
--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.18.0"
+version = "7.18.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/DiffEqBase/src/solve.jl
+++ b/lib/DiffEqBase/src/solve.jl
@@ -839,8 +839,11 @@ Base.@inline @generated function _invoke_parameter_despecialization(
         f, args::Tuple{Vararg{Any, N}}
     ) where {N}
     parameter_indices = findall(T -> T <: SciMLBase.DespecializedParameters, args.parameters)
-    length(parameter_indices) == 1 ||
-        error("a parameter-despecialization barrier requires exactly one parameter wrapper")
+    length(parameter_indices) <= 1 ||
+        error("a parameter-despecialization barrier requires at most one parameter wrapper")
+    # Nested AutoDespecialize calls can re-enter after an inner NonlinearFunction has
+    # already unwrapped the parameters.
+    isempty(parameter_indices) && return :(_invoke_parameter_despecialization(f, args...))
     parameter_index = only(parameter_indices)
     call_args = [
         i == parameter_index ? :(SciMLBase.unwrap_parameters(args[$i])) : :(args[$i])

--- a/lib/DiffEqBase/test/despecialized_p_test.jl
+++ b/lib/DiffEqBase/test/despecialized_p_test.jl
@@ -229,3 +229,18 @@ end
     @test seen_sdde_noise_parameter[] === DynamicSDEParameters
     @test SciMLBase.unwrapped_f(sdde_concrete.f.g) === dynamic_sdde_noise!
 end
+
+@testset "the barrier accepts already-unwrapped parameters" begin
+    p = DynamicP(0.5)
+    collect_args(args...) = args
+
+    wrapped = SciMLBase.DespecializedParameters(p)
+    @test DiffEqBase._invoke_parameter_despecialization(collect_args, (1, wrapped, 2)) ==
+        (1, p, 2)
+
+    @test DiffEqBase._invoke_parameter_despecialization(collect_args, (1, p, 2)) == (1, p, 2)
+
+    @test_throws "at most one parameter wrapper" DiffEqBase._invoke_parameter_despecialization(
+        collect_args, (wrapped, wrapped)
+    )
+end


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.**

## What changed and why

Allow the parameter-despecialization barrier to receive zero `DespecializedParameters` wrappers and pass that call through unchanged. DAE initialization wraps its residual in a `NonlinearFunction`, which unwraps parameters before forwarding to the outer `AutoDespecialize` function; the barrier therefore re-enters with zero wrappers and previously threw. More than one wrapper remains an error.

The branch is rebuilt as one commit on current master while preserving the original author and the required Chris Rackauckas co-author trailer. DiffEqBase is bumped from 7.18.0 to 7.18.1.

## Failing before / passing after

With the checked-in regression test present and the source fix reverted, the full DiffEqBase Core group fails:

```text
the barrier accepts already-unwrapped parameters: Error During Test
Expression: DiffEqBase._invoke_parameter_despecialization(collect_args, (1, p, 2)) == (1, p, 2)
a parameter-despecialization barrier requires exactly one parameter wrapper
Despecialized-p Hook | Pass 45 Fail 1 Error 1 Total 47
ERROR: Package DiffEqBase errored during testing
```

With the fix restored, the identical full Core command passes:

```text
Despecialized-p Hook | Pass 47 Total 47
Testing DiffEqBase tests passed
```

The public DAE reproducer also reaches a successful solve and satisfies its algebraic constraint:

```text
retcode=Success, constraint=1.0
```

## Local verification

- `GROUP=Core julia +1.12 --startup-file=no --project=lib/DiffEqBase -e 'using Pkg; Pkg.test()'`: passed on current master; the discriminating hook is 47/47.
- `GROUP=QA julia +1.12 --startup-file=no --project=lib/DiffEqBase -e 'using Pkg; Pkg.test()'`: Aqua 9/9; package tests passed.
- Standalone public DAE solve using `DFBDF`, `AutoDespecialize`, and `BrownFullBasicInit`: `retcode=Success`, constraint sum 1.0.
- Runic `--check --diff`, `typos` on all changed files, and `git diff --check`: passed.

The complete Downstream/Downstream2, GPU, and prerelease-Julia groups were not run locally. The public DAE reproducer covers the observed behavior, while the full Core and QA groups cover the changed DiffEqBase package.
