### PR TITLE
Bump versions for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEq"
 uuid = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "7.6.0"
+version = "7.7.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.15.0"
+version = "7.16.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/DiffEqDevTools/Project.toml
+++ b/lib/DiffEqDevTools/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqDevTools"
 uuid = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "3.2.0"
+version = "3.3.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/OrdinaryDiffEqAdamsBashforthMoulton/Project.toml
+++ b/lib/OrdinaryDiffEqAdamsBashforthMoulton/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqAdamsBashforthMoulton"
 uuid = "89bda076-bce5-4f1c-845f-551c83cdda9a"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.2"
+version = "2.2.0"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.14.3"
+version = "4.15.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqExplicitRK/Project.toml
+++ b/lib/OrdinaryDiffEqExplicitRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExplicitRK"
 uuid = "9286f039-9fbf-40e8-bf65-aa933bdc4db0"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.1"
+version = "2.2.0"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqExponentialRK/Project.toml
+++ b/lib/OrdinaryDiffEqExponentialRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExponentialRK"
 uuid = "e0540318-69ee-4070-8777-9e2de6de23de"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.1"
+version = "2.3.0"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqHighOrderRK/Project.toml
+++ b/lib/OrdinaryDiffEqHighOrderRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqHighOrderRK"
 uuid = "d28bc4f8-55e1-4f49-af69-84c1a99f0f58"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.1"
+version = "2.2.0"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqIMEXMultistep/Project.toml
+++ b/lib/OrdinaryDiffEqIMEXMultistep/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqIMEXMultistep"
 uuid = "9f002381-b378-40b7-97a6-27a27c83f129"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.3"
+version = "2.2.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqLinear/Project.toml
+++ b/lib/OrdinaryDiffEqLinear/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqLinear"
 uuid = "521117fe-8c41-49f8-b3b6-30780b3f0fb5"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.1"
+version = "2.3.0"
 
 [deps]
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"

--- a/lib/OrdinaryDiffEqLowStorageRK/Project.toml
+++ b/lib/OrdinaryDiffEqLowStorageRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqLowStorageRK"
 uuid = "b0944070-b475-4768-8dec-fb6eb410534d"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "3.3.0"
+version = "3.4.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/OrdinaryDiffEqNewmark/Project.toml
+++ b/lib/OrdinaryDiffEqNewmark/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqNewmark"
 uuid = "d204908a-63b9-11ef-18f5-cfec7123a93b"
-version = "2.3.0"
+version = "2.4.0"
 authors = ["Dennis Ogiermann <termi-official@users.noreply.github.com>"]
 
 [deps]

--- a/lib/OrdinaryDiffEqNordsieck/Project.toml
+++ b/lib/OrdinaryDiffEqNordsieck/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNordsieck"
 uuid = "c9986a66-5c92-4813-8696-a7ec84c806c8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.2"
+version = "2.3.0"
 
 [deps]
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"

--- a/lib/OrdinaryDiffEqPDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqPDIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqPDIRK"
 uuid = "5dd0a6cf-3d4b-4314-aa06-06d4e299bc89"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.3.0"
+version = "2.4.0"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqQPRK/Project.toml
+++ b/lib/OrdinaryDiffEqQPRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqQPRK"
 uuid = "04162be5-8125-4266-98ed-640baecc6514"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.3"
+version = "2.2.0"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqRKN/Project.toml
+++ b/lib/OrdinaryDiffEqRKN/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqRKN"
 uuid = "af6ede74-add8-4cfd-b1df-9a4dbb109d7a"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.2"
+version = "2.2.0"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqSDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqSDIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSDIRK"
 uuid = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.8.2"
+version = "2.9.0"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/lib/OrdinaryDiffEqSSPRK/Project.toml
+++ b/lib/OrdinaryDiffEqSSPRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSSPRK"
 uuid = "669c94d9-1f4b-4b64-b377-1aa079aa2388"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.2"
+version = "2.3.0"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqStabilizedRK/Project.toml
+++ b/lib/OrdinaryDiffEqStabilizedRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqStabilizedRK"
 uuid = "358294b1-0aab-51c3-aafe-ad5ab194a2ad"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.5.1"
+version = "2.6.0"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqTaylorSeries/Project.toml
+++ b/lib/OrdinaryDiffEqTaylorSeries/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqTaylorSeries"
 uuid = "9c7f1690-dd92-42a3-8318-297ee24d8d39"
 authors = ["Songchen Tan <i@tansongchen.com>"]
-version = "2.1.2"
+version = "2.2.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/OrdinaryDiffEqVerner/Project.toml
+++ b/lib/OrdinaryDiffEqVerner/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqVerner"
 uuid = "79d7bb75-1356-48c1-b8c0-6832512096c2"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.2"
+version = "2.3.0"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/StochasticDiffEqCore/Project.toml
+++ b/lib/StochasticDiffEqCore/Project.toml
@@ -1,6 +1,6 @@
 name = "StochasticDiffEqCore"
 uuid = "19c5a474-6cd1-4a5f-be79-46dc34e54d7f"
-version = "2.0.6"
+version = "2.1.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]

--- a/lib/StochasticDiffEqHighOrder/Project.toml
+++ b/lib/StochasticDiffEqHighOrder/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqHighOrder"
 uuid = "0520c28c-50fd-4d16-9c96-902fc80b3bab"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.1.3"
+version = "2.2.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/StochasticDiffEqIIF/Project.toml
+++ b/lib/StochasticDiffEqIIF/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqIIF"
 uuid = "ebf54054-c36b-4494-9aba-657e36df524f"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.3"
+version = "2.1.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/StochasticDiffEqImplicit/Project.toml
+++ b/lib/StochasticDiffEqImplicit/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqImplicit"
 uuid = "5080b986-4c76-4669-b5dc-373a41579d5b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.1.3"
+version = "2.2.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/StochasticDiffEqLeaping/Project.toml
+++ b/lib/StochasticDiffEqLeaping/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqLeaping"
 uuid = "aefaaa88-39f2-4e89-b162-d61b7e8cc81b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.3"
+version = "2.1.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/StochasticDiffEqLevyArea/Project.toml
+++ b/lib/StochasticDiffEqLevyArea/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqLevyArea"
 uuid = "90dbc90e-856a-4131-af2c-e8c5aa0f35b5"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.3"
+version = "2.1.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/lib/StochasticDiffEqMilstein/Project.toml
+++ b/lib/StochasticDiffEqMilstein/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqMilstein"
 uuid = "8c95a807-c8e7-4581-8419-890d001af53e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.3"
+version = "2.1.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/StochasticDiffEqROCK/Project.toml
+++ b/lib/StochasticDiffEqROCK/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqROCK"
 uuid = "db241ea8-0e6b-4abc-8f2d-1adff2294fd9"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.3"
+version = "2.1.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/StochasticDiffEqRODE/Project.toml
+++ b/lib/StochasticDiffEqRODE/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqRODE"
 uuid = "49714585-0aa1-4f53-b1e6-a9b8c0d5e03f"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.3"
+version = "2.1.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/StochasticDiffEqWeak/Project.toml
+++ b/lib/StochasticDiffEqWeak/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqWeak"
 uuid = "af2a2fcd-1c36-4cbe-a6d0-5afda784a085"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.1.3"
+version = "2.2.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Version bumps only -- no source changes.

Each package below has `src/` changes since its last registered version (verified by comparing the registry's recorded `git-tree-sha1` for that version against the current tree), but its `Project.toml` version still equals the registered one, so there is nothing to register.

Increment is minor, which is a valid standard increment under the General [sequential version number](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) guideline.

- DiffEqBase 7.15.0 -> 7.16.0
- DiffEqDevTools 3.2.0 -> 3.3.0
- OrdinaryDiffEq 7.6.0 -> 7.7.0
- OrdinaryDiffEqAdamsBashforthMoulton 2.1.2 -> 2.2.0
- OrdinaryDiffEqCore 4.14.3 -> 4.15.0
- OrdinaryDiffEqExplicitRK 2.1.1 -> 2.2.0
- OrdinaryDiffEqExponentialRK 2.2.1 -> 2.3.0
- OrdinaryDiffEqHighOrderRK 2.1.1 -> 2.2.0
- OrdinaryDiffEqIMEXMultistep 2.1.3 -> 2.2.0
- OrdinaryDiffEqLinear 2.2.1 -> 2.3.0
- OrdinaryDiffEqLowStorageRK 3.3.0 -> 3.4.0
- OrdinaryDiffEqNewmark 2.3.0 -> 2.4.0
- OrdinaryDiffEqNordsieck 2.2.2 -> 2.3.0
- OrdinaryDiffEqPDIRK 2.3.0 -> 2.4.0
- OrdinaryDiffEqQPRK 2.1.3 -> 2.2.0
- OrdinaryDiffEqRKN 2.1.2 -> 2.2.0
- OrdinaryDiffEqSDIRK 2.8.2 -> 2.9.0
- OrdinaryDiffEqSSPRK 2.2.2 -> 2.3.0
- OrdinaryDiffEqStabilizedRK 2.5.1 -> 2.6.0
- OrdinaryDiffEqTaylorSeries 2.1.2 -> 2.2.0
- OrdinaryDiffEqVerner 2.2.2 -> 2.3.0
- StochasticDiffEqCore 2.0.6 -> 2.1.0
- StochasticDiffEqHighOrder 2.1.3 -> 2.2.0
- StochasticDiffEqIIF 2.0.3 -> 2.1.0
- StochasticDiffEqImplicit 2.1.3 -> 2.2.0
- StochasticDiffEqLeaping 2.0.3 -> 2.1.0
- StochasticDiffEqLevyArea 2.0.3 -> 2.1.0
- StochasticDiffEqMilstein 2.0.3 -> 2.1.0
- StochasticDiffEqROCK 2.0.3 -> 2.1.0
- StochasticDiffEqRODE 2.0.3 -> 2.1.0
- StochasticDiffEqWeak 2.1.3 -> 2.2.0