### PR TITLE
Floor the Newton direction's linear tolerance at sqrt(eps)

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/test/krylov_linear_tolerance_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/krylov_linear_tolerance_tests.jl
@@ -21,12 +21,15 @@ newton_cache(integrator) = integrator.cache.nlsolver.cache.linsolve
 @testset "integrator tolerance reaches the Krylov cache" begin
     # Newton path: `build_nlsolver` builds the `LinearCache` without tolerances, so
     # `dolinsolve` is the only thing that can put the integrator's `reltol` there.
+    # A Newton direction is floored at `sqrt(eps)` however loose the integrator is, because
+    # a correction solved only to `reltol` cannot drive the stage to `reltol` (#4293), so a
+    # looser tolerance clamps and a tighter one passes through unchanged.
     for tol in (1.0e-6, 1.0e-10)
         integrator = init(prob, FBDF(linsolve = KrylovJL_GMRES()); reltol = tol, abstol = tol)
         for _ in 1:5
             step!(integrator)
         end
-        @test newton_cache(integrator).reltol == tol
+        @test newton_cache(integrator).reltol == min(tol, sqrt(eps(Float64)))
     end
 
     integrator = init(prob, KenCarp4(linsolve = KrylovJL_GMRES()); reltol = 1.0e-7, abstol = 1.0e-7)

--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.10.0"
+version = "2.10.1"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -616,6 +616,30 @@ end
 end
 
 """
+    newton_linear_reltol(reltol, uT) -> reltol
+
+Relative tolerance for the iterative linear solve that produces the modified Newton
+direction.
+
+The correction has to be more accurate than the tolerance it is being used to reach.
+Solving the stage system only to the integrator's own `reltol` gives a direction good to
+`reltol`, so the stage never converges there, `dt` collapses and the step controller gives
+up. That is SciML/OrdinaryDiffEq.jl#4293: the `Hairer4` and `Hairer42` runs in
+`test/Regression_I/newton_krylov_roundoff.jl` call `solve` with no tolerances, so the
+Krylov solve inherits the default `reltol` of 1e-3 and both return `Unstable`.
+
+The floor is `sqrt(eps)`, which is where LinearSolve's own default sat before the linear
+tolerance became integrator-driven, so a looser integrator behaves as it did before and a
+tighter one still gets the tighter linear solve.
+
+This is about Newton directions specifically. A Rosenbrock stage is a single linear solve
+whose accuracy caps the stage directly instead of feeding an iteration, and
+`NonlinearSolveAlg`'s inner descent carries its own convergence handling, so neither is
+floored here.
+"""
+newton_linear_reltol(reltol, uT) = reltol isa Number ? min(reltol, sqrt(eps(uT))) : reltol
+
+"""
     compute_step!(nlsolver::NLSolver{<:NLNewton}, integrator)
 
 Compute next iterate of numerically stable modified Newton iteration
@@ -717,7 +741,7 @@ end
     end
 
     if integrator.opts.adaptive
-        reltol = integrator.opts.reltol
+        reltol = newton_linear_reltol(integrator.opts.reltol, real(one(eltype(dz))))
     else
         reltol = eps(real(one(eltype(dz))))
     end


### PR DESCRIPTION
Fixes #4293.

`compute_step!` for `NLNewton` hands `integrator.opts.reltol` straight to the linear solve.
A Newton correction has to be more accurate than the tolerance it is being used to reach, so
at the default `reltol = 1e-3` the Krylov solve returns a direction good only to 1e-3, the
stage never converges to 1e-3, `dt` collapses and the step controller gives up.

`test/Regression_I/newton_krylov_roundoff.jl` is the thing that broke because it calls `solve`
with no tolerances, so the linear solve inherits the 1e-3 default. On `upstream/master` at
202f5fda90:

| | retcode | accepted | rejected | drift |
| --- | --- | --- | --- | --- |
| `Hairer4` master | Unstable | 3 | 31 | n/a |
| `Hairer42` master | Unstable | 5 | 31 | n/a |
| `Hairer4` here | Success | 21 | 1 | 4.44e-16 |
| `Hairer42` here | Success | 21 | 1 | 6.66e-16 |

The gate is `drift < 1e-5` and that file's own comment puts a round-off reproducible run in
the 1e-15 to 1e-7 band.

The floor is `sqrt(eps)` because that is LinearSolve's own default, which is where this sat
before #4192 made the linear tolerance integrator-driven. It is not a constant fitted to this
reproducer. A run looser than that behaves as it did before #4192, a tighter one still gets
the tighter linear solve.

## Why here and not in `set_linear_reltol!`

Clamping inside `set_linear_reltol!` also fixes the reproducer, and I measured it, but it
floors every caller including the Rosenbrock path. A Rosenbrock stage is a single linear solve
whose accuracy caps the stage directly rather than feeding an iteration, so `reltol` is the
right target there and flooring it is just over-solving: at `reltol = 1e-3` on Robertson it
moves `Rodas5P` from 1.1e-3 error to 2.1e-6 while doing more work for accuracy nobody asked
for. It also fails four assertions across two files rather than one.

I also tried extending the same floor to `set_inner_linear_reltol!`, on the theory that
`NonlinearSolveAlg`'s inner Krylov descent is a Newton direction too. That fails two more
assertions in `nsa_krylov_tolerance_tests.jl`, and that file's third testset already measures
the loose tolerance there as costing no accuracy and no `nnonlinconvfail`, so there is nothing
to fix on that path. Left alone.

## Test change, please look at this one

`lib/OrdinaryDiffEqDifferentiation/test/krylov_linear_tolerance_tests.jl` asserted
`newton_cache(integrator).reltol == tol` for `tol = 1e-6`, which is the behaviour that breaks
#4293, so it had to move to `min(tol, sqrt(eps(Float64)))`. The `tol = 1e-10` case in the same
loop is unchanged and still checks that a tighter tolerance passes through. The other three
assertions in that file, and all three testsets of `nsa_krylov_tolerance_tests.jl`, are
untouched and pass.

## Testing

Ran against this branch: `krylov_linear_tolerance_tests.jl`, `nf_accounting_tests.jl`,
`warm_start_default_tests.jl`, `stale_w_linear_operator_tests.jl`, `newton_krylov_roundoff.jl`,
`linear_nonlinear_tests.jl`, `nsa_krylov_tolerance_tests.jl`, `nsa_residual_convergence_tests.jl`,
`nsa_conditioning_tests.jl`, `mass_matrix_tests.jl`. All pass. `newton_tests.jl` I could not run
locally, `DiffEqDevTools` fails to precompile on my Julia 1.10 for unrelated reasons.

Also swept `Hairer4`, `Hairer42`, `TRBDF2`, `KenCarp4`, `FBDF`, `QNDF`, `Rodas5P`,
`Rosenbrock23` and the `NonlinearSolveAlg` variants of `TRBDF2` and `KenCarp4` with
`KrylovJL_GMRES` at default tolerances over an index-1 DAE, Allen-Cahn and Robertson. Every
case that succeeded on master still succeeds, and `KenCarp4` and `FBDF` on Robertson improve
from 2.7e-4 and 5.7e-4 error to 1.4e-6 and 3.1e-5.

One thing that sweep turned up and that this PR does not address: `Rosenbrock23` with
`KrylovJL_GMRES` on a mass-matrix problem with a `jac_prototype` errors with
`MethodError: no method matching jacobian!(::SciMLOperators.NullOperator, ...)`. That happens
on unmodified master too, so it is a separate bug. I can file it if it is not already known.

## AI Disclosure

Claude assisted with this work.
