### PR TITLE
ExpRK: cache ishermitian implementation

### DIFF
--- a/lib/OrdinaryDiffEqExponentialRK/Project.toml
+++ b/lib/OrdinaryDiffEqExponentialRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExponentialRK"
 uuid = "e0540318-69ee-4070-8777-9e2de6de23de"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.3.0"
+version = "2.3.1"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -15,6 +15,7 @@ ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -28,7 +29,6 @@ OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
-SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
@@ -66,4 +66,4 @@ Reexport = "1.2.2"
 SafeTestsets = "0.1.0"
 
 [targets]
-test = ["DiffEqDevTools", "Random", "SafeTestsets", "Test", "OrdinaryDiffEqTsit5", "LinearSolve", "SparseArrays", "OrdinaryDiffEqVerner", "OrdinaryDiffEqSDIRK", "Pkg", "SciMLTesting", "SciMLOperators"]
+test = ["DiffEqDevTools", "Random", "SafeTestsets", "Test", "OrdinaryDiffEqTsit5", "LinearSolve", "SparseArrays", "OrdinaryDiffEqVerner", "OrdinaryDiffEqSDIRK", "Pkg", "SciMLTesting"]

--- a/lib/OrdinaryDiffEqExponentialRK/src/OrdinaryDiffEqExponentialRK.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/OrdinaryDiffEqExponentialRK.jl
@@ -31,6 +31,7 @@ import ADTypes: AutoForwardDiff
 using Reexport: Reexport, @reexport
 @reexport using SciMLBase
 using SciMLBase: SciMLBase, SplitFunction
+using SciMLOperators: isconstant
 
 include("algorithms.jl")
 include("alg_utils.jl")

--- a/lib/OrdinaryDiffEqExponentialRK/src/OrdinaryDiffEqExponentialRK.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/OrdinaryDiffEqExponentialRK.jl
@@ -15,7 +15,7 @@ using RecursiveArrayTools: RecursiveArrayTools
 import RecursiveArrayTools: recursivecopy!
 using MuladdMacro: MuladdMacro, @muladd
 using FastBroadcast: FastBroadcast, @..
-using LinearAlgebra: axpy!, mul!
+using LinearAlgebra: axpy!, mul!, ishermitian
 import DiffEqBase
 import DiffEqBase: calculate_residuals, calculate_residuals!, initialize!
 using ExponentialUtilities: ExponentialUtilities, ExpvCache, KrylovSubspace,

--- a/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_caches.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_caches.jl
@@ -112,8 +112,23 @@ Symmetry of the ExpRK linear operator, or `nothing` when it cannot safely be cac
 `ETDRK4` step. For a sparse symmetric operator that check is a full `O(nnz)` scan (it can only
 exit early on finding an asymmetry), costing roughly 10% of a Krylov build at `m = 15`.
 
-A `SplitFunction`'s linear part is fixed for the whole solve, so the answer can be computed
-once. Everything else returns `nothing`, and `arnoldi!` derives the flag itself as before.
+Caching a *value* -- "are these entries symmetric?" -- is only accurate while the entries cannot
+change, so two conditions must hold. Anything else returns `nothing` and `arnoldi!` derives the
+flag itself on every call, exactly as before:
+
+  * `f isa SplitFunction`, so `A` is the fixed linear part rather than a Jacobian that
+    `calc_J!` rebuilds every step; and
+  * `isconstant(A)`, so the operator carries no `update_func` that `update_coefficients[!]`
+    could fire to replace its entries part-way through the solve.
+
+The second condition matters because the error is asymmetric. A stale `false` merely costs
+performance -- `arnoldi!` runs full Arnoldi. A stale `true` sends it to `lanczos!`, whose
+three-term recurrence is valid only for symmetric operators, and the result is *silently wrong*.
+
+Not covered: mutating the underlying array in place through a reference held outside the solver
+without going through `update_coefficients!`. That is outside the SciMLOperators contract and is
+already unsupported here -- the `krylov = false` path precomputes `expRK_operators(alg, dt, A)`
+once at cache construction and would ignore such a change entirely.
 """
 function _cached_ishermitian(f)
     isa(f, SplitFunction) || return nothing
@@ -121,6 +136,7 @@ function _cached_ishermitian(f)
     # `MatrixOperator` rather than a bare `AbstractMatrix`, so do not require the latter --
     # just ask whether `ishermitian` is defined for it, exactly as `arnoldi!` would.
     A = f.f1.f
+    isconstant(A) || return nothing
     applicable(ishermitian, A) || return nothing
     return ishermitian(A)
 end

--- a/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_caches.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_caches.jl
@@ -103,6 +103,48 @@ for (Alg, Cache) in [
 end
 
 """
+    _cached_ishermitian(f) -> Union{Bool,Nothing}
+
+Symmetry of the ExpRK linear operator, or `nothing` when it cannot safely be cached.
+
+`arnoldi!` takes `ishermitian` as a keyword argument whose default is
+`LinearAlgebra.ishermitian(A)`, so the property is re-derived on *every* call -- five times per
+`ETDRK4` step. For a sparse symmetric operator that check is a full `O(nnz)` scan (it can only
+exit early on finding an asymmetry), costing roughly 10% of a Krylov build at `m = 15`.
+
+A `SplitFunction`'s linear part is fixed for the whole solve, so the answer can be computed
+once. Everything else returns `nothing`, and `arnoldi!` derives the flag itself as before.
+"""
+function _cached_ishermitian(f)
+    isa(f, SplitFunction) || return nothing
+    # `f.f1.f` is the same object handed to `arnoldi!` in `perform_step!`. It is usually a
+    # `MatrixOperator` rather than a bare `AbstractMatrix`, so do not require the latter --
+    # just ask whether `ishermitian` is defined for it, exactly as `arnoldi!` would.
+    A = f.f1.f
+    applicable(ishermitian, A) || return nothing
+    return ishermitian(A)
+end
+
+"""
+    _arnoldi_kwargs(alg, A, integrator, herm)
+
+Keyword bundle shared by the `arnoldi!` calls within one `perform_step!`.
+
+`herm` is the flag cached by [`_cached_ishermitian`](@ref), or `nothing` when it could not be
+cached, in which case it is derived here exactly as `arnoldi!` would have. The returned
+`NamedTuple` always has the same shape, so the call sites stay type-stable.
+"""
+@inline function _arnoldi_kwargs(alg, A, integrator, herm)
+    ish = herm === nothing ? ishermitian(A) : herm
+    return (
+        m = min(alg.m, size(A, 1)),
+        opnorm = integrator.opts.internalopnorm,
+        iop = alg.iop,
+        ishermitian = ish,
+    )
+end
+
+"""
     alg_cache_expRK(alg, u, uEltypeNoUnits, uprev, f, t, dt, p, du1, tmp, dz, plist)
 
 Construct the non-standard caches (not uType or rateType) for ExpRK integrators.
@@ -139,7 +181,7 @@ function alg_cache_expRK(
         Ks = KrylovSubspace{T}(n, m)
         phiv_cache = PhivCache(u, m, maximum(plist))
         ws = [Matrix{T}(undef, n, plist[i] + 1) for i in 1:length(plist)]
-        KsCache = (Ks, phiv_cache, ws)
+        KsCache = (Ks, phiv_cache, ws, _cached_ishermitian(f))
     else
         KsCache = nothing
         # Precompute the operators
@@ -859,7 +901,9 @@ function alg_cache_exprb(
     Ks = KrylovSubspace{T}(n, m)
     phiv_cache = PhivCache(u, m, maximum(plist))
     ws = [Matrix{T}(undef, n, plist[i] + 1) for i in 1:length(plist)]
-    KsCache = (Ks, phiv_cache, ws)
+    # `nothing`: the exponential Rosenbrock methods rebuild the Jacobian every step, so its
+    # symmetry cannot be cached across the solve. `_arnoldi_kwargs` derives it per call.
+    KsCache = (Ks, phiv_cache, ws, nothing)
     return uf, jac_config, J, KsCache
 end
 

--- a/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_perform_step.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_perform_step.jl
@@ -199,11 +199,9 @@ function perform_step!(integrator, cache::ETDRK2Cache, repeat_step = false)
         F1 = integrator.fsalfirst
         Ks, phiv_cache, ws, herm = KsCache
         w1, w2 = ws
+        kwargs = _arnoldi_kwargs(alg, A, integrator, herm)
         # Krylov for F1
-        arnoldi!(
-            Ks, A, F1; m = min(alg.m, size(A, 1)),
-            opnorm = integrator.opts.internalopnorm, iop = alg.iop
-        )
+        arnoldi!(Ks, A, F1; kwargs...)
         phiv!(w1, dt, Ks, 2; cache = phiv_cache)
         # Krylov for F2
         @muladd @.. broadcast = false tmp = uprev + dt * @view(w1[:, 2])
@@ -214,10 +212,7 @@ function perform_step!(integrator, cache::ETDRK2Cache, repeat_step = false)
             OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
         end
         F2 .+= mul!(rtmp, A, uprev)
-        arnoldi!(
-            Ks, A, F2; m = min(alg.m, size(A, 1)),
-            opnorm = integrator.opts.internalopnorm, iop = alg.iop
-        )
+        arnoldi!(Ks, A, F2; kwargs...)
         phiv!(w2, dt, Ks, 2; cache = phiv_cache)
         # Update u
         u .= uprev

--- a/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_perform_step.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_perform_step.jl
@@ -127,7 +127,7 @@ function perform_step!(integrator, cache::NorsettEulerCache, repeat_step = false
     alg = unwrap_alg(integrator, true)
 
     if alg.krylov
-        Ks, phiv_cache, ws = KsCache
+        Ks, phiv_cache, ws, herm = KsCache
         w = ws[1]
         arnoldi!(
             Ks, A, integrator.fsalfirst; m = min(alg.m, size(A, 1)),
@@ -197,7 +197,7 @@ function perform_step!(integrator, cache::ETDRK2Cache, repeat_step = false)
 
     if alg.krylov
         F1 = integrator.fsalfirst
-        Ks, phiv_cache, ws = KsCache
+        Ks, phiv_cache, ws, herm = KsCache
         w1, w2 = ws
         # Krylov for F1
         arnoldi!(
@@ -256,10 +256,7 @@ function perform_step!(integrator, cache::ETDRK3ConstantCache, repeat_step = fal
     Au = A * uprev
     F1 = integrator.fsalfirst
     if alg.krylov
-        kwargs = (
-            m = min(alg.m, size(A, 1)), opnorm = integrator.opts.internalopnorm,
-            iop = alg.iop,
-        )
+        kwargs = _arnoldi_kwargs(alg, A, integrator, nothing)
         # Krylov on F1 (first column)
         Ks = arnoldi(A, F1; kwargs...)
         w1_half = phiv(dt / 2, Ks, 1)
@@ -317,12 +314,9 @@ function perform_step!(integrator, cache::ETDRK3Cache, repeat_step = false)
     mul!(Au, A, uprev)
     halfdt = dt / 2
     if alg.krylov
-        Ks, phiv_cache, ws = KsCache
+        Ks, phiv_cache, ws, herm = KsCache
         w1_half, w1, w2, w3 = ws
-        kwargs = (
-            m = min(alg.m, size(A, 1)), opnorm = integrator.opts.internalopnorm,
-            iop = alg.iop,
-        )
+        kwargs = _arnoldi_kwargs(alg, A, integrator, herm)
         # Krylov for F1 (first column)
         arnoldi!(Ks, A, F1; kwargs...)
         phiv!(w1_half, halfdt, Ks, 1; cache = phiv_cache)
@@ -386,10 +380,7 @@ function perform_step!(integrator, cache::ETDRK4ConstantCache, repeat_step = fal
     F1 = integrator.fsalfirst
     halfdt = dt / 2
     if alg.krylov
-        kwargs = (
-            m = min(alg.m, size(A, 1)), opnorm = integrator.opts.internalopnorm,
-            iop = alg.iop,
-        )
+        kwargs = _arnoldi_kwargs(alg, A, integrator, nothing)
         # Krylov on F1 (first column)
         Ks = arnoldi(A, F1; kwargs...)
         w1_half = phiv(halfdt, Ks, 1)
@@ -457,12 +448,9 @@ function perform_step!(integrator, cache::ETDRK4Cache, repeat_step = false)
     mul!(Au, A, uprev)
     halfdt = dt / 2
     if alg.krylov
-        Ks, phiv_cache, ws = KsCache
+        Ks, phiv_cache, ws, herm = KsCache
         w1_half, w2_half, w1, w2, w3, w4 = ws
-        kwargs = (
-            m = min(alg.m, size(A, 1)), opnorm = integrator.opts.internalopnorm,
-            iop = alg.iop,
-        )
+        kwargs = _arnoldi_kwargs(alg, A, integrator, herm)
         # Krylov for F1 (first column)
         arnoldi!(Ks, A, F1; kwargs...)
         phiv!(w1_half, halfdt, Ks, 1; cache = phiv_cache)
@@ -548,10 +536,7 @@ function perform_step!(integrator, cache::HochOst4ConstantCache, repeat_step = f
     F1 = integrator.fsalfirst
     halfdt = dt / 2
     if alg.krylov
-        kwargs = (
-            m = min(alg.m, size(A, 1)), opnorm = integrator.opts.internalopnorm,
-            iop = alg.iop,
-        )
+        kwargs = _arnoldi_kwargs(alg, A, integrator, nothing)
         # Krylov on F1 (first column)
         Ks = arnoldi(A, F1; kwargs...)
         w1_half = phiv(halfdt, Ks, 3)
@@ -634,12 +619,9 @@ function perform_step!(integrator, cache::HochOst4Cache, repeat_step = false)
     mul!(Au, A, uprev)
     halfdt = dt / 2
     if alg.krylov
-        Ks, phiv_cache, ws = KsCache
+        Ks, phiv_cache, ws, herm = KsCache
         w1_half, w2_half, w3_half, w4_half, w1, w2, w3, w4, w5 = ws
-        kwargs = (
-            m = min(alg.m, size(A, 1)), opnorm = integrator.opts.internalopnorm,
-            iop = alg.iop,
-        )
+        kwargs = _arnoldi_kwargs(alg, A, integrator, herm)
         # Krylov on F1 (first column)
         arnoldi!(Ks, A, F1; kwargs...)
         phiv!(w1_half, halfdt, Ks, 3; cache = phiv_cache)
@@ -1509,7 +1491,7 @@ function perform_step!(integrator, cache::Exprb32Cache, repeat_step = false)
     alg = unwrap_alg(integrator, true)
 
     F1 = integrator.fsalfirst
-    Ks, phiv_cache, ws = KsCache
+    Ks, phiv_cache, ws, herm = KsCache
     w1, w2 = ws
     # Krylov for F1
     arnoldi!(
@@ -1555,10 +1537,7 @@ function perform_step!(integrator, cache::Exprb43ConstantCache, repeat_step = fa
 
     Au = A * uprev
     F1 = integrator.fsalfirst
-    kwargs = (
-        m = min(alg.m, size(A, 1)), opnorm = integrator.opts.internalopnorm,
-        iop = alg.iop,
-    )
+    kwargs = _arnoldi_kwargs(alg, A, integrator, nothing)
     # Krylov on F1 (first column)
     Ks = arnoldi(A, F1; kwargs...)
     w1_half = phiv(dt / 2, Ks, 1)
@@ -1605,7 +1584,7 @@ function perform_step!(integrator, cache::Exprb43Cache, repeat_step = false)
     F1 = integrator.fsalfirst
     mul!(Au, J, uprev)
     halfdt = dt / 2
-    Ks, phiv_cache, ws = KsCache
+    Ks, phiv_cache, ws, herm = KsCache
     w1_half, w1, w2, w3 = ws
     kwargs = (
         m = min(alg.m, size(J, 1)), opnorm = integrator.opts.internalopnorm,

--- a/lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_krylov_tests.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_krylov_tests.jl
@@ -1,6 +1,6 @@
 using OrdinaryDiffEqExponentialRK, Test, Random, LinearAlgebra, SparseArrays
 using OrdinaryDiffEqTsit5
-using SciMLOperators: MatrixOperator
+using SciMLOperators: MatrixOperator, isconstant
 using SciMLBase: successful_retcode
 using OrdinaryDiffEqExponentialRK: _cached_ishermitian, _arnoldi_kwargs
 
@@ -171,6 +171,30 @@ end
     @test _cached_ishermitian(ODEProblem((du, u, p, t) -> (@. du = -u), [1.0],
         (0.0, 1.0)).f) === nothing
 
+    # An operator may be symmetric at t=0 and not afterwards. A Jacobian cannot reach here
+    # (the SplitFunction guard above sends it down the uncached path), but a SplitFunction
+    # whose linear part carries an `update_func` can have its entries replaced by
+    # `update_coefficients!`. Caching `true` there would send `arnoldi!` to `lanczos!`,
+    # whose three-term recurrence assumes symmetry -- silently wrong, not merely slow. So
+    # anything that is not `isconstant` must decline to cache and fall back per call.
+    varying = SplitODEProblem(
+        MatrixOperator(sparse(sym.f.f1.f.A);
+            update_func = (A, u, p, t) -> (B = copy(A); B[1, 2] += t; B)),
+        g!, normalize(randn(N)), (0.0, 0.1))
+
+    @test ishermitian(varying.f.f1.f) === true    # symmetric at construction ...
+    @test isconstant(varying.f.f1.f) === false    # ... but free to stop being so
+    @test _cached_ishermitian(varying.f) === nothing
+
+    # having declined, the per-call fallback must still produce the right answer
+    @test _arnoldi_kwargs(ETDRK4(krylov = true, m = 15), varying.f.f1.f,
+        (; opts = (; internalopnorm = opnorm)), nothing).ishermitian ===
+          ishermitian(varying.f.f1.f)
+
+    # and the cache must actually hold `nothing`, not a stale snapshot
+    @test init(varying, ETDRK4(krylov = true, m = 15); dt = 1.0e-3).cache.KsCache[4] ===
+          nothing
+
     # when nothing was cached, the fallback must derive the same value, with the same
     # NamedTuple shape so the call sites stay type-stable
     let A = sym.f.f1.f, integ = (; opts = (; internalopnorm = opnorm)),
@@ -182,9 +206,13 @@ end
               keys(_arnoldi_kwargs(alg, A, integ, nothing))
     end
 
-    # the flag must reach every cache. Checked per algorithm on purpose: ETDRK2 builds its
-    # `arnoldi!` keywords inline rather than via the shared bundle, so one representative
-    # method would not catch a missed call site.
+    # The flag must reach every cache. Checked per algorithm rather than on one
+    # representative, since each `perform_step!` builds its own `arnoldi!` keywords.
+    # NOTE this asserts only that the flag is STORED: `alg_cache_expRK` populates
+    # `KsCache[4]` identically for all of them, so it cannot catch a `perform_step!` that
+    # receives the flag and then ignores it. All four in-place caches route through
+    # `_arnoldi_kwargs`; a new scheme that hand-rolls its keywords would pass this and
+    # still silently re-derive `ishermitian` on every build.
     for prob in (sym, nonsym), Alg in (ETDRK2, ETDRK3, ETDRK4, HochOst4)
         cache = init(prob, Alg(krylov = true, m = 15); dt = 1.0e-3).cache
         @test cache.KsCache[4] == ishermitian(prob.f.f1.f)

--- a/lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_krylov_tests.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_krylov_tests.jl
@@ -1,6 +1,8 @@
 using OrdinaryDiffEqExponentialRK, Test, Random, LinearAlgebra, SparseArrays
 using OrdinaryDiffEqTsit5
 using SciMLOperators: MatrixOperator
+using SciMLBase: successful_retcode
+using OrdinaryDiffEqExponentialRK: _cached_ishermitian, _arnoldi_kwargs
 
 let N = 20
     Random.seed!(0)
@@ -141,4 +143,56 @@ end
     prob = ODEProblem(exp_fun, u0, (0.0, 1.0))
     sol = solve(prob, LawsonEuler(krylov = true, m = N); dt = 0.1)
     @test sol(1.0) ≈ exp_fun.analytic(u0, nothing, 1.0)
+end
+
+@testset "Cached ishermitian flag" begin
+    # `arnoldi!` takes `ishermitian` as a default keyword argument, so it re-derives the
+    # property on every call -- five times per ETDRK4 step, and for a symmetric sparse
+    # operator that is a full O(nnz) scan. A SplitFunction's linear part is fixed for the
+    # whole solve, so `alg_cache_expRK` evaluates it once and `_arnoldi_kwargs` threads it
+    # through. These problems are split, unlike the ODEProblem fixtures above.
+    Random.seed!(0)
+    N = 32
+    g!(du, u, p, t) = (@. du = u - u^3)
+    split_prob(A) = SplitODEProblem(MatrixOperator(sparse(A)), g!,
+                                    normalize(randn(N)), (0.0, 0.1))
+
+    sym = split_prob(begin                       # periodic Laplacian => symmetric
+            A = diagm(-1 => ones(N - 1), 0 => -2ones(N), 1 => ones(N - 1)) .* 50.0
+            A[1, N] = A[N, 1] = 50.0
+            A
+        end)
+    nonsym = split_prob(                         # upwind-biased => not symmetric
+        diagm(-1 => 3ones(N - 1), 0 => -4ones(N), 1 => ones(N - 1)) .* 50.0)
+
+    # the three distinct outcomes
+    @test _cached_ishermitian(sym.f) === true
+    @test _cached_ishermitian(nonsym.f) === false
+    @test _cached_ishermitian(ODEProblem((du, u, p, t) -> (@. du = -u), [1.0],
+        (0.0, 1.0)).f) === nothing
+
+    # when nothing was cached, the fallback must derive the same value, with the same
+    # NamedTuple shape so the call sites stay type-stable
+    let A = sym.f.f1.f, integ = (; opts = (; internalopnorm = opnorm)),
+        alg = ETDRK4(krylov = true, m = 15)
+
+        @test _arnoldi_kwargs(alg, A, integ, true).ishermitian ===
+              _arnoldi_kwargs(alg, A, integ, nothing).ishermitian === true
+        @test keys(_arnoldi_kwargs(alg, A, integ, true)) ===
+              keys(_arnoldi_kwargs(alg, A, integ, nothing))
+    end
+
+    # the flag must reach every cache. Checked per algorithm on purpose: ETDRK2 builds its
+    # `arnoldi!` keywords inline rather than via the shared bundle, so one representative
+    # method would not catch a missed call site.
+    for prob in (sym, nonsym), Alg in (ETDRK2, ETDRK3, ETDRK4, HochOst4)
+        cache = init(prob, Alg(krylov = true, m = 15); dt = 1.0e-3).cache
+        @test cache.KsCache[4] == ishermitian(prob.f.f1.f)
+    end
+
+    # smoke: the split path still integrates (the fixtures above are all non-split)
+    for prob in (sym, nonsym)
+        @test successful_retcode(solve(prob, ETDRK4(krylov = true, m = 15);
+            dt = 1.0e-3, save_everystep = false))
+    end
 end


### PR DESCRIPTION
## Checklist

- [ Yes] Appropriate tests were added
- [ No] Any code changes were done in a way that does not break public API
- [ N/A] All documentation related to code changes were updated
- [ Yes] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ N/A] Any new documentation only uses public API
  
## Additional context
While reviewing the Benchmark results of Exponential Utilties came across a way to improve the performance of ETDRK methods by caching the ishermitian call results. 

These are the results of the time savings with the implementation for per arnoldi call.

 -- per Arnoldi build (ms, min of 100 calls) --
  operator                                                ishermitian(A)   arnoldi! before   arnoldi!-after   saving
  Brusselator N=32 (symmetric L)               0.02463           0.24900          0.22187          10.9%
  upwind 1-D n=2048 (non-symmetric L)          0.00025           0.22587    0.22350          1.1%

