### PR TITLE
Fix GlobalDiffEq QA metadata and Muladd floor

### DIFF
--- a/lib/GlobalDiffEq/Project.toml
+++ b/lib/GlobalDiffEq/Project.toml
@@ -1,7 +1,7 @@
 name = "GlobalDiffEq"
 uuid = "1d72d19b-84cc-4cb7-a099-7cbdb9ccc67c"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.3.0"
+version = "1.3.1"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -25,7 +25,7 @@ OrdinaryDiffEqTsit5 = {path = "../OrdinaryDiffEqTsit5"}
 DiffEqBase = "7"
 FastBroadcast = "1.3"
 LinearAlgebra = "1"
-MuladdMacro = "0.2.1"
+MuladdMacro = "0.2.4"
 OrdinaryDiffEqCore = "4"
 OrdinaryDiffEqSSPRK = "2"
 OrdinaryDiffEqTsit5 = "2"

--- a/lib/GlobalDiffEq/Project.toml
+++ b/lib/GlobalDiffEq/Project.toml
@@ -35,7 +35,7 @@ Reexport = "0.2, 1.0"
 Richardson = "1.2"
 SafeTestsets = "0.0.1, 0.1"
 SciMLBase = "3"
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 Test = "1"
 julia = "1.10"
 

--- a/test/qa/qa_tests.jl
+++ b/test/qa/qa_tests.jl
@@ -17,7 +17,7 @@ using Test
             occursin(r"(?m)^OrdinaryDiffEqCore = ", project)
         has_muladdmacro && uses_core
     end
-    @test length(projects) == 40
+    @test length(projects) == 41
     for package in projects
         project = read(joinpath(lib_dir, package, "Project.toml"), String)
         floor_match = match(r"(?m)^MuladdMacro = \"([0-9]+\.[0-9]+\.[0-9]+)", project)


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.**

## What changed and why

Register GlobalDiffEq's addition in the root QA package count, raise its MuladdMacro floor from 0.2.1 to the repository-required 0.2.4, and bump GlobalDiffEq to 1.3.1. The GLEE solver addition introduced both root QA failures by adding the 41st qualifying subpackage with a stale MuladdMacro floor.

An independent runtime bisect identified https://github.com/SciML/OrdinaryDiffEq.jl/commit/a114bc638624189e739784216e5b3ea3c989bc85 as the first bad commit.

## Failing before / passing after

On clean master, the root QA group failed both checks:

```text
projects = 41
Test Failed: 41 == 40

bad_floor = GlobalDiffEq 0.2.1
Test Failed: v"0.2.1" >= v"0.2.4"

Quality Assurance Tests | Pass 81 Fail 2 Total 83
```

With this patch, the same group passes:

```text
Test Summary:           | Pass  Total   Time
Quality Assurance Tests |   92     92  22.2s
Testing OrdinaryDiffEq tests passed
```

## Local verification

- `GROUP=QA julia +1.12 --startup-file=no --project -e 'using Pkg; Pkg.test()'`: 92/92 passed.
- `ODEDIFFEQ_TEST_GROUP=Core julia +1.12 --startup-file=no --project=lib/GlobalDiffEq -e 'using Pkg; Pkg.test()'`: Basic functionality 1/1, traits 3/3, GLEE 37/37, BigFloat 2/2; package tests passed.
- `ODEDIFFEQ_TEST_GROUP=QA julia +1.12 --startup-file=no --project=lib/GlobalDiffEq -e 'using Pkg; Pkg.test()'`: 23 passed, 1 pre-existing broken, package tests passed.
- Runic check on `test/qa/qa_tests.jl`, `typos` on both changed files, and `git diff --check`: passed.

Docs, GPU, downstream, and prerelease-Julia groups were not run because this changes package metadata and its root QA expectation, not public API or solver behavior.
