### PR TITLE
Restore the scalar DAE Jacobian test helper

### DIFF
--- a/lib/OrdinaryDiffEqBDF/test/dae_convergence_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/dae_convergence_tests.jl
@@ -104,10 +104,7 @@ end
 
 f_dae_linear = (du, u, p, t) -> (@. du - u)
 function f_dae_linear_jac(du, u, p, gamma, t)
-    J = zeros(2, 2)
-    J[1, 1] = gamma - 1.0
-    J[2, 2] = gamma - 1.0
-    return
+    return gamma - 1.0
 end
 f_dae_linear_analytic = (du0, u0, p, t) -> @. u0 * exp(t)
 prob_dae_linear_oop = DAEProblem(


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.**

## What changed and why

Return the scalar Jacobian value from the out-of-place DAE convergence-test helper. A Runic cleanup converted its previous value-returning assignment into a bare `return`, so downgrade CI passed `nothing` to `lu` before reaching the convergence assertion.

An exact-action reproduction and source-history check identified https://github.com/SciML/OrdinaryDiffEq.jl/commit/09173df89968f4f9843239179bb29e9bfe2f591b as the introducing commit.

## Failing before / passing after

The existing downgrade test discriminates without adding or weakening an assertion. On unfixed master:

```text
DAE Convergence Tests | Pass 45 Error 1 Total 46
MethodError: no method matching lu(::Nothing; check::Bool)
```

With the one-line return restored, the identical command passes the full BDF Core group:

```text
DAE Convergence Tests | 50/50
DAE AD Tests | 40/40
DAE Event Tests | 4/4
DAE derivative_discontinuity! Tests | 11/11
DAE Initialization Tests | 38 passed, 2 existing broken
DAE Nonlinear Solve Path Tests | 16/16
BDF Inference Tests | 1/1
BDF Convergence Tests | 84/84
BDF Regression Tests | 33/33
Nordsieck BDF Tests | 101/101
Testing OrdinaryDiffEqBDF tests passed
```

## Local verification

- Exact downgrade action on Julia 1.11: `TMPDIR="$PWD/.ci-tmp" JULIA_DEPOT_PATH="$PWD/.ci-depot" JULIA_NUM_PRECOMPILE_TASKS=2 GROUP=Core julia +1.11 --startup-file=no --color=no --project=lib/OrdinaryDiffEqBDF -e 'using Pkg; Pkg.test(; allow_reresolve = false)'`: full group passed after the 45-pass/1-error failure above.
- `GROUP=QA julia +1.12 --startup-file=no --project=lib/OrdinaryDiffEqBDF -e 'using Pkg; Pkg.test()'`: Allocation 2 pass/18 pre-existing broken, JET 18 pass/23 pre-existing broken, Aqua 21/21; package tests passed.
- Runic, `typos`, and `git diff --check`: passed.

Docs, GPU, downstream, and prerelease-Julia groups were not run because this only repairs a test helper used by the BDF Core/downgrade group.
