### PR TITLE
Handle matrix-free instability diagnostics

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "3.9.0"
+version = "3.9.1"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -357,10 +357,12 @@ end
 function get_fresh_jacobian(integrator, cache::OrdinaryDiffEqCache)
     (; stats) = integrator
     njacs, nf = stats.njacs, stats.nf
-    J = if SciMLBase.isinplace(integrator.sol.prob)
+    J = if SciMLBase.isinplace(integrator.sol.prob) && cache.J isa AbstractMatrix
         Jfresh = zero(cache.J)
         calc_J!(Jfresh, integrator, cache)
         Jfresh
+    elseif SciMLBase.isinplace(integrator.sol.prob)
+        nothing
     else
         calc_J(integrator, cache)
     end

--- a/lib/OrdinaryDiffEqDifferentiation/test/nojac_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/nojac_tests.jl
@@ -1,5 +1,7 @@
 using OrdinaryDiffEqSDIRK, OrdinaryDiffEqRosenbrock, RecursiveFactorization, LinearSolve,
     Test, ADTypes
+using OrdinaryDiffEqCore: get_fresh_jacobian
+using SparseArrays: sparse
 
 const N = 32
 const xyd_brusselator = range(0, stop = 1, length = N)
@@ -259,6 +261,19 @@ prob = ODEProblem(ODEFunction(pollu, jac = fjac), u0, (0.0, 60.0))
 
 integ = init(prob, Rosenbrock23(), abstol = 1.0e-6, reltol = 1.0e-6)
 @test integ.cache.jac_config === (nothing, nothing)
+
+@testset "Matrix-free diagnostic Jacobian" begin
+    f = ODEFunction(
+        (du, u, p, t) -> (du .= -u);
+        jac_prototype = sparse([1.0 0.0; 0.0 1.0])
+    )
+    prob = ODEProblem(f, ones(2), (0.0, 1.0))
+    integrator = init(prob, Rosenbrock23(linsolve = KrylovJL_GMRES()))
+    work = (integrator.stats.nf, integrator.stats.njacs)
+
+    @test get_fresh_jacobian(integrator, integrator.cache) === nothing
+    @test (integrator.stats.nf, integrator.stats.njacs) == work
+end
 integ = init(
     prob, Rosenbrock23(linsolve = SimpleLUFactorization()), abstol = 1.0e-6,
     reltol = 1.0e-6


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.**

## What changed and why

Return `nothing` from the fresh-Jacobian diagnostic hook when an in-place solver cache is matrix-free. The current code calls `zero(cache.J)` and receives a `NullOperator` for a Krylov `JVPCache`, then passes that operator to the matrix-only `calc_J!` path and errors while trying to report numerical instability. The Core diagnostic caller already treats `nothing` as “stored Jacobian unavailable.”

The regression is covered with an in-place Rosenbrock23/Krylov cache and verifies both the return value and unchanged solver work counters. OrdinaryDiffEqDifferentiation is bumped to 3.9.1.

An independent runtime bisect identified https://github.com/SciML/OrdinaryDiffEq.jl/commit/0ed2615804a38c915846358d39987f689f2511e6 as the first bad commit. Its parent returns a dense matrix for the same reproducer; the bad commit errors in `jacobian!(::NullOperator, ...)`.

## Failing before / passing after

With the regression test present and the source fix reverted:

```text
Matrix-free diagnostic Jacobian: Error During Test
Expression: get_fresh_jacobian(integrator, integrator.cache) === nothing
MethodError: no method matching jacobian!(::SciMLOperators.NullOperator, ...)

No Jac Tests | Pass 8 Error 1 Total 9
```

With this patch, the same test and full Core group pass:

```text
No Jac Tests | Pass 9 Total 9
Krylov nf accounting | Pass 21 Total 21
Krylov linear tolerance | Pass 7 Total 7
Testing OrdinaryDiffEqDifferentiation tests passed
```

A direct after-fix reproduction returned `nothing` with counters unchanged at `(nf, njacs) = (3, 0)`.

## Local verification

- `GROUP=Core julia +1.12 --project=lib/OrdinaryDiffEqDifferentiation --startup-file=no -e 'using Pkg; Pkg.test()'`: full package group passed. This includes DAE jacobian2W 4/4, scalar-operator mass matrix 9/9, No Jac 9/9, stale W 12/12, nf accounting 21/21, and Krylov tolerance 7/7.
- `GROUP=QA julia +1.12 --project=lib/OrdinaryDiffEqDifferentiation --startup-file=no -e 'using Pkg; Pkg.test()'`: JET 1/1 and Aqua 19/19; package tests passed.
- Runic, `typos`, and `git diff --check`: passed.

The CUDA job was not run locally because this machine has no GPU. The failure was reproduced through the same matrix-free cache path on CPU; broad CI should verify the GPU path. Docs and prerelease-Julia groups were not run because this adds no public API or documentation.

Failing CI job: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/32353535950/job/96379682877
