### PR TITLE
Bump DiffEqDevTools after source changes

### DIFF
--- a/lib/DiffEqDevTools/Project.toml
+++ b/lib/DiffEqDevTools/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqDevTools"
 uuid = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "3.3.0"
+version = "3.3.1"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.**

## What changed and why

Bump DiffEqDevTools from 3.3.0 to 3.3.1. Commit https://github.com/SciML/OrdinaryDiffEq.jl/commit/3a4ec518795ca32aac04b829177a54baa5dc7959 changed four DiffEqDevTools source files after the 3.3.0 tag without changing the package version. Aqua's persistent-task test builds a wrapper around the local package; in a cache containing registered 3.3.0, the same UUID/version with different source can make wrapper precompilation exit before creating `done.log`.

This is a standalone mechanical version correction. The independent missing package-docs entry remains in a separate focused fix.

## Failing before / passing after

In the same shared, collision-prone depot before the bump:

```text
Unexpected error: .../done.log was not created, but precompilation exited
Persistent tasks: Test Failed
Aqua | Pass 14 Fail 1 Total 15
```

After changing only `version = "3.3.0"` to `version = "3.3.1"`:

```text
Persistent tasks | Pass 1 Total 1  1m00.1s
```

The QA process then continued to the independent rendered-doc assertion and reported only `unrendered = [:ConvergenceTrajectory]`; no persistent-task failure remained.

## Local verification

- `GROUP=QA TMPDIR="$PWD/.agent_tmp" JULIA_PKG_PRECOMPILE_AUTO=0 julia +1.12 --startup-file=no --project=lib/DiffEqDevTools -e 'using Pkg; Pkg.test()'`: local DiffEqDevTools 3.3.1 resolved and Aqua Persistent tasks passed 1/1. The separate rendered-doc check remained the sole failure.
- `typos lib/DiffEqDevTools/Project.toml` and `git diff --check`: passed.

The complete DiffEqDevTools QA group is also being checked with this bump plus the separate docs entry; this PR deliberately contains only the mechanical version correction. Docs, GPU, downstream, and prerelease-Julia groups were not run for this metadata-only branch.
