### PR TITLE
Render ConvergenceTrajectory in package docs

### DIFF
--- a/lib/DiffEqDevTools/docs/src/index.md
+++ b/lib/DiffEqDevTools/docs/src/index.md
@@ -7,6 +7,7 @@ tableau utilities.
 
 ```@docs
 DiffEqDevTools.ConvergenceSimulation
+DiffEqDevTools.ConvergenceTrajectory
 DiffEqDevTools.test_convergence
 DiffEqDevTools.analyticless_test_convergence
 DiffEqDevTools.appxtrue


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.**

## What changed and why

Add the exported `ConvergenceTrajectory` type to DiffEqDevTools' package-local rendered API page. The root OrdinaryDiffEq docs already rendered its docstring, but DiffEqDevTools QA deliberately checks `lib/DiffEqDevTools/docs/src`; the type was therefore public and documented yet still failed the package's rendered-doc assertion.

An independent bisect identified https://github.com/SciML/OrdinaryDiffEq.jl/commit/528f8214fc3933577e94084b4cb0a0fcfc580329 as the first bad commit. That change introduced and exported the type but added it only to the root docs tree.

## Failing before / passing after

Before this entry:

```text
Public API documentation: Test Failed
unrendered = [:ConvergenceTrajectory]
```

With this patch, the focused check passes:

```text
Test Summary:             | Pass  Total  Time
Public API documentation  |    2      2  0.3s
```

## Local verification

- The exact `SciMLTesting.run_api_docs` package check: 2/2 passed after failing on the unfixed docs tree.
- `julia +1.12 --startup-file=no --project=docs docs/make.jl`: completed successfully and rendered the full documentation site.
- Runic `--check --docstrings`, `typos`, and `git diff --check`: passed.

The complete package QA group still encounters the independent Aqua persistent-task failure present on master. A proposed version-only workaround was tested with fresh before/after cache controls, failed identically, and was closed at https://github.com/SciML/OrdinaryDiffEq.jl/pull/4311. This PR fixes the rendered-doc assertion only. GPU, downstream, and prerelease-Julia groups were not run because this changes documentation only.
