### PR TITLE
Document StochasticDiffEqCore DiffCache

### DIFF
--- a/docs/src/devtools/internals/public_api.md
+++ b/docs/src/devtools/internals/public_api.md
@@ -422,6 +422,7 @@ algorithm pages to select methods for `solve`.
 StochasticDiffEqCore.AbstractJ
 StochasticDiffEqCore.AbstractJCommute
 StochasticDiffEqCore.AbstractJDiagonal
+StochasticDiffEqCore.DiffCache
 StochasticDiffEqCore.DiffEqNLSolveTag
 StochasticDiffEqCore.IICommutative
 StochasticDiffEqCore.IIFNLSolveFunc


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

Add the already-public `StochasticDiffEqCore.DiffCache` to the rendered public API list. Strict rendered-documentation QA was enabled by https://github.com/SciML/OrdinaryDiffEq.jl/commit/da6a633b4f991cae8f518c37e0329b587991f104 without listing this name, leaving current master red with `unrendered = [:DiffCache]`.

## Verification

Failing before, on the unmodified source:

```text
GROUP=QA JULIA_DEPOT_PATH="$PWD/.agent_depot" /home/crackauc/.juliaup/bin/julia +1.12 --startup-file=no --project=lib/StochasticDiffEqCore -e 'using Pkg; Pkg.test()'
...
unrendered = [:DiffCache]
Test Summary: | Pass  Fail  Total
Aqua          |   20     1     21
```

Passing after the one-line docs entry:

```text
GROUP=QA JULIA_DEPOT_PATH="$PWD/.agent_depot" /home/crackauc/.juliaup/bin/julia +1.12 --startup-file=no --project=lib/StochasticDiffEqCore -e 'using Pkg; Pkg.test()'
...
Test Summary: | Pass  Total
Aqua          |   21     21
Testing StochasticDiffEqCore tests passed
```

The documentation environment was freshly instantiated, then the full docs build completed through template expansion, cross-reference checks, and HTML rendering:

```text
JULIA_DEPOT_PATH="$PWD/.agent_depot" /home/crackauc/.juliaup/bin/julia +1.12 --startup-file=no --project=docs docs/make.jl
# exit 0
```

`typos docs/src/devtools/internals/public_api.md` and `git diff --check` both exited 0. Runic does not format Markdown; the repository-wide Runic failures already present on master are handled separately.

I did not run GPU groups or `GROUP=Everything`; this is a rendered-documentation-only change.
