### PR TITLE
fix: align GlobalDiffEq MuladdMacro QA floor

### DIFF
--- a/lib/GlobalDiffEq/Project.toml
+++ b/lib/GlobalDiffEq/Project.toml
@@ -25,7 +25,7 @@ OrdinaryDiffEqTsit5 = {path = "../OrdinaryDiffEqTsit5"}
 DiffEqBase = "7"
 FastBroadcast = "1.3"
 LinearAlgebra = "1"
-MuladdMacro = "0.2.1"
+MuladdMacro = "0.2.4"
 OrdinaryDiffEqCore = "4"
 OrdinaryDiffEqSSPRK = "2"
 OrdinaryDiffEqTsit5 = "2"

--- a/test/qa/qa_tests.jl
+++ b/test/qa/qa_tests.jl
@@ -17,7 +17,7 @@ using Test
             occursin(r"(?m)^OrdinaryDiffEqCore = ", project)
         has_muladdmacro && uses_core
     end
-    @test length(projects) == 40
+    @test length(projects) == 41
     for package in projects
         project = read(joinpath(lib_dir, package, "Project.toml"), String)
         floor_match = match(r"(?m)^MuladdMacro = \"([0-9]+\.[0-9]+\.[0-9]+)", project)


### PR DESCRIPTION
This PR fixes a pre-existing root QA failure introduced when GlobalDiffEq began depending on OrdinaryDiffEqCore and MuladdMacro. It raises GlobalDiffEq's MuladdMacro compat floor to 0.2.4 and updates the root QA project count from 40 to 41.

Please ignore this draft until reviewed by @ChrisRackauckas.

## Evidence

Clean `upstream/master` reproduced:

```text
GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary:                           | Pass  Fail  Total
Quality Assurance Tests                 |   90     2     92
Evaluated: 41 == 40
Evaluated: v"0.2.1" >= v"0.2.4"
```

The failing-before state was bisected with a static reproduction of the QA predicate. `a114bc6386` (`Add GLEE23/GLEE24/GLEE35 and MM5GEE global-error-estimating solvers`) is the first bad commit; it added the matching GlobalDiffEq project with `MuladdMacro = "0.2.1"`.

With this patch applied:

```text
GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary:           | Pass  Total
Quality Assurance Tests |   92     92
Testing OrdinaryDiffEq tests passed
```

Also ran `typos lib/GlobalDiffEq/Project.toml test/qa/qa_tests.jl` and `git diff --check`.
