### PR TITLE
Define the Milstein drift predictor across noise branches

### DIFF
--- a/lib/StochasticDiffEqMilstein/Project.toml
+++ b/lib/StochasticDiffEqMilstein/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqMilstein"
 uuid = "8c95a807-c8e7-4581-8419-890d001af53e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/StochasticDiffEqMilstein/src/perform_step/rkmilgeneral.jl
+++ b/lib/StochasticDiffEqMilstein/src/perform_step/rkmilgeneral.jl
@@ -281,11 +281,11 @@ end
 
     du1 = integrator.f(uprev, p, t)
     L = integrator.f.g(uprev, p, t)
+    K = @.. uprev + dt * du1
     mil_correction = zero(u)
     ggprime_norm = zero(eltype(u))
 
     if dW isa Number || is_diagonal_noise(integrator.sol.prob)
-        K = @.. uprev + dt * du1
         utilde = (
             SciMLBase.alg_interpretation(integrator.alg) ==
                 SciMLBase.AlgorithmInterpretation.Ito ? K : uprev
@@ -295,8 +295,8 @@ end
         u = K + L .* dW + mil_correction
     else
         for i in 1:length(dW)
-            K = uprev + dt * du1 + integrator.sqdt * @view(L[:, i])
-            gtmp = integrator.f.g(K, p, t)
+            Ktmp = K + integrator.sqdt * @view(L[:, i])
+            gtmp = integrator.f.g(Ktmp, p, t)
             ggprime = @.. (gtmp - L) / integrator.sqdt
             ggprime_norm = zero(eltype(u))
             if integrator.opts.adaptive
@@ -304,12 +304,7 @@ end
             end
             mil_correction += ggprime * @view(J[i, :])
         end
-        if integrator.opts.adaptive
-            K = @.. uprev + dt * du1
-            u = K + L * dW + mil_correction
-        else
-            u = uprev + dt * du1 + L * dW + mil_correction
-        end
+        u = K + L * dW + mil_correction
     end
 
     if integrator.opts.adaptive


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

Compute RKMilGeneral's deterministic drift predictor once before dispatching on the noise shape, and use a separate `Ktmp` for each general-noise perturbation. This makes the final update use a definitely assigned `K` in both adaptive and non-adaptive paths while consolidating algebraically identical updates. `StochasticDiffEqMilstein` is bumped from 2.1.0 to 2.1.1.

The latent control flow entered the monorepo in https://github.com/SciML/OrdinaryDiffEq.jl/commit/4900b054db660d8e77a3a2595480611aae985cf3; its parent has no Milstein sublibrary. The failing sublibrary JET lane was later added by https://github.com/SciML/OrdinaryDiffEq.jl/commit/c538565b25ff19e661e5bf788fe1953a154d64e9. A clean historical control pinned to https://github.com/SciML/SciMLTesting.jl/releases/tag/v2.8.0 also fails `16 pass, 1 fail, 4 broken`: its BasicPass includes the same undefined `K`. The recent SciMLTesting mode change therefore narrowed the report but did not introduce this finding.

## Verification

Failing before on an unmodified clean master checkout:

```text
GROUP=QA JULIA_DEPOT_PATH="$PWD/.agent_depot" /home/crackauc/.juliaup/bin/julia +1.12 --startup-file=no --project=lib/StochasticDiffEqMilstein -e 'using Pkg; Pkg.test()'
...
local variable `K` may be undefined
Test Summary: | Pass  Fail  Broken  Total
JET Tests     |   16     1       4     21
ERROR: Some tests did not pass: 16 passed, 1 failed, 4 broken.
```

The identical QA group passes with this change:

```text
Test Summary: | Pass  Broken  Total      Time
JET Tests     |   17       4     21  1m49.6s
Testing StochasticDiffEqMilstein tests passed
```

The full Core group also passes:

```text
GROUP=Core JULIA_DEPOT_PATH="$PWD/.agent_depot" /home/crackauc/.juliaup/bin/julia +1.12 --startup-file=no --project=lib/StochasticDiffEqMilstein -e 'using Pkg; Pkg.test()'
...
Module loads and algorithm constructors | 7/7
RKMilGeneral diagonal noise regression  | 9/9
Testing StochasticDiffEqMilstein tests passed
```

Runic check, `typos` on both changed files, and `git diff --check` all exited 0. No public API or documentation changed.

I did not run GPU groups, prerelease Julia, or `GROUP=Everything` locally.

Failing CI job: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/32364530209/job/96412309146
