### PR TITLE
Initialize conditional nonlinear solver state for JET

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.10.0"
+version = "2.10.1"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -508,6 +508,9 @@ end
 
     nlstep_data = get_nlstep_data(integrator.f)
     nlcache = nlsolver.cache.cache
+    innersol = nothing
+    fnorm_prev = nothing
+    γΔt = nothing
     if nlcache isa NonlinearSolveNoInitCache
         # A no-init cache holds no iteration state, so it cannot be driven one `step!` at a
         # time: `solve!` runs the complete inner solve and its returned solution is the only
@@ -558,8 +561,9 @@ end
             # in a no-init cache here too. The solution `solve!` already returned is used
             # as-is instead of rebuilding one from `nlcache.retcode`/`nlcache.stats`/
             # `get_fu`, none of which exist on this cache.
-            active_fu = innersol.resid
-            nlstepsol = innersol
+            inner_solution = something(innersol)
+            active_fu = inner_solution.resid
+            nlstepsol = inner_solution
         else
             active_fu = get_fu(nlcache)
             # No `trace` is attached: this solution only feeds `nlprobmap` right below, and
@@ -588,7 +592,11 @@ end
         # no displacement to be misled by.
         cache.stalled = false
     else
-        active_u = nlcache isa NonlinearSolveNoInitCache ? innersol.u : get_u(nlcache)
+        active_u = if nlcache isa NonlinearSolveNoInitCache
+            something(innersol).u
+        else
+            get_u(nlcache)
+        end
         @.. broadcast = false ztmp = active_u
         ustep = if nlsolve_f(integrator) isa DAEFunction
             _uprev = get_dae_uprev(integrator, uprev)
@@ -599,7 +607,7 @@ end
         @.. broadcast = false atmp = z - ztmp
         if !(nlcache isa NonlinearSolveNoInitCache)
             cache.stalled = stalled_inner_step(
-                nlcache, maxabs(atmp), maxabs(z), fnorm_prev, γΔt
+                nlcache, maxabs(atmp), maxabs(z), something(fnorm_prev), something(γΔt)
             )
         end
         calculate_residuals!(


### PR DESCRIPTION
## What changed

Initialize the nonlinear-step values that are assigned only in cache-specific branches, and unwrap them with `something` only where control flow guarantees that the assignment occurred. This preserves runtime behavior while giving JET a concrete proof that `innersol`, `fnorm_prev`, and `γΔt` are defined. OrdinaryDiffEqNonlinearSolve is bumped from 2.10.0 to 2.10.1.

Ignore this PR until reviewed by @ChrisRackauckas.

## Failing before

The existing QA test on the unfixed code reports five possible undefined-variable paths:

```console
$ cd lib/OrdinaryDiffEqNonlinearSolve/test/qa
$ julia +1.12 --startup-file=no --project=. -e 'using Test; include("jet.jl")'
═════ 5 possible errors found ═════
innersol may be undefined       newton.jl:464, :465, :494
fnorm_prev may be undefined     newton.jl:499
γΔt may be undefined            newton.jl:499
Test Summary: | Pass  Fail  Broken  Total
JET Tests     |   12     1      33     46
ERROR: 12 passed, 1 failed, 33 broken.
```

The three `innersol` reports were introduced by https://github.com/SciML/OrdinaryDiffEq.jl/commit/35c381311b4638a1a90d25599e388101ce84064e. The other two were introduced by https://github.com/SciML/OrdinaryDiffEq.jl/commit/0c38614b65f07981a9deb6c1cd4d49e8991e3827.

## Passing after

The full QA group passes after the change:

```console
$ GROUP=QA julia +1.12 --startup-file=no --project=lib/OrdinaryDiffEqNonlinearSolve -e 'using Pkg; Pkg.test()'
JET Tests | 13 pass, 33 broken, 46 total
Aqua      | 41 pass, 41 total
Testing OrdinaryDiffEqNonlinearSolve tests passed
```

The focused functional tests that exercise both affected paths also pass:

```text
NonlinearSolve no-init tests    | 102 pass, 102 total
Residual convergence tests     | 13 pass, 13 total
```

Runic over `newton.jl`, typos over the diff, and `git diff --check` passed.

## Not verified

The full Core group advanced through Developer, Newton, Sparse DAE, and LinearNonlinear tests, then stopped on the independent clean-master `NullOperator` diagnostic regression covered by https://github.com/SciML/OrdinaryDiffEq.jl/pull/4310. GPU and version-matrix jobs were not run locally. No docs build was run because this changes no public API, docstring, or documentation.
