### PR TITLE
Terminate community callback on either crossing

### DIFF
--- a/lib/DiffEqBase/test/downstream/community_callback_tests.jl
+++ b/lib/DiffEqBase/test/downstream/community_callback_tests.jl
@@ -226,7 +226,7 @@ function cond!(out, u, t, i)
     return nothing
 end
 function terminate_affect!(int, events)
-    return any(isone, events) && terminate!(int)
+    return any(!iszero, events) && terminate!(int)
 end
 cb = VectorContinuousCallback(cond!, terminate_affect!, 1)
 


### PR DESCRIPTION
## What changed and why

Restore the community callback test's stated behavior: terminate on the first nonzero vector-continuous-callback crossing, regardless of direction. The test currently checks `any(isone, events)`, so it ignores the `-1` downcrossing at π/2 and terminates at the next `+1` upcrossing near 3π/2.

This is a test correction for the documented event-direction convention, not a tolerance change or solver behavior change.

Ignore this PR until reviewed by @ChrisRackauckas.

## Failing before

The exact community example on clean current master returns the second crossing:

```console
$ julia +1.12 --startup-file=no --project=. callback_mwe.jl
4.712335206969428
ERROR: expected the first crossing near π/2
```

The test predicate regression begins at https://github.com/SciML/OrdinaryDiffEq.jl/commit/b35b3c3b71f7f274e246df2ceeedd3579585b380, merged through https://github.com/SciML/OrdinaryDiffEq.jl/pull/3914. That commit changed `any(!iszero, events)` to `any(isone, events)` while retaining the expected time π/2.

## Passing after

The identical reproducer with the corrected predicate terminates on the first crossing:

```console
$ julia +1.12 --startup-file=no --project=. callback_mwe.jl
1.5707927986456003
```

The full owning Downstream2 group passes:

```text
Community Callback    | 16 pass, 16 total
Problem Kwargs        | 3 pass, 3 total
Unwrapping            | 3 pass, 3 total
DE stats              | 4 pass, 4 total
Distributed Ensemble  | 4 pass, 4 total
Testing DiffEqBase tests passed
```

The full DiffEqBase QA group also passes:

```text
Aqua | 9 pass, 9 total
Testing DiffEqBase tests passed
```

Runic over the changed test file, typos over the diff, and `git diff --check` passed. No version bump is needed for a test-only correction.

## Not verified

GPU and Julia version-matrix jobs were not run locally. No docs build was run because this changes no public API, docstring, or documentation.