### PR TITLE
Run ProbNum downstream tests on Julia 1.12

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
-    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.julia-version }}
+    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.package.julia || matrix.julia-version }}
     runs-on: ${{ matrix.os }}
     env:
       GROUP: ${{ matrix.package.group }}
@@ -31,14 +31,14 @@ jobs:
           - {user: SciML, repo: ModelingToolkit.jl, group: InterfaceII}
           - {user: SciML, repo: ModelingToolkit.jl, group: Initialization}
           - {user: SciML, repo: ModelingToolkit.jl, group: SymbolicIndexingInterface}
-          - {user: nathanaelbosch, repo: ProbNumDiffEq.jl, group: Downstream}
+          - {user: nathanaelbosch, repo: ProbNumDiffEq.jl, group: Downstream, julia: '1.12'}
           - {user: SKopecz, repo: PositiveIntegrators.jl, group: Downstream}
 
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: ${{ matrix.julia-version }}
+          version: ${{ matrix.package.julia || matrix.julia-version }}
           arch: x64
       - name: Clone Downstream
         uses: actions/checkout@v7


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Allow individual Downstream matrix entries to select a Julia version, and run ProbNumDiffEq on Julia 1.12. Its current test environment no longer resolves on Julia 1.10: JET's project constraint and Julia compatibility have no common version, with a secondary PrecompileTools conflict. All other downstream entries continue using the existing matrix Julia versions.

The ProbNum test requirement was introduced by https://github.com/nathanaelbosch/ProbNumDiffEq.jl/commit/e0ed536b2c2bc9309734b67a067357002ceef8ff. OrdinaryDiffEq began surfacing downstream resolver failures in https://github.com/SciML/OrdinaryDiffEq.jl/commit/fd8861edd500f8bba76a4f2a865e304d10881fe8.

## Verification

Failing before, using the Downstream workflow's Julia 1.10 environment:

```text
[ Warning: julia version requirement for project not satisfied
ERROR: Unsatisfiable requirements detected for package JET [c3a54625]
...
caused by: Unsatisfiable requirements detected for package PrecompileTools [aea7be01]
```

Passing after, using the same downstream checkout and test command on Julia 1.12:

```text
Testing ProbNumDiffEq tests passed
```

The complete ProbNum suite ran through its solver-correctness, AD, compatibility, solution, and DE-stats test sets before reporting success.

Workflow validation:

```text
actionlint .github/workflows/Downstream.yml  # exit 0
typos .github/workflows/Downstream.yml       # exit 0
git diff --check                             # exit 0
```

## Not verified

I did not rerun the other Downstream matrix entries because their Julia-version selection is unchanged. GPU and `GROUP=Everything` were not run.

Failing CI job: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/32364529686/job/96411063562
