### PR TITLE
Fix definite assignment in ROCK stages

### DIFF
--- a/lib/StochasticDiffEqROCK/Project.toml
+++ b/lib/StochasticDiffEqROCK/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqROCK"
 uuid = "db241ea8-0e6b-4abc-8f2d-1adff2294fd9"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/StochasticDiffEqROCK/src/algorithms.jl
+++ b/lib/StochasticDiffEqROCK/src/algorithms.jl
@@ -9,8 +9,8 @@ stiff SDE.
 
 # Keywords
 
-- `interpretation = SciMLBase.AlgorithmInterpretation.Ito`: Stochastic
-  interpretation used by the method.
+- `interpretation = SciMLBase.AlgorithmInterpretation.Ito`: Choose either the Itô or
+  Stratonovich interpretation.
 - `eigen_est = nothing`: Optional estimate of the stiff eigenvalues.
 
 # Examples
@@ -26,6 +26,10 @@ struct SROCK1{interpretation, E} <: StochasticDiffEqAlgorithm
     eigen_est::E
 end
 function SROCK1(; interpretation = SciMLBase.AlgorithmInterpretation.Ito, eigen_est = nothing)
+    if interpretation != SciMLBase.AlgorithmInterpretation.Ito &&
+            interpretation != SciMLBase.AlgorithmInterpretation.Stratonovich
+        throw(ArgumentError("SROCK1 only supports Itô and Stratonovich interpretations"))
+    end
     return SROCK1{interpretation, typeof(eigen_est)}(eigen_est)
 end
 

--- a/lib/StochasticDiffEqROCK/src/perform_step/SROCK_perform_step.jl
+++ b/lib/StochasticDiffEqROCK/src/perform_step/SROCK_perform_step.jl
@@ -1,3 +1,9 @@
+function _srock1_stratonovich_coefficients(mdeg, ω₀, cosh_inv)
+    α = cosh(mdeg * cosh_inv) / (2 * ω₀ * cosh((mdeg - 1) * cosh_inv))
+    γ = 1 / (2 * α)
+    return α, γ, -γ
+end
+
 @muladd function perform_step!(integrator, cache::SROCK1ConstantCache)
     (; t, dt, uprev, u, W, p, f) = integrator
 
@@ -13,10 +19,10 @@
     Sqrt_ω = sqrt(ωSq)
     cosh_inv = log(ω₀ + Sqrt_ω)             # arcosh(ω₀)
     ω₁ = (Sqrt_ω * cosh(mdeg * cosh_inv)) / (mdeg * sinh(mdeg * cosh_inv))
-
-    α = cosh(mdeg * cosh_inv) / (2 * ω₀ * cosh((mdeg - 1) * cosh_inv))
-    γ = 1 / (2 * α)
-    β = -γ
+    interpretation = SciMLBase.alg_interpretation(integrator.alg)
+    stratonovich_coefficients = interpretation ==
+        SciMLBase.AlgorithmInterpretation.Stratonovich ?
+        _srock1_stratonovich_coefficients(mdeg, ω₀, cosh_inv) : nothing
 
     uᵢ₋₂ = copy(uprev)
     k = integrator.f(uprev, p, t)
@@ -40,9 +46,8 @@
         k = integrator.f(uᵢ₋₁, p, tᵢ₋₁)
 
         u = dt * μ * k + ν * uᵢ₋₁ + κ * uᵢ₋₂
-        if (i > mdeg - 2) &&
-                SciMLBase.alg_interpretation(integrator.alg) ==
-                SciMLBase.AlgorithmInterpretation.Stratonovich
+        if (i > mdeg - 2) && interpretation == SciMLBase.AlgorithmInterpretation.Stratonovich
+            α, γ, β = something(stratonovich_coefficients)
             if i == mdeg - 1
                 gₘ₋₂ = integrator.f.g(uᵢ₋₁, p, tᵢ₋₁)
                 if W.dW isa Number || !is_diagonal_noise(integrator.sol.prob)
@@ -58,9 +63,7 @@
                     u .+= (β .* gₘ₋₂ .+ γ .* gₘ₋₁) .* W.dW
                 end
             end
-        elseif (i == mdeg) &&
-                SciMLBase.alg_interpretation(integrator.alg) ==
-                SciMLBase.AlgorithmInterpretation.Ito
+        elseif (i == mdeg) && interpretation == SciMLBase.AlgorithmInterpretation.Ito
             if W.dW isa Number
                 gₘ₋₂ = integrator.f.g(uᵢ₋₁, p, tᵢ₋₁)
                 uᵢ₋₂ = uᵢ₋₁ + sqrt(abs(dt)) * gₘ₋₂
@@ -107,10 +110,10 @@ end
     Sqrt_ω = sqrt(ωSq)
     cosh_inv = log(ω₀ + Sqrt_ω)             # arcosh(ω₀)
     ω₁ = (Sqrt_ω * cosh(mdeg * cosh_inv)) / (mdeg * sinh(mdeg * cosh_inv))
-
-    α = cosh(mdeg * cosh_inv) / (2 * ω₀ * cosh((mdeg - 1) * cosh_inv))
-    γ = 1 / (2 * α)
-    β = -γ
+    interpretation = SciMLBase.alg_interpretation(integrator.alg)
+    stratonovich_coefficients = interpretation ==
+        SciMLBase.AlgorithmInterpretation.Stratonovich ?
+        _srock1_stratonovich_coefficients(mdeg, ω₀, cosh_inv) : nothing
 
     @.. uᵢ₋₂ = uprev
     Tᵢ₋₂ = oneunit(t)
@@ -133,9 +136,8 @@ end
         κ = - Tᵢ₋₂ / Tᵢ
         integrator.f(k, uᵢ₋₁, p, tᵢ₋₁)
         @.. u = dt * μ * k + ν * uᵢ₋₁ + κ * uᵢ₋₂
-        if (i > mdeg - 2) &&
-                SciMLBase.alg_interpretation(integrator.alg) ==
-                SciMLBase.AlgorithmInterpretation.Stratonovich
+        if (i > mdeg - 2) && interpretation == SciMLBase.AlgorithmInterpretation.Stratonovich
+            α, γ, β = something(stratonovich_coefficients)
             if i == mdeg - 1
                 integrator.f.g(gₘ₋₂, uᵢ₋₁, p, tᵢ₋₁)
                 if W.dW isa Number || is_diagonal_noise(integrator.sol.prob)
@@ -155,9 +157,7 @@ end
                     @.. u += γ * k
                 end
             end
-        elseif (i == mdeg) &&
-                SciMLBase.alg_interpretation(integrator.alg) ==
-                SciMLBase.AlgorithmInterpretation.Ito
+        elseif (i == mdeg) && interpretation == SciMLBase.AlgorithmInterpretation.Ito
             if W.dW isa Number || is_diagonal_noise(integrator.sol.prob)
                 integrator.f.g(gₘ₋₂, uᵢ₋₁, p, tᵢ₋₁)
                 @.. uᵢ₋₂ = uᵢ₋₁ + sqrt(abs(dt)) * gₘ₋₂

--- a/lib/StochasticDiffEqROCK/src/perform_step/SROCK_perform_step.jl
+++ b/lib/StochasticDiffEqROCK/src/perform_step/SROCK_perform_step.jl
@@ -14,12 +14,9 @@
     cosh_inv = log(ω₀ + Sqrt_ω)             # arcosh(ω₀)
     ω₁ = (Sqrt_ω * cosh(mdeg * cosh_inv)) / (mdeg * sinh(mdeg * cosh_inv))
 
-    if SciMLBase.alg_interpretation(integrator.alg) ==
-            SciMLBase.AlgorithmInterpretation.Stratonovich
-        α = cosh(mdeg * cosh_inv) / (2 * ω₀ * cosh((mdeg - 1) * cosh_inv))
-        γ = 1 / (2 * α)
-        β = -γ
-    end
+    α = cosh(mdeg * cosh_inv) / (2 * ω₀ * cosh((mdeg - 1) * cosh_inv))
+    γ = 1 / (2 * α)
+    β = -γ
 
     uᵢ₋₂ = copy(uprev)
     k = integrator.f(uprev, p, t)
@@ -111,12 +108,9 @@ end
     cosh_inv = log(ω₀ + Sqrt_ω)             # arcosh(ω₀)
     ω₁ = (Sqrt_ω * cosh(mdeg * cosh_inv)) / (mdeg * sinh(mdeg * cosh_inv))
 
-    if SciMLBase.alg_interpretation(integrator.alg) ==
-            SciMLBase.AlgorithmInterpretation.Stratonovich
-        α = cosh(mdeg * cosh_inv) / (2 * ω₀ * cosh((mdeg - 1) * cosh_inv))
-        γ = 1 / (2 * α)
-        β = -γ
-    end
+    α = cosh(mdeg * cosh_inv) / (2 * ω₀ * cosh((mdeg - 1) * cosh_inv))
+    γ = 1 / (2 * α)
+    β = -γ
 
     @.. uᵢ₋₂ = uprev
     Tᵢ₋₂ = oneunit(t)
@@ -765,9 +759,9 @@ end
         end
         winc = rand() * 6
         if winc < 1
-            u -= (sqrt(3 * dt) * ccache.mc[mdeg - 1]) * uᵢ₋₁
+            u -= (sqrt(3 * dt) * cache.mc[mdeg - 1]) * uᵢ₋₁
         elseif winc < 2
-            u += (sqrt(3 * dt) * ccache.mc[mdeg - 1]) * uᵢ₋₁
+            u += (sqrt(3 * dt) * cache.mc[mdeg - 1]) * uᵢ₋₁
         end
     end
     integrator.u = u
@@ -928,7 +922,7 @@ end
     Û₂ = zero(u)
     t̂₁ = t̂₂ = zero(t)
     tᵢ = tᵢ₋₁ = tᵢ₋₂ = tₓ = t
-    uᵢ₋₂ = uprev
+    uᵢ = uᵢ₋₁ = uₓ = uᵢ₋₂ = uprev
 
     for i in 0:(mdeg + 1)
         if i == 1
@@ -1042,9 +1036,8 @@ end
 
         for i in 1:length(W.dW)
             for j in 1:length(W.dW)
-                (i > j) && (WikJ = (1 // 2) * (1 + η₂) * W.dW[j])
-                (i < j) && (WikJ = (1 // 2) * (1 - η₂) * W.dW[j])
-                (i == j) && (WikJ = (1 // 2) * (η₁ * sqrt_dt))
+                WikJ = i > j ? (1 // 2) * (1 + η₂) * W.dW[j] :
+                    i < j ? (1 // 2) * (1 - η₂) * W.dW[j] : (1 // 2) * (η₁ * sqrt_dt)
 
                 uᵢ₋₁ += @view(Gₛ[:, j]) * WikJ
             end
@@ -1213,9 +1206,8 @@ end
 
         for i in 1:length(W.dW)
             for j in 1:length(W.dW)
-                (i > j) && (WikJ = (1 // 2) * (1 + η₂) * W.dW[j])
-                (i < j) && (WikJ = (1 // 2) * (1 - η₂) * W.dW[j])
-                (i == j) && (WikJ = (1 // 2) * (η₁ * sqrt_dt))
+                WikJ = i > j ? (1 // 2) * (1 + η₂) * W.dW[j] :
+                    i < j ? (1 // 2) * (1 - η₂) * W.dW[j] : (1 // 2) * (η₁ * sqrt_dt)
 
                 @.. uᵢ₋₁ += @view(Gₛ[:, j]) * WikJ
             end

--- a/lib/StochasticDiffEqROCK/test/srock_nondiag_tests.jl
+++ b/lib/StochasticDiffEqROCK/test/srock_nondiag_tests.jl
@@ -100,7 +100,14 @@ end
         SDEProblem(f_iip, g_full_iip, u0, tspan; noise_rate_prototype = nrp),
     )
 
-    for alg in (SROCK1(), SKSROCK(post_processing = true), TangXiaoSROCK2())
+    @test_throws ArgumentError SROCK1(interpretation = :unsupported)
+
+    for alg in (
+            SROCK1(),
+            SROCK1(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich),
+            SKSROCK(post_processing = true),
+            TangXiaoSROCK2(),
+        )
         @testset "$(nameof(typeof(alg)))" begin
             for (i, prob) in enumerate(problems)
                 Random.seed!(100 + i)

--- a/lib/StochasticDiffEqROCK/test/srock_nondiag_tests.jl
+++ b/lib/StochasticDiffEqROCK/test/srock_nondiag_tests.jl
@@ -75,3 +75,39 @@ end
         @test all(isfinite, sol_grid.u[end])
     end
 end
+
+@testset "definite assignment paths" begin
+    f_oop(u, p, t) = -u
+    g_diag_oop(u, p, t) = 0.1u
+    g_full_oop(u, p, t) = [0.1u[1] 0.05u[2]; 0.05u[1] 0.1u[2]]
+    f_iip(du, u, p, t) = (du .= -u)
+    g_diag_iip(du, u, p, t) = (du .= 0.1 .* u)
+    function g_full_iip(du, u, p, t)
+        du[1, 1] = 0.1u[1]
+        du[1, 2] = 0.05u[2]
+        du[2, 1] = 0.05u[1]
+        du[2, 2] = 0.1u[2]
+        return nothing
+    end
+
+    u0 = [1.0, 0.5]
+    tspan = (0.0, 0.125)
+    nrp = zeros(2, 2)
+    problems = (
+        SDEProblem(f_oop, g_diag_oop, u0, tspan),
+        SDEProblem(f_iip, g_diag_iip, u0, tspan),
+        SDEProblem(f_oop, g_full_oop, u0, tspan; noise_rate_prototype = nrp),
+        SDEProblem(f_iip, g_full_iip, u0, tspan; noise_rate_prototype = nrp),
+    )
+
+    for alg in (SROCK1(), SKSROCK(post_processing = true), TangXiaoSROCK2())
+        @testset "$(nameof(typeof(alg)))" begin
+            for (i, prob) in enumerate(problems)
+                Random.seed!(100 + i)
+                sol = solve(prob, alg; dt = 1 / 64, adaptive = false)
+                @test SciMLBase.successful_retcode(sol)
+                @test all(isfinite, sol.u[end])
+            end
+        end
+    end
+end


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Make the ROCK stage variables definitely assigned on every runtime path: keep the SROCK1 Stratonovich coefficients in a definitely-assigned tuple, read SKSROCK's constant-cache coefficient from `cache`, initialize the Tang-Xiao rotations together, and express the `WikJ` cases exhaustively. SROCK1 retains its implemented Itô and Stratonovich paths, computes the extra coefficients only for Stratonovich steps, and now rejects unsupported interpretations at construction. The regression tests exercise both SROCK1 interpretations, post-processed SKSROCK, and TangXiaoSROCK2 across in-place/out-of-place and diagonal/non-diagonal noise. StochasticDiffEqROCK is bumped from 2.1.0 to 2.1.1.

The source defects entered with the ROCK subpackage import in https://github.com/SciML/OrdinaryDiffEq.jl/commit/4900b054db660d8e77a3a2595480611aae985cf3. They first made the package QA command red when the ROCK JET lane was added in https://github.com/SciML/OrdinaryDiffEq.jl/commit/c538565b25ff19e661e5bf788fe1953a154d64e9. A similar fix was buried in the closed omnibus https://github.com/SciML/OrdinaryDiffEq.jl/pull/3861; this PR contains only the ROCK correction and focused regression coverage.

## Failing before

Clean master QA:

```text
JET: 38 possible errors found
Test Summary: | Pass  Fail  Broken  Total
JET Tests     |   16     1       4     21
```

The new out-of-place post-processed SKSROCK case fails on the unfixed source with:

```text
UndefVarError: `ccache` not defined in local scope
```

The interpretation regression test also discriminates the review update on the preceding PR source:

```text
Test Failed at srock_nondiag_tests.jl:103
Expression: SROCK1(interpretation = :unsupported)
Expected: ArgumentError
  No exception thrown
```

Failing CI job: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/32364530209/job/96412309026

## Passing after

```text
$ GROUP=Core julia +1.12 --startup-file=no --project=lib/StochasticDiffEqROCK -e 'using Pkg; Pkg.test()'
Module loads and constructors          |  7 pass /  7 total
KomBurSROCK2 non-diagonal noise        |  6 pass /  6 total
SROCK non-diagonal noise regressions   | 67 pass / 67 total
Testing StochasticDiffEqROCK tests passed

$ GROUP=QA julia +1.12 --startup-file=no --project=lib/StochasticDiffEqROCK -e 'using Pkg; Pkg.test()'
QA (Aqua and JET) | 17 pass / 4 broken / 21 total
Testing StochasticDiffEqROCK tests passed

$ julia +1.12 --startup-file=no --project=docs docs/make.jl
Documenter HTML render completed; exit 0

$ julia +1.12 --startup-file=no -m Runic --check <changed Julia files>
exit 0
$ typos --diff <changed paths>
exit 0
$ git diff --check
exit 0
```

Seeded SROCK1 Itô controls were bit-for-bit identical before and after in all four in-place/out-of-place and diagonal/non-diagonal cases.

## Not verified

GPU, prerelease Julia, and `GROUP=Everything` were not run locally.
