### PR TITLE
Restore allocation-free ExplicitTaylor stepping

### DIFF
--- a/lib/OrdinaryDiffEqTaylorSeries/src/TaylorSeries_caches.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/src/TaylorSeries_caches.jl
@@ -46,11 +46,12 @@ end
 get_fsalfirstlast(cache::ExplicitTaylor2Cache, u) = (cache.k1, cache.k1)
 
 @cache struct ExplicitTaylorCache{
-        P, tType, uType, taylorType, uNoUnitsType, StageLimiter, StepLimiter,
-        Thread,
+        P, jetType, uType, taylorType, coeffType, uNoUnitsType, StageLimiter,
+        StepLimiter, Thread,
     } <: OrdinaryDiffEqMutableCache
     order::Val{P}
-    jet::FunctionWrapper{Nothing, Tuple{taylorType, uType, tType}}
+    jet::jetType
+    coeffs::coeffType
     u::uType
     uprev::uType
     utaylor::taylorType
@@ -70,13 +71,13 @@ function alg_cache(
     ) where {P, uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
     _, jet_iip = build_jet(f, p, alg.order, length(u))
     utaylor = TaylorDiff.make_seed(u, zero(u), alg.order)
-    jet_wrapped = FunctionWrapper{Nothing, Tuple{typeof(utaylor), typeof(u), typeof(t)}}(jet_iip)
+    coeffs = Vector{eltype(u)}(undef, length(u) * (P + 1))
     utilde = zero(u)
     atmp = similar(u, uEltypeNoUnits)
     recursivefill!(atmp, false)
     tmp = zero(u)
     return ExplicitTaylorCache(
-        alg.order, jet_wrapped, u, uprev, utaylor, utilde, tmp, atmp,
+        alg.order, jet_iip, coeffs, u, uprev, utaylor, utilde, tmp, atmp,
         alg.stage_limiter!, alg.step_limiter!, alg.thread
     )
 end
@@ -106,14 +107,15 @@ end
 
 @cache struct ExplicitTaylorAdaptiveOrderCache{
         P, Q,
-        tType, uType, taylorType, uNoUnitsType, StageLimiter, StepLimiter,
+        tType, uType, taylorType, coeffType, uNoUnitsType, StageLimiter, StepLimiter,
         Thread,
     } <: OrdinaryDiffEqMutableCache
     min_order::Val{P}
     max_order::Val{Q}
     current_order::Base.RefValue{Int}
     order_history::Vector{Int}
-    jets::Vector{FunctionWrapper{Nothing, Tuple{taylorType, uType, tType}}}
+    jets::Vector{FunctionWrapper{Nothing, Tuple{taylorType, coeffType, uType, tType}}}
+    coeffs::Vector{coeffType}
     u::uType
     uprev::uType
     utaylor::taylorType
@@ -132,11 +134,16 @@ function alg_cache(
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
     min_order_value, max_order_value = order_window(alg)
     utaylor = TaylorDiff.make_seed(u, zero(u), alg.max_order)
-    jets = FunctionWrapper{Nothing, Tuple{typeof(utaylor), typeof(u), typeof(t)}}[]
+    coeffType = Vector{eltype(u)}
+    jets = FunctionWrapper{
+        Nothing, Tuple{typeof(utaylor), coeffType, typeof(u), typeof(t)},
+    }[]
+    coeffs = coeffType[]
     # every order shares the single `max_order` buffer, so the jets have to fill it
     for order in min_order_value:max_order_value
         jet_iip = build_jet(f, p, Val(order), length(u), alg.max_order)[2]
         push!(jets, jet_iip)
+        push!(coeffs, coeffType(undef, length(u) * (order + 1)))
     end
     utilde = zero(u)
     atmp = similar(u, uEltypeNoUnits)
@@ -146,7 +153,7 @@ function alg_cache(
     order_history = Vector{Int}()
     return ExplicitTaylorAdaptiveOrderCache(
         alg.min_order, alg.max_order, current_order, order_history,
-        jets, u, uprev, utaylor, utilde, tmp, atmp,
+        jets, coeffs, u, uprev, utaylor, utilde, tmp, atmp,
         alg.stage_limiter!, alg.step_limiter!, alg.thread
     )
 end

--- a/lib/OrdinaryDiffEqTaylorSeries/src/TaylorSeries_perform_step.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/src/TaylorSeries_perform_step.jl
@@ -108,9 +108,9 @@ end
         integrator, cache::ExplicitTaylorCache{P}, repeat_step = false
     ) where {P}
     (; t, dt, uprev, u, f, p) = integrator
-    (; jet, utaylor, utilde, tmp, atmp, thread) = cache
+    (; jet, coeffs, utaylor, utilde, tmp, atmp, thread) = cache
 
-    jet(utaylor, uprev, t)
+    jet(utaylor, coeffs, uprev, t)
     for i in eachindex(utaylor)
         u[i] = @inline evaluate_polynomial(utaylor[i], dt)
     end
@@ -148,7 +148,7 @@ end
     )
     (; t, dt, uprev, u, f, p) = integrator
     alg = unwrap_alg(integrator, false)
-    (; jets, current_order, min_order, max_order, utaylor, utilde, tmp, atmp, thread) = cache
+    (; jets, coeffs, current_order, min_order, max_order, utaylor, utilde, tmp, atmp, thread) = cache
 
     min_order_value = get_value(min_order)
     max_order_value = get_value(max_order)
@@ -156,7 +156,7 @@ end
     jet_index = current_order[] - min_order_value + 1
     # compute one additional order for adaptive order
     jet = jets[jet_index + 1]
-    jet(utaylor, uprev, t)
+    jet(utaylor, coeffs[jet_index + 1], uprev, t)
     for i in eachindex(utaylor)
         u[i] = @inline evaluate_polynomial(utaylor[i], dt)
     end

--- a/lib/OrdinaryDiffEqTaylorSeries/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/src/alg_utils.jl
@@ -78,6 +78,12 @@ end
 # `TaylorScalar` there is a copy that the compiler does not always elide.
 @inline set_taylor_order(t::TaylorScalar{T, Q}, ::Val{Q}) where {T, Q} = t
 
+@inline function taylor_from_coefficients(coeffs, i, ::Val{P}, buffer_order) where {P}
+    offset = (i - 1) * (P + 1)
+    taylor = TaylorScalar(ntuple(j -> coeffs[offset + j], Val(P + 1)))
+    return set_taylor_order(taylor, buffer_order)
+end
+
 function build_jet(
         f::ODEFunction{iip}, p, order, length = nothing, buffer_order = order
     ) where {iip}
@@ -123,34 +129,28 @@ function build_jet(
     if u isa TaylorScalar
         # Scalar case: build function for array of coefficients
         coeffs = collect(TaylorDiff.flatten(u))
-        jet_coeffs = build_function(coeffs, u0, t0; expression = Val(false), cse = true)
+        scalar_jet_coeffs = build_function(
+            coeffs, u0, t0; expression = Val(false), cse = true
+        )
         # Wrap to return TaylorScalar
         jet = (u0_val, t0_val) -> set_taylor_order(
-            TaylorScalar(Tuple(jet_coeffs[1](u0_val, t0_val))), buffer_order
+            TaylorScalar(Tuple(scalar_jet_coeffs[1](u0_val, t0_val))), buffer_order
         )
     elseif u isa AbstractArray && eltype(u) <: TaylorScalar
-        # Array case: build function for matrix of coefficients
-        # Each row is the coefficients of one TaylorScalar
         n = Base.length(u)
-        coeffs_matrix = [TaylorDiff.flatten(u[i])[j] for i in 1:n, j in 1:(P + 1)]
-        jet_coeffs = build_function(coeffs_matrix, u0, t0; expression = Val(false), cse = true)
-        # Wrap to return array of TaylorScalars
+        coeffs = [TaylorDiff.flatten(u[i])[j] for i in 1:n for j in 1:(P + 1)]
+        array_jet_coeffs = build_function(
+            coeffs, u0, t0; expression = Val(false), cse = true
+        )
         jet = (
             (u0_val, t0_val) -> begin
-                coeffs_out = jet_coeffs[1](u0_val, t0_val)
-                return [
-                    set_taylor_order(TaylorScalar(Tuple(coeffs_out[i, :])), buffer_order)
-                        for i in 1:n
-                ]
+                coeffs_out = array_jet_coeffs[1](u0_val, t0_val)
+                return [taylor_from_coefficients(coeffs_out, i, order, buffer_order) for i in 1:n]
             end,
-            (out, u0_val, t0_val) -> begin
-                coeffs_out = jet_coeffs[2](
-                    similar(coeffs_matrix, eltype(u0_val)), u0_val, t0_val
-                )
+            (out, coeffs_out, u0_val, t0_val) -> begin
+                array_jet_coeffs[2](coeffs_out, u0_val, t0_val)
                 for i in 1:n
-                    out[i] = set_taylor_order(
-                        TaylorScalar(Tuple(coeffs_out[i, :])), buffer_order
-                    )
+                    out[i] = taylor_from_coefficients(coeffs_out, i, order, buffer_order)
                 end
                 return out
             end,

--- a/lib/OrdinaryDiffEqTaylorSeries/test/qa/allocation_tests.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/test/qa/allocation_tests.jl
@@ -14,10 +14,10 @@ using Test
     # Use FullSpecialize to avoid FunctionWrappers dynamic dispatch noise
     prob = ODEProblem{true, FullSpecialize}(simple_system!, [1.0, 1.0], (0.0, 1.0))
 
-    # ExplicitTaylor2 is allocation-free
-    passing_solvers = [ExplicitTaylor2()]
-    # Higher-order and adaptive methods allocate
-    broken_solvers = [ExplicitTaylor(order = Val(4)), ExplicitTaylorAdaptiveOrder()]
+    # Fixed-order methods are allocation-free.
+    passing_solvers = [ExplicitTaylor2(), ExplicitTaylor(order = Val(4))]
+    # Adaptive order selection allocates while evaluating controller candidates.
+    broken_solvers = [ExplicitTaylorAdaptiveOrder()]
 
     @testset "TaylorSeries perform_step! Static Analysis" begin
         for solver in passing_solvers

--- a/lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl
@@ -68,7 +68,7 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
         # that many nonzero coefficients on top of the value
         for (i, jet) in enumerate(cache.jets)
             fill!(cache.utaylor, zero(eltype(cache.utaylor)))
-            jet(cache.utaylor, integ.uprev, integ.t)
+            jet(cache.utaylor, cache.coeffs[i], integ.uprev, integ.t)
             @test count(!iszero, TaylorDiff.flatten(cache.utaylor[1])) == i + 2
         end
     end


### PR DESCRIPTION
## Summary

Restore allocation-free stepping for mutable fixed-order `ExplicitTaylor` integrators. The Symbolics jet cache was hitting correctly; the hot-path regression came from reconstructing the Symbolics v7 flattened output through a newly allocated coefficient matrix on every step, plus a boxed generated-function capture.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

- Generate a flat coefficient vector and let the in-place Symbolics function write into per-integrator coefficient storage.
- Reconstruct `TaylorScalar`s from that reusable storage without slices or intermediate arrays.
- Store the fixed-order generated jet at its concrete type instead of dispatching through `FunctionWrapper`.
- Give scalar and array generated functions separate bindings so the array closure no longer captures a `Core.Box`.
- Give adaptive-order jets separate coefficient workspaces while retaining wrappers for their heterogeneous function types.
- Promote fixed-order `ExplicitTaylor` from the allocation test's broken set to its passing set.

The Symbolics v7 flattening itself remains necessary because `build_function` cannot directly return `TaylorScalar`. Adaptive order selection still has separate controller-candidate allocations and remains covered by the pre-existing broken allocation assertion.

## Regression evidence

The same allocation test was run after moving `ExplicitTaylor(order = Val(4))` into `passing_solvers`.

Before the source fix:

```text
ExplicitTaylor{4, typeof(OrdinaryDiffEqCore.trivial_limiter!), typeof(OrdinaryDiffEqCore.trivial_limiter!), FastBroadcast.Serial} perform_step! allocation check: Test Failed
  Expression: length(allocs) == 0
   Evaluated: 5 == 0
AllocCheck found 5 allocation sites in ExplicitTaylor{4, typeof(OrdinaryDiffEqCore.trivial_limiter!), typeof(OrdinaryDiffEqCore.trivial_limiter!), FastBroadcast.Serial} perform_step!
Test Summary:     | Pass  Fail  Broken  Total
Allocation Tests |    1     1       1      3
```

After the source fix:

```text
ExplicitTaylor2{typeof(OrdinaryDiffEqCore.trivial_limiter!), typeof(OrdinaryDiffEqCore.trivial_limiter!), FastBroadcast.Serial} perform_step! appears allocation-free with AllocCheck
ExplicitTaylor{4, typeof(OrdinaryDiffEqCore.trivial_limiter!), typeof(OrdinaryDiffEqCore.trivial_limiter!), FastBroadcast.Serial} perform_step! appears allocation-free with AllocCheck
AllocCheck found 9 allocation sites in ExplicitTaylorAdaptiveOrder{1, 10, typeof(OrdinaryDiffEqCore.trivial_limiter!), typeof(OrdinaryDiffEqCore.trivial_limiter!), FastBroadcast.Serial} perform_step!
Test Summary:     | Pass  Broken  Total
Allocation Tests |    2       1      3
```

A direct warmed measurement also reports:

```text
perform_step_bytes=0
```

## Performance

Order-8 Lorenz solve over `(0, 10)` with `dt = 1e-4`, `adaptive = false`, and `save_everystep = false` (100,001 steps). All runs produced the same final state, `[-5.857685382421507, -5.831082486605415, 23.932132986732203]`.

```text
origin/master:
run=2 time=0.690008988 bytes=164806640
run=3 time=0.643178297 bytes=164806640

this branch:
run=2 time=0.029609404 bytes=6720
run=3 time=0.029887653 bytes=6720
```

This is about 22× faster in steady state, while removing the per-step heap allocation.

## Verification

```text
GROUP=Core julia --project=lib/OrdinaryDiffEqTaylorSeries -e 'using Pkg; Pkg.test()'
127 assertions passed across the Core testsets
Testing OrdinaryDiffEqTaylorSeries tests passed

GROUP=QA julia --project=lib/OrdinaryDiffEqTaylorSeries -e 'using Pkg; Pkg.test()'
Allocation Tests | 2 passed, 1 pre-existing broken
JET Tests        | 1 passed
Aqua             | 15 passed
Testing OrdinaryDiffEqTaylorSeries tests passed

julia +release -m Runic --check <five changed Julia files>
no output; exit 0

git diff --unified=0 | typos -
no output; exit 0

git diff --check
no output; exit 0
```

Documentation was not built because this changes no docstrings, public API, or documentation files. `GROUP=Everything`, GPU, downstream, and allowed-to-fail jobs were not run locally.

## Links

- Symbolics v7 migration that introduced the per-step matrix reconstruction: https://github.com/SciML/OrdinaryDiffEq.jl/commit/85c7c24ff8e3b1e4c6fa55f904db6d036abcadb4
