### PR TITLE
Use the shared downstream workflow on Julia 1

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -11,15 +11,10 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
-    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.julia-version }}
-    runs-on: ${{ matrix.os }}
-    env:
-      GROUP: ${{ matrix.package.group }}
+    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/1
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.10']
-        os: [ubuntu-latest]
         package:
           - {user: SciML, repo: DiffEqCallbacks.jl, group: All}
           - {user: SciML, repo: SciMLSensitivity.jl, group: Core1}
@@ -33,30 +28,11 @@ jobs:
           - {user: SciML, repo: ModelingToolkit.jl, group: SymbolicIndexingInterface}
           - {user: nathanaelbosch, repo: ProbNumDiffEq.jl, group: Downstream}
           - {user: SKopecz, repo: PositiveIntegrators.jl, group: Downstream}
-
-    steps:
-      - uses: actions/checkout@v7
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-          arch: x64
-      - name: Clone Downstream
-        uses: actions/checkout@v7
-        with:
-          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
-          path: downstream
-      - name: Load this and run the downstream tests
-        shell: julia --color=yes --project=downstream {0}
-        run: |
-          using Pkg
-          Pkg.develop(PackageSpec(path="."))
-          Pkg.develop(map(path -> Pkg.PackageSpec(; path = joinpath("lib", path)), readdir("lib")))
-          Pkg.update()
-          Pkg.test(coverage=true)
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v7
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: lcov.info
-          fail_ci_if_error: false
-          disable_safe_directory: true
+    uses: "SciML/.github/.github/workflows/downstream.yml@d5748d7f7e95749cb0a5acaed6e69162623be862"
+    with:
+      owner: "${{ matrix.package.user }}"
+      repo: "${{ matrix.package.repo }}"
+      upstream-subdirs: ".,lib/*"
+      group: "${{ matrix.package.group }}"
+      julia-version: "1"
+    secrets: "inherit"


### PR DESCRIPTION
## What changed

Use SciML's shared downstream workflow on the current Julia 1 release and develop both the OrdinaryDiffEq root project and every immediate `lib/*` project. This replaces the repository-specific Julia 1.10 runner, whose resolver now fails before ProbNumDiffEq's tests start.

The reusable workflow is pinned to the merge commit from https://github.com/SciML/.github/pull/128 because the moving `v1` tag has not yet been released with `upstream-subdirs` glob support.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Regression evidence

Before, the downstream job's Julia 1.10 environment failed during resolution, before running ProbNumDiffEq tests:

```text
[ Warning: julia version requirement for project not satisfied
ERROR: Unsatisfiable requirements detected for package JET [c3a54625]
...
caused by: Unsatisfiable requirements detected for package PrecompileTools [aea7be01]
```

After switching the same downstream package to Julia 1.12.7 and developing `.` plus all `lib/*` projects, I ran the complete downstream test command:

```text
ProbNumDiffEq | Pass 780  Broken 28  Total 808  50m49.4s
Testing ProbNumDiffEq tests passed
```

## Verification

```text
GROUP=QA julia +1 --project -e 'using Pkg; Pkg.test()'
Quality Assurance Tests | Pass 92  Total 92
Testing OrdinaryDiffEq tests passed

actionlint .github/workflows/Downstream.yml
typos .github/workflows/Downstream.yml
git diff --check
# all exited 0
```

I did not run the other eleven downstream repositories locally; the workflow matrix will exercise them. This workflow-only change does not touch docs, public API, or GPU code.

Supersedes the repository-local approach in https://github.com/SciML/OrdinaryDiffEq.jl/pull/4320.
