### PR TITLE
Wrap NLStep parameters for despecialized caches

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.10.1"
+version = "2.10.2"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -142,7 +142,13 @@ function initialize!(
             nlstep_data.set_outer_tmp(nlstep_data.nlprob, atmp)
         end
         nlstep_data.nlprob.u0 .= @view z[nlstep_data.u0perm]
-        SciMLBase.reinit!(cache.cache, nlstep_data.nlprob.u0, p = nlstep_data.nlprob.p)
+        nlprob_p = if SciMLBase.specialization(nlstep_data.nlprob.f) ===
+                SciMLBase.AutoDespecialize
+            SciMLBase.DespecializedParameters(nlstep_data.nlprob.p)
+        else
+            nlstep_data.nlprob.p
+        end
+        SciMLBase.reinit!(cache.cache, nlstep_data.nlprob.u0, p = nlprob_p)
     else
         if cache.W !== nothing
             dtgamma = method === DIRK ? γ * dt : γ * dt / α

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_nlstep_data_field_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_nlstep_data_field_tests.jl
@@ -105,7 +105,7 @@ end
 
     nlstep = SciMLBase.ODENLStepData(
         NonlinearProblem(
-            NonlinearFunction{true}(ode_stage!), zeros(1),
+            NonlinearFunction{true, SciMLBase.AutoDespecialize}(ode_stage!), zeros(1),
             StageParams(1.0, 1.0, 1.0, 0.0, zeros(1), zeros(1))
         ),
         1:1, set_γ_c!, set_outer!, set_inner!, (ztmp, sol) -> (ztmp .= sol.u)


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Rewrap the current NLStep parameter payload when reinitializing an inner `AutoDespecialize` `NonlinearFunction`. ModelingToolkit's AutoDespecialize default exposed that the nonlinear cache owns a `DespecializedParameters` field while OrdinaryDiffEqNonlinearSolve was passing the raw, newly updated parameter object to `reinit!`, causing a conversion error before the solve began.

The specialization decision comes from the inner `NonlinearFunction` that owns the cache, using the public `SciMLBase.specialization` and `SciMLBase.DespecializedParameters` APIs. The regression test reuses the existing mutable `StageParams` case, so it also verifies that each reinitialization wraps the current payload rather than retaining stale parameters. OrdinaryDiffEqNonlinearSolve is bumped from 2.10.1 to 2.10.2.

The dependency boundary is ModelingToolkit commit https://github.com/SciML/ModelingToolkit.jl/commit/55856687b1c25e1b767d6834589cba26dbd0ead6, which changed ModelingToolkit problems to AutoDespecialize by default. Its direct parent passes the Robertson reproducer; the commit fails with `Cannot convert MTKParameters to SciMLBase.DespecializedParameters`.

## Failing before

The same focused command was run before and after the source change:

```text
$ julia +1.12 --project=.agent_nlstep_env -e 'include("lib/OrdinaryDiffEqNonlinearSolve/test/nsa_nlstep_data_field_tests.jl")'
NLStep Data Field Tests        | 3 pass
Full-specialized Stage Params  | 4 pass
AutoDespecialize Stage Params  | 1 error
MethodError: Cannot convert StageParams to SciMLBase.DespecializedParameters
```

The exact Robertson `FBDF` + `NonlinearSolveAlg` reproducer against the first-bad ModelingToolkit commit failed with the same conversion at `NonlinearSolveBase.JacobianCache.reinit!`.

Failing CI job: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/32391250140/job/96529067841

## Passing after

```text
$ julia +1.12 --project=.agent_nlstep_env -e 'include("lib/OrdinaryDiffEqNonlinearSolve/test/nsa_nlstep_data_field_tests.jl")'
NLStep Data Field Tests        | 3 pass
Full-specialized Stage Params  | 4 pass
AutoDespecialize Stage Params  | 3 pass

$ timeout 3600 env JULIA_DEPOT_PATH="$PWD/../../.agent_mtk_depot:/home/crackauc/.julia" JULIA_PKG_PRECOMPILE_AUTO=0 julia +1.12 --startup-file=no --project=lib/OrdinaryDiffEqNonlinearSolve/test/modelingtoolkit -e 'using Pkg; Pkg.resolve(); Pkg.status(["ModelingToolkit", "OrdinaryDiffEqNonlinearSolve"], mode=Pkg.PKGMODE_MANIFEST); include(".agent_mtk_repro.jl"); println("ROBERTSON_SUCCESS")'
ModelingToolkit v11.39.1 at 55856687b1c25e1b767d6834589cba26dbd0ead6
OrdinaryDiffEqNonlinearSolve v2.10.2 from this branch
ROBERTSON_SUCCESS

$ GROUP=QA julia +1.12 --project=lib/OrdinaryDiffEqNonlinearSolve -e 'using Pkg; Pkg.test()'
JET Tests | 13 pass, 33 broken, 46 total
Aqua      | 41 pass, 41 total
Testing OrdinaryDiffEqNonlinearSolve tests passed

$ GROUP=Core julia +1.12 --project=lib/OrdinaryDiffEqNonlinearSolve -e 'using Pkg; Pkg.test()'
OrdinaryDiffEqNonlinearSolve Core | 890 pass, 40 broken, 930 total
Testing OrdinaryDiffEqNonlinearSolve tests passed

Runic --check --diff  # exit 0
typos                # exit 0
git diff --check     # exit 0
```

The full Core run used this source change together with the matrix-free and JET fixes now merged in the base branch; the only later base change was an unrelated OrdinaryDiffEqDefault compat floor. The rebased focused branch was rerun through QA and both discriminating reproducers.

## Independent ModelingToolkit-group failure

This focused branch reaches six pre-existing fixed-step convergence-order assertions in `nlstep_tests.jl`; it does not change or suppress them. They reproduce with the parent of the ModelingToolkit AutoDespecialize commit and bisect independently to OrdinaryDiffEq commit https://github.com/SciML/OrdinaryDiffEq.jl/commit/523c650cb60b755b4f60d0ee47c235b00f241279.

A separate stacked follow-up fixes that regression. With both focused changes applied, the full ModelingToolkit group passes:

```text
NLStep Tests                     | 23 pass, 2 broken, 25 total
Preconditioner Tests             | 18 pass, 18 total
DAE Initialize Integration Tests | 21 pass, 21 total
```

## Not verified

GPU, prerelease Julia, and `GROUP=Everything` were not run locally. No docs build was run because this changes no public API, docstring, or documentation.
