### PR TITLE
Isolate initdt exception handling from forward AD

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.15.0"
+version = "4.15.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqCore/src/initdt.jl
+++ b/lib/OrdinaryDiffEqCore/src/initdt.jl
@@ -14,6 +14,17 @@
     return r isa Bool ? r : all(r)
 end
 
+# Keep exception-handling control flow out of callers differentiated in forward mode.
+Base.@noinline function _try_init_mass_matrix_solve!(integrator, ftmp, mass_matrix, f₀)
+    try
+        integrator.alg.linsolve(ftmp, copy(mass_matrix), f₀, true)
+        copyto!(f₀, ftmp)
+        return true
+    catch
+        return false
+    end
+end
+
 @muladd function _ode_initdt_iip(
         u0, t, tdir, dtmax, abstol, reltol, internalnorm,
         prob, g, noise_prototype, order, integrator
@@ -148,10 +159,7 @@ end
                 any(mm != I for mm in prob.f.mass_matrix)
         )
         ftmp = zero(f₀)
-        try
-            integrator.alg.linsolve(ftmp, copy(prob.f.mass_matrix), f₀, true)
-            copyto!(f₀, ftmp)
-        catch
+        if !_try_init_mass_matrix_solve!(integrator, ftmp, prob.f.mass_matrix, f₀)
             result_dt = tdir * max(smalldt, dtmin)
             @SciMLMessage(
                 lazy"Mass matrix appears singular, using default small timestep: dt = $(result_dt)",

--- a/test/AD/ad_tests.jl
+++ b/test/AD/ad_tests.jl
@@ -485,6 +485,12 @@ end ≈ [6.765310476296564]
     # in-place ODE with default sensealg dispatch).
     grad_mc = DI.gradient(loss_fn, AutoMooncake(; config = nothing), p_test)
     @test grad_mc ≈ ref_grad rtol = 1.0e-6
+
+    cache = Mooncake.prepare_derivative_cache(
+        loss_fn, p_test; config = Mooncake.Config(enable_nfwd = false)
+    )
+    _, gradients_forward_mc = Mooncake.value_and_gradient!!(cache, loss_fn, p_test)
+    @test last(gradients_forward_mc) ≈ ref_grad rtol = 1.0e-6
 end
 
 # Tests migrated from DiffEqBase downstream to cover complex numbers, StaticArrays,


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

Move the existing mass-matrix `linsolve` exception path out of `_ode_initdt_iip` into a private, non-inlined helper. Mooncake forward mode generated invalid IR when the `try`/`catch` was inlined into the differentiated caller on Julia 1.10; the helper preserves the existing fallback while keeping that control flow out of the generated rule.

The regression test differentiates the existing in-place ODE loss through Mooncake's public forward-mode cache API. OrdinaryDiffEqCore is bumped from 4.15.0 to 4.15.1. No public API is added.

## Failing before, passing after

The same new official `DifferentiationInterface multi-backend tests` case was run from `test/AD/ad_tests.jl` on clean master and with this patch.

Clean master:

```text
DifferentiationInterface multi-backend tests | 2 Pass 1 Error 3 Total
ERROR: Operand 1 of PhiC node 326 must reference an Upsilon node.
```

Patched:

```text
DifferentiationInterface multi-backend tests | 3 Pass 3 Total
```

The inline mass-matrix `try`/`catch` dates to https://github.com/SciML/OrdinaryDiffEq.jl/commit/e14d90ff00dc8a9db72187f9028c859635067e8a. That is the source-introduction boundary, not a runnable historical Mooncake bisect: the source predates Mooncake and the current Julia compiler by years.

## Verification

```bash
GROUP=QA timeout 3600 julia +1 --project=. -e 'using Pkg; Pkg.test(coverage=false)'
```

```text
Quality Assurance Tests | 92 Pass 92 Total
Testing OrdinaryDiffEq tests passed
```

```bash
GROUP=InterfaceI timeout 3600 julia +1 --project=. -e 'using Pkg; Pkg.test(coverage=false)'
```

Current master independently fails the tstop assertion fixed by https://github.com/SciML/OrdinaryDiffEq.jl/pull/4261. With that exact one-line prerequisite temporarily applied:

```text
Tstops Tests | 62 Pass
Initdt Tests | 37 Pass
Testing OrdinaryDiffEq tests passed
Total: 1866.3 seconds
```

```bash
GROUP=AD timeout 21600 julia +1.10.12 --project=. -e 'using Pkg; Pkg.test(coverage=false)'
```

Current master independently fails the tangent-shape assertion fixed by https://github.com/SciML/OrdinaryDiffEq.jl/pull/4242. With that exact source prerequisite temporarily applied and OrdinaryDiffEqCore path-pinned to this checkout:

```text
AD Tests               | 28302 Pass
Autodiff Events Tests  | 11 Pass 3 Broken
Discrete Adjoint Tests | 1 Pass
Testing OrdinaryDiffEq tests passed
Total: 2235.9 seconds
```

Both prerequisite hunks were removed after validation. Runic, `typos`, and `git diff --check` exit successfully on the focused three-file diff.

A Julia 1.10.12 SciMLSensitivity `concrete_solve_derivatives.jl` control with this patch and the independently validated local Mooncake array-growth patch also exited 0. Relevant summaries include `Struct-Based Loss Functions | 32/32`, `BouncingBall ODE | 4/4`, and `SDE Gradients | 6/6`.

## Not verified

GPU paths were not run. The Mooncake array-growth change used by the product control is external and is not included here.

Original downstream failure: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/32392240811/job/96500863594
