### PR TITLE
Rename the GLEE global-error temporary so the spell check passes

### DIFF
--- a/lib/GlobalDiffEq/src/glee/solve.jl
+++ b/lib/GlobalDiffEq/src/glee/solve.jl
@@ -122,10 +122,10 @@ end
 # holds the error partition, and the interpolation projects onto the solution.
 function _split_global_error_solution(ext_sol, prob)
     us = [u.x[1] for u in ext_sol.u]
-    ges = [u.x[2] for u in ext_sol.u]
+    global_errors = [u.x[2] for u in ext_sol.u]
     sol = @set ext_sol.interp = GLEESolutionInterpolation(ext_sol.interp)
     sol = @set sol.prob = prob
-    sol = @set sol.global_error = ges
+    sol = @set sol.global_error = global_errors
     # Set `u` last: `setproperties` recomputes the solution's `T`/`N` type
     # parameters from the new (unpartitioned) `u`.
     return @set sol.u = us


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

## What changed and why

`lib/GlobalDiffEq/src/glee/solve.jl` (added in #4267) names a local `ges`, which `typos` flags as a misspelling of `goes`/`guess`. That fails the repo-wide **Spell Check with Typos** job on master, and therefore on every PR branched from it — e.g. https://github.com/SciML/OrdinaryDiffEq.jl/pull/4272 fails spell check on code it does not touch.

Renamed the local to `global_errors`. No behaviour change; it is a temporary used two lines later to fill `sol.global_error`.

## Verification

Failing before, on clean master `13da423dd`:

```
$ typos .
error: `ges` should be `goes`, `guess`
   --> ./lib/GlobalDiffEq/src/glee/solve.jl:125:5
    |
125 |     ges = [u.x[2] for u in ext_sol.u]
    |     ^^^
error: `ges` should be `goes`, `guess`
   --> ./lib/GlobalDiffEq/src/glee/solve.jl:128:35
    |
128 |     sol = @set sol.global_error = ges
    |                                   ^^^
```

Passing after (same command, whole repo): exit 0, no output.

`Pkg.test()` for `lib/GlobalDiffEq` on this branch (Julia 1.12.4):

```
Basic functionality          |  1   1
Algorithm traits forwarding  |  3   3
GLEE solvers                 | 91  91
BigFloat support             |  2   2
```

Runic 1.7 on the changed file: clean.

## Not verified

Nothing else was run — this is a one-identifier rename in a single file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiHL8AqRSy2VQZF6j68ovM
