### PR TITLE
Set explicit tolerances in Hairer Krylov regression test

### DIFF
--- a/test/Regression_I/newton_krylov_roundoff.jl
+++ b/test/Regression_I/newton_krylov_roundoff.jl
@@ -51,8 +51,14 @@ end
 @testset "Newton-Krylov round-off reproducibility ($(nameof(alg)))" for alg in (
         Hairer4, Hairer42,
     )
-    a = solve(dae_prob(U0), alg(linsolve = KrylovJL_GMRES()); maxiters = 10_000)
-    b = solve(dae_prob(U0_PERTURBED), alg(linsolve = KrylovJL_GMRES()); maxiters = 10_000)
+    a = solve(
+        dae_prob(U0), alg(linsolve = KrylovJL_GMRES());
+        reltol = 1.0e-8, abstol = 1.0e-6, maxiters = 10_000
+    )
+    b = solve(
+        dae_prob(U0_PERTURBED), alg(linsolve = KrylovJL_GMRES());
+        reltol = 1.0e-8, abstol = 1.0e-6, maxiters = 10_000
+    )
     @test successful_retcode(a)
     @test successful_retcode(b)
     drift = maximum(


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What changed

Set explicit `reltol = 1.0e-8` and `abstol = 1.0e-6` on both solves in the Hairer4/Hairer42 Newton–Krylov round-off regression test. This follows the review direction on the closed solver-side attempt: the correction belongs in the test tolerances.

The solver source, package versions, successful-retcode assertions, and `drift < 1.0e-5` regression gate are unchanged.

## Failing before / passing after

I created a persistent local test environment containing this worktree's OrdinaryDiffEq, OrdinaryDiffEqNonlinearSolve, and OrdinaryDiffEqSDIRK sources plus the file's direct LinearSolve and SciMLBase dependencies. I then ran the same command with the test change stashed and restored.

```sh
JULIA_DEPOT_PATH="$PWD/.hairer-test-depot:/home/crackauc/.julia" \
  julia +1.12 --startup-file=no --project=.hairer-focused-env \
  -e 'using Test; include("test/Regression_I/newton_krylov_roundoff.jl")'
```

Unfixed current master:

```text
Newton-Krylov round-off reproducibility (Hairer4) | 0 passed, 3 failed, 3 total
successful_retcode(a) failed
successful_retcode(b) failed
Evaluated: 4096.0 < 1.0e-5
```

With this test-tolerance change, the identical command passed:

```text
Newton-Krylov round-off reproducibility (Hairer4)  | 3/3 passed
Newton-Krylov round-off reproducibility (Hairer42) | 3/3 passed
```

## Verification

Full relevant group:

```sh
GROUP=Regression_I JULIA_DEPOT_PATH="$PWD/.hairer-test-depot:/home/crackauc/.julia" \
  julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
```

```text
Dense Tests                       | 4104/4104 passed
Special Interp Tests              | 30/30 passed
Inplace Tests                     | 2/2 passed
Adaptive Tests                    | 46/46 passed
Hard DAE Tests                    | 36/36 passed
Newton-Krylov Round-off Tests     | 6/6 passed
Testing OrdinaryDiffEq tests passed
```

QA:

```sh
GROUP=QA JULIA_DEPOT_PATH="$PWD/.hairer-test-depot:/home/crackauc/.julia" \
  julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
```

```text
Quality Assurance Tests | 92/92 passed
Testing OrdinaryDiffEq tests passed
```

Runic, `typos` over the diff, and `git diff --check` all exited 0.

I did not run Julia LTS/pre or GPU/downstream jobs locally. I did not run docs because this is a test-only change with no docs, docstring, or public API changes.

## Links

- Review direction and prior closed attempt: https://github.com/SciML/OrdinaryDiffEq.jl/pull/4301
- “update the test” comment: https://github.com/SciML/OrdinaryDiffEq.jl/pull/4301#issuecomment-5358090184
- “tolerances” clarification: https://github.com/SciML/OrdinaryDiffEq.jl/pull/4301#issuecomment-5358092557
- Original regression report: https://github.com/SciML/OrdinaryDiffEq.jl/issues/4293
