### PR TITLE
Give the Newton-Krylov round-off test explicit tolerances

### DIFF
--- a/test/Regression_I/newton_krylov_roundoff.jl
+++ b/test/Regression_I/newton_krylov_roundoff.jl
@@ -17,10 +17,16 @@ then amplifies last-ulp input differences without bound. That is what
 SciML/OrdinaryDiffEq.jl#4034 measured: perturbing `u0[1]` by one ulp moved the
 `Hairer4` solution of this index-1 DAE by 3.7e-03.
 
-The gate is deliberately loose relative to the values it protects: a
-round-off-reproducible integration lands at 1e-15 … 1e-7 here (the step sequence
-itself is mildly chaotic), while the regression it catches sits at 5.7e-04
-(`Hairer42`) and 3.7e-03 (`Hairer4`).
+Both solves ask for a tolerance rather than taking the default. The linear solve
+inherits `reltol`, and at the default 1e-3 a Krylov solve returns a Newton
+direction accurate only to 1e-3, which cannot drive the stage to 1e-3: `dt`
+collapses and both methods return `Unstable` before this measures anything
+(SciML/OrdinaryDiffEq.jl#4293).
+
+The gate is deliberately loose relative to the values it protects: at 1e-12 a
+round-off-reproducible integration lands at 6.0e-07 (`Hairer4`) and 4.6e-07
+(`Hairer42`), the step sequence itself being mildly chaotic, while the regression
+it catches sits at 5.7e-04 (`Hairer42`) and 3.7e-03 (`Hairer4`).
 =#
 
 dae!(du, u, p, t) = mul!(du, p, u)
@@ -51,8 +57,14 @@ end
 @testset "Newton-Krylov round-off reproducibility ($(nameof(alg)))" for alg in (
         Hairer4, Hairer42,
     )
-    a = solve(dae_prob(U0), alg(linsolve = KrylovJL_GMRES()); maxiters = 10_000)
-    b = solve(dae_prob(U0_PERTURBED), alg(linsolve = KrylovJL_GMRES()); maxiters = 10_000)
+    a = solve(
+        dae_prob(U0), alg(linsolve = KrylovJL_GMRES());
+        reltol = 1.0e-12, abstol = 1.0e-12, maxiters = 10_000
+    )
+    b = solve(
+        dae_prob(U0_PERTURBED), alg(linsolve = KrylovJL_GMRES());
+        reltol = 1.0e-12, abstol = 1.0e-12, maxiters = 10_000
+    )
     @test successful_retcode(a)
     @test successful_retcode(b)
     drift = maximum(


### PR DESCRIPTION
Fixes #4293. Test only, no library change, per @ChrisRackauckas on #4301.

`newton_krylov_roundoff.jl` called `solve` with no tolerances. The linear solve inherits
`reltol`, so the Krylov solve ran at the default 1e-3 and returned a Newton direction accurate
only to 1e-3, which cannot drive the stage to 1e-3. `dt` collapses and both methods return
`Unstable`.

The part worth checking is that the test had stopped discriminating. At the default tolerance it
fails identically whether the warm start is the guarded one that #4040 shipped or the
unpredictive reuse that #4034 reported, so it was not testing anything:

| warm start | default tolerance | `reltol = abstol = 1e-12` |
| --- | --- | --- |
| guarded Hegedüs, current default | Unstable | Success, drift 6.0e-07 and 4.6e-07 |
| `WarmStart.Previous`, regression proxy | Unstable | Unstable |

At 1e-12 the good configuration passes and the bad one still fails, so the gate protects what it
was written to protect.

On picking 1e-12, measured on this DAE with `maxiters = 10_000` left as it was:

| tolerance | `Hairer4` | `Hairer42` |
| --- | --- | --- |
| default 1e-3 | Unstable | Unstable |
| 1e-7 | drift 2.0e-04 | drift 5.1e-05 |
| 1e-8 | drift 3.1e-05 | drift 3.4e-05 |
| 1e-9 | drift 1.1e-06 | drift 2.7e-05 |
| 1e-10, 1e-11 | MaxIters | MaxIters |
| 1e-12 | drift 6.0e-07, 1211 steps | drift 4.6e-07, 1326 steps |

1e-7 through 1e-9 complete but sit at or above the 1e-5 gate, so they would not be a working
test. 1e-12 clears the gate by a factor of 16 and uses 1211 and 1326 of the 10,000 step budget.
The non-monotonic MaxIters at 1e-10 and 1e-11 is the chaotic step sequence the file's comment
already describes.

The comment block is updated to say why the tolerances are explicit and to quote the drift
actually measured, since the old text described a 1e-15 to 1e-7 band that no longer matches.

Verified by running the file against unmodified `master` at 13da423dd4: 3/3 and 3/3, exit 0.

## AI Disclosure

Claude assisted with this work.
