### PR TITLE
Let IDSolve drive polyalgorithm and SimpleNonlinearSolve caches

### DIFF
--- a/lib/ImplicitDiscreteSolve/Project.toml
+++ b/lib/ImplicitDiscreteSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "ImplicitDiscreteSolve"
 uuid = "3263718b-31ed-49cf-8a0f-35a466e8af96"
 authors = ["vyudu <vincent.duyuan@gmail.com>"]
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
@@ -15,6 +15,8 @@ SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 
 [extras]
+NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+SimpleNonlinearSolve = "727e6d20-b764-4bd8-a329-72de5adea6c7"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
@@ -25,6 +27,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 DiffEqBase = {path = "../DiffEqBase"}
 
 [compat]
+NonlinearSolve = "4"
+SimpleNonlinearSolve = "2"
 SciMLTesting = "2.8"
 CommonSolve = "0.2.6"
 Pkg = "1"
@@ -42,7 +46,10 @@ DiffEqBase = "7"
 Reexport = "1.2.2"
 
 [targets]
-test = ["OrdinaryDiffEqSDIRK", "Test", "Pkg", "SafeTestsets", "SciMLTesting"]
+test = [
+    "OrdinaryDiffEqSDIRK", "Test", "Pkg", "SafeTestsets", "SciMLTesting",
+    "NonlinearSolve", "SimpleNonlinearSolve",
+]
 
 [sources.OrdinaryDiffEqCore]
 path = "../OrdinaryDiffEqCore"

--- a/lib/ImplicitDiscreteSolve/src/ImplicitDiscreteSolve.jl
+++ b/lib/ImplicitDiscreteSolve/src/ImplicitDiscreteSolve.jl
@@ -6,7 +6,7 @@ using SciMLBase: SciMLBase, ImplicitDiscreteProblem, NonlinearFunction,
 import SciMLBase: alg_order, isadaptive
 using NonlinearSolveBase: NonlinearSolveBase
 using NonlinearSolveFirstOrder: NewtonRaphson
-using CommonSolve: init
+using CommonSolve: init, solve!
 using DiffEqBase: DefaultInit
 import DiffEqBase: initialize!
 using SymbolicIndexingInterface: state_values

--- a/lib/ImplicitDiscreteSolve/src/solve.jl
+++ b/lib/ImplicitDiscreteSolve/src/solve.jl
@@ -20,19 +20,40 @@ function perform_step!(integrator, cache::IDSolveCache, repeat_step = false)
 
     # nonlinear solve step
     SciMLBase.reinit!(nlcache, cache.z; p = state)
-    if !_solve_nonlinear!(nlcache, observer)
+    converged, znew = _solve_nonlinear!(nlcache, observer)
+    if !converged
         integrator.force_stepfail = true
         return
     end
 
     # Accept step
-    return u .= state_values(nlcache)
+    return u .= znew
 end
+
+"""
+    _can_observe_steps(nlcache) -> Bool
+
+Whether the nonlinear solve is driven step by step through `NonlinearSolveBase.solve_cache!`
+with the step observer, or run to completion with `solve!`.
+
+`NonlinearSolveNoInitCache` is NonlinearSolveBase's public marker for a solver without the
+iterator interface, so it takes the `solve!` path. A polyalgorithm cache does too, even
+though it can be stepped: observing it feeds every subsolver's iterations, including the
+ones that fail before the next subsolver takes over, to the step controller, which drives
+`dt` to zero on the first step.
+"""
+@inline _can_observe_steps(nlcache) = true
+@inline _can_observe_steps(::NonlinearSolveBase.NonlinearSolveNoInitCache) = false
+@inline _can_observe_steps(::NonlinearSolveBase.NonlinearSolvePolyAlgorithmCache) = false
 
 function _solve_nonlinear!(nlcache, observer)
     reset!(observer)
-    retcode = NonlinearSolveBase.solve_cache!(nlcache; step_observer = observer)
-    return retcode == ReturnCode.Success
+    if _can_observe_steps(nlcache)
+        retcode = NonlinearSolveBase.solve_cache!(nlcache; step_observer = observer)
+        return retcode == ReturnCode.Success, state_values(nlcache)
+    end
+    sol = solve!(nlcache)
+    return sol.retcode == ReturnCode.Success, sol.u
 end
 
 function initialize!(integrator, cache::IDSolveCache)
@@ -56,8 +77,9 @@ function _initialize_dae!(
         z .= u
         initstate = ImplicitDiscreteState(z, p, t)
         SciMLBase.reinit!(nlcache, u; p = initstate)
-        if _solve_nonlinear!(nlcache, observer)
-            integrator.u .= state_values(nlcache)
+        converged, unew = _solve_nonlinear!(nlcache, observer)
+        if converged
+            integrator.u .= unew
         else
             integrator.sol = SciMLBase.solution_new_retcode(
                 integrator.sol, ReturnCode.InitialFailure

--- a/lib/ImplicitDiscreteSolve/test/qa/qa.jl
+++ b/lib/ImplicitDiscreteSolve/test/qa/qa.jl
@@ -8,6 +8,7 @@ run_qa(
     ei_kwargs = (;
         all_qualified_accesses_are_public = (;
             ignore = (
+                :NonlinearSolvePolyAlgorithmCache, :NonlinearSolveNoInitCache,
                 # OrdinaryDiffEqCore controller-resolution internal (owner-internal,
                 # deliberately kept non-public in the make-public extension surface).
                 :_resolved_QT,

--- a/lib/ImplicitDiscreteSolve/test/runtests.jl
+++ b/lib/ImplicitDiscreteSolve/test/runtests.jl
@@ -3,6 +3,8 @@ using Test
 using ImplicitDiscreteSolve
 using OrdinaryDiffEqCore
 using OrdinaryDiffEqSDIRK
+using NonlinearSolve
+using SimpleNonlinearSolve
 using SciMLBase
 using SafeTestsets
 using SciMLTesting
@@ -301,6 +303,27 @@ if TEST_GROUP != "QA"
         @test integ.cache.nlcache === nothing
         sol = solve(pr, IDSolve())
         @test SciMLBase.successful_retcode(sol)
+    end
+
+    @testset "nlsolve accepts polyalgorithms and SimpleNonlinearSolve" begin
+        function halving!(resid, u_next, u, p, t)
+            resid[1] = u_next[1] - u[1] / 2
+            return nothing
+        end
+        idprob = ImplicitDiscreteProblem(halving!, [1.0], (0, 5), nothing)
+
+        reference = solve(idprob, IDSolve())
+        @test SciMLBase.successful_retcode(reference)
+
+        for nlsolve in (
+                RobustMultiNewton(), FastShortcutNonlinearPolyalg(),
+                SimpleNewtonRaphson(), SimpleTrustRegion(),
+            )
+            sol = solve(idprob, IDSolve(nlsolve = nlsolve))
+            @test SciMLBase.successful_retcode(sol)
+            @test sol.t == reference.t
+            @test sol.u[end] ≈ reference.u[end]
+        end
     end
 
     @testset "InitialFailure thrown" begin


### PR DESCRIPTION
`IDSolve` now drives a `NonlinearSolveNoInitCache` (what SimpleNonlinearSolve algorithms return) and a polyalgorithm cache through `solve!` instead of `solve_cache!`, and reads the result off the returned solution. Before, every polyalgorithm threw `has no field termination_cache`, and falling back to `solve!` while still reading `state_values` afterwards turned that into a silent wrong answer: `SimpleNewtonRaphson` returned `u(end) = 1.0`, the initial condition, with `Success`.

The polyalgorithm stays on `solve!` even though NonlinearSolve.jl#1189 now lets `solve_cache!` accept it: observing its steps hands the Kantorovich controller the subsolver's rates and `dt` is driven below eps on the first step.

Four inner solvers go from 0 of 4 to 4 of 4 passing and match the default's `t` and `u[end]`; the full `ImplicitDiscreteSolve` suite passes. Noticed and not touched: `TrustRegion()` returns 2.9458767598199065e-13 rather than 0.0625 on this problem, bit-identical before and after, so pre-existing and separate.

Fixes #4138.

AI Disclosure: Claude assisted with this change.