### PR TITLE
Measure CG4a's order inside the asymptotic regime

### DIFF
--- a/lib/OrdinaryDiffEqLinear/test/linear_method_tests.jl
+++ b/lib/OrdinaryDiffEqLinear/test/linear_method_tests.jl
@@ -93,14 +93,31 @@ test_setup = Dict(:alg => Vern6(), :reltol => 1.0e-14, :abstol => 1.0e-14)
 sim = analyticless_test_convergence(dts, prob, CG3(), test_setup)
 @test sim.𝒪est[:l2] ≈ 3 atol = 0.2
 
-A = MatrixOperator(ones(2, 2); update_func!)
-prob = ODEProblem(A, ones(2), (0, 30.0))
-sol1 = solve(prob, Vern9(), dt = 1 / 4)
-sol2 = solve(prob, CG4a(), dt = 1 / 4)
-dts = (0.38) .^ (6:-1:1)
+# CG4a is a commutator-free Magnus method, derived for `u' = A(t) u`. It is fourth order
+# there, and this measures that on a non-commuting `A(t)`.
+function cg4a_time_dependent!(A, u, p, t)
+    A[1, 1] = 0
+    A[2, 1] = sin(t)
+    A[1, 2] = -1
+    A[2, 2] = 0
+    return
+end
+A = MatrixOperator(ones(2, 2); update_func! = cg4a_time_dependent!)
+prob = ODEProblem(A, ones(2), (0, 5.0))
+dts = 1 ./ 2 .^ (7:-1:2)
 test_setup = Dict(:alg => Vern9(), :reltol => 1.0e-14, :abstol => 1.0e-14)
 sim = analyticless_test_convergence(dts, prob, CG4a(), test_setup)
-@test sim.𝒪est[:l2] ≈ 4 atol = 0.28
+@test sim.𝒪est[:l2] ≈ 4 atol = 0.1
+
+# On the state-dependent `A(u)` above it drops to third order, which is the usual order
+# reduction for a Lie group method outside the problem class it was derived for. This grid is
+# inside the asymptotic regime; the previous one reached dt = 0.38, where the error is 24 and
+# the least-squares slope is a fit to the pre-asymptotic tail rather than an order (#3466).
+A = MatrixOperator(ones(2, 2); update_func!)
+prob = ODEProblem(A, ones(2), (0, 30.0))
+dts = 1 ./ 2 .^ (11:-1:8)
+sim = analyticless_test_convergence(dts, prob, CG4a(), test_setup)
+@test sim.𝒪est[:l2] ≈ 3 atol = 0.1
 
 function update_func!(A, u, p, t)
     A[1, 1] = 0


### PR DESCRIPTION
Fixes #3466.

@ChrisRackauckas asked on the issue whether this could be bisected. It cannot: no commit
introduced it, the assertion was never measuring an order.

`dts = (0.38) .^ (6:-1:1)` reaches `dt = 0.38`, where `CG4a`'s error on this problem is 24.2
against a solution of size 1. The pairwise slopes over that grid are

```
dt 0.00301 -> 0.00792 : 3.0004
dt 0.00792 -> 0.02085 : 2.9996
dt 0.02085 -> 0.05487 : 2.9931
dt 0.05487 -> 0.14440 : 2.8349
dt 0.14440 -> 0.38000 : 3.5964      <- error 0.747 -> 24.2
```

so the least-squares fit over all six is 4.31, and it passed a `4 ± 0.28` check only because the
pre-asymptotic tail dragged the slope up to about where 4 sits. Fit the finest three, four or
five points instead and it is 3.0000, 2.9979, 2.9648.

`CG4a` is not broken. It is a commutator-free Magnus method, derived for `u' = A(t) u`, and it
is fourth order there: on a non-commuting `A(t) = [0 -1; sin(t) 0]` the measured order is 4.009.
The test problem has `A[2,1] = sin(u[1])`, so `A` depends on the state, and the order drops to
3, which is the usual order reduction for a Lie group method outside the class it was derived
for.

So this now measures both: order 4 on a genuinely linear `A(t)`, and order 3 on the existing
state-dependent problem, each on a grid inside the asymptotic regime, with `atol = 0.1` rather
than 0.28 because both are now tight (4.0094 and 2.9998).

## Worth knowing, not changed here

The same measurement over the rest of the file, on an asymptotic grid `1 ./ 2 .^ (11:-1:8)`:

| method | asserted | measured |
| --- | --- | --- |
| `RKMK2` | 2 | 2.013 |
| `RKMK4` | 4 | 3.004 |
| `CG2` | 2 | 2.011 |
| `CG3` | 3 | 3.001 |
| `CG4a` | 4 | 2.999 |

`RKMK4` has the same problem `CG4a` had and is currently passing for the same reason, and
`LieRK4` asserts order 5 for a method named 4. I have left both alone since they are not what
this issue is about, but they will not survive a stricter grid either.

## AI Disclosure

Claude assisted with this work.
