### PR TITLE
Declare SciMLOperators as an OrdinaryDiffEqBDF test dependency

### DIFF
--- a/lib/OrdinaryDiffEqBDF/Project.toml
+++ b/lib/OrdinaryDiffEqBDF/Project.toml
@@ -23,6 +23,7 @@ DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [extras]
+SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -50,6 +51,7 @@ OrdinaryDiffEqRosenbrock = {path = "../OrdinaryDiffEqRosenbrock"}
 OrdinaryDiffEqSDIRK = {path = "../OrdinaryDiffEqSDIRK"}
 
 [compat]
+SciMLOperators = "1.27"
 SciMLTesting = "2.8"
 Pkg = "1"
 NonlinearSolve = "4.20.3"
@@ -84,4 +86,4 @@ SafeTestsets = "0.1.0"
 StaticArrays = "1.9.18"
 
 [targets]
-test = ["DiffEqDevTools", "DifferentiationInterface", "ForwardDiff", "Random", "SafeTestsets", "StaticArrays", "Test", "ODEProblemLibrary", "NonlinearSolve", "Enzyme", "LinearSolve", "Pkg", "SciMLTesting", "OrdinaryDiffEqRosenbrock", "SparseArrays", "OrdinaryDiffEqFIRK"]
+test = ["SciMLOperators", "DiffEqDevTools", "DifferentiationInterface", "ForwardDiff", "Random", "SafeTestsets", "StaticArrays", "Test", "ODEProblemLibrary", "NonlinearSolve", "Enzyme", "LinearSolve", "Pkg", "SciMLTesting", "OrdinaryDiffEqRosenbrock", "SparseArrays", "OrdinaryDiffEqFIRK"]


### PR DESCRIPTION
`lib/OrdinaryDiffEqBDF/test/lhl_factorization_tests.jl` does

```julia
using SciMLOperators: WOperator, jacobian_stale
```

but `SciMLOperators` is not in `OrdinaryDiffEqBDF`'s `[deps]`, `[extras]` or the test target. The
file came in with #4266 and the dependency was never declared, so the downgrade job fails:

```
LoadError: ArgumentError: Package SciMLOperators not found in current path.
ERROR: LoadError: Some tests did not pass: 0 passed, 0 failed, 1 errored, 0 broken.
```

`downgrade-sublibraries / test (lib/OrdinaryDiffEqBDF)` has been red on master since; the run at
2026-08-22T07:31 fails this way.

The regular Sublibrary CI passes, which is why this went unnoticed: that path resolves
`SciMLOperators` through the monorepo `[sources]`, while the downgrade job builds the test
environment from the declared target and gets nothing.

`OrdinaryDiffEqBDF`'s own source does not use `SciMLOperators`, so this is `[extras]` plus the
test target rather than a runtime dependency. The `[compat]` entry matches what
`OrdinaryDiffEqDifferentiation`, `OrdinaryDiffEqNonlinearSolve` and `OrdinaryDiffEqLinear`
already pin.

## Verified

Built the test environment exactly as `Pkg.test` does, from the package plus its declared test
target, and toggled only this entry:

```
targets without SciMLOperators : ArgumentError: Package SciMLOperators not found in current path.
targets with SciMLOperators    : loads
```

which is the CI message reproduced locally. With the entry present and the sibling sublibraries
resolved from the monorepo, `lhl_factorization_tests.jl` passes 18 of 18.

## AI Disclosure

Claude assisted with this work.
