### PR TITLE
Keep the sparsity pattern when building the diagnostic Jacobian

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "3.10.0"
+version = "3.10.1"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -358,7 +358,11 @@ function get_fresh_jacobian(integrator, cache::OrdinaryDiffEqCache)
     (; stats) = integrator
     njacs, nf = stats.njacs, stats.nf
     J = if SciMLBase.isinplace(integrator.sol.prob) && cache.J isa AbstractMatrix
-        Jfresh = zero(cache.J)
+        # `zero` on a `SparseMatrixCSC` returns a matrix with no stored entries, which
+        # drops the sparsity pattern `calc_J!` colours against and makes it throw
+        # `DimensionMismatch`. `fill!(similar(...))` keeps the pattern and still hands
+        # `calc_J!` a zeroed buffer, and is the same thing as `zero` for a dense `J`.
+        Jfresh = fill!(similar(cache.J), zero(eltype(cache.J)))
         calc_J!(Jfresh, integrator, cache)
         Jfresh
     elseif SciMLBase.isinplace(integrator.sol.prob)

--- a/lib/OrdinaryDiffEqDifferentiation/test/nojac_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/nojac_tests.jl
@@ -1,7 +1,7 @@
 using OrdinaryDiffEqSDIRK, OrdinaryDiffEqRosenbrock, RecursiveFactorization, LinearSolve,
     Test, ADTypes
 using OrdinaryDiffEqCore: get_fresh_jacobian
-using SparseArrays: sparse
+using SparseArrays: sparse, spdiagm, nnz, SparseMatrixCSC
 
 const N = 32
 const xyd_brusselator = range(0, stop = 1, length = N)
@@ -273,6 +273,41 @@ integ = init(prob, Rosenbrock23(), abstol = 1.0e-6, reltol = 1.0e-6)
 
     @test get_fresh_jacobian(integrator, integrator.cache) === nothing
     @test (integrator.stats.nf, integrator.stats.njacs) == work
+end
+
+@testset "get_fresh_jacobian keeps a sparse J's pattern" begin
+    # `zero(::SparseMatrixCSC)` has no stored entries, so it drops the pattern `calc_J!`
+    # colours against and the instability diagnostic threw `DimensionMismatch` instead of
+    # reporting the Jacobian it was asked for.
+    n = 12
+    diffusivity = 50.0
+    function heat!(du, u, p, t)
+        for i in 1:n
+            l = i == 1 ? zero(eltype(u)) : u[i - 1]
+            r = i == n ? zero(eltype(u)) : u[i + 1]
+            du[i] = diffusivity * (l - 2u[i] + r)
+        end
+        return
+    end
+    u0 = [sinpi(i / (n + 1)) for i in 1:n]
+    trueJ = diffusivity *
+        Matrix(spdiagm(-1 => ones(n - 1), 0 => fill(-2.0, n), 1 => ones(n - 1)))
+    pattern = spdiagm(-1 => ones(n - 1), 0 => ones(n), 1 => ones(n - 1))
+
+    for proto in (copy(pattern), Matrix(pattern))
+        prob = ODEProblem(ODEFunction(heat!; jac_prototype = proto), u0, (0.0, 1.0))
+        # `instability_jacobian` only reaches this hook for caches that carry `J`
+        # themselves, which is the Rosenbrock and Radau shape.
+        for alg in (Rosenbrock23(), Rodas5P())
+            integrator = init(prob, alg; dt = 0.01, adaptive = false)
+            step!(integrator)
+            step!(integrator)
+            J = get_fresh_jacobian(integrator, integrator.cache)
+            @test J !== nothing
+            @test Matrix(J) ≈ trueJ
+            proto isa SparseMatrixCSC && @test nnz(J) == nnz(pattern)
+        end
+    end
 end
 integ = init(
     prob, Rosenbrock23(linsolve = SimpleLUFactorization()), abstol = 1.0e-6,


### PR DESCRIPTION
`get_fresh_jacobian` builds its scratch Jacobian with

```julia
Jfresh = zero(cache.J)
```

`zero` on a `SparseMatrixCSC` returns a matrix with no stored entries. That is the pattern
`calc_J!` colours against, so the next line throws:

```
DimensionMismatch: `A` and `bg.S2` must have the same sparsity pattern.
```

This is the numerical-instability diagnostic path, reached from `instability_jacobian` for the
caches that carry `J` themselves. So a sparse solve that goes unstable raises a confusing
`DimensionMismatch` from the reporting code instead of returning `retcode = Unstable` with the
Jacobian it was trying to show.

It needs nothing unusual to hit. A correct tridiagonal prototype for a heat equation is enough:

```julia
n = 12
tri = spdiagm(-1 => ones(n - 1), 0 => ones(n), 1 => ones(n - 1))
prob = ODEProblem(ODEFunction(heat!; jac_prototype = tri), u0, (0.0, 1.0))
integ = init(prob, Rosenbrock23(); dt = 0.01, adaptive = false)
step!(integ); step!(integ)
OrdinaryDiffEqCore.get_fresh_jacobian(integ, integ.cache)   # throws on master
```

`nnz(cache.J)` is 34 there and `nnz(zero(cache.J))` is 0. `RadauIIA5` behaves the same.

`fill!(similar(cache.J), zero(eltype(cache.J)))` keeps the pattern and still hands `calc_J!` a
zeroed buffer, and is the same thing as `zero` for a dense `J`. It needs no `SparseArrays`
dependency in this file.

## Testing

Added to `nojac_tests.jl`, which already imports `get_fresh_jacobian`: with both a sparse and a
dense prototype, on `Rosenbrock23` and `Rodas5P`, the returned Jacobian must match the analytic
one and keep `nnz`.

Verified red to green against `upstream/master`: without the change the new testset errors with
the `DimensionMismatch` above; with it the file passes 19 of 19. The recovered Jacobian is exact,
`maxabsdiff` against the analytic Jacobian is 0 for sparse and dense on both algorithms.

Found while working #4140, but it is independent of that: this fires with a fully correct
sparsity pattern, not only a degenerate one.

## AI Disclosure

Claude assisted with this work.
