### PR TITLE
Unpack promote_f's pullback rdata by the tuple's own type

### DIFF
--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.18.1"
+version = "7.18.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/DiffEqBase/ext/DiffEqBaseMooncakeExt.jl
+++ b/lib/DiffEqBase/ext/DiffEqBaseMooncakeExt.jl
@@ -102,21 +102,16 @@ function rrule!!(
     )
     lazy_f = f_out_is_identity ? nothing : lazy_zero_rdata(f_primal)
 
-    # dy's shape depends on whether f_out/p_out carry real rdata: mutable outputs (e.g.
-    # array p_out) get their gradient via fdata mutation instead, so dy collapses from a
-    # 2-tuple down to a single rdata, or a bare NoRData() if both sides are trivial.
-    RDf = Mooncake.rdata_type(Mooncake.tangent_type(typeof(f_out)))
-    RDp = Mooncake.rdata_type(Mooncake.tangent_type(typeof(p_out)))
+    # `rdata_type` on a tuple collapses to a bare `NoRData` only when *every* field has
+    # `NoRData`. With one differentiable field it keeps the full 2-tuple, e.g.
+    # `Tuple{NoRData, Float64}` for a scalar `p` alongside an array-carrying `f_out`. It
+    # never degrades a 2-tuple to a single bare rdata, so `dy` here is either `NoRData()`
+    # or a 2-tuple, and there is no third shape to unpack.
+    RDy = Mooncake.rdata_type(
+        Mooncake.tangent_type(Tuple{typeof(f_out), typeof(p_out)})
+    )
     function promote_f_pb!!(dy)
-        df_out, dp_out = if RDf === NoRData && RDp === NoRData
-            NoRData(), NoRData()
-        elseif RDf === NoRData
-            NoRData(), dy
-        elseif RDp === NoRData
-            dy, NoRData()
-        else
-            dy
-        end
+        df_out, dp_out = RDy === NoRData ? (NoRData(), NoRData()) : dy
         df = f_out_is_identity ? df_out : instantiate(lazy_f)
         return (
             instantiate(lazy_pf), df, instantiate(lazy_specialize), instantiate(lazy_u0),

--- a/test/AD/discrete_adjoints.jl
+++ b/test/AD/discrete_adjoints.jl
@@ -65,5 +65,33 @@ fdd = DI.derivative(f_dt_sum_scalar, AutoForwardDiff(), 1.0)
             @test mkd isa typeof(fdd)
             @test mkd ≈ fdd rtol = 1.0e-6
         end
+        @testset "promote_f rdata over p types and specializations" begin
+            # `rdata_type` on a tuple keeps the full 2-tuple unless *every* field is
+            # `NoRData`, so the shape of the pullback's `dy` depends on `p`. The tests
+            # above only exercise an array `p`, which is the one configuration where the
+            # old unpacking happened to be right.
+            lin!(du, u, p, t) = (du .= -0.3 .* u)
+            linp!(du, u, p, t) = (du .= -(p isa Number ? p : p[1]) .* u)
+            v0 = [1.0, 2.0]
+
+            for p in (SciMLBase.NullParameters(), [0.3, 1.0], 0.3, (0.3, 0.5))
+                for spec in (SciMLBase.FullSpecialize, SciMLBase.NoSpecialize)
+                    rhs = p isa SciMLBase.NullParameters ? lin! : linp!
+                    g = let p = p, spec = spec, rhs = rhs
+                        function (x)
+                            prob = ODEProblem{true, spec}(rhs, x, (0.0, 1.0), p)
+                            sol = DiffEqBase.solve(
+                                prob, Tsit5(); abstol = 1.0e-10, reltol = 1.0e-10,
+                                sensealg = DiffEqBase.SensitivityADPassThrough()
+                            )
+                            return sum(abs2, sol.u[end])
+                        end
+                    end
+                    reference = DI.gradient(g, AutoForwardDiff(), v0)
+                    @test DI.gradient(g, AutoMooncake(; config = nothing), v0) ≈
+                        reference rtol = 1.0e-6
+                end
+            end
+        end
     end
 end


### PR DESCRIPTION
Second half of #4294. #4242 fixed the forward side; this is the pullback.

`rdata_type` on a tuple collapses to a bare `NoRData` only when *every* field has `NoRData`.
With one differentiable field it keeps the full 2-tuple:

```julia
rdata_type(tangent_type(Tuple{Vector{Float64}, Float64}))   # Tuple{NoRData, Float64}
rdata_type(tangent_type(Tuple{Vector{Float64}, Vector{Float64}}))   # NoRData
```

`promote_f_pb!!` assumed the other thing, that a 2-tuple degrades to one bare field when either
side is trivial:

```julia
elseif RDf === NoRData
    NoRData(), dy
elseif RDp === NoRData
    dy, NoRData()
```

Those two branches never see a bare rdata. When they run, `dy` is the whole 2-tuple and it goes
into a single argument slot:

```
MethodError: no method matching increment!!(::Float64, ::Tuple{Mooncake.NoRData, Float64})
TypeError: in setfield!, expected Union{ZeroRData, RData{@NamedTuple{f, mass_matrix, ...}}},
           got a value of type Tuple{RData{@NamedTuple{...}}, NoRData}
```

Since the collapse is all or nothing, `dy` is either `NoRData()` or a 2-tuple and there is no
third shape, so the whole thing is one branch on the tuple's own rdata type. `RDy === NoRData` is
exactly the old `RDf === NoRData && RDp === NoRData`; only the two unreachable-correct branches
go. The comment above them encoded the wrong model, so it goes too.

## Testing

The existing coverage only used an array `p`, which is the single configuration where the old
unpacking happened to be right. Extended `discrete_adjoints.jl` over
`p in (NullParameters(), [0.3, 1.0], 0.3, (0.3, 0.5))` and
`specialize in (FullSpecialize, NoSpecialize)`, against ForwardDiff.

Red to green on `upstream/master`, which already carries #4242: without this the new testset
errors with the `setfield!` type above, 4 of 8 configurations fail (`Float64` and `Tuple` p on
`FullSpecialize` with the `increment!!` MethodError, `NullParameters` and `Vector` on
`NoSpecialize` with the `setfield!` one). With it, 8 of 8, and `Discrete Adjoints` passes 12/12.

## AI Disclosure

Claude assisted with this work.
