### PR TITLE
Reject a jac_prototype that declares no structural nonzeros

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "3.11.4"
+version = "3.11.5"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 

--- a/lib/OrdinaryDiffEqDifferentiation/ext/OrdinaryDiffEqDifferentiationSparseArraysExt.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/ext/OrdinaryDiffEqDifferentiationSparseArraysExt.jl
@@ -2,11 +2,15 @@ module OrdinaryDiffEqDifferentiationSparseArraysExt
 
 using OrdinaryDiffEqDifferentiation
 import SparseArrays
-import SparseArrays: nonzeros, spzeros, SparseMatrixCSC, AbstractSparseMatrix
+import SparseArrays: nonzeros, spzeros, SparseMatrixCSC, AbstractSparseMatrix, nnz
 
 # Override the sparse checking functions
 OrdinaryDiffEqDifferentiation.is_sparse(::AbstractSparseMatrix) = true
 OrdinaryDiffEqDifferentiation.is_sparse_csc(::SparseMatrixCSC) = true
+
+function OrdinaryDiffEqDifferentiation._declares_no_nonzeros(S::AbstractSparseMatrix)
+    return nnz(S) == 0
+end
 
 # Override the sparse array manipulation functions
 OrdinaryDiffEqDifferentiation.nonzeros(A::AbstractSparseMatrix) = nonzeros(A)

--- a/lib/OrdinaryDiffEqDifferentiation/src/OrdinaryDiffEqDifferentiation.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/OrdinaryDiffEqDifferentiation.jl
@@ -59,6 +59,18 @@ import DiffEqBase: OrdinaryDiffEqTag
 is_sparse(::Any) = false
 is_sparse_csc(::Any) = false
 
+"""
+    _declares_no_nonzeros(S) -> Bool
+
+Whether `S`, used as a `jac_prototype`/`sparsity`, stores no entries at all, so the
+coloring is empty and AD writes nothing into the Jacobian.
+
+Only structural emptiness counts: a `SparseMatrixCSC` whose stored entries are all
+`0.0` still stores them. The test needs `nnz`, so it lives in the SparseArrays
+extension alongside `is_sparse_csc`.
+"""
+_declares_no_nonzeros(::Any) = false
+
 # Seeding a sparsity pattern from the mass matrix uses `findall`/`getindex`, which a
 # SciMLOperator does not support. `convert` reads the operator's currently-cached array
 # rather than re-evaluating it, which is what is wanted here: only the structural

--- a/lib/OrdinaryDiffEqDifferentiation/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/alg_utils.jl
@@ -122,6 +122,22 @@ function prepare_user_sparsity(ad_alg, prob)
     end
 
     if !isnothing(sparsity) && !(ad_alg isa AutoSparse)
+        # Checked before the mass-matrix patch below writes stored entries into the prototype.
+        if !SciMLBase.has_jac(prob.f) && !SciMLBase.has_Wfact(prob.f) &&
+                !SciMLBase.has_Wfact_t(prob.f) && _declares_no_nonzeros(sparsity)
+            throw(
+                ArgumentError(
+                    "the `jac_prototype`/`sparsity` given for this problem declares no " *
+                        "structural nonzeros (a sparse matrix with no stored entries), " *
+                        "i.e. that the Jacobian is zero " *
+                        "everywhere. Automatic differentiation would leave it " *
+                        "identically zero and the solve would be silently wrong. Pass " *
+                        "`nothing`, the default, for a dense AD Jacobian, or a prototype " *
+                        "whose stored structure is the real sparsity pattern, or supply " *
+                        "`jac`."
+                )
+            )
+        end
         if is_sparse_csc(sparsity) && !SciMLBase.has_jac(prob.f)
             if prob.f.mass_matrix isa UniformScaling
                 idxs = diagind(sparsity)

--- a/lib/OrdinaryDiffEqDifferentiation/test/prepare_user_sparsity_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/prepare_user_sparsity_tests.jl
@@ -1,5 +1,6 @@
 using OrdinaryDiffEqDifferentiation
 using SparseArrays
+using LinearAlgebra
 using SciMLOperators
 using SciMLBase
 using ADTypes
@@ -84,4 +85,29 @@ end
 
     @test prob.f.sparsity === Jop
     @test OrdinaryDiffEqDifferentiation.prepare_user_sparsity(ad_alg, prob) === ad_alg
+end
+
+@testset "a prototype declaring no structural nonzeros is rejected" begin
+    ad_alg = AutoForwardDiff()
+    prob_with(P) = ODEProblem(ODEFunction(f!; jac_prototype = P), ones(2), (0.0, 1.0))
+
+    P = spzeros(2, 2)
+    @test OrdinaryDiffEqDifferentiation._declares_no_nonzeros(P)
+    @test_throws ArgumentError OrdinaryDiffEqDifferentiation.prepare_user_sparsity(
+        ad_alg, prob_with(P)
+    )
+
+    for P in (
+            zeros(2, 2), ones(2, 2), falses(2, 2), Diagonal(zeros(2)),
+            Symmetric(zeros(2, 2)), Tridiagonal(zeros(1), zeros(2), zeros(1)),
+            SparseMatrixCSC(2, 2, [1, 2, 4], [1, 1, 2], [0.0, 0.0, 0.0]),
+        )
+        @test !OrdinaryDiffEqDifferentiation._declares_no_nonzeros(P)
+        @test_nowarn OrdinaryDiffEqDifferentiation.prepare_user_sparsity(ad_alg, prob_with(P))
+    end
+
+    jacf = ODEFunction(f!; jac_prototype = spzeros(2, 2), jac = (J, u, p, t) -> (J .= 1))
+    @test_nowarn OrdinaryDiffEqDifferentiation.prepare_user_sparsity(
+        ad_alg, ODEProblem(jacf, ones(2), (0.0, 1.0))
+    )
 end

--- a/lib/OrdinaryDiffEqDifferentiation/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/qa/qa.jl
@@ -45,12 +45,13 @@ run_qa(
                 # OrdinaryDiffEqCore internal not yet in its public block
                 :_get_fwd_chunksize_int,
                 # SciMLBase Jacobian-interface predicates (make-public candidates)
-                :has_Wfact_t, :has_colorvec, :has_jac_du, :has_jac_u,
+                :has_Wfact, :has_Wfact_t, :has_colorvec, :has_jac_du, :has_jac_u,
                 # DifferentiationInterface internals
                 Symbol("prepare!_derivative"), Symbol("prepare!_jacobian"),
                 # this sublib's own internal sparse-handling API, accessed
                 # qualified from OrdinaryDiffEqDifferentiationSparseArraysExt
-                :get_nzval, :is_sparse, :is_sparse_csc, :nonzeros,
+                :_declares_no_nonzeros, :get_nzval, :is_sparse, :is_sparse_csc,
+                :nonzeros,
                 Symbol("set_all_nzval!"), :spzeros,
             ),
         ),


### PR DESCRIPTION
`prepare_alg` now throws when a sparse `jac_prototype` stores no entries and there is no analytic `jac` or `Wfact`, because an empty pattern gives the coloring nothing to write and the solve then runs on whatever the mass matrix diagonal patch leaves behind. On #4140's 2x2 problem that is a diagonal `J` with the coupling missing, and `Rosenbrock23` at dt = 0.005 returns `Success` with relative error 8.4e168 while `Rodas5P` at 1e-10 takes 494 steps against 27.
The test is structural, so it is the SparseArrays extension's `nnz(S) == 0` and nothing is converted to sparse to count; a sparse prototype whose stored entries are all zero still stores them and is accepted. It runs before the mass matrix patch writes into the prototype.
The dense all-zero prototype in #4140's title is not covered here. It leaves `J == 0` and a silent wrong answer for the same reason, but rejecting it means reading a dense buffer's values as structure, which is a separate call to make.
AI Disclosure: Claude assisted with this change.
