### PR TITLE
Fix crashes when a cache holds a vector of nonlinear solvers

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.15.3"
+version = "4.15.4"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
@@ -811,6 +811,7 @@ function instability_jacobian(integrator)
         #radau
         get_fresh_jacobian(integrator, integrator.cache)
     elseif hasproperty(integrator.cache, :nlsolver) &&
+            hasproperty(integrator.cache.nlsolver, :cache) &&
             hasproperty(integrator.cache.nlsolver.cache, :J)
         #BDF
         integrator.cache.nlsolver.cache.J

--- a/lib/OrdinaryDiffEqCore/test/instability_diagnostics_tests.jl
+++ b/lib/OrdinaryDiffEqCore/test/instability_diagnostics_tests.jl
@@ -1,0 +1,15 @@
+using OrdinaryDiffEqCore
+using Test
+
+struct VectorSolverCache
+    nlsolver::Vector{Int}
+end
+
+struct FakeIntegrator
+    cache::VectorSolverCache
+end
+
+@testset "instability diagnostics with a vector of nonlinear solvers" begin
+    integrator = FakeIntegrator(VectorSolverCache([1, 2]))
+    @test OrdinaryDiffEqCore.instability_jacobian(integrator) === nothing
+end

--- a/lib/OrdinaryDiffEqCore/test/runtests.jl
+++ b/lib/OrdinaryDiffEqCore/test/runtests.jl
@@ -46,4 +46,5 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "Algebraic Vars Detection" include("algebraic_vars_detection_tests.jl")
     @time @safetestset "Interpolation Search Hint" include("interpolation_hint_tests.jl")
     @time @safetestset "Bool Equal Coercion" include("bool_equal_tests.jl")
+    @time @safetestset "Instability Diagnostics" include("instability_diagnostics_tests.jl")
 end

--- a/lib/OrdinaryDiffEqPDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqPDIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqPDIRK"
 uuid = "5dd0a6cf-3d4b-4314-aa06-06d4e299bc89"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.5.1"
+version = "2.5.2"
 
 [deps]
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"

--- a/lib/OrdinaryDiffEqPDIRK/src/pdirk_caches.jl
+++ b/lib/OrdinaryDiffEqPDIRK/src/pdirk_caches.jl
@@ -10,6 +10,10 @@ end
 # Non-FSAL
 get_fsalfirstlast(cache::PDIRK44Cache, u) = (nothing, nothing)
 
+function SciMLBase.get_tmp_cache(integrator, ::PDIRK44, cache::PDIRK44Cache)
+    return (first(cache.nlsolver).tmp, first(cache.nlsolver).z)
+end
+
 struct PDIRK44ConstantCache{N, TabType} <: OrdinaryDiffEqConstantCache
     nlsolver::N
     tab::TabType

--- a/lib/OrdinaryDiffEqPDIRK/test/core_interface_tests.jl
+++ b/lib/OrdinaryDiffEqPDIRK/test/core_interface_tests.jl
@@ -1,0 +1,15 @@
+using OrdinaryDiffEqPDIRK
+using SciMLBase
+using Test
+
+@testset "PDIRK44 exposes scratch buffers from its solver vector" begin
+    prob = ODEProblem((du, u, p, t) -> (du .= -u), [1.0, 1.0], (0.0, 1.0))
+    integrator = init(prob, PDIRK44(); dt = 0.1, adaptive = false)
+    step!(integrator)
+
+    @test integrator.cache.nlsolver isa AbstractVector
+
+    tmp_cache = SciMLBase.get_tmp_cache(integrator)
+    @test tmp_cache isa NTuple{2, <:AbstractVector}
+    @test all(buf -> axes(buf) == axes(prob.u0), tmp_cache)
+end

--- a/lib/OrdinaryDiffEqPDIRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqPDIRK/test/runtests.jl
@@ -35,3 +35,4 @@ end
 
 @time @safetestset "Convergence Tests" include("pdirk_convergence_tests.jl")
 @time @safetestset "nlsolve! Arguments" include("nlsolve_argument_tests.jl")
+@time @safetestset "Core Interface Tests" include("core_interface_tests.jl")


### PR DESCRIPTION
`instability_jacobian` and `get_tmp_cache` assumed `cache.nlsolver` is one `NLSolver`; `PDIRK44` keeps one per parallel stage in a `Vector`, so both threw `type Array has no field ...` when reached. The diagnostic now checks the property first and `PDIRK44` gets its own `get_tmp_cache`.

Both fail on master with those errors and pass after; covered in `instability_diagnostics_tests.jl` and `core_interface_tests.jl`. #4351 bumps the same Core version line, so whichever lands second needs it refreshed.

AI Disclosure: Claude assisted with this change.