### PR TITLE
Renumber four sublibraries to the next consecutive version

### DIFF
--- a/lib/DelayDiffEq/Project.toml
+++ b/lib/DelayDiffEq/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.1.5"
+version = "6.2.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/OrdinaryDiffEqExtrapolation/Project.toml
+++ b/lib/OrdinaryDiffEqExtrapolation/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExtrapolation"
 uuid = "becaefa8-8ca2-5cf9-886d-c06f3d2bd2c4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.5.1"
+version = "2.5.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.10.3"
+version = "2.9.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/OrdinaryDiffEqSDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqSDIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSDIRK"
 uuid = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.9.1"
+version = "2.9.0"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"


### PR DESCRIPTION
Four sublibraries carry version numbers on `master` that skip over versions never registered in General. AutoMerge's [sequential version number guideline](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) rejects them, so their registration PRs sit failing and the releases cannot complete.

| package | master | registered max | new |
|---|---|---|---|
| OrdinaryDiffEqExtrapolation | 2.5.1 | 2.4.1 | **2.5.0** |
| OrdinaryDiffEqNonlinearSolve | 2.10.3 | 2.8.0 | **2.9.0** |
| OrdinaryDiffEqSDIRK | 2.9.1 | 2.8.2 | **2.9.0** |
| DelayDiffEq | 6.1.5 | 6.1.2 | **6.2.0** |

Each now takes the next consecutive minor from its latest registered version. None of the skipped numbers was ever registered, so no user-visible version is being reused or renamed.

Every in-repo compat entry for these four is a loose bound (`"2"`, `"2.5"`, `"2.6"`, `"6"`), so the renumbering does not invalidate any sibling's compat — verified by grepping all `Project.toml` files in the monorepo.

Version metadata only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
