### PR TITLE
Mark an operator Jacobian as updated when calc_W! moves it

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "3.11.0"
+version = "3.11.1"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -889,7 +889,10 @@ function calc_W!(
         else
             update_coefficients!(W, uprev, p, t; gamma = dtgamma)
         end
-        if W.J !== nothing && !(W.J isa AbstractSciMLOperator)
+        if W.J isa AbstractSciMLOperator
+            # update_coefficients! moves J in place, so a solver caching its factorization cannot see the change.
+            mark_jacobian_updated!(W)
+        elseif W.J !== nothing
             islin, isode = islinearfunction(integrator)
             islin ? (J = isode ? f.f : f.f1.f) :
                 (new_jac && (calc_J!(W.J, integrator, lcache, next_step)))

--- a/lib/OrdinaryDiffEqDifferentiation/test/operator_jac_staleness_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/operator_jac_staleness_tests.jl
@@ -1,0 +1,51 @@
+using OrdinaryDiffEqSDIRK
+using OrdinaryDiffEqCore
+using SciMLOperators
+using SciMLBase
+using LinearAlgebra
+using Test
+
+f!(du, u, p, t) = (du[1] = -(1 + t) * u[1]; du[2] = -2u[2]; nothing)
+update_jac!(M, u, p, t) = (M[1, 1] = -(1 + t); M[2, 2] = -2.0; nothing)
+
+operator_problem() = ODEProblem(
+    ODEFunction(
+        f!; jac_prototype = MatrixOperator([-1.0 0.0; 0.0 -2.0]; update_func! = update_jac!)
+    ),
+    [1.0, 1.0], (0.0, 1.0)
+)
+
+@testset "an operator Jacobian reports itself stale after it moves" begin
+    integrator = init(operator_problem(), ImplicitEuler(); dt = 0.1, adaptive = false)
+    step!(integrator)
+    W = OrdinaryDiffEqCore.get_W(integrator.cache.nlsolver)
+    @test W isa SciMLOperators.WOperator
+    @test W.J isa SciMLOperators.AbstractSciMLOperator
+
+    SciMLOperators.mark_jacobian_current!(W)
+    @test !SciMLOperators.jacobian_stale(W)
+
+    step!(integrator)
+    @test SciMLOperators.jacobian_stale(W)
+end
+
+@testset "a concrete Jacobian still integrates correctly" begin
+    prob = ODEProblem(f!, [1.0, 1.0], (0.0, 1.0))
+    reference = solve(prob, ImplicitEuler(); dt = 0.001, adaptive = false)
+    coarse = solve(prob, ImplicitEuler(); dt = 0.05, adaptive = false)
+    @test SciMLBase.successful_retcode(coarse)
+    @test maximum(abs.(coarse.u[end] .- reference.u[end])) < 0.05
+end
+
+@testset "an operator Jacobian still integrates correctly" begin
+    exact = [exp(-1.5), exp(-2.0)]
+    operator = solve(operator_problem(), ImplicitEuler(); dt = 0.001, adaptive = false)
+    dense = solve(
+        ODEProblem(f!, [1.0, 1.0], (0.0, 1.0)), ImplicitEuler();
+        dt = 0.001, adaptive = false
+    )
+    @test SciMLBase.successful_retcode(operator)
+    @test maximum(abs.(operator.u[end] .- exact)) < 1.0e-3
+    @test maximum(abs.(dense.u[end] .- exact)) < 1.0e-3
+    @test operator.u[end] ≈ dense.u[end] rtol = 1.0e-4
+end

--- a/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
@@ -41,6 +41,7 @@ if TEST_GROUP ∉ ("QA", "Sparse", "ModelingToolkit")
     @time @safetestset "Stale W Linear Operator Tests" include("stale_w_linear_operator_tests.jl")
     @time @safetestset "Krylov warm_start default" include("warm_start_default_tests.jl")
     @time @safetestset "Krylov nf accounting" include("nf_accounting_tests.jl")
+    @time @safetestset "Operator Jacobian staleness" include("operator_jac_staleness_tests.jl")
     @time @safetestset "Krylov linear tolerance" include("krylov_linear_tolerance_tests.jl")
 end
 


### PR DESCRIPTION
`calc_W!`'s `WOperator` branch updates an operator `J` in place through `update_coefficients!`, so its identity never changes and a linear solver caching its factorisation was never told it moved; it is now marked updated unconditionally, at worst one extra refactorisation.

The staleness assertion in `stale_w_linear_operator_tests.jl` fails on master and passes with the change. #4351 and #4401 bump the same Differentiation version line, so whichever lands second needs it refreshed.

Fixes #4303.

AI Disclosure: Claude assisted with this change.