### PR TITLE
Pass the integrator and the stage buffer to stage limiters

### DIFF
--- a/lib/OrdinaryDiffEqLowOrderRK/Project.toml
+++ b/lib/OrdinaryDiffEqLowOrderRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqLowOrderRK"
 uuid = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.3"
+version = "2.2.4"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqLowOrderRK/src/fixed_timestep_perform_step.jl
+++ b/lib/OrdinaryDiffEqLowOrderRK/src/fixed_timestep_perform_step.jl
@@ -219,7 +219,7 @@ end
     stage_limiter! = integrator.opts.stage_limiter!
     halfdt = dt / 2
     @.. broadcast = false thread = thread tmp = uprev + halfdt * fsalfirst
-    stage_limiter!(k, tmp, p, t + halfdt)
+    stage_limiter!(tmp, integrator, p, t + halfdt)
     f(k, tmp, p, t + halfdt)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     @.. broadcast = false thread = thread u = uprev + dt * k

--- a/lib/OrdinaryDiffEqQPRK/Project.toml
+++ b/lib/OrdinaryDiffEqQPRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqQPRK"
 uuid = "04162be5-8125-4266-98ed-640baecc6514"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqQPRK/src/qprk_perform_step.jl
+++ b/lib/OrdinaryDiffEqQPRK/src/qprk_perform_step.jl
@@ -134,7 +134,7 @@ end
     stage_limiter!(tmp, integrator, p, t + d4 * dt)
     f(k4, tmp, p, t + d4 * dt)
     @.. broadcast = false thread = thread tmp = uprev + dt * (b51 * k1 + b53 * k3 + b54 * k4)
-    stage_limiter!(uprev, integrator, p, t + d5 * dt)
+    stage_limiter!(tmp, integrator, p, t + d5 * dt)
     f(k5, tmp, p, t + d5 * dt)
     @.. broadcast = false thread = thread tmp = uprev + dt * (b61 * k1 + b64 * k4 + b65 * k5)
     stage_limiter!(tmp, integrator, p, t + d6 * dt)
@@ -212,7 +212,7 @@ end
             + b16_10 * k10 + b16_11 * k11 + b16_12 * k12
             + b16_13 * k13 + b16_14 * k14
     )
-    stage_limiter!(u, integrator, p, t + dt)
+    stage_limiter!(tmp, integrator, p, t + dt)
     f(k16, tmp, p, t + dt)
 
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 16)

--- a/lib/OrdinaryDiffEqTsit5/Project.toml
+++ b/lib/OrdinaryDiffEqTsit5/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqTsit5"
 uuid = "b1df2697-797e-41e3-8120-5422d3b24e4a"
-version = "2.1.3"
+version = "2.1.4"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 
 [deps]

--- a/lib/OrdinaryDiffEqTsit5/src/tsit_perform_step.jl
+++ b/lib/OrdinaryDiffEqTsit5/src/tsit_perform_step.jl
@@ -210,24 +210,24 @@ end
     stage_limiter! = integrator.opts.stage_limiter!
     a = dt * a21
     @.. broadcast = false thread = thread tmp = uprev + a * k1
-    stage_limiter!(tmp, f, p, t + c1 * dt)
+    stage_limiter!(tmp, integrator, p, t + c1 * dt)
     f(k2, tmp, p, t + c1 * dt)
     @.. broadcast = false thread = thread tmp = uprev + dt * (a31 * k1 + a32 * k2)
-    stage_limiter!(tmp, f, p, t + c2 * dt)
+    stage_limiter!(tmp, integrator, p, t + c2 * dt)
     f(k3, tmp, p, t + c2 * dt)
     @.. broadcast = false thread = thread tmp = uprev + dt * (a41 * k1 + a42 * k2 + a43 * k3)
-    stage_limiter!(tmp, f, p, t + c3 * dt)
+    stage_limiter!(tmp, integrator, p, t + c3 * dt)
     f(k4, tmp, p, t + c3 * dt)
     @.. broadcast = false thread = thread tmp = uprev +
         dt * (a51 * k1 + a52 * k2 + a53 * k3 + a54 * k4)
-    stage_limiter!(tmp, f, p, t + c4 * dt)
+    stage_limiter!(tmp, integrator, p, t + c4 * dt)
     f(k5, tmp, p, t + c4 * dt)
     @.. broadcast = false thread = thread tmp = uprev +
         dt * (
         a61 * k1 + a62 * k2 + a63 * k3 + a64 * k4 +
             a65 * k5
     )
-    stage_limiter!(tmp, f, p, t + dt)
+    stage_limiter!(tmp, integrator, p, t + dt)
     f(k6, tmp, p, t + dt)
     @.. broadcast = false thread = thread u = uprev +
         dt * (

--- a/test/Integrators_I/step_limiter_test.jl
+++ b/test/Integrators_I/step_limiter_test.jl
@@ -191,3 +191,63 @@ end
         @test_throws ErrorException solve(prob, alg, dt = 0.1; stage_limiter = slim!)
     end
 end
+
+# The stage limiter contract is `limiter!(u, integrator, p, t)`
+# (`OrdinaryDiffEqCore.trivial_limiter!`). The limiters above ignore their
+# arguments, so they accept whatever is handed to them; that is how `Tsit5` shipped
+# with the `ODEFunction` in the integrator slot, `Midpoint` with a stage buffer, and
+# `QPRK98` limiting `uprev`. These testsets pin down which objects get passed rather
+# than how many times the limiter is called.
+const LIMITER_ALGS = [
+    Euler, Heun, Ralston, Midpoint, RK4, BS3, OwrenZen3, DP5, Tsit5,
+    Vern6, Vern9, DP8, TanYam7, TsitPap8, QPRK98,
+    SSPRK22, SSPRK43, SSPRK104, SSPRK932,
+    CarpenterKennedy2N54, ORK256, RDPK3Sp35, NDBLSRK124,
+    Rosenbrock23, ROS3P, Rodas4, Rodas5P,
+]
+
+@testset "stage limiter receives the integrator" begin
+    prob = ODEProblem((du, u, p, t) -> du .= u, [1.0, 1.0], (0.0, 1.0))
+    for A in LIMITER_ALGS
+        ok = Ref(true)
+        calls = Ref(0)
+        limiter! = function (u, integrator, p, t)
+            calls[] += 1
+            integrator isa SciMLBase.DEIntegrator || (ok[] = false)
+            return nothing
+        end
+        solve(prob, A(), dt = 0.1; stage_limiter = limiter!)
+        @test calls[] > 0
+        @test ok[]
+    end
+end
+
+# The limiter mutates whatever it is given, so handing it `uprev` corrupts every
+# later stage and the step update. `QPRK98` stage 5 did exactly that.
+@testset "stage limiter is never handed uprev" begin
+    prob = ODEProblem((du, u, p, t) -> du .= u, [1.0, 1.0], (0.0, 1.0))
+    for A in LIMITER_ALGS
+        ok = Ref(true)
+        limiter! = function (u, integrator, p, t)
+            u === integrator.uprev && (ok[] = false)
+            return nothing
+        end
+        solve(prob, A(), dt = 0.1; stage_limiter = limiter!)
+        @test ok[]
+    end
+end
+
+# End-to-end: with `QPRK98` stage 5 clamping `uprev` in place, `uprev` changed
+# value partway through a single step.
+@testset "uprev is stable across one step" begin
+    prob = ODEProblem((du, u, p, t) -> du .= u, [-1.0], (0.0, 0.1))
+    seen = Float64[]
+    positivity! = function (u, integrator, p, t)
+        push!(seen, integrator.uprev[1])
+        @. u = max(u, 0.0)
+        return nothing
+    end
+    solve(prob, QPRK98(), dt = 0.1, adaptive = false; stage_limiter = positivity!)
+    @test !isempty(seen)
+    @test all(==(seen[1]), seen)
+end


### PR DESCRIPTION
Three explicit RK methods pass the wrong object to a user-supplied stage limiter.
The limiter contract is `limiter!(u, integrator, p, t)`
(`OrdinaryDiffEqCore.trivial_limiter!`), and all four arguments are untyped, so a
wrong one type-checks and the default no-op limiter hides it.

## What is wrong

`Tsit5` (in-place) passes the `ODEFunction` where the integrator belongs, at five
of its six stages:

```julia
stage_limiter!(tmp, f, p, t + c1 * dt)      # arg 2 should be `integrator`
```

The sixth call in the same method uses `integrator`, so this is not a local
convention. Any limiter that reads the integrator throws `type ODEFunction has no
field ...` on `Tsit5` but works on `RK4`.

`Midpoint` (in-place) passes the stage buffer as the integrator *and* limits the
wrong array:

```julia
@.. tmp = uprev + halfdt * fsalfirst
stage_limiter!(k, tmp, p, t + halfdt)       # limits `k`, hands over `tmp`
f(k, tmp, p, t + halfdt)                    # overwrites `k`; `tmp` was never limited
```

The limiter's writes land in `k`, which the next line overwrites, so the midpoint
stage is never limited at all.

`QPRK98` (in-place) hands `uprev` to the limiter at stage 5, where the other 14
stages pass `tmp`:

```julia
@.. tmp = uprev + dt * (b51 * k1 + b53 * k3 + b54 * k4)
stage_limiter!(uprev, integrator, p, t + d5 * dt)
f(k5, tmp, p, t + d5 * dt)
```

The limiter mutates what it is given, so this writes into the previous step's
value, which every later stage and the step update then read. Stage 16 likewise
limits `u` while `f` consumes `tmp`.

## Effect

Limiters that only clamp `u` and ignore their other arguments — the common case,
and what the existing tests use — are unaffected on `Tsit5`. On `Midpoint` the
stage limiter is a no-op regardless. On `QPRK98`, an ordinary positivity limiter
corrupts `uprev`: on `u' = u`, `u0 = [-1.0]`, one step of `dt = 0.1`, `uprev`
changes from `-1.0` to `0.0` partway through the step.

## What this changes for users

A limiter that only clamps `u` and ignores its other arguments -- the common case --
sees no difference on `Tsit5`, because the object in the wrong slot was never used.

`Midpoint` and `QPRK98` do change. `Midpoint`'s stage limiter was a no-op and now
runs, so a solve that passes one will give different numbers; those numbers are the
limited ones it was asking for. `QPRK98` stops writing into `uprev`, which is a
straight correctness fix -- any limiter that mutated its argument was corrupting the
step.

## Testing

`test/Integrators_I/step_limiter_test.jl` gains three testsets. The existing
limiters there ignore their arguments, which is why this was not caught; the new
ones assert which objects are passed:

- the second argument is a `DEIntegrator`, over 27 stage-limiter-supporting methods
- the limiter is never handed `integrator.uprev`, same set
- `uprev` holds one value across a single `QPRK98` step

Each fails on master and passes here: the first reports `Midpoint, Tsit5`, the
second reports `QPRK98`, and the third sees `uprev` take both `-1.0` and `0.0`.

Bumps `OrdinaryDiffEqTsit5`, `OrdinaryDiffEqLowOrderRK` and `OrdinaryDiffEqQPRK`
one patch from master.

#4035 also edits `test/Integrators_I/step_limiter_test.jl`. It is a different bug --
refreshing FSAL after solve-level *step* limiters, where this is about which
arguments the *stage* limiters receive -- but whichever lands second will need a
rebase in that file. No version overlap: #4035 bumps Core and ExponentialRK.

## AI Disclosure

Claude assisted with this change.
