### PR TITLE
Give SSPRK932 its own fsalfirst buffer

### DIFF
--- a/lib/OrdinaryDiffEqSSPRK/Project.toml
+++ b/lib/OrdinaryDiffEqSSPRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSSPRK"
 uuid = "669c94d9-1f4b-4b64-b377-1aa079aa2388"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.3.0"
+version = "2.3.1"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqSSPRK/src/ssprk_caches.jl
+++ b/lib/OrdinaryDiffEqSSPRK/src/ssprk_caches.jl
@@ -1047,9 +1047,6 @@ function alg_cache(
         ::Val{true}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
     k = zero(rate_prototype)
-    # The `u6*` stage reads `f(uprev)` back out of `fsalfirst`, after six `f(k, ...)`
-    # calls have overwritten `k`. Aliasing the two when `calck` is false -- as the
-    # other SSPRK caches do -- silently drops this method to first order.
     fsalfirst = zero(k)
     utilde = zero(u)
     atmp = similar(u, uEltypeNoUnits)

--- a/lib/OrdinaryDiffEqSSPRK/src/ssprk_caches.jl
+++ b/lib/OrdinaryDiffEqSSPRK/src/ssprk_caches.jl
@@ -1047,11 +1047,10 @@ function alg_cache(
         ::Val{true}, verbose
     ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
     k = zero(rate_prototype)
-    if calck
-        fsalfirst = zero(k)
-    else
-        fsalfirst = k
-    end
+    # The `u6*` stage reads `f(uprev)` back out of `fsalfirst`, after six `f(k, ...)`
+    # calls have overwritten `k`. Aliasing the two when `calck` is false -- as the
+    # other SSPRK caches do -- silently drops this method to first order.
+    fsalfirst = zero(k)
     utilde = zero(u)
     atmp = similar(u, uEltypeNoUnits)
     recursivefill!(atmp, false)

--- a/lib/OrdinaryDiffEqSSPRK/test/ode_ssprk_tests.jl
+++ b/lib/OrdinaryDiffEqSSPRK/test/ode_ssprk_tests.jl
@@ -507,12 +507,14 @@ integ = init(
     prob_ode_large, alg, dt = 1.0e-2, save_start = false, save_end = false,
     save_everystep = false
 )
-@test Base.summarysize(integ) ÷ Base.summarysize(u0_large) <= 6
+# One buffer more than the other SSPRK methods: `SSPRK932` needs `f(uprev)` at its
+# `u6*` stage, so unlike its siblings it cannot alias `fsalfirst` onto `k`.
+@test Base.summarysize(integ) ÷ Base.summarysize(u0_large) <= 7
 integ = init(
     prob_ode_large, alg, dt = 1.0e-2, save_start = false, save_end = false,
     save_everystep = false, alias = ODEAliasSpecifier(alias_u0 = true)
 )
-@test Base.summarysize(integ) ÷ Base.summarysize(u0_large) <= 5
+@test Base.summarysize(integ) ÷ Base.summarysize(u0_large) <= 6
 
 println("SSPRK54")
 alg = SSPRK54()
@@ -611,4 +613,19 @@ sol = solve(
 
     @test sol_SA ≈ sol_SV
     @test sol_SV.stats.naccept == sol_SA.stats.naccept
+end
+
+# Without dense output or intermediate saves the integrator sets `calck = false`, and
+# the in-place SSPRK caches then alias `fsalfirst` to `k` to save an allocation.
+# `SSPRK932` reads `f(uprev)` back out of `fsalfirst` at its `u6*` stage, after six
+# `f(k, ...)` calls have overwritten `k`, so that alias silently cost it two orders.
+# Every convergence test above runs with the default `calck = true`, which hides it.
+# `SSPRK33`/`SSPRK43` keep the alias and are here as controls.
+@testset "order is preserved when calck is false" begin
+    for alg in (SSPRK932(), SSPRK33(), SSPRK43())
+        for prob in test_problems_nonlinear
+            sim = test_convergence(dts, prob, alg; save_everystep = false, dense = false)
+            @test sim.𝒪est[:final] ≈ OrdinaryDiffEqSSPRK.alg_order(alg) atol = testTol
+        end
+    end
 end


### PR DESCRIPTION
`SSPRK932` is third order with dense output on and first order with it off.

```julia
f!(du, u, p, t) = (@. du = -0.7u + 0.3sin(t) + 0.1u^2; nothing)
prob = ODEProblem(f!, [1.0], (0.0, 1.0))
```

Measured against a fine `SSPRK104` reference, over `dt = 2^-4 … 2^-8`:

```
dense = true                       err 3.8e-11   orders [3.0, 3.0, 3.0, 2.99]
save_everystep = false, dense = false   err 1.1e-4    orders [1.01, 1.0, 1.0, 1.0]
```

## Cause

With no dense output, no intermediate saves, no callbacks and no `saveat`, the
integrator sets `calck = false`, and the in-place SSPRK caches then alias
`fsalfirst` to `k` to save an allocation
(`lib/OrdinaryDiffEqSSPRK/src/ssprk_caches.jl`):

```julia
k = zero(rate_prototype)
if calck
    fsalfirst = zero(k)
else
    fsalfirst = k
end
```

Seventeen SSPRK caches do this, and for sixteen of them it is fine: they write
`fsalfirst` once at the top of the step and never read it again. `SSPRK932` is
the exception. Its `u6*` stage reads the value back out:

```julia
f(fsalfirst, uprev, p, t)
...                                  # six `f(k, u, ...)` calls, k === fsalfirst
@.. u = (3 * uprev + dt_2 * integrator.fsalfirst + 2 * u) / 5
```

By the time that line runs, `fsalfirst` holds `f(u5)` or `f(u6)` instead of
`f(uprev)`. `isfsal(::SSPRK932) == false`, so this is not an FSAL value being
carried between steps — it is a scratch buffer the method needs to keep for the
whole step, and it cannot share storage with `k`.

## Fix

Always allocate `fsalfirst` for `SSPRK932`. The other sixteen caches keep the
alias.

This costs one array. `SSPRK932` needs `f(uprev)` alive for the whole step while
`k` is reused by every stage, so there is no way for it to be both correct and
share the buffer. The storage assertions in the `SSPRK932` block go from
`<= 6`/`<= 5` to `<= 7`/`<= 6` (measured: 7 and 6). No other method's storage
changes -- `SSPRK33` is 4/3, `SSPRK43` and `SSPRK104` are 6/5, unchanged.

## Testing

Swept all sixteen exported SSPRK methods for a `dense=true` vs
`save_everystep=false, dense=false` order gap. `SSPRK932` was the only one
affected, and it is 2.99 in both columns after this change.

`lib/OrdinaryDiffEqSSPRK/test/ode_ssprk_tests.jl` gains a testset that runs the
existing convergence problems with `save_everystep = false, dense = false` for
`SSPRK932` plus `SSPRK33`/`SSPRK43` as controls. Every convergence test in that
file currently runs with the default `calck = true`, which is why this was not
caught. The new testset fails on master and passes here.

Bumps `OrdinaryDiffEqSSPRK` one patch from master.

## AI Disclosure

Claude assisted with this change.
