### PR TITLE
Give RKV76IIa's k8 and k10 their own storage

### DIFF
--- a/lib/OrdinaryDiffEqVerner/Project.toml
+++ b/lib/OrdinaryDiffEqVerner/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqVerner"
 uuid = "79d7bb75-1356-48c1-b8c0-6832512096c2"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.4.0"
+version = "2.4.1"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqVerner/src/verner_caches.jl
+++ b/lib/OrdinaryDiffEqVerner/src/verner_caches.jl
@@ -347,9 +347,6 @@ function alg_cache(
     k5 = zero(rate_prototype)
     k6 = zero(rate_prototype)
     k7 = zero(rate_prototype)
-    # `Vern7Cache` can alias its later stages because `a_i2 == 0` for `i >= 4` and
-    # `b2 == 0`. That does not carry over: RKV76IIa has `a93 = -459.7`, `a103 = -493.2`
-    # and `b4 != 0`, so `k8` and `k10` need storage of their own.
     k8 = zero(rate_prototype)
     k9 = zero(rate_prototype)
     k10 = zero(rate_prototype)

--- a/lib/OrdinaryDiffEqVerner/src/verner_caches.jl
+++ b/lib/OrdinaryDiffEqVerner/src/verner_caches.jl
@@ -347,9 +347,12 @@ function alg_cache(
     k5 = zero(rate_prototype)
     k6 = zero(rate_prototype)
     k7 = zero(rate_prototype)
-    k8 = k3
+    # `Vern7Cache` can alias its later stages because `a_i2 == 0` for `i >= 4` and
+    # `b2 == 0`. That does not carry over: RKV76IIa has `a93 = -459.7`, `a103 = -493.2`
+    # and `b4 != 0`, so `k8` and `k10` need storage of their own.
+    k8 = zero(rate_prototype)
     k9 = zero(rate_prototype)
-    k10 = k4
+    k10 = zero(rate_prototype)
     utilde = zero(u)
     tmp = zero(u)
     atmp = similar(u, uEltypeNoUnits)

--- a/lib/OrdinaryDiffEqVerner/test/ode_verner_tests.jl
+++ b/lib/OrdinaryDiffEqVerner/test/ode_verner_tests.jl
@@ -130,6 +130,17 @@ println("RKV76IIa")
 dts = [2, 1, 0.5, 0.25]
 
 check_convergence(dts, prob_oop, RKV76IIa(), 7)
+# The in-place cache used to alias `k8` onto `k3` and `k10` onto `k4`, copying
+# `Vern7Cache`, whose tableau permits it. RKV76IIa's does not, and only the
+# out-of-place path was covered here, so the in-place method silently returned
+# garbage with `retcode = Success`.
+check_convergence(dts, prob_iip, RKV76IIa(), 7)
+
+let dt = 0.25
+    oop = solve(prob_oop, RKV76IIa(); dt = dt, adaptive = false)
+    iip = solve(prob_iip, RKV76IIa(); dt = dt, adaptive = false)
+    @test iip.u[end][1] ≈ oop.u[end] rtol = 1.0e-10
+end
 
 # -------------------------------------------------------------
 ### Backward solve lazy interpolation dt sign regression test

--- a/lib/OrdinaryDiffEqVerner/test/ode_verner_tests.jl
+++ b/lib/OrdinaryDiffEqVerner/test/ode_verner_tests.jl
@@ -130,10 +130,6 @@ println("RKV76IIa")
 dts = [2, 1, 0.5, 0.25]
 
 check_convergence(dts, prob_oop, RKV76IIa(), 7)
-# The in-place cache used to alias `k8` onto `k3` and `k10` onto `k4`, copying
-# `Vern7Cache`, whose tableau permits it. RKV76IIa's does not, and only the
-# out-of-place path was covered here, so the in-place method silently returned
-# garbage with `retcode = Success`.
 check_convergence(dts, prob_iip, RKV76IIa(), 7)
 
 let dt = 0.25


### PR DESCRIPTION
`RKV76IIa` returns garbage in place while the out-of-place path is correct, and it
reports `retcode = Success` while doing it.

On `u'' = -sin(u)`, `u0 = [2.0, 0.0]`, `tspan = (0.0, 20.0)`, fixed steps, against a
tight `Vern9` reference:

```
in-place      err 1.96e4
out-of-place  err 8.57e-4
```

On the linear `u' = [u2, -u1]` over `(0, 1)` the in-place answers come out around
`1e9`-`1e12` where the exact value is `0.54`, with `retcode = Success` at every
step size.

## Cause

`lib/OrdinaryDiffEqVerner/src/verner_caches.jl`, the `RKV76IIa` in-place cache:

```julia
k3 = k2
k8 = k3
k10 = k4
```

`Vern7Cache` has `k3 = k2` and allocates the rest. The two extra aliases were added
here, and RKV76IIa's tableau does not permit them: `f(k8, ...)` overwrites `k3`,
which stages 9 and 10 then use with `a93 = -459.7` and `a103 = -493.2`, and `k10`
overwrites `k4` while `b4 != 0`. Vern7 gets away with `k3 = k2` because `a_i2 == 0`
for `i >= 4` and `b2 == 0`; that argument does not extend to the other two.

## Fix

Give `k8` and `k10` their own storage. `k3 = k2` is kept -- it is valid here for the
same reason it is valid in `Vern7Cache`.

After the change the two paths agree to `4.3e-12` across `dt = 20/2^5 ... 20/2^9`,
and both measure the expected order.

## Testing

The `RKV76IIa` block in `lib/OrdinaryDiffEqVerner/test/ode_verner_tests.jl` only ran
`check_convergence(dts, prob_oop, ...)`. `prob_iip` is defined at the top of that
file and was never used, so the in-place path of this method had no coverage at all
-- every other algorithm in the file exercises in-place through `probbig`.

Added the matching `check_convergence(dts, prob_iip, RKV76IIa(), 7)` and an explicit
in-place vs out-of-place agreement assertion. Both fail on master and pass here.

Bumps `OrdinaryDiffEqVerner` one patch from master.

## AI Disclosure

Claude assisted with this change.
