### PR TITLE
Fill k in ExplicitRK's addsteps! when there is no B_interp

### DIFF
--- a/lib/OrdinaryDiffEqExplicitRK/Project.toml
+++ b/lib/OrdinaryDiffEqExplicitRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExplicitRK"
 uuid = "9286f039-9fbf-40e8-bf65-aa933bdc4db0"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqExplicitRK/src/interpolants.jl
+++ b/lib/OrdinaryDiffEqExplicitRK/src/interpolants.jl
@@ -16,9 +16,13 @@ const ExplicitRKCacheTypes = Union{ExplicitRKCache, ExplicitRKConstantCache}
         always_calc_begin = false, allow_calc_end = true,
         force_calc_end = false
     )
-    # Only compute all stage vectors when B_interp is available for generic RK
-    # interpolation. Without B_interp, the default Hermite addsteps suffices.
-    isnothing(cache.B_interp) && return nothing
+    if isnothing(cache.B_interp)
+        if length(k) < 2 || always_calc_begin
+            copyat_or_push!(k, 1, f(uprev, p, t))
+            copyat_or_push!(k, 2, f(u, p, t + dt))
+        end
+        return nothing
+    end
 
     (; A, c, stages) = cache
 
@@ -41,9 +45,15 @@ end
         always_calc_begin = false, allow_calc_end = true,
         force_calc_end = false
     )
-    # Only compute all stage vectors when B_interp is available for generic RK
-    # interpolation. Without B_interp, the default Hermite addsteps suffices.
-    isnothing(cache.tab.B_interp) && return nothing
+    if isnothing(cache.tab.B_interp)
+        if length(k) < 2 || always_calc_begin
+            f(cache.kk[1], uprev, p, t)
+            copyat_or_push!(k, 1, cache.kk[1])
+            f(cache.kk[1], u, p, t + dt)
+            copyat_or_push!(k, 2, cache.kk[1])
+        end
+        return nothing
+    end
 
     (; kk, tmp, tab) = cache
     (; A, c, stages) = tab

--- a/lib/OrdinaryDiffEqExplicitRK/test/interpolation_tests.jl
+++ b/lib/OrdinaryDiffEqExplicitRK/test/interpolation_tests.jl
@@ -157,3 +157,21 @@ end
     avg_order = sum(orders) / length(orders)
     @test avg_order > 3.5
 end
+
+@testset "interpolating before the first step" begin
+    f!(du, u, p, t) = (du .= -u; nothing)
+    prob = ODEProblem(f!, [1.0, 2.0], (0.0, 1.0))
+
+    integ = init(prob, ExplicitRK(); dt = 0.1)
+    @test integ.sol(0.0) ≈ [1.0, 2.0]
+
+    integ.sol(0.0, Val{1})
+    @test integ.sol.k[1][1] ≈ [-1.0, -2.0]
+    @test integ.sol.k[1][2] ≈ [-1.0, -2.0]
+
+    integ2 = init(prob, ExplicitRK(); dt = 0.1)
+    out = zeros(2)
+    integ2.sol(out, 0.0, Val{1})
+    @test integ2.sol.k[1][1] ≈ [-1.0, -2.0]
+    @test integ2.sol.k[1][2] ≈ [-1.0, -2.0]
+end


### PR DESCRIPTION
`sol(t0, Val{1})` on an `ExplicitRK` solution reads past the end of `k` before the first step:

```julia
f!(du, u, p, t) = (du .= -u; nothing)
integ = init(ODEProblem(f!, [1.0, 2.0], (0.0, 1.0)), ExplicitRK(); dt = 0.1)
integ.sol(0.0, Val{1})   # BoundsError under --check-bounds=yes, silent OOB read otherwise
```

`hermite_interpolant!` reads `k[2][i]` under `@inbounds @simd ivdep`, so on the default `--check-bounds=auto` this is an unchecked read rather than an error.

## Cause

`_ode_addsteps!` for `ExplicitRK` returns without doing anything when there is no `B_interp`:

```julia
# Without B_interp, the default Hermite addsteps suffices.
isnothing(cache.B_interp) && return nothing
```

The comment states the intent, but defining the method is what prevents it: the generic `_ode_addsteps!` in `generic_dense.jl` is what fills `k[1]`/`k[2]`, and this specialisation shadows it. So `k` stays at length 1.

Instrumenting which path runs:

```
sol(t0)          addsteps! not called   (i₋ == i₊ && deriv === Val{0} short-circuits, #4214)
sol(t0, Val{1})  addsteps! called, B_interp === nothing, length(k) == 1, returns without filling
```

## Fix

The no-`B_interp` branch now does the two evaluations the generic method would, so `k[1] == f(uprev)` and `k[2] == f(u)`.

`sol(t0, Val{1})` then returns `NaN`, because the Hermite derivative divides by `dt == 0`. On erroring instead: that would make `ExplicitRK` the only method that does, since the rest of the Hermite-fallback set returns `NaN` here too.

```
ExplicitRK      [NaN, NaN]
RK4             [NaN, NaN]
Midpoint        [NaN, NaN]
BS3             [NaN, NaN]
ImplicitEuler   [NaN, NaN]
Tsit5           [-1.0, -2.0]
Vern7           [-1.0, -2.0]
```

Worth noting the methods with their own interpolants do return the correct `f(u0)`, so the Hermite fallback giving `NaN` at `dt == 0` is a real gap, just a wider one than this PR. Happy to raise it separately; changing it here would only move `ExplicitRK` out of step with the other five.

## Testing

The new testset asserts the `k` values rather than the interpolant output, so it pins the fix rather than the symptom. It errors on master with the `BoundsError` and passes here. Full `interpolation_tests.jl` passes under `--check-bounds=yes`.

Bumps `OrdinaryDiffEqExplicitRK` one patch from master.

## AI Disclosure

Claude assisted with this change.
