### PR TITLE
Reformat generic_imex_perform_step.jl for Runic 1.9

### DIFF
--- a/lib/OrdinaryDiffEqSDIRK/src/generic_imex_perform_step.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/generic_imex_perform_step.jl
@@ -119,7 +119,7 @@ end
             @.. broadcast = false zs[1] = u - uprev
         elseif tab.stage1_extrapolation && (
                 predictor == Predictor.Linear ||
-                (E === :ie_dd2 && !hasproperty(alg, :predictor))
+                    (E === :ie_dd2 && !hasproperty(alg, :predictor))
             )
             @.. broadcast = false zs[1] = dt * integrator.fsalfirst
         else
@@ -1403,7 +1403,7 @@ end
             z1 = current_extrapolant(t + dt, integrator) - uprev
         elseif tab.stage1_extrapolation && (
                 predictor == Predictor.Linear ||
-                (E === :ie_dd2 && !hasproperty(alg, :predictor))
+                    (E === :ie_dd2 && !hasproperty(alg, :predictor))
             )
             z1 = dt * integrator.fsalfirst
         else


### PR DESCRIPTION
The `Runic / Runic Format Check` job is failing on every open PR, including ones
that touch neither this file nor `OrdinaryDiffEqSDIRK`. Confirmed on #4356, #4357
and #4358, and on the older #4351 and #4354.

The single file it rejects is
`lib/OrdinaryDiffEqSDIRK/src/generic_imex_perform_step.jl`, at two continuation
lines inside an `elseif` condition:

```julia
elseif tab.stage1_extrapolation && (
        predictor == Predictor.Linear ||
-       (E === :ie_dd2 && !hasproperty(alg, :predictor))
+           (E === :ie_dd2 && !hasproperty(alg, :predictor))
    )
```

Runic 1.5 accepts the current indentation and Runic 1.9 does not, so this appeared
without the file being touched -- the CI action tracks the latest release.

This is the output of `Runic.main(["--inplace", ...])` under 1.9.0, nothing hand
written. Formatting only, no behaviour change, so no version bump.

With it applied, `Runic.main(["--check", "."])` over the whole repository exits 0.

## AI Disclosure

Claude assisted with this change.
