### PR TITLE
Keep ExplicitTaylor2's Taylor seed out of the output slot

### DIFF
--- a/lib/OrdinaryDiffEqTaylorSeries/Project.toml
+++ b/lib/OrdinaryDiffEqTaylorSeries/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqTaylorSeries"
 uuid = "9c7f1690-dd92-42a3-8318-297ee24d8d39"
 authors = ["Songchen Tan <i@tansongchen.com>"]
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/OrdinaryDiffEqTaylorSeries/src/TaylorSeries_perform_step.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/src/TaylorSeries_perform_step.jl
@@ -58,11 +58,6 @@ end
     f(k1, uprev, p, t)
     u1 = make_taylor(uprev, k1)
     t1 = TaylorScalar{1}(t, one(t))
-    # The value slot must not be `k1`: that is `u1`'s first-order partial, and an RHS
-    # that zeroes `du` before accumulating into it (`fill!(du, 0)`, or any `du .= 0`
-    # followed by `+=`) would wipe the Taylor seed it is being evaluated on, leaving
-    # `k2 == 0` and silently dropping the method to first order. `k3` is unused --
-    # the interpolant reads only `k[1]` and `k[2]` -- so this stays non-allocating.
     out1 = make_taylor(k3, k2)
     f(out1, u1, p, t1)
     @.. u = uprev + dt * k1 + dt^2 / 2 * k2

--- a/lib/OrdinaryDiffEqTaylorSeries/src/TaylorSeries_perform_step.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/src/TaylorSeries_perform_step.jl
@@ -58,7 +58,12 @@ end
     f(k1, uprev, p, t)
     u1 = make_taylor(uprev, k1)
     t1 = TaylorScalar{1}(t, one(t))
-    out1 = make_taylor(k1, k2)
+    # The value slot must not be `k1`: that is `u1`'s first-order partial, and an RHS
+    # that zeroes `du` before accumulating into it (`fill!(du, 0)`, or any `du .= 0`
+    # followed by `+=`) would wipe the Taylor seed it is being evaluated on, leaving
+    # `k2 == 0` and silently dropping the method to first order. `k3` is unused --
+    # the interpolant reads only `k[1]` and `k[2]` -- so this stays non-allocating.
+    out1 = make_taylor(k3, k2)
     f(out1, u1, p, t1)
     @.. u = uprev + dt * k1 + dt^2 / 2 * k2
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 3)

--- a/lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl
+++ b/lib/OrdinaryDiffEqTaylorSeries/test/runtests.jl
@@ -22,6 +22,33 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
         @test sim.𝒪est[:final] ≈ 2 atol = testTol
     end
 
+    # The in-place step evaluates `f` into a Taylor buffer whose value slot used to be
+    # `k1` -- which is also the first-order partial of the input. An RHS that zeroes
+    # `du` before accumulating into it therefore wiped its own Taylor seed, leaving
+    # `k2 == 0` and dropping the method to first order. The library problems above
+    # assign `du` directly, so they never exercised it.
+    @testset "ExplicitTaylor2 with a zero-then-accumulate RHS" begin
+        dts = 2.0 .^ (-8:-4)
+        testTol = 0.2
+        analytic = (u0, p, t) -> u0 * exp(-t)
+
+        direct! = (du, u, p, t) -> (@. du = -u; nothing)
+        accumulate! = (du, u, p, t) -> (fill!(du, 0); @. du = du - u; nothing)
+
+        for rhs! in (direct!, accumulate!)
+            prob = ODEProblem(ODEFunction(rhs!; analytic = analytic), [1.0], (0.0, 1.0))
+            sim = test_convergence(dts, prob, ExplicitTaylor2())
+            @test sim.𝒪est[:final] ≈ 2 atol = testTol
+        end
+
+        # Both spellings are the same ODE, so they must give the same answer.
+        pd = ODEProblem(ODEFunction(direct!; analytic = analytic), [1.0], (0.0, 1.0))
+        pa = ODEProblem(ODEFunction(accumulate!; analytic = analytic), [1.0], (0.0, 1.0))
+        sd = solve(pd, ExplicitTaylor2(); dt = 2.0^-6, adaptive = false)
+        sa = solve(pa, ExplicitTaylor2(); dt = 2.0^-6, adaptive = false)
+        @test sd.u[end] ≈ sa.u[end] rtol = 1.0e-12
+    end
+
     @testset "ExplicitTaylorN Convergence Tests" begin
         # Test convergence
         dts = 2.0 .^ (-8:-4)


### PR DESCRIPTION
`ExplicitTaylor2` is second order or first order depending on how the right-hand
side is spelled. Same ODE, `u' = -u`, in place:

```julia
direct!(du, u, p, t)     = (@. du = -u; nothing)
accumulate!(du, u, p, t) = (fill!(du, 0); @. du = du - u; nothing)
```

```
@. du = -u              err 9.38e-7   orders [2.03, 2.02, 2.01, 2.0]
fill!(du,0); du -= u    err 7.20e-4   orders [1.02, 1.01, 1.00, 1.0]
```

Zero-then-accumulate is the normal shape for a PDE semi-discretisation and for
ModelingToolkit-generated code, so this is not an exotic spelling.

## Cause

`lib/OrdinaryDiffEqTaylorSeries/src/TaylorSeries_perform_step.jl`:

```julia
f(k1, uprev, p, t)
u1 = make_taylor(uprev, k1)     # k1 is u1's first-order partial
t1 = TaylorScalar{1}(t, one(t))
out1 = make_taylor(k1, k2)      # k1 is *also* the output value slot
f(out1, u1, p, t1)
@.. u = uprev + dt * k1 + dt^2 / 2 * k2
```

`out1.value === k1 === u1.partials[1]`. Writing the output therefore writes the
input seed. It survives only if the user's `f` assigns every element of `du` exactly
once; the moment `f` zeroes `du` first, the seed becomes zero, `k2` comes out zero,
and the `dt^2/2 * k2` term disappears. No error, no warning -- the method just
silently becomes Euler.

## Fix

Use `k3` as the value slot. `k3` is already allocated in the cache and wired to
`integrator.k[3]`, but nothing writes or reads it -- the `ExplicitTaylor2`
interpolant uses only `k[1]` and `k[2]` (`interpolants.jl`). So the step stays fully
non-allocating and `k1` is left intact. `out1.value` receives `f(uprev)`, which `k1`
already holds, so nothing is lost by discarding it.

## Testing

The existing convergence tests use `prob_ode_linear`/`prob_ode_2Dlinear`, whose RHS
assign `du` directly, which is why this was never caught.

Added a testset that runs the convergence check with both spellings and asserts the
two give the same answer. It measures order 1.02 for the accumulating RHS on master
and 2.03 with this change.

Bumps `OrdinaryDiffEqTaylorSeries` one patch from master.

## AI Disclosure

Claude assisted with this change.
