### PR TITLE
Copy into IRKC's f1ⱼ₋₂ buffer instead of rebinding onto du₁

### DIFF
--- a/lib/OrdinaryDiffEqStabilizedIRK/Project.toml
+++ b/lib/OrdinaryDiffEqStabilizedIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqStabilizedIRK"
 uuid = "e3e12d00-db14-5390-b879-ac3dd2ef6296"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.1"
+version = "2.1.2"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqStabilizedIRK/src/irkc_perform_step.jl
+++ b/lib/OrdinaryDiffEqStabilizedIRK/src/irkc_perform_step.jl
@@ -169,11 +169,6 @@ function perform_step!(integrator, cache::IRKCCache, repeat_step = false)
     Bⱼ₋₁ = 1 / ω₀
 
     #stage-1
-    # Copy, not rebind: the cache's own `f1ⱼ₋₂` buffer is the target. Rebinding the
-    # name to `du₁` makes the in-place `@.. f1ⱼ₋₂ = f1ⱼ₋₁` below write through to
-    # `du₁`, which has to hold `f1(uprev)` for the whole step -- it is read again on
-    # every stage and after the loop. The out-of-place method rebinds safely because
-    # there the same assignment is a value copy.
     @.. broadcast = false f1ⱼ₋₂ = du₁
     @.. broadcast = false gprev2 = uprev
     μs = ω₁ * Bⱼ₋₁

--- a/lib/OrdinaryDiffEqStabilizedIRK/src/irkc_perform_step.jl
+++ b/lib/OrdinaryDiffEqStabilizedIRK/src/irkc_perform_step.jl
@@ -169,7 +169,12 @@ function perform_step!(integrator, cache::IRKCCache, repeat_step = false)
     Bⱼ₋₁ = 1 / ω₀
 
     #stage-1
-    f1ⱼ₋₂ = du₁
+    # Copy, not rebind: the cache's own `f1ⱼ₋₂` buffer is the target. Rebinding the
+    # name to `du₁` makes the in-place `@.. f1ⱼ₋₂ = f1ⱼ₋₁` below write through to
+    # `du₁`, which has to hold `f1(uprev)` for the whole step -- it is read again on
+    # every stage and after the loop. The out-of-place method rebinds safely because
+    # there the same assignment is a value copy.
+    @.. broadcast = false f1ⱼ₋₂ = du₁
     @.. broadcast = false gprev2 = uprev
     μs = ω₁ * Bⱼ₋₁
     μs₁ = μs

--- a/lib/OrdinaryDiffEqStabilizedIRK/test/irkc_tests.jl
+++ b/lib/OrdinaryDiffEqStabilizedIRK/test/irkc_tests.jl
@@ -28,3 +28,38 @@ using OrdinaryDiffEqStabilizedIRK: maxeig!
         @test_nowarn solve(prob, alg)
     end
 end
+
+# `f1ⱼ₋₂ = du₁` in the in-place `perform_step!` rebound the name onto `du₁`, so the
+# stage shift `@.. f1ⱼ₋₂ = f1ⱼ₋₁` wrote through to `du₁` -- which has to hold
+# `f1(uprev)` for the whole step. That cost the in-place method an order. The
+# out-of-place method does the same assignment safely, because there it is a value
+# copy, so the two paths disagreeing is the sharpest signal.
+@testset "IRKC in-place matches out-of-place" begin
+    A1 = [-100.0 0.0; 0.0 -50.0]
+    A2 = [0.0 1.0; -1.0 0.0]
+    u0 = [1.0, 1.0]
+    tspan = (0.0, 0.1)
+    exact = exp((A1 + A2) * 0.1) * u0
+
+    f1! = (du, u, p, t) -> (mul!(du, A1, u); nothing)
+    f2! = (du, u, p, t) -> (mul!(du, A2, u); nothing)
+    f1 = (u, p, t) -> A1 * u
+    f2 = (u, p, t) -> A2 * u
+    prob_iip = SplitODEProblem(f1!, f2!, u0, tspan)
+    prob_oop = SplitODEProblem(f1, f2, u0, tspan)
+
+    dts = [0.1 / 2^i for i in 3:7]
+    err(prob) = [
+        maximum(abs.(solve(prob, IRKC(); dt = dt, adaptive = false).u[end] .- exact))
+            for dt in dts
+    ]
+    eiip = err(prob_iip)
+    eoop = err(prob_oop)
+
+    # Same problem, same method: the two paths must agree closely.
+    @test maximum(abs.(eiip .- eoop)) < 1.0e-10
+
+    # ...and the in-place path must show the method's order, not one less.
+    orders = [log2(eiip[i] / eiip[i + 1]) for i in 1:(length(dts) - 1)]
+    @test minimum(orders) > 1.5
+end


### PR DESCRIPTION
`IRKC` is order 1 in place and order 2 out of place.

Split linear problem, `f1 = diagm([-100, -50])` (stiff, implicit), `f2 = [0 1; -1 0]`
(non-stiff, explicit), `u0 = [1, 1]`, `t ∈ (0, 0.1)`, against `exp((A1+A2)t)u0`:

```
in-place       err 4.98e-3   orders [0.82, 0.93, 0.97, 0.99]
out-of-place   err 1.31e-3   orders [2.29, 2.06, 1.92, 1.78]
```

## Cause

`lib/OrdinaryDiffEqStabilizedIRK/src/irkc_perform_step.jl`, stage 1 of the in-place
method:

```julia
f1ⱼ₋₂ = du₁
```

`f1ⱼ₋₂` is a cache field (`irkc_caches.jl:17`) and is destructured a few lines above,
so this rebinds the name onto `du₁` and orphans the buffer. The stage shift inside
the loop is an in-place broadcast:

```julia
@.. broadcast = false f1ⱼ₋₂ = f1ⱼ₋₁
```

which therefore writes into `du₁`. `du₁` holds `f1(uprev)` and is read on every stage
-- the `nlsolver.tmp` expression uses `du₁` and `f1ⱼ₋₂` as two separate terms, so
after the first iteration both read the same array -- and again after the loop in
`@.. f1ⱼ₋₁ = du₁`.

The out-of-place method has the identical two lines and is fine, because there both
are value assignments and `du₁` is never mutated. That is why only the in-place path
loses an order.

## Fix

Copy instead of rebinding, so the cache's own buffer is the target:

```julia
@.. broadcast = false f1ⱼ₋₂ = du₁
```

Afterwards the two paths agree to better than 1e-10 at every step size tested, and
in-place measures the same orders as out-of-place.

## Testing

`lib/OrdinaryDiffEqStabilizedIRK/test/irkc_tests.jl` covered the eigenvalue estimator
and `@test_nowarn solve(prob, alg)`. Nothing checked convergence order, and nothing
compared the two paths, which is why an order loss in one of them went unnoticed.

Added a testset asserting the two paths agree and that the in-place order is above
1.5. Both assertions fail on master and pass here. The existing eigenvalue testset is
unchanged and still passes.

Bumps `OrdinaryDiffEqStabilizedIRK` one patch from master.

## AI Disclosure

Claude assisted with this change.
