### PR TITLE
Resolve current sub-cache in PredictiveControllerCache for composite algorithms (#4364)

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
@@ -1206,15 +1206,19 @@ end
             # not this branch's own cache (which is what `iter`/`nlsolver` live
             # on) -- resolve the currently active sub-cache the same way the
             # CompositeControllerCache dispatch above already selected `cache`
-            # and `alg` for this call.
-            alg_cache = integrator.cache isa CompositeCache ?
+            # and `alg` for this call. DefaultCache (DefaultODEAlgorithm) is
+            # deliberately not handled here: it holds cache1..cache6 rather
+            # than caches/current, but none of its members are FIRK or set
+            # fac_default_gamma(alg) == false, so this branch is unreachable
+            # for it today.
+            current_cache = integrator.cache isa CompositeCache ?
                 @inbounds(integrator.cache.caches[integrator.cache.current]) :
                 integrator.cache
             if isfirk(alg)
-                (; iter) = alg_cache
+                (; iter) = current_cache
                 (; maxiters) = alg
             else
-                (; iter, maxiters) = alg_cache.nlsolver
+                (; iter, maxiters) = current_cache.nlsolver
             end
             fac = min(gamma, (1 + 2 * maxiters) * gamma / (iter + 2 * maxiters))
         end

--- a/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
@@ -1202,11 +1202,19 @@ end
         if fac_default_gamma(alg)
             fac = gamma
         else
+            # For a CompositeAlgorithm, integrator.cache is the CompositeCache,
+            # not this branch's own cache (which is what `iter`/`nlsolver` live
+            # on) -- resolve the currently active sub-cache the same way the
+            # CompositeControllerCache dispatch above already selected `cache`
+            # and `alg` for this call.
+            alg_cache = integrator.cache isa CompositeCache ?
+                @inbounds(integrator.cache.caches[integrator.cache.current]) :
+                integrator.cache
             if isfirk(alg)
-                (; iter) = integrator.cache
+                (; iter) = alg_cache
                 (; maxiters) = alg
             else
-                (; iter, maxiters) = integrator.cache.nlsolver
+                (; iter, maxiters) = alg_cache.nlsolver
             end
             fac = min(gamma, (1 + 2 * maxiters) * gamma / (iter + 2 * maxiters))
         end

--- a/test/InterfaceI/composite_algorithm_test.jl
+++ b/test/InterfaceI/composite_algorithm_test.jl
@@ -133,7 +133,9 @@ sol = solve(prob_mm, DefaultODEAlgorithm(), callback = cb)
     prob_stiff = ODEProblem(rober_stiff!, [1.0, 0.0, 0.0], (0.0, 1.0e5))
 
     for alg in (
+            AutoVern7(RadauIIA3(autodiff = AutoFiniteDiff()); stiffalgfirst = true),
             AutoVern7(RadauIIA5(autodiff = AutoFiniteDiff()); stiffalgfirst = true),
+            AutoVern7(RadauIIA9(autodiff = AutoFiniteDiff()); stiffalgfirst = true),
             AutoTsit5(RadauIIA5(autodiff = AutoFiniteDiff()); stiffalgfirst = true),
         )
         sol = solve(prob_stiff, alg)

--- a/test/InterfaceI/composite_algorithm_test.jl
+++ b/test/InterfaceI/composite_algorithm_test.jl
@@ -2,6 +2,7 @@ using OrdinaryDiffEq, OrdinaryDiffEqCore, Test, LinearAlgebra
 import ODEProblemLibrary: prob_ode_linear, prob_ode_2Dlinear
 using DiffEqDevTools, ADTypes
 using OrdinaryDiffEqAdamsBashforthMoulton, OrdinaryDiffEqExplicitRK, OrdinaryDiffEqRosenbrock
+using OrdinaryDiffEqFIRK
 import OrdinaryDiffEqExplicitTableaus
 using OrdinaryDiffEqCore: CompositeAlgorithm
 
@@ -114,3 +115,28 @@ cb = DiscreteCallback(
     (u, t, integrator) -> true, (integrator) -> derivative_discontinuity!(integrator, true)
 )
 sol = solve(prob_mm, DefaultODEAlgorithm(), callback = cb)
+
+# https://github.com/SciML/OrdinaryDiffEq.jl/issues/4364
+# PredictiveControllerCache's `isfirk(alg)` branch destructured `integrator.cache`
+# directly for `iter`, which is the CompositeCache when the FIRK method is a
+# composite member (not the FIRK sub-cache the destructuring assumes) --
+# "type CompositeCache has no field iter". Every FIRK stiff member of an
+# AutoSwitch composite hit this once the switch reached the stiff branch.
+@testset "AutoSwitch composite with a FIRK stiff member (#4364)" begin
+    function rober_stiff!(du, u, p, t)
+        y1, y2, y3 = u
+        du[1] = -0.04 * y1 + 1.0e4 * y2 * y3
+        du[2] = 0.04 * y1 - 1.0e4 * y2 * y3 - 3.0e7 * y2^2
+        du[3] = 3.0e7 * y2^2
+        return nothing
+    end
+    prob_stiff = ODEProblem(rober_stiff!, [1.0, 0.0, 0.0], (0.0, 1.0e5))
+
+    for alg in (
+            AutoVern7(RadauIIA5(autodiff = AutoFiniteDiff()); stiffalgfirst = true),
+            AutoTsit5(RadauIIA5(autodiff = AutoFiniteDiff()); stiffalgfirst = true),
+        )
+        sol = solve(prob_stiff, alg)
+        @test sol.retcode == ReturnCode.Success
+    end
+end


### PR DESCRIPTION
## Summary

- `PredictiveControllerCache`'s `stepsize_controller!` reads `integrator.cache` directly to get `iter` (FIRK branch) or `integrator.cache.nlsolver` (non-FIRK branch). For a `CompositeAlgorithm`, `integrator.cache` is the `CompositeCache`, not the active branch's own cache — so `(; iter) = integrator.cache` throws `type CompositeCache has no field iter` the moment an `AutoSwitch` composite's stiff branch is a FIRK method (`RadauIIA3/5/9`).
- The `nlsolver` branch has the same latent bug for any non-`fac_default_gamma`, non-FIRK algorithm used as a composite member — it just isn't exercised by the reporter's repro because the non-FIRK stiff algorithms they tried (`FBDF`, `KenCarp4`) have `fac_default_gamma(alg) == true`, which skips this code path entirely, not because `integrator.cache.nlsolver` actually resolves correctly for a composite cache (there is no `getproperty` override anywhere in this codebase that would make that work).
- Fix: resolve the currently active sub-cache the same way `CompositeControllerCache`'s own `stepsize_controller!` dispatch (one call frame up) already selected `cache` and `alg` for this call — `integrator.cache.caches[integrator.cache.current]` when `integrator.cache isa CompositeCache`, else `integrator.cache` unchanged. Applied to both branches.

Fixes #4364.

## Test plan

- [x] New regression testset in `test/InterfaceI/composite_algorithm_test.jl`: `AutoVern7(RadauIIA5(autodiff = AutoFiniteDiff()); stiffalgfirst = true)` and `AutoTsit5(RadauIIA5(autodiff = AutoFiniteDiff()); stiffalgfirst = true)` on the issue's ROBER reproducer — both crashed on unpatched master, both `retcode == ReturnCode.Success` with this patch.
- [x] Verified locally against the exact reproducer in the issue body (all 4 cases, including the non-FIRK `AutoVern7(Rodas5P())` control): unpatched master crashes on the two FIRK-stiff-branch cases with `type CompositeCache has no field iter`; patched branch completes all four (`Success`, 57 / 73 / 54 steps respectively).
