### PR TITLE
Fix SBDF order ramp, history-shift timing, and dt-change reset

### DIFF
--- a/lib/OrdinaryDiffEqBDF/src/bdf_caches.jl
+++ b/lib/OrdinaryDiffEqBDF/src/bdf_caches.jl
@@ -89,7 +89,7 @@ end
 
 # SBDF
 
-@cache mutable struct SBDFConstantCache{rateType, N, uType} <: OrdinaryDiffEqConstantCache
+@cache mutable struct SBDFConstantCache{rateType, N, uType, dtType} <: OrdinaryDiffEqConstantCache
     cnt::Int
     ark::Bool
     k2::rateType
@@ -102,9 +102,10 @@ end
     k₃::rateType
     du₁::rateType
     du₂::rateType
+    dtprev::dtType
 end
 
-@cache mutable struct SBDFCache{uType, rateType, N} <: BDFMutableCache
+@cache mutable struct SBDFCache{uType, rateType, N, dtType} <: BDFMutableCache
     cnt::Int
     ark::Bool
     u::uType
@@ -119,6 +120,7 @@ end
     k₃::rateType
     du₁::rateType
     du₂::rateType
+    dtprev::dtType
 end
 
 function alg_cache(
@@ -143,10 +145,11 @@ function alg_cache(
     uprev2 = u
     uprev3 = u
     uprev4 = u
+    dtprev = zero(dt)
 
     return SBDFConstantCache(
         1, alg.ark, k2, nlsolver, uprev2, uprev3, uprev4, k₁, k₂, k₃, du₁,
-        du₂
+        du₂, dtprev
     )
 end
 
@@ -174,10 +177,11 @@ function alg_cache(
     uprev2 = zero(u)
     uprev3 = order >= 3 ? zero(u) : uprev2
     uprev4 = order == 4 ? zero(u) : uprev2
+    dtprev = zero(dt)
 
     return SBDFCache(
         1, alg.ark, u, uprev, fsalfirst, nlsolver, uprev2, uprev3, uprev4, k₁, k₂, k₃,
-        du₁, du₂
+        du₁, du₂, dtprev
     )
 end
 

--- a/lib/OrdinaryDiffEqBDF/src/bdf_perform_step.jl
+++ b/lib/OrdinaryDiffEqBDF/src/bdf_perform_step.jl
@@ -207,8 +207,17 @@ function perform_step!(integrator, cache::SBDFConstantCache, repeat_step = false
     alg = unwrap_alg(integrator, true)
     (; uprev2, uprev3, uprev4, du₁, du₂, k₁, k₂, k₃, nlsolver) = cache
     (; f1, f2) = integrator.f
-    cnt = cache.cnt = min(alg.order, integrator.iter + 1)
+    # cnt tracks how many past (uprev_i, k_i) points the fixed-coefficient
+    # formulas below can validly read, which is the number of completed
+    # steps -- not one more than that (that was defect 1: it ran a k-point
+    # formula with only k-1 points on record). It must also drop back to 1
+    # whenever dt changes: the BDF coefficients below are derived assuming
+    # the whole history is spaced at the current dt, so history recorded at
+    # a different dt (e.g. a step clipped to land on tspan[2]) makes the
+    # formula wrong, not just less accurate (see #4329).
+    cnt = cache.cnt = min(alg.order, integrator.iter)
     integrator.iter == 1 && !integrator.derivative_discontinuity && (cnt = cache.cnt = 1)
+    dt != cache.dtprev && (cnt = cache.cnt = 1)
     nlsolver.γ = γ = inv(γₖ[cnt])
     if cache.ark
         # Additive Runge-Kutta Method
@@ -247,11 +256,19 @@ function perform_step!(integrator, cache::SBDFConstantCache, repeat_step = false
     nlsolvefail(nlsolver) && return
     u = nlsolver.tmp + γ * z
 
-    cnt == 4 && (
+    # Shift the history every step (not gated on cnt, which only says how
+    # much of it is *usable yet* -- defect 2 was gating the shift itself on
+    # cnt, so the first step that could validly read a slot found it still
+    # holding its cache-construction value). Gated on alg.order instead,
+    # which is fixed per algorithm instance: for order < 4 (< 3), uprev4/k₃
+    # (uprev3/k₂) alias uprev2/k₁ as a memory optimization in the mutable
+    # cache's constructor, and writing through an aliased slot here would
+    # corrupt uprev2/k₁ before the unaliased lines below read them.
+    alg.order == 4 && (
         cache.uprev4 = uprev3;
         cache.k₃ = k₂
     )
-    cnt >= 3 && (
+    alg.order >= 3 && (
         cache.uprev3 = uprev2;
         cache.k₂ = k₁
     )
@@ -259,6 +276,7 @@ function perform_step!(integrator, cache::SBDFConstantCache, repeat_step = false
         cache.uprev2 = uprev;
         cache.k₁ = du₂
     )
+    cache.dtprev = dt
     cache.du₁ = f1(u, p, t + dt)
     cache.du₂ = f2(u, p, t + dt)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
@@ -290,8 +308,12 @@ function perform_step!(integrator, cache::SBDFCache, repeat_step = false)
     (; uprev2, uprev3, uprev4, k₁, k₂, k₃, du₁, du₂, nlsolver) = cache
     (; tmp, z) = nlsolver
     (; f1, f2) = integrator.f
-    cnt = cache.cnt = min(alg.order, integrator.iter + 1)
+    # See the matching branch in the constant-cache method for why cnt is
+    # min(order, iter) rather than iter + 1, and why it also resets on a
+    # dt change (#4329).
+    cnt = cache.cnt = min(alg.order, integrator.iter)
     integrator.iter == 1 && !integrator.derivative_discontinuity && (cnt = cache.cnt = 1)
+    dt != cache.dtprev && (cnt = cache.cnt = 1)
     nlsolver.γ = γ = inv(γₖ[cnt])
     # Explicit part
     if cache.ark
@@ -330,11 +352,17 @@ function perform_step!(integrator, cache::SBDFCache, repeat_step = false)
     nlsolvefail(nlsolver) && return
     @.. broadcast = false u = tmp + γ * z
 
-    cnt == 4 && (
+    # See the matching comment in the constant-cache method: gated on
+    # alg.order (fixed), not cnt (varies per step and was defect 2), and
+    # the alg.order gate is what keeps this safe under the mutable cache's
+    # order<4/order<3 buffer aliasing (uprev4≡uprev2, k₃≡k₁ / uprev3≡uprev2,
+    # k₂≡k₁) -- each destination below is only written after every line
+    # that still needs its old contents as a source has already run.
+    alg.order == 4 && (
         cache.uprev4 .= uprev3;
         cache.k₃ .= k₂
     )
-    cnt >= 3 && (
+    alg.order >= 3 && (
         cache.uprev3 .= uprev2;
         cache.k₂ .= k₁
     )
@@ -342,6 +370,7 @@ function perform_step!(integrator, cache::SBDFCache, repeat_step = false)
         cache.uprev2 .= uprev;
         cache.k₁ .= du₂
     )
+    cache.dtprev = dt
     f1(du₁, u, p, t + dt)
     f2(du₂, u, p, t + dt)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)

--- a/lib/OrdinaryDiffEqBDF/test/bdf_convergence_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/bdf_convergence_tests.jl
@@ -118,6 +118,68 @@ end
     @test_nowarn solve(prob, FBDF())
 end
 
+@testset "SBDF" begin
+    # Regression for #4329: SBDF2/3/4 silently ran below their nominal order.
+    # `measured_order` runs a fixed-dt, non-adaptive solve at two step sizes
+    # and infers the order from the error ratio (test_convergence's
+    # simulation machinery assumes a plain ODEProblem; SBDF is IMEX-only).
+    # Errors are reduced with `maximum(abs, ...)` so this works for both the
+    # scalar and vector (in-place) problems below.
+    exact(t) = exp(-t)
+    function measured_order(prob, alg, dts)
+        errs = [
+            maximum(abs, solve(prob, alg; dt, adaptive = false).u[end] .- exact(prob.tspan[2]))
+                for dt in dts
+        ]
+        return log(errs[1] / errs[2]) / log(dts[1] / dts[2])
+    end
+
+    @testset "pure-BDF equivalent (f2 ≡ 0), out-of-place" begin
+        prob = SplitODEProblem((u, p, t) -> -u, (u, p, t) -> 0.0, 1.0, (0.0, 1.0))
+        for (alg, order) in ((SBDF2(), 2), (SBDF3(), 2), (SBDF4(), 2))
+            # Capped at 2 regardless of alg.order: the first alg.order - 1
+            # steps bootstrap through the lower-order family members (no
+            # trusted multi-point history exists yet), and the first step's
+            # O(dt^2) local error survives in the global error for every
+            # later step -- this is expected multistep start-up behavior,
+            # not a defect (see #4329's "related observations").
+            @test measured_order(prob, alg, (1.0e-2, 1.0e-3)) ≈ order atol = 0.2
+        end
+    end
+
+    @testset "genuine IMEX split, out-of-place and in-place" begin
+        # The first step happens to be the trapezoidal rule on an equal
+        # split, so the start-up cap here is 3, not 2.
+        prob = SplitODEProblem((u, p, t) -> -0.5 * u, (u, p, t) -> -0.5 * u, 1.0, (0.0, 1.0))
+        prob_ip = SplitODEProblem(
+            (du, u, p, t) -> (du .= -0.5 .* u; nothing),
+            (du, u, p, t) -> (du .= -0.5 .* u; nothing),
+            [1.0], (0.0, 1.0)
+        )
+        for (p, order) in ((prob, 2), (prob_ip, 2))
+            @test measured_order(p, SBDF2(), (1.0e-2, 1.0e-3)) ≈ order atol = 0.2
+        end
+        for p in (prob, prob_ip)
+            @test measured_order(p, SBDF3(), (1.0e-2, 1.0e-3)) ≈ 3 atol = 0.2
+            @test measured_order(p, SBDF4(), (1.0e-2, 1.0e-3)) ≈ 3 atol = 0.2
+        end
+    end
+
+    @testset "step-size change does not corrupt the fixed-coefficient history" begin
+        # A clipped final step (dt landing just short of tspan[2]) must not
+        # pollute the result -- this reproduces the ~4200x error inflation
+        # from #4329 (defect 3) if unfixed.
+        prob = SplitODEProblem((u, p, t) -> -u, (u, p, t) -> 0.0, 1.0, (0.0, 2.0))
+        err_clipped = abs(
+            solve(prob, SBDF2(); dt = 1.0e-3, adaptive = false).u[end] - exact(2.0)
+        )
+        err_exact_binary = abs(
+            solve(prob, SBDF2(); dt = 2.0^-10, adaptive = false).u[end] - exact(2.0)
+        )
+        @test err_clipped < 5 * err_exact_binary
+    end
+end
+
 @testset "Static Array (SVector) Tests" begin
     f_oop(u, p, t) = -0.5 * u
     u0_sv = SVector(1.0, 2.0)


### PR DESCRIPTION
## Summary

SBDF (SBDF2/3/4) is a fixed-coefficient IMEX multistep method and requires a uniform step-size history. Three issues combined to make it silently run below its nominal convergence order:

- The bootstrap counter allowed the higher-order formula to be used one step before enough trusted history existed.
- The buffer history shift was gated on the bootstrap counter instead of the algorithm order, so high-order runs could skip a needed shift during ramp-up.
- No reset occurred when dt changed, so the fixed-coefficient formula was silently applied across a non-uniform step history (e.g. on a clipped final step), inflating the error by orders of magnitude.

Fixes #4329.

## Test plan

- Added an `SBDF` convergence testset measuring empirical order for pure-BDF and genuine IMEX splits, out-of-place and in-place, across SBDF2/SBDF3/SBDF4.
- Verified against both reproducers from the issue.
- Checked the ARK variant, a `tstops`-forced mid-integration dt change, `reinit!` + re-solve consistency, and in-place order-4 correctness.
- Confirmed no allocation or type-stability change relative to the unpatched baseline.