### PR TITLE
Unwrap the composite algorithm before reading AdaptiveRadau's max_order

### DIFF
--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFIRK"
 uuid = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.8.0"
+version = "2.8.1"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -22,6 +22,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 
 [extras]
+OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -36,6 +37,7 @@ DiffEqBase = {path = "../DiffEqBase"}
 DiffEqDevTools = {path = "../DiffEqDevTools"}
 
 [compat]
+OrdinaryDiffEqTsit5 = "2"
 SciMLTesting = "2.8"
 Pkg = "1"
 Test = "<0.0.1, 1"
@@ -63,7 +65,7 @@ SafeTestsets = "0.1.0"
 SciMLOperators = "1.24.3"
 
 [targets]
-test = ["DiffEqDevTools", "GenericSchur", "Random", "SafeTestsets", "Test", "ODEProblemLibrary", "Pkg", "SciMLTesting"]
+test = ["DiffEqDevTools", "GenericSchur", "OrdinaryDiffEqTsit5", "Random", "SafeTestsets", "Test", "ODEProblemLibrary", "Pkg", "SciMLTesting"]
 
 [sources.OrdinaryDiffEqDifferentiation]
 path = "../OrdinaryDiffEqDifferentiation"
@@ -73,3 +75,6 @@ path = "../OrdinaryDiffEqNonlinearSolve"
 
 [sources.OrdinaryDiffEqCore]
 path = "../OrdinaryDiffEqCore"
+
+[sources.OrdinaryDiffEqTsit5]
+path = "../OrdinaryDiffEqTsit5"

--- a/lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
@@ -144,7 +144,9 @@ function initialize!(integrator, cache::RadauIIA9Cache)
 end
 
 function initialize!(integrator, cache::AdaptiveRadauConstantCache)
-    max_stages = (integrator.alg.max_order - 1) ÷ 4 * 2 + 1
+    # `integrator.alg` is the `CompositeAlgorithm` when this method is a composite
+    # member, and that has no `max_order`.
+    max_stages = (unwrap_alg(integrator, true).max_order - 1) ÷ 4 * 2 + 1
     integrator.kshortsize = max_stages + 2
     integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
     integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t) # Pre-start fsal
@@ -161,7 +163,8 @@ function initialize!(integrator, cache::AdaptiveRadauConstantCache)
 end
 
 function initialize!(integrator, cache::AdaptiveRadauCache)
-    max_stages = (integrator.alg.max_order - 1) ÷ 4 * 2 + 1
+    # See the constant-cache `initialize!` above: unwrap before reading `max_order`.
+    max_stages = (unwrap_alg(integrator, true).max_order - 1) ÷ 4 * 2 + 1
     integrator.kshortsize = max_stages + 2
     resize!(integrator.k, integrator.kshortsize)
     integrator.k[1] = integrator.fsalfirst

--- a/lib/OrdinaryDiffEqFIRK/test/ode_firk_tests.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/ode_firk_tests.jl
@@ -1,4 +1,5 @@
 using OrdinaryDiffEqFIRK, DiffEqDevTools, Test, LinearAlgebra
+using OrdinaryDiffEqTsit5: AutoTsit5
 import ODEProblemLibrary: prob_ode_linear, prob_ode_2Dlinear, prob_ode_vanderpol
 
 testTol = 0.5
@@ -202,4 +203,24 @@ end
     vanstiff = ODEProblem(vanderpol_firk, [sqrt(3), 0.0], (0.0, 1.0), [1.0e6])
     integ = init(vanstiff, AdaptiveRadau())
     @test all(x -> all(iszero, x), integ.k[3:(integ.kshortsize)])
+end
+
+# https://github.com/SciML/OrdinaryDiffEq.jl/issues/4367
+# `initialize!` read `integrator.alg.max_order`, which is the `CompositeAlgorithm`
+# when `AdaptiveRadau` is a composite member, so building the integrator threw
+# "type CompositeAlgorithm has no field max_order" before a single step was taken.
+# The bare algorithm was unaffected, which is why the convergence tests above never
+# saw it. `init` is the right granularity here: it runs `initialize!` and stops.
+# A full `solve` additionally needs the composite fixes tracked in #4364.
+@testset "AdaptiveRadau as a composite member (#4367)" begin
+    f_comp = (du, u, p, t) -> (du[1] = -1000u[1] + u[2]; du[2] = u[1] - 2u[2]; nothing)
+    prob_comp = ODEProblem(f_comp, [1.0, 1.0], (0.0, 1.0))
+
+    integ = init(prob_comp, AutoTsit5(AdaptiveRadau(); stiffalgfirst = true))
+    @test integ isa SciMLBase.DEIntegrator
+
+    # `kshortsize` is what the offending line was computing; check it came out of the
+    # AdaptiveRadau member rather than defaulting or erroring.
+    bare = init(prob_comp, AdaptiveRadau())
+    @test integ.kshortsize == bare.kshortsize
 end


### PR DESCRIPTION
Fixes #4367.

`AdaptiveRadau` inside any `CompositeAlgorithm` throws before it can take a step:

```julia
f!(du, u, p, t) = (du[1] = -1000u[1] + u[2]; du[2] = u[1] - 2u[2]; nothing)
prob = ODEProblem(f!, [1.0, 1.0], (0.0, 1.0))

init(prob, AdaptiveRadau())                                          # fine
init(prob, AutoTsit5(AdaptiveRadau(); stiffalgfirst = true))         # type CompositeAlgorithm has no field max_order
```

## Cause

Both `initialize!` methods for `AdaptiveRadau` read the field off `integrator.alg`:

```julia
max_stages = (integrator.alg.max_order - 1) ÷ 4 * 2 + 1
```

For a composite, `integrator.alg` is the `CompositeAlgorithm`, which has no `max_order`.
`alg_cache` is dispatched on `AdaptiveRadau` so it gets the real algorithm and is unaffected,
which is why only `initialize!` fails.

## Fix

Use `unwrap_alg(integrator, true)`, the same accessor `OrdinaryDiffEqBDF` uses throughout its
`perform_step!` methods. `OrdinaryDiffEqFIRK` already imports it. For a non-composite algorithm
it returns the algorithm unchanged, so the bare path is untouched.

Applied to both `AdaptiveRadauConstantCache` and `AdaptiveRadauCache`.

The other `alg.max_order` reads in this package are fine and are left alone: `firk_caches.jl:531`
and `:618` are inside `alg_cache(alg::AdaptiveRadau, ...)`, and `controllers.jl:27` takes `alg`
as a parameter that the composite dispatch has already unwrapped.

## Scope

This clears the first failure only. A full `solve` of the same composite then hits the separate
`integrator.cache` problems tracked in #4364: the `iter` read that #4365 fixes, and
`get_current_adaptive_order(alg, integrator.cache)` at `controllers.jl:1221`, which reaches
`get_current_adaptive_order(alg::AdaptiveRadau, cache) = cache.num_stages`
(`OrdinaryDiffEqFIRK/src/alg_utils.jl:23`) with the `CompositeCache`. I have noted that second
one on #4365, since the local it already introduces is what resolves it.

So this PR is not enough on its own to make `solve(prob, AutoTsit5(AdaptiveRadau()))` work, and
does not claim to be. It is the FIRK-side half, and it is independent of #4365: neither PR
depends on the other, and they touch different packages.

## Testing

The test uses `init` rather than `solve`, deliberately. `init` runs `initialize!` and stops,
which is exactly the code this changes, so the test passes now instead of waiting on #4364. It
also checks the composite integrator's `kshortsize` matches the bare `AdaptiveRadau` one, so the
assertion is about the value the offending line computes and not merely that nothing threw.

On master the testset errors with `type CompositeAlgorithm has no field max_order`; with this
change it passes.

`OrdinaryDiffEqTsit5` is added as a test-only dependency, because `AutoSwitch` needs a genuine
non-stiff member. A composite of two FIRK methods is not a substitute: `AutoSwitch` calls
`alg_stability_size` on the non-stiff member and FIRK methods do not define it.

Bumps `OrdinaryDiffEqFIRK` one patch from master, which is `next_patch` of the registered 2.8.0.

## AI Disclosure

Claude assisted with this change.
