### PR TITLE
Use released downstream workflow v1

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -28,7 +28,7 @@ jobs:
           - {user: SciML, repo: ModelingToolkit.jl, group: SymbolicIndexingInterface}
           - {user: nathanaelbosch, repo: ProbNumDiffEq.jl, group: Downstream}
           - {user: SKopecz, repo: PositiveIntegrators.jl, group: Downstream}
-    uses: "SciML/.github/.github/workflows/downstream.yml@d5748d7f7e95749cb0a5acaed6e69162623be862"
+    uses: "SciML/.github/.github/workflows/downstream.yml@v1"
     with:
       owner: "${{ matrix.package.user }}"
       repo: "${{ matrix.package.repo }}"

--- a/lib/OrdinaryDiffEqSDIRK/src/generic_imex_perform_step.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/generic_imex_perform_step.jl
@@ -119,7 +119,7 @@ end
             @.. broadcast = false zs[1] = u - uprev
         elseif tab.stage1_extrapolation && (
                 predictor == Predictor.Linear ||
-                (E === :ie_dd2 && !hasproperty(alg, :predictor))
+                    (E === :ie_dd2 && !hasproperty(alg, :predictor))
             )
             @.. broadcast = false zs[1] = dt * integrator.fsalfirst
         else
@@ -1403,7 +1403,7 @@ end
             z1 = current_extrapolant(t + dt, integrator) - uprev
         elseif tab.stage1_extrapolation && (
                 predictor == Predictor.Linear ||
-                (E === :ie_dd2 && !hasproperty(alg, :predictor))
+                    (E === :ie_dd2 && !hasproperty(alg, :predictor))
             )
             z1 = dt * integrator.fsalfirst
         else


### PR DESCRIPTION
## Summary

- Follow up on #4323 by replacing the temporary SciML/.github merge-commit pin with the released moving `v1` tag.
- SciML/.github [`v1.28.0`](https://github.com/SciML/.github/releases/tag/v1.28.0) and `v1` both resolve to `d5748d7f7e95749cb0a5acaed6e69162623be862`, so this changes the reference without changing the reusable workflow content.
- Keep `upstream-subdirs: ".,lib/*"` unchanged.
- Apply the two indentation changes required by Runic 1.9.0, which current master also reports.

## Verification

- `actionlint` 1.7.12 on `.github/workflows/Downstream.yml`: passed.
- `typos` on both changed files: passed.
- `git diff --check`: passed.
- Confirmed all twelve SciML reusable workflow calls in this repository now use `@v1`.
- Ran the real `GROUP=QA Pkg.test()` on Julia 1.12.7 with fresh unconstrained resolution to GenericSchur 0.5.8: 92 of 92 passed.
- Ran Runic 1.9.0 over the full repository: passed.

## Initial CI context

The first CI run resolved GenericSchur 0.5.7 and hit [GenericSchur #24](https://github.com/RalphAS/GenericSchur.jl/issues/24) while precompiling ExponentialUtilities. The identical failure was already present on [current master CI](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/32769905769/job/97567841365). [GenericSchur #25](https://github.com/RalphAS/GenericSchur.jl/pull/25) has since merged, and v0.5.8 is released and registered.

No dependency workaround is included in this branch. The follow-up push reruns CI against the patched release.
