### PR TITLE
Fix HVP through `ode_determine_initdt`

### DIFF
--- a/lib/OrdinaryDiffEqCore/ext/OrdinaryDiffEqCoreMooncakeExt.jl
+++ b/lib/OrdinaryDiffEqCore/ext/OrdinaryDiffEqCoreMooncakeExt.jl
@@ -1,8 +1,8 @@
 module OrdinaryDiffEqCoreMooncakeExt
 
 using OrdinaryDiffEqCore, Mooncake
-using Mooncake: @zero_adjoint, @is_primitive, MinimalCtx, CoDual, Dual, NoRData,
-    MutableTangent, NoTangent, primal, lazy_zero_rdata, instantiate
+using Mooncake: @zero_adjoint, @zero_derivative, @is_primitive, MinimalCtx, CoDual, Dual,
+    NoRData, MutableTangent, NoTangent, primal, lazy_zero_rdata, instantiate
 
 # Most of these rules mirror the inactive_noinl rules in
 # OrdinaryDiffEqCoreEnzymeCoreExt. They cover bookkeeping/logging/error
@@ -47,14 +47,19 @@ Mooncake.@zero_adjoint Mooncake.MinimalCtx Tuple{
     typeof(OrdinaryDiffEqCore.final_progress), Vararg,
 }
 # NOTE: ode_determine_initdt depends on `u0`, so its return value (dt0) IS
-# mathematically a function of `u0`. Marking it @zero_adjoint is therefore
+# mathematically a function of `u0`. Marking it zero-derivative is therefore
 # not strictly correct — it drops the (small) contribution of dt0 to the
 # gradient. We keep it because the underlying `_ode_initdt_iip` contains
 # try/catch blocks that Mooncake cannot trace through (UpsilonNode error).
 # In practice the introduced error is at the level of the controller's
 # first-step correction and the resulting gradient still matches ForwardDiff
 # to ~10 digits in the tests below.
-Mooncake.@zero_adjoint Mooncake.MinimalCtx Tuple{
+#
+# Both modes, not just @zero_adjoint (ReverseMode only): HVP forward-differentiates
+# whatever reverse rule gets built, so a ReverseMode-only primitive still lets the outer
+# forward pass recurse into this function's body under HVP, hitting the same
+# UpsilonNode/try-catch error one level up instead of avoiding it.
+Mooncake.@zero_derivative Mooncake.MinimalCtx Tuple{
     typeof(OrdinaryDiffEqCore.ode_determine_initdt), Vararg,
 }
 


### PR DESCRIPTION
`ode_determine_initdt`'s Mooncake rule is registered with `@zero_adjoint`, which only marks it primitive under `ReverseMode`. That's fine for a plain gradient, but HVP forward-differentiates whatever reverse rule got built, so the outer forward pass still recurses into `ode_determine_initdt`'s body and hits `_ode_initdt_iip`'s try/catch (an UpsilonNode IR verification error).

Switching to `@zero_derivative` registers both modes, so the outer forward pass treats it as a primitive too and never reaches the try/catch.

Verified on Julia 1.10 and 1.11 against SciML/SciMLSensitivity.jl#1427's HVP regression, gradients matching ForwardDiff.