### PR TITLE
Declare the BDF LHL test's dependencies so the test can run

### DIFF
--- a/lib/OrdinaryDiffEqBDF/Project.toml
+++ b/lib/OrdinaryDiffEqBDF/Project.toml
@@ -23,6 +23,7 @@ DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [extras]
+SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -41,6 +42,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [sources]
+OrdinaryDiffEqFIRK = {path = "../OrdinaryDiffEqFIRK"}
 DiffEqBase = {path = "../DiffEqBase"}
 DiffEqDevTools = {path = "../DiffEqDevTools"}
 OrdinaryDiffEqCore = {path = "../OrdinaryDiffEqCore"}
@@ -50,6 +52,7 @@ OrdinaryDiffEqRosenbrock = {path = "../OrdinaryDiffEqRosenbrock"}
 OrdinaryDiffEqSDIRK = {path = "../OrdinaryDiffEqSDIRK"}
 
 [compat]
+SciMLOperators = "1.25"
 SciMLTesting = "2.8"
 Pkg = "1"
 NonlinearSolve = "4.20.3"
@@ -84,4 +87,4 @@ SafeTestsets = "0.1.0"
 StaticArrays = "1.9.18"
 
 [targets]
-test = ["DiffEqDevTools", "DifferentiationInterface", "ForwardDiff", "Random", "SafeTestsets", "StaticArrays", "Test", "ODEProblemLibrary", "NonlinearSolve", "Enzyme", "LinearSolve", "Pkg", "SciMLTesting", "OrdinaryDiffEqRosenbrock", "SparseArrays", "OrdinaryDiffEqFIRK"]
+test = ["DiffEqDevTools", "DifferentiationInterface", "ForwardDiff", "Random", "SafeTestsets", "StaticArrays", "Test", "ODEProblemLibrary", "NonlinearSolve", "Enzyme", "LinearSolve", "Pkg", "SciMLTesting", "OrdinaryDiffEqRosenbrock", "SparseArrays", "OrdinaryDiffEqFIRK", "SciMLOperators"]


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

## What changed and why

`lib/OrdinaryDiffEqBDF/test/lhl_factorization_tests.jl` (added by #4266) has two undeclared dependencies, so the testset has never actually run:

1. It does `using SciMLOperators: WOperator, jacobian_stale`, but `SciMLOperators` is in neither `[deps]` nor `[extras]` of `lib/OrdinaryDiffEqBDF/Project.toml`. The file fails to load, and `downgrade-sublibraries / test (lib/OrdinaryDiffEqBDF)` is red on master and on every PR branched from it.
2. Once it loads, `FIRK refuses a reduction it cannot reuse` fails. The `ArgumentError` it expects is raised in the **in-repo** `lib/OrdinaryDiffEqFIRK/src/firk_operators.jl:153`, but `OrdinaryDiffEqFIRK` is not in BDF's `[sources]`, so the test environment resolves the **registered** `OrdinaryDiffEqFIRK v2.7.0` — which predates that change — instead of the repo's `v2.8.0`.

Fix: add `SciMLOperators` to `[extras]`, `[compat]` and `[targets].test`, and add `OrdinaryDiffEqFIRK = {path = "../OrdinaryDiffEqFIRK"}` to `[sources]`. Project.toml only; no code or test changes.

## Verification

`GROUP=Core Pkg.test()` on `lib/OrdinaryDiffEqBDF`, clean master `13da423dd`, Julia 1.12.4.

**Before** — the testset cannot load:
```
LHL Factorization Tests: Error During Test at SafeTestsets.jl:30
  Got exception outside of a @test
  LoadError: ArgumentError: Package SciMLOperators not found in current path.
Test Summary:           | Error  Total  Time
LHL Factorization Tests |     1      1  1.1s
exit=1
```

**With only the `SciMLOperators` entry** — it loads, and the real failure appears:
```
FIRK refuses a reduction it cannot reuse: Test Failed at .../lhl_factorization_tests.jl:64
  Expression: solve(PROB, RadauIIA5(linsolve = LHLFactorization()))
    Expected: ArgumentError
  No exception thrown
Test Summary:           | Pass  Fail  Total     Time
LHL Factorization Tests |   17     1     18  1m01.2s
exit=1
```
(resolved `OrdinaryDiffEqFIRK v2.7.0` — the registered one)

**After** — both entries, same command:
```
  [5960d6e9] OrdinaryDiffEqFIRK v2.8.0 `../OrdinaryDiffEqFIRK`
LHL Factorization Tests | 18  18  38.6s
exit=0
```
Whole `GROUP=Core` group green; `typos` on the changed file clean.

## Not verified

Only BDF's `Core` group was run. The QA group, other sublibraries, GPU lanes and downstream packages were not.

## Note for the reviewer

Worth deciding whether the in-repo-path question generalises: any sublibrary test that exercises unreleased behaviour of a sibling sublibrary needs that sibling in `[sources]`, otherwise it silently tests the registered version and the assertion passes or fails for the wrong reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiHL8AqRSy2VQZF6j68ovM
