### PR TITLE
Drop explanatory comments from the added testsets

### DIFF
--- a/lib/OrdinaryDiffEqFIRK/test/ode_firk_tests.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/ode_firk_tests.jl
@@ -205,13 +205,6 @@ end
     @test all(x -> all(iszero, x), integ.k[3:(integ.kshortsize)])
 end
 
-# https://github.com/SciML/OrdinaryDiffEq.jl/issues/4367
-# `initialize!` read `integrator.alg.max_order`, which is the `CompositeAlgorithm`
-# when `AdaptiveRadau` is a composite member, so building the integrator threw
-# "type CompositeAlgorithm has no field max_order" before a single step was taken.
-# The bare algorithm was unaffected, which is why the convergence tests above never
-# saw it. `init` is the right granularity here: it runs `initialize!` and stops.
-# A full `solve` additionally needs the composite fixes tracked in #4364.
 @testset "AdaptiveRadau as a composite member (#4367)" begin
     f_comp = (du, u, p, t) -> (du[1] = -1000u[1] + u[2]; du[2] = u[1] - 2u[2]; nothing)
     prob_comp = ODEProblem(f_comp, [1.0, 1.0], (0.0, 1.0))
@@ -219,8 +212,6 @@ end
     integ = init(prob_comp, AutoTsit5(AdaptiveRadau(); stiffalgfirst = true))
     @test integ isa SciMLBase.DEIntegrator
 
-    # `kshortsize` is what the offending line was computing; check it came out of the
-    # AdaptiveRadau member rather than defaulting or erroring.
     bare = init(prob_comp, AdaptiveRadau())
     @test integ.kshortsize == bare.kshortsize
 end

--- a/lib/OrdinaryDiffEqSSPRK/test/ode_ssprk_tests.jl
+++ b/lib/OrdinaryDiffEqSSPRK/test/ode_ssprk_tests.jl
@@ -507,8 +507,6 @@ integ = init(
     prob_ode_large, alg, dt = 1.0e-2, save_start = false, save_end = false,
     save_everystep = false
 )
-# One buffer more than the other SSPRK methods: `SSPRK932` needs `f(uprev)` at its
-# `u6*` stage, so unlike its siblings it cannot alias `fsalfirst` onto `k`.
 @test Base.summarysize(integ) ÷ Base.summarysize(u0_large) <= 7
 integ = init(
     prob_ode_large, alg, dt = 1.0e-2, save_start = false, save_end = false,
@@ -615,12 +613,6 @@ sol = solve(
     @test sol_SV.stats.naccept == sol_SA.stats.naccept
 end
 
-# Without dense output or intermediate saves the integrator sets `calck = false`, and
-# the in-place SSPRK caches then alias `fsalfirst` to `k` to save an allocation.
-# `SSPRK932` reads `f(uprev)` back out of `fsalfirst` at its `u6*` stage, after six
-# `f(k, ...)` calls have overwritten `k`, so that alias silently cost it two orders.
-# Every convergence test above runs with the default `calck = true`, which hides it.
-# `SSPRK33`/`SSPRK43` keep the alias and are here as controls.
 @testset "order is preserved when calck is false" begin
     for alg in (SSPRK932(), SSPRK33(), SSPRK43())
         for prob in test_problems_nonlinear

--- a/lib/OrdinaryDiffEqStabilizedIRK/test/irkc_tests.jl
+++ b/lib/OrdinaryDiffEqStabilizedIRK/test/irkc_tests.jl
@@ -29,11 +29,6 @@ using OrdinaryDiffEqStabilizedIRK: maxeig!
     end
 end
 
-# `f1ⱼ₋₂ = du₁` in the in-place `perform_step!` rebound the name onto `du₁`, so the
-# stage shift `@.. f1ⱼ₋₂ = f1ⱼ₋₁` wrote through to `du₁` -- which has to hold
-# `f1(uprev)` for the whole step. That cost the in-place method an order. The
-# out-of-place method does the same assignment safely, because there it is a value
-# copy, so the two paths disagreeing is the sharpest signal.
 @testset "IRKC in-place matches out-of-place" begin
     A1 = [-100.0 0.0; 0.0 -50.0]
     A2 = [0.0 1.0; -1.0 0.0]
@@ -56,10 +51,8 @@ end
     eiip = err(prob_iip)
     eoop = err(prob_oop)
 
-    # Same problem, same method: the two paths must agree closely.
     @test maximum(abs.(eiip .- eoop)) < 1.0e-10
 
-    # ...and the in-place path must show the method's order, not one less.
     orders = [log2(eiip[i] / eiip[i + 1]) for i in 1:(length(dts) - 1)]
     @test minimum(orders) > 1.5
 end

--- a/test/Integrators_I/step_limiter_test.jl
+++ b/test/Integrators_I/step_limiter_test.jl
@@ -192,12 +192,6 @@ end
     end
 end
 
-# The stage limiter contract is `limiter!(u, integrator, p, t)`
-# (`OrdinaryDiffEqCore.trivial_limiter!`). The limiters above ignore their
-# arguments, so they accept whatever is handed to them; that is how `Tsit5` shipped
-# with the `ODEFunction` in the integrator slot, `Midpoint` with a stage buffer, and
-# `QPRK98` limiting `uprev`. These testsets pin down which objects get passed rather
-# than how many times the limiter is called.
 const LIMITER_ALGS = [
     Euler, Heun, Ralston, Midpoint, RK4, BS3, OwrenZen3, DP5, Tsit5,
     Vern6, Vern9, DP8, TanYam7, TsitPap8, QPRK98,
@@ -222,8 +216,6 @@ const LIMITER_ALGS = [
     end
 end
 
-# The limiter mutates whatever it is given, so handing it `uprev` corrupts every
-# later stage and the step update. `QPRK98` stage 5 did exactly that.
 @testset "stage limiter is never handed uprev" begin
     prob = ODEProblem((du, u, p, t) -> du .= u, [1.0, 1.0], (0.0, 1.0))
     for A in LIMITER_ALGS
@@ -237,8 +229,6 @@ end
     end
 end
 
-# End-to-end: with `QPRK98` stage 5 clamping `uprev` in place, `uprev` changed
-# value partway through a single step.
 @testset "uprev is stable across one step" begin
     prob = ODEProblem((du, u, p, t) -> du .= u, [-1.0], (0.0, 0.1))
     seen = Float64[]


### PR DESCRIPTION
Removes the explanatory comments I left above the testsets added in #4356, #4357, #4363 and #4368.

They restate what the PR bodies already say, and the standard is that a comment earns its place only when the WHY is not obvious from the code. These do not. @ChrisRackauckas already deleted the equivalent comments from the source files by suggestion on those PRs; this is the same cleanup for the test files, which the suggestions did not cover.

Deletions only, 34 lines across 4 files. No test logic touched, no source change, so no version bumps.

## AI Disclosure

Claude assisted with this change.
