### PR TITLE
Preserve sparse diagnostic Jacobian patterns through zero pruning

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "3.10.0"
+version = "3.10.1"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -265,10 +265,10 @@ function calc_tderivative(integrator, cache)
 end
 
 """
-    prepare_sparse_jac!(J, jac_prototype)
+    prepare_sparse_jac!(J, jac_prototype; nzval = false)
 
-Give `J` the sparsity structure of `jac_prototype` with all stored values zeroed,
-ready for a user-supplied `f.jac` to write into.
+Give `J` the sparsity structure of `jac_prototype` and fill its stored entries with
+`nzval`. By default, the entries are zeroed for a user-supplied `f.jac` to write into.
 
 `f.jac` only assigns into already-stored entries, so `J`'s structure is invariant
 across the solve and the (O(nnz), allocating) structural rebuild is only needed when
@@ -279,15 +279,15 @@ strict Rosenbrock methods (e.g. `Rodas5P`) that re-evaluate `J` every step.
 See https://github.com/SciML/OrdinaryDiffEq.jl/issues/2653 for why the structure must
 track `jac_prototype` rather than whatever `f.jac` happens to fill in.
 """
-function prepare_sparse_jac!(J, jac_prototype)
+function prepare_sparse_jac!(J, jac_prototype; nzval = false)
     if ArrayInterface.same_sparsity_structure(J, jac_prototype)
-        set_all_nzval!(J, false)
+        set_all_nzval!(J, nzval)
     else
         # `jac_prototype`'s stored values must be made nonzero first: the broadcast
         # below prunes numerical zeros, which would drop those entries from `J`.
         set_all_nzval!(jac_prototype, true)
         J .= true .* jac_prototype
-        set_all_nzval!(J, false)
+        set_all_nzval!(J, nzval)
     end
     return J
 end
@@ -358,11 +358,13 @@ function get_fresh_jacobian(integrator, cache::OrdinaryDiffEqCache)
     (; stats) = integrator
     njacs, nf = stats.njacs, stats.nf
     J = if SciMLBase.isinplace(integrator.sol.prob) && cache.J isa AbstractMatrix
-        # `zero` on a `SparseMatrixCSC` returns a matrix with no stored entries, which
-        # drops the sparsity pattern `calc_J!` colours against and makes it throw
-        # `DimensionMismatch`. `fill!(similar(...))` keeps the pattern and still hands
-        # `calc_J!` a zeroed buffer, and is the same thing as `zero` for a dense `J`.
-        Jfresh = fill!(similar(cache.J), zero(eltype(cache.J)))
+        Jfresh = if is_sparse(cache.J)
+            prepare_sparse_jac!(
+                similar(cache.J), cache.J; nzval = one(eltype(cache.J))
+            )
+        else
+            zero(cache.J)
+        end
         calc_J!(Jfresh, integrator, cache)
         Jfresh
     elseif SciMLBase.isinplace(integrator.sol.prob)

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -358,7 +358,11 @@ function get_fresh_jacobian(integrator, cache::OrdinaryDiffEqCache)
     (; stats) = integrator
     njacs, nf = stats.njacs, stats.nf
     J = if SciMLBase.isinplace(integrator.sol.prob) && cache.J isa AbstractMatrix
-        Jfresh = zero(cache.J)
+        # `zero` on a `SparseMatrixCSC` returns a matrix with no stored entries, which
+        # drops the sparsity pattern `calc_J!` colours against and makes it throw
+        # `DimensionMismatch`. `fill!(similar(...))` keeps the pattern and still hands
+        # `calc_J!` a zeroed buffer, and is the same thing as `zero` for a dense `J`.
+        Jfresh = fill!(similar(cache.J), zero(eltype(cache.J)))
         calc_J!(Jfresh, integrator, cache)
         Jfresh
     elseif SciMLBase.isinplace(integrator.sol.prob)

--- a/lib/OrdinaryDiffEqDifferentiation/test/nojac_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/nojac_tests.jl
@@ -1,7 +1,7 @@
 using OrdinaryDiffEqSDIRK, OrdinaryDiffEqRosenbrock, RecursiveFactorization, LinearSolve,
     Test, ADTypes
 using OrdinaryDiffEqCore: get_fresh_jacobian
-using SparseArrays: sparse
+using SparseArrays: sparse, spdiagm, nnz, SparseMatrixCSC
 
 const N = 32
 const xyd_brusselator = range(0, stop = 1, length = N)
@@ -273,6 +273,41 @@ integ = init(prob, Rosenbrock23(), abstol = 1.0e-6, reltol = 1.0e-6)
 
     @test get_fresh_jacobian(integrator, integrator.cache) === nothing
     @test (integrator.stats.nf, integrator.stats.njacs) == work
+end
+
+@testset "get_fresh_jacobian keeps a sparse J's pattern" begin
+    # `zero(::SparseMatrixCSC)` has no stored entries, so it drops the pattern `calc_J!`
+    # colours against and the instability diagnostic threw `DimensionMismatch` instead of
+    # reporting the Jacobian it was asked for.
+    n = 12
+    diffusivity = 50.0
+    function heat!(du, u, p, t)
+        for i in 1:n
+            l = i == 1 ? zero(eltype(u)) : u[i - 1]
+            r = i == n ? zero(eltype(u)) : u[i + 1]
+            du[i] = diffusivity * (l - 2u[i] + r)
+        end
+        return
+    end
+    u0 = [sinpi(i / (n + 1)) for i in 1:n]
+    trueJ = diffusivity *
+        Matrix(spdiagm(-1 => ones(n - 1), 0 => fill(-2.0, n), 1 => ones(n - 1)))
+    pattern = spdiagm(-1 => ones(n - 1), 0 => ones(n), 1 => ones(n - 1))
+
+    for proto in (copy(pattern), Matrix(pattern))
+        prob = ODEProblem(ODEFunction(heat!; jac_prototype = proto), u0, (0.0, 1.0))
+        # `instability_jacobian` only reaches this hook for caches that carry `J`
+        # themselves, which is the Rosenbrock and Radau shape.
+        for alg in (Rosenbrock23(), Rodas5P())
+            integrator = init(prob, alg; dt = 0.01, adaptive = false)
+            step!(integrator)
+            step!(integrator)
+            J = get_fresh_jacobian(integrator, integrator.cache)
+            @test J !== nothing
+            @test Matrix(J) ≈ trueJ
+            proto isa SparseMatrixCSC && @test nnz(J) == nnz(pattern)
+        end
+    end
 end
 integ = init(
     prob, Rosenbrock23(linsolve = SimpleLUFactorization()), abstol = 1.0e-6,

--- a/lib/OrdinaryDiffEqDifferentiation/test/prepare_sparse_jac_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/prepare_sparse_jac_tests.jl
@@ -39,6 +39,16 @@ struct_eq(A, B) = getcolptr(A) == getcolptr(B) && rowvals(A) == rowvals(B)
         @test struct_eq(J, Jref) && nonzeros(J) == nonzeros(Jref)
     end
 
+    @testset "nonzero stored-value sentinel" begin
+        J = similar(proto)
+
+        prepare_sparse_jac!(J, proto; nzval = one(eltype(J)))
+
+        @test all(isone, nonzeros(J))
+        dropzeros!(J)
+        @test struct_eq(J, proto)
+    end
+
     @testset "mismatched structure (rebuild path)" begin
         # J starts with a different (sparser) pattern than the prototype.
         J = sparse([1, 2], [1, 2], [9.0, 9.0], 3, 3)


### PR DESCRIPTION
This draft PR should be ignored until reviewed by @ChrisRackauckas.

## What changed and why

This rebases and supersedes Harsh's sparse diagnostic-Jacobian fix from https://github.com/SciML/OrdinaryDiffEq.jl/pull/4342 on the current `master`, then extends it so stored sparse entries start at `one(eltype(J))`. This keeps the sparsity pattern alive if an intermediate backend calls `dropzeros!` before overwriting the diagnostic Jacobian.

The sparse path now uses `prepare_sparse_jac!` rather than duplicating its structure-management logic. `prepare_sparse_jac!` accepts an `nzval` keyword, defaulting to the existing zero-filled behavior for user-provided Jacobians; `get_fresh_jacobian` requests a nonzero sentinel only for its fresh diagnostic buffer. Because the destination is `similar(cache.J)`, it already has the same structure, so the live cache matrix is not mutated.

## Failing before / passing after

On Harsh's rebased commit https://github.com/SciML/OrdinaryDiffEq.jl/commit/e9909661d3aa7166969bc17784b083632e5ea149, I added the exact new sentinel test and ran:

```text
/home/crackauc/.juliaup/bin/julia +1.10 --check-bounds=yes --project=lib/OrdinaryDiffEqDifferentiation -e 'using Pkg; Pkg.instantiate(); include("lib/OrdinaryDiffEqDifferentiation/test/prepare_sparse_jac_tests.jl")'

nonzero stored-value sentinel: Error During Test
MethodError: no method matching prepare_sparse_jac!(...; nzval::Float64)
Test Summary:       | Pass  Error  Total
prepare_sparse_jac! |    9      1     10
```

With this change applied, the same test is part of the Core run and passes, including the assertion that `dropzeros!` leaves the structure unchanged:

```text
Test Summary:       | Pass  Total
prepare_sparse_jac! |   11     11
Testing OrdinaryDiffEqDifferentiation tests passed
```

## Verification

```text
GROUP=Core /home/crackauc/.juliaup/bin/julia +1.10 --check-bounds=yes --project=lib/OrdinaryDiffEqDifferentiation -e 'using Pkg; Pkg.test()'

prepare_sparse_jac! | 11/11 passed
No Jac Tests        | 19/19 passed
Testing OrdinaryDiffEqDifferentiation tests passed
```

The dedicated non-full-diagonal sparse test was also run with all monorepo `[sources]` developed locally:

```text
/home/crackauc/.juliaup/bin/julia +1.10 --check-bounds=yes --project=<local-source-env> -e 'include("lib/OrdinaryDiffEqDifferentiation/test/sparse/nonfulldiagonal_sparse_tests.jl")'

Sparse Jacobian caches are initialized with stored values | 2/2 passed
```

The normal QA command currently cannot resolve on clean `master` because the release commit https://github.com/SciML/OrdinaryDiffEq.jl/commit/2bb1ccf8b7a20248796b8f1008f9eb34bc0c54d5 raises the root package's `OrdinaryDiffEqBDF` floor to 2.4.5 while Julia 1.10's group environment selects registered 2.4.4. This was reproduced on clean `master` and bisected independently; it is not caused by this branch. With the monorepo source closure developed locally, the QA bodies pass:

```text
JET Tests         | 1/1 passed
Quality Assurance | 17/17 passed
```

Formatting, spelling, and the diff check passed:

```text
/home/crackauc/.juliaup/bin/julia +1.10 --project=<runic-env> -e 'using Runic; exit(Runic.main(ARGS))' -- --check <changed-files>
typos <changed-files>
git diff --check
```

The docs build was run with `/home/crackauc/.juliaup/bin/julia +1.10 --project=docs docs/make.jl`, but did not pass. It reached Documenter and failed on unrelated unresolved references (`SciMLBase.has_global_error`, `SciMLBase.ODENLStepData`, several ADTypes names, and `SciMLOperators.AbstractSciMLOperator`) plus a missing `CommonSolve.solve` manual entry. A clean-master investigation is in progress; none of those bindings or documentation pages is touched here.

GPU and downstream test groups were not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a8b-1c18-7c30-a972-9185753183d1
