### PR TITLE
Add preset tags for known algorithm traits

### DIFF
--- a/docs/src/devtools/alg_dev/benchmarks.md
+++ b/docs/src/devtools/alg_dev/benchmarks.md
@@ -86,17 +86,17 @@ and a print which will show some relevant information.
 
 A benchmark usually wants several views of the same data: each family of methods on its
 own, then the best of each family against each other, with a couple of reference methods
-in every plot. Tagging the setups produces all of those from a single run. Add a `:tags`
-entry to each setup, request every error metric the plots need with `error_estimates`,
-and slice the result afterwards:
+in every plot. Preset tags derived from algorithm traits and supertypes produce all of
+those from a single run. Add only benchmark-specific tags such as `:reference`, request
+every error metric the plots need with `error_estimates`, and slice the result afterwards:
 
 ```julia
 setups = [
-    Dict(:alg => Rosenbrock23(), :tags => [:rosenbrock, :second_order]),
-    Dict(:alg => Rodas5P(), :tags => [:rosenbrock, :fifth_order]),
-    Dict(:alg => TRBDF2(), :tags => [:sdirk, :second_order]),
-    Dict(:alg => KenCarp4(), :tags => [:sdirk, :fourth_order]),
-    Dict(:alg => RadauIIA5(), :tags => [:firk, :reference]),
+    Dict(:alg => Rosenbrock23()),
+    Dict(:alg => Rodas5P()),
+    Dict(:alg => TRBDF2()),
+    Dict(:alg => KenCarp4()),
+    Dict(:alg => RadauIIA5(), :tags => [:reference]),
 ]
 wp_set = WorkPrecisionSet(
     prob, abstols, reltols, setups;
@@ -113,6 +113,10 @@ plot(
     reference_tags = [:reference]
 )
 ```
+
+For example, `auto_tags(KenCarp4())` includes `:order_4`, `:adaptive`, `:implicit`,
+`:sdirk`, `:esdirk`, and `:split`. Explicit setup tags are appended without duplicates.
+Use `:auto_tags => false` when a setup needs only its manually supplied tags.
 
 `plot(wp_set; tags)` keeps the entries carrying all of `tags`, `include_tags` adds
 entries back regardless of that filter, and `exclude_tags` drops entries. Entries
@@ -137,6 +141,7 @@ DiffEqDevTools.get_sample_errors
 ### Tagging and comparison helpers
 
 ```@docs
+DiffEqDevTools.auto_tags
 DiffEqDevTools.get_tags
 DiffEqDevTools.unique_tags
 DiffEqDevTools.filter_by_tags

--- a/lib/DiffEqDevTools/Project.toml
+++ b/lib/DiffEqDevTools/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqDevTools"
 uuid = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "3.4.0"
+version = "3.5.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
@@ -17,6 +17,12 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SimpleNonlinearSolve = "727e6d20-b764-4bd8-a329-72de5adea6c7"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+
+[weakdeps]
+OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+
+[extensions]
+DiffEqDevToolsOrdinaryDiffEqCoreExt = "OrdinaryDiffEqCore"
 
 [sources]
 DelayDiffEq = {path = "../DelayDiffEq"}

--- a/lib/DiffEqDevTools/docs/src/index.md
+++ b/lib/DiffEqDevTools/docs/src/index.md
@@ -27,6 +27,7 @@ DiffEqDevTools.get_sample_errors
 ## Tagging and comparison helpers
 
 ```@docs
+DiffEqDevTools.auto_tags
 DiffEqDevTools.get_tags
 DiffEqDevTools.unique_tags
 DiffEqDevTools.filter_by_tags

--- a/lib/DiffEqDevTools/ext/DiffEqDevToolsOrdinaryDiffEqCoreExt.jl
+++ b/lib/DiffEqDevTools/ext/DiffEqDevToolsOrdinaryDiffEqCoreExt.jl
@@ -1,0 +1,47 @@
+module DiffEqDevToolsOrdinaryDiffEqCoreExt
+
+import DiffEqDevTools
+import OrdinaryDiffEqCore
+
+const ODEC = OrdinaryDiffEqCore
+
+function DiffEqDevTools._preset_algorithm_tags(
+        alg::Union{
+            ODEC.OrdinaryDiffEqAlgorithm,
+            ODEC.DAEAlgorithm,
+            ODEC.StochasticDiffEqAlgorithm,
+            ODEC.StochasticDiffEqRODEAlgorithm,
+        }
+    )
+    tags = Symbol[]
+
+    if alg isa ODEC.DAEAlgorithm
+        append!(tags, (:dae, :implicit))
+    elseif alg isa ODEC.OrdinaryDiffEqAlgorithm
+        push!(tags, ODEC.isimplicit(alg) ? :implicit : :explicit)
+    elseif alg isa ODEC.StochasticDiffEqAlgorithm
+        push!(tags, :sde)
+    else
+        push!(tags, :rode)
+    end
+
+    alg isa ODEC.RosenbrockAlgorithm && push!(tags, :rosenbrock)
+    alg isa ODEC.ExponentialAlgorithm && push!(tags, :exponential)
+    alg isa ODEC.PartitionedAlgorithm && push!(tags, :partitioned)
+    alg isa ODEC.OrdinaryDiffEqCompositeAlgorithm && push!(tags, :composite)
+    if alg isa ODEC.OrdinaryDiffEqAdamsVarOrderVarStepAlgorithm
+        append!(tags, (:adams, :variable_order, :multistep))
+    end
+
+    applicable(ODEC.isfirk, alg) && ODEC.isfirk(alg) && push!(tags, :firk)
+    if applicable(ODEC.isesdirk, alg) && ODEC.isesdirk(alg)
+        append!(tags, (:sdirk, :esdirk))
+    end
+    applicable(ODEC.issplit, alg) && ODEC.issplit(alg) && push!(tags, :split)
+    applicable(ODEC.ismultistep, alg) && ODEC.ismultistep(alg) &&
+        push!(tags, :multistep)
+
+    return unique!(tags)
+end
+
+end

--- a/lib/DiffEqDevTools/src/DiffEqDevTools.jl
+++ b/lib/DiffEqDevTools/src/DiffEqDevTools.jl
@@ -68,7 +68,7 @@ export test_convergence, analyticless_test_convergence, appxtrue
 export get_sample_errors
 
 #Tagging and filtering
-export filter_by_tags, exclude_by_tags, get_tags, unique_tags, merge_wp_sets
+export auto_tags, filter_by_tags, exclude_by_tags, get_tags, unique_tags, merge_wp_sets
 
 #Multiple error estimates from one run
 export available_errors

--- a/lib/DiffEqDevTools/src/benchmark.jl
+++ b/lib/DiffEqDevTools/src/benchmark.jl
@@ -6,6 +6,52 @@ _nan_errors() = Dict{Symbol, Float64}(:l∞ => NaN, :L2 => NaN, :final => NaN, :
 _setup_tags(setup) = Vector{Symbol}(get(setup, :tags, Symbol[]))
 _setup_name(setup) = get(setup, :name, _default_name(setup[:alg]))
 
+_preset_algorithm_tags(alg) = Symbol[]
+
+function _known_alg_order(alg)
+    applicable(SciMLBase.alg_order, alg) || return nothing
+    try
+        return SciMLBase.alg_order(alg)
+    catch err
+        if err isa ErrorException && err.msg == "Order is not defined for this algorithm"
+            return nothing
+        end
+        rethrow()
+    end
+end
+
+_order_tag(order) = Symbol("order_", replace(string(order), "//" => "_", "." => "_"))
+
+"""
+    auto_tags(alg) -> Vector{Symbol}
+
+Return preset metadata tags derived from the public traits and type hierarchy of `alg`.
+Differential-equation algorithms receive an order tag such as `:order_5` (or
+`:order_3_2` for order `3 // 2`) when their order is defined, plus `:adaptive` or
+`:fixed_step`. When OrdinaryDiffEqCore is loaded, the result also describes known
+implicitness, families, and structural traits such as `:rosenbrock`, `:firk`, `:sdirk`,
+`:split`, and `:multistep`.
+
+Algorithms without applicable traits return an empty vector. [`WorkPrecision`](@ref)
+and [`WorkPrecisionSet`](@ref) merge these presets with explicit tags by default.
+"""
+auto_tags(alg) = Symbol[]
+function auto_tags(alg::AbstractDEAlgorithm)
+    presets = _preset_algorithm_tags(alg)
+    tags = Symbol[]
+    order = :variable_order in presets ? nothing : _known_alg_order(alg)
+    order === nothing || push!(tags, _order_tag(order))
+    push!(tags, SciMLBase.isadaptive(alg) ? :adaptive : :fixed_step)
+    append!(tags, presets)
+    return unique!(tags)
+end
+
+function _combined_tags(alg, tags, include_auto_tags)
+    combined = include_auto_tags ? auto_tags(alg) : Symbol[]
+    append!(combined, tags)
+    return unique!(combined)
+end
+
 function _timed_out(timeout, solve_time, name, abstol)
     (timeout === nothing || solve_time <= timeout) && return false
     @warn "$name exceeded the $(timeout)s timeout at abstol=$abstol " *
@@ -219,7 +265,8 @@ Base.lastindex(shoot::ShootoutSet) = lastindex(shoot.shootouts)
     WorkPrecision(
         prob, alg, abstols, reltols, dts = nothing;
         name = nothing, appxsol = nothing, error_estimate = :final,
-        numruns = 20, seconds = 2, tags = Symbol[], timeout = nothing, kwargs...
+        numruns = 20, seconds = 2, tags = Symbol[], auto_tags = true,
+        timeout = nothing, kwargs...
     )
 
 Measure error and execution time for `alg` at corresponding absolute and relative
@@ -229,6 +276,7 @@ inputs for plotting a work-precision diagram.
 
 Use `appxsol` as a numerical reference when the problem has no analytic solution.
 `tags` attaches metadata symbols used by [`filter_by_tags`](@ref) and the plot recipe.
+They are merged with [`auto_tags(alg)`](@ref) unless `auto_tags = false`.
 `timeout` gives a per-tolerance wall-clock budget in seconds; see
 [`WorkPrecisionSet`](@ref). Additional keyword arguments are forwarded to `solve`.
 """
@@ -262,10 +310,11 @@ end
 Build one [`WorkPrecision`](@ref) result for each solver configuration in `setups` so
 their work-precision curves can be compared. Each setup is a dictionary containing an
 `:alg` and may override the shared tolerances or fixed step sizes with `:abstols`,
-`:reltols`, or `:dts`, or its legend entry with `:name`. A `:tags` entry attaches
-metadata symbols to that setup's curve, which [`filter_by_tags`](@ref),
-[`best_of_families`](@ref), [`autoplot`](@ref) and the plot recipe use to build family
-and cross-family comparisons.
+`:reltols`, or `:dts`, or its legend entry with `:name`. Preset tags from
+[`auto_tags`](@ref) are attached by default and merged with any `:tags` entry. Set
+`:auto_tags => false` in a setup to use only its explicit tags. The resulting metadata
+is used by [`filter_by_tags`](@ref), [`best_of_families`](@ref), [`autoplot`](@ref),
+and the plot recipe to build family and cross-family comparisons.
 
 `error_estimates` requests several error metrics from a single run (for example
 `[:final, :l2, :L2]`), so plots for each metric can be drawn without re-solving; the
@@ -316,7 +365,7 @@ function WorkPrecision(
         numruns = 20, seconds = 2, timeout = nothing,
         timeseries_errors::Union{Bool, Nothing} = nothing,
         dense_errors::Union{Bool, Nothing} = nothing,
-        tags::Vector{Symbol} = Symbol[], kwargs...
+        tags::Vector{Symbol} = Symbol[], auto_tags::Bool = true, kwargs...
     )
     N = length(abstols)
     errors = Vector{Dict{Symbol, Float64}}(undef, N)
@@ -444,7 +493,8 @@ function WorkPrecision(
     end
     return WorkPrecision(
         prob, abstols, reltols, _dicts_to_structarray(errors),
-        times, dts, stats, name, error_estimate, N, tags
+        times, dts, stats, name, error_estimate, N,
+        _combined_tags(alg, tags, auto_tags)
     )
 end
 
@@ -455,7 +505,7 @@ function WorkPrecision(
         numruns = 20, seconds = 2, timeout = nothing,
         timeseries_errors::Union{Bool, Nothing} = nothing,
         dense_errors::Union{Bool, Nothing} = nothing,
-        tags::Vector{Symbol} = Symbol[], kwargs...
+        tags::Vector{Symbol} = Symbol[], auto_tags::Bool = true, kwargs...
     )
     N = length(abstols)
     errors = Vector{Dict{Symbol, Float64}}(undef, N)
@@ -583,7 +633,8 @@ function WorkPrecision(
     end
     return WorkPrecision(
         prob, abstols, reltols, _dicts_to_structarray(errors),
-        times, dts, stats, name, error_estimate, N, tags
+        times, dts, stats, name, error_estimate, N,
+        _combined_tags(alg, tags, auto_tags)
     )
 end
 
@@ -591,7 +642,8 @@ end
 function WorkPrecision(
         prob::NonlinearProblem, alg, abstols, reltols, dts = nothing; name = nothing,
         appxsol = nothing, error_estimate = :l2, numruns = 20, seconds = 2,
-        timeout = nothing, tags::Vector{Symbol} = Symbol[], kwargs...
+        timeout = nothing, tags::Vector{Symbol} = Symbol[], auto_tags::Bool = true,
+        kwargs...
     )
     N = length(abstols)
     errors = Vector{Dict{Symbol, Float64}}(undef, N)
@@ -654,7 +706,8 @@ function WorkPrecision(
 
     return WorkPrecision(
         prob, abstols, reltols, _dicts_to_structarray(errors),
-        times, dts, stats, name, error_estimate, N, tags
+        times, dts, stats, name, error_estimate, N,
+        _combined_tags(alg, tags, auto_tags)
     )
 end
 
@@ -691,6 +744,7 @@ function WorkPrecisionSet(
             timeseries_errors,
             dense_errors,
             tags = _setup_tags(setups[i]),
+            auto_tags = get(setups[i], :auto_tags, true),
             name = names[i], kwargs..., filtered_setup...
         )
     end
@@ -863,7 +917,10 @@ function WorkPrecisionSet(
                 prob, _abstols[i], _reltols[i],
                 _dicts_to_structarray(errors[i]),
                 times[:, i], _dts[i], stats, names[i], error_estimate, N,
-                _setup_tags(setups[i])
+                _combined_tags(
+                    setups[i][:alg], _setup_tags(setups[i]),
+                    get(setups[i], :auto_tags, true)
+                )
             )
             for i in 1:N
     ]
@@ -1015,7 +1072,10 @@ function WorkPrecisionSet(
         WorkPrecision(
                 prob, _abstols[i], _reltols[i], errors[i], times[:, i],
                 _dts[i], stats, names[i], error_estimate, N,
-                _setup_tags(setups[i])
+                _combined_tags(
+                    setups[i][:alg], _setup_tags(setups[i]),
+                    get(setups[i], :auto_tags, true)
+                )
             )
             for i in 1:N
     ]
@@ -1059,6 +1119,7 @@ function WorkPrecisionSet(
             timeseries_errors,
             dense_errors,
             tags = _setup_tags(setups[i]),
+            auto_tags = get(setups[i], :auto_tags, true),
             name = names[i], kwargs..., filtered_setup...
         )
     end

--- a/lib/DiffEqDevTools/test/tagging_tests.jl
+++ b/lib/DiffEqDevTools/test/tagging_tests.jl
@@ -1,5 +1,9 @@
 using OrdinaryDiffEq, DiffEqDevTools, Test
+using OrdinaryDiffEqFIRK: RadauIIA5
 using OrdinaryDiffEqLowOrderRK: Euler, Midpoint, BS3, DP5, RK4
+using OrdinaryDiffEqRosenbrock: Rosenbrock23
+using OrdinaryDiffEqSDIRK: KenCarp4, TRBDF2
+using StochasticDiffEqHighOrder: SRIW1
 using ODEProblemLibrary: prob_ode_linear
 
 prob = prob_ode_linear
@@ -15,20 +19,57 @@ setups = [
 ]
 wp_set = WorkPrecisionSet(prob, abstols, reltols, setups; dt = 1 / 2^4, numruns = 2)
 
+@testset "automatic algorithm tags" begin
+    for (alg, expected) in [
+            (Euler(), [:order_1, :fixed_step, :explicit]),
+            (DP5(), [:order_5, :adaptive, :explicit]),
+            (
+                Rosenbrock23(),
+                [:order_2, :adaptive, :implicit, :rosenbrock],
+            ),
+            (
+                TRBDF2(),
+                [:order_2, :adaptive, :implicit, :sdirk, :esdirk],
+            ),
+            (
+                KenCarp4(),
+                [:order_4, :adaptive, :implicit, :sdirk, :esdirk, :split],
+            ),
+            (RadauIIA5(), [:order_5, :adaptive, :implicit, :firk]),
+            (SRIW1(), [:order_3_2, :adaptive, :sde]),
+        ]
+        @test auto_tags(alg) == expected
+    end
+end
+
 @testset "tags reach the WorkPrecision entries" begin
     @test get_tags(wp_set) == [
-        [:rk, :fourth_order], [:rk, :fifth_order], [:rk, :third_order],
-        [:euler, :first_order, :reference], Symbol[],
+        [:order_4, :adaptive, :explicit, :rk, :fourth_order],
+        [:order_5, :adaptive, :explicit, :rk, :fifth_order],
+        [:order_3, :adaptive, :explicit, :rk, :third_order],
+        [:order_1, :fixed_step, :explicit, :euler, :first_order, :reference],
+        [:order_2, :adaptive, :explicit],
     ]
     @test unique_tags(wp_set) ==
-        sort([:rk, :fourth_order, :fifth_order, :third_order, :euler, :first_order, :reference])
+        sort(
+        [
+            :adaptive, :euler, :explicit, :fifth_order, :first_order, :fixed_step,
+            :fourth_order, :order_1, :order_2, :order_3, :order_4, :order_5, :reference,
+            :rk, :third_order,
+        ]
+    )
 
     wp = WorkPrecision(
         prob, DP5(), abstols, reltols; name = "DP5", numruns = 2,
         tags = [:rk, :fifth_order]
     )
-    @test wp.tags == [:rk, :fifth_order]
-    @test isempty(WorkPrecision(prob, DP5(), abstols, reltols; numruns = 2).tags)
+    @test wp.tags == [:order_5, :adaptive, :explicit, :rk, :fifth_order]
+    @test WorkPrecision(prob, DP5(), abstols, reltols; numruns = 2).tags ==
+        [:order_5, :adaptive, :explicit]
+    @test WorkPrecision(
+        prob, DP5(), abstols, reltols; numruns = 2,
+        tags = [:manual], auto_tags = false
+    ).tags == [:manual]
 end
 
 @testset "filter_by_tags" begin
@@ -58,7 +99,8 @@ end
     merged = merge_wp_sets(filter_by_tags(wp_set, :euler), filter_by_tags(wp_set, :rk))
     @test length(merged) == 4
     @test merged.names == ["Euler", "RK4", "DP5", "BS3"]
-    @test get_tags(merged)[1] == [:euler, :first_order, :reference]
+    @test get_tags(merged)[1] ==
+        [:order_1, :fixed_step, :explicit, :euler, :first_order, :reference]
     @test available_errors(merged) == available_errors(wp_set)
     @test_throws ArgumentError merge_wp_sets()
 end

--- a/lib/DiffEqDevTools/test/wp_selection_tests.jl
+++ b/lib/DiffEqDevTools/test/wp_selection_tests.jl
@@ -70,8 +70,10 @@ end
     end
 
     @testset "auto-detected families" begin
-        # :rk is on 4/5 entries, :fifth_order on 2/5; a tag on every entry is dropped
-        @test DiffEqDevTools._auto_detect_families(wp_set) == unique_tags(wp_set)
+        # :rk is on 4/5 entries, :fifth_order on 2/5; :explicit is on every entry
+        # and is therefore dropped.
+        @test DiffEqDevTools._auto_detect_families(wp_set) ==
+            filter(!=(:explicit), unique_tags(wp_set))
         uniform = filter_by_tags(wp_set, :rk)
         @test :rk ∉ DiffEqDevTools._auto_detect_families(uniform)
         @test haskey(autoplot(wp_set), "family_fifth_order")
@@ -118,7 +120,10 @@ end
             ); numruns = 2
         )
         @test ad_set.names == ["Rosenbrock23", "Rosenbrock23 (FiniteDiff)"]
-        @test get_tags(ad_set) == [[:autodiff_default], [:autodiff_finitediff]]
+        @test get_tags(ad_set) == [
+            [:order_2, :adaptive, :implicit, :rosenbrock, :autodiff_default],
+            [:order_2, :adaptive, :implicit, :rosenbrock, :autodiff_finitediff],
+        ]
         @test ad_set.setups[2][:alg].autodiff isa AutoFiniteDiff
     end
 end


### PR DESCRIPTION
## What changed and why

Add `auto_tags(alg)` so work-precision entries receive stable tags derived from public algorithm traits and supertypes: order, adaptivity, implicitness, equation kind, and known families such as Rosenbrock, FIRK, ESDIRK, split, exponential, partitioned, composite, Adams, and multistep. Explicit `:tags` remain additive, while `:auto_tags => false` (or `auto_tags = false` for `WorkPrecision`) preserves a manual-only path.

This is a follow-up to https://github.com/SciML/OrdinaryDiffEq.jl/pull/3287 and addresses the preset-tag request in https://github.com/SciML/DiffEqDevTools.jl/issues/177. The new public API is documented in both rendered documentation entrypoints, and the `DiffEqDevTools` minor version is bumped from 3.4.0 to 3.5.0.

## Verification

Before the change, the focused contract failed as expected:

```text
UndefVarError: `auto_tags` not defined in `DiffEqDevTools`
```

Full local validation was run after the implementation and again after the first upstream rebase:

```text
GROUP=Core julia +release --project=lib/DiffEqDevTools -e 'using Pkg; Pkg.test()'

Analyticless Stochastic WP |    2      2  45m04.3s
Tagging                   |   32     32       9.2s
Best-of-Family Selection  |   40     40       9.2s
Testing DiffEqDevTools tests passed
```

```text
GROUP=QA julia +release --project=lib/DiffEqDevTools -e 'using Pkg; Pkg.test()'

Aqua | 15  15  50.9s
Testing DiffEqDevTools tests passed
```

```text
julia +release --project=docs -e 'using Pkg; Pkg.resolve(); include("docs/make.jl")'

SetupBuildDirectory
Doctest
CheckDocument
RenderDocument
exit code 0
```

After the final disjoint upstream rebase to `724ffe9097`, the feature diff was unchanged and the focused trait/extension checks were rerun:

```text
auto_tags(GenericAlg()) = [:order_5, :adaptive]
auto_tags(SRIW1()) = [:order_3_2, :adaptive, :sde]
```

These pre-push checks also exited cleanly:

```text
julia --project=@runic -e 'using Runic; exit(Runic.main(["--check", "lib/DiffEqDevTools/src", "lib/DiffEqDevTools/ext", "lib/DiffEqDevTools/test/tagging_tests.jl", "lib/DiffEqDevTools/test/wp_selection_tests.jl"]))'
typos docs/src/devtools/alg_dev/benchmarks.md lib/DiffEqDevTools
git diff upstream/master...HEAD --check
```

## Review notes

- Automatic tags change the default metadata attached to new `WorkPrecision`/`WorkPrecisionSet` results, which can change `autoplot` family discovery. The explicit opt-out is intentional for benchmarks that require an exact manual taxonomy.
- `OrdinaryDiffEqCore` is added only as a weak dependency and extension trigger. It is MIT-licensed within this repository, so this does not introduce or un-gate a copyleft dependency.
- GPU, downstream, Julia pre-release, and `GROUP=Everything` jobs were not run locally.

Please ignore this draft until it has been reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03caf-aae8-74c3-9a79-53b836434858
