### PR TITLE
test: compare W-prototype solutions on a common grid

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/test/wprototype_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/wprototype_tests.jl
@@ -49,20 +49,21 @@ for prob in (prob_ode_vanderpol_stiff,)
         end
 
         # Run solves
-        sol = solve(prob, alg)
-        sol_J = solve(prob_J, alg) # note: direct linsolve in this case is broken, see #1998
-        sol_W = solve(prob_W, alg)
+        sol = solve(prob, alg; abstol = 1.0e-7, reltol = 1.0e-4)
+        sol_J = solve(prob_J, alg; abstol = 1.0e-7, reltol = 1.0e-4) # note: direct linsolve in this case is broken, see #1998
+        sol_W = solve(prob_W, alg; abstol = 1.0e-7, reltol = 1.0e-4)
 
         rtol = 1.0e-2
 
         @test prob_J.f.sparsity.A == prob_W.f.sparsity.A
 
-        @test all(isapprox.(sol_J.t, sol_W.t; rtol))
-        @test all(isapprox.(sol_J.u, sol_W.u; rtol))
+        solutions = (sol, sol_J, sol_W)
+        @test all(s -> first(s.t) == first(prob.tspan) && last(s.t) == last(prob.tspan), solutions)
 
-        @test all(isapprox.(sol_J.t, sol.t; rtol))
-        @test all(isapprox.(sol_J.u, sol.u; rtol))
-        @test all(isapprox.(sol_W.t, sol.t; rtol))
-        @test all(isapprox.(sol_W.u, sol.u; rtol))
+        # Adaptive solutions can select distinct grids, so compare every saved time from their union.
+        sample_times = sort!(unique!(vcat(sol.t, sol_J.t, sol_W.t)))
+        for (left, right) in ((sol_J, sol_W), (sol_J, sol), (sol_W, sol))
+            @test all(t -> isapprox(left(t), right(t); rtol), sample_times)
+        end
     end
 end


### PR DESCRIPTION
## Summary

Compare the W-prototype test's independently adaptive solutions through their dense interpolants on the union of all saved times. Require every solve to cover the full problem interval and use tighter solve tolerances so the existing `rtol = 1e-2` comparison remains discriminating.

This fixes a clean-master test failure without changing solver code, aligning time grids, truncating data, or loosening an assertion.

Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## Root cause

Commit https://github.com/SciML/OrdinaryDiffEq.jl/commit/e1065b27dfc2136dbab8f80a83152cfc51b3ec5c added direct broadcast comparisons between adaptive solutions' saved `t` and `u` vectors. That assumption remained latent while the three formulations happened to save on matching grids.

Commit https://github.com/SciML/OrdinaryDiffEq.jl/commit/4bb84954086103d6a3a472673cee84db18b7c816 from https://github.com/SciML/OrdinaryDiffEq.jl/pull/4192 corrected the differentiation path and exposed the invalid test assumption: the FBDF base, Jacobian-prototype, and W-prototype solves now save 262, 261, and 264 points respectively. Distinct adaptive grids are valid; the state trajectories, rather than the storage layout, are what this test needs to compare.

## Failing before the fix

Running the W-prototype test from clean master with the current dependency stack produced:

```text
DimensionMismatch: arrays could not be broadcast to a common size:
a has axes Base.OneTo(261) and b has axes Base.OneTo(264)
```

The same focused test with the union-grid comparison but the original default solve tolerances also fails its unchanged `rtol = 1e-2` assertion. This verifies that the explicit `abstol = 1e-7, reltol = 1e-4` solve tolerances are required; they are not incidental churn.

## Verification after the fix

- Focused exact-head run:
  `julia --project=<local-focused-env> -e 'include("lib/OrdinaryDiffEqNonlinearSolve/test/wprototype_tests.jl")'`
  exited 0.
- Full package group:
  `GROUP=Core julia --project=lib/OrdinaryDiffEqNonlinearSolve -e 'using Pkg; Pkg.test()'`
  reached `W-Operator Prototype Tests | 14 | 14` and ended with `Testing OrdinaryDiffEqNonlinearSolve tests passed`. This ran before the final rebase; the three intervening upstream commits do not touch this sublibrary's source, project, or tests.
- Exact rebased QA:
  `GROUP=QA julia --project=lib/OrdinaryDiffEqNonlinearSolve -e 'using Pkg; Pkg.test()'`
  completed JET with 13 passes and 33 existing broken cases, Aqua with 41/41 passes, and package exit 0.
- Runic check passed for the changed test file.
- `typos lib/OrdinaryDiffEqNonlinearSolve/test/wprototype_tests.jl` passed.
- `git diff --check upstream/master...HEAD` passed.

## Not verified

Julia `pre`, downstream, and GPU jobs were not run locally. Documentation was not built because this PR changes only an internal test and no public API or docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
