### PR TITLE
Accept stochastic caches in nlsolve!

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.9.1"
+version = "2.9.2"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/nlsolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/nlsolve.jl
@@ -115,7 +115,7 @@ function nlsolve!(
         # Checking the type, not just `nothing`: passing something else entirely
         # in this slot went unnoticed because `update_W!` happens not to read it
         # on the out-of-place path.
-        cache isa Union{OrdinaryDiffEqCore.OrdinaryDiffEqCache, Nothing} ||
+        cache isa Union{SciMLBase.DECache, Nothing} ||
             throw(
             ArgumentError(
                 "`nlsolve!` expects the integrator cache in its third argument, got a " *

--- a/lib/StochasticDiffEq/test/events_test.jl
+++ b/lib/StochasticDiffEq/test/events_test.jl
@@ -113,7 +113,9 @@ affect2!(integrator) = integrator.u[4] = integrator.u[4] - params.gSyn; # Inhibi
 cb = ContinuousCallback(condition2, affect2!, nothing);
 prob = SDEProblem(HM_neuron!, HM_noise!, x0, (0.0, 1999.9), params);
 sol = solve(prob, ImplicitEM(), reltol = 1.0e-4, abstol = 1.0e-6, dense = true, callback = cb);
+@test SciMLBase.successful_retcode(sol)
 sol = solve(prob, SKenCarp(), reltol = 1.0e-4, abstol = 1.0e-6, dense = true, callback = cb);
+@test SciMLBase.successful_retcode(sol)
 
 using DiffEqCallbacks
 


### PR DESCRIPTION
> Ignore this draft until it has been reviewed by @ChrisRackauckas.

## What changed

OrdinaryDiffEqNonlinearSolve.nlsolve! is also used by StochasticDiffEq, whose integrator caches subtype the public common SciMLBase.DECache abstraction rather than OrdinaryDiffEqCache. The cache-slot validation added in https://github.com/SciML/OrdinaryDiffEq.jl/pull/4352 therefore rejected valid ISSEMCache, ImplicitEMCache, and ImplicitEMConstantCache values.

This accepts SciMLBase.DECache while continuing to reject non-cache values, bumps OrdinaryDiffEqNonlinearSolve to 2.9.2, and adds explicit successful-retcode assertions to the implicit event solves.

## Regression identification

The first bad commit is https://github.com/SciML/OrdinaryDiffEq.jl/commit/e4f0c5ebbb4ef8a29dfb7e66477df37bfef77390. Before that commit, the downstream Interface3 job passed with OrdinaryDiffEqNonlinearSolve 2.9.0; after it, the new OrdinaryDiffEqCache guard rejected StochasticDiffEq caches. SciMLBase's PR and master jobs have identical failures and the same solver package versions, so this is not caused by the SciMLBase change under test.

## Verification

I reproduced all four failures on clean current SciMLBase master from the StochasticDiffEq test environment:

    GROUP=Interface1 julia +1.12 --project=lib/StochasticDiffEq -e 'using Pkg; Pkg.test()'
    # Default Solver Tests | 5 pass, 1 error, 6 total
    # ArgumentError: nlsolve! ... got ... ISSEMCache

    GROUP=Interface2 julia +1.12 --project=lib/StochasticDiffEq -e 'using Pkg; Pkg.test()'
    # Basic Tau Leaping Tests | 1 pass, 1 error, 2 total
    # ArgumentError: nlsolve! ... got ... ImplicitEMCache

    GROUP=Interface3 julia +1.12 --project=lib/StochasticDiffEq -e 'using Pkg; Pkg.test()'
    # Events Tests | 9 pass, 1 error, 10 total
    # ArgumentError: nlsolve! ... got ... ImplicitEMCache

    GROUP=AlgConvergence julia +1.12 --project=lib/StochasticDiffEq -e 'using Pkg; Pkg.test()'
    # Convergence Tests | 0 pass, 1 error, 1 total
    # ArgumentError: nlsolve! ... got ... ImplicitEMConstantCache

With this commit, the same full groups pass:

    Interface1: Default Solver Tests | 8 pass, 8 total
                Testing StochasticDiffEq tests passed
    Interface2: Basic Tau Leaping Tests | 15 pass, 15 total
                Testing StochasticDiffEq tests passed
    Interface3: Events Tests | 14 pass, 14 total
                Testing StochasticDiffEq tests passed
    AlgConvergence: Convergence Tests | 93 pass, 93 total
                    Testing StochasticDiffEq tests passed

Additional local checks:

    GROUP=QA ... --project=lib/OrdinaryDiffEqNonlinearSolve
    JET Tests | 13 pass, 33 broken, 46 total
    Aqua      | 41 pass, 41 total
    Testing OrdinaryDiffEqNonlinearSolve tests passed

    GROUP=QA ... --project=lib/StochasticDiffEq
    Testing StochasticDiffEq tests passed

    Runic --check --diff .: passed
    typos .: passed
    git diff --check: passed

The full GROUP=Core OrdinaryDiffEqNonlinearSolve run was also attempted with a one-hour timeout. Developer API, Newton, sparse DAE initialization, linear nonlinear solver, linear solver, and split-ODE testsets passed; the run reached mass_matrix_tests.jl but did not finish before the timeout. I did not run GROUP=Everything, Julia LTS/pre, GPU groups, or docs. Docs were not run because this changes no docs, docstrings, or public API.

Reviewer judgment: accepting every SciMLBase.DECache intentionally uses the shared public cache contract. It preserves the guard against the non-cache third argument that motivated https://github.com/SciML/OrdinaryDiffEq.jl/pull/4352.

## Links

- SciMLBase issue: https://github.com/SciML/SciMLBase.jl/issues/1551
- Introducing commit: https://github.com/SciML/OrdinaryDiffEq.jl/commit/e4f0c5ebbb4ef8a29dfb7e66477df37bfef77390
- Introducing PR: https://github.com/SciML/OrdinaryDiffEq.jl/pull/4352
- Earlier passing Interface3 job: https://github.com/SciML/SciMLBase.jl/actions/runs/32881086199/job/97910507370
- Interface1 PR job: https://github.com/SciML/SciMLBase.jl/actions/runs/32941912220/job/98094430661
- Interface1 master job: https://github.com/SciML/SciMLBase.jl/actions/runs/32932330417/job/98066818055
- Interface2 PR job: https://github.com/SciML/SciMLBase.jl/actions/runs/32941912220/job/98094430685
- Interface2 master job: https://github.com/SciML/SciMLBase.jl/actions/runs/32932330417/job/98066818323
- Interface3 PR job: https://github.com/SciML/SciMLBase.jl/actions/runs/32941912220/job/98094430225
- Interface3 master job: https://github.com/SciML/SciMLBase.jl/actions/runs/32932330417/job/98066818556
- AlgConvergence PR job: https://github.com/SciML/SciMLBase.jl/actions/runs/32941912220/job/98094430569
- AlgConvergence master job: https://github.com/SciML/SciMLBase.jl/actions/runs/32932330417/job/98066817974

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03c36-0ac6-7311-82e4-20b12ea6f040
