### PR TITLE
DiffEqDevTools: preserve ensemble work-precision error names

### DIFF
--- a/lib/DiffEqDevTools/src/benchmark.jl
+++ b/lib/DiffEqDevTools/src/benchmark.jl
@@ -1070,7 +1070,9 @@ function WorkPrecisionSet(
     stats = nothing
     wps = [
         WorkPrecision(
-                prob, _abstols[i], _reltols[i], errors[i], times[:, i],
+                prob, _abstols[i], _reltols[i],
+                _dicts_to_structarray([Dict(error_estimate => err) for err in errors[i]]),
+                times[:, i],
                 _dts[i], stats, names[i], error_estimate, N,
                 _combined_tags(
                     setups[i][:alg], _setup_tags(setups[i]),

--- a/lib/DiffEqDevTools/test/analyticless_stochastic_wp.jl
+++ b/lib/DiffEqDevTools/test/analyticless_stochastic_wp.jl
@@ -130,7 +130,7 @@ wp2 = @time WorkPrecisionSet(
     trajectories = numtraj, error_estimate = :weak_final
 )
 
-err1 = [wp1.wps[i].errors for i in 1:length(setups)]
-err2 = [wp2.wps[i].errors for i in 1:length(setups)]
+err1 = [wp1.wps[i].errors.weak_final for i in 1:length(setups)]
+err2 = [wp2.wps[i].errors.weak_final for i in 1:length(setups)]
 
 @test isapprox(err1, err2, atol = 1.0e-3)

--- a/lib/DiffEqDevTools/test/plotrecipes_tests.jl
+++ b/lib/DiffEqDevTools/test/plotrecipes_tests.jl
@@ -171,3 +171,27 @@ end
         @test plt[1][i][:label] == names[i]
     end
 end
+
+@testset "Ensemble weak WorkPrecisionSet" begin
+    f!(du, u, p, t) = (du[1] = -u[1]; nothing)
+    g!(du, u, p, t) = (du[1] = u[1]; nothing)
+    prob = SDEProblem(f!, g!, [1.0], (0.0, 0.1))
+    seeds = rand(UInt, 4)
+    ensemble_prob = EnsembleProblem(
+        prob;
+        output_func = (sol, ctx) -> (sol.u[end][1], false),
+        prob_func = (prob, ctx) -> remake(prob; seed = seeds[ctx.sim_id])
+    )
+    tolerances = 1.0 ./ 4.0 .^ (1:2)
+    setups = [Dict(:alg => EM(), :dts => [0.05, 0.025], :adaptive => false)]
+    wp = WorkPrecisionSet(
+        ensemble_prob, tolerances, tolerances, setups;
+        numruns = 1, trajectories = 4, expected_value = exp(-0.1),
+        save_everystep = false, save_start = false, error_estimate = :weak_final,
+        ensemblealg = EnsembleSerial()
+    )
+
+    @test propertynames(wp[1].errors) == (:weak_final,)
+    plt = plot(wp)
+    @test plt[1][1][:x] == wp[1].errors.weak_final
+end


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

Ensemble `WorkPrecisionSet` construction now stores each weak-error vector in the same structured error representation used by the other constructors. The plotting recipe selects an error series by property name, so the previous raw `Vector{Float64}` made every ensemble weak-error plot fail with `Key weak_final does not specify a valid property of WorkPrecision`.

The regression test checks both the stored `weak_final` property and the x data produced by `plot(wp)`. Existing analyticless stochastic comparisons now select that property explicitly.

This addresses the ensemble plotting half of https://github.com/SciML/SciMLBenchmarks.jl/issues/1662. It does not address that issue's separate `PL1WM` failure.

Historical source bisection identifies https://github.com/SciML/DiffEqDevTools.jl/commit/3513711b9073fe0ba399e835f7cfc69d56c4f9a4 as the introducing commit: the plot recipe began selecting `getproperty(wp.errors, wp.error_estimate)`, while the ensemble constructor continued storing raw vectors.

## Verification

Julia 1.11.9, DiffEqDevTools 3.5.0 from this checkout, StochasticDiffEq 7.1.5, Plots 1.41.7.

The exact new regression test logic on clean pre-fix `master` (`4e29f1a4ff7e3facbffcbdf6ca5f6a81c79ce7e9`) fails before the source fix:

```text
ArgumentError: Key weak_final does not specify a valid property of WorkPrecision
Test Summary:                  | Fail  Error  Total   Time
Ensemble weak WorkPrecisionSet |    1      1      2  16.2s
exit=1
```

The same test passes after the fix:

```text
Test Summary:                  | Pass  Total   Time
Ensemble weak WorkPrecisionSet |    2      2  14.6s
exit=0
```

The benchmark-shaped standalone reproducer also changes from the same `ArgumentError` on clean `master` and registered DiffEqDevTools 3.4.0 to:

```text
errors_type=StructArrays.StructVector{@NamedTuple{weak_final::Float64}, @NamedTuple{weak_final::Vector{Float64}}, Int64}
error_properties=(:weak_final,)
plot=success
```

Additional checks:

```text
$ GROUP=Core julia +1.11.9 --startup-file=no --project=lib/DiffEqDevTools -e 'using Pkg; Pkg.test()'
Test Summary:                             | Pass  Total      Time
Benchmark Tests                           |   15     15   5m36.3s
ODE AppxTrue Tests                        |    7      7       6.3s
Analyticless Convergence Tests            |    7      7   8m43.0s
Analyticless Stochastic WP                |    2      2  31m27.0s
Convergence retain_solutions              |   35     35      13.8s
Stability Region Tests                    |    7      7      17.4s
Plot Recipes                              |   58     58   4m53.1s
Plot Recipes (Nonlinearsolve WP-diagrams) |    6      6       9.5s
Tagging                                   |   32     32       4.7s
Multiple Error Estimates                  |   12     12       2.0s
Best-of-Family Selection                  |   40     40       9.5s
Timeout                                   |    7      7       4.0s
Testing DiffEqDevTools tests passed

$ GROUP=QA julia +1.11.9 --startup-file=no --project=lib/DiffEqDevTools -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total   Time
Aqua          |   15     15  31.1s
Testing DiffEqDevTools tests passed

$ julia +1.11.9 --project=../.runic-env -e 'using Runic; exit(Runic.main(ARGS))' -- --check --diff <changed files>
exit=0

$ git diff HEAD^ -- <changed files> | typos --format brief -
exit=0

$ git diff --check HEAD^
exit=0
```

Documentation was not built because this changes neither public API nor documentation. GPU and downstream tests were not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
