### PR TITLE
Move nonlinear cache guard test to owning sublibrary

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/test/developer_api_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/developer_api_tests.jl
@@ -67,6 +67,18 @@ const ExternalClient = ExternalNonlinearSolverClient
     @test ExternalClient.markfirststage!(newton) === nothing
     @test ExternalClient.isfirststage(newton)
 
+    oop_newton_integrator = ExternalClient.init(
+        oop_prob, ExternalClient.ImplicitEuler(); dt = 0.1, adaptive = false
+    )
+    oop_newton = ExternalClient.build_solver(
+        oop_prob, ExternalClient.NLNewton(), Val(false)
+    )
+    for invalid_cache in (0.5, nothing)
+        @test_throws ArgumentError ExternalClient.nlsolve!(
+            oop_newton, oop_newton_integrator, invalid_cache, false
+        )
+    end
+
     @test !ExternalClient.nlsolvefail(ExternalClient.FastConvergence)
     @test !ExternalClient.nlsolvefail(ExternalClient.Convergence)
     @test ExternalClient.nlsolvefail(ExternalClient.SlowConvergence)

--- a/lib/OrdinaryDiffEqPDIRK/test/nlsolve_argument_tests.jl
+++ b/lib/OrdinaryDiffEqPDIRK/test/nlsolve_argument_tests.jl
@@ -1,13 +1,7 @@
 using OrdinaryDiffEqPDIRK
-using OrdinaryDiffEqCore
-using OrdinaryDiffEqNonlinearSolve: nlsolve!
 using SciMLBase
 using Test
 
-# The out-of-place branch used to pass `γ * dt` where `nlsolve!` takes the
-# integrator cache. Nothing complained: the `NLNewton` guard only rejected
-# `nothing`, and `update_W!` happens not to read that argument on the
-# out-of-place path. Both halves are covered here.
 @testset "PDIRK44 out-of-place agrees with in-place" begin
     oop = ODEProblem((u, p, t) -> -u * (1 + 0.1u), 1.0, (0.0, 1.0))
     iip = ODEProblem((du, u, p, t) -> (du[1] = -u[1] * (1 + 0.1u[1]); nothing), [1.0], (0.0, 1.0))
@@ -17,12 +11,4 @@ using Test
         @test SciMLBase.successful_retcode(a)
         @test a.u[end] ≈ b.u[end][1] rtol = 1.0e-10
     end
-end
-
-@testset "nlsolve! rejects a third argument that is not a cache" begin
-    prob = ODEProblem((du, u, p, t) -> (du[1] = -u[1]; nothing), [1.0], (0.0, 1.0))
-    integrator = init(prob, PDIRK44(threading = false); dt = 0.1, adaptive = false)
-    nlsolver = first(integrator.cache.nlsolver)
-    @test_throws ArgumentError nlsolve!(nlsolver, integrator, 0.5, false)
-    @test_throws ArgumentError nlsolve!(nlsolver, integrator, nothing, false)
 end


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What changed

Move the `nlsolve!` invalid-cache guard assertions from the PDIRK tests to the `OrdinaryDiffEqNonlinearSolve` developer-API tests that own the guard. PDIRK's out-of-place cache fix is compatible with `OrdinaryDiffEqNonlinearSolve` 2.0.0, but the direct guard assertion added with that fix requires the guard introduced in 2.9.1. Keeping the assertion in PDIRK therefore made the minimum-version job test dependency behavior newer than PDIRK's valid compat range.

The PDIRK suite retains its four end-to-end out-of-place/in-place comparisons. This does not change source code, compat, or public API.

## Regression evidence

I reproduced the CI environment with `julia-actions/julia-downgrade-compat` at commit `30b83cf94e89744fcbd7ea5496be4967d6fbe540`. It selected `OrdinaryDiffEqCore` 4.6.0, `OrdinaryDiffEqDifferentiation` 3.3.0, and `OrdinaryDiffEqNonlinearSolve` 2.0.0.

Before this patch, the downgraded PDIRK test failed:

```text
Test Summary:                                           | Pass  Fail  Total
nlsolve! Arguments                                      |    5     1      6
  Expected: ArgumentError
  No exception thrown
```

After this patch, the same command passed:

```text
Test Summary:     | Pass  Total
Convergence Tests |    4      4
Test Summary:      | Pass  Total
nlsolve! Arguments |    4      4
Testing OrdinaryDiffEqPDIRK tests passed
```

The relocated test also discriminates the nonlinear-solver guard itself. With the guard temporarily reverted from `OrdinaryDiffEqNonlinearSolve/src/nlsolve.jl`, the focused test failed 22/23 with `No exception thrown`; with the guard restored, the same test passed 23/23.

## Verification

- Downgraded PDIRK Core: 8/8 passed.
- Current PDIRK Core: 8/8 passed.
- PDIRK QA: JET 1/1 and Aqua 21/21 passed; the existing allocation test remained expected-broken.
- Focused `OrdinaryDiffEqNonlinearSolve/test/developer_api_tests.jl`: 23/23 passed.
- OrdinaryDiffEqNonlinearSolve QA: JET 13 passed with 33 existing expected-broken tests; Aqua 41/41 passed.
- Runic 1.9.0 check passed on both changed files.
- `typos` and `git diff --check` passed.

The full OrdinaryDiffEqNonlinearSolve Core group was attempted twice. The shared-depot run reached the 3,600-second Bash timeout amid package-cache contention from concurrent worktrees. A clean isolated-depot run advanced past the changed developer-API test and remained CPU-active in the pre-existing `linear_solver_tests.jl` `g_helper` solve until the 3,600-second Bash timeout. I did not verify that full group to completion. Docs were not run because this is test-only and changes no documentation or public API; GPU and downstream jobs were not run locally.

The first commit containing the misplaced assertion was https://github.com/SciML/OrdinaryDiffEq.jl/commit/e4f0c5ebbb4ef8a29dfb7e66477df37bfef77390, from https://github.com/SciML/OrdinaryDiffEq.jl/pull/4352. The reproduced CI failure is https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33001678312/job/98308409387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
