### PR TITLE
Fix SIMDRK with despecialized parameters

### DIFF
--- a/lib/OrdinaryDiffEqSIMDRK/src/OrdinaryDiffEqSIMDRK.jl
+++ b/lib/OrdinaryDiffEqSIMDRK/src/OrdinaryDiffEqSIMDRK.jl
@@ -5,7 +5,7 @@ using FastBroadcast: Serial
 using OrdinaryDiffEqCore: OrdinaryDiffEqAdaptiveAlgorithm, OrdinaryDiffEqConstantCache,
     trivial_limiter!, calculate_residuals, constvalue
 import OrdinaryDiffEqCore: initialize!, perform_step!, alg_cache
-using SciMLBase: ODEFunction
+using SciMLBase: DespecializedParameters, ODEFunction, invoke_with_despecialized_parameters
 
 using Reexport: @reexport
 @reexport using OrdinaryDiffEqCore

--- a/lib/OrdinaryDiffEqSIMDRK/src/perform_step.jl
+++ b/lib/OrdinaryDiffEqSIMDRK/src/perform_step.jl
@@ -43,9 +43,17 @@ end
 
 # pirate
 @inline function (f::ODEFunction)(
-        v::AbstractArray{<:VectorizationBase.AbstractSIMD}, args...
+        v::AbstractArray{<:VectorizationBase.AbstractSIMD}, p, t
     )
-    return @inline f.f(v, args...)
+    return @inline f.f(v, p, t)
+end
+
+@inline function (f::ODEFunction)(
+        v::AbstractArray{<:VectorizationBase.AbstractSIMD},
+        p::DespecializedParameters,
+        t
+    )
+    return @inline invoke_with_despecialized_parameters(f.f, (v, p, t))
 end
 
 @muladd function perform_step!(

--- a/lib/OrdinaryDiffEqSIMDRK/test/despecialized_parameters_tests.jl
+++ b/lib/OrdinaryDiffEqSIMDRK/test/despecialized_parameters_tests.jl
@@ -1,0 +1,11 @@
+using OrdinaryDiffEqSIMDRK, Test
+using SciMLBase: AutoDespecialize, ODEProblem, solve, successful_retcode
+
+f(u, p, t) = p[1] .* u
+prob = ODEProblem{false, AutoDespecialize}(f, [1.0], (0.0, 1.0), [1.0])
+
+for alg in (MER5v2(), MER6v2(), RK6v4())
+    sol = solve(prob, alg)
+    @test successful_retcode(sol)
+    @test only(sol.u[end]) ≈ exp(1) rtol = 1.0e-5
+end

--- a/lib/OrdinaryDiffEqSIMDRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqSIMDRK/test/runtests.jl
@@ -15,6 +15,9 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "Adaptivity Tests" begin
         include("adaptivity_tests.jl")
     end
+    @time @safetestset "Despecialized Parameters" begin
+        include("despecialized_parameters_tests.jl")
+    end
 end
 
 # Run QA tests (AllocCheck, JET) - skip on pre-release Julia


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What changed

Resolve SIMDRK's `ODEFunction` call ambiguity with `AutoDespecialize` parameters. The existing SIMD-array overload is narrowed from arbitrary trailing arguments to the three-argument out-of-place call that SIMDRK actually makes, and the intersection with `SciMLBase.DespecializedParameters` forwards through SciMLBase's public `invoke_with_despecialized_parameters` barrier.

The regression test solves the same `AutoDespecialize` problem with `MER5v2`, `MER6v2`, and `RK6v4`. This adds no public API, dependency, or compatibility change.

## Failing before / passing after

The focused test failed on unmodified master:

```text
ERROR: MethodError: (::ODEFunction)(
    ::Vector{VectorizationBase.Vec{2, Float64}},
    ::SciMLBase.DespecializedParameters,
    ::VectorizationBase.Vec{2, Float64}
) is ambiguous.

Candidates:
  (f::ODEFunction)(v::AbstractArray{<:VectorizationBase.AbstractSIMD}, args...)
  (f::ODEFunction)(u, p::SciMLBase.DespecializedParameters, t)
```

With the fix applied, the identical test file passes:

```text
Test Summary:            | Pass  Total   Time
Despecialized Parameters |    6      6  12.7s
```

The exact reported `MER5v2` reproducer now returns:

```text
sol.retcode = SciMLBase.ReturnCode.Success
sol.u[end] = [2.718281085165132]
```

An executable bisect identified https://github.com/SciML/OrdinaryDiffEq.jl/commit/6f9ca9a9b3c29520dca5d6cfe32cd1bcf89abf14 as the first bad commit. Its parent solves successfully. That commit introduced the generic `AutoDespecialize` path and exposed the pre-existing SIMDRK SIMD overload's method intersection.

## Verification

```text
GROUP=Core julia +1.11.9 --project=lib/OrdinaryDiffEqSIMDRK -e 'using Pkg; Pkg.test()'
Convergence Tests          | 3 / 3
Adaptivity Tests           | 3 / 3
Despecialized Parameters   | 6 / 6
Testing OrdinaryDiffEqSIMDRK tests passed

GROUP=QA julia +1.11.9 --project=lib/OrdinaryDiffEqSIMDRK -e 'using Pkg; Pkg.test()'
Allocation Tests           | 2 existing broken / 2
JET Tests                  | 1 / 1
Testing OrdinaryDiffEqSIMDRK tests passed
```

`Test.detect_ambiguities(OrdinaryDiffEqSIMDRK, SciMLBase; recursive = true)` reports zero ambiguities after the fix. Runic 1.9.0, `typos`, and `git diff --check` pass on the final diff.

Docs were not run because no public API or documentation changed. GPU jobs, the external NonStiffODE benchmark, and other downstream packages were not run locally.

The introducing change was https://github.com/SciML/OrdinaryDiffEq.jl/pull/4216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
