### PR TITLE
Release the leaf solver sub-libraries reexporting the SciMLBase common interface

### DIFF
--- a/lib/OrdinaryDiffEqDefault/Project.toml
+++ b/lib/OrdinaryDiffEqDefault/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqDefault"
 uuid = "50262376-6c5a-4cf5-baba-aaf4f84d72d7"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.5.0"
+version = "2.6.0"
 
 [deps]
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"

--- a/lib/OrdinaryDiffEqExtrapolation/Project.toml
+++ b/lib/OrdinaryDiffEqExtrapolation/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExtrapolation"
 uuid = "becaefa8-8ca2-5cf9-886d-c06f3d2bd2c4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.5.0"
+version = "2.6.0"
 
 [deps]
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"

--- a/lib/OrdinaryDiffEqIMEXMultistep/Project.toml
+++ b/lib/OrdinaryDiffEqIMEXMultistep/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqIMEXMultistep"
 uuid = "9f002381-b378-40b7-97a6-27a27c83f129"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.0"
+version = "2.3.0"
 
 [deps]
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"

--- a/lib/OrdinaryDiffEqPDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqPDIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqPDIRK"
 uuid = "5dd0a6cf-3d4b-4314-aa06-06d4e299bc89"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.4.1"
+version = "2.5.0"
 
 [deps]
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"

--- a/lib/OrdinaryDiffEqQPRK/Project.toml
+++ b/lib/OrdinaryDiffEqQPRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqQPRK"
 uuid = "04162be5-8125-4266-98ed-640baecc6514"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.2.1"
+version = "2.3.0"
 
 [deps]
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"

--- a/lib/OrdinaryDiffEqTaylorSeries/Project.toml
+++ b/lib/OrdinaryDiffEqTaylorSeries/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqTaylorSeries"
 uuid = "9c7f1690-dd92-42a3-8318-297ee24d8d39"
 authors = ["Songchen Tan <i@tansongchen.com>"]
-version = "2.2.1"
+version = "2.3.0"
 
 [deps]
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"


### PR DESCRIPTION
#4272 restored a uniform SciMLBase reexport surface across nine leaf solver packages using `@reexport using SciMLBase: ...` — roughly 60 names each (`ODEProblem`, `solve`, `init`, the callback and ensemble types, and so on). That **grows the public API**, so these are minor bumps.

| sub-library | from | to |
|---|---|---|
| OrdinaryDiffEqDefault | 2.5.0 | 2.6.0 |
| OrdinaryDiffEqExtrapolation | 2.5.0 | 2.6.0 |
| OrdinaryDiffEqIMEXMultistep | 2.2.0 | 2.3.0 |
| OrdinaryDiffEqPDIRK | 2.4.1 | **2.5.0** |
| OrdinaryDiffEqQPRK | 2.2.1 | **2.3.0** |
| OrdinaryDiffEqTaylorSeries | 2.2.1 | **2.3.0** |

The last three had been given *patch* bumps. A patch that adds ~60 exported names understates the change and leaves downstreams unable to floor on the restored interface, so they are corrected to minor here. None of those patch versions was registered, so nothing is skipped.

Feagin (2.3.0), FunctionMap (2.3.0) and PRK (2.4.0) were already bumped correctly and are untouched; they are registered alongside these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R