### PR TITLE
Allow sparse WOperators with LHLFactorization

### DIFF
--- a/lib/OrdinaryDiffEqBDF/test/lhl_factorization_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/lhl_factorization_tests.jl
@@ -3,8 +3,8 @@ using SciMLOperators: WOperator, jacobian_stale
 
 # `LHLFactorization` needs W left split as J plus a scalar shift so that a new dtgamma
 # costs O(n²).  These tests pin down that the split form is what the integrator builds,
-# that it produces the same trajectory as an assembled W, and that the combinations the
-# reduction cannot serve are rejected rather than silently densified.
+# that it produces the same trajectory as an assembled W, and that unsupported mass
+# matrices are rejected rather than silently densified.
 
 function rober_like(n)
     # A stiff, strongly coupled system with a dense Jacobian and no sparsity to exploit.
@@ -55,11 +55,21 @@ end
     @test !jacobian_stale(integ.cache.nlsolver.cache.W)
 end
 
-@testset "unsupported combinations are rejected" begin
-    f = ODEFunction((du, u, p, t) -> (du .= -u); jac_prototype = spzeros(3, 3))
-    sprob = ODEProblem(f, ones(3), (0.0, 1.0))
-    @test_throws ArgumentError solve(sprob, NordsieckBDF(linsolve = LHLFactorization()))
+@testset "sparse Jacobian is kept split" begin
+    A = sparse([1, 2, 3, 2, 3, 1], [1, 2, 3, 1, 2, 3], [-4.0, -5.0, -6.0, 1.0, 1.0, 1.0], 3, 3)
+    f! = (du, u, p, t) -> mul!(du, A, u)
+    jac! = (J, u, p, t) -> copyto!(J, A)
+    prob = ODEProblem(ODEFunction(f!; jac = jac!, jac_prototype = copy(A)), ones(3), (0.0, 0.1))
+    integ = init(prob, FBDF(linsolve = LHLFactorization()); abstol = 1.0e-10, reltol = 1.0e-10)
 
+    @test integ.cache.nlsolver.cache.W isa WOperator
+    @test integ.cache.nlsolver.cache.W.J isa SparseMatrixCSC
+    sol = solve!(integ)
+    @test SciMLBase.successful_retcode(sol)
+    @test sol.u[end] ≈ exp(0.1 * Matrix(A)) * ones(3) rtol = 1.0e-7
+end
+
+@testset "unsupported mass matrix is rejected" begin
     fm = ODEFunction((du, u, p, t) -> (du .= -u); mass_matrix = Diagonal([1.0, 2.0, 3.0]))
     mprob = ODEProblem(fm, ones(3), (0.0, 1.0))
     @test_throws ArgumentError solve(mprob, NordsieckBDF(linsolve = LHLFactorization()))

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -712,10 +712,13 @@ function _uses_split_W(alg, f)
             )
         )
     end
-    if !(f.jac_prototype === nothing || f.jac_prototype isa Matrix)
+    if !(
+            f.jac_prototype === nothing || f.jac_prototype isa Matrix ||
+                is_sparse_csc(f.jac_prototype)
+        )
         throw(
             ArgumentError(
-                "LHLFactorization needs a dense Jacobian; got a jac_prototype of type $(typeof(f.jac_prototype)). The Hessenberg reduction fills in, so a sparse Jacobian buys nothing — drop `jac_prototype`/`sparse` or choose a sparse linear solver."
+                "LHLFactorization needs a dense or `SparseMatrixCSC` Jacobian; got a jac_prototype of type $(typeof(f.jac_prototype))."
             )
         )
     end


### PR DESCRIPTION
> Draft: ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

This permits `LHLFactorization` to retain the split `WOperator` representation when an ODE function supplies a `SparseMatrixCSC` Jacobian prototype. Other sparse/operator prototypes and non-scalar mass matrices remain rejected, so the split representation is only used by matrix types supported by LinearSolve's LHL cache.

The regression test uses FBDF on a coupled, irreducible sparse linear system. It verifies that the integrator builds a sparse-backed `WOperator`, completes successfully, and matches the matrix-exponential solution.

This depends on https://github.com/SciML/LinearSolve.jl/pull/1266.

## Verification

Failing before the change:

```text
With the new FBDF sparse-Jacobian test and the previous _uses_split_W guard:
ArgumentError: LHLFactorization needs a dense Jacobian; got a jac_prototype of type SparseMatrixCSC...
```

Passing after the change:

```text
Sparse FBDF regression test                    | 4 passed / 4 total
LHL Factorization Tests                        | 19 passed / 19 total

OrdinaryDiffEqBDF, GROUP=Core
  DAE Convergence Tests                        | 50 passed
  DAE AD Tests                                 | 40 passed
  DAE Event Tests                              | 4 passed
  DAE derivative_discontinuity Tests           | 11 passed
  DAE Initialization Tests                     | 38 passed, 2 broken
  DAE nonlinear solve path                     | 16 passed
  BDF inference                                | 1 passed
  BDF Convergence Tests                        | 84 passed
  BDF Regression Tests                         | 35 passed
  Nordsieck BDF Tests                          | 101 passed
  LHL Factorization Tests                      | 19 passed
  OrdinaryDiffEqBDF tests passed

OrdinaryDiffEqDifferentiation, GROUP=Core
  all testsets passed; OrdinaryDiffEqDifferentiation tests passed

OrdinaryDiffEqBDF, GROUP=QA
  Allocation Tests                             | 2 passed, 18 broken
  JET Tests                                    | 18 passed, 23 broken
  Aqua                                         | 21 passed
  OrdinaryDiffEqBDF tests passed

OrdinaryDiffEqDifferentiation, GROUP=QA
  JET Tests                                    | 1 passed
  Aqua                                         | 19 passed
  OrdinaryDiffEqDifferentiation tests passed

julia +release --startup-file=no -m Runic --check <changed Julia files>
typos --format brief <changed files>
git diff --check
  all exited 0 with no output
```

Not verified locally: GPU jobs, downstream jobs, docs (no docstrings, public API, or docs files changed), or `GROUP=Everything`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WbHDQHK9XRA9xUqTmW2N2
