### PR TITLE
Support generic callback event storage

### DIFF
--- a/docs/src/devtools/internals/public_api.md
+++ b/docs/src/devtools/internals/public_api.md
@@ -29,6 +29,7 @@ DiffEqBase.default_factorize
 DiffEqBase.finalize!
 DiffEqBase.find_callback_time
 DiffEqBase.find_first_continuous_callback
+DiffEqBase.findall_events!
 DiffEqBase.get_condition
 DiffEqBase.get_tstops
 DiffEqBase.get_tstops_array

--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.18.2"
+version = "7.19.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/DiffEqBase/src/DiffEqBase.jl
+++ b/lib/DiffEqBase/src/DiffEqBase.jl
@@ -209,7 +209,8 @@ export AutoDespecialize, AutoRespecialize, AutoDePSpecialize
             # Callback API (DiffEqBase-owned shared functionality used by downstream solvers)
             :apply_callback!, :apply_discrete_callback!, :CallbackCache,
             :find_first_continuous_callback, :find_callback_time,
-            :max_vector_callback_length, :max_vector_callback_length_int, :get_condition,
+            :findall_events!, :max_vector_callback_length, :max_vector_callback_length_int,
+            :get_condition,
             # Default-callback API (integrator defaults overridable via solver keywords)
             :ODE_DEFAULT_NORM, :ODE_DEFAULT_ISOUTOFDOMAIN, :ODE_DEFAULT_PROG_MESSAGE,
             :ODE_DEFAULT_UNSTABLE_CHECK, :NAN_CHECK,

--- a/lib/DiffEqBase/src/callbacks.jl
+++ b/lib/DiffEqBase/src/callbacks.jl
@@ -496,31 +496,8 @@ Modifies `next_sign` to be an array of booleans for if there is a sign change
 in the interval between prev_sign and next_sign.
 Return `true` if any event occurred.
 """
-function findall_events!(
-        next_sign::Union{Array, SubArray},
-        prev_sign::Union{Array, SubArray}
-    )
-    # `VectorContinuousCallback` only has `affect!` (no `affect_neg!`) and
-    # `apply_callback!` invokes it with the `simultaneous_events` mask, so
-    # detection only needs to fire on any sign change away from a non-zero
-    # `prev_sign`.
-    #
-    # The `prev_sign[i] != 0` guard is load-bearing: state-machine
-    # callbacks (conditions of the form `(state == X) * (expr)`) snap
-    # other-state condition values to exactly 0 the instant the affect
-    # changes state. Without the guard, `prev_sign[i] * next_sign[i] <= 0`
-    # would fire on every subsequent step (0 * ±1 = 0 ≤ 0) and the
-    # rootfinder would re-fire the just-handled callback indefinitely —
-    # the scalar `is_event_occurrence` already excludes `prev_sign == 0`
-    # implicitly via its direction checks.
-    @inbounds for i in 1:length(prev_sign)
-        next_sign[i] = prev_sign[i] != 0 && prev_sign[i] * next_sign[i] <= 0
-    end
-    return any(isone, next_sign)
-end
-
 function findall_events!(next_sign, prev_sign)
-    map!((next, prev) -> prev != 0 && prev * next <= 0, next_sign, next_sign, prev_sign)
+    map!(is_event_occurrence, next_sign, prev_sign, next_sign)
     return any(isone, next_sign)
 end
 
@@ -532,6 +509,22 @@ function is_event_occurrence(prev_sign::Number, next_sign::Number, affect!::F1, 
         (prev_sign < 0 && affect! !== nothing) ||
             (prev_sign > 0 && affect_neg! !== nothing)
     ) && prev_sign * next_sign <= 0
+end
+
+# `VectorContinuousCallback` only has `affect!` (no `affect_neg!`) and
+# `apply_callback!` invokes it with the `simultaneous_events` mask, so
+# detection only needs to fire on any sign change away from a non-zero
+# `prev_sign`.
+#
+# The `prev_sign != 0` guard is load-bearing: state-machine callbacks
+# (conditions of the form `(state == X) * (expr)`) snap other-state
+# condition values to exactly 0 the instant the affect changes state.
+# Without the guard, `prev_sign * next_sign <= 0` would fire on every
+# subsequent step (0 * ±1 = 0 ≤ 0) and the rootfinder would re-fire the
+# just-handled callback indefinitely. The 4-argument method already
+# excludes `prev_sign == 0` via its direction checks.
+function is_event_occurrence(prev_sign::Number, next_sign::Number)
+    return prev_sign != 0 && prev_sign * next_sign <= 0
 end
 
 """

--- a/lib/DiffEqBase/src/callbacks.jl
+++ b/lib/DiffEqBase/src/callbacks.jl
@@ -519,6 +519,11 @@ function findall_events!(
     return any(isone, next_sign)
 end
 
+function findall_events!(next_sign, prev_sign)
+    map!((next, prev) -> prev != 0 && prev * next <= 0, next_sign, next_sign, prev_sign)
+    return any(isone, next_sign)
+end
+
 """
 Return `true` if an event occurred.
 """

--- a/lib/DiffEqBase/test/callbacks.jl
+++ b/lib/DiffEqBase/test/callbacks.jl
@@ -1,5 +1,20 @@
 using DiffEqBase, Test
 
+struct GenericEventArray{T} <: AbstractVector{T}
+    data::Vector{T}
+end
+Base.size(array::GenericEventArray) = size(array.data)
+Base.getindex(array::GenericEventArray, index::Int) = array.data[index]
+Base.setindex!(array::GenericEventArray, value, index::Int) = array.data[index] = value
+
+@testset "generic vector callback event storage" begin
+    next_sign = GenericEventArray([1.0, -1.0, 1.0, -1.0])
+    prev_sign = GenericEventArray([-1.0, 1.0, 0.0, -1.0])
+
+    @test DiffEqBase.findall_events!(next_sign, prev_sign)
+    @test next_sign == [1.0, 1.0, 0.0, 0.0]
+end
+
 condition = function (u, t, integrator) # Event when event_f(u,t,k) == 0
     return t - 2.95
 end

--- a/lib/DiffEqBase/test/callbacks.jl
+++ b/lib/DiffEqBase/test/callbacks.jl
@@ -8,12 +8,29 @@ Base.getindex(array::GenericEventArray, index::Int) = array.data[index]
 Base.setindex!(array::GenericEventArray, value, index::Int) = array.data[index] = value
 
 @testset "generic vector callback event storage" begin
-    next_sign = GenericEventArray([1.0, -1.0, 1.0, -1.0])
-    prev_sign = GenericEventArray([-1.0, 1.0, 0.0, -1.0])
+    @test DiffEqBase.is_event_occurrence(-1.0, 1.0)
+    @test DiffEqBase.is_event_occurrence(1.0, -1.0)
+    @test DiffEqBase.is_event_occurrence(1.0, 0.0)
+    @test !DiffEqBase.is_event_occurrence(0.0, 1.0)
+    @test !DiffEqBase.is_event_occurrence(1.0, 1.0)
+    @test !DiffEqBase.is_event_occurrence(-1.0, -1.0)
 
-    @test DiffEqBase.findall_events!(next_sign, prev_sign)
-    @test next_sign == [1.0, 1.0, 0.0, 0.0]
+    next_generic = GenericEventArray([1.0, -1.0, 1.0, -1.0])
+    prev_generic = GenericEventArray([-1.0, 1.0, 0.0, -1.0])
+    @test DiffEqBase.findall_events!(next_generic, prev_generic)
+    @test next_generic == [1.0, 1.0, 0.0, 0.0]
+
+    next_array = [1.0, -1.0, 1.0, -1.0]
+    prev_array = [-1.0, 1.0, 0.0, -1.0]
+    @test DiffEqBase.findall_events!(next_array, prev_array)
+    @test next_array == [1.0, 1.0, 0.0, 0.0]
+
+    next_parent = [1.0, -1.0, 1.0, -1.0, 5.0]
+    prev_parent = [-1.0, 1.0, 0.0, -1.0, 1.0]
+    @test DiffEqBase.findall_events!(view(next_parent, 1:4), view(prev_parent, 1:4))
+    @test next_parent == [1.0, 1.0, 0.0, 0.0, 5.0]
 end
+
 
 condition = function (u, t, integrator) # Event when event_f(u,t,k) == 0
     return t - 2.95


### PR DESCRIPTION
## What changed and why

`findall_events!` now uses a single `map!` method for all callback sign storage, including GPU-backed arrays. It calls the two-argument `is_event_occurrence` rather than a per-call closure. The CPU `Array`/`SubArray` loop specialization was dropped after a microbenchmark showed `map!` of that named function matches the `@inbounds` loop at callback-relevant lengths. The helper is now public and documented, and DiffEqBase is bumped from 7.18.2 to 7.19.0 because this adds public API.

This is the prerequisite for fixing vector continuous callbacks in DiffEqGPU's `EnsembleGPUArray` path.

> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

Failing before the implementation, using the added generic-array regression test on clean `upstream/master`:

```text
MethodError: no method matching findall_events!(::GenericEventArray{Float64}, ::GenericEventArray{Float64})
generic vector callback event storage | Fail 1  Error 1  Total 2
```

Passing after the implementation:

```text
generic vector callback event storage | Pass 2  Total 2
Callbacks                             | Pass 25 Total 25
Testing DiffEqBase tests passed
```

After the follow-up that always uses `map!(is_event_occurrence, …)` (head `085a21e87`), the same Core/QA commands completed locally:

```text
GROUP=Core julia +release --project=lib/DiffEqBase -e 'using Pkg; Pkg.test()'
  Callbacks | Pass 35 Total 35
  Testing DiffEqBase tests passed

GROUP=QA julia +release --project=lib/DiffEqBase -e 'using Pkg; Pkg.test()'
  Aqua | Pass 9 Total 9
  Testing DiffEqBase tests passed
```

After rebasing over upstream `master` at `a27ee037e`, these exact commands completed locally on the previous head:

```text
GROUP=Core julia +release --project=lib/DiffEqBase -e 'using Pkg; Pkg.test()'
  Callbacks | Pass 25 Total 25
  Testing DiffEqBase tests passed

GROUP=QA julia +release --project=lib/DiffEqBase -e 'using Pkg; Pkg.test()'
  Aqua | Pass 9 Total 9
  Testing DiffEqBase tests passed

julia +release --project=docs docs/make.jl
  completed through RenderDocument; deployment skipped outside CI; exit 0

julia +release -m Runic --check lib/DiffEqBase/src/DiffEqBase.jl lib/DiffEqBase/src/callbacks.jl lib/DiffEqBase/test/callbacks.jl
typos --force-exclude --format brief lib/DiffEqBase/Project.toml lib/DiffEqBase/src/DiffEqBase.jl lib/DiffEqBase/src/callbacks.jl lib/DiffEqBase/test/callbacks.jl docs/src/devtools/internals/public_api.md
git diff --check upstream/master...HEAD
  all exited 0 with no output
```

## CI failure classification

All 14 failed checks on head `e919d5b34` reproduce on clean upstream or are unchanged pre-existing failures outside this PR's DiffEqBase callback-event diff. No CI failure is branch-introduced, so this PR adds no unrelated fix.

| Failure family | Red checks | Clean-base evidence / prerequisite |
|---|---|---|
| Stochastic nonlinear-cache contract | [Stochastic Interface1](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33117550351/job/98684577739), [Interface3](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33117550351/job/98684577511), [AlgConvergence](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33117550351/job/98684578629), [AlgConvergence3](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33117550351/job/98684578585), [Stochastic downgrade](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33117550110/job/98683960474), [DelayDiffEq SDDE](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33117550351/job/98684572785) | Each rejects a `StochasticDiffEqImplicit` cache at `nlsolve!`. Clean master has the identical downgrade failure in [job 98649264888](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33106687753/job/98649264888). The focused prerequisite accepts the shared SciML cache contract: https://github.com/ChrisRackauckas-Claude/OrdinaryDiffEq.jl/commit/d7dad1314f986ec3155e4d231e0d4019eb4ff8d2 |
| TauLeaping cache interface | [Stochastic Interface2](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33117550351/job/98684578822) | `TauLeaping` still defines the legacy stochastic `alg_cache` signature while current `OrdinaryDiffEqCore` calls the generic signature. Both definitions are identical on the PR base and current master; the legacy method entered with https://github.com/SciML/OrdinaryDiffEq.jl/commit/cea8ebb30f81ab7e1844bac977fece70dbb4e847. This needs a separate Stochastic fix. |
| Hairer4 Newton-Krylov reproducibility | [Regression_I Julia 1](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33117550130/job/98684259697), [Regression_I Julia pre](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33117550130/job/98684260158) | The unchanged test reports drift `1.4306299457644833e-4` and `5.135110298093437e-5` against `1e-5`. The existing focused test setup fix is https://github.com/ChrisRackauckas-Claude/OrdinaryDiffEq.jl/commit/04240ce1050e7e84d2ad937c536e74c0774b5849. |
| PDIRK downgrade floor | [OrdinaryDiffEqPDIRK downgrade](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33117550110/job/98683960406) | Clean master has the same guard-test failure in [job 98649264702](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33106687753/job/98649264702). The focused compat-floor prerequisite is https://github.com/ChrisRackauckas-Claude/OrdinaryDiffEq.jl/commit/cffd6ea5188f8458241f8ee10ad4abcec317dc0d. |
| ModelingToolkit / SymbolicUtils metadata corruption | [MTK InterfaceI](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33117550096/job/98675980253), [MTK InterfaceII](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33117550096/job/98675980305), [MTK Initialization](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33117550096/job/98675980083) | Clean master has the same `Base.ImmutableDict{DataType,Any}` typeassert failures in [InterfaceI](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33106687768/job/98638298190), [InterfaceII](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33106687768/job/98638298578), and [Initialization](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33106687768/job/98638298291). The owning-package fix is https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1033. InterfaceII also encounters the Stochastic cache failure above. |
| SciMLSensitivity mixed-precision Enzyme activity | [SciMLSensitivity Core1](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33117550096/job/98675980127) | Clean master has the identical `EnzymeRuntimeActivityError` at `scimlstructures_interface.jl:154` in [job 98638298114](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33106687768/job/98638298114). The focused SciMLSensitivity prerequisite is https://github.com/ChrisRackauckas-Claude/SciMLSensitivity.jl/commit/aaf98127599539443f941dd6b6a9e3b91925e215. |

Current upstream master is one unrelated DiffEqDevTools commit ahead (`468bea34e`); rebasing solely for that commit would invalidate this audited CI run and trigger the full matrix again.

## Not verified locally

No CUDA device is available on this host, so the downstream CUDA callback path remains for DiffEqGPU CI to verify after this prerequisite is available. The unrelated failure families above were classified from their complete logs and matching clean-master runs; their separate focused fixes were not combined with this PR.

## Links

- DiffEqGPU callback fix: https://github.com/SciML/DiffEqGPU.jl/pull/503
- Audited PR checks: https://github.com/SciML/OrdinaryDiffEq.jl/pull/4398/checks
- Clean-master integration run: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33106687768
- Clean-master downgrade-sublibraries run: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33106687753

🤖 Generated with Codex CLI 0.150.1 (model: unknown; session: local session ID 01a0441e-3d2f-7170-ab6e-58ef72975a9f).

Follow-up `085a21e87` generated with Grok 1.0.5 (model: grok-4.6; session: local session ID 01a045f9-5360-7622-b38d-e4d084141432).

