### PR TITLE
Rebuild the linear W whenever gamma dt changes on fixed steps

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "3.11.1"
+version = "3.11.2"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -550,7 +550,9 @@ function do_newJW(integrator, alg, nlsolver, repeat_step)::NTuple{2, Bool}
         isnewton(nlsolver) || return false, true
         W_iγdt = inv(nlsolver.cache.W_γdt)
         iγdt = inv(nlsolver.γ * integrator.dt)
-        smallstepchange = abs(iγdt / W_iγdt - 1) <= get_new_W_γdt_cutoff(nlsolver)
+        cutoff = integrator.opts.adaptive && !_uses_split_W(alg, integrator.f) ?
+            get_new_W_γdt_cutoff(nlsolver) : zero(get_new_W_γdt_cutoff(nlsolver))
+        smallstepchange = abs(iγdt / W_iγdt - 1) <= cutoff
         return false, !smallstepchange
     end
     !integrator.opts.adaptive && return true, true # Not adaptive will always refactorize

--- a/lib/OrdinaryDiffEqDifferentiation/test/stale_w_linear_operator_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/stale_w_linear_operator_tests.jl
@@ -6,6 +6,7 @@
 # that rebuilds WOperator._concrete_form on convert for operator Jacobians.
 using OrdinaryDiffEqSDIRK, OrdinaryDiffEqDifferentiation, LinearSolve, SciMLOperators
 using SciMLBase, LinearAlgebra, Test
+using OrdinaryDiffEqSDIRK: NLNewton
 
 @testset "stale W with linear operator f and concrete-A linsolve" begin
     A = [-2.0 1.0; 1.0 -2.0]
@@ -41,4 +42,53 @@ using SciMLBase, LinearAlgebra, Test
         abstol = 1.0e-8, reltol = 1.0e-8
     )
     @test norm(sol_krylov.u[end] - uref) / norm(uref) < 1.0e-3
+end
+
+@testset "fixed-step linear W is rebuilt whenever γdt changes (#4370)" begin
+    A = [-20.0 1.0; 1.0 -20.0]
+    u0 = [1.0, 0.5]
+    prob = ODEProblem(ODEFunction(MatrixOperator(A)), u0, (0.0, 1.0))
+
+    function stepped(cutoff)
+        integ = init(
+            prob, SDIRK2(nlsolve = NLNewton(new_W_dt_cutoff = cutoff));
+            dt = 1.0e-2, adaptive = false
+        )
+        for k in 1:20
+            set_proposed_dt!(integ, (1.0e-2, 1.15e-2)[mod1(k, 2)])
+            step!(integ)
+        end
+        return integ.u, integ.t
+    end
+
+    u_exact_W, t = stepped(0.0)
+    u_default, _ = stepped(0.2)
+    @test u_default ≈ u_exact_W rtol = 1.0e-10
+
+    uref = exp(A * t) * u0
+    @test norm(u_default - uref) / norm(uref) < 0.05
+end
+
+@testset "split W (LHLFactorization) takes every γdt change (#4370)" begin
+    A = [-20.0 1.0; 1.0 -20.0]
+    u0 = [1.0, 0.5]
+    prob = ODEProblem(ODEFunction(MatrixOperator(A)), u0, (0.0, 1.0))
+    lhl(cutoff) = SDIRK2(linsolve = LHLFactorization(), nlsolve = NLNewton(new_W_dt_cutoff = cutoff))
+
+    loose = solve(prob, lhl(0.2); abstol = 1.0e-6, reltol = 1.0e-6)
+    exact = solve(prob, lhl(0.0); abstol = 1.0e-6, reltol = 1.0e-6)
+    @test loose.u[end] == exact.u[end]
+    @test loose.stats.naccept == exact.stats.naccept
+
+    integ = init(prob, lhl(0.2); dt = 1.0e-2, adaptive = false)
+    for k in 1:20
+        set_proposed_dt!(integ, (1.0e-2, 1.15e-2)[mod1(k, 2)])
+        step!(integ)
+    end
+    integ_exact = init(prob, lhl(0.0); dt = 1.0e-2, adaptive = false)
+    for k in 1:20
+        set_proposed_dt!(integ_exact, (1.0e-2, 1.15e-2)[mod1(k, 2)])
+        step!(integ_exact)
+    end
+    @test integ.u == integ_exact.u
 end


### PR DESCRIPTION
On fixed steps the linear-operator path kept a stale `W = M - γ dt J` whenever `dt` drifted by less than `new_W_dt_cutoff`, so `adaptive = false` solves reused `W` across step-size changes; the cutoff is now zero unless the solve is adaptive. Comparing `γ dt` rather than forcing a rebuild halves the factorisations, because the two stages of a step share one `W`, and `njacs` stays 0 on the linear path.
On the issue's problem with `dt` alternating against `1.15 dt`, exact `W` converges at second order (0.0159, 0.00443, 0.00117 over three halvings) while the default cutoff stalled near 6.5e-3; after the change both cutoffs give identical results.
The test steps a `MatrixOperator` problem with alternating fixed steps, in `stale_w_linear_operator_tests.jl`, which already covers the sibling stale-`W` bug #3933. The adaptive half of #4370, where a carried-over `η` lets Newton stop early against a stale `W`, is separate.
Fixes the fixed-step half of #4370.
With `LHLFactorization` the W stays split and LHL absorbs each new γdt from `W.gamma` on every solve, but inside the cutoff `W_γdt` was left at the old value, so the Newton step's `dz` rescale in `compute_step!` corrected for a staleness that was not there; the cutoff is now zero for a split W on adaptive steps as well, which keeps `W_γdt` equal to γdt and drops the rescale. The new test checks cutoff 0.2 and 0 give identical results with LHL, adaptive and fixed-step; on master the end states differ.
AI Disclosure: Claude assisted with this change.
