### PR TITLE
Add explicit benchmark tag semantics

### DIFF
--- a/docs/src/devtools/alg_dev/benchmarks.md
+++ b/docs/src/devtools/alg_dev/benchmarks.md
@@ -117,6 +117,10 @@ plot(
 For example, `auto_tags(KenCarp4())` includes `:order_4`, `:adaptive`, `:implicit`,
 `:sdirk`, `:esdirk`, and `:split`. Explicit setup tags are appended without duplicates.
 Use `:auto_tags => false` when a setup needs only its manually supplied tags.
+[`tag_kind`](@ref) distinguishes algorithm families from traits, benchmark roles,
+providers, variants, and problem domains. This lets `autoplot(wp_set)` discover family
+views without treating tags such as `:order_4` or `:reference` as families. Pass
+`families` explicitly for one-off custom family tags.
 
 `plot(wp_set; tags)` keeps the entries carrying all of `tags`, `include_tags` adds
 entries back regardless of that filter, and `exclude_tags` drops entries. Entries
@@ -142,6 +146,7 @@ DiffEqDevTools.get_sample_errors
 
 ```@docs
 DiffEqDevTools.auto_tags
+DiffEqDevTools.tag_kind
 DiffEqDevTools.get_tags
 DiffEqDevTools.unique_tags
 DiffEqDevTools.filter_by_tags

--- a/lib/DiffEqDevTools/Project.toml
+++ b/lib/DiffEqDevTools/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqDevTools"
 uuid = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "3.5.0"
+version = "3.6.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/DiffEqDevTools/docs/src/index.md
+++ b/lib/DiffEqDevTools/docs/src/index.md
@@ -28,6 +28,7 @@ DiffEqDevTools.get_sample_errors
 
 ```@docs
 DiffEqDevTools.auto_tags
+DiffEqDevTools.tag_kind
 DiffEqDevTools.get_tags
 DiffEqDevTools.unique_tags
 DiffEqDevTools.filter_by_tags

--- a/lib/DiffEqDevTools/src/DiffEqDevTools.jl
+++ b/lib/DiffEqDevTools/src/DiffEqDevTools.jl
@@ -68,7 +68,8 @@ export test_convergence, analyticless_test_convergence, appxtrue
 export get_sample_errors
 
 #Tagging and filtering
-export auto_tags, filter_by_tags, exclude_by_tags, get_tags, unique_tags, merge_wp_sets
+export auto_tags, tag_kind, filter_by_tags, exclude_by_tags, get_tags, unique_tags,
+    merge_wp_sets
 
 #Multiple error estimates from one run
 export available_errors

--- a/lib/DiffEqDevTools/src/autoplot.jl
+++ b/lib/DiffEqDevTools/src/autoplot.jl
@@ -12,8 +12,8 @@ plots, without re-solving anything:
   - `"all"`, the full input set
 
 Each value plots directly with `plot(subset)`. When `families` is not given it is taken
-from the tags in use, dropping tags carried by more than 80% of the entries, since those
-describe the benchmark as a whole (`:stiff`, `:nonstiff`) rather than a family.
+from tags for which [`tag_kind`](@ref) returns `:family`. Traits, roles, providers,
+variants, domains, and unknown custom tags are not mistaken for families.
 """
 function autoplot(
         wp_set::WorkPrecisionSet;
@@ -44,9 +44,5 @@ function autoplot(
 end
 
 function _auto_detect_families(wp_set::WorkPrecisionSet)
-    n_methods = length(wp_set.wps)
-    n_methods == 0 && return Symbol[]
-    return filter(unique_tags(wp_set)) do tag
-        count(wp -> tag in wp.tags, wp_set.wps) <= 0.8 * n_methods
-    end
+    return filter(tag -> tag_kind(tag) === :family, unique_tags(wp_set))
 end

--- a/lib/DiffEqDevTools/src/benchmark.jl
+++ b/lib/DiffEqDevTools/src/benchmark.jl
@@ -8,6 +8,51 @@ _setup_name(setup) = get(setup, :name, _default_name(setup[:alg]))
 
 _preset_algorithm_tags(alg) = Symbol[]
 
+const _FAMILY_TAGS = Set(
+    [
+        :adams, :bdf, :esdirk, :exponential, :explicit_rk, :extrapolation, :firk, :imex,
+        :low_storage_rk, :multistep, :partitioned, :rk, :rkn, :rosenbrock, :sdirk,
+        :ssprk, :stabilized, :stabilized_rk, :symplectic,
+    ]
+)
+const _TRAIT_TAGS = Set(
+    [
+        :adaptive, :composite, :explicit, :fixed_step, :implicit, :split, :variable_order,
+    ]
+)
+const _ROLE_TAGS = Set([:recommended, :reference])
+const _PROVIDER_TAGS = Set([:external, :lsoda, :odeinterface, :ordinarydiffeq, :sundials])
+const _VARIANT_TAGS = Set(
+    [
+        :dae_residual, :dense, :dense_output, :dynamic, :endpoint, :mass_matrix,
+        :matrix_free, :sparse, :static, :timeseries,
+    ]
+)
+const _DOMAIN_TAGS = Set([:bv, :dae, :dde, :nonstiff, :ode, :pde, :rode, :sde, :stiff])
+
+"""
+    tag_kind(tag::Symbol) -> Symbol
+
+Return the semantic kind of a benchmark tag: `:family`, `:trait`, `:role`, `:provider`,
+`:variant`, `:domain`, or `:unknown`. Order tags such as `:order_5` are traits, and
+automatic-differentiation tags such as `:autodiff_forwarddiff` are variants.
+
+[`autoplot`](@ref) uses only `:family` tags for automatic family discovery. Pass its
+`families` keyword for one-off custom families. Packages defining a stable family tag
+can make it discoverable with a specialization such as
+`DiffEqDevTools.tag_kind(::Val{:my_family}) = :family`.
+"""
+tag_kind(tag::Symbol) = tag_kind(Val(tag))
+function tag_kind(::Val{tag}) where {tag}
+    tag in _FAMILY_TAGS && return :family
+    (tag in _TRAIT_TAGS || startswith(string(tag), "order_")) && return :trait
+    tag in _ROLE_TAGS && return :role
+    tag in _PROVIDER_TAGS && return :provider
+    (tag in _VARIANT_TAGS || startswith(string(tag), "autodiff_")) && return :variant
+    tag in _DOMAIN_TAGS && return :domain
+    return :unknown
+end
+
 function _known_alg_order(alg)
     applicable(SciMLBase.alg_order, alg) || return nothing
     try

--- a/lib/DiffEqDevTools/test/tagging_tests.jl
+++ b/lib/DiffEqDevTools/test/tagging_tests.jl
@@ -42,6 +42,25 @@ wp_set = WorkPrecisionSet(prob, abstols, reltols, setups; dt = 1 / 2^4, numruns 
     end
 end
 
+DiffEqDevTools.tag_kind(::Val{:package_family}) = :family
+
+@testset "tag semantics" begin
+    for (tag, expected) in [
+            (:rk, :family),
+            (:rosenbrock, :family),
+            (:order_5, :trait),
+            (:adaptive, :trait),
+            (:reference, :role),
+            (:sundials, :provider),
+            (:dense_output, :variant),
+            (:stiff, :domain),
+            (:package_family, :family),
+            (:benchmark_specific, :unknown),
+        ]
+        @test tag_kind(tag) == expected
+    end
+end
+
 @testset "tags reach the WorkPrecision entries" begin
     @test get_tags(wp_set) == [
         [:order_4, :adaptive, :explicit, :rk, :fourth_order],

--- a/lib/DiffEqDevTools/test/wp_selection_tests.jl
+++ b/lib/DiffEqDevTools/test/wp_selection_tests.jl
@@ -70,13 +70,12 @@ end
     end
 
     @testset "auto-detected families" begin
-        # :rk is on 4/5 entries, :fifth_order on 2/5; :explicit is on every entry
-        # and is therefore dropped.
-        @test DiffEqDevTools._auto_detect_families(wp_set) ==
-            filter(!=(:explicit), unique_tags(wp_set))
+        @test DiffEqDevTools._auto_detect_families(wp_set) == [:rk]
         uniform = filter_by_tags(wp_set, :rk)
-        @test :rk ∉ DiffEqDevTools._auto_detect_families(uniform)
-        @test haskey(autoplot(wp_set), "family_fifth_order")
+        @test DiffEqDevTools._auto_detect_families(uniform) == [:rk]
+        @test haskey(autoplot(wp_set), "family_rk")
+        @test !haskey(autoplot(wp_set), "family_fifth_order")
+        @test !haskey(autoplot(wp_set), "family_reference")
     end
 
     @testset "families with no entries are skipped" begin


### PR DESCRIPTION
> Draft — please ignore until reviewed by @ChrisRackauckas.

## What changed and why

This adds a public `tag_kind(tag)` classification API for benchmark tags and changes `autoplot` to identify algorithm families from those semantics. The previous automatic family selection treated any tag present on at most 80% of methods as a family, which could plot traits such as `:fifth_order` or roles such as `:reference` while suppressing a real family such as `:rk` when every method shared it.

Built-in tags are classified as `:family`, `:trait`, `:role`, `:provider`, `:variant`, or `:domain`; unknown tags return `:unknown`. Packages can specialize `DiffEqDevTools.tag_kind(::Val{:custom_tag})`, while callers can still pass explicit `families` to `autoplot`. The new public API is documented in both OrdinaryDiffEq and DiffEqDevTools, and DiffEqDevTools is bumped from 3.5.0 to 3.6.0.

This is the first unchecked implementation item in the consolidated benchmarking roadmap: https://github.com/SciML/OrdinaryDiffEq.jl/issues/3286.

## Regression evidence

Before the implementation, the new semantic tests failed on the unfixed tree:

```text
automatic algorithm tags | 7 7
tag semantics | Error 9/9
UndefVarError: `tag_kind` not defined in `Main`
ERROR: Package DiffEqDevTools errored during testing
```

With the implementation applied, the same focused test files pass:

```text
automatic algorithm tags | 7/7
tag semantics | 10/10
tags reach the WorkPrecision entries | 5/5
filter_by_tags | 12/12
exclude_by_tags | 3/3
merge_wp_sets | 5/5
wp_area | 2/2
best_by_tag | 7/7
best_of_families | 5/5
autoplot | 13/13
with_autodiff_variants | 15/15
Testing DiffEqDevTools tests passed
```

The `autoplot` regression assertions verify that a uniform `:rk` tag still produces `family_rk`, while `:fifth_order` and `:reference` do not produce family plots.

## Verification

- `GROUP=TagSemantics julia +release --project=lib/DiffEqDevTools -e 'using Pkg; Pkg.test()'`
  - All 79 focused assertions passed after rebasing onto https://github.com/SciML/OrdinaryDiffEq.jl/commit/468bea34e0.
- `GROUP=Core julia +release --project=lib/DiffEqDevTools -e 'using Pkg; Pkg.test()'`
  - The full Core group passed after the final rebase: Benchmark Tests 15/15, ODE AppxTrue 7/7, Analyticless Convergence 7/7, Analyticless Stochastic WP 2/2, Convergence retain_solutions 35/35, Stability Region 7/7, Plot Recipes 58/58, nonlinear work-precision diagrams 6/6, Tagging 42/42, Multiple Error Estimates 12/12, Best-of-Family Selection 42/42, and Timeout 7/7.
- `GROUP=QA julia +release --project=lib/DiffEqDevTools -e 'using Pkg; Pkg.test()'`
  - Aqua 15/15; package tests passed after the final rebase.
- `julia +release --project=docs docs/make.jl`
  - Doctest, document checks, and rendering completed successfully. Existing page-size warnings and the expected local deployment-detection warning remained. The feature patch was unchanged by the subsequent rebase.
- `/home/crackauc/.juliaup/bin/julia +1.12 -e 'using Runic; exit(Runic.main(ARGS))' -- --check <changed Julia files>`
  - Clean after the final rebase.
- `typos <changed files>`
  - Clean after the final rebase.
- `git diff --check upstream/master...HEAD`
  - Clean after the final rebase.

The feature patch ID remained `8ccf6815a29f14ec186eba13c707a8368a8f8fee` across both rebases.

## Review notes and unverified paths

The initial built-in classification is API policy and is the main judgment call to review. One-off custom families do not become automatic merely because they are uncommon: they should be passed explicitly or registered through the `Val` extension point.

I did not run `GROUP=Everything`, GPU jobs, or Julia pre-release jobs locally. I ran the ModelingToolkit `InterfaceII` downstream group only on a clean base checkout to classify unrelated failures from the first CI run, not as feature-branch validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03caf-aae8-74c3-9a79-53b836434858
