### PR TITLE
Fix nlsolve! cache validation for stochastic integrators

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/nlsolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/nlsolve.jl
@@ -115,7 +115,11 @@ function nlsolve!(
         # Checking the type, not just `nothing`: passing something else entirely
         # in this slot went unnoticed because `update_W!` happens not to read it
         # on the out-of-place path.
-        cache isa Union{OrdinaryDiffEqCore.OrdinaryDiffEqCache, Nothing} ||
+        cache isa Union{
+            OrdinaryDiffEqCore.OrdinaryDiffEqCache,
+            OrdinaryDiffEqCore.StochasticDiffEqCache,
+            Nothing,
+        } ||
             throw(
             ArgumentError(
                 "`nlsolve!` expects the integrator cache in its third argument, got a " *

--- a/lib/StochasticDiffEqImplicit/test/runtests.jl
+++ b/lib/StochasticDiffEqImplicit/test/runtests.jl
@@ -21,6 +21,18 @@ if TEST_GROUP == "ALL" || TEST_GROUP == "Core"
         @test ISSEulerHeun() isa StochasticDiffEqNewtonAdaptiveAlgorithm
         @test SKenCarp() isa StochasticDiffEqNewtonAdaptiveAlgorithm
     end
+
+    @time @safetestset "ImplicitEM solve" begin
+        using SciMLBase: SDEProblem, successful_retcode
+        using StochasticDiffEqImplicit: ImplicitEM, solve
+        using Test
+
+        drift!(du, u, p, t) = (du .= -u; nothing)
+        diffusion!(du, u, p, t) = (du .= 0.1 .* u; nothing)
+        prob = SDEProblem(drift!, diffusion!, [1.0], (0.0, 0.1))
+        sol = solve(prob, ImplicitEM(); dt = 0.01, adaptive = false, seed = 1)
+        @test successful_retcode(sol)
+    end
 end
 
 # Run QA tests (Aqua, JET) - skip on pre-release Julia


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

`nlsolve!` recently began validating that its third argument is an `OrdinaryDiffEqCache`. That rejected the parallel, documented `StochasticDiffEqCache` hierarchy, so every implicit stochastic solve failed before its first nonlinear iteration. This adds `StochasticDiffEqCache` to the accepted cache types while preserving the guard against non-cache arguments, and adds an end-to-end `ImplicitEM` regression test.

This fixes the failure independently reproduced on Catalyst master in https://github.com/SciML/Catalyst.jl/actions/runs/33106322786 and in the Symbolics downstream job https://github.com/JuliaSymbolics/Symbolics.jl/actions/runs/33110901212/job/98653136685. The regression was introduced by https://github.com/SciML/OrdinaryDiffEq.jl/commit/e4f0c5ebbb4ef8a29dfb7e66477df37bfef77390.

## Verification

Failing before, with the new test present and the cache guard restored to the current master implementation:

```text
GROUP=Core julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Test Summary:    | Error  Total   Time
ImplicitEM solve |     1      1  11.5s
ArgumentError: `nlsolve!` expects the integrator cache in its third argument, got a StochasticDiffEqImplicit.ImplicitEMCache{...}
ERROR: Package StochasticDiffEqImplicit errored during testing
```

Passing after the fix, rebased onto current master:

```text
GROUP=Core julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Test Summary:                 | Pass  Total  Time
Module loads and constructors |    8      8  4.8s
Test Summary:    | Pass  Total   Time
ImplicitEM solve |    1      1  13.3s
Testing StochasticDiffEqImplicit tests passed
```

The original strict-validation tests still pass:

```text
GROUP=Core julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Test Summary:      | Pass  Total  Time
nlsolve! Arguments |    6      6  9.9s
Testing OrdinaryDiffEqPDIRK tests passed
```

QA:

```text
GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
QA (Aqua and JET) | 21  21  1m46.7s
Testing StochasticDiffEqImplicit tests passed

GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Aqua | 41  41  51.8s
Testing OrdinaryDiffEqNonlinearSolve tests passed
```

Downstream Catalyst master with this local fix:

```text
GROUP=Modeling julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Symbolic Stoichiometry | 30  30  1m28.3s
Testing Catalyst tests passed
```

Formatting and spelling:

```text
julia +1.12 -m Runic --check lib/OrdinaryDiffEqNonlinearSolve/src/nlsolve.jl lib/StochasticDiffEqImplicit/test/runtests.jl
git diff --check
typos over added diff lines
# all exited 0 with no output
```

## Not verified

GPU jobs, Julia pre-release jobs, and the full monorepo suite were not run locally. The docs build was not run because this changes neither documentation nor public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/019f4028-d2ae-7a12-aff0-7d996bd9c791
