### PR TITLE
Fix PDIRK nonlinear solver compat floor

### DIFF
--- a/lib/OrdinaryDiffEqPDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqPDIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqPDIRK"
 uuid = "5dd0a6cf-3d4b-4314-aa06-06d4e299bc89"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.5.0"
+version = "2.5.1"
 
 [deps]
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
@@ -34,7 +34,7 @@ MuladdMacro = "0.2.4"
 ODEProblemLibrary = "1"
 OrdinaryDiffEqCore = "4.6"
 OrdinaryDiffEqDifferentiation = "3.3"
-OrdinaryDiffEqNonlinearSolve = "2"
+OrdinaryDiffEqNonlinearSolve = "2.9.1"
 Pkg = "1"
 Random = "<0.0.1, 1"
 SciMLBase = "3.39"


### PR DESCRIPTION
> Ignore this draft until reviewed by @ChrisRackauckas.

## What changed

Raise `OrdinaryDiffEqPDIRK`'s `OrdinaryDiffEqNonlinearSolve` compatibility floor from `2` to `2.9.1`, the first release containing the cache-aware `nlsolve!` argument guard used by PDIRK. Bump the PDIRK patch version to `2.5.1`.

The regression was introduced by https://github.com/SciML/OrdinaryDiffEq.jl/commit/e4f0c5ebbb4ef8a29dfb7e66477df37bfef77390: its implementation and test require `OrdinaryDiffEqNonlinearSolve` 2.9.1 behavior, but the existing broad compat allowed the downgrade job to select 2.0.0.

## Verification

Failing before, on clean OrdinaryDiffEq commit `a27ee037e97c9feeb9bc813a645812f2bbf8c0cd`, using Julia 1.11.9 and `julia-actions/julia-downgrade-compat` commit `30b83cf94e89744fcbd7ea5496be4967d6fbe540` in `alldeps` mode:

```text
Test Failed at lib/OrdinaryDiffEqPDIRK/test/nlsolve_argument_tests.jl:26
Expression: nlsolve!(nlsolver, integrator, 0.5, false)
Expected: ArgumentError
No exception thrown
Test Summary:      | Pass  Fail  Total
nlsolve! Arguments |    5     1      6
```

The downgraded environment selected `OrdinaryDiffEqNonlinearSolve` 2.0.0.

Passing after, with the same downgrade action and test command:

```text
Test Summary:     | Pass  Total   Time
Convergence Tests |    4      4  31.3s
Test Summary:      | Pass  Total   Time
nlsolve! Arguments |    6      6  10.5s
Testing OrdinaryDiffEqPDIRK tests passed
```

The corrected downgraded environment selected `OrdinaryDiffEqNonlinearSolve` 2.9.1. The normal current-dependency Core run also passed:

```text
Test Summary:     | Pass  Total   Time
Convergence Tests |    4      4  53.3s
Test Summary:      | Pass  Total   Time
nlsolve! Arguments |    6      6  12.9s
Testing OrdinaryDiffEqPDIRK tests passed
```

QA passed:

```text
Test Summary: | Pass  Total     Time
JET Tests     |    1      1  1m02.9s
Test Summary: | Pass  Total     Time
Aqua          |   21     21  2m02.2s
Testing OrdinaryDiffEqPDIRK tests passed
```

Additional checks:

- `git diff | typos -` — passed
- `git diff --check` — passed
- Runic is not applicable because this focused compat/version patch changes only TOML.
- Docs were not built because this changes no docs, docstrings, or public API.

The original CI failure is https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33115250405/job/98684924151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03ea3-e59c-7cd0-a4d2-0191af417f31
