### PR TITLE
Accept SciML DECache values in nlsolve!

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.9.1"
+version = "2.9.2"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/nlsolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/nlsolve.jl
@@ -115,7 +115,7 @@ function nlsolve!(
         # Checking the type, not just `nothing`: passing something else entirely
         # in this slot went unnoticed because `update_W!` happens not to read it
         # on the out-of-place path.
-        cache isa Union{OrdinaryDiffEqCore.OrdinaryDiffEqCache, Nothing} ||
+        cache isa Union{SciMLBase.DECache, Nothing} ||
             throw(
             ArgumentError(
                 "`nlsolve!` expects the integrator cache in its third argument, got a " *

--- a/lib/StochasticDiffEqImplicit/test/runtests.jl
+++ b/lib/StochasticDiffEqImplicit/test/runtests.jl
@@ -10,6 +10,7 @@ end
 if TEST_GROUP == "ALL" || TEST_GROUP == "Core"
     @time @safetestset "Module loads and constructors" begin
         using StochasticDiffEqImplicit
+        using SciMLBase: SDEProblem, solve, successful_retcode
         using Test
 
         @test ImplicitEM() isa StochasticDiffEqNewtonAdaptiveAlgorithm
@@ -20,6 +21,12 @@ if TEST_GROUP == "ALL" || TEST_GROUP == "Core"
         @test ISSEM() isa StochasticDiffEqNewtonAdaptiveAlgorithm
         @test ISSEulerHeun() isa StochasticDiffEqNewtonAdaptiveAlgorithm
         @test SKenCarp() isa StochasticDiffEqNewtonAdaptiveAlgorithm
+
+        f = (du, u, p, t) -> (du .= -u; nothing)
+        g = (du, u, p, t) -> (du .= zero(eltype(u)); nothing)
+        prob = SDEProblem(f, g, ones(2), (0.0, 1.0))
+        sol = solve(prob, ISSEM(); dt = 0.1, adaptive = false)
+        @test successful_retcode(sol)
     end
 end
 


### PR DESCRIPTION
> Ignore this draft until reviewed by @ChrisRackauckas.

## What changed

Accept any `SciMLBase.DECache` as the cache argument to `OrdinaryDiffEqNonlinearSolve.nlsolve!`, rather than accepting only `OrdinaryDiffEqCore.OrdinaryDiffEqCache`. StochasticDiffEq's implicit caches implement the shared `DECache` interface but do not subtype the OrdinaryDiffEq-specific cache, so the narrower check rejected valid solver calls.

This also bumps `OrdinaryDiffEqNonlinearSolve` to 2.9.2 and adds an `ISSEM` solve regression test in `StochasticDiffEqImplicit`.

The narrow guard was introduced by https://github.com/SciML/OrdinaryDiffEq.jl/commit/e4f0c5ebbb4ef8a29dfb7e66477df37bfef77390.

## Verification

I first added the `ISSEM` regression test, reverted the implementation change, and ran:

```console
GROUP=Core julia +1.11.9 --project=lib/StochasticDiffEqImplicit -e 'using Pkg; Pkg.test()'
```

It failed on the unfixed implementation:

```text
Module loads and constructors: Error During Test
ArgumentError: nlsolve! expects integrator cache ..., got StochasticDiffEqImplicit.ISSEMCache ...
Test Summary:                    | Pass  Error  Total
Module loads and constructors    |    8      1      9
```

The same command passed after restoring the fix:

```text
Test Summary:                 | Pass  Total   Time
Module loads and constructors |    9      9  38.8s
Testing StochasticDiffEqImplicit tests passed
```

The changed package's QA group passed:

```text
Test Summary: | Pass  Total     Time
Aqua          |   41     41  1m25.8s
Testing OrdinaryDiffEqNonlinearSolve tests passed
```

`GROUP=QA` for `StochasticDiffEqImplicit` reached 20 passing checks but also reproduced one unrelated current-master ExplicitImports error:

```text
ImplicitImportsException: Module StochasticDiffEqImplicit relying on implicit import:
StochasticDiffEqCore exported by StochasticDiffEqCore
Test Summary: | Pass  Error  Total
QA            |   20      1     21
```

That pre-existing module-source failure is being investigated separately and is not hidden or changed here.

Additional checks:

- Runic over both changed Julia ranges — passed
- `git diff | typos -` — passed
- `git diff --check` — passed
- Docs were not built because this changes no docs, docstrings, or public API.

Related baseline failures:

- https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33115250405/job/98684924288
- https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33115250686/job/98668119554

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03ea3-e59c-7cd0-a4d2-0191af417f31
