### PR TITLE
Fix StochasticDiffEqImplicit explicit import order

### DIFF
--- a/lib/StochasticDiffEqImplicit/src/StochasticDiffEqImplicit.jl
+++ b/lib/StochasticDiffEqImplicit/src/StochasticDiffEqImplicit.jl
@@ -1,8 +1,8 @@
 module StochasticDiffEqImplicit
 
 using Reexport: Reexport, @reexport
-@reexport using StochasticDiffEqCore
 import StochasticDiffEqCore
+@reexport using StochasticDiffEqCore
 import DiffEqBase
 
 import OrdinaryDiffEqCore


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Import `StochasticDiffEqCore` before reexporting it from `StochasticDiffEqImplicit`. On Julia 1.11, creating the binding through `@reexport using` first causes ExplicitImports to retain it as an implicit import even when a later `import StochasticDiffEqCore` appears in the same module.

The regression was bisected to https://github.com/SciML/OrdinaryDiffEq.jl/commit/661f605637cfee546437c09f7dd7ed2873ee55d2, which enabled ExplicitImports for the sublibrary and added the explicit import after the reexport.

## Failing before

On clean `master` at `468bea34e07adda8e3b6327119a65e50c7fc89c9`:

```sh
GROUP=QA ~/.juliaup/bin/julia +1.11.9 --project=lib/StochasticDiffEqImplicit --startup-file=no -e 'using Pkg; Pkg.test()'
```

```text
ImplicitImportsException
Module `StochasticDiffEqImplicit` is relying on the following implicit imports:
* `StochasticDiffEqCore` which is exported by `StochasticDiffEqCore`

Test Summary:     | Pass  Error  Total
QA (Aqua and JET) |   20      1     21
ERROR: Package StochasticDiffEqImplicit errored during testing
```

## Verification

The same Julia 1.11.9 QA command on this branch:

```text
Test Summary:     | Pass  Total     Time
QA (Aqua and JET) |   21     21  1m54.0s
Testing StochasticDiffEqImplicit tests passed
```

Additional checks:

```text
GROUP=Core julia +1.11.9 ... Pkg.test()
Module loads and constructors | 8/8 passed

GROUP=QA julia +1.12 ... Pkg.test()
QA (Aqua and JET) | 21/21 passed

julia +1.12 -m Runic --check lib/StochasticDiffEqImplicit/src/StochasticDiffEqImplicit.jl
exit 0

typos lib/StochasticDiffEqImplicit/src/StochasticDiffEqImplicit.jl
exit 0

git diff --check upstream/master...HEAD
exit 0
```

## Not verified

The root `Everything`, GPU, downgrade, and documentation jobs were not run. This change only reorders two existing imports, does not alter the public API or documentation, and is covered by the sublibrary's discriminating QA and Core groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03caf-aae8-74c3-9a79-53b836434858
