### PR TITLE
test: account for Hairer4 BLAS variation

### DIFF
--- a/test/Regression_I/newton_krylov_roundoff.jl
+++ b/test/Regression_I/newton_krylov_roundoff.jl
@@ -17,10 +17,12 @@ then amplifies last-ulp input differences without bound. That is what
 SciML/OrdinaryDiffEq.jl#4034 measured: perturbing `u0[1]` by one ulp moved the
 `Hairer4` solution of this index-1 DAE by 3.7e-03.
 
-The gate is deliberately loose relative to the values it protects: a
-round-off-reproducible integration lands at 1e-15 … 1e-7 here (the step sequence
-itself is mildly chaotic), while the regression it catches sits at 5.7e-04
-(`Hairer42`) and 3.7e-03 (`Hairer4`).
+The gate is deliberately loose relative to the values it protects. Different
+BLAS kernels can perturb the nonlinear solve enough to select different step
+sequences, so `Hairer4` can drift by 1.5e-04 while its direct-factorization
+control also crosses 1e-05. Its 5e-04 bound remains more than sevenfold below
+the 3.7e-03 regression, while the unchanged `Hairer42` bound remains more than
+fiftyfold below its 5.7e-04 regression.
 =#
 
 dae!(du, u, p, t) = mul!(du, p, u)
@@ -48,8 +50,8 @@ const U0_PERTURBED = let u = copy(U0)
     u
 end
 
-@testset "Newton-Krylov round-off reproducibility ($(nameof(alg)))" for alg in (
-        Hairer4, Hairer42,
+@testset "Newton-Krylov round-off reproducibility ($(nameof(alg)))" for (alg, drift_limit) in (
+        (Hairer4, 5.0e-4), (Hairer42, 1.0e-5),
     )
     a = solve(
         dae_prob(U0), alg(linsolve = KrylovJL_GMRES());
@@ -65,5 +67,5 @@ end
         maximum(abs.(a(t) .- b(t)))
             for t in DAE_TSPAN[1]:0.1:DAE_TSPAN[2]
     )
-    @test drift < 1.0e-5
+    @test drift < drift_limit
 end


### PR DESCRIPTION
## What changed and why

This gives the Hairer4 Newton–Krylov round-off regression test an algorithm-specific drift limit while retaining the tighter Hairer42 limit. Julia 1.12.7 CI observed a Hairer4 drift of `1.4306299457644833e-4`; deterministic local controls show that selecting a different OpenBLAS kernel can move the adaptive step grid enough for both Krylov and direct-factorization Hairer4 solves to cross the old `1e-5` gate.

The new Hairer4 limit is `5e-4`, 7.4× smaller than the original bad `3.7e-3` drift, so it still rejects the regression this test was introduced to catch. Hairer42 remains unchanged at `1e-5`, 57× smaller than its original bad `5.7e-4` drift.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Investigation

On Julia 1.12.7, the Hairer4 drift is deterministic for a given OpenBLAS kernel:

- native Haswell/Zen: `1.9762512959431433e-8`
- Sandybridge/Nehalem: `3.544154607149075e-5`
- CI runner: `1.4306299457644833e-4`

With `OPENBLAS_CORETYPE=Sandybridge`, direct-factorization Hairer4 also drifts `4.3069318102717524e-5`. Replacing the matrix-vector RHS with scalar arithmetic does not change the result. Zeroing LinearSolve's absolute tolerance floor improves Krylov Hairer4 only to `1.6816736305602653e-5`; tighter relative tolerances do not improve it and eventually exhaust the four-dimensional Krylov solve. These controls identify benign floating-point perturbations being amplified through different accepted adaptive step sequences, rather than a remaining Krylov or warm-start defect.

The CI gate itself was introduced with the guarded Hegedüs fix; its parent has no test file. The observed architecture-sensitive behavior predates this PR, while this PR preserves the gate's ability to discriminate the measured regression.

## Failing before / passing after

The checked-in test file was run from a temporary local environment that developed this checkout:

```text
OPENBLAS_CORETYPE=Sandybridge julia +1.12 --project=scratch_newton_env --startup-file=no -e 'include("test/Regression_I/newton_krylov_roundoff.jl")'
```

Before, with Hairer4 using the common `1e-5` limit:

```text
Expression: drift < drift_limit
 Evaluated: 3.544154607149075e-5 < 1.0e-5
Test Summary:                                     | Pass  Fail  Total
Newton-Krylov round-off reproducibility (Hairer4) |    2     1      3
```

After, with the algorithm-specific limits:

```text
Test Summary:                                     | Pass  Total
Newton-Krylov round-off reproducibility (Hairer4) |    3      3
Test Summary:                                      | Pass  Total
Newton-Krylov round-off reproducibility (Hairer42) |    3      3
```

## Verification

After rebasing onto `upstream/master` at `52bf8f3cad`, the focused repository gate passed under the failing kernel:

```text
OPENBLAS_CORETYPE=Sandybridge GROUP=Regression_I julia +1.12 --project=. --startup-file=no -e 'using Pkg; Pkg.test()'
Test Summary:                 | Pass  Total     Time
Newton-Krylov Round-off Tests |    6      6  1m55.6s
Testing OrdinaryDiffEq tests passed
```

The full relevant group passed under Sandybridge before the two-commit rebase; the post-rebase focused gate above covers the only affected test and the intervening nonlinear-solver change:

```text
OPENBLAS_CORETYPE=Sandybridge GROUP=Regression_I julia +1.12 --project=. --startup-file=no -e 'using Pkg; Pkg.test()'
Dense Tests                     4104/4104
Special Interp Tests              30/30
Inplace Tests                       2/2
Adaptive Tests                     46/46
Hard DAE Tests                     36/36
Newton-Krylov Round-off Tests        6/6
Testing OrdinaryDiffEq tests passed
```

Quality assurance passed before the same two-commit rebase; this branch's only change is the regression test:

```text
GROUP=QA julia +1.12 --project=. --startup-file=no -e 'using Pkg; Pkg.test()'
Test Summary:           | Pass  Total      Time
Quality Assurance Tests |  106    106  13m09.1s
Testing OrdinaryDiffEq tests passed
```

Formatting and spelling passed:

```text
julia +1.12 --startup-file=no -m Runic --check --diff test/Regression_I/newton_krylov_roundoff.jl
typos test/Regression_I/newton_krylov_roundoff.jl
git diff --check
```

Documentation was not built because this changes only an internal regression test. GPU, Julia pre, and downstream jobs were not run locally.

## Links

- Failing Julia 1.12.7 CI job: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33130210901/job/98718263475
- Original regression report: https://github.com/SciML/OrdinaryDiffEq.jl/issues/4034
- Commit that introduced the gate: https://github.com/SciML/OrdinaryDiffEq.jl/commit/1c85484d24

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03caf-aae8-74c3-9a79-53b836434858
