### PR TITLE
Fix Rosenbrock interpolation after callback truncation

### DIFF
--- a/lib/OrdinaryDiffEqRosenbrock/src/stiff_addsteps.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/stiff_addsteps.jl
@@ -87,7 +87,7 @@ function _ode_addsteps!(
         end
 
         num_stages = size(A, 1)
-        du = f(u, p, t)
+        du = f(uprev, p, t)
         linsolve_tmp = @.. du + dtd[1] * dT
         k1 = _restructure_state(uprev, W \ _vec(linsolve_tmp))
         # constant number for type stability make sure this is greater than num_stages
@@ -185,7 +185,7 @@ function _ode_addsteps!(
                     @.. linsolve_tmp += dtC[stage, i] * _vec(ks[i])
                 end
             else
-                du1 .= du
+                fill!(du1, zero(eltype(du1)))
                 for i in 1:(stage - 1)
                     @.. du1 += dtC[stage, i] * _vec(ks[i])
                 end

--- a/lib/OrdinaryDiffEqRosenbrock/test/callback_truncated_interpolation.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/callback_truncated_interpolation.jl
@@ -1,0 +1,35 @@
+using OrdinaryDiffEqRosenbrock, DiffEqBase, LinearAlgebra, Test
+
+function linear_dae!(du, u, p, t)
+    du[1] = -1
+    du[2] = u[2] - u[1]
+    return nothing
+end
+linear_dae(u, p, t) = [-1, u[2] - u[1]]
+
+mass_matrix = Diagonal([1.0, 0.0])
+callback = ContinuousCallback((u, t, integrator) -> u[1] - 0.3, terminate!)
+
+@testset "Callback-truncated interpolation" begin
+    @testset "Mass-matrix DAE" begin
+        for f in (linear_dae!, linear_dae), alg in (Rodas4(), Rodas4P(), Rodas5P())
+            prob = ODEProblem(ODEFunction(f; mass_matrix), [1.0, 1.0], (0.0, 1.0))
+            sol = solve(prob, alg; adaptive = false, dt = 1.0, callback, initializealg = NoInit())
+
+            @test sol.t[end] ≈ 0.7 atol = 1.0e-12
+            @test sol.u[end] ≈ [0.3, 0.3] atol = 1.0e-12
+            @test sol(0.35) ≈ [0.65, 0.65] atol = 1.0e-12
+        end
+    end
+
+    @testset "Out-of-place ODE" begin
+        prob = ODEProblem((u, p, t) -> u, [1.0], (0.0, 1.0))
+        callback = ContinuousCallback((u, t, integrator) -> u[1] - exp(0.7), terminate!)
+
+        for alg in (Rodas4(), Rodas4P(), Rodas5P())
+            sol = solve(prob, alg; adaptive = false, dt = 1.0, callback)
+            tmiddle = sol.t[end] / 2
+            @test sol(tmiddle)[1] ≈ exp(tmiddle) rtol = 1.0e-2
+        end
+    end
+end

--- a/lib/OrdinaryDiffEqRosenbrock/test/runtests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/runtests.jl
@@ -22,6 +22,7 @@ end
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "DAE Rosenbrock AD Tests" include("dae_rosenbrock_ad_tests.jl")
+    @time @safetestset "Callback-truncated interpolation" include("callback_truncated_interpolation.jl")
     @time @safetestset "Rosenbrock AD Tests" include("rosenbrock_ad_tests.jl")
     @time @safetestset "Rosenbrock Convergence Tests" include("ode_rosenbrock_tests.jl")
 end


### PR DESCRIPTION
> **Ignore until reviewed by @ChrisRackauckas.**

## What changed and why

Callback truncation asks `addsteps!` to reconstruct Rosenbrock interpolation stages for the shortened final step. The out-of-place path evaluated the first stage at a scratch state instead of `uprev`, while the mutable mass-matrix path seeded its stage accumulator with `du` and therefore added an extra `M * du`. This changes those two expressions and adds a fixed-step callback regression covering Rodas4, Rodas4P, and Rodas5P for in-place/out-of-place mass-matrix DAEs and an out-of-place ODE.

## Verification

### Failing before the fix

```text
TMPDIR="$HOME/tmp" julia +1.10 --project=lib/OrdinaryDiffEqRosenbrock lib/OrdinaryDiffEqRosenbrock/test/callback_truncated_interpolation.jl

Test Summary:                    | Pass  Fail  Total
Callback-truncated interpolation |   15     6     21
  Mass-matrix DAE                |   15     3     18
  Out-of-place ODE               |          3      3
```

The DAE midpoint should be `0.65`; the unfixed Rodas4/Rodas4P/Rodas5P results were `0.37279301599954645`, `0.18292522392043037`, and `0.7915660962809313`. The out-of-place ODE midpoint errors were also reproduced for all three algorithms.

### Passing with the fix

```text
TMPDIR="$HOME/tmp" julia +1.10 --project=lib/OrdinaryDiffEqRosenbrock lib/OrdinaryDiffEqRosenbrock/test/callback_truncated_interpolation.jl

Test Summary:                    | Pass  Total   Time
Callback-truncated interpolation |   21     21  34.3s
```

```text
TMPDIR="$HOME/tmp" GROUP=Core julia +1.10 --project=lib/OrdinaryDiffEqRosenbrock -e "using Pkg; Pkg.test()"

DAE Rosenbrock AD Tests          |  16/16 passed
Callback-truncated interpolation |  21/21 passed
Rosenbrock AD Tests              |  64/64 passed
Rosenbrock Convergence Tests     | 195/195 passed
Testing OrdinaryDiffEqRosenbrock tests passed
```

```text
TMPDIR="$HOME/tmp" GROUP=QA julia +1.10 --project=lib/OrdinaryDiffEqRosenbrock -e "using Pkg; Pkg.test()"

Inference Tests | 40/40 passed
JET Tests       |  1/1 passed
Aqua            | 19/19 passed
Testing OrdinaryDiffEqRosenbrock tests passed
```

Runic (`--check --diff`), `typos`, and `git diff --check` also passed.

### Original LyoPronto reproducer

Using LyoPronto commit `b907e35dbefbc010a2f742dddadc0f480a7a529f`, 1,001 dense-output samples over the final callback-truncated step had zero overshoot and zero increasing intervals for Rodas4, Rodas4P, and Rodas5P.

## Not verified

GPU and downstream-package test groups were not run. No documentation build was run because the change does not touch documentation or public API.

🤖 Generated with Codex API (model: unknown; session: unknown).