### PR TITLE
Convert dt to the time type before building the cache

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.15.1"
+version = "4.15.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqCore/src/solve.jl
+++ b/lib/OrdinaryDiffEqCore/src/solve.jl
@@ -561,7 +561,7 @@ Base.@constprop :aggressive function _ode_init(
         isdiscretealg(alg) && isempty(tstops) ?
             eltype(prob.tspan)(1) : eltype(prob.tspan)(0)
     else
-        dt
+        tType(dt)
     end
     if _cache !== nothing
         cache = _cache

--- a/lib/OrdinaryDiffEqRosenbrock/test/rosenbrock_ad_tests.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/rosenbrock_ad_tests.jl
@@ -1,6 +1,7 @@
 using OrdinaryDiffEqRosenbrock, Test
-using SciMLBase: ODEProblem
+using SciMLBase: ODEProblem, ODEFunction, ContinuousCallback, terminate!
 using ForwardDiff
+using LinearAlgebra: Diagonal
 
 # Regression test for issue #3486 — nested ForwardDiff (hessian /
 # gradient-of-gradient) through a Rosenbrock solve used to error with:
@@ -94,4 +95,21 @@ const ROSENBROCK_ALGS_TO_TEST = (
     H = ForwardDiff.hessian(loss, [1.0, 1.0])
     @test all(isfinite, H)
     @test H ≈ [0.25 0.0; 0.0 0.25] atol = 1.0e-4
+end
+
+@testset "dt kwarg with a continuous callback under ForwardDiff (issue #4399)" begin
+    function rhs_massmatrix!(du, u, p, t)
+        du[1] = -p[1] * u[1]
+        du[2] = u[1] + u[2] - one(eltype(u))
+        return nothing
+    end
+    F = ODEFunction{true}(rhs_massmatrix!, mass_matrix = Diagonal([1.0, 0.0]))
+    cb = ContinuousCallback((u, t, i) -> u[1] - 1.0e-10, terminate!)
+
+    function loss_dt(k)
+        prob = ODEProblem(F, [1.0, 0.0], (0.0, 1.0), [k]; dt = 0.1, callback = cb)
+        return solve(prob, Rodas5P(); abstol = 1.0e-8, reltol = 1.0e-8).u[end][2]
+    end
+
+    @test ForwardDiff.derivative(loss_dt, 2.0) ≈ exp(-2.0) rtol = 1.0e-6
 end


### PR DESCRIPTION
Fixes #4399.

`solve(prob, alg; dt = 0.1)` threw `MethodError: no method matching Float64(::ForwardDiff.Dual{...})` when differentiating through the solve, but only when the problem also carried a `ContinuousCallback`.

`promote_tspan` promotes `tspan` to the `Dual` type when `u0` is `Dual` and a continuous callback is present, because the event time is differentiable. `_ode_init` then built `_dt` two different ways:

```julia
_dt = if isnothing(dt)
    isdiscretealg(alg) && isempty(tstops) ?
        eltype(prob.tspan)(1) : eltype(prob.tspan)(0)
else
    dt
end
```

The `nothing` branch takes its type from `tspan`; the other keeps the raw keyword argument. So when `dt` was passed, `tspan` was `Dual` while `_dt` stayed `Float64`. `alg_cache` gets `_dt`, and the Rosenbrock cache sizes `dtC`/`dtd` off it, so they were allocated as `Float64`. On the first step `@. dtC = C * inv(dt)` tries to write a `Dual` into them and throws.

`dtcache = tType(_dt)` already runs a few lines further down, so the conversion existed, only after `alg_cache` had used the unconverted value. This moves it to where `_dt` is built.

That also accounts for the shape of the reproducer: with no `dt`, `_dt` is built from `eltype(tspan)`; with no callback, `tspan` is never promoted. Only both together split the two types apart.

Testing:

- The reproducer from the issue returns `0.13533528321892258`, against the analytic `d/dk (1 - e^-k) = e^-2 = 0.1353352832366127`.
- Reverting the one line reproduces the reported `MethodError` on the new test.
- `rosenbrock_ad_tests.jl` and `dae_rosenbrock_ad_tests.jl` pass.
- Checked `tType(dt)` against `Int`, `Rational`, `Float32` and `BigFloat` tspans, and unitful `dt = 1u"s"/10` as used in `units_tests.jl`. All bit-identical to master.

AI Disclosure: Claude assisted with this change.
