### PR TITLE
Fix weak Platen methods for scalar Wiener processes

### DIFF
--- a/lib/StochasticDiffEqWeak/src/perform_step/srk_weak.jl
+++ b/lib/StochasticDiffEqWeak/src/perform_step/srk_weak.jl
@@ -1056,9 +1056,16 @@ end
     m = length(W.dW)
     sq3dt = sqrt(3 * dt)
     # define three-point distributed random variables
-    @.. chi1 = W.dW / integrator.sqdt
-    calc_threepoint_random!(_dW, sq3dt, NORMAL_ONESIX_QUANTILE, chi1)
-    map!(x -> (x^2 - dt) / 4, chi1, _dW)
+    if W.dW isa Number
+        _dW = calc_threepoint_random(
+            sq3dt, NORMAL_ONESIX_QUANTILE, W.dW / integrator.sqdt
+        )
+        chi1 = (_dW^2 - dt) / 4
+    else
+        @.. chi1 = W.dW / integrator.sqdt
+        calc_threepoint_random!(_dW, sq3dt, NORMAL_ONESIX_QUANTILE, chi1)
+        map!(x -> (x^2 - dt) / 4, chi1, _dW)
+    end
     if !(W.dW isa Number) || m > 1
         # define two-point distributed random variables
         calc_twopoint_random!(_dZ, integrator.sqdt, W.dZ)
@@ -1068,18 +1075,18 @@ end
     integrator.f.g(g1, uprev, p, t)
 
     # Y, Yp, Ym
-    if !is_diagonal_noise(integrator.sol.prob) || W.dW isa Number
+    if W.dW isa Number
+        @.. tmp1 = g1 * _dW
+        @.. Y = uprev + k1 * dt + tmp1
+        @.. Yp[1] = uprev + k1 * dt + g1 * integrator.sqdt
+        @.. Ym[1] = uprev + k1 * dt - g1 * integrator.sqdt
+    elseif !is_diagonal_noise(integrator.sol.prob)
         mul!(tmp1, g1, _dW)
         @.. Y = uprev + k1 * dt + tmp1
-        if W.dW isa Number
-            @.. Yp = uprev + k1 * dt + g1 * integrator.sqdt
-            @.. Ym = uprev + k1 * dt - g1 * integrator.sqdt
-        else
-            for k in 1:m
-                g1k = @view g1[:, k]
-                @.. Yp[k] = uprev + k1 * dt + g1k * integrator.sqdt
-                @.. Ym[k] = uprev + k1 * dt - g1k * integrator.sqdt
-            end
+        for k in 1:m
+            g1k = @view g1[:, k]
+            @.. Yp[k] = uprev + k1 * dt + g1k * integrator.sqdt
+            @.. Ym[k] = uprev + k1 * dt - g1k * integrator.sqdt
         end
     else
         @.. Y = uprev + k1 * dt + g1 * _dW
@@ -1096,8 +1103,8 @@ end
 
     # add noise
     if W.dW isa Number
-        integrator.f.g(tmpg1, Yp, p, t)
-        integrator.f.g(tmpg2, Ym, p, t)
+        integrator.f.g(tmpg1, Yp[1], p, t)
+        integrator.f.g(tmpg2, Ym[1], p, t)
         @.. u = u + 1 // 4 * (tmpg1 + tmpg2 + 2 * g1) * _dW + (tmpg1 - tmpg2) * chi1 / integrator.sqdt #(1.1)
     else
         if !is_diagonal_noise(integrator.sol.prob) || W.dW isa Number
@@ -1192,18 +1199,26 @@ end
 
     sq3dt = sqrt(3 * dt)
     # define three-point distributed random variables
-    @.. chi1 = W.dW / integrator.sqdt
-    calc_threepoint_random!(_dW, sq3dt, NORMAL_ONESIX_QUANTILE, chi1)
+    if W.dW isa Number
+        _dW = calc_threepoint_random(
+            sq3dt, NORMAL_ONESIX_QUANTILE, W.dW / integrator.sqdt
+        )
+    else
+        @.. chi1 = W.dW / integrator.sqdt
+        calc_threepoint_random!(_dW, sq3dt, NORMAL_ONESIX_QUANTILE, chi1)
+    end
 
     # compute stage values
     integrator.f(k1, uprev, p, t)
     integrator.f.g(g1, uprev, p, t)
 
     # Y, Yp, Ym
-    if !is_diagonal_noise(integrator.sol.prob) || W.dW isa Number
+    if W.dW isa Number
+        @.. tmp1 = g1 * _dW
+        @.. Y = uprev + k1 * dt + tmp1
+    elseif !is_diagonal_noise(integrator.sol.prob)
         mul!(tmp1, g1, _dW)
         @.. Y = uprev + k1 * dt + tmp1
-
     else
         @.. tmp1 = g1 * _dW
         @.. Y = uprev + k1 * dt + tmp1

--- a/lib/StochasticDiffEqWeak/test/adaptive/sde_weak_brusselator_adaptive.jl
+++ b/lib/StochasticDiffEqWeak/test/adaptive/sde_weak_brusselator_adaptive.jl
@@ -1,4 +1,5 @@
 using StochasticDiffEqWeak, Test, DiffEqNoiseProcess
+using SciMLBase
 using Random
 
 function brusselator_f!(du, u, p, t)
@@ -13,6 +14,14 @@ function scalar_noise!(du, u, p, t)
     @inbounds begin
         du[1] = p[2] * u[1] * (1 + u[1])
         du[2] = -p[2] * u[1] * (1 + u[1])
+    end
+    return nothing
+end
+
+function additive_scalar_noise!(du, u, p, t)
+    @inbounds begin
+        du[1] = p[2]
+        du[2] = -p[2]
     end
     return nothing
 end
@@ -40,6 +49,18 @@ prob = SDEProblem(brusselator_f!, scalar_noise!, u0, tspan, p, noise = W)
 ensembleprob = EnsembleProblem(prob; prob_func)
 
 @info "Brusselator"
+
+short_prob = remake(prob; tspan = (0.0f0, 1.0f0))
+short_additive_prob = SDEProblem(
+    brusselator_f!, additive_scalar_noise!, u0, (0.0f0, 1.0f0), p,
+    noise = WienerProcess(0.0, 0.0, 0.0)
+)
+
+@testset "$(nameof(typeof(alg))) with scalar Wiener process" for (alg, short_test_prob) in
+    ((PL1WM(), short_prob), (PL1WMA(), short_additive_prob))
+    sol = solve(short_test_prob, alg; dt = 0.1f0, adaptive = false)
+    @test SciMLBase.successful_retcode(sol)
+end
 
 #Performance check with nvvp
 # CUDAnative.CUDAdrv.@profile


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

The mutable-cache implementations of `PL1WM` and `PL1WMA` treated a scalar Wiener increment as a mutable array. `PL1WM` also wrote scalar-noise stage states into the entire `Vector{u}` cache and then passed that container to the diffusion function instead of its sole state.

Use the scalar random-variable helper and elementwise state updates when `W.dW` is a number. Keep the existing mutating helpers for array-valued increments, and index the sole `Yp`/`Ym` state on the scalar-noise path. The regression tests cover multiplicative `PL1WM` and additive `PL1WMA` solves with an explicit scalar `WienerProcess`.

## Verification

### Failing before the fix

With the scalar-Wiener regression test added and the implementation unchanged:

```console
$ GROUP=WeakAdaptiveCPU julia +1.11.9 --project=lib/StochasticDiffEqWeak -e 'using Pkg; Pkg.test()'
Test Summary:     | Pass  Total     Time
CPU Weak adaptive |    6      6  7m10.5s
CPU Weak adaptive step size Brusselator: Error During Test
  LoadError: MethodError: no method matching fill!(::Float64, ::Float64)
  ...
  [2] perform_step!(..., cache::StochasticDiffEqWeak.PL1WMCache...)
      @ StochasticDiffEqWeak .../perform_step/srk_weak.jl:1059
ERROR: Some tests did not pass: 0 passed, 0 failed, 1 errored, 0 broken.
```

### Passing after the fix

```console
$ GROUP=WeakAdaptiveCPU julia +1.11.9 --project=lib/StochasticDiffEqWeak -e 'using Pkg; Pkg.test()'
Test Summary:     | Pass  Total     Time
CPU Weak adaptive |    6      6  4m12.6s
Test Summary:                           | Pass  Total   Time
CPU Weak adaptive step size Brusselator |    3      3  23.7s
Testing StochasticDiffEqWeak tests passed

$ GROUP=WeakConvergence1 julia +1.11.9 --project=lib/StochasticDiffEqWeak -e 'using Pkg; Pkg.test()'
Test Summary:                    | Pass  Total     Time
Platen's PL1WM weak second order |   10     10  6m20.6s
Testing StochasticDiffEqWeak tests passed

$ GROUP=Core julia +1.11.9 --project=lib/StochasticDiffEqWeak -e 'using Pkg; Pkg.test()'
Test Summary:                 | Pass  Total  Time
Module loads and constructors |   23     23  6.4s
Testing StochasticDiffEqWeak tests passed

$ GROUP=QA julia +1.11.9 --project=lib/StochasticDiffEqWeak -e 'using Pkg; Pkg.test()'
Test Summary:     | Pass  Broken  Total     Time
QA (Aqua and JET) |   17       4     21  2m01.1s
Testing StochasticDiffEqWeak tests passed

$ julia +1.11.9 --project=.validation/runic-env -e 'using Runic; exit(Runic.main(ARGS))' -- --check lib/StochasticDiffEqWeak/src/perform_step/srk_weak.jl lib/StochasticDiffEqWeak/test/adaptive/sde_weak_brusselator_adaptive.jl
# exit 0

$ typos --format brief lib/StochasticDiffEqWeak/src/perform_step/srk_weak.jl lib/StochasticDiffEqWeak/test/adaptive/sde_weak_brusselator_adaptive.jl
# exit 0
```

Documentation was not built because this changes no public API or documentation. GPU paths were not tested; the affected regression uses the CPU mutable-cache path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
