### PR TITLE
Release StochasticDiffEqWeak 2.2.1

### DIFF
--- a/lib/StochasticDiffEqWeak/Project.toml
+++ b/lib/StochasticDiffEqWeak/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqWeak"
 uuid = "af2a2fcd-1c36-4cbe-a6d0-5afda784a085"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
> Ignore until reviewed by @ChrisRackauckas.

## What changed and why

Bump `StochasticDiffEqWeak` from 2.2.0 to 2.2.1 so the merged scalar-Wiener PL1WM/PL1WMA fix can be registered. The source fix is https://github.com/SciML/OrdinaryDiffEq.jl/pull/4413.

This is a mechanical, one-line version bump; no source, dependency, or API changes are included.

## Verification

Run on the final branch after rebasing onto current `master`:

```
GROUP=Core julia +1.11.9 --startup-file=no --project=lib/StochasticDiffEqWeak -e 'using Pkg; Pkg.test()'
Test Summary:                 | Pass  Total  Time
Module loads and constructors |   23     23  6.3s
Testing StochasticDiffEqWeak tests passed
```

```
GROUP=QA julia +1.11.9 --startup-file=no --project=lib/StochasticDiffEqWeak -e 'using Pkg; Pkg.test()'
Test Summary:     | Pass  Broken  Total     Time
QA (Aqua and JET) |   17       4     21  2m02.1s
Testing StochasticDiffEqWeak tests passed
```

`git diff --check` and `typos lib/StochasticDiffEqWeak/Project.toml` both passed. Runic is not applicable to the TOML-only change.

## Not verified

The full `Everything` suite, downstream suites, GPU jobs, and docs were not run because this PR only changes the subpackage version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
