### PR TITLE
OrdinaryDiffEqSIMDRK: raise SciMLBase floor to 3.45 and release 2.2.0

### DIFF
--- a/lib/OrdinaryDiffEqSIMDRK/Project.toml
+++ b/lib/OrdinaryDiffEqSIMDRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSIMDRK"
 uuid = "dc97f408-7a72-40e4-9b0d-228a53b292f8"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Elrod <elrodc@gmail.com>"]
-version = "2.1.3"
+version = "2.2.0"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -28,7 +28,7 @@ DiffEqDevTools = "3"
 FastBroadcast = "1.3"
 MuladdMacro = "0.2.4"
 OrdinaryDiffEqCore = "4.15.1"
-SciMLBase = "3.39"
+SciMLBase = "3.45"
 SLEEFPirates = "0.6.43"
 VectorizationBase = "0.21.70"
 StaticArrays = "1.9.18"


### PR DESCRIPTION
`src/OrdinaryDiffEqSIMDRK.jl` now does `using SciMLBase: DespecializedParameters, invoke_with_despecialized_parameters`. Neither name exists before SciMLBase 3.45 (absent in 3.43 and 3.44, present in 3.45), and an explicit `using X: name` fails at load time when the name is missing - so the downgrade lane would fail to load the package at the declared floor of 3.39. Raise the floor and cut 2.2.0 for the new despecialized parameter support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R