### PR TITLE
Bump OrdinaryDiffEqFIRK Differentiation floor to 3.11

### DIFF
--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFIRK"
 uuid = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.8.1"
+version = "2.8.2"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -48,7 +48,7 @@ FastGaussQuadrature = "1.2"
 MuladdMacro = "0.2.4"
 LinearSolve = "5.12"
 LinearAlgebra = "1.10"
-OrdinaryDiffEqDifferentiation = "3.9"
+OrdinaryDiffEqDifferentiation = "3.11"
 SciMLBase = "3.39"
 OrdinaryDiffEqCore = "4.15.1"
 GenericSchur = "0.5"


### PR DESCRIPTION
## Summary
- OrdinaryDiffEqFIRK imports `drain_jvp_count!` from OrdinaryDiffEqDifferentiation (added in the 3.10 line; current Differentiation is 3.11.0).
- Compat still allowed Differentiation `3.9`, so Downgrade resolves (e.g. ModelingToolkitBase Dynamic Optimization Collocation on Downgrade Sublibraries) could load FIRK against a Differentiation without that binding → `UndefVarError: drain_jvp_count! not defined`.
- Bump FIRK → 2.8.2 and Differentiation floor → `3.11`.

Ignore until reviewed by @ChrisRackauckas.

## Test plan
- [ ] Downgrade Sublibraries / OrdinaryDiffEqFIRK
- [ ] After register: ModelingToolkit Downgrade Sublibraries ModelingToolkitBase collocation path

Made with [Cursor](https://cursor.com)