### PR TITLE
Resolve the active sub-cache in PredictiveControllerCache

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.16.0"
+version = "4.16.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqCore/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/alg_utils.jl
@@ -155,13 +155,13 @@ method and needs no such opt-in.)
 """
 has_stage_limiter(alg) = false
 
-# evaluates f(t[i])
-_eval_index(f::F, t::Tuple{A}, _) where {F, A} = f(t[1])
-function _eval_index(f::F, t::Tuple{A, Vararg}, i) where {F, A}
+# evaluates f(t[i], args...)
+_eval_index(f::F, t::Tuple{A}, _, args...) where {F, A} = f(t[1], args...)
+function _eval_index(f::F, t::Tuple{A, Vararg}, i, args...) where {F, A}
     return if i == 1
-        f(t[1])
+        f(t[1], args...)
     else
-        _eval_index(f, Base.tail(t), i - 1)
+        _eval_index(f, Base.tail(t), i - 1, args...)
     end
 end
 

--- a/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
@@ -1192,6 +1192,15 @@ function setup_controller_cache(alg, cache, controller::PredictiveController, ::
     )
 end
 
+current_newton_iter(cache) = cache.iter
+function current_newton_iter(cache::CompositeCache)
+    return _eval_index(current_newton_iter, cache.caches, cache.current)::Int
+end
+current_nlsolver_iters(cache) = (cache.nlsolver.iter, cache.nlsolver.maxiters)
+function current_nlsolver_iters(cache::CompositeCache)
+    return _eval_index(current_nlsolver_iters, cache.caches, cache.current)::Tuple{Int, Int}
+end
+
 @inline function stepsize_controller!(integrator, cache::PredictiveControllerCache, alg)
     (; qmin, qmax, gamma) = cache.controller.basic
     qmax = get_current_qmax(integrator, qmax)
@@ -1203,10 +1212,10 @@ end
             fac = gamma
         else
             if isfirk(alg)
-                (; iter) = integrator.cache
+                iter = current_newton_iter(integrator.cache)
                 (; maxiters) = alg
             else
-                (; iter, maxiters) = integrator.cache.nlsolver
+                iter, maxiters = current_nlsolver_iters(integrator.cache)
             end
             fac = min(gamma, (1 + 2 * maxiters) * gamma / (iter + 2 * maxiters))
         end

--- a/test/InterfaceI/composite_algorithm_test.jl
+++ b/test/InterfaceI/composite_algorithm_test.jl
@@ -2,6 +2,7 @@ using OrdinaryDiffEq, OrdinaryDiffEqCore, Test, LinearAlgebra
 import ODEProblemLibrary: prob_ode_linear, prob_ode_2Dlinear
 using DiffEqDevTools, ADTypes
 using OrdinaryDiffEqAdamsBashforthMoulton, OrdinaryDiffEqExplicitRK, OrdinaryDiffEqRosenbrock
+using OrdinaryDiffEqFIRK
 import OrdinaryDiffEqExplicitTableaus
 using OrdinaryDiffEqCore: CompositeAlgorithm
 
@@ -114,3 +115,26 @@ cb = DiscreteCallback(
     (u, t, integrator) -> true, (integrator) -> derivative_discontinuity!(integrator, true)
 )
 sol = solve(prob_mm, DefaultODEAlgorithm(), callback = cb)
+
+@testset "AutoSwitch composite with a FIRK stiff member (#4364)" begin
+    function rober_stiff!(du, u, p, t)
+        y1, y2, y3 = u
+        du[1] = -0.04 * y1 + 1.0e4 * y2 * y3
+        du[2] = 0.04 * y1 - 1.0e4 * y2 * y3 - 3.0e7 * y2^2
+        du[3] = 3.0e7 * y2^2
+        return nothing
+    end
+    prob_stiff = ODEProblem(rober_stiff!, [1.0, 0.0, 0.0], (0.0, 1.0e5))
+
+    for alg in (
+            AutoVern7(RadauIIA3(autodiff = AutoFiniteDiff()); stiffalgfirst = true),
+            AutoVern7(RadauIIA5(autodiff = AutoFiniteDiff()); stiffalgfirst = true),
+            AutoTsit5(RadauIIA5(autodiff = AutoFiniteDiff()); stiffalgfirst = true),
+        )
+        sol = solve(prob_stiff, alg)
+        @test sol.retcode == ReturnCode.Success
+    end
+
+    integ = init(prob_stiff, AutoTsit5(RadauIIA5(autodiff = AutoFiniteDiff()); stiffalgfirst = true))
+    @test @inferred(OrdinaryDiffEqCore.current_newton_iter(integ.cache)) isa Int
+end


### PR DESCRIPTION
`PredictiveControllerCache`'s FIRK branch read `iter` from `integrator.cache`, which is the `CompositeCache` when a Radau method is an AutoSwitch member, so `AutoVern7(RadauIIA5())` threw `type CompositeCache has no field iter`; it now resolves the active sub-cache first. `DefaultCache` is not handled: it holds `cache1..cache6` rather than `caches`/`current`, but none of its members are FIRK, so the branch is unreachable for it.

niy-ati's fix from #4365, rebased onto current master with the Core bump added and the comments removed; `composite_algorithm_test.jl` 16/16, and reverting the change brings the error back.

This stops the crash only; the composite then hangs on `NaN` stage guesses, and five lines below this patch `controllers.jl` still passes `integrator.cache` to `get_current_adaptive_order`, which throws for `AdaptiveRadau`. #4421 fixes both on the FIRK side.

Fixes #4364 together with #4421. Supersedes #4365.

AI Disclosure: Claude assisted with this change.