### PR TITLE
Initialise FIRK dtprev so composite members can take a first step

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.16.0"
+version = "4.16.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqCore/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/alg_utils.jl
@@ -155,13 +155,13 @@ method and needs no such opt-in.)
 """
 has_stage_limiter(alg) = false
 
-# evaluates f(t[i])
-_eval_index(f::F, t::Tuple{A}, _) where {F, A} = f(t[1])
-function _eval_index(f::F, t::Tuple{A, Vararg}, i) where {F, A}
+# evaluates f(t[i], args...)
+_eval_index(f::F, t::Tuple{A}, _, args...) where {F, A} = f(t[1], args...)
+function _eval_index(f::F, t::Tuple{A, Vararg}, i, args...) where {F, A}
     return if i == 1
-        f(t[1])
+        f(t[1], args...)
     else
-        _eval_index(f, Base.tail(t), i - 1)
+        _eval_index(f, Base.tail(t), i - 1, args...)
     end
 end
 

--- a/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/controllers.jl
@@ -1192,6 +1192,15 @@ function setup_controller_cache(alg, cache, controller::PredictiveController, ::
     )
 end
 
+current_newton_iter(cache) = cache.iter
+function current_newton_iter(cache::CompositeCache)
+    return _eval_index(current_newton_iter, cache.caches, cache.current)::Int
+end
+current_nlsolver_iters(cache) = (cache.nlsolver.iter, cache.nlsolver.maxiters)
+function current_nlsolver_iters(cache::CompositeCache)
+    return _eval_index(current_nlsolver_iters, cache.caches, cache.current)::Tuple{Int, Int}
+end
+
 @inline function stepsize_controller!(integrator, cache::PredictiveControllerCache, alg)
     (; qmin, qmax, gamma) = cache.controller.basic
     qmax = get_current_qmax(integrator, qmax)
@@ -1203,10 +1212,10 @@ end
             fac = gamma
         else
             if isfirk(alg)
-                (; iter) = integrator.cache
+                iter = current_newton_iter(integrator.cache)
                 (; maxiters) = alg
             else
-                (; iter, maxiters) = integrator.cache.nlsolver
+                iter, maxiters = current_nlsolver_iters(integrator.cache)
             end
             fac = min(gamma, (1 + 2 * maxiters) * gamma / (iter + 2 * maxiters))
         end

--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFIRK"
 uuid = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.8.2"
+version = "2.8.3"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqFIRK/src/OrdinaryDiffEqFIRK.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/OrdinaryDiffEqFIRK.jl
@@ -4,7 +4,7 @@ import OrdinaryDiffEqCore: unwrap_alg,
     default_controller, PredictiveController, PIController,
     OrdinaryDiffEqNewtonAdaptiveAlgorithm,
     OrdinaryDiffEqMutableCache, OrdinaryDiffEqConstantCache,
-    alg_cache, @threaded, isthreaded,
+    alg_cache, @threaded, isthreaded, CompositeCache,
     Sequential, BaseThreads, PolyesterThreads,
     constvalue,
     differentiation_rk_docstring, trivial_limiter!,
@@ -47,7 +47,7 @@ import SciMLOperators: AbstractSciMLOperator
 # dependency from registering as stale.
 import OrdinaryDiffEqNonlinearSolve
 
-import OrdinaryDiffEqCore: PredictiveControllerCache
+import OrdinaryDiffEqCore: PredictiveControllerCache, _eval_index
 
 @static if Base.pkgversion(OrdinaryDiffEqCore) >= v"3.10"
     @eval begin

--- a/lib/OrdinaryDiffEqFIRK/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/alg_utils.jl
@@ -21,6 +21,14 @@ alg_adaptive_order(alg::RadauIIA9) = 5
 
 get_current_alg_order(alg::AdaptiveRadau, cache) = cache.num_stages * 2 - 1
 get_current_adaptive_order(alg::AdaptiveRadau, cache) = cache.num_stages
+current_num_stages(cache) = cache.num_stages
+function current_num_stages(cache::CompositeCache)
+    return _eval_index(current_num_stages, cache.caches, cache.current)::Int
+end
+get_current_alg_order(alg::AdaptiveRadau, cache::CompositeCache) =
+    2 * current_num_stages(cache) - 1
+get_current_adaptive_order(alg::AdaptiveRadau, cache::CompositeCache) =
+    current_num_stages(cache)
 
 function has_stiff_interpolation(::Union{RadauIIA3, RadauIIA5, RadauIIA9, AdaptiveRadau})
     return true

--- a/lib/OrdinaryDiffEqFIRK/src/controllers.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/controllers.jl
@@ -1,10 +1,20 @@
+with_current_cache(f::F, cache, args...) where {F} = f(cache, args...)
+function with_current_cache(f::F, cache::CompositeCache, args...) where {F}
+    return _eval_index(f, cache.caches, cache.current, args...)
+end
+
 function step_accept_controller!(
         integrator, ccache::PredictiveControllerCache, alg::AdaptiveRadau, q
+    )
+    return with_current_cache(firk_step_accept_controller!, integrator.cache, integrator, ccache, alg, q)
+end
+
+function firk_step_accept_controller!(
+        cache, integrator, ccache::PredictiveControllerCache, alg::AdaptiveRadau, q
     )
     (; controller) = ccache
     (; qmin, qmax, gamma, qsteady_min, qsteady_max) = controller.basic
     qmax = get_current_qmax(integrator, qmax)
-    (; cache) = integrator
     (; num_stages, step, iter, hist_iter, index) = cache
 
     EEst = value(OrdinaryDiffEqCore.get_EEst(integrator))
@@ -56,9 +66,16 @@ end
 function step_reject_controller!(
         integrator, ccache::PredictiveControllerCache, alg::AdaptiveRadau
     )
+    with_current_cache(firk_step_reject_controller!, integrator.cache, integrator, ccache, alg)
+    return nothing
+end
+
+function firk_step_reject_controller!(
+        cache, integrator, ccache::PredictiveControllerCache, alg::AdaptiveRadau
+    )
     (; controller) = ccache
     (; discontinuity_detection) = controller.basic
-    (; dt, success_iter, cache) = integrator
+    (; dt, success_iter) = integrator
     (; num_stages, step, iter, hist_iter) = cache
     integrator.dt = success_iter == 0 ? 0.1 * dt : dt / ccache.qold
     cache.step = step + 1

--- a/lib/OrdinaryDiffEqFIRK/src/firk_caches.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_caches.jl
@@ -30,7 +30,7 @@ function alg_cache(
     J = false .* _vec(rate_prototype) .* _vec(rate_prototype)'
 
     return RadauIIA3ConstantCache(
-        uf, tab, κ, one(uToltype), 10000, u, u, dt, dt,
+        uf, tab, κ, one(uToltype), 10000, u, u, one(dt), dt,
         Convergence, J
     )
 end
@@ -129,7 +129,7 @@ function alg_cache(
         du1, fsalfirst, k, k2, fw1, fw2,
         J, W1,
         uf, tab, κ, one(uToltype), 10000,
-        tmp, atmp, jac_config, linsolve, rtol, atol, dt, dt,
+        tmp, atmp, jac_config, linsolve, rtol, atol, one(dt), dt,
         Convergence, alg.step_limiter!
     )
 end
@@ -164,7 +164,7 @@ function alg_cache(
     J = false .* _vec(rate_prototype) .* _vec(rate_prototype)'
 
     return RadauIIA5ConstantCache(
-        uf, tab, κ, one(uToltype), 10000, u, u, u, dt, dt,
+        uf, tab, κ, one(uToltype), 10000, u, u, u, one(dt), dt,
         Convergence, J
     )
 end
@@ -286,7 +286,7 @@ function alg_cache(
         du1, fsalfirst, k, k1, k2, k3, fw1, fw2, fw3,
         J, W1, W2,
         uf, tab, κ, one(uToltype), 10000,
-        tmp, atmp, jac_config, linsolve1, linsolve2, rtol, atol, dt, dt,
+        tmp, atmp, jac_config, linsolve1, linsolve2, rtol, atol, one(dt), dt,
         Convergence, alg.step_limiter!
     )
 end
@@ -323,7 +323,7 @@ function alg_cache(
     J = false .* _vec(rate_prototype) .* _vec(rate_prototype)'
 
     return RadauIIA9ConstantCache(
-        uf, tab, κ, one(uToltype), 10000, u, u, u, u, u, dt, dt,
+        uf, tab, κ, one(uToltype), 10000, u, u, u, u, u, one(dt), dt,
         Convergence, J
     )
 end
@@ -496,7 +496,7 @@ function alg_cache(
         J, W1, W2, W3,
         uf, tab, κ, one(uToltype), 10000,
         tmp, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7, tmp8, tmp9, tmp10, atmp, jac_config,
-        linsolve1, linsolve2, linsolve3, rtol, atol, dt, dt,
+        linsolve1, linsolve2, linsolve3, rtol, atol, one(dt), dt,
         Convergence, alg.step_limiter!
     )
 end
@@ -553,7 +553,7 @@ function alg_cache(
     κ = alg.κ !== nothing ? convert(uToltype, alg.κ) : convert(uToltype, 1 // 100)
     J = false .* _vec(rate_prototype) .* _vec(rate_prototype)'
     return AdaptiveRadauConstantCache(
-        uf, tabs, κ, one(uToltype), 10000, cont, dt, dt,
+        uf, tabs, κ, one(uToltype), 10000, cont, one(dt), dt,
         Convergence, J, num_stages, 1, 0.0, index
     )
 end
@@ -708,7 +708,7 @@ function alg_cache(
         J, W1, W2,
         uf, tabs, κ, one(uToltype), 10000, tmp,
         atmp, jac_config,
-        linsolve1, linsolve2, rtol, atol, dt, dt,
+        linsolve1, linsolve2, rtol, atol, one(dt), dt,
         Convergence, alg.step_limiter!, num_stages, 1, 0.0, index
     )
 end
@@ -745,7 +745,7 @@ function alg_cache(
         cont[i] = zero(u)
     end
     return GaussLegendreConstantCache(
-        uf, tab, κ, one(uToltype), 10000, cont, dt, dt,
+        uf, tab, κ, one(uToltype), 10000, cont, one(dt), dt,
         Convergence, J, num_stages
     )
 end
@@ -861,7 +861,7 @@ function alg_cache(
         du1, fsalfirst, k, ks, fw,
         J, W,
         uf, tab, κ, one(uToltype), 10000,
-        tmp, atmp, jac_config, linsolve, rtol, atol, dt, dt,
+        tmp, atmp, jac_config, linsolve, rtol, atol, one(dt), dt,
         Convergence, alg.step_limiter!, num_stages
     )
 end

--- a/lib/OrdinaryDiffEqFIRK/test/ode_firk_tests.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/ode_firk_tests.jl
@@ -1,5 +1,6 @@
 using OrdinaryDiffEqFIRK, DiffEqDevTools, Test, LinearAlgebra
 using OrdinaryDiffEqTsit5: AutoTsit5
+using ADTypes: AutoFiniteDiff
 import ODEProblemLibrary: prob_ode_linear, prob_ode_2Dlinear, prob_ode_vanderpol, prob_ode_rober
 
 testTol = 0.5
@@ -226,4 +227,32 @@ end
         @test sol.u[end][3] ≈ ref.u[end][3] rtol = 1.0e-7
         @test abs(sum(sol.u[end]) - 1) < 1.0e-8
     end
+end
+
+@testset "FIRK stiff member of an AutoSwitch composite (#4364)" begin
+    function rober_firk!(du, u, p, t)
+        y1, y2, y3 = u
+        du[1] = -0.04 * y1 + 1.0e4 * y2 * y3
+        du[2] = 0.04 * y1 - 1.0e4 * y2 * y3 - 3.0e7 * y2^2
+        du[3] = 3.0e7 * y2^2
+        return nothing
+    end
+    prob_rober = ODEProblem(rober_firk!, [1.0, 0.0, 0.0], (0.0, 1.0e5))
+    reference = solve(prob_rober, RadauIIA5(); abstol = 1.0e-10, reltol = 1.0e-10).u[end]
+
+    for stiffalg in (
+            RadauIIA3(autodiff = AutoFiniteDiff()),
+            RadauIIA5(autodiff = AutoFiniteDiff()),
+            AdaptiveRadau(autodiff = AutoFiniteDiff()),
+        )
+        sol = solve(prob_rober, AutoTsit5(stiffalg); abstol = 1.0e-8, reltol = 1.0e-8)
+        @test sol.retcode == ReturnCode.Success
+        @test count(==(2), sol.alg_choice) > 0
+        @test sol.u[end] ≈ reference rtol = 1.0e-4
+    end
+
+    integ = init(
+        prob_rober, AutoTsit5(AdaptiveRadau(autodiff = AutoFiniteDiff()); stiffalgfirst = true)
+    )
+    @test @inferred(OrdinaryDiffEqCore.get_current_adaptive_order(integ.alg.algs[2], integ.cache)) isa Int
 end

--- a/lib/OrdinaryDiffEqFIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/qa/qa.jl
@@ -18,7 +18,7 @@ run_qa(
         all_explicit_imports_are_public = (;
             ignore = (
                 # OrdinaryDiffEqCore — owner-internal, no public alternative
-                :PredictiveControllerCache,
+                :PredictiveControllerCache, :_eval_index,
                 # OrdinaryDiffEqCore — private codegen macro / default no-op limiter,
                 # kept owner-internal (no public alternative).
                 Symbol("@threaded"), :trivial_limiter!,

--- a/test/InterfaceI/composite_algorithm_test.jl
+++ b/test/InterfaceI/composite_algorithm_test.jl
@@ -2,6 +2,7 @@ using OrdinaryDiffEq, OrdinaryDiffEqCore, Test, LinearAlgebra
 import ODEProblemLibrary: prob_ode_linear, prob_ode_2Dlinear
 using DiffEqDevTools, ADTypes
 using OrdinaryDiffEqAdamsBashforthMoulton, OrdinaryDiffEqExplicitRK, OrdinaryDiffEqRosenbrock
+using OrdinaryDiffEqFIRK
 import OrdinaryDiffEqExplicitTableaus
 using OrdinaryDiffEqCore: CompositeAlgorithm
 
@@ -114,3 +115,26 @@ cb = DiscreteCallback(
     (u, t, integrator) -> true, (integrator) -> derivative_discontinuity!(integrator, true)
 )
 sol = solve(prob_mm, DefaultODEAlgorithm(), callback = cb)
+
+@testset "AutoSwitch composite with a FIRK stiff member (#4364)" begin
+    function rober_stiff!(du, u, p, t)
+        y1, y2, y3 = u
+        du[1] = -0.04 * y1 + 1.0e4 * y2 * y3
+        du[2] = 0.04 * y1 - 1.0e4 * y2 * y3 - 3.0e7 * y2^2
+        du[3] = 3.0e7 * y2^2
+        return nothing
+    end
+    prob_stiff = ODEProblem(rober_stiff!, [1.0, 0.0, 0.0], (0.0, 1.0e5))
+
+    for alg in (
+            AutoVern7(RadauIIA3(autodiff = AutoFiniteDiff()); stiffalgfirst = true),
+            AutoVern7(RadauIIA5(autodiff = AutoFiniteDiff()); stiffalgfirst = true),
+            AutoTsit5(RadauIIA5(autodiff = AutoFiniteDiff()); stiffalgfirst = true),
+        )
+        sol = solve(prob_stiff, alg)
+        @test sol.retcode == ReturnCode.Success
+    end
+
+    integ = init(prob_stiff, AutoTsit5(RadauIIA5(autodiff = AutoFiniteDiff()); stiffalgfirst = true))
+    @test @inferred(OrdinaryDiffEqCore.current_newton_iter(integ.cache)) isa Int
+end


### PR DESCRIPTION
Initialise `dtprev = one(dt)` in the ten FIRK cache constructors so a Radau member of an AutoSwitch composite can take its first step; `alg_cache` receives `dt = 0` on adaptive solves and the only repair sat behind `integrator.iter == 1`, which is false when the member first activates mid solve. BDF already initialises it this way.

With `dtprev = 0` the dense extrapolant divides by it, the stage guesses come out `NaN`, Newton never converges, and `AutoVern7(RadauIIA5())` on ROBER hangs at 653241 steps with zero stiff steps accepted; it now takes 53. That hang is why #4420's own test passes `stiffalgfirst = true`.

`AdaptiveRadau` also needed its controller and order lookups to resolve the active sub-cache rather than the `CompositeCache`, a crash #4420 does not cover.

Standalone FIRK is unchanged (orders and step counts bit-identical); `ode_firk_tests.jl` 118/118. `AutoVern7(RadauIIA9)` is intermittently non-deterministic in a composite, before and after this change alike, roughly one run in fifteen, while standalone `RadauIIA9` is deterministic; that is pre-existing and needs its own issue, so the new test covers RadauIIA3, RadauIIA5 and AdaptiveRadau.

Stacked on #4420, which must merge first; together they finish #4364.

AI Disclosure: Claude assisted with this change.