### PR TITLE
treat AutoSparse(ForwardDiff) as isAD in dae reinit

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/initialize_dae.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/initialize_dae.jl
@@ -16,6 +16,10 @@ end
     end
 end
 
+# A `jac_prototype` makes `prepare_alg` wrap the AD choice in `AutoSparse`, so ask the dense
+# type underneath whether the initialization residual will be called with Duals.
+_isforwarddiff_alg(alg) = ADTypes.dense_ad(alg_autodiff(alg)) isa AutoForwardDiff
+
 _tagged_autodiff(u, ::Val{nothing}) = _tagged_autodiff(u, Val(1))
 _tagged_autodiff(u, ::Val{0}) = _tagged_autodiff(u, Val(1))
 function _tagged_autodiff(u, ::Val{CS} = Val(1)) where {CS}
@@ -259,8 +263,7 @@ function _initialize_dae!(
             tmp = copy(_u0)
         end
 
-        isAD = alg_autodiff(integrator.alg) isa AutoForwardDiff ||
-            typeof(u0) !== typeof(_u0)
+        isAD = _isforwarddiff_alg(integrator.alg) || typeof(u0) !== typeof(_u0)
         if isAD
             chunk = ForwardDiff.pickchunksize(length(tmp))
             _tmp = DiffCache(tmp, chunk)
@@ -394,7 +397,7 @@ function _initialize_dae!(
             jac
         )
         nlprob = NonlinearProblem(nlfunc, u0)
-        isAD = alg_autodiff(integrator.alg) isa AutoForwardDiff
+        isAD = _isforwarddiff_alg(integrator.alg)
         nlsolve = default_nlsolve(
             alg.nlsolve, isinplace, u0, nlprob, isAD,
             SciMLBase.forwarddiff_chunksize(integrator.alg)
@@ -453,7 +456,7 @@ function _initialize_dae!(
         tmp = copy(_u0)
     end
 
-    isAD = alg_autodiff(integrator.alg) isa AutoForwardDiff || typeof(u0) !== typeof(_u0)
+    isAD = _isforwarddiff_alg(integrator.alg) || typeof(u0) !== typeof(_u0)
     if isAD
         chunk = ForwardDiff.pickchunksize(length(tmp))
         _tmp = DiffCache(tmp, chunk)
@@ -548,7 +551,7 @@ function _initialize_dae!(
         jac
     )
     nlprob = NonlinearProblem(nlfunc, u0)
-    isAD = alg_autodiff(integrator.alg) isa AutoForwardDiff
+    isAD = _isforwarddiff_alg(integrator.alg)
     nlsolve = default_nlsolve(
         alg.nlsolve, isinplace, u0, nlprob, isAD,
         SciMLBase.forwarddiff_chunksize(integrator.alg)
@@ -630,7 +633,7 @@ function _initialize_dae!(
         tmp = SciMLBase.value.(tmp)
     end
 
-    isAD = alg_autodiff(integrator.alg) isa AutoForwardDiff || typeof(u) !== typeof(_u)
+    isAD = _isforwarddiff_alg(integrator.alg) || typeof(u) !== typeof(_u)
     if isAD
         # A larger chunksize, calibrated according to count(algebraic_vars),
         # would be more efficient but cannot be inferred from types
@@ -706,7 +709,7 @@ function _initialize_dae!(
 
     check_dae_tolerance(integrator, resid, alg.abstol, t, isinplace) && return
 
-    isAD = alg_autodiff(integrator.alg) isa AutoForwardDiff
+    isAD = _isforwarddiff_alg(integrator.alg)
     if isAD
         # A larger chunksize, calibrated according to count(algebraic_vars),
         # would be more efficient but cannot be inferred from types
@@ -802,7 +805,7 @@ function _initialize_dae!(
         error("differential_vars must be set for DAE initialization to occur. Either set consistent initial conditions, differential_vars, or use a different initialization algorithm.")
     end
 
-    isAD = alg_autodiff(integrator.alg) isa AutoForwardDiff || typeof(u) !== typeof(_u)
+    isAD = _isforwarddiff_alg(integrator.alg) || typeof(u) !== typeof(_u)
     if isAD
         chunk = ForwardDiff.pickchunksize(length(tmp))
         _tmp = DiffCache(tmp, chunk)
@@ -895,7 +898,7 @@ function _initialize_dae!(
     )
     nlprob = NonlinearProblem(nlfunc, ifelse.(differential_vars, du, u))
 
-    isAD = alg_autodiff(integrator.alg) isa AutoForwardDiff
+    isAD = _isforwarddiff_alg(integrator.alg)
     nlsolve = default_nlsolve(
         alg.nlsolve, isinplace, integrator.u, nlprob, isAD,
         SciMLBase.forwarddiff_chunksize(integrator.alg)

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/sparse_dae_initialization_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/sparse_dae_initialization_tests.jl
@@ -2,7 +2,10 @@ using Test
 using SparseArrays
 using LinearAlgebra
 using OrdinaryDiffEqSDIRK
-using OrdinaryDiffEqNonlinearSolve: find_algebraic_vars_eqs, algebraic_jacobian, BrownFullBasicInit
+using OrdinaryDiffEqNonlinearSolve: find_algebraic_vars_eqs, algebraic_jacobian,
+    BrownFullBasicInit, alg_autodiff, _isforwarddiff_alg
+using NonlinearSolve: NewtonRaphson, FastShortcutNonlinearPolyalg
+using ADTypes: AutoSparse
 using SciMLBase: ReturnCode
 
 @testset "Sparse jac_prototype in BrownFullBasicInit" begin
@@ -262,5 +265,40 @@ using SciMLBase: ReturnCode
             abs.(sol.u[1][1:N] .- sol.u[1][(N + 1):(2N)] .^ 3)
         )
         @test max_violation < 1.0e-4
+    end
+
+    # A ForwardDiff `nlsolve` has to keep working when a `jac_prototype` is set.
+    @testset "ForwardDiff nlsolve with sparse jac_prototype" begin
+        function f_fd!(du, u, p, t)
+            du[1] = -u[1] + u[2]
+            du[2] = u[1] - u[2]^3
+            nothing
+        end
+        M = Diagonal([1.0, 0.0])
+        jac_proto = sparse([1.0 1.0; 1.0 1.0])
+        u0 = [1.0, 0.5]  # inconsistent
+        f_ode = ODEFunction(f_fd!; mass_matrix = M, jac_prototype = jac_proto)
+        makeprob(nlsolve) = ODEProblem(
+            f_ode, u0, (0.0, 1.0); initializealg = BrownFullBasicInit(; nlsolve)
+        )
+
+        # A `jac_prototype` makes `prepare_alg` wrap the AD choice in `AutoSparse`.
+        # Initialization has to see the ForwardDiff underneath, otherwise it hands the
+        # residual plain `Float64` buffers and any Dual written into them errors.
+        integ = init(makeprob(nothing), Trapezoid())
+        @test alg_autodiff(integ.alg) isa AutoSparse
+        @test _isforwarddiff_alg(integ.alg)
+
+        # `must_use_jacobian` skips the Jacobian-free head of the polyalgorithm, so the
+        # default `nlsolve` reaches the same Newton path a user-supplied one takes.
+        nlsolves = (
+            NewtonRaphson(),
+            FastShortcutNonlinearPolyalg(; must_use_jacobian = Val(true)),
+        )
+        for nlsolve in nlsolves
+            sol = solve(makeprob(nlsolve), Trapezoid())
+            @test sol.retcode == ReturnCode.Success
+            @test abs(sol.u[1][1] - sol.u[1][2]^3) < 1.0e-6
+        end
     end
 end


### PR DESCRIPTION
Previously, AutoSparse(ForwardDiff) was classified as non-AD during reinit which lead to wrong buffers and Float64(Dual) errors.

This broke reinit of systems with sparse jac_prototypes (only sometimes though, Brydon and Klement don't need a jac so it only failed if the polyalg reached Newton. If a sparse system should maybe skip the non-jacobian solvers per default in the polyalg is a different question).

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
