### PR TITLE
Format clean-master drift with Runic 1.10

### DIFF
--- a/lib/DiffEqDevTools/src/benchmark.jl
+++ b/lib/DiffEqDevTools/src/benchmark.jl
@@ -901,13 +901,13 @@ function WorkPrecisionSet(
     ]
     solutions = [
         [
-                SciMLBase.calculate_ensemble_errors(
-                    sim;
-                    weak_timeseries_errors,
-                    weak_dense_errors
-                )
+            SciMLBase.calculate_ensemble_errors(
+                sim;
+                weak_timeseries_errors,
+                weak_dense_errors
+            )
                 for sim in sol_k
-            ] for sol_k in _solutions_k
+        ] for sol_k in _solutions_k
     ]
     if error_estimate ∈ WEAK_ERRORS
         errors = [[solutions[j][i].weak_errors for i in 1:M] for j in 1:N]
@@ -959,14 +959,14 @@ function WorkPrecisionSet(
     stats = nothing
     wps = [
         WorkPrecision(
-                prob, _abstols[i], _reltols[i],
-                _dicts_to_structarray(errors[i]),
-                times[:, i], _dts[i], stats, names[i], error_estimate, N,
-                _combined_tags(
-                    setups[i][:alg], _setup_tags(setups[i]),
-                    get(setups[i], :auto_tags, true)
-                )
+            prob, _abstols[i], _reltols[i],
+            _dicts_to_structarray(errors[i]),
+            times[:, i], _dts[i], stats, names[i], error_estimate, N,
+            _combined_tags(
+                setups[i][:alg], _setup_tags(setups[i]),
+                get(setups[i], :auto_tags, true)
             )
+        )
             for i in 1:N
     ]
     return WorkPrecisionSet(
@@ -1028,26 +1028,26 @@ function WorkPrecisionSet(
             if error_estimate == :weak_final
                 errors = [
                     [
-                            LinearAlgebra.norm(
-                                Statistics.mean(
-                                    solutions[i, j].u .-
+                        LinearAlgebra.norm(
+                            Statistics.mean(
+                                solutions[i, j].u .-
                                     expected_value
-                                )
                             )
+                        )
                             for i in 1:M
-                        ] for j in 1:N
+                    ] for j in 1:N
                 ]
             elseif error_estimate == :weak_l2
                 errors = [
                     [
-                            LinearAlgebra.norm(
-                                Statistics.mean(
-                                    solutions[i, j] .-
+                        LinearAlgebra.norm(
+                            Statistics.mean(
+                                solutions[i, j] .-
                                     expected_value
-                                )
                             )
+                        )
                             for i in 1:M
-                        ] for j in 1:N
+                    ] for j in 1:N
                 ]
             else
                 error("Error estimate $error_estimate is not implemented yet.")
@@ -1060,9 +1060,9 @@ function WorkPrecisionSet(
             )
             errors = [
                 [
-                        LinearAlgebra.norm(Statistics.mean(solutions[i, j].u .- sol.u))
+                    LinearAlgebra.norm(Statistics.mean(solutions[i, j].u .- sol.u))
                         for i in 1:M
-                    ] for j in 1:N
+                ] for j in 1:N
             ]
         end
     else
@@ -1115,15 +1115,15 @@ function WorkPrecisionSet(
     stats = nothing
     wps = [
         WorkPrecision(
-                prob, _abstols[i], _reltols[i],
-                _dicts_to_structarray([Dict(error_estimate => err) for err in errors[i]]),
-                times[:, i],
-                _dts[i], stats, names[i], error_estimate, N,
-                _combined_tags(
-                    setups[i][:alg], _setup_tags(setups[i]),
-                    get(setups[i], :auto_tags, true)
-                )
+            prob, _abstols[i], _reltols[i],
+            _dicts_to_structarray([Dict(error_estimate => err) for err in errors[i]]),
+            times[:, i],
+            _dts[i], stats, names[i], error_estimate, N,
+            _combined_tags(
+                setups[i][:alg], _setup_tags(setups[i]),
+                get(setups[i], :auto_tags, true)
             )
+        )
             for i in 1:N
     ]
     return WorkPrecisionSet(
@@ -1241,9 +1241,9 @@ function get_sample_errors(
         # Use the mean of the means as the analytical mean
         analytical_mean_end = mean(
             mean(
-                    tmp_solutions[i].u[end]
+                tmp_solutions[i].u[end]
                     for i in 1:length(tmp_solutions)
-                )
+            )
                 for tmp_solutions in tmp_solutions_full
         )
     end

--- a/lib/DiffEqDevTools/src/convergence.jl
+++ b/lib/DiffEqDevTools/src/convergence.jl
@@ -370,10 +370,10 @@ function analyticless_test_convergence(
     _solutions = [EnsembleSolution(tmp_solutions[:, i], 0.0, true) for i in 1:length(dts)]
     solutions = [
         SciMLBase.calculate_ensemble_errors(
-                sim;
-                weak_timeseries_errors,
-                weak_dense_errors
-            )
+            sim;
+            weak_timeseries_errors,
+            weak_dense_errors
+        )
             for sim in _solutions
     ]
     auxdata = Dict("dts" => dts)
@@ -396,9 +396,9 @@ function test_convergence(
     N = length(dts)
     solutions = [
         solve(
-                prob, alg; dt = dts[i], save_everystep,
-                adaptive, kwargs...
-            ) for i in 1:N
+            prob, alg; dt = dts[i], save_everystep,
+            adaptive, kwargs...
+        ) for i in 1:N
     ]
     auxdata = Dict(:dts => dts)
     return ConvergenceSimulation(solutions, dts; auxdata)
@@ -413,9 +413,9 @@ function analyticless_test_convergence(
     N = length(dts)
     _solutions = [
         solve(
-                prob, alg; dt = dts[i], save_everystep,
-                adaptive, kwargs...
-            ) for i in 1:N
+            prob, alg; dt = dts[i], save_everystep,
+            adaptive, kwargs...
+        ) for i in 1:N
     ]
     solutions = [appxtrue(sol, true_sol) for sol in _solutions]
     auxdata = Dict(:dts => dts)

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_wrappers.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_wrappers.jl
@@ -374,8 +374,8 @@ function resize_jac_config!(cache, integrator)
         cache.jac_config = (
             [
                 DI.prepare!_jacobian(
-                        uf, cache.du1, config, ad, integrator.u
-                    )
+                    uf, cache.du1, config, ad, integrator.u
+                )
                     for (ad, config) in zip(
                         (ad_right, ad_left), cache.jac_config
                     )
@@ -407,8 +407,8 @@ function resize_grad_config!(cache, integrator)
         cache.grad_config = (
             [
                 DI.prepare!_derivative(
-                        cache.tf, cache.du1, config, ad, integrator.t
-                    )
+                    cache.tf, cache.du1, config, ad, integrator.t
+                )
                     for (ad, config) in zip(
                         (ad_right, ad_left), cache.grad_config
                     )

--- a/lib/OrdinaryDiffEqFIRK/src/firk_caches.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_caches.jl
@@ -689,12 +689,12 @@ function alg_cache(
 
     linsolve2 = [
         init(
-                LinearProblem(W2[i], _vec(cubuff[i]), (nothing, u, p, t); u0 = _vec(dw2[i])),
-                alg.linsolve, alias = LinearAliasSpecifier(
-                    alias_A = true, alias_b = true
-                ),
-                assumptions = LinearSolve.OperatorAssumptions(true), verbose = verbose.linear_verbosity
-            )
+            LinearProblem(W2[i], _vec(cubuff[i]), (nothing, u, p, t); u0 = _vec(dw2[i])),
+            alg.linsolve, alias = LinearAliasSpecifier(
+                alias_A = true, alias_b = true
+            ),
+            assumptions = LinearSolve.OperatorAssumptions(true), verbose = verbose.linear_verbosity
+        )
             for i in 1:((max_stages - 1) ÷ 2)
     ]
 

--- a/lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
@@ -2351,9 +2351,9 @@ end
         ndwprev = ndw
         ndw = sum(
             internalnorm(
-                    calculate_residuals(dw[i], uprev_local, uprev_local, atol, rtol, internalnorm, t_local),
-                    t_local
-                )
+                calculate_residuals(dw[i], uprev_local, uprev_local, atol, rtol, internalnorm, t_local),
+                t_local
+            )
                 for i in 1:num_stages
         )
 
@@ -2546,9 +2546,9 @@ end
         ndwprev = ndw
         ndw = sum(
             begin
-                    calculate_residuals!(atmp, dw[i], uprev_local, uprev_local, atol, rtol, internalnorm, t_local)
-                    internalnorm(atmp, t_local)
-                end for i in 1:num_stages
+                calculate_residuals!(atmp, dw[i], uprev_local, uprev_local, atol, rtol, internalnorm, t_local)
+                internalnorm(atmp, t_local)
+            end for i in 1:num_stages
         )
 
         if iter > 1

--- a/test/multirate/mreef_tests.jl
+++ b/test/multirate/mreef_tests.jl
@@ -42,12 +42,12 @@ using OrdinaryDiffEqMultirate, Test, LinearAlgebra
             alg = MREEF(m = 10, order = target_order)
             errs = [
                 begin
-                        sol = solve(
-                            SplitODEProblem(f1!, f2!, u0, (0.0, 1.0)),
-                            alg, dt = d, adaptive = false
-                        )
-                        norm(sol.u[end] - exact)
-                    end for d in dts
+                    sol = solve(
+                        SplitODEProblem(f1!, f2!, u0, (0.0, 1.0)),
+                        alg, dt = d, adaptive = false
+                    )
+                    norm(sol.u[end] - exact)
+                end for d in dts
             ]
 
             ratios = [errs[i] / errs[i + 1] for i in 1:3]
@@ -69,12 +69,12 @@ using OrdinaryDiffEqMultirate, Test, LinearAlgebra
             alg = MREEF(m = 10, order = target_order, seq = :romberg)
             errs = [
                 begin
-                        sol = solve(
-                            SplitODEProblem(f1!, f2!, u0, (0.0, 1.0)),
-                            alg, dt = d, adaptive = false
-                        )
-                        norm(sol.u[end] - exact)
-                    end for d in dts
+                    sol = solve(
+                        SplitODEProblem(f1!, f2!, u0, (0.0, 1.0)),
+                        alg, dt = d, adaptive = false
+                    )
+                    norm(sol.u[end] - exact)
+                end for d in dts
             ]
 
             ratios = [errs[i] / errs[i + 1] for i in 1:3]


### PR DESCRIPTION
## What changed

Format all six files with clean-master drift under Runic 1.10.0. The repository's `runic-version: 1` CI input now resolves to Runic 1.10.0, while Runic 1.9.0 accepted the original formatting.

This is a mechanical formatting-only PR: `git diff --ignore-all-space origin/master -- '*.jl'` is empty. Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Failing before

The original MREEF file failed on unmodified `master` (`0542c1019a8a3be6ea77fb5363d057d8c2cade9e`) with Julia 1.12.7 and Runic 1.10.0, but passed with Runic 1.9.0. After formatting that file, the hosted action still failed and exposed five more files:

```text
lib/DiffEqDevTools/src/benchmark.jl
lib/DiffEqDevTools/src/convergence.jl
lib/OrdinaryDiffEqDifferentiation/src/derivative_wrappers.jl
lib/OrdinaryDiffEqFIRK/src/firk_caches.jl
lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
```

The action-equivalent whole-tree check reproduced this locally with exit code 1. The earlier local claim that all files passed was incorrect: that shell pipeline did inspect every file and returned nonzero, but the script did not stop or inspect the pipeline status before an unconditional PASS message.

## Passing after

The exact `runic-action` file enumeration and arguments now pass over all 1,090 tracked Julia files:

```text
$ julia --version
julia version 1.12.7
$ julia --project=<Runic environment> -e 'using Pkg; Pkg.status("Runic")'
[62bfec6d] Runic v1.10.0
$ julia --project=<Runic environment> check-action.jl
[   1/1090] Checking `benchmark/benchmarks.jl` ... ✔
⋮
[1090/1090] Checking `test/shared/sparsediff_tests.jl` ... ✔
ACTION_FINAL=PASS
$ git diff --check
DIFF_CHECK=PASS
$ typos <six changed Julia files>
TYPOS=PASS files=6
$ git diff --ignore-all-space --exit-code origin/master -- '*.jl'
WHITESPACE_ONLY=PASS
```

The affected sublibrary test groups pass:

```text
$ GROUP=OrdinaryDiffEqDifferentiation_Core julia --project=. -e 'using Pkg; Pkg.test()'
Testing OrdinaryDiffEqDifferentiation tests passed
Testing OrdinaryDiffEq tests passed

$ GROUP=OrdinaryDiffEqFIRK_Core julia --project=. -e 'using Pkg; Pkg.test()'
FIRK Tests                   | 109  109
FIRK Krylov Tests            |  93   93
FIRK LHL Factorization Tests |  22   22
Testing OrdinaryDiffEqFIRK tests passed

$ GROUP=OrdinaryDiffEqMultirate_Core julia --project=. -e 'using Pkg; Pkg.test()'
MREEF Tests    | 19  19
MRAB Tests     | 16  16
MRI-GARK Tests | 28  28
MIS Tests      |  7   7
Testing OrdinaryDiffEqMultirate tests passed
```

The DiffEqDevTools tests directly covering the formatted `benchmark.jl` and `convergence.jl` files passed before the full group reached its one-hour outer Bash timeout in a later stochastic work-precision test:

```text
$ GROUP=DiffEqDevTools_Core julia --project=. -e 'using Pkg; Pkg.test()'
Benchmark Tests                | 15  15
ODE AppxTrue Tests             |  7   7
Analyticless Convergence Tests |  7   7
GROUP_RESULT=DiffEqDevTools_Core FAIL exit=124
```

The root QA group passes:

```text
$ GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'
Quality Assurance Tests | 106  106  6m56.2s
Testing OrdinaryDiffEq tests passed
```

## Not verified

The complete `DiffEqDevTools_Core` group did not finish within the one-hour local outer timeout; it had no assertion failure before termination. The docs build, GPU jobs, and `GROUP=Everything` were not run because this PR changes only formatting and adds no public API or documentation.

## Links

- Draft PR: https://github.com/SciML/OrdinaryDiffEq.jl/pull/4423
- Hosted Runic failure identifying the remaining files: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33208120043/job/98974313061
- Initial Runic failure exposing the clean-master problem: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33206025518/job/98967153752
- Original MREEF commit: https://github.com/SciML/OrdinaryDiffEq.jl/commit/a2c092a14654f6dd10ef92ce8cb9b84edb86ab34

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
