### PR TITLE
Reformat six files for Runic 1.10

### DIFF
--- a/lib/DiffEqDevTools/src/benchmark.jl
+++ b/lib/DiffEqDevTools/src/benchmark.jl
@@ -901,13 +901,13 @@ function WorkPrecisionSet(
     ]
     solutions = [
         [
-                SciMLBase.calculate_ensemble_errors(
-                    sim;
-                    weak_timeseries_errors,
-                    weak_dense_errors
-                )
+            SciMLBase.calculate_ensemble_errors(
+                sim;
+                weak_timeseries_errors,
+                weak_dense_errors
+            )
                 for sim in sol_k
-            ] for sol_k in _solutions_k
+        ] for sol_k in _solutions_k
     ]
     if error_estimate ∈ WEAK_ERRORS
         errors = [[solutions[j][i].weak_errors for i in 1:M] for j in 1:N]
@@ -959,14 +959,14 @@ function WorkPrecisionSet(
     stats = nothing
     wps = [
         WorkPrecision(
-                prob, _abstols[i], _reltols[i],
-                _dicts_to_structarray(errors[i]),
-                times[:, i], _dts[i], stats, names[i], error_estimate, N,
-                _combined_tags(
-                    setups[i][:alg], _setup_tags(setups[i]),
-                    get(setups[i], :auto_tags, true)
-                )
+            prob, _abstols[i], _reltols[i],
+            _dicts_to_structarray(errors[i]),
+            times[:, i], _dts[i], stats, names[i], error_estimate, N,
+            _combined_tags(
+                setups[i][:alg], _setup_tags(setups[i]),
+                get(setups[i], :auto_tags, true)
             )
+        )
             for i in 1:N
     ]
     return WorkPrecisionSet(
@@ -1028,26 +1028,26 @@ function WorkPrecisionSet(
             if error_estimate == :weak_final
                 errors = [
                     [
-                            LinearAlgebra.norm(
-                                Statistics.mean(
-                                    solutions[i, j].u .-
+                        LinearAlgebra.norm(
+                            Statistics.mean(
+                                solutions[i, j].u .-
                                     expected_value
-                                )
                             )
+                        )
                             for i in 1:M
-                        ] for j in 1:N
+                    ] for j in 1:N
                 ]
             elseif error_estimate == :weak_l2
                 errors = [
                     [
-                            LinearAlgebra.norm(
-                                Statistics.mean(
-                                    solutions[i, j] .-
+                        LinearAlgebra.norm(
+                            Statistics.mean(
+                                solutions[i, j] .-
                                     expected_value
-                                )
                             )
+                        )
                             for i in 1:M
-                        ] for j in 1:N
+                    ] for j in 1:N
                 ]
             else
                 error("Error estimate $error_estimate is not implemented yet.")
@@ -1060,9 +1060,9 @@ function WorkPrecisionSet(
             )
             errors = [
                 [
-                        LinearAlgebra.norm(Statistics.mean(solutions[i, j].u .- sol.u))
+                    LinearAlgebra.norm(Statistics.mean(solutions[i, j].u .- sol.u))
                         for i in 1:M
-                    ] for j in 1:N
+                ] for j in 1:N
             ]
         end
     else
@@ -1115,15 +1115,15 @@ function WorkPrecisionSet(
     stats = nothing
     wps = [
         WorkPrecision(
-                prob, _abstols[i], _reltols[i],
-                _dicts_to_structarray([Dict(error_estimate => err) for err in errors[i]]),
-                times[:, i],
-                _dts[i], stats, names[i], error_estimate, N,
-                _combined_tags(
-                    setups[i][:alg], _setup_tags(setups[i]),
-                    get(setups[i], :auto_tags, true)
-                )
+            prob, _abstols[i], _reltols[i],
+            _dicts_to_structarray([Dict(error_estimate => err) for err in errors[i]]),
+            times[:, i],
+            _dts[i], stats, names[i], error_estimate, N,
+            _combined_tags(
+                setups[i][:alg], _setup_tags(setups[i]),
+                get(setups[i], :auto_tags, true)
             )
+        )
             for i in 1:N
     ]
     return WorkPrecisionSet(
@@ -1241,9 +1241,9 @@ function get_sample_errors(
         # Use the mean of the means as the analytical mean
         analytical_mean_end = mean(
             mean(
-                    tmp_solutions[i].u[end]
+                tmp_solutions[i].u[end]
                     for i in 1:length(tmp_solutions)
-                )
+            )
                 for tmp_solutions in tmp_solutions_full
         )
     end

--- a/lib/DiffEqDevTools/src/convergence.jl
+++ b/lib/DiffEqDevTools/src/convergence.jl
@@ -370,10 +370,10 @@ function analyticless_test_convergence(
     _solutions = [EnsembleSolution(tmp_solutions[:, i], 0.0, true) for i in 1:length(dts)]
     solutions = [
         SciMLBase.calculate_ensemble_errors(
-                sim;
-                weak_timeseries_errors,
-                weak_dense_errors
-            )
+            sim;
+            weak_timeseries_errors,
+            weak_dense_errors
+        )
             for sim in _solutions
     ]
     auxdata = Dict("dts" => dts)
@@ -396,9 +396,9 @@ function test_convergence(
     N = length(dts)
     solutions = [
         solve(
-                prob, alg; dt = dts[i], save_everystep,
-                adaptive, kwargs...
-            ) for i in 1:N
+            prob, alg; dt = dts[i], save_everystep,
+            adaptive, kwargs...
+        ) for i in 1:N
     ]
     auxdata = Dict(:dts => dts)
     return ConvergenceSimulation(solutions, dts; auxdata)
@@ -413,9 +413,9 @@ function analyticless_test_convergence(
     N = length(dts)
     _solutions = [
         solve(
-                prob, alg; dt = dts[i], save_everystep,
-                adaptive, kwargs...
-            ) for i in 1:N
+            prob, alg; dt = dts[i], save_everystep,
+            adaptive, kwargs...
+        ) for i in 1:N
     ]
     solutions = [appxtrue(sol, true_sol) for sol in _solutions]
     auxdata = Dict(:dts => dts)

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_wrappers.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_wrappers.jl
@@ -374,8 +374,8 @@ function resize_jac_config!(cache, integrator)
         cache.jac_config = (
             [
                 DI.prepare!_jacobian(
-                        uf, cache.du1, config, ad, integrator.u
-                    )
+                    uf, cache.du1, config, ad, integrator.u
+                )
                     for (ad, config) in zip(
                         (ad_right, ad_left), cache.jac_config
                     )
@@ -407,8 +407,8 @@ function resize_grad_config!(cache, integrator)
         cache.grad_config = (
             [
                 DI.prepare!_derivative(
-                        cache.tf, cache.du1, config, ad, integrator.t
-                    )
+                    cache.tf, cache.du1, config, ad, integrator.t
+                )
                     for (ad, config) in zip(
                         (ad_right, ad_left), cache.grad_config
                     )

--- a/lib/OrdinaryDiffEqFIRK/src/firk_caches.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_caches.jl
@@ -689,12 +689,12 @@ function alg_cache(
 
     linsolve2 = [
         init(
-                LinearProblem(W2[i], _vec(cubuff[i]), (nothing, u, p, t); u0 = _vec(dw2[i])),
-                alg.linsolve, alias = LinearAliasSpecifier(
-                    alias_A = true, alias_b = true
-                ),
-                assumptions = LinearSolve.OperatorAssumptions(true), verbose = verbose.linear_verbosity
-            )
+            LinearProblem(W2[i], _vec(cubuff[i]), (nothing, u, p, t); u0 = _vec(dw2[i])),
+            alg.linsolve, alias = LinearAliasSpecifier(
+                alias_A = true, alias_b = true
+            ),
+            assumptions = LinearSolve.OperatorAssumptions(true), verbose = verbose.linear_verbosity
+        )
             for i in 1:((max_stages - 1) ÷ 2)
     ]
 

--- a/lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
@@ -2351,9 +2351,9 @@ end
         ndwprev = ndw
         ndw = sum(
             internalnorm(
-                    calculate_residuals(dw[i], uprev_local, uprev_local, atol, rtol, internalnorm, t_local),
-                    t_local
-                )
+                calculate_residuals(dw[i], uprev_local, uprev_local, atol, rtol, internalnorm, t_local),
+                t_local
+            )
                 for i in 1:num_stages
         )
 
@@ -2546,9 +2546,9 @@ end
         ndwprev = ndw
         ndw = sum(
             begin
-                    calculate_residuals!(atmp, dw[i], uprev_local, uprev_local, atol, rtol, internalnorm, t_local)
-                    internalnorm(atmp, t_local)
-                end for i in 1:num_stages
+                calculate_residuals!(atmp, dw[i], uprev_local, uprev_local, atol, rtol, internalnorm, t_local)
+                internalnorm(atmp, t_local)
+            end for i in 1:num_stages
         )
 
         if iter > 1

--- a/test/multirate/mreef_tests.jl
+++ b/test/multirate/mreef_tests.jl
@@ -42,12 +42,12 @@ using OrdinaryDiffEqMultirate, Test, LinearAlgebra
             alg = MREEF(m = 10, order = target_order)
             errs = [
                 begin
-                        sol = solve(
-                            SplitODEProblem(f1!, f2!, u0, (0.0, 1.0)),
-                            alg, dt = d, adaptive = false
-                        )
-                        norm(sol.u[end] - exact)
-                    end for d in dts
+                    sol = solve(
+                        SplitODEProblem(f1!, f2!, u0, (0.0, 1.0)),
+                        alg, dt = d, adaptive = false
+                    )
+                    norm(sol.u[end] - exact)
+                end for d in dts
             ]
 
             ratios = [errs[i] / errs[i + 1] for i in 1:3]
@@ -69,12 +69,12 @@ using OrdinaryDiffEqMultirate, Test, LinearAlgebra
             alg = MREEF(m = 10, order = target_order, seq = :romberg)
             errs = [
                 begin
-                        sol = solve(
-                            SplitODEProblem(f1!, f2!, u0, (0.0, 1.0)),
-                            alg, dt = d, adaptive = false
-                        )
-                        norm(sol.u[end] - exact)
-                    end for d in dts
+                    sol = solve(
+                        SplitODEProblem(f1!, f2!, u0, (0.0, 1.0)),
+                        alg, dt = d, adaptive = false
+                    )
+                    norm(sol.u[end] - exact)
+                end for d in dts
             ]
 
             ratios = [errs[i] / errs[i + 1] for i in 1:3]


### PR DESCRIPTION
Runic 1.10.0 was released on 2026-08-28 and the `Runic / Runic Format Check` lane tracks the latest
release, so it is now red on every open pull request regardless of content (checked on five of
mine pushed after the release; all flag the same untouched files). Same situation as #4360 when
1.9 landed.

`runic --inplace .` with 1.10.0 on current master changes six files, 73 lines, all indentation
inside nested array literals; `git diff -w` is empty. `runic --check .` is clean afterwards.

```
lib/DiffEqDevTools/src/benchmark.jl
lib/DiffEqDevTools/src/convergence.jl
lib/OrdinaryDiffEqDifferentiation/src/derivative_wrappers.jl
lib/OrdinaryDiffEqFIRK/src/firk_caches.jl
lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
test/multirate/mreef_tests.jl
```

Formatting only, no version bumps, following #4360, #3758 and #3765.

AI Disclosure: Claude assisted with this change.
