### PR TITLE
Require SciMLBase 3.46 in OrdinaryDiffEqBDF and OrdinaryDiffEqNonlinearSolve

### DIFF
--- a/lib/OrdinaryDiffEqBDF/Project.toml
+++ b/lib/OrdinaryDiffEqBDF/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqBDF"
 uuid = "6ad6398a-0878-4a85-9266-38940aa047c8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.4.5"
+version = "2.4.6"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -66,7 +66,7 @@ LinearAlgebra = "1.10"
 OrdinaryDiffEqDifferentiation = "3.3"
 OrdinaryDiffEqSDIRK = "2.9.1"
 TruncatedStacktraces = "1.4"
-SciMLBase = "3.39"
+SciMLBase = "3.46"
 SciMLOperators = "1.27"
 OrdinaryDiffEqCore = "4.15.1"
 ArrayInterface = "7.28"

--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.9.2"
+version = "2.9.3"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
@@ -68,7 +68,7 @@ OrdinaryDiffEqFIRK = "2"
 OrdinaryDiffEqRosenbrock = "2"
 OrdinaryDiffEqSDIRK = "2.9"
 Statistics = "1.10.0"
-SciMLBase = "3.43"
+SciMLBase = "3.46"
 OrdinaryDiffEqCore = "4.13"
 SimpleNonlinearSolve = "2.11.1"
 FastClosures = "0.3.2"


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

`OrdinaryDiffEqBDF` and `OrdinaryDiffEqNonlinearSolve` both reference SciMLBase names that were introduced in **SciMLBase v3.46.0**, while declaring lower bounds below it:

| File | Symbol referenced | Declared | Required |
|---|---|---|---|
| `lib/OrdinaryDiffEqBDF/src/OrdinaryDiffEqBDF.jl:152` | `SciMLBase.AutoDespecialize` | `SciMLBase = "3.39"` | `3.46` |
| `lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl:149` | `SciMLBase.AutoDespecialize`, `SciMLBase.DespecializedParameters` | `SciMLBase = "3.43"` | `3.46` |

`AutoDespecialize` was added in SciMLBase 3.46.0, with no releases between 3.45.0 and 3.46.0, so 3.46.0 is the exact floor:

```console
$ for v in v3.45.0 v3.46.0; do
    printf "%s : " $v
    curl -sL "https://raw.githubusercontent.com/SciML/SciMLBase.jl/$v/src/scimlfunctions.jl" \
      | grep -c "^struct AutoDespecialize"
  done
v3.45.0 : 0
v3.46.0 : 1
```

`DespecializedParameters` follows the same boundary (0 occurrences in 3.43.0, 4 in 3.46.0).

Each sublibrary gets a patch bump so the corrected bound reaches the registry.

## Honest scope: this is not a live failure from `master`

**On `master` these bounds are currently masked and do not produce a resolution failure.** `OrdinaryDiffEqBDF` requires `OrdinaryDiffEqCore = "4.15.1"`, and `OrdinaryDiffEqCore` ≥ 4.15.2 itself requires `SciMLBase = "3.49.2 - 3"`, so SciMLBase cannot fall below 3.49.2 in that dependency set regardless of what BDF declares. My attempt to build a failing-before case against `master` confirmed this — the resolver rejected the pin for the *transitive* reason, not the declared one:

```
 ├─restricted to versions 3.39.0 - 3   by OrdinaryDiffEqBDF  [6ad6398a]
 ├─restricted to versions 3.49.2 - 3   by OrdinaryDiffEqCore [bbf590c4]
 │   ├─restricted to versions 4.15.1 - 4 by OrdinaryDiffEqBDF
 └─restricted to versions 3.39.1 by an explicit requirement — no versions left
```

So this PR is **correctness hygiene**: it makes each package's declared bound reflect the symbols it actually uses, instead of depending on a sibling's stricter constraint that could be relaxed later. I am not claiming it fixes a currently-reachable bug on `master`.

Where the too-low bound *is* reachable is in already-registered versions whose `OrdinaryDiffEqCore` bound is looser — `OrdinaryDiffEqBDF` 2.4.3/2.4.4 declare `OrdinaryDiffEqCore = "4.12.0 - 4"`, which lets the resolver walk back to 4.14.1 and admit SciMLBase 3.39.1:

```console
$ julia +1.12 --project=$(mktemp -d) -e '
    using Pkg
    Pkg.add(name="OrdinaryDiffEqBDF", version="2.4.4")
    Pkg.add(name="SciMLBase", version="3.39.1")
    Pkg.precompile(; strict=true)'
              ✗ OrdinaryDiffEqBDF
ERROR: LoadError: UndefVarError: `AutoDespecialize` not defined in `SciMLBase`
exit=1
```

That is being addressed separately by a retroactive registry compat fix: https://github.com/JuliaRegistries/General/pull/166465. This PR is the forward-looking half, so future releases carry a truthful bound.

## Verification

Both sublibraries dev'd from this branch and precompiled with `strict = true`, confirming the raised bound does not disturb normal resolution:

```console
$ julia +1.12 --project=$TMP -e 'using Pkg
    Pkg.develop(path="lib/OrdinaryDiffEqBDF"); Pkg.precompile(; strict=true)'
  [0bca4576] + SciMLBase v3.50.0
  36420.9 ms  ✓ OrdinaryDiffEqBDF
exit=0

$ julia +1.12 --project=$TMP -e 'using Pkg
    Pkg.develop(path="lib/OrdinaryDiffEqNonlinearSolve"); Pkg.precompile(; strict=true)'
  [0bca4576] + SciMLBase v3.50.0
   8179.2 ms  ✓ OrdinaryDiffEqNonlinearSolve
exit=0
```

`typos` clean on both changed files.

## What I did *not* verify

- **I did not run the test suites** for either sublibrary. This is a compat-and-version-only change touching no code, but the suites were not run locally and I am not claiming they pass.
- **No failing-before test exists for this diff**, for the masking reason explained above. The failing-before evidence belongs to the registry PR, against already-registered versions.
- **The `OrdinaryDiffEqNonlinearSolve` reference is a latent runtime path, not a load-time one.** It sits inside a function body on the opt-in `NonlinearSolveAlg` path, so `OrdinaryDiffEqNonlinearSolve@2.9.2` precompiles cleanly against SciMLBase 3.43.0 (verified, exit=0). I did not construct a runtime reproduction of it.
- Downstream packages were not re-resolved against these bumps.

## For a reviewer to push back on

Whether the patch bumps are the right SemVer call — raising a lower compat bound restricts what downstream can resolve, and if you would rather these be minor bumps, say so and I will change them.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])
https://claude.ai/code/session_016yBsJDGXDqPHqaJCVzpyr9
