### PR TITLE
Document the limiter keywords with their real names

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.15.2"
+version = "4.15.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqCore/src/doc_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/doc_utils.jl
@@ -70,14 +70,14 @@ function explicit_rk_docstring(
         extra_keyword_default::String = ""
     )
     keyword_default = """
-        stage_limiter = OrdinaryDiffEq.trivial_limiter!,
-        step_limiter = OrdinaryDiffEq.trivial_limiter!,
+        stage_limiter! = OrdinaryDiffEq.trivial_limiter!,
+        step_limiter! = OrdinaryDiffEq.trivial_limiter!,
         thread = Serial(),
         """ * extra_keyword_default
 
     keyword_default_description = """
-        - `stage_limiter`: function of the form `limiter!(u, integrator, p, t)`
-        - `step_limiter`: function of the form `limiter!(u, integrator, p, t)`, applied once to each accepted endpoint after adaptive error and domain checks. For FSAL methods, a non-trivial limiter causes the derivative to be refreshed before the next step; dense interpolants between accepted endpoints are not limited.
+        - `stage_limiter!`: function of the form `limiter!(u, integrator, p, t)`
+        - `step_limiter!`: function of the form `limiter!(u, integrator, p, t)`, applied once to each accepted endpoint after adaptive error and domain checks. For FSAL methods, a non-trivial limiter causes the derivative to be refreshed before the next step; dense interpolants between accepted endpoints are not limited.
         - `thread`: determines whether internal broadcasting on appropriate CPU arrays should be serial (`thread = Serial()`) or use multiple threads (`thread = Threaded()`) when Julia is started with multiple threads.
         """ * extra_keyword_description
 


### PR DESCRIPTION
The generated docstrings list the limiter keywords as `stage_limiter = OrdinaryDiffEq.trivial_limiter!` and `step_limiter = OrdinaryDiffEq.trivial_limiter!`, but the constructors only accept `stage_limiter!` and `step_limiter!`: `Tsit5(stage_limiter = f)` is a MethodError while `Tsit5(stage_limiter! = f)` works.
Renamed both in the keyword line and the description bullet of `doc_utils.jl`, checked on `string(@doc Tsit5)` before and after.
AI Disclosure: Claude assisted with this change.
