### PR TITLE
Fix the AitkenNeville evaluation count and array states

### DIFF
--- a/lib/OrdinaryDiffEqExtrapolation/Project.toml
+++ b/lib/OrdinaryDiffEqExtrapolation/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExtrapolation"
 uuid = "becaefa8-8ca2-5cf9-886d-c06f3d2bd2c4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.6.0"
+version = "2.6.1"
 
 [deps]
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"

--- a/lib/OrdinaryDiffEqExtrapolation/src/extrapolation_caches.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/extrapolation_caches.jl
@@ -89,7 +89,11 @@ function alg_cache(
     dtpropose = zero(dt)
     cur_order = max(alg.init_order, alg.min_order)
     T = Array{typeof(u), 2}(undef, alg.max_order, alg.max_order)
-    @.. broadcast = false T = u
+    for i in 1:(alg.max_order)
+        for j in 1:i
+            T[i, j] = zero(u)
+        end
+    end
     work = zero(dt)
     A = one(Int)
     step_no = zero(Int)

--- a/lib/OrdinaryDiffEqExtrapolation/src/extrapolation_perform_step.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/extrapolation_perform_step.jl
@@ -67,7 +67,7 @@ function perform_step!(integrator, cache::AitkenNevilleCache, repeat_step = fals
                 end
             end
         end
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)^max_order - 1
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2^max_order - 1)
     end
 
     # Richardson extrapolation
@@ -192,7 +192,7 @@ function perform_step!(integrator, cache::AitkenNevilleConstantCache, repeat_ste
             end
         end
 
-        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2)^max_order - 1
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 2^max_order - 1)
     end
 
     # Richardson extrapolation

--- a/lib/OrdinaryDiffEqExtrapolation/test/ode_extrapolation_tests.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/ode_extrapolation_tests.jl
@@ -302,3 +302,20 @@ testTol = 0.2
         @test all(all(s1[i] - s2[i] .< 5.0e-6) for i in 1:length(s1))
     end
 end # Extrapolation methods
+
+@testset "AitkenNeville function evaluation count is independent of threading" begin
+    prob_iip = ODEProblem((du, u, p, t) -> (du .= -u), [1.0, 2.0], (0.0, 1.0))
+    prob_oop = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 1.0))
+    for prob in (prob_iip, prob_oop), max_order in (3, 5)
+        serial = solve(
+            prob, AitkenNeville(; max_order, init_order = max_order, threading = false);
+            dt = 0.1, adaptive = false
+        )
+        threaded = solve(
+            prob, AitkenNeville(; max_order, init_order = max_order, threading = true);
+            dt = 0.1, adaptive = false
+        )
+        @test threaded.stats.nf == serial.stats.nf
+        @test serial.stats.nf == 10 * 2^max_order + 1
+    end
+end

--- a/lib/OrdinaryDiffEqExtrapolation/test/ode_extrapolation_tests.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/ode_extrapolation_tests.jl
@@ -319,3 +319,12 @@ end # Extrapolation methods
         @test serial.stats.nf == 10 * 2^max_order + 1
     end
 end
+
+@testset "AitkenNeville out-of-place with an array state" begin
+    prob = ODEProblem((u, p, t) -> -u, [1.0, 2.0], (0.0, 1.0))
+    for threading in (false, true)
+        sol = solve(prob, AitkenNeville(; threading); abstol = 1.0e-8, reltol = 1.0e-8)
+        @test SciMLBase.successful_retcode(sol)
+        @test sol.u[end] ≈ [1.0, 2.0] .* exp(-1) rtol = 1.0e-6
+    end
+end


### PR DESCRIPTION
Two AitkenNeville fixes.
The threaded branch charged `increment_nf!(stats, 2)^max_order - 1`, which adds 2 and throws the power away, so `threading = true` reported 31 function evaluations for a 10-step fixed-dt solve where the serial branch reports 81 at `max_order = 3` and 321 at `max_order = 5`; it now charges `2^max_order - 1` per step and the two branches agree at every order.
The constant cache filled its extrapolation table with `T .= u`, which is a `DimensionMismatch` for any array state; out-of-place `AitkenNeville` with a vector `u0` now solves, matching every other extrapolation method, which already handled that case.
Both have tests; the Extrapolation suite passes locally (296 tests), and its two Aqua failures reproduce on master.
AI Disclosure: Claude assisted with this change.
