### PR TITLE
Tag the AD type for adaptive exponential algorithms

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "3.11.0"
+version = "3.11.1"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 

--- a/lib/OrdinaryDiffEqDifferentiation/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/alg_utils.jl
@@ -32,6 +32,7 @@ function DiffEqBase.prepare_alg(
             OrdinaryDiffEqImplicitAlgorithm,
             DAEAlgorithm,
             OrdinaryDiffEqExponentialAlgorithm,
+            OrdinaryDiffEqAdaptiveExponentialAlgorithm,
         },
         u0::AbstractArray{T},
         p, prob

--- a/lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_convergence_tests.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_convergence_tests.jl
@@ -212,3 +212,15 @@ end
         @test sim.𝒪est[:l2] ≈ alg_order(Alg()) atol = 0.1
     end
 end
+
+@testset "Exprb methods with the default in-place problem specialization" begin
+    f! = (du, u, p, t) -> (du .= -u .+ u .^ 2 ./ 10)
+    prob = ODEProblem(f!, [1.0, 0.5], (0.0, 1.0))
+    prob_full = ODEProblem{true, SciMLBase.FullSpecialize}(f!, [1.0, 0.5], (0.0, 1.0))
+    for alg in (Exprb32(), Exprb43())
+        sol = solve(prob, alg; abstol = 1.0e-8, reltol = 1.0e-8)
+        sol_full = solve(prob_full, alg; abstol = 1.0e-8, reltol = 1.0e-8)
+        @test SciMLBase.successful_retcode(sol)
+        @test sol.u[end] ≈ sol_full.u[end]
+    end
+end


### PR DESCRIPTION
`Exprb32()` and `Exprb43()` fail on a default in-place `ODEProblem` with "First call to automatic differentiation for the Jacobian failed ... No matching function wrapper was found!", while `Rosenbrock23`, `Exp4` and `EPIRK4s3A` solve the same problem, and the two Exprb methods work with `FullSpecialize`, `NoSpecialize` or an analytic Jacobian.
`prepare_alg` in OrdinaryDiffEqDifferentiation tags the AD type with `OrdinaryDiffEqTag` for a `Union` of algorithm supertypes that includes `OrdinaryDiffEqExponentialAlgorithm` but not `OrdinaryDiffEqAdaptiveExponentialAlgorithm`, which is a sibling under `OrdinaryDiffEqAdaptiveAlgorithm` rather than a subtype, so the Exprb Jacobian config is built with the untagged `UJacobianWrapper` tag that the `AutoSpecialize` function wrappers were never compiled for.
Added the adaptive exponential type to the `Union`; the new test solves both methods on a default in-place problem and checks them against the `FullSpecialize` solution, and the ExponentialRK suite passes locally.
AI Disclosure: Claude assisted with this change.
