### PR TITLE
Give each threaded complex stage its own JVP operator

### DIFF
--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFIRK"
 uuid = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.8.3"
+version = "2.8.4"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqFIRK/src/OrdinaryDiffEqFIRK.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/OrdinaryDiffEqFIRK.jl
@@ -4,7 +4,7 @@ import OrdinaryDiffEqCore: unwrap_alg,
     default_controller, PredictiveController, PIController,
     OrdinaryDiffEqNewtonAdaptiveAlgorithm,
     OrdinaryDiffEqMutableCache, OrdinaryDiffEqConstantCache,
-    alg_cache, @threaded, isthreaded, CompositeCache,
+    alg_cache, @threaded, isthreaded, CompositeCache, alg_autodiff,
     Sequential, BaseThreads, PolyesterThreads,
     constvalue,
     differentiation_rk_docstring, trivial_limiter!,
@@ -37,7 +37,7 @@ import FastPower: fastpower
 using OrdinaryDiffEqDifferentiation: build_J_W, build_jac_config,
     calc_J!, dolinsolve, calc_J,
     islinearfunction, drain_jvp_count!, set_linear_reltol!
-import OrdinaryDiffEqDifferentiation: jvp_counter
+import OrdinaryDiffEqDifferentiation: jvp_counter, JVPCache
 import ADTypes: AutoForwardDiff
 import SciMLOperators
 import SciMLOperators: AbstractSciMLOperator

--- a/lib/OrdinaryDiffEqFIRK/src/firk_operators.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_operators.jl
@@ -162,6 +162,12 @@ function build_complex_W(alg, f, u, J, W1)
         )
     end
     jacvec = W1 isa SciMLOperators.WOperator ? W1.jacvec : nothing
+    if alg isa AdaptiveRadau && isthreaded(alg.threading) && jacvec isa JVPCache
+        jacvec = JVPCache(
+            jacvec.f, copy(jacvec.du), jacvec.u, jacvec.p, jacvec.t;
+            autodiff = alg_autodiff(alg)
+        )
+    end
     return ComplexWOperator(f.mass_matrix, complex(one(eltype(W1))), J, u, jacvec)
 end
 
@@ -189,13 +195,23 @@ function firk_new_J!(J, W, integrator, cache, extra_Ws...)
     # tell an in-place refresh from the unchanged object.
     _mark_J_moved!(W)
     foreach(_mark_J_moved!, extra_Ws)
+    foreach(Ws -> _move_jacvec!(Ws, J, uprev, p, t), extra_Ws)
     return nothing
 end
+
+function _move_jacvec!(W::ComplexWOperator, J, u, p, t)
+    W.jacvec === nothing || W.jacvec === J ||
+        SciMLOperators.update_coefficients!(W.jacvec, u, p, t)
+    return nothing
+end
+_move_jacvec!(Ws::AbstractVector, J, u, p, t) = foreach(W -> _move_jacvec!(W, J, u, p, t), Ws)
+_move_jacvec!(::Any, J, u, p, t) = nothing
 
 _mark_J_moved!(W::SciMLOperators.WOperator) = SciMLOperators.mark_jacobian_updated!(W)
 _mark_J_moved!(Ws::AbstractVector) = foreach(_mark_J_moved!, Ws)
 _mark_J_moved!(::Any) = nothing
 
-# A `ComplexWOperator` applies the same real JVP operator its `W` does, so the products it
-# performs are already on that operator's tally and `drain_jvp_count!` needs nothing else.
+# A `ComplexWOperator` reports the JVP operator it applies: the one shared with `W1` on the
+# serial paths, its own copy on the threaded AdaptiveRadau path, so draining every stage
+# counts each product once.
 jvp_counter(W::ComplexWOperator) = jvp_counter(_jacobian_operator(W))

--- a/lib/OrdinaryDiffEqFIRK/test/firk_krylov_tests.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/firk_krylov_tests.jl
@@ -140,3 +140,21 @@ end
     @test SciMLBase.successful_retcode(sol)
     @test maximum(abs, sol.u[end] - ref) < 1.0e-8
 end
+
+@testset "Threaded AdaptiveRadau stages own their JVP operators" begin
+    n = 60
+    A = Tridiagonal(fill(1.0, n - 1), fill(-2.0, n), fill(1.0, n - 1)) .* (n + 1)^2
+    f! = (du, u, p, t) -> mul!(du, A, u)
+    u0 = [sin(pi * i / (n + 1)) for i in 1:n]
+    prob = ODEProblem(f!, u0, (0.0, 0.1))
+    kw = (; min_order = 9, max_order = 9, linsolve = KrylovJL_GMRES())
+    integ = init(prob, AdaptiveRadau(; threading = true, kw...); abstol = 1.0e-7, reltol = 1.0e-7)
+    W2 = integ.cache.W2
+    @test W2[1].jacvec !== W2[2].jacvec
+    @test W2[1].jacvec !== integ.cache.W1.jacvec
+    threaded = [solve(prob, AdaptiveRadau(; threading = true, kw...); abstol = 1.0e-7, reltol = 1.0e-7) for _ in 1:4]
+    serial = solve(prob, AdaptiveRadau(; threading = false, kw...); abstol = 1.0e-7, reltol = 1.0e-7)
+    @test all(sol -> sol.u[end] == threaded[1].u[end], threaded)
+    @test threaded[1].u[end] ≈ serial.u[end] rtol = 1.0e-6
+    @test threaded[1].stats.nf == serial.stats.nf
+end

--- a/lib/OrdinaryDiffEqFIRK/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/qa/qa.jl
@@ -27,6 +27,9 @@ run_qa(
                 # Genuine external deps, non-public in their owner.
                 :fastpower,               # FastPower
                 :AbstractSciMLOperator,   # SciMLOperators
+                # OrdinaryDiffEqDifferentiation — matrix-free Jacobian operator,
+                # owner-internal like `jvp_counter`'s tally it carries.
+                :JVPCache,
             ),
         ),
         all_qualified_accesses_are_public = (;


### PR DESCRIPTION
`AdaptiveRadau(threading = true)` with a matrix-free Jacobian is nondeterministic once the method has two complex stage pairs: ten solves of a 200-point heat equation at `min_order = max_order = 9` with `KrylovJL_GMRES()` gave ten different answers, spread 1.4e-3 apart at tolerance 1e-7, with one Julia thread they agree exactly.
Every `ComplexWOperator` is built from the same `W1.jacvec`, so the stage solves that `@threaded` runs in parallel all push through one `JVPCache` and race on its pushforward buffers and its product tally; the threaded `nf` came out 566 where the serial solve counts 163.
When threading is on and the Jacobian is a `JVPCache`, `build_complex_W` now gives each complex stage its own operator, `firk_new_J!` moves those operators with the real one, and the existing per-stage drain picks up their tallies, so ten threaded solves now agree to the bit and report the serial `nf`.
The new test checks the operators are distinct, that repeated threaded solves agree, and that the threaded and serial `nf` match; the FIRK Krylov file passes on four threads.
AI Disclosure: Claude assisted with this change.
