### PR TITLE
Tighten the AdaptiveRadau Newton tolerance with the stage count

### DIFF
--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFIRK"
 uuid = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.8.2"
+version = "2.8.3"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
@@ -143,6 +143,13 @@ function initialize!(integrator, cache::RadauIIA9Cache)
     return nothing
 end
 
+
+function newton_tolerance(κ, rtol, num_stages)
+    r = rtol isa Number ? rtol : minimum(rtol)
+    fnewt = max(10 * eps(one(r)) / r, min(3 // 100, r^((num_stages - 1) / (num_stages + 1))))
+    return convert(typeof(κ), fnewt)
+end
+
 function initialize!(integrator, cache::AdaptiveRadauConstantCache)
     # `integrator.alg` is the `CompositeAlgorithm` when this method is a composite
     # member, and that has no `max_order`.
@@ -1659,6 +1666,9 @@ end
     # precalculations rtol pow is (num stages + 1)/(2*num stages)
     rtol = @.. reltol^((num_stages + 1) / (num_stages * 2)) / 10
     atol = @.. rtol * (abstol / reltol)
+    if alg.κ === nothing
+        κ = newton_tolerance(κ, rtol, num_stages)
+    end
 
     γdt, αdt, βdt = γ / dt, α ./ dt, β ./ dt
 
@@ -1810,7 +1820,7 @@ end
             if diverge || veryslowconvergence
                 break
             end
-            η = θ / (1 - θ)
+            η = iszero(ndw) ? η : θ / (1 - θ)
         end
 
         for i in 1:num_stages
@@ -1929,6 +1939,10 @@ end
             @.. cache.rtol = reltol^((num_stages + 1) / (2 * num_stages)) / 10
             @.. cache.atol = cache.rtol * (abstol / reltol)
         end
+        if alg.κ === nothing
+            cache.κ = newton_tolerance(cache.κ, cache.rtol, num_stages)
+        end
+        κ = cache.κ
     end
 
     (new_jac = do_newJ(integrator, alg, cache, repeat_step)) &&
@@ -2140,7 +2154,7 @@ end
             if diverge || veryslowconvergence
                 break
             end
-            η = θ / (1 - θ)
+            η = iszero(ndw) ? η : θ / (1 - θ)
         end
 
         @.. w[1] = w[1] - dw1

--- a/lib/OrdinaryDiffEqFIRK/test/ode_firk_tests.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/ode_firk_tests.jl
@@ -1,6 +1,6 @@
 using OrdinaryDiffEqFIRK, DiffEqDevTools, Test, LinearAlgebra
 using OrdinaryDiffEqTsit5: AutoTsit5
-import ODEProblemLibrary: prob_ode_linear, prob_ode_2Dlinear, prob_ode_vanderpol
+import ODEProblemLibrary: prob_ode_linear, prob_ode_2Dlinear, prob_ode_vanderpol, prob_ode_rober
 
 testTol = 0.5
 
@@ -214,4 +214,16 @@ end
 
     bare = init(prob_comp, AdaptiveRadau())
     @test integ.kshortsize == bare.kshortsize
+end
+
+@testset "AdaptiveRadau Newton tolerance follows the stage count" begin
+    prob = prob_ode_rober
+    ref = solve(prob, RadauIIA5(); abstol = 1.0e-12, reltol = 1.0e-12, save_everystep = false)
+    for alg in (AdaptiveRadau(), AdaptiveRadau(; min_order = 13, max_order = 13))
+        sol = solve(prob, alg; abstol = 1.0e-8, reltol = 1.0e-8, save_everystep = false)
+        @test sol.retcode == ReturnCode.Success
+        @test sol.stats.naccept < 500
+        @test sol.u[end][3] ≈ ref.u[end][3] rtol = 1.0e-7
+        @test abs(sum(sol.u[end]) - 1) < 1.0e-8
+    end
 end


### PR DESCRIPTION
`AdaptiveRadau()` on `prob_ode_rober` at `abstol = reltol = 1e-8` takes 188192 accepted and 73644 rejected steps and returns `u(1e11) = [-1.44e7, -4.0e-6, 1.44e7]` with retcode `Success`; the reference is `[2.08e-8, 8.3e-14, 0.99999998]`, and `min_order = max_order = 5` reproduces RadauIIA5's 167 steps exactly, so the damage is at the higher orders. The out-of-place path does the same (320363 steps at order 13, `u3` off by 6e7).
Both the Newton norm and the error estimate already use Hairer's rescaled tolerance `0.1 reltol^((s+1)/2s)`, but the Newton stopping factor `κ` stays at 0.01 for every stage count where `radau.f` uses `FNEWT = max(10 eps / rtol, min(0.03, rtol^((s-1)/(s+1))))`, which is 6.8e-4 at three stages and 6.7e-5 at seven for this tolerance; with κ that loose the seven-stage Newton iteration stops above the level the error estimate needs, the estimate becomes iteration noise, and once the solution enters the long tail the controller oscillates between 3-iteration and 1-iteration steps until the answer is gone.
When the user passes no `κ`, both AdaptiveRadau steps now derive it from the stage count and the rescaled tolerance each step; Robertson at 1e-8 becomes 173 steps with the default and 73 at fixed order 13 (78 and 63 out of place), 1e-6 goes from 26281 steps to 1474, and Van der Pol and the linear problem are unchanged within a few steps.
The tighter κ exposed a second problem on inexact linear solves: when GMRES returns an exactly zero increment, `θ = 0` made `η = 0`, which was carried into the next steps as `eps^0.8` and let every later Newton stop after one iteration whatever the increment; the Brusselator Krylov test went from 4.8e-9 to 1.2e-6 that way. `η` now keeps its previous value on a zero increment, and that test lands at 1.9e-10.
One cost to know about: at 1e-10 the default now takes 341 steps against 102, because the tighter Newton needs more iterations and the order controller's `hist_iter < 2.6` rule then keeps the order at 5; Hairer's rule promotes on the contraction rate θ instead, which is a separate change.
The test solves the default and the fixed order 13 on Robertson and checks the step count, the end state and mass conservation; on master it fails with the values above.
AI Disclosure: Claude assisted with this change.
