### PR TITLE
Correct skipped sublibrary version numbers

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.15.4"
+version = "4.15.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFIRK"
 uuid = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.8.3"
+version = "2.8.2"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"


### PR DESCRIPTION
`OrdinaryDiffEqCore` is registered up to 4.15.2 and `OrdinaryDiffEqFIRK` up to 2.8.1, but master had moved to 4.15.4 and 2.8.3 - so both skip a version and AutoMerge rejects them on the sequential-version guideline. Neither 4.15.3 nor 2.8.2 was ever registered (no registry PR exists for either), so those numbers are free. Step back onto them rather than approving a skip.

(`OrdinaryDiffEqCore` 5.0.0 exists in the registry but is yanked, so 4.15.x remains the live series.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R