### PR TITLE
Stabilize Hairer GPU DAE comparisons

### DIFF
--- a/test/gpu/dae_tests.jl
+++ b/test/gpu/dae_tests.jl
@@ -242,6 +242,13 @@ function build_cases(;
     return cases
 end
 
+function solve_kwargs(case::TestCase)
+    # These Hairer/Krylov cases amplify stage-predictor roundoff at default tolerances.
+    case.jac_name == "CSC" && case.solver ∈ (Hairer4, Hairer42) &&
+        return (; SOLVE_KWARGS..., reltol = 1.0e-8, abstol = 1.0e-6)
+    return SOLVE_KWARGS
+end
+
 function maxerrs(sol_a, sol_b)
     max_abs = 0.0
     max_rel = 0.0
@@ -285,10 +292,11 @@ function run_case(case::TestCase)
     cpu_alg = case.needs_krylov_cpu ?
         case.solver(linsolve = KrylovJL_GMRES()) :
         case.solver()
+    kwargs = solve_kwargs(case)
 
     sol_cpu = nothing
     try
-        sol_cpu = solve(PROB_CPU, cpu_alg; SOLVE_KWARGS...)
+        sol_cpu = solve(PROB_CPU, cpu_alg; kwargs...)
         result.cpu_retcode = sol_cpu.retcode
         if ok(sol_cpu.retcode)
             result.cpu_abs, result.cpu_rel = maxerrs(sol_cpu, ref)
@@ -305,7 +313,7 @@ function run_case(case::TestCase)
             case.jac_prototype
         )
         prob_d = ODEProblem(odef_d, U0_D, TSPAN, P_D; initializealg = INITALG)
-        sol_gpu = solve(prob_d, cpu_alg; SOLVE_KWARGS...)
+        sol_gpu = solve(prob_d, cpu_alg; kwargs...)
         result.gpu_retcode = sol_gpu.retcode
         if ok(sol_gpu.retcode) && sol_cpu !== nothing && ok(sol_cpu.retcode)
             result.gpu_abs, result.gpu_rel = maxerrs(sol_gpu, sol_cpu)
@@ -434,9 +442,10 @@ function debug_case(solver::Type; jac = "none", mass = "diag_cu")
     cpu_alg = case.needs_krylov_cpu ?
         case.solver(linsolve = KrylovJL_GMRES()) :
         case.solver()
+    kwargs = solve_kwargs(case)
 
     @info "CPU solve"
-    sol_cpu = solve(PROB_CPU, cpu_alg; SOLVE_KWARGS...)
+    sol_cpu = solve(PROB_CPU, cpu_alg; kwargs...)
     @info "CPU retcode" sol_cpu.retcode
     @info "GPU solve"
     odef_d = make_odef(;
@@ -444,7 +453,7 @@ function debug_case(solver::Type; jac = "none", mass = "diag_cu")
         case.jac_prototype
     )
     prob_d = ODEProblem(odef_d, U0_D, TSPAN, P_D; initializealg = INITALG)
-    sol_gpu = solve(prob_d, case.solver(); SOLVE_KWARGS...)
+    sol_gpu = solve(prob_d, case.solver(); kwargs...)
     @info "GPU retcode" sol_gpu.retcode
 
     cpu_abs, cpu_rel = maxerrs(sol_cpu, ref)


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

The GPU DAE compatibility matrix deterministically fails only the Hairer4 and Hairer42 CSC/Krylov rows because default integration accuracy amplifies CPU/GPU roundoff beyond the existing comparison threshold. This applies `reltol = 1e-8, abstol = 1e-6` equally to the CPU and GPU solves for those two rows, while leaving `GPU_MATCH_TOL = (atol = 1e-3, rtol = 1e-3)` and every assertion unchanged.

The mismatch first became visible in https://github.com/SciML/OrdinaryDiffEq.jl/commit/5a2cb948c7b5c005ebe58dc3beecd605733683dd, when https://github.com/SciML/OrdinaryDiffEq.jl/pull/4026 restored the intended Hairer stage predictor and changed these cases from CPU `Unstable` skips into successful solves.

## Failing before

The latest equivalent GPU job on the unfixed code fails the same two rows:
https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33270493344/job/99148058794

```text
[116/144] Hairer4 [jac=CSC, mass=diag_cu] ... ✗ gpu mismatch
[119/144] Hairer42 [jac=CSC, mass=diag_cu] ... ✗ gpu mismatch
GPU Tests | 158 pass, 2 fail, 12 broken, 172 total
```

A CPU perturbation diagnostic shows why default tolerances are not stable enough for this comparison:

| Method | Default exact error | Tight exact error | Default one-ULP drift | Tight one-ULP drift |
|---|---:|---:|---:|---:|
| Hairer4 | 7.2797e-3 | 6.0799e-4 | 6.6250e-3 | 1.9763e-8 |
| Hairer42 | 5.5456e-3 | 5.1777e-4 | 4.1888e-3 | 4.4616e-8 |

## Passing after

The final pushed head (`5f6ce493ebb0c1be409e7543866923c1e4871dd6`) passed both formerly failing rows:
https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33308865121/job/99265102818

```text
[116/144] Hairer4 [jac=CSC, mass=diag_cu] ... ✓
[119/144] Hairer42 [jac=CSC, mass=diag_cu] ... ✓
GPU Tests | 160 pass, 12 broken, 172 total
```

The complete final-head CI workflow passed 45 of 45 jobs, and all ten substantive final-head workflows completed successfully:
https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33308865121

Local focused regression:

```text
Newton-Krylov round-off reproducibility (Hairer4)  | 3 pass / 3 total
Newton-Krylov round-off reproducibility (Hairer42) | 3 pass / 3 total
```

Root QA:

```text
Quality Assurance Tests | 106 pass / 106 total
Testing OrdinaryDiffEq tests passed
```

Static validation:

```text
julia +1.12 --startup-file=no -m Runic --check test/gpu/dae_tests.jl  # exit 0
typos test/gpu/dae_tests.jl                                           # exit 0
git diff --check                                                      # exit 0
```

The focused regression command exited 0. `GROUP=QA` exited 0.

## Not verified locally

- A full `GROUP=Regression_I` run reached the repository's 3600-second local timeout in the pre-existing `hard_dae.jl:244` case before the focused Newton-Krylov file; no assertion failure was observed, but this is not reported as a passing full group.
- GPU hardware and prerelease environments were verified by the successful PR workflow rather than locally.

## Reviewer judgment

The judgment call is the case-specific solve tolerance. The patch changes solution accuracy for only the two Hairer CSC/Krylov matrix rows; it does not loosen the CPU/GPU match threshold or suppress a failure.

🤖 Generated with Codex (version unknown) (model: GPT-5). Session: unknown
