### PR TITLE
Fix conditioning for OOP no-init nonlinear solves

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl
@@ -472,15 +472,16 @@ end
 
     nlcache = nlsolver.cache.cache
     if nlcache isa NonlinearSolveNoInitCache
-        # A no-init cache holds no iteration state, so it cannot be driven one `step!` at a
-        # controller the way `NLNewton` reports a failed linear solve. A complete solve
-        # leaves no half-taken step behind, so there is nothing for the residual to veto.
+        # A no-init cache can only run a complete inner solve.
         if integrator.f isa DAEFunction
             nlp_params = (tmp, α, tstep, invγdt, p, dt, uprev, integrator.f)
         else
             nlp_params = (tmp, γ, α, tstep, invγdt, method, p, dt, integrator.f)
         end
-        innersol = solve(NonlinearProblem(nlcache.prob.f, z, nlp_params), nlcache.alg)
+        innersol = solve(
+            NonlinearProblem(nlcache.prob.f, z, nlp_params), nlcache.alg;
+            conditioning_kwargs(cache)...
+        )
         if !SciMLBase.successful_retcode(innersol.retcode)
             return convert(eltype(z), Inf)
         end

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl
@@ -1109,7 +1109,8 @@ function build_nlsolver(
             )
             W_ref = nothing
             if cache isa NonlinearSolveNoInitCache
-                if !isdae && f.nlstep_data === nothing && W isa StaticWOperator
+                if !isdae && f.nlstep_data === nothing && precondition === nothing &&
+                        W isa StaticWOperator
                     W_ref = Ref(W.W)
                     nlf_jac = let W_ref = W_ref
                         (z, p) -> W_ref[]

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_conditioning_tests.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/nsa_conditioning_tests.jl
@@ -1,8 +1,22 @@
 using OrdinaryDiffEqNonlinearSolve, OrdinaryDiffEqSDIRK, OrdinaryDiffEqBDF
-using NonlinearSolve, SciMLBase, Test
+using NonlinearSolve, NonlinearSolveBase, SciMLBase, Test
 using ADTypes: AutoFiniteDiff, AutoForwardDiff
+using StaticArrays
 
 const NSA = OrdinaryDiffEqNonlinearSolve.NonlinearSolveAlg
+
+struct NoInitPostconditionProbe{A, R} <: NonlinearSolveBase.AbstractNonlinearSolveAlgorithm
+    alg::A
+    seen::R
+end
+NonlinearSolveBase.supports_postcondition(::NoInitPostconditionProbe) = true
+function SciMLBase.__solve(
+        prob::NonlinearProblem, alg::NoInitPostconditionProbe, args...;
+        postcondition = nothing, kwargs...
+    )
+    alg.seen[] |= postcondition !== nothing
+    return solve(prob, alg.alg, args...; kwargs...)
+end
 
 # `u' = -k u` keeps the state inside `[exp(-1), 1]` over `tspan`, while the stage unknown
 # `z` stays within one step of zero. The two ranges do not overlap, which is what lets the
@@ -267,6 +281,18 @@ end
     @test all(v -> exp(-1.0) - 0.05 <= v[1] <= 1.05, seen_u)
 end
 
+@testset "postcondition reaches a no-init inner solve" begin
+    seen = Ref(false)
+    inner = NoInitPostconditionProbe(SimpleNewtonRaphson(), seen)
+    H(u, uprev, p, cache) = u
+    sol = solve(
+        scalar_prob(), ImplicitEuler(nlsolve = NSA(inner; postcondition = H));
+        dt = 0.1, adaptive = false
+    )
+    @test SciMLBase.successful_retcode(sol)
+    @test seen[]
+end
+
 @testset "in-place precondition rejects dual-based inner autodiff" begin
     # Dropping `W` reuse leaves the inner solver differentiating the in-place stage
     # residual, which writes through preallocated `Float64` buffers. Better an explanation
@@ -315,6 +341,21 @@ end
     )
     # A corrector does not change the residual, so `W` reuse stays valid.
     @test post.cache.nlsolver.cache.W !== nothing
+
+    static_prob = ODEProblem((u, p, t) -> -u, SVector(1.0), (0.0, 1.0))
+    inner = SimpleNewtonRaphson(autodiff = AutoFiniteDiff())
+    static_plain = init(
+        static_prob, ImplicitEuler(nlsolve = NSA(inner), concrete_jac = true); dt = 0.1
+    )
+    @test static_plain.cache.nlsolver.cache.W isa Ref
+    static_cond = init(
+        static_prob,
+        ImplicitEuler(
+            nlsolve = NSA(inner; precondition = (fu, u, p) -> 2fu), concrete_jac = true
+        );
+        dt = 0.1
+    )
+    @test static_cond.cache.nlsolver.cache.W === nothing
 end
 
 @testset "corrector survives a resize" begin


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

This is a focused follow-up to the now-merged https://github.com/SciML/OrdinaryDiffEq.jl/pull/3798. It keeps out-of-place `W` reuse for unconditioned `SimpleNonlinearSolve` no-init solvers while preserving conditioning semantics:

- the complete no-init solve now receives supported `postcondition` data;
- a preconditioned residual no longer reuses the raw residual's `StaticWOperator`;
- regression tests cover both paths alongside the existing no-init allocation and nested-AD coverage.

`precondition` itself remains embedded in the `NonlinearProblem` through `PreconditionWrapper`; the bug was specifically that `W` reuse supplied a Jacobian for the untransformed residual. Generic traced algorithms continue to use the no-init fallback, so this does not make `ReverseDiffAdjoint` depend on a mutating inner cache.

## Regression evidence

I checked both focused probes against the unfixed stacked parent commit https://github.com/ChrisRackauckas-Claude/OrdinaryDiffEq.jl/commit/9b6517a90.

The postcondition probe defines a no-init algorithm with `supports_postcondition(::NoInitPostconditionProbe) = true`, records whether `postcondition` reaches `SciMLBase.__solve`, and asserts the record after an `ImplicitEuler` solve. With Julia 1.12.7, `--compiled-modules=no`, and an isolated local test environment, the unfixed code produced:

```text
Test Failed at none:19
  Expression: seen[]
ERROR: There was an error during testing
EXIT_CODE=1
```

The static out-of-place probe used this assertion sequence:

```julia
static_prob = ODEProblem((u, p, t) -> -u, SVector(1.0), (0.0, 1.0))
inner = SimpleNewtonRaphson(autodiff = AutoFiniteDiff())
static_plain = init(
    static_prob, ImplicitEuler(nlsolve = NSA(inner), concrete_jac = true); dt = 0.1
)
@test static_plain.cache.nlsolver.cache.W isa Ref
static_cond = init(
    static_prob,
    ImplicitEuler(
        nlsolve = NSA(inner; precondition = (fu, u, p) -> 2fu), concrete_jac = true
    );
    dt = 0.1
)
@test static_cond.cache.nlsolver.cache.W === nothing
```

The unfixed code produced:

```text
Test Failed at none:10
  Expression: static_cond.cache.nlsolver.cache.W === nothing
   Evaluated: Base.RefValue{SMatrix{1, 1, Float64, 1}}([-1.0;;]) === nothing
ERROR: There was an error during testing
EXIT_CODE=1
```

With the final fix commit https://github.com/ChrisRackauckas-Claude/OrdinaryDiffEq.jl/commit/35685f96b4c996c3912ecdebcf82cbf73b8e11c8 applied, the combined probes completed with exit code 0:

```text
focused OOP no-init conditioning probes passed
```

## Verification

Formatting, additions-only spelling, and diff checks:

```bash
~/.julia/packages/Runic/rL5ii/bin/runic --check \
  lib/OrdinaryDiffEqNonlinearSolve/src/newton.jl \
  lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl \
  lib/OrdinaryDiffEqNonlinearSolve/test/nsa_conditioning_tests.jl
git diff origin/master...HEAD --no-ext-diff --unified=0 | \
  sed -n '/^+/ { /^+++/d; s/^+//; p; }' | typos -
git diff origin/master...HEAD --check
```

All completed successfully with no findings.

QA group:

```bash
QA_DEPOT="$PWD/.qa-depot-codex-rebase2-01a04fd1"
JULIA_DEPOT_PATH="$QA_DEPOT:$HOME/.julia" TMPDIR="$HOME/tmp" GROUP=QA \
  ~/.juliaup/bin/julia +1.12 --project=lib/OrdinaryDiffEqNonlinearSolve \
  -e 'using Pkg; Pkg.test()'
```

```text
JET: 13 passed, 33 expected broken, 46 total
Aqua: 41 passed, 41 total
Testing OrdinaryDiffEqNonlinearSolve tests passed
```

Core group:

```bash
CORE_DEPOT="$PWD/.core-depot-codex-rebase2-01a04fd1"
JULIA_DEPOT_PATH="$CORE_DEPOT:$HOME/.julia" TMPDIR="$HOME/tmp" GROUP=Core \
  ~/.juliaup/bin/julia +1.12 --project=lib/OrdinaryDiffEqNonlinearSolve \
  -e 'using Pkg; Pkg.test()'
```

```text
Linear Nonlinear Solver Tests: 56 passed, 56 total
Nested AD over NonlinearSolveAlg: 5 passed, 5 total
NonlinearSolveAlg No-Init Inner Solver Tests: 102 passed, 102 total
NonlinearSolveAlg Preconditioning Tests: 74 passed, 74 total
Testing OrdinaryDiffEqNonlinearSolve tests passed
```

The full Core group passed, including every remaining declared Core testset. Master advanced afterward by one commit that only formats two `OrdinaryDiffEqDifferentiation` test files; I inspected that delta, rebased onto it, then reran Runic, typos, the diff check, and both focused probes on the exact final tree.

## Not verified

- `GROUP=Everything` was not run.
- GPU-specific groups were not run locally.
- The docs build was not run because this changes no public API, docstrings, or documentation.

## Reviewer note

`conditioning_kwargs(cache)` intentionally forwards only conditioning supported by the selected inner algorithm. Its unconditioned result remains the specialized empty named tuple, preserving the allocation behavior added by the parent PR.

🤖 Generated with Codex 0.151.0 (model: gpt-5; session: local session ID 01a04fd1-292a-7cf3-b2e1-c6924b2a96c9).
