### PR TITLE
OrdinaryDiffEqCore: 4.16.1 -> 4.16.0

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.16.1"
+version = "4.16.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
The live 4.x series tops out at 4.15.3 (5.0.0 exists but is yanked), so 4.16.1 skips 4.16.0 and trips AutoMerge's sequential-version guideline. 4.16.0 was never registered and has no registry PR, so step onto it rather than approving a skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R