### PR TITLE
Label the IMEX and SSP multistep methods as non-adaptive

### DIFF
--- a/docs/src/explicit/SSPRK.md
+++ b/docs/src/explicit/SSPRK.md
@@ -64,7 +64,7 @@ The SSP coefficient determines the maximum allowable timestep for stability pres
 
   - **`SSPRK432`**: Third-order with error control
   - **`SSPRK932`**: High-stage adaptive method
-  - **`SSPRKMSVS43`**: Multistep adaptive variant
+  - **`SSPRKMSVS43`**: Four-step multistep variant
 
 ```@eval
 first_steps = evalfile("./common_first_steps.jl")

--- a/lib/OrdinaryDiffEqSDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqSDIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSDIRK"
 uuid = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.9.1"
+version = "2.9.2"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/lib/OrdinaryDiffEqSDIRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/algorithms.jl
@@ -38,6 +38,10 @@ function SDIRK_docstring(
 end
 
 abstract type OrdinaryDiffEqNewtonAdaptiveESDIRKAlgorithm <: OrdinaryDiffEqNewtonAdaptiveAlgorithm end
+abstract type OrdinaryDiffEqNewtonNonAdaptiveESDIRKAlgorithm <: OrdinaryDiffEqNewtonAlgorithm end
+const OrdinaryDiffEqNewtonESDIRKAlgorithm = Union{
+    OrdinaryDiffEqNewtonAdaptiveESDIRKAlgorithm, OrdinaryDiffEqNewtonNonAdaptiveESDIRKAlgorithm,
+}
 abstract type OrdinaryDiffEqNewtonNonAdaptiveSDIRKAlgorithm <: OrdinaryDiffEqNewtonAlgorithm end
 abstract type OrdinaryDiffEqNewtonAdaptiveSDIRKAlgorithm <: OrdinaryDiffEqNewtonAdaptiveAlgorithm end
 
@@ -1489,7 +1493,7 @@ end
     """
 )
 struct ARS343{AD, F, F2, StepLimiter, CJ} <:
-    OrdinaryDiffEqNewtonAdaptiveESDIRKAlgorithm
+    OrdinaryDiffEqNewtonNonAdaptiveESDIRKAlgorithm
     linsolve::F
     nlsolve::F2
     smooth_est::Bool
@@ -1539,7 +1543,7 @@ end
     """
 )
 struct ARS222{AD, F, F2, StepLimiter, CJ} <:
-    OrdinaryDiffEqNewtonAdaptiveESDIRKAlgorithm
+    OrdinaryDiffEqNewtonNonAdaptiveESDIRKAlgorithm
     linsolve::F
     nlsolve::F2
     smooth_est::Bool
@@ -1589,7 +1593,7 @@ end
     """
 )
 struct ARS232{AD, F, F2, StepLimiter, CJ} <:
-    OrdinaryDiffEqNewtonAdaptiveESDIRKAlgorithm
+    OrdinaryDiffEqNewtonNonAdaptiveESDIRKAlgorithm
     linsolve::F
     nlsolve::F2
     smooth_est::Bool
@@ -1639,7 +1643,7 @@ end
     """
 )
 struct ARS443{AD, F, F2, StepLimiter, CJ} <:
-    OrdinaryDiffEqNewtonAdaptiveESDIRKAlgorithm
+    OrdinaryDiffEqNewtonNonAdaptiveESDIRKAlgorithm
     linsolve::F
     nlsolve::F2
     smooth_est::Bool
@@ -1713,7 +1717,7 @@ for (name, desc) in (
             """
         )
         struct $name{AD, F, F2, StepLimiter, CJ} <:
-            OrdinaryDiffEqNewtonAdaptiveESDIRKAlgorithm
+            OrdinaryDiffEqNewtonNonAdaptiveESDIRKAlgorithm
             linsolve::F
             nlsolve::F2
             smooth_est::Bool
@@ -1764,7 +1768,7 @@ end
     """
 )
 struct BHR553{AD, F, F2, StepLimiter, CJ} <:
-    OrdinaryDiffEqNewtonAdaptiveESDIRKAlgorithm
+    OrdinaryDiffEqNewtonNonAdaptiveESDIRKAlgorithm
     linsolve::F
     nlsolve::F2
     smooth_est::Bool

--- a/lib/OrdinaryDiffEqSDIRK/src/sdirk_caches.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/sdirk_caches.jl
@@ -12,12 +12,12 @@ const _PureSDIRKAlg = Union{
 }
 
 # step_limiter! accessor — only some pure SDIRK algorithms have the field
-_esdirk_step_limiter!(alg::OrdinaryDiffEqNewtonAdaptiveESDIRKAlgorithm) = alg.step_limiter!
+_esdirk_step_limiter!(alg::OrdinaryDiffEqNewtonESDIRKAlgorithm) = alg.step_limiter!
 _esdirk_step_limiter!(alg::Union{ImplicitMidpoint, SDIRK2, TRBDF2, ImplicitEuler, Trapezoid}) = alg.step_limiter!
 _esdirk_step_limiter!(alg) = trivial_limiter!
 
 # smooth_est accessor — only adaptive algorithms carry this flag
-_esdirk_smooth_est(alg::OrdinaryDiffEqNewtonAdaptiveESDIRKAlgorithm) = alg.smooth_est
+_esdirk_smooth_est(alg::OrdinaryDiffEqNewtonESDIRKAlgorithm) = alg.smooth_est
 _esdirk_smooth_est(alg::OrdinaryDiffEqNewtonAdaptiveSDIRKAlgorithm) = alg.smooth_est
 _esdirk_smooth_est(alg) = false
 
@@ -98,7 +98,7 @@ function OrdinaryDiffEqCore.strip_cache(cache::ESDIRKIMEXCache)
 end
 
 function alg_cache(
-        alg::OrdinaryDiffEqNewtonAdaptiveESDIRKAlgorithm, u, rate_prototype, ::Type{uEltypeNoUnits},
+        alg::OrdinaryDiffEqNewtonESDIRKAlgorithm, u, rate_prototype, ::Type{uEltypeNoUnits},
         ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits},
         uprev, uprev2, f, t, dt, reltol, p, calck,
         ::Val{false}, verbose
@@ -114,7 +114,7 @@ function alg_cache(
 end
 
 function alg_cache(
-        alg::OrdinaryDiffEqNewtonAdaptiveESDIRKAlgorithm, u, rate_prototype, ::Type{uEltypeNoUnits},
+        alg::OrdinaryDiffEqNewtonESDIRKAlgorithm, u, rate_prototype, ::Type{uEltypeNoUnits},
         ::Type{uBottomEltypeNoUnits},
         ::Type{tTypeNoUnits}, uprev, uprev2, f, t, dt, reltol, p, calck,
         ::Val{true}, verbose

--- a/lib/OrdinaryDiffEqSDIRK/test/sdirk_convergence_tests.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/sdirk_convergence_tests.jl
@@ -2,6 +2,7 @@
 using OrdinaryDiffEqSDIRK, ODEProblemLibrary, DiffEqDevTools, ADTypes
 using OrdinaryDiffEqNonlinearSolve: NLFunctional, NLAnderson, NonlinearSolveAlg
 using Test, Random
+using OrdinaryDiffEqCore: OrdinaryDiffEqCore
 Random.seed!(100)
 
 ## Convergence Testing
@@ -266,4 +267,18 @@ end
 
     sim_iip = test_convergence(dts, prob_iip, Kvaerno4())
     @test sim_iip.𝒪est[:l∞] ≈ 4 atol = testTol
+end
+
+@testset "IMEX methods without an embedded pair are not adaptive" begin
+    f1 = (u, p, t) -> -u
+    f2 = (u, p, t) -> 0.1 * u
+    prob = SplitODEProblem(f1, f2, 1.0, (0.0, 1.0))
+    for alg in (
+            ARS222(), ARS232(), ARS343(), ARS443(),
+            IMEXSSP222(), IMEXSSP2322(), IMEXSSP3332(), IMEXSSP3433(), BHR553(),
+        )
+        @test !OrdinaryDiffEqCore.isadaptive(alg)
+        @test_throws ArgumentError solve(prob, alg)
+        @test solve(prob, alg; dt = 0.1).retcode == ReturnCode.Success
+    end
 end

--- a/lib/OrdinaryDiffEqSSPRK/Project.toml
+++ b/lib/OrdinaryDiffEqSSPRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSSPRK"
 uuid = "669c94d9-1f4b-4b64-b377-1aa079aa2388"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.3.1"
+version = "2.3.2"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqSSPRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqSSPRK/src/algorithms.jl
@@ -126,7 +126,7 @@ size.",
     [DOI: 10.1137/0909073](https://doi.org/10.1137/0909073)"
 )
 Base.@kwdef struct SSPRKMSVS32{StageLimiter, StepLimiter, Thread} <:
-    OrdinaryDiffEqAdaptiveAlgorithm
+    OrdinaryDiffEqAlgorithm
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()
@@ -203,7 +203,7 @@ size.",
     [DOI: 10.1137/0909073](https://doi.org/10.1137/0909073)"
 )
 Base.@kwdef struct SSPRKMSVS43{StageLimiter, StepLimiter, Thread} <:
-    OrdinaryDiffEqAdaptiveAlgorithm
+    OrdinaryDiffEqAlgorithm
     stage_limiter!::StageLimiter = trivial_limiter!
     step_limiter!::StepLimiter = trivial_limiter!
     thread::Thread = Serial()

--- a/lib/OrdinaryDiffEqSSPRK/test/ode_ssprk_tests.jl
+++ b/lib/OrdinaryDiffEqSSPRK/test/ode_ssprk_tests.jl
@@ -1,4 +1,5 @@
 using OrdinaryDiffEqSSPRK, DiffEqDevTools, Test, Random
+using OrdinaryDiffEqCore: OrdinaryDiffEqCore
 import OrdinaryDiffEqLowStorageRK
 import ODEProblemLibrary: prob_ode_linear, prob_ode_2Dlinear, prob_ode_bigfloat2Dlinear
 
@@ -619,5 +620,14 @@ end
             sim = test_convergence(dts, prob, alg; save_everystep = false, dense = false)
             @test sim.𝒪est[:final] ≈ OrdinaryDiffEqSSPRK.alg_order(alg) atol = testTol
         end
+    end
+end
+
+@testset "SSP multistep methods are not adaptive" begin
+    prob = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 1.0))
+    for alg in (SSPRKMSVS32(), SSPRKMSVS43())
+        @test !OrdinaryDiffEqCore.isadaptive(alg)
+        @test_throws ArgumentError solve(prob, alg)
+        @test solve(prob, alg; dt = 0.05).retcode == ReturnCode.Success
     end
 end


### PR DESCRIPTION
`ARS222`, `ARS232`, `ARS343`, `ARS443`, `IMEXSSP222`, `IMEXSSP2322`, `IMEXSSP3332`, `IMEXSSP3433`, `BHR553`, `SSPRKMSVS32` and `SSPRKMSVS43` were declared adaptive but never set `EEst`, so it stayed at its initial 1 and the step size sat wherever `ode_determine_initdt` put it: four IMEX methods of three different orders took exactly 5906 identical steps on the same problem where `KenCarp3` took 45.
None of their sources gives embedded weights (Ascher, Ruuth and Spiteri 1997; Pareschi and Russo 2005; Boscarino and Russo 2009; Shu 1988 for the SSP multistep pair), so they are now labelled what they are: the nine IMEX methods sit on a new `OrdinaryDiffEqNewtonNonAdaptiveESDIRKAlgorithm <: OrdinaryDiffEqNewtonAlgorithm`, with a `Union` covering the four cache and limiter dispatch sites they share with the KenCarp family, and the two SSP multistep methods on `OrdinaryDiffEqAlgorithm`. `solve` without `dt` now raises the usual fixed-timestep `ArgumentError` instead of running uncontrolled; `SSPRKMSVS32`'s docstring already said it needs a fixed step, and the SSPRK page no longer calls `SSPRKMSVS43` adaptive.
This changes what existing calls do: a solve that passed only tolerances errors now rather than silently running at the initial dt. Tests assert `!isadaptive`, the error without `dt`, and a successful solve with it, for all eleven.
Fixes #4362.
AI Disclosure: Claude assisted with this change.
