### PR TITLE
Skip sparsity prep for matrix-free jac_prototype operators

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "3.11.3"
+version = "3.11.4"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 

--- a/lib/OrdinaryDiffEqDifferentiation/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/alg_utils.jl
@@ -114,6 +114,13 @@ function prepare_user_sparsity(ad_alg, prob)
     jac_prototype = prob.f.jac_prototype
     sparsity = prob.f.sparsity
 
+    # `ODEFunction` defaults `sparsity` to `jac_prototype`. A matrix-free operator
+    # carries no sparsity pattern, so `KnownJacobianSparsityDetector` must not see it
+    # (that path needs an `AbstractMatrix` via `concrete_mass_matrix`).
+    if sparsity isa AbstractSciMLOperator && !SciMLOperators.isconvertible(sparsity)
+        return ad_alg
+    end
+
     if !isnothing(sparsity) && !(ad_alg isa AutoSparse)
         if is_sparse_csc(sparsity) && !SciMLBase.has_jac(prob.f)
             if prob.f.mass_matrix isa UniformScaling

--- a/lib/OrdinaryDiffEqDifferentiation/test/nojac_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/nojac_tests.jl
@@ -275,6 +275,27 @@ integ = init(prob, Rosenbrock23(), abstol = 1.0e-6, reltol = 1.0e-6)
     @test (integrator.stats.nf, integrator.stats.njacs) == work
 end
 
+# `ODEFunction` defaults `sparsity` to a matrix-free `jac_prototype`; that used to
+# crash in `prepare_user_sparsity` before any linear solve ran (#4302).
+@testset "Matrix-free FunctionOperator jac_prototype prepares" begin
+    using SciMLOperators: FunctionOperator
+    using LinearAlgebra: mul!, I
+    using Random: MersenneTwister
+    using DiffEqBase: prepare_alg
+
+    n = 40
+    A = randn(MersenneTwister(1), n, n) - 20I
+    rhs!(du, u, p, t) = mul!(du, A, u)
+    jv(v, u, p, t) = A * v
+    jv(w, v, u, p, t) = mul!(w, A, v)
+    Jop = FunctionOperator(jv, zeros(n), zeros(n); islinear = true)
+    prob = ODEProblem(ODEFunction(rhs!; jac_prototype = Jop), ones(n), (0.0, 1.0))
+
+    alg = prepare_alg(TRBDF2(linsolve = KrylovJL_GMRES()), ones(n), SciMLBase.NullParameters(), prob)
+    @test !(alg.autodiff isa AutoSparse)
+    @test_nowarn init(prob, TRBDF2(linsolve = KrylovJL_GMRES()); abstol = 1e-8, reltol = 1e-8)
+end
+
 @testset "get_fresh_jacobian keeps a sparse J's pattern" begin
     # `zero(::SparseMatrixCSC)` has no stored entries, so it drops the pattern `calc_J!`
     # colours against and the instability diagnostic threw `DimensionMismatch` instead of

--- a/lib/OrdinaryDiffEqDifferentiation/test/prepare_user_sparsity_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/prepare_user_sparsity_tests.jl
@@ -70,3 +70,19 @@ end
     OrdinaryDiffEqDifferentiation.prepare_user_sparsity(ad_alg, prob)
     @test Matrix(prob.f.jac_prototype) == Matrix(M)
 end
+
+# Matrix-free `jac_prototype` is copied into `sparsity` by `ODEFunction`; it is not a
+# sparsity pattern and must not enter the `KnownJacobianSparsityDetector` path (#4302).
+@testset "Matrix-free FunctionOperator jac_prototype skips sparsity prep" begin
+    using LinearAlgebra: mul!
+    A = [1.0 2.0; 0.0 1.0]
+    jv(v, u, p, t) = A * v
+    jv(w, v, u, p, t) = mul!(w, A, v)
+    Jop = FunctionOperator(jv, zeros(2), zeros(2); islinear = true)
+    odef = ODEFunction(f!; jac_prototype = Jop)
+    prob = ODEProblem(odef, ones(2), (0.0, 1.0))
+
+    @test prob.f.sparsity === Jop
+    @test OrdinaryDiffEqDifferentiation.prepare_user_sparsity(ad_alg, prob) === ad_alg
+end
+


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.**

## What changed and why

`ODEFunction` defaults `sparsity` to `jac_prototype`. When that prototype is a matrix-free `AbstractSciMLOperator` (e.g. `FunctionOperator`), `prepare_user_sparsity` still entered the `KnownJacobianSparsityDetector` path and called `concrete_mass_matrix`, which needs an `AbstractMatrix` conversion. That threw in `prepare_alg` before any linear solve ran, so the matrix-free path was unusable regardless of `linsolve`.

Skip sparsity preparation when `sparsity` is a non-convertible SciML operator. Convertible operators such as `MatrixOperator` still unwrap as before. OrdinaryDiffEqDifferentiation is bumped to 3.11.4.

Fixes #4302.

## Failing before / passing after

With the regression present and the source fix reverted, the issue reproducer throws:

```text
MethodError: Cannot `convert` an object of type typeof(jv) to an object of type AbstractMatrix
...
concrete_mass_matrix(::FunctionOperator)
prepare_user_sparsity
prepare_alg
```

With this patch, `prepare_user_sparsity` returns the dense AD algorithm unchanged, and `init`/`prepare_alg` succeed for a `FunctionOperator` `jac_prototype`.

## Local verification

- `GROUP=Core julia +1.12 --project=lib/OrdinaryDiffEqDifferentiation --startup-file=no -e 'using Pkg; Pkg.test()'`: package Core tests passed, including prepare_user_sparsity (11/11) and No Jac (21/21).
- Direct include of `prepare_user_sparsity_tests.jl` after the final edit: all 6 subsets passed.


Made with [Cursor](https://cursor.com)