### PR TITLE
Format newly added differentiation tests

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/test/nojac_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/nojac_tests.jl
@@ -293,7 +293,7 @@ end
 
     alg = prepare_alg(TRBDF2(linsolve = KrylovJL_GMRES()), ones(n), SciMLBase.NullParameters(), prob)
     @test !(alg.autodiff isa AutoSparse)
-    @test_nowarn init(prob, TRBDF2(linsolve = KrylovJL_GMRES()); abstol = 1e-8, reltol = 1e-8)
+    @test_nowarn init(prob, TRBDF2(linsolve = KrylovJL_GMRES()); abstol = 1.0e-8, reltol = 1.0e-8)
 end
 
 @testset "get_fresh_jacobian keeps a sparse J's pattern" begin

--- a/lib/OrdinaryDiffEqDifferentiation/test/prepare_user_sparsity_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/prepare_user_sparsity_tests.jl
@@ -85,4 +85,3 @@ end
     @test prob.f.sparsity === Jop
     @test OrdinaryDiffEqDifferentiation.prepare_user_sparsity(ad_alg, prob) === ad_alg
 end
-


### PR DESCRIPTION
## What changed and why

Apply Runic v1.10 formatting to the two differentiation test files added by https://github.com/SciML/OrdinaryDiffEq.jl/pull/4445. That merge introduced the only two formatting failures on `master`, causing https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33337246186 to fail.

This is a mechanical formatting-only change: it normalizes two floating-point literals and removes one trailing blank line. It does not change source code, assertions, tolerances, or test coverage.

> [!IMPORTANT]
> Ignore this draft PR until it has been reviewed by @ChrisRackauckas.

## Verification

Failing before, on clean `master` commit `27f8eb9637d1a67ba0a725f1ed8e7da16b8fe66f`:

```text
$ julia +1.12 --startup-file=no --project=.runic-env -m Runic --check --diff \
    lib/OrdinaryDiffEqDifferentiation/test/nojac_tests.jl \
    lib/OrdinaryDiffEqDifferentiation/test/prepare_user_sparsity_tests.jl
-    @test_nowarn init(...; abstol = 1e-8, reltol = 1e-8)
+    @test_nowarn init(...; abstol = 1.0e-8, reltol = 1.0e-8)
...
-<trailing blank line>
exit status: 1
```

The same command exits `0` on the parent commit `ef4cb09584`, identifying `27f8eb9637` as the introducing commit.

Passing after this change:

```text
$ git ls-files -z -- '*.jl' | xargs -0 --no-run-if-empty \
    julia +1.12 --startup-file=no --project=.runic-env -m Runic --check --diff
exit status: 0

$ GROUP=Core julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
prepare_user_sparsity mass matrix | 11 pass / 11 total
No Jac Tests                    | 21 pass / 21 total
Core aggregate                  | 159 pass / 159 total
Testing OrdinaryDiffEqDifferentiation tests passed

$ GROUP=QA julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
JET Tests | 1 pass / 1 total
Aqua      | 19 pass / 19 total
Testing OrdinaryDiffEqDifferentiation tests passed

$ typos lib/OrdinaryDiffEqDifferentiation/test/nojac_tests.jl \
    lib/OrdinaryDiffEqDifferentiation/test/prepare_user_sparsity_tests.jl
exit status: 0

$ git diff --check
exit status: 0
```

## Not verified

Docs, GPU, downstream, and unrelated test groups were not run because this PR only formats tests and changes no package behavior or public API.

🤖 Generated with Codex (version unknown) (model: GPT-5; session: unknown).
