### PR TITLE
Read the test group from GROUP like the CI passes it

### DIFF
--- a/lib/GlobalDiffEq/Project.toml
+++ b/lib/GlobalDiffEq/Project.toml
@@ -1,7 +1,7 @@
 name = "GlobalDiffEq"
 uuid = "1d72d19b-84cc-4cb7-a099-7cbdb9ccc67c"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/lib/GlobalDiffEq/test/runtests.jl
+++ b/lib/GlobalDiffEq/test/runtests.jl
@@ -3,7 +3,7 @@ using Test
 using SciMLTesting
 
 run_tests(;
-    env = "ODEDIFFEQ_TEST_GROUP",
+    env = "GROUP",
     core = function ()
         @safetestset "Basic functionality" begin
             include("basic_functionality_tests.jl")


### PR DESCRIPTION
GlobalDiffEq's `runtests.jl` reads the test group from `ODEDIFFEQ_TEST_GROUP` while both sublibrary CI workflows pass `GROUP`, so every lane has been running the default group and the QA checks never ran on CI; it is the only sublibrary with that variable name.
With the fix, locally on Julia 1.10.12: `GROUP=Core` runs the four Core testsets (97 tests pass) and `GROUP=QA` runs the QA group for the first time, 21 pass and 1 pre-existing broken.
AI Disclosure: Claude assisted with this change.
