### PR TITLE
Copy the W prototype so integrators stop sharing it

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "3.11.4"
+version = "3.11.5"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -568,6 +568,7 @@ function do_newJW(integrator, alg, nlsolver, repeat_step)::NTuple{2, Bool}
     isfreshJ = isJcurrent(nlsolver, integrator) && !integrator.derivative_discontinuity
     iszero(nlsolver.fast_convergence_cutoff) && return isfs && !isfreshJ, isfs
     isdae = alg isa DAEAlgorithm
+    is_varying_mm = false
     if !isdae
         mm = integrator.f.mass_matrix
         is_varying_mm = !isconstant(mm)
@@ -1296,8 +1297,9 @@ function build_J_W(
         if !(f.jac_prototype isa AbstractSciMLOperator)
             error("SciMLOperator for W_prototype only supported when jac_prototype is a SciMLOperator, but got $(typeof(f.jac_prototype))")
         end
-        W = f.W_prototype
-        J = f.jac_prototype
+        # One deepcopy of the pair keeps a `W_prototype` that references
+        # `jac_prototype` pointing at the copy of `J`, not the original.
+        W, J = deepcopy((f.W_prototype, f.jac_prototype))
     elseif f.jac_prototype isa AbstractSciMLOperator
         J = deepcopy(f.jac_prototype)
         if J isa AbstractMatrix

--- a/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
@@ -24,6 +24,7 @@ end
 if TEST_GROUP ∉ ("Core", "Sparse", "ModelingToolkit") && isempty(VERSION.prerelease)
     activate_qa_env()
     @time @safetestset "JET Tests" include("qa/jet.jl")
+    @time @safetestset "W prototype aliasing" include("w_prototype_aliasing_tests.jl")
     @time @safetestset "Aqua" include("qa/qa.jl")
 end
 

--- a/lib/OrdinaryDiffEqDifferentiation/test/w_prototype_aliasing_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/w_prototype_aliasing_tests.jl
@@ -1,0 +1,35 @@
+using OrdinaryDiffEqSDIRK, OrdinaryDiffEqDifferentiation, SciMLOperators, LinearAlgebra
+using SciMLBase, Test
+
+@testset "integrators from one ODEFunction do not share the W_prototype" begin
+    mutable struct ParamA
+        a::Float64
+    end
+    f!(du, u, p, t) = (du .= p.a .* u)
+    Jop = MatrixOperator(
+        zeros(2, 2); update_func! = (A, u, p, t) -> (A .= p.a * Matrix(1.0I, 2, 2))
+    )
+    Wop = MatrixOperator(
+        zeros(2, 2);
+        update_func! = (A, u, p, t; gamma = 1.0) ->
+        (A .= p.a * Matrix(1.0I, 2, 2) .- Matrix(1.0I, 2, 2) ./ gamma),
+        accepted_kwargs = (:gamma,),
+    )
+    odef = ODEFunction(f!; jac_prototype = Jop, W_prototype = Wop)
+    prob1 = ODEProblem(odef, ones(2), (0.0, 1.0), ParamA(-1.0))
+    prob2 = ODEProblem(odef, ones(2), (0.0, 1.0), ParamA(-1000.0))
+
+    i1 = init(prob1, TRBDF2(); abstol = 1.0e-8, reltol = 1.0e-8)
+    i2 = init(prob2, TRBDF2(); abstol = 1.0e-8, reltol = 1.0e-8)
+    @test i1.cache.nlsolver.cache.W !== i2.cache.nlsolver.cache.W
+    @test i1.cache.nlsolver.cache.W !== odef.W_prototype
+    @test i1.cache.nlsolver.cache.J !== odef.jac_prototype
+
+    for _ in 1:200
+        i1.t < 1.0 && step!(i1)
+        i2.t < 1.0 && step!(i2)
+        i1.t >= 1.0 && i2.t >= 1.0 && break
+    end
+    @test i1.u[1] ≈ exp(-1.0) rtol = 1.0e-3
+    @test abs(i2.u[1]) < 1.0e-6
+end


### PR DESCRIPTION
`build_J_W`'s `W_prototype` branch returns `W = f.W_prototype; J = f.jac_prototype` while the branch below it deepcopy's, so every integrator built from one `ODEFunction` holds the same two operator objects; the pair is now copied together, which keeps a `W_prototype` that references `jac_prototype` pointing at its own copy.
No wrong result demonstrates on the factorization path, because every Newton solve rewrites W before using it; the sharing is still a hazard for any path that reads W's contents outside a fresh update, and it made two integrators' behaviour depend on each other's update order.
Copying the pair widens what inference can prove about `W` and `J`, which made JET's typo mode report `is_varying_mm` in `do_newJW` as possibly undefined on the Julia 1 QA lane; the variable can never actually be undefined, since it is assigned and read under the same `isdae` test, so it is now initialised before the branch.
The new test builds two integrators from one function, asserts the operators are distinct, and steps both interleaved to their correct solutions.
AI Disclosure: Claude assisted with this change.
