### PR TITLE
Raise root GPU test timeout to 120 minutes

### DIFF
--- a/test/qa/qa_tests.jl
+++ b/test/qa/qa_tests.jl
@@ -1,8 +1,14 @@
+using Pkg
 using SciMLTesting, OrdinaryDiffEq
 using ADTypes, CommonSolve, DiffEqBase, OrdinaryDiffEqBDF, OrdinaryDiffEqDefault,
     OrdinaryDiffEqRosenbrock, OrdinaryDiffEqTsit5, OrdinaryDiffEqVerner,
     SciMLBase, SciMLLogging
 using Test
+
+@testset "GPU test group timeout" begin
+    groups = Pkg.TOML.parsefile(joinpath(@__DIR__, "..", "test_groups.toml"))
+    @test groups["GPU"]["timeout"] >= 120
+end
 
 @testset "PureKLU-compatible MuladdMacro floors" begin
     lib_dir = joinpath(@__DIR__, "..", "..", "lib")

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -34,4 +34,4 @@ versions = ["lts"]
 [GPU]
 versions = ["1"]
 runner = ["self-hosted", "Linux", "X64", "gpu"]
-timeout = 60
+timeout = 120


### PR DESCRIPTION
## What changed and why

The root GPU integration job was cancelled by its configured 60-minute limit after reaching case 125/144 with every completed case passing. This raises only that root lane's timeout to 120 minutes and adds a QA assertion that prevents the limit from being reduced below the required budget.

The smaller sublibrary GPU lanes keep their existing 60-minute limits.

## Verification

### Failing before

With the QA assertion applied and the timeout still set to 60:

```text
GROUP=QA /home/crackauc/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test()'
Quality Assurance Tests | 108 passed, 1 failed, 109 total
Expression: groups["GPU"]["timeout"] >= 120
Evaluated: 60 >= 120
```

The CI reproducer was cancelled at 60 minutes after 125/144 GPU cases; the completed cases, including Hairer4 and Hairer42 CSC/CSR, passed: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33354641952/job/99374441344

An independent clean-master audit confirmed the same configured cutoff in https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33355900438/job/99446579190. That run spent its test-step budget retrying a `CUDA_Runtime` artifact download after a `Data Error` and was cancelled before tests, so it is runner/artifact evidence rather than a product-test failure. A recent healthy run completed the full GPU suite in 36m39s with 160 passes and 12 broken tests: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33308865121/job/99265102818

History review found that https://github.com/SciML/OrdinaryDiffEq.jl/commit/72706ab35816b50a30a49612e2028e1342fa7357 introduced the 60-minute root-lane limit. The later 144-case DAE matrix was added by https://github.com/SciML/OrdinaryDiffEq.jl/commit/5e1bd9329105d1838a330ffda8d9d4d85613a25a, and its first master run exhausted the 60-minute limit after 135/144 completed cases passed: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/28853849480/job/85575493608

### Passing after

With the timeout set to 120, the identical QA command completed successfully:

```text
Quality Assurance Tests | 109 passed, 109 total
Testing OrdinaryDiffEq tests passed
```

The pre-rebase PR head completed the self-hosted GPU job in 43m33s. Its test step finished in 27m46s with the full suite accounted for:

```text
GPU Tests | 160 pass | 12 broken | 172 total
```

GPU job: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33392051593/job/99500188861

After rebasing onto the merged Julia LTS QA fix, the combined source tree passed both QA lanes locally:

```text
Julia 1.10: Quality Assurance Tests | 107 passed, 107 total
Julia release: Quality Assurance Tests | 109 passed, 109 total
```

The pre-rebase CI run had one unrelated Julia LTS `Integrators_II` error (`cannot resize array with shared data`) after the same master tree had passed that job earlier. Two full local replays did not reproduce it:

```text
SciMLBase 3.50.2 + OrdinaryDiffEqDifferentiation 3.11.3 (exact failed resolution): tests passed in 2235.81s
SciMLBase 3.50.2 + OrdinaryDiffEqDifferentiation 3.11.4 (current resolution): tests passed in 2295.76s
Cache Tests in each replay: 214 pass, 4 existing broken, 218 total
```

Failed CI job: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33392051593/job/99500187575

Earlier passing job on the identical master commit: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33355900438/job/99446579698

Additional local checks:

```text
Runic 1.10.0: test/qa/qa_tests.jl — exit 0
typos test/qa/qa_tests.jl test/test_groups.toml — exit 0
git diff --check — exit 0
```

The rebased exact head completed all 10 substantive pull-request workflows successfully. The main CI matrix passed 45/45 jobs, including Julia LTS `Integrators_II` and the self-hosted GPU job:

```text
GPU Tests | 160 pass | 12 broken | 172 total | 56m19.8s
```

- Main CI: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33416954830
- GPU job: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33416954830/job/99591047419
- Julia LTS `Integrators_II`: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33416954830/job/99591047548
- IntegrationTest (12/12 jobs): https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33416954356
- Downgrade Sublibraries (60/60 jobs): https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33416954511
- Post-merge documentation cleanup: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33439676986

After merge, current master `f50245c0bb47d949c2be7170e6a4036a5ff6b50b` also completed every substantive push workflow successfully. Main CI passed 45/45 jobs, IntegrationTest passed 12/12 jobs, and Downgrade Sublibraries passed 60/60 jobs. The master GPU summary was 160 passed, 12 broken, and 172 total in 56m53.5s.

- Current-master CI: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33439676181
- Current-master GPU job: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33439676181/job/99656480096
- Current-master IntegrationTest: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33439675775
- Current-master Downgrade Sublibraries: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/33439675936

## Not verified

- The full root GPU suite cannot run on this local machine; the rebased exact-head self-hosted job completed it successfully.
- `GROUP=Everything` was not run because this changes only CI scheduling metadata and its focused QA guard.
- The docs build was not run locally because no documentation, docstring, or public API changed; the exact-head Documentation workflow passed.

## Reviewer attention

The 120-minute limit doubles the observed cutoff while remaining below the 240–420 minute budgets already used by the repository's heaviest test groups.

The latest clean-master run also exposed a runner/artifact-download problem. This timeout increase gives a transient retry room to finish, but it is not a fix for a persistently broken artifact source or cache; if this PR stalls at the same download, the self-hosted runner should be investigated instead of increasing the timeout again.

Draft — ignore until reviewed by @ChrisRackauckas.

🤖 Generated with Codex (version unknown) (model: GPT-5; session: unknown).
