### PR TITLE
Fix SciMLBase reexport QA on Julia LTS

### DIFF
--- a/test/qa/reexport_tests.jl
+++ b/test/qa/reexport_tests.jl
@@ -12,7 +12,12 @@ using SciMLBase, Test
     @test length(documented) > 50
 
     exported = setdiff(names(SciMLBase), [:SciMLBase])
-    @test isempty(setdiff(documented, exported))
+    is_scimlbase_api(name) = @static if isdefined(Base, :ispublic)
+        Base.ispublic(SciMLBase, name)
+    else
+        isdefined(SciMLBase, name)
+    end
+    @test all(is_scimlbase_api, documented)
 
     common_interface = read(
         joinpath(repo_dir, "docs", "src", "api", "common_interface.md"), String


### PR DESCRIPTION
## What changed and why

Make the SciMLBase re-export audit compatible with Julia 1.10 LTS. Julia 1.10 cannot introspect names declared only through SciMLPublic's `@public` backport, so the audit incorrectly rejected 15 valid, defined SciMLBase bindings; the test now checks native public status when `Base.ispublic` exists and binding availability on LTS.

`git bisect` identified the test's introducing commit as https://github.com/SciML/OrdinaryDiffEq.jl/commit/93b959822987114c970fd1fefda2c91a4f566136.

> Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## Failing before / passing after

Before the fix, on unmodified `master` at `b7a983f325087c34d92c77e795bab337662894f3`:

```text
$ GROUP=QA julia +lts --project -e 'using Pkg; Pkg.test()'
Expression: isempty(setdiff(documented, exported))
Evaluated: isempty([:successful_retcode, :DEStats, :NLStats, :NullParameters,
  :AutoSpecialize, :FullSpecialize, :NoSpecialize, :FunctionWrapperSpecialize,
  :NoInit, :OverrideInit, :LeftRootFind, :RightRootFind, :NoRootFind,
  :check_error!, :set_ut!])
Test Summary:           | Pass  Fail  Total
Quality Assurance Tests |  105     1    106
ERROR: Package OrdinaryDiffEq errored during testing
```

With this fix, the same group and Julia channel pass:

```text
$ GROUP=QA julia +lts --project -e 'using Pkg; Pkg.test()'
Test Summary:           | Pass  Total   Time
Quality Assurance Tests |  106    106  14.4s
Testing OrdinaryDiffEq tests passed
```

The focused test also changes from 13 pass / 1 fail to 14 / 14.

## Verification

```text
$ GROUP=QA julia +release --project -e 'using Pkg; Pkg.test()'
Test Summary:           | Pass  Total   Time
Quality Assurance Tests |  108    108  17.3s
Testing OrdinaryDiffEq tests passed

$ julia +1.12 --startup-file=no -m Runic --check test/qa/reexport_tests.jl
$ typos test/qa/reexport_tests.jl
$ git diff --check
runic=0 typos=0 diff_check=0
```

## Not verified

The docs build, GPU jobs, and unrelated test groups were not run because this changes only the version-aware QA assertion. Julia 1.10 cannot retain native public-name metadata, so that lane can prove the documented bindings exist but cannot independently distinguish `public` bindings from other defined bindings; Julia 1.12 continues to check `Base.ispublic` for every documented name.

## Links

- Introducing commit: https://github.com/SciML/OrdinaryDiffEq.jl/commit/93b959822987114c970fd1fefda2c91a4f566136
- Original re-export PR: https://github.com/SciML/OrdinaryDiffEq.jl/pull/4272

🤖 Generated with Codex (version unknown) (model: GPT-5; session: unknown)
