### PR TITLE
Build W through the allocating path for a sparse GPU Jacobian with a scalar mass matrix

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -645,7 +645,15 @@ function jacobian2W!(
         @boundscheck axes(mass_matrix) == axes(W) || _throwWMerror(W, mass_matrix)
     @inbounds begin
         invdtgamma = inv(dtgamma)
-        if _is_scalar_massmatrix(mass_matrix)
+        if _is_scalar_massmatrix(mass_matrix) && _use_allocating_sparse_W_path(W)
+            # A sparse GPU `W` can be neither scalar-indexed nor broadcast into on its
+            # diagonal, so build the shifted matrix and copy it in. Without this the
+            # branch below reaches `@view(W[idxs])`, which falls back to
+            # `getindex(W, i, j)` and scalar-indexes the device storage.
+            # `dae_jacobian2W!` already guards its sparse-GPU case the same way.
+            λ = -_scalar_massmatrix_λ(mass_matrix)
+            copyto!(W, J + (λ * invdtgamma) * I)
+        elseif _is_scalar_massmatrix(mass_matrix)
             copyto!(W, J)
             idxs = diagind(W)
             λ = -_scalar_massmatrix_λ(mass_matrix)

--- a/lib/OrdinaryDiffEqDifferentiation/test/jacobian2w_sparse_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/jacobian2w_sparse_tests.jl
@@ -1,0 +1,41 @@
+using OrdinaryDiffEqDifferentiation
+using LinearAlgebra
+using SparseArrays
+using Test
+
+# `jacobian2W!` forms W = J - M/dtgamma. With a scalar mass matrix it writes the
+# diagonal, which a sparse GPU `W` supports neither by scalar indexing nor by
+# broadcasting into a diagonal view, so that case takes the allocating path instead.
+# The allocating path is only selected for GPU storage, so the equivalence of the two
+# formulas is what can be checked on CPU; the GPU dispatch itself is covered by
+# test/gpu/sparse_jac_prototype.jl.
+
+J = sparse([3.0 1.0; 0.5 2.0])
+dtgamma = 0.25
+invdtgamma = inv(dtgamma)
+
+for mm in (I, 2.0 * I)
+    λ = -OrdinaryDiffEqDifferentiation._scalar_massmatrix_λ(mm)
+
+    W = similar(J)
+    fill!(nonzeros(W), 0)
+    OrdinaryDiffEqDifferentiation.jacobian2W!(W, mm, dtgamma, J)
+
+    # The formula the sparse-GPU branch uses must agree with the diagonal write.
+    allocating = J + (λ * invdtgamma) * I
+    @test Matrix(W) ≈ Matrix(allocating)
+    @test Matrix(W) ≈ Matrix(J) - OrdinaryDiffEqDifferentiation._scalar_massmatrix_λ(mm) *
+        invdtgamma * Matrix(I, 2, 2)
+end
+
+# CPU sparse storage is scalar-indexable, so it keeps the in-place diagonal write; a
+# dense matrix is not sparse at all. Only GPU storage takes the allocating branch.
+W = similar(J)
+@test !OrdinaryDiffEqDifferentiation._use_allocating_sparse_W_path(W)
+@test !OrdinaryDiffEqDifferentiation._use_allocating_sparse_W_path(ones(2, 2))
+
+# The dense `Matrix` method must be unaffected by the sparse guard.
+Jd = Matrix(J)
+Wd = similar(Jd)
+OrdinaryDiffEqDifferentiation.jacobian2W!(Wd, I, dtgamma, Jd)
+@test Wd ≈ Jd - invdtgamma * Matrix(I, 2, 2)

--- a/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/runtests.jl
@@ -30,6 +30,7 @@ end
 # Run functional tests
 if TEST_GROUP ∉ ("QA", "Sparse", "ModelingToolkit")
     @time @safetestset "DAE jacobian2W sparse" include("dae_jacobian2w_sparse_tests.jl")
+    @time @safetestset "jacobian2W sparse" include("jacobian2w_sparse_tests.jl")
     @time @safetestset "prepare_user_sparsity mass matrix" include("prepare_user_sparsity_tests.jl")
     @time @safetestset "ScalarOperator mass matrix" include("scalar_operator_massmatrix_tests.jl")
     @time @safetestset "nzval helpers" include("nzval_helpers_tests.jl")

--- a/test/gpu/sparse_jac_prototype.jl
+++ b/test/gpu/sparse_jac_prototype.jl
@@ -1,0 +1,79 @@
+using OrdinaryDiffEq
+using LinearAlgebra, SparseArrays, Test
+using CUDA, CUDA.CUSPARSE
+using CUDSS
+using OrdinaryDiffEqRosenbrock: Rosenbrock23
+using OrdinaryDiffEqBDF: FBDF
+using LinearSolve: LUFactorization, KrylovJL_GMRES
+using SciMLBase: successful_retcode
+
+#=
+A stiff ODE with a sparse GPU `jac_prototype`. `jacobian2W!` forms W = J - M/dtgamma;
+with the default mass matrix `I` it used to write the diagonal of `W` directly, which a
+CuSparseMatrix supports neither by scalar indexing nor by broadcasting into a diagonal
+view, so every implicit solver threw "Scalar indexing is disallowed" on the first step.
+See https://github.com/SciML/OrdinaryDiffEq.jl/issues/1566.
+
+The RHS is pure broadcast on purpose: `mul!` with a CuSparseMatrixCSR has no
+ForwardDiff.Dual kernel and would scalar-index inside the user function, which would
+fail for reasons that have nothing to do with the solver.
+=#
+
+CUDA.allowscalar(false)
+
+const NN = 128
+const DIFF = 50.0
+const REACT = 100.0
+
+rhs! = function (du, u, p, t)
+    du .= DIFF .* (circshift(u, 1) .+ circshift(u, -1) .- 2 .* u) .+
+        REACT .* u .* (1 .- u)
+    return nothing
+end
+
+pattern = spdiagm(-1 => ones(NN - 1), 0 => ones(NN), 1 => ones(NN - 1))
+pattern[1, NN] = 1.0
+pattern[NN, 1] = 1.0
+
+u0 = @. 0.5 + 0.4 * sin(2pi * (1:NN) / NN)
+tspan = (0.0, 0.02)
+
+reference = solve(
+    ODEProblem(rhs!, u0, tspan), Rosenbrock23();
+    save_everystep = false, abstol = 1.0e-12, reltol = 1.0e-12
+).u[end]
+
+@testset "sparse GPU jac_prototype (#1566)" begin
+    # A CPU control at the same settings: if this disagrees with the reference the
+    # problem setup is wrong and the GPU comparisons below mean nothing.
+    cpu = solve(
+        ODEProblem(ODEFunction(rhs!; jac_prototype = pattern), u0, tspan),
+        Rosenbrock23(); save_everystep = false
+    ).u[end]
+    @test norm(cpu - reference) / norm(reference) < 1.0e-2
+
+    if !CUDA.functional()
+        @info "CUDA is not functional; skipping the GPU solves"
+    else
+        u0_gpu = CuArray(u0)
+        proto = CuSparseMatrixCSR(CuSparseMatrixCSC(pattern))
+
+        # The W build is what regressed, so cover the direct and the Krylov paths as
+        # well as a second solver family.
+        algs = (
+            ("default", Rosenbrock23()),
+            ("LU", Rosenbrock23(linsolve = LUFactorization())),
+            ("GMRES", Rosenbrock23(linsolve = KrylovJL_GMRES(), concrete_jac = true)),
+            ("FBDF", FBDF(linsolve = KrylovJL_GMRES(), concrete_jac = true)),
+        )
+
+        @testset "$name" for (name, alg) in algs
+            sol = solve(
+                ODEProblem(ODEFunction(rhs!; jac_prototype = proto), u0_gpu, tspan),
+                alg; save_everystep = false
+            )
+            @test successful_retcode(sol)
+            @test norm(Array(sol.u[end]) - reference) / norm(reference) < 1.0e-2
+        end
+    end
+end

--- a/test/gpu/sparse_jac_prototype.jl
+++ b/test/gpu/sparse_jac_prototype.jl
@@ -6,6 +6,7 @@ using OrdinaryDiffEqRosenbrock: Rosenbrock23
 using OrdinaryDiffEqBDF: FBDF
 using LinearSolve: LUFactorization, KrylovJL_GMRES
 using SciMLBase: successful_retcode
+using OrdinaryDiffEqDifferentiation: jacobian2W!, _use_allocating_sparse_W_path
 
 #=
 A stiff ODE with a sparse GPU `jac_prototype`. `jacobian2W!` forms W = J - M/dtgamma;
@@ -76,4 +77,32 @@ reference = solve(
             @test norm(Array(sol.u[end]) - reference) / norm(reference) < 1.0e-2
         end
     end
+end
+
+# A prototype whose diagonal is not fully stored: `W = J - M/dtgamma` fills those
+# entries in, so the sum has more stored entries than the preallocated `W`. Both
+# patterns used above store the whole diagonal, so this case needs its own test.
+@testset "prototype with a structural zero on the diagonal (#4452)" begin
+    m = 6
+    Jcpu = sparse(
+        [1, 2, 3, 4, 5, 6, 1, 2], [1, 2, 4, 4, 5, 6, 2, 1],
+        [2.0, 3.0, 1.0, 4.0, 5.0, 6.0, 0.5, 0.7], m, m
+    )
+    stored = count(i -> Jcpu[i, i] != 0, 1:m)
+    @test stored < m          # the point of the test is that some are missing
+
+    dtgamma = 0.25
+    reference = Matrix(Jcpu) - inv(dtgamma) * Matrix(I, m, m)
+
+    Jgpu = CUSPARSE.CuSparseMatrixCSR(CUSPARSE.CuSparseMatrixCSC(Jcpu))
+    W = CUSPARSE.CuSparseMatrixCSR(CUSPARSE.CuSparseMatrixCSC(copy(Jcpu)))
+    @test _use_allocating_sparse_W_path(W)
+
+    jacobian2W!(W, I, dtgamma, Jgpu)
+
+    # Reading back is allowed to index scalars; it is the check, not the code
+    # under test. What matters is that the filled-in diagonal is present and right.
+    got = CUDA.@allowscalar Matrix(CUSPARSE.CuSparseMatrixCSC(W))
+    @test nnz(W) == nnz(Jcpu) + (m - stored)
+    @test got ≈ reference
 end


### PR DESCRIPTION
`jacobian2W!` forms `W = J - M/dtgamma`. When the mass matrix is scalar (`I`, the default), it writes `W`'s diagonal in place, either by scalar indexing or by broadcasting into `@view(W[idxs])`. Neither works for a `CuSparseMatrix`: the view falls back to `getindex(W, i, j)`, so every implicit solver given a sparse GPU `jac_prototype` threw `Scalar indexing is disallowed` on the first step.

The allocating path for this already exists and is what `dae_jacobian2W!` uses, but in `jacobian2W!` it sits in an `elseif` that a scalar mass matrix never reaches. This adds the guard ahead of the diagonal write, using the same `copyto!(W, ...)` form. The CPU branches are untouched, and the dense `Matrix` method is not affected.

This unblocks the Brusselator from #1566. On a T4 that example now solves with a `CuSparseMatrixCSR` jac_prototype under Rosenbrock23, Rosenbrock23 with `KrylovJL_GMRES`, and FBDF, matching the CPU reference to about 1e-10. With this branch disabled all three fail with scalar indexing, so the change is required rather than incidental. That example also needs its RHS to broadcast over a device-resident index set, which is a property of the script rather than of the solver, and is noted on the issue.

Tests: a CPU unit test that the allocating formula agrees with the diagonal write, and that CPU sparse and dense still take the old branch; plus `test/gpu/sparse_jac_prototype.jl`, which `gpu_group()` picks up automatically. That GPU test passes with the fix and errors on all four solver configurations without it.

`jacobian2W!` is a hot path. The new condition is a branch ahead of the CPU code and should fold away for non-GPU arrays, but it is worth a second opinion.

AI Disclosure: Used Opus 5
