### PR TITLE
Fix default SDE dt vector lengths

### DIFF
--- a/lib/DiffEqDevTools/src/benchmark.jl
+++ b/lib/DiffEqDevTools/src/benchmark.jl
@@ -920,7 +920,7 @@ function WorkPrecisionSet(
     # Now time it
     _abstols = [get(setups[k], :abstols, abstols) for k in 1:N]
     _reltols = [get(setups[k], :reltols, reltols) for k in 1:N]
-    _dts = [get(setups[k], :dts, zeros(length(_abstols))) for k in 1:N]
+    _dts = [get(setups[k], :dts, zeros(length(_abstols[k]))) for k in 1:N]
     for k in 1:N
         # precompile
         GC.gc()
@@ -1003,7 +1003,7 @@ function WorkPrecisionSet(
     # First calculate all of the errors
     _abstols = [get(setups[k], :abstols, abstols) for k in 1:N]
     _reltols = [get(setups[k], :reltols, reltols) for k in 1:N]
-    _dts = [get(setups[k], :dts, zeros(length(_abstols))) for k in 1:N]
+    _dts = [get(setups[k], :dts, zeros(length(_abstols[k]))) for k in 1:N]
     for k in 1:N
         filtered_setup = filter(p -> p.first in SciMLBase.allowedkeywords, setups[k])
 

--- a/lib/DiffEqDevTools/test/analyticless_stochastic_wp.jl
+++ b/lib/DiffEqDevTools/test/analyticless_stochastic_wp.jl
@@ -1,7 +1,14 @@
 using Random
 using StochasticDiffEq, DiffEqDevTools, Test
-using SDEProblemLibrary: prob_sde_additivesystem
+using SDEProblemLibrary: prob_sde_additivesystem, prob_sde_linear
 using SciMLLogging: None
+
+linear_prob = remake(prob_sde_linear, tspan = (0.0, 0.1))
+wp_default_dts = WorkPrecisionSet(
+    linear_prob, [1.0e-2, 1.0e-3], [1.0e-2, 1.0e-3], [Dict(:alg => SRIW1())];
+    numruns = 1, numruns_error = 1, error_estimate = :l2
+)
+@test wp_default_dts.wps[1].dts == zeros(2)
 
 prob = prob_sde_additivesystem
 prob = SDEProblem(prob.f, prob.g, prob.u0, (0.0, 0.1), prob.p)


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

The SDE/ensemble `WorkPrecisionSet` paths constructed each setup's default `dts` vector from the number of setups instead of that setup's number of tolerances. A single setup with two tolerance levels therefore allocated one `dt` and failed on the second tolerance. Both equivalent paths now size their default `dts` from `_abstols[k]`, and the stochastic work-precision tests cover this case.

This code previously lived in the now-archived `SciML/DiffEqDevTools.jl` repository. A bisect there identified https://github.com/SciML/DiffEqDevTools.jl/commit/05220512c4d023db5b9e514ee2dcfb3a959f0fb1 as the introducing commit.

## Fail before

With the regression test applied but the source change reverted:

```console
$ GROUP=Core julia +1.11.9 --project=lib/DiffEqDevTools -e 'using Pkg; Pkg.test()'
[ Info: Error calculation: 1/1
Analyticless Stochastic WP: Error During Test at .../lib/DiffEqDevTools/test/runtests.jl:29
  Got exception outside of a @test
  BoundsError: attempt to access 1-element Vector{Float64} at index [2]
  Stacktrace:
    [1] throw_boundserror(A::Vector{Float64}, I::Tuple{Int64})
    [2] getindex
    [3] WorkPrecisionSet(...)
      @ DiffEqDevTools .../lib/DiffEqDevTools/src/benchmark.jl:941
    [4] top-level scope
      @ .../lib/DiffEqDevTools/test/analyticless_stochastic_wp.jl:7
Test Summary:              | Error  Total   Time
Analyticless Stochastic WP |     1      1  23.6s
```

## Pass after

The same official test and full declared Core group passed after the fix:

```console
$ GROUP=Core julia +1.11.9 --project=lib/DiffEqDevTools -e 'using Pkg; Pkg.test()'
Test Summary:              | Pass  Total      Time
Analyticless Stochastic WP |    3      3  30m29.6s
...
Test Summary: | Pass  Total  Time
Timeout       |    7      7  4.4s
     Testing DiffEqDevTools tests passed
```

The required QA and static gates also passed:

```console
$ GROUP=QA julia +1.11.9 --project=lib/DiffEqDevTools -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total   Time
Aqua          |   15     15  30.5s
     Testing DiffEqDevTools tests passed

$ julia +1.11.9 --project=../.tools/runic -e 'using Runic; exit(Runic.main(copy(ARGS)))' -- --check lib/DiffEqDevTools/src/benchmark.jl lib/DiffEqDevTools/test/analyticless_stochastic_wp.jl
$ typos lib/DiffEqDevTools/src/benchmark.jl lib/DiffEqDevTools/test/analyticless_stochastic_wp.jl
$ git diff --check
```

All three static commands exited successfully with no output. A docs build was not run because this changes neither public API nor documentation. GPU and downstream jobs were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
