### PR TITLE
Carry the QNDF2 difference array across steps

### DIFF
--- a/lib/OrdinaryDiffEqBDF/Project.toml
+++ b/lib/OrdinaryDiffEqBDF/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqBDF"
 uuid = "6ad6398a-0878-4a85-9266-38940aa047c8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.4.6"
+version = "2.4.7"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqBDF/src/bdf_caches.jl
+++ b/lib/OrdinaryDiffEqBDF/src/bdf_caches.jl
@@ -307,6 +307,7 @@ end
     uprev3::uType
     fsalfirst::rateType
     D::coefType1
+    Dtmp::coefType1
     D2::coefType2
     R::coefType
     U::coefType
@@ -359,12 +360,15 @@ function alg_cache(
     fsalfirst = zero(rate_prototype)
 
     D = Array{typeof(u)}(undef, 1, 2)
+    Dtmp = Array{typeof(u)}(undef, 1, 2)
     D2 = Array{typeof(u)}(undef, 1, 3)
     R = fill(zero(t), 2, 2)
     U = fill(zero(t), 2, 2)
 
     D[1] = zero(u)
     D[2] = zero(u)
+    Dtmp[1] = zero(u)
+    Dtmp[2] = zero(u)
     D2[1] = zero(u)
     D2[2] = zero(u)
     D2[3] = zero(u)
@@ -380,7 +384,7 @@ function alg_cache(
     dtₙ₋₂ = zero(dt)
 
     return QNDF2Cache(
-        uprev2, uprev3, fsalfirst, D, D2, R, U, atmp,
+        uprev2, uprev3, fsalfirst, D, Dtmp, D2, R, U, atmp,
         utilde, nlsolver, dtₙ₋₁, dtₙ₋₂, alg.step_limiter!
     )
 end

--- a/lib/OrdinaryDiffEqBDF/src/bdf_perform_step.jl
+++ b/lib/OrdinaryDiffEqBDF/src/bdf_perform_step.jl
@@ -547,41 +547,35 @@ function perform_step!(integrator, cache::QNDF2ConstantCache, repeat_step = fals
         κ = zero(alg.kappa)
         γ₁ = Int64(1) // 1
         γ₂ = Int64(1) // 1
-    elseif dtₙ₋₁ != dtₙ₋₂
-        κ = alg.kappa
-        γ₁ = Int64(1) // 1
-        γ₂ = Int64(1) // 1 + Int64(1) // 2
-        ρ₁ = dt / dtₙ₋₁
-        ρ₂ = dt / dtₙ₋₂
-        D[1] = uprev - uprev2
-        D[1] = D[1] * ρ₁
-        D[2] = D[1] - ((uprev2 - uprev3) * ρ₂)
     else
         κ = alg.kappa
         γ₁ = Int64(1) // 1
         γ₂ = Int64(1) // 1 + Int64(1) // 2
-        ρ = dt / dtₙ₋₁
-        # backward diff
-        D[1] = uprev - uprev2
-        D[2] = D[1] - (uprev2 - uprev3)
-        if ρ != 1
-            R!(k, ρ, cache)
-            R .= R * U
-            D[1] = D[1] * R[1, 1] + D[2] * R[2, 1]
-            D[2] = D[1] * R[1, 2] + D[2] * R[2, 2]
-        end
+    end
+
+    # `D` stays at the step size its differences were formed with, so a change of
+    # `dt` scales them through `R * U` instead of rebuilding them from the
+    # solution history, and a rejected attempt leaves `D` untouched.
+    if cnt > 2 && dt != dtₙ₋₁
+        R!(k, dt / dtₙ₋₁, cache)
+        R .= R * U
+        d₁ = D[1] * R[1, 1] + D[2] * R[2, 1]
+        d₂ = D[1] * R[1, 2] + D[2] * R[2, 2]
+    else
+        d₁ = D[1]
+        d₂ = D[2]
     end
 
     β₀ = inv((1 - κ) * γ₂)
     α₀ = 1
 
-    u₀ = uprev + D[1] + D[2]
-    ϕ = (γ₁ * D[1] + γ₂ * D[2]) * β₀
+    u₀ = uprev + d₁ + d₂
+    ϕ = (γ₁ * d₁ + γ₂ * d₂) * β₀
 
     markfirststage!(nlsolver)
 
     # initial guess
-    nlsolver.z = uprev + sum(D)
+    nlsolver.z = u₀
 
     mass_matrix = f.mass_matrix
 
@@ -612,8 +606,8 @@ function perform_step!(integrator, cache::QNDF2ConstantCache, repeat_step = fals
             OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
         else
             D2[1] = u - uprev
-            D2[2] = D2[1] - D[1]
-            D2[3] = D2[2] - D[2]
+            D2[2] = D2[1] - d₁
+            D2[3] = D2[2] - d₂
             utilde = (κ * γ₂ + inv(k + 1)) * D2[3]
             atmp = calculate_residuals(
                 utilde, uprev, u, integrator.opts.abstol,
@@ -627,6 +621,9 @@ function perform_step!(integrator, cache::QNDF2ConstantCache, repeat_step = fals
         return
     end
 
+    Δ = u - uprev
+    cache.D[1] = Δ
+    cache.D[2] = integrator.success_iter == 0 ? zero(Δ) : Δ - d₁
     cache.uprev3 = uprev2
     cache.uprev2 = uprev
     cache.dtₙ₋₂ = dtₙ₋₁
@@ -651,7 +648,7 @@ end
 
 function perform_step!(integrator, cache::QNDF2Cache, repeat_step = false)
     (; t, dt, uprev, u, f, p) = integrator
-    (; uprev2, uprev3, dtₙ₋₁, dtₙ₋₂, D, D2, R, U, utilde, atmp, nlsolver) = cache
+    (; uprev2, uprev3, dtₙ₋₁, dtₙ₋₂, D, Dtmp, D2, R, U, utilde, atmp, nlsolver) = cache
     (; z, tmp, ztmp) = nlsolver
     alg = unwrap_alg(integrator, true)
     cnt = integrator.iter
@@ -660,41 +657,35 @@ function perform_step!(integrator, cache::QNDF2Cache, repeat_step = false)
         κ = zero(alg.kappa)
         γ₁ = Int64(1) // 1
         γ₂ = Int64(1) // 1
-    elseif dtₙ₋₁ != dtₙ₋₂
-        κ = alg.kappa
-        γ₁ = Int64(1) // 1
-        γ₂ = Int64(1) // 1 + Int64(1) // 2
-        ρ₁ = dt / dtₙ₋₁
-        ρ₂ = dt / dtₙ₋₂
-        @.. broadcast = false D[1] = uprev - uprev2
-        @.. broadcast = false D[1] = D[1] * ρ₁
-        @.. broadcast = false D[2] = D[1] - ((uprev2 - uprev3) * ρ₂)
     else
         κ = alg.kappa
         γ₁ = Int64(1) // 1
         γ₂ = Int64(1) // 1 + Int64(1) // 2
-        ρ = dt / dtₙ₋₁
-        # backward diff
-        @.. broadcast = false D[1] = uprev - uprev2
-        @.. broadcast = false D[2] = D[1] - (uprev2 - uprev3)
-        if ρ != 1
-            R!(k, ρ, cache)
-            R .= R * U
-            @.. broadcast = false D[1] = D[1] * R[1, 1] + D[2] * R[2, 1]
-            @.. broadcast = false D[2] = D[1] * R[1, 2] + D[2] * R[2, 2]
-        end
+    end
+
+    # `D` stays at the step size its differences were formed with, so a change of
+    # `dt` scales them through `R * U` instead of rebuilding them from the
+    # solution history, and a rejected attempt leaves `D` untouched.
+    if cnt > 2 && dt != dtₙ₋₁
+        R!(k, dt / dtₙ₋₁, cache)
+        R .= R * U
+        @.. broadcast = false Dtmp[1] = D[1] * R[1, 1] + D[2] * R[2, 1]
+        @.. broadcast = false Dtmp[2] = D[1] * R[1, 2] + D[2] * R[2, 2]
+    else
+        @.. broadcast = false Dtmp[1] = D[1]
+        @.. broadcast = false Dtmp[2] = D[2]
     end
 
     β₀ = inv((1 - κ) * γ₂)
     α₀ = 1
 
-    u₀ = uprev + D[1] + D[2]
-    ϕ = (γ₁ * D[1] + γ₂ * D[2]) * β₀
+    u₀ = uprev + Dtmp[1] + Dtmp[2]
+    ϕ = (γ₁ * Dtmp[1] + γ₂ * Dtmp[2]) * β₀
 
     markfirststage!(nlsolver)
 
     # initial guess
-    nlsolver.z = uprev + sum(D)
+    nlsolver.z = u₀
 
     mass_matrix = f.mass_matrix
 
@@ -728,8 +719,8 @@ function perform_step!(integrator, cache::QNDF2Cache, repeat_step = false)
             OrdinaryDiffEqCore.set_EEst!(integrator, integrator.opts.internalnorm(atmp, t))
         else
             @.. broadcast = false D2[1] = u - uprev
-            @.. broadcast = false D2[2] = D2[1] - D[1]
-            @.. broadcast = false D2[3] = D2[2] - D[2]
+            @.. broadcast = false D2[2] = D2[1] - Dtmp[1]
+            @.. broadcast = false D2[3] = D2[2] - Dtmp[2]
             @.. broadcast = false utilde = (κ * γ₂ + inv(k + 1)) * D2[3]
             calculate_residuals!(
                 atmp, utilde, uprev, u, integrator.opts.abstol,
@@ -742,6 +733,12 @@ function perform_step!(integrator, cache::QNDF2Cache, repeat_step = false)
         return
     end
 
+    if integrator.success_iter == 0
+        @.. broadcast = false D[2] = false
+    else
+        @.. broadcast = false D[2] = (u - uprev) - Dtmp[1]
+    end
+    @.. broadcast = false D[1] = u - uprev
     cache.uprev3 .= uprev2
     cache.uprev2 .= uprev
     cache.dtₙ₋₂ = dtₙ₋₁

--- a/lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl
@@ -219,3 +219,13 @@ end
     @test sol.u[end] isa ArrayPartition
     @test norm(sol.u[end] - ref.u[end]) < 1.0e-6
 end
+
+@testset "QNDF2 step size control does not thrash (#4332)" begin
+    prob = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 10.0))
+    for alg in (QNDF2(), QBDF2())
+        sol = solve(prob, alg, reltol = 1.0e-8, abstol = 1.0e-8)
+        @test sol.retcode == ReturnCode.Success
+        @test sol.stats.nreject < sol.stats.naccept / 10
+        @test abs(sol.u[end] - exp(-10.0)) < 1.0e-6
+    end
+end


### PR DESCRIPTION
`QNDF2` rebuilt its backward differences from `uprev`, `uprev2` and `uprev3` on every step and corrected a change of step size with a first-order scaling, so an O(h^2) error sat inside a quantity whose signal is O(h^3) and the local error estimate tracked `dt/dtₙ₋₁` instead of the error. There was no step size at which the estimate settled near 1, so the controller alternated between growing by the maximum factor and rejecting.

`D` now stays at the step size its differences were formed with, a step that changes `dt` scales them through the exact `R * U` transform into locals, and a successful step commits the new differences incrementally, which is what variable-order `QNDF` already does. Reading `D` and writing locals also removes the aliasing in `D[2] = D[1] * R[1, 2] + D[2] * R[2, 2]`, which used the `D[1]` assigned on the line above; that was inert because `(R * U)[1, 2]` is zero for `k = 2`.

On `u' = -u` at `1e-8`, `QNDF2` goes from 4211 accepted and 6427 rejected to 765 and 2. On the issue's stiff 2x2 at `1e-8`, `QBDF2` goes from 5491 and 10456 to 923 and 23. On Robertson at `1e-8`, `QNDF2` goes from 5874 and 6115 to 1505 and 11, and the mass matrix form from 6214 and 11144 to 1504 and 9. Fixed-step convergence is unchanged at 1.88, 2.00, 2.01, 2.01.

The regression test asserts `QNDF2` and `QBDF2` reject fewer than a tenth of the steps they accept on `u' = -u` at `1e-8`; on master they reject more than they accept.

This still reproduced on master after #4328, which was suggested as the fix on the issue. Fixes #4332.

AI Disclosure: Claude assisted with this change.
