### PR TITLE
DAE interpolation after Rosenbrock solve: still some problems

### DIFF
--- a/lib/OrdinaryDiffEqRosenbrock/test/callback_truncated_interpolation.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/callback_truncated_interpolation.jl
@@ -19,8 +19,17 @@ callback = ContinuousCallback((u, t, integrator) -> t - 0.7, terminate!)
 
             @test sol.t[end] ≈ 0.7 atol = 1.0e-12
             @test sol.u[end] ≈ [exp(-0.7), 1-exp(-0.7)] atol = 1.0e-4
+            t_dense = range(0, stop=sol.t[end], length=101)
             @testset "Dense interpolation" begin
-                t_dense = range(0, stop=sol.t[end], length=101)
+                for ti in t_dense
+                    @test sol(ti) ≈ [exp.(-ti), 1 .- exp.(-ti)] atol = 1.0e-2
+                end
+            end
+
+            # With saveat:
+            t_dense = range(0, stop=0.7, length=101)
+            sol = solve(prob, alg; callback, initializealg = CheckInit(), saveat=t_dense)
+            @testset "Dense saveat" begin
                 for ti in t_dense
                     @test sol(ti) ≈ [exp.(-ti), 1 .- exp.(-ti)] atol = 1.0e-2
                 end
@@ -37,6 +46,14 @@ callback = ContinuousCallback((u, t, integrator) -> t - 0.7, terminate!)
             @test sol(tmiddle)[1] ≈ exp(tmiddle) rtol = 1.0e-2
             @testset "Dense interpolation" begin
                 t_dense = range(0, stop=sol.t[end], length=101)
+                for ti in t_dense
+                    @test sol(ti) ≈ [exp.(ti)] atol = 1.0e-2
+                end
+            end
+            # With saveat:
+            t_dense = range(0, stop=0.7, length=101)
+            sol = solve(prob, alg; callback, saveat=t_dense)
+            @testset "Dense saveat" begin
                 for ti in t_dense
                     @test sol(ti) ≈ [exp.(ti)] atol = 1.0e-2
                 end

--- a/lib/OrdinaryDiffEqRosenbrock/test/callback_truncated_interpolation.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/callback_truncated_interpolation.jl
@@ -1,35 +1,46 @@
 using OrdinaryDiffEqRosenbrock, DiffEqBase, LinearAlgebra, Test
 
 function linear_dae!(du, u, p, t)
-    du[1] = -1
-    du[2] = u[2] - u[1]
+    du[1] = -u[1]
+    du[2] = u[2] + u[1] - 1
     return nothing
 end
-linear_dae(u, p, t) = [-1, u[2] - u[1]]
+linear_dae(u, p, t) = [-u[1], u[2] + u[1] -1]
 
 mass_matrix = Diagonal([1.0, 0.0])
-callback = ContinuousCallback((u, t, integrator) -> u[1] - 0.3, terminate!)
+callback = ContinuousCallback((u, t, integrator) -> t - 0.7, terminate!)
 
 @testset "Callback-truncated interpolation" begin
     @testset "Mass-matrix DAE" begin
         for f in (linear_dae!, linear_dae), alg in (Rodas4(), Rodas4P(), Rodas5P())
-            prob = ODEProblem(ODEFunction(f; mass_matrix), [1.0, 1.0], (0.0, 1.0))
-            sol = solve(prob, alg; adaptive = false, dt = 1.0, callback, initializealg = NoInit())
+            prob = ODEProblem(ODEFunction(f; mass_matrix), [1.0, 0.0], (0.0, 1.0))
+            sol = solve(prob, alg; callback, initializealg = CheckInit())
+            @test sol.retcode == SciMLBase.ReturnCode.Terminated
 
             @test sol.t[end] ≈ 0.7 atol = 1.0e-12
-            @test sol.u[end] ≈ [0.3, 0.3] atol = 1.0e-12
-            @test sol(0.35) ≈ [0.65, 0.65] atol = 1.0e-12
+            @test sol.u[end] ≈ [exp(-0.7), 1-exp(-0.7)] atol = 1.0e-4
+            @testset "Dense interpolation" begin
+                t_dense = range(0, stop=sol.t[end], length=101)
+                for ti in t_dense
+                    @test sol(ti) ≈ [exp.(-ti), 1 .- exp.(-ti)] atol = 1.0e-2
+                end
+            end
         end
     end
 
     @testset "Out-of-place ODE" begin
         prob = ODEProblem((u, p, t) -> u, [1.0], (0.0, 1.0))
-        callback = ContinuousCallback((u, t, integrator) -> u[1] - exp(0.7), terminate!)
-
         for alg in (Rodas4(), Rodas4P(), Rodas5P())
-            sol = solve(prob, alg; adaptive = false, dt = 1.0, callback)
+            sol = solve(prob, alg; callback)
+            @test sol.retcode == SciMLBase.ReturnCode.Terminated
             tmiddle = sol.t[end] / 2
             @test sol(tmiddle)[1] ≈ exp(tmiddle) rtol = 1.0e-2
+            @testset "Dense interpolation" begin
+                t_dense = range(0, stop=sol.t[end], length=101)
+                for ti in t_dense
+                    @test sol(ti) ≈ [exp.(ti)] atol = 1.0e-2
+                end
+            end
         end
     end
 end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

#4411 seems to improve the situation, but the tests added there were still not exhaustive enough: in my downstream use case (in LyoPronto.jl), I am still getting interpolations like the following:

<img width="600" height="400" alt="plot_20" src="https://github.com/user-attachments/assets/9193535f-33d8-4398-9a34-82404cb0fab3" />

where the interpolation should go smoothly down to ~0 rather than having a step change.

This PR adds some dense interpolation tests, which currently fail for the in-place DAE with mass matrix (but pass for the out-of-place DAE and ODE). 