### PR TITLE
DiffEqBase: wrap mass-matrix problems on the finite-difference promote_f path (default algorithm was never despecialized)

### DIFF
--- a/lib/DiffEqBase/src/solve.jl
+++ b/lib/DiffEqBase/src/solve.jl
@@ -1081,7 +1081,6 @@ function promote_f(
     end
 
     wrap_path = f isa ODEFunction && isinplace(f) && !(f.f isa AbstractSciMLOperator) &&
-        f.mass_matrix isa UniformScaling &&
         f.jac === nothing &&
         !(u0 isa SubArray) &&
         (

--- a/lib/DiffEqBase/test/despecialize_mass_matrix.jl
+++ b/lib/DiffEqBase/test/despecialize_mass_matrix.jl
@@ -1,0 +1,44 @@
+using DiffEqBase, SciMLBase, LinearAlgebra, Test
+using DiffEqBase: FunctionWrappersWrappers
+
+# The resolved default algorithm uses finite differences, so concretization takes the
+# non-ForwardDiff `promote_f` path. A mass matrix must not disable wrapping there,
+# otherwise every mass-matrix model solved with the default algorithm keeps its own
+# RHS type in the integrator and recompiles the whole solve.
+struct FiniteDiffAlg <: SciMLBase.AbstractODEAlgorithm end
+SciMLBase.forwarddiffs_model(::FiniteDiffAlg) = false
+SciMLBase.isadaptive(::FiniteDiffAlg) = true
+
+g1(du, u, p, t) = (du[1] = u[1]; du[2] = -u[2] + u[1]; nothing)
+g2(du, u, p, t) = (du[1] = u[1]; du[2] = -2u[2] + u[1]; nothing)
+M = Diagonal([0.0, 1.0])
+u0 = [0.0, 1.0]
+
+@testset "mass-matrix problems are wrapped on the finite-difference path" begin
+    for spec in (SciMLBase.AutoDespecialize, SciMLBase.AutoSpecialize)
+        probs = map((g1, g2)) do g
+            ODEProblem{true, spec}(
+                ODEFunction{true, spec}(g; mass_matrix = M), u0, (0.0, 1.0), (; k = 1.0)
+            )
+        end
+        concrete = map(p -> DiffEqBase.get_concrete_problem(p, true; alg = FiniteDiffAlg()), probs)
+        for c in concrete
+            @test c.f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper
+            @test c.f.mass_matrix === M
+            du = similar(u0)
+            c.f(du, u0, c.p, 0.0)
+            @test du[1] == u0[1]
+        end
+        @test typeof(concrete[1]) === typeof(concrete[2])
+    end
+end
+
+@testset "a user Jacobian still opts out of the finite-difference wrapping path" begin
+    jac!(J, u, p, t) = (J .= [1.0 0.0; 1.0 -1.0]; nothing)
+    prob = ODEProblem{true, SciMLBase.AutoSpecialize}(
+        ODEFunction{true, SciMLBase.AutoSpecialize}(g1; mass_matrix = M, jac = jac!),
+        u0, (0.0, 1.0)
+    )
+    c = DiffEqBase.get_concrete_problem(prob, true; alg = FiniteDiffAlg())
+    @test !(c.f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper)
+end

--- a/lib/DiffEqBase/test/runtests.jl
+++ b/lib/DiffEqBase/test/runtests.jl
@@ -49,6 +49,7 @@ end
         @time @safetestset "Problem Kwargs Merging" include("problem_kwargs_merging.jl")
         @time @safetestset "Opaque-p Hook" include("opaque_p_test.jl")
         @time @safetestset "Despecialized-p Hook" include("despecialized_p_test.jl")
+        @time @safetestset "Despecialized mass-matrix problems" include("despecialize_mass_matrix.jl")
         @time @safetestset "Verbose Inference" include("verbose_inference.jl")
     end
 


### PR DESCRIPTION
> **Draft — please ignore until reviewed by @ChrisRackauckas.**

## What changed and why

`solve(prob)` / `init(prob)` with no algorithm resolves, via `prepare_alg(nothing, …)`, to `DefaultODEAlgorithm(autodiff = AutoFiniteDiff())`. Because that algorithm does not use ForwardDiff, `get_concrete_problem` takes the non-ForwardDiff `promote_f` path, and that path refused to wrap any `ODEFunction` whose `mass_matrix` is not `UniformScaling`. So on every mass-matrix problem the default algorithm ran with the model's own RHS type baked into the integrator: the whole composite solve compiled again per model (~12 s each in the reproducer below), while an explicit `Rodas5P()`, which takes the ForwardDiff path, already shared one integrator type across models. The gate was introduced with the `forwarddiffs_model` split (48b10437) without a stated reason for the mass-matrix exclusion; finite differences only ever call the RHS with the state's eltype, so the single-signature wrapper is sufficient. The `jac === nothing` opt-out on that path is unchanged.

This is the last piece that kept ModelingToolkit mass-matrix DAEs from being despecialized under the default algorithm (context: https://github.com/ChrisRackauckas/InternalJunk/issues/88 and https://github.com/SciML/ModelingToolkit.jl/pull/5061).

## Verification

New `lib/DiffEqBase/test/despecialize_mass_matrix.jl` (Core group): two mass-matrix problems with different RHS types, concretized with a non-ForwardDiff algorithm (`forwarddiffs_model(::FiniteDiffAlg) = false`, mirroring the resolved default), must both come back wrapped and with identical concretized types, for `AutoDespecialize` and `AutoSpecialize`; a user Jacobian must still opt out.

Unmodified `lib/DiffEqBase/src/solve.jl` (`git stash` of the one-line change), same test file:

```
Test Summary:                                                  | Pass  Fail  Total  Time
mass-matrix problems are wrapped on the finite-difference path |    8     6     14  5.4s
```

With the change:

```
Test Summary:                                                  | Pass  Total  Time
mass-matrix problems are wrapped on the finite-difference path |   14     14  2.8s
Test Summary:                                                         | Pass  Total  Time
a user Jacobian still opts out of the finite-difference wrapping path |    1      1  0.8s
```

End to end (pure OrdinaryDiffEq 7.8.1, Julia 1.12.7, two `AutoDespecialize` mass-matrix problems with different RHS functions, `init(prob)` then `solve!`; `@timed` compile seconds):

| | integrator types identical | `integ.f.f` | `solve!` model A | `solve!` model B |
|---|---|---|---|---|
| default algorithm, before | false | raw `g1` | 12.75 | 11.56 |
| default algorithm, after | **true** | `FunctionWrappersWrapper` | 13.50 | **0.00** |
| `Rodas5P()` (unchanged) | true | `FunctionWrappersWrapper` | 4.19 | 0.05 |

Groups run locally from `lib/DiffEqBase` (`GROUP=<name> julia --project=lib/DiffEqBase -e 'using Pkg; Pkg.test()'`, Julia 1.12.7):

```
Core          -> Despecialized mass-matrix problems | 15 15 3.2s ... Testing DiffEqBase tests passed
QA            -> Testing DiffEqBase tests passed
ModelingToolkit -> Null DE Handling | 36 36 2m39.9s ... Testing DiffEqBase tests passed
                 (run with https://github.com/SciML/SparseColumnPivotedQR.jl/pull/71 developed into the test env: AMD 0.5.4
                 otherwise breaks LinearSolve's precompile in every freshly resolved environment, master included)
```

Runic and typos clean on the touched files.

## Not verified

- `Downstream`, `Downstream2`, `Static`, `Sundials` groups and Julia 1.10.
- Non-ForwardDiff *explicit* stiff algorithms on mass-matrix problems now also get the single-signature wrapper (e.g. `Rodas5P(autodiff = AutoFiniteDiff())`); the finite-difference Jacobian only calls the RHS with the state eltype, and the `FunctionWrappersWrapper` fallback policy (`AllowNonIsBits`) makes any other call fall back to the raw function rather than error, but I did not run those algorithms' own test suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5-1)
https://claude.ai/code/session_01FeJYXni9MkJhPFA9yxYvfn
