### PR TITLE
Refresh implicit caches after DDE history updates

### DIFF
--- a/lib/DelayDiffEq/Project.toml
+++ b/lib/DelayDiffEq/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.3.0"
+version = "6.3.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/DelayDiffEq/src/fpsolve/functional.jl
+++ b/lib/DelayDiffEq/src/fpsolve/functional.jl
@@ -1,3 +1,14 @@
+function recompute_history_step!(integrator::DDEIntegrator)
+    was_discontinuous = integrator.derivative_discontinuity
+    SciMLBase.derivative_discontinuity!(integrator, true)
+    try
+        OrdinaryDiffEqCore.perform_step!(integrator, integrator.cache, false)
+    finally
+        SciMLBase.derivative_discontinuity!(integrator, was_discontinuous)
+    end
+    return nothing
+end
+
 function OrdinaryDiffEqNonlinearSolve.compute_step!(
         fpsolver::FPSolver{<:NLFunctional},
         integrator::DDEIntegrator
@@ -86,7 +97,7 @@ function compute_step_fixedpoint!(
     ode_integrator = integrator.integrator
 
     # recompute next integration step
-    OrdinaryDiffEqCore.perform_step!(integrator, integrator.cache, true)
+    recompute_history_step!(integrator)
 
     # compute residuals
     dz = integrator.u .- ode_integrator.u
@@ -117,7 +128,7 @@ function compute_step_fixedpoint!(
     ode_integrator = integrator.integrator
 
     # recompute next integration step
-    OrdinaryDiffEqCore.perform_step!(integrator, integrator.cache, true)
+    recompute_history_step!(integrator)
 
     # compute residuals
     @.. dz = integrator.u - ode_integrator.u

--- a/lib/DelayDiffEq/test/regression/dde_sdirk_history_recompute.jl
+++ b/lib/DelayDiffEq/test/regression/dde_sdirk_history_recompute.jl
@@ -1,0 +1,29 @@
+using Test, DelayDiffEq, OrdinaryDiffEqSDIRK
+using OrdinaryDiffEqCore: IController
+using SciMLBase: ReturnCode
+
+@testset "history updates refresh implicit solver caches" begin
+    τ = 0.01
+
+    function robertson!(du, u, h, p, t)
+        delayed_u2 = h(p, t - τ; idxs = 2)
+        reaction = 0.04 * u[1] - 10_000 * delayed_u2 * u[3]
+        decay = 3.0e7 * u[2]^2
+        du[1] = -reaction
+        du[2] = reaction - decay
+        du[3] = decay
+        return nothing
+    end
+
+    history(p, t; idxs = nothing) = idxs === nothing ? [1.0, 0.0, 0.0] : 0.0
+    prob = DDEProblem(robertson!, history, (0.0, 0.5); constant_lags = [τ])
+    method = SDIRK2()
+    controller = IController(method; qmax = 10, qmax_first_step = 10)
+    sol = solve(
+        prob, MethodOfSteps(method); controller, reltol = 0.1, abstol = 1.0e-4,
+        dt = 1.0e-6, maxiters = 1000, save_everystep = false,
+        timeseries_errors = false, dense_errors = false
+    )
+
+    @test sol.retcode == ReturnCode.Success
+end

--- a/lib/DelayDiffEq/test/runtests.jl
+++ b/lib/DelayDiffEq/test/runtests.jl
@@ -120,6 +120,9 @@ if TEST_GROUP == "ALL" || TEST_GROUP == "Regression"
     @time @safetestset "DDE/SDIRK stage-1 tmp aliasing" begin
         include("regression/dde_sdirk_stage1_tmp_aliasing.jl")
     end
+    @time @safetestset "DDE/SDIRK history recomputation" begin
+        include("regression/dde_sdirk_history_recompute.jl")
+    end
 end
 
 if TEST_GROUP == "ALL" || TEST_GROUP == "SDDE"


### PR DESCRIPTION
## What changed

MethodOfSteps fixed-point iterations now mark the updated DDE history as a derivative discontinuity before recomputing an implicit ODE step. The recomputation uses the public `SciMLBase.derivative_discontinuity!` API, performs a fresh step rather than a rejected-step retry, and restores the prior discontinuity flag in `finally`.

This refreshes the Jacobian and iteration matrix after the history changes. It does not inspect nonlinear-solver caches and leaves the existing SDIRK stage-1 scratch-buffer copy intact.

Fixes https://github.com/SciML/OrdinaryDiffEq.jl/issues/4389.

## Failing before / passing after

I ran the Robertson DDE from the regression test on Julia 1.11.9 with the benchmark controller, `IController(SDIRK2(); qmax = 10, qmax_first_step = 10)`, from an isolated depot.

On clean unmodified `f50245c0bb47d949c2be7170e6a4036a5ff6b50b`:

```text
[2906218] signal 15: Terminated
...
_reuse_qr_fallback at LinearSolve/src/default.jl:814
...
compute_step_fixedpoint! at lib/DelayDiffEq/src/fpsolve/functional.jl:120
Allocations: 7092559303 (Pool: 7092556976; Big: 2327); GC: 1037423
Command exited with non-zero status 124
wall=3600.34 exit=124 maxrss_kb=4148264
```

With this change, the identical solve completed:

```text
Julia Version 1.11.9
starting SDIRK2 solve
elapsed=19.178829554 retcode=Success t=0.5 stats=SciMLBase.DEStats(1523, 0, 86, 1503, 17, 1222, 49, 201, 11, 0, 22, 0, 0.0)
wall=508.76 exit=0 maxrss_kb=4277692
```

The wall time includes 474 seconds of isolated-depot precompilation; the solve itself took 19.18 seconds.

## Verification

All package tests used Julia 1.11.9 and an isolated writable depot. A local ignored manifest held AMD at 0.5.3 to avoid the independent AMD 0.5.4 / SparseColumnPivotedQR 2.1.7 precompile failure; there is no tracked dependency change for that workaround.

```text
GROUP=Regression julia +1.11.9 --project=lib/DelayDiffEq -e 'using Pkg; Pkg.test()'
DDE/SDIRK history recomputation | 1  1  1m16.7s
Testing DelayDiffEq tests passed
wall=1137.38 exit=0

GROUP=QA julia +1.11.9 --project=lib/DelayDiffEq -e 'using Pkg; Pkg.test()'
QA Tests | 20  20  19m16.1s
Testing DelayDiffEq tests passed
wall=1174.54 exit=0

GROUP=Interface julia +1.11.9 --project=lib/DelayDiffEq -e 'using Pkg; Pkg.test()'
Multi-Algorithm Tests | 28  28  4m24.5s
Testing DelayDiffEq tests passed
wall=1220.13 exit=0

GROUP=Integrators julia +1.11.9 --project=lib/DelayDiffEq -e 'using Pkg; Pkg.test()'
SDIRK Tests | 45  36 broken  81  26m38.1s
Initialization | 2  2  6.2s
Testing DelayDiffEq tests passed
wall=2575.19 exit=0

julia +1.12 -m Runic --check --diff <changed Julia files>
# exit 0

typos --format brief <changed files>
# exit 0

git diff --check
# exit 0
```

I did not run the root monorepo `Everything` suite or Julia prerelease jobs. I did not build docs because this changes no public API or documentation.

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
