### PR TITLE
Release DiffEqDevTools 3.6.2

### DIFF
--- a/lib/DiffEqDevTools/Project.toml
+++ b/lib/DiffEqDevTools/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqDevTools"
 uuid = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "3.6.1"
+version = "3.6.2"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Bump DiffEqDevTools from 3.6.1 to 3.6.2 so the merged fix for per-setup default SDE timestep vector lengths can be registered. The source change and its regression test are in https://github.com/SciML/OrdinaryDiffEq.jl/pull/4454; this PR contains release metadata only.

## Verification

- Full package suite: `/home/crackauc/.juliaup/bin/julia +1.11.9 --startup-file=no --project=lib/DiffEqDevTools -e "using Pkg; Pkg.test()"` — passed; final reported test sets included Analyticless Stochastic WP 3/3, Plot Recipes 58/58, and all other package test sets; wall time 1:33:13, exit 0.
- QA: `GROUP=QA /home/crackauc/.juliaup/bin/julia +1.11.9 --startup-file=no --project=lib/DiffEqDevTools -e "using Pkg; Pkg.test()"` — Aqua 15/15 passed; wall time 4:38.60, exit 0.
- `typos lib/DiffEqDevTools/Project.toml` — exit 0.
- `git diff --check upstream/master...HEAD` — exit 0.

Runic was not applicable because the only changed file is TOML. Documentation was not rebuilt because this changes no documentation, docstring, or public API. GPU and downstream tests were not run.

After merging, register with `@JuliaRegistrator register subdir=lib/DiffEqDevTools`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512