### PR TITLE
Fix threaded stochastic work-precision race

### DIFF
--- a/lib/DiffEqDevTools/src/DiffEqDevTools.jl
+++ b/lib/DiffEqDevTools/src/DiffEqDevTools.jl
@@ -27,10 +27,10 @@ using Statistics: mean, std
 
 import Base: length
 
-# These problem/solution/algorithm abstracts and `@def` are owned by SciMLBase but
-# not yet declared `public` there; accessed via SciMLBase (their owner).
+# These problem/solution/algorithm abstracts are owned by SciMLBase but not yet declared
+# `public` there; accessed via SciMLBase (their owner).
 using SciMLBase: AbstractDDEAlgorithm, AbstractODESolution, AbstractRODEProblem,
-    AbstractSDDEProblem, AbstractBVProblem, @def
+    AbstractSDDEProblem, AbstractBVProblem
 # `ConvergenceSetup` and `ODERKTableau` are defined and owned only in DiffEqBase
 # (not re-exported by SciMLBase) and are not declared `public` there.
 using DiffEqBase: ConvergenceSetup, ODERKTableau

--- a/lib/DiffEqDevTools/src/benchmark.jl
+++ b/lib/DiffEqDevTools/src/benchmark.jl
@@ -799,7 +799,10 @@ function WorkPrecisionSet(
     )
 end
 
-@def error_calculation begin
+function _calculate_error!(
+        i, tmp_solutions, prob, setups, abstols, reltols, test_dt,
+        appxsol_setup, timeseries_errors, dense_errors, kwargs
+    )
     if !SciMLBase.has_analytic(prob.f)
         t = prob.tspan[1]:test_dt:prob.tspan[2]
         brownian_values = cumsum(
@@ -841,7 +844,7 @@ end
         dense_errors = false
     )
 
-    for j in 1:M, k in 1:N
+    for j in eachindex(abstols), k in eachindex(setups)
         _abstols = get(setups[k], :abstols, abstols)
         _reltols = get(setups[k], :reltols, reltols)
         _dts = get(setups[k], :dts, zeros(length(_abstols)))
@@ -857,6 +860,7 @@ end
         SciMLBase.has_analytic(prob.f) ? err_sol = sol : err_sol = appxtrue(sol, true_sol)
         tmp_solutions[i, j, k] = err_sol
     end
+    return nothing
 end
 
 function WorkPrecisionSet(
@@ -886,12 +890,18 @@ function WorkPrecisionSet(
     # First calculate all of the errors
     if parallel_type == :threads
         Threads.@threads for i in 1:numruns_error
-            @error_calculation
+            _calculate_error!(
+                i, tmp_solutions, prob, setups, abstols, reltols, test_dt,
+                appxsol_setup, timeseries_errors, dense_errors, kwargs
+            )
         end
     elseif parallel_type == :none
         for i in 1:numruns_error
             @info "Error calculation: $i/$numruns_error"
-            @error_calculation
+            _calculate_error!(
+                i, tmp_solutions, prob, setups, abstols, reltols, test_dt,
+                appxsol_setup, timeseries_errors, dense_errors, kwargs
+            )
         end
     end
 
@@ -1217,11 +1227,17 @@ function get_sample_errors(
         dense_errors = false
         if parallel_type == :threads
             Threads.@threads for i in 1:maxnumruns
-                @error_calculation
+                _calculate_error!(
+                    i, tmp_solutions, prob, setups, abstols, reltols, test_dt,
+                    appxsol_setup, timeseries_errors, dense_errors, kwargs
+                )
             end
         elseif parallel_type == :none
             for i in 1:maxnumruns
-                @error_calculation
+                _calculate_error!(
+                    i, tmp_solutions, prob, setups, abstols, reltols, test_dt,
+                    appxsol_setup, timeseries_errors, dense_errors, kwargs
+                )
             end
         end
         tmp_solutions = vec(tmp_solutions)

--- a/lib/DiffEqDevTools/test/analyticless_stochastic_wp.jl
+++ b/lib/DiffEqDevTools/test/analyticless_stochastic_wp.jl
@@ -35,6 +35,23 @@ setups = [
     )
     Dict(:alg => SRA1())
 ]
+
+threaded_prob = SDEProblem(
+    (du, u, p, t) -> (du .= u), (du, u, p, t) -> (du .= 0.1 .* u),
+    [1.0, 1.0], (0.0, 0.1)
+)
+threaded_setups = [
+    Dict(:alg => SRIW1()),
+    Dict(:alg => RKMil(), :dts => fill(0.001, length(reltols)), :adaptive => false),
+]
+threaded_wp = WorkPrecisionSet(
+    threaded_prob, abstols, reltols, threaded_setups, 0.01;
+    numruns = 1, numruns_error = max(32, Threads.nthreads()),
+    parallel_type = :threads, error_estimate = :final,
+    appxsol_setup = Dict(:alg => SRIW1(), :abstol => 1.0e-4, :reltol => 1.0e-4)
+)
+@test length(threaded_wp.wps) == 2
+
 _names = ["SRIW1", "EM", "RKMil", "SRIW1 Fixed", "SRA1 Fixed", "SRA1"]
 test_dt = 0.1
 wp = WorkPrecisionSet(


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What changed and why

`WorkPrecisionSet(...; parallel_type = :threads)` expanded `@error_calculation` directly inside a threaded loop. The macro-created locals were captured by the enclosing function, so concurrent stochastic error calculations could replace one another's tolerance and timestep bindings. In mixed adaptive/fixed-step setups, an RKMil solve could therefore receive the adaptive setup's zero/absent timestep and fail nondeterministically.

Move one error calculation into the private module-level `_calculate_error!` function so every threaded call owns its bindings. Add a regression using an analyticless SDE with adaptive SRIW1 and fixed-step RKMil setups across at least 32 threaded error samples. The same helper also replaces the duplicate macro expansion in `get_sample_errors`.

No public API or dependency changed.

## Failing before the fix

On DiffEqDevTools v3.6.2 (`cd5ccd7f8e`) with the regression test applied but the implementation reverted:

```text
$ timeout 3600 julia +1.11.9 --startup-file=no --threads=auto --project=.validation/test-env -e 'include("lib/DiffEqDevTools/test/analyticless_stochastic_wp.jl")'
ERROR: TaskFailedException
    nested task error: ArgumentError: Fixed timestep methods require a choice of dt or an algorithm with an automatic dt choice.
    ...
    dt::Nothing
Process exited with status 1
Elapsed: 1:08.77
```

The clean standalone reproducer passed with one Julia thread and failed with 128 threads. A diagnostic assertion also observed the shared `_dts` binding change between evaluating a condition and capturing its value.

## Passing after the fix

The exact official test file passes with 128 threads:

```text
$ timeout 3600 julia +1.11.9 --startup-file=no --threads=auto --project=.validation/test-env -e 'include("lib/DiffEqDevTools/test/analyticless_stochastic_wp.jl")'
Test Summary:              | Pass  Total     Time
Analyticless Stochastic WP |    4      4  6m18.9s
Process exited with status 0
```

An independent clean worktree repeated that test successfully in 6m40s. A 10-trial standalone threaded reproducer also completed all trials successfully in 46.95s; an independent clean worktree repeated it in 57.54s.

The SciMLBenchmarks page that originally exposed the race completed against this local source:

```text
$ timeout 7200 julia +1.11.9 --startup-file=no --threads=auto --project=.validation/root-env -e 'using SciMLBenchmarks; SciMLBenchmarks.weave_file("benchmarks/NonStiffSDE", "LotkaVolterraSDE.jmd", (:script, :github))'
Process exited with status 0
Elapsed: 38:25.48
Maximum resident set size: 133256684 kbytes
```

The generated Markdown referenced four valid 576×384 PNGs. Inspection found all strong-error, weak-error, and sample-error curves populated and no runtime error markers.

## Local verification

```text
$ GROUP=QA timeout 3600 julia +1.11.9 --startup-file=no --threads=auto --project=lib/DiffEqDevTools -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total  Time
QA            |   15     15  36.1s
Testing DiffEqDevTools tests passed
Process exited with status 0 (elapsed 1:47)

$ GROUP=Core timeout 7200 julia +1.11.9 --threads=auto --project=lib/DiffEqDevTools -e 'using Pkg; Pkg.test()'
Test Summary:              | Pass  Total     Time
Analyticless Stochastic WP |    4      4  7m20.0s
...
Test Summary: | Pass  Total  Time
Timeout       |    7      7  4.2s
Testing DiffEqDevTools tests passed
Process exited with status 0 (elapsed 19:36.78; max RSS 7519644 kbytes)

$ julia +1.11.9 --project=/home/crackauc/.julia/environments/runic -e 'using Runic; exit(Runic.main(["--check", "lib/DiffEqDevTools/src/DiffEqDevTools.jl", "lib/DiffEqDevTools/src/benchmark.jl", "lib/DiffEqDevTools/test/analyticless_stochastic_wp.jl"]))'
$ typos lib/DiffEqDevTools/src/DiffEqDevTools.jl lib/DiffEqDevTools/src/benchmark.jl lib/DiffEqDevTools/test/analyticless_stochastic_wp.jl
$ git diff --check
```

All three final checks exited 0 with no output.

## Not verified

No GPU or downstream test groups were run. Documentation was not built because this changes no public API, docstring, or documentation source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
