### PR TITLE
Preserve the DAE step start during callback interpolation

### DIFF
--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_interface.jl
@@ -56,12 +56,12 @@ function SciMLBase.reeval_internals_due_to_modification!(
         callback_initializealg = nothing
     )
     if integrator.isdae
+        # Reinitialization changes the right endpoint; uprev must still describe tprev.
         SciMLBase.initialize_dae!(
             integrator,
             isnothing(callback_initializealg) ? integrator.initializealg :
                 callback_initializealg
         )
-        update_uprev!(integrator)
     end
 
     if continuous_modification && integrator.opts.calck

--- a/lib/OrdinaryDiffEqRosenbrock/test/callback_truncated_interpolation.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/callback_truncated_interpolation.jl
@@ -33,3 +33,30 @@ callback = ContinuousCallback((u, t, integrator) -> u[1] - 0.3, terminate!)
         end
     end
 end
+
+
+@testset "Adaptive DAE callback interpolation" begin
+    function exponential_dae!(du, u, p, t)
+        du[1] = -u[1]
+        du[2] = u[2] + u[1] - 1
+        return nothing
+    end
+    exponential_dae(u, p, t) = [-u[1], u[2] + u[1] - 1]
+    exact(t) = [exp(-t), 1 - exp(-t)]
+
+    @testset "$(nameof(typeof(alg))), inplace=$(f === exponential_dae!), terminate=$stop, saveat=$(saveat !== ())" for
+        alg in (Rodas4(), Rodas4P(), Rodas5P()),
+            f in (exponential_dae!, exponential_dae), stop in (true, false),
+            saveat in ((), range(0.0, stop ? 0.7 : 1.0; length = 101))
+        affect! = stop ? terminate! : integrator -> nothing
+        callback = ContinuousCallback((u, t, integrator) -> t - 0.7, affect!)
+        prob = ODEProblem(ODEFunction(f; mass_matrix), [1.0, 0.0], (0.0, 1.0))
+        sol = solve(prob, alg; callback, initializealg = CheckInit(), saveat)
+        @test sol.retcode == (stop ? SciMLBase.ReturnCode.Terminated : SciMLBase.ReturnCode.Success)
+        @test sol.t[end] ≈ (stop ? 0.7 : 1.0) atol = 1.0e-12
+        @test sol.u[end] ≈ exact(sol.t[end]) atol = 1.0e-4
+        for t in range(0.0, sol.t[end]; length = 101)
+            @test sol(t) ≈ exact(t) atol = 1.0e-2
+        end
+    end
+end


### PR DESCRIPTION
DAE callback reinitialization overwrote `uprev` with the event state before rebuilding the shortened step's interpolation and processing `saveat`. Preserve the left endpoint until the normal next-step update. The adaptive regression covers Rodas4, Rodas4P, and Rodas5P, in-place/out-of-place problems, terminating/continuing callbacks, and dense output/`saveat`; the existing fixed-step regression remains intact.

Addresses the reproducer contributed in https://github.com/SciML/OrdinaryDiffEq.jl/pull/4456 and follows https://github.com/SciML/OrdinaryDiffEq.jl/pull/4411.

**Ignore this PR until reviewed by @ChrisRackauckas.**

### Failing before / passing after

The original PR's exact test script on unmodified master, then with the fix:

```text
Before: Callback-truncated interpolation | 1712 pass, 130 fail, 1842 total
After:  Callback-truncated interpolation | 1842 pass, 1842 total
```

Both runs used Julia 1.12.7 and the local Rosenbrock project with `--compiled-modules=existing`. This loading option avoided shared precompile-cache waits; assertions and test groups were unchanged.

The final regression was also run against independent clean-master and controlled-reversal worktrees:

```sh
~/.juliaup/bin/julia +1.12 --compiled-modules=existing --project=base-investigation/lib/OrdinaryDiffEqRosenbrock OrdinaryDiffEq.jl/lib/OrdinaryDiffEqRosenbrock/test/callback_truncated_interpolation.jl
~/.juliaup/bin/julia +1.12 --compiled-modules=existing --project=base-reversal/lib/OrdinaryDiffEqRosenbrock OrdinaryDiffEq.jl/lib/OrdinaryDiffEqRosenbrock/test/callback_truncated_interpolation.jl
```

```text
Before:
Callback-truncated interpolation    |   21 pass,            21 total
Adaptive DAE callback interpolation | 2277 pass, 219 fail, 2496 total

After:
Callback-truncated interpolation    |   21 pass,   21 total
Adaptive DAE callback interpolation | 2496 pass, 2496 total
```

The reversal worktree differs from master by exactly the deleted `update_uprev!` call. This is a controlled hunk reversal on current master, not a full historical bisect.

### Root cause history

`git blame` traces the removed reset to https://github.com/SciML/OrdinaryDiffEq.jl/commit/3d9cb3ed690019ea3228209d41884639f8b48a75. Its separate initial-solve state reset is preserved. The normal `apply_step!` path already updates `uprev` before the next step.


### Local validation

All package-test commands used `TMPDIR="$PWD/../tmp"` and `JULIA_PKG_PRECOMPILE_AUTO=0` from the repository root.

```sh
GROUP=Core ~/.juliaup/bin/julia +1.12 --compiled-modules=existing --project=lib/OrdinaryDiffEqRosenbrock -e 'using Pkg; Pkg.test(; julia_args=["--compiled-modules=existing"])'
GROUP=Core ~/.juliaup/bin/julia +1.12 --compiled-modules=existing --project=lib/OrdinaryDiffEqCore -e 'using Pkg; Pkg.test(; julia_args=["--compiled-modules=existing"])'
GROUP=QA ~/.juliaup/bin/julia +1.12 --compiled-modules=existing --project=lib/OrdinaryDiffEqCore -e 'using Pkg; Pkg.test(; julia_args=["--compiled-modules=existing"])'
GROUP=InterfaceIII ~/.juliaup/bin/julia +1.12 --compiled-modules=existing --project -e 'using Pkg; Pkg.test(; julia_args=["--compiled-modules=existing"])'
GROUP=QA ~/.juliaup/bin/julia +1.12 --compiled-modules=existing --project -e 'using Pkg; Pkg.test(; julia_args=["--compiled-modules=existing"])'
```

```text
DAE Rosenbrock AD Tests          |   16 / 16 passed
Callback-truncated interpolation | 2517 / 2517 passed
Rosenbrock AD Tests              |   65 / 65 passed
Rosenbrock Convergence Tests     |  195 / 195 passed
Testing OrdinaryDiffEqRosenbrock tests passed

OrdinaryDiffEqCore Core: 117 passed
OrdinaryDiffEqCore QA: 57 passed, 1 pre-existing broken
Testing OrdinaryDiffEqCore tests passed

InterfaceIII: 262 passed, 4 pre-existing broken
Quality Assurance Tests | 109 / 109 passed
Testing OrdinaryDiffEq tests passed
```

Runic (`--check --diff`), `typos` on both changed files, and `git diff --check` passed.

### Validation environment

An initial diagnostic-profiled QA process crashed inside Julia's profiler module loader. A subsequent unprofiled QA run passed inference, JET, and the other Aqua checks but failed the persistent-task precompilation check. That failure also reproduced on clean master with `--compiled-modules=existing`; the unchanged check with the same 60-second limit passed on both revisions with normal module caching. The original `--compiled-modules=existing` check also passed after the caches warmed, isolating the failure to cache state rather than repository source. No assertions, tolerances, or existing broken/skip declarations were changed.


The final **standard** Rosenbrock QA group passed:

```sh
TMPDIR="$PWD/../tmp" JULIA_PKG_PRECOMPILE_AUTO=0 GROUP=QA ~/.juliaup/bin/julia +1.12 --project=lib/OrdinaryDiffEqRosenbrock -e 'using Pkg; Pkg.test()'
```

```text
Allocation Tests | Broken 20, Total 20 (pre-existing)
Inference Tests  | Pass 40, Total 40
JET Tests        | Pass 1, Total 1
Aqua             | Pass 21, Total 21
Testing OrdinaryDiffEqRosenbrock tests passed
```

### CI status (2026-09-05 15:15 UTC)

For commit `09302abd5ac328c2fa6947c4c569a9a9e29e868b`, GitHub reports **254 successful checks, zero failures, one skipped workflow matrix entry, and four queued GPU checks**. All CPU test matrices, QA, formatting, spelling, documentation, dependency-downgrade tests, and downstream integration tests have passed. Root GPU tests and the Core, LowStorageRK, StabilizedRK, and RKIP sublibrary GPU tests have also passed.

The remaining Rosenbrock, BDF, Default, and Linear GPU checks are waiting for runners. Full CI completion is therefore still pending; these checks have not been disabled or cancelled. Current results: https://github.com/SciML/OrdinaryDiffEq.jl/pull/4466/checks

### Not verified locally

Other Julia versions (including prerelease), GPU, downstream packages, and the full monorepo `Everything` suite were not run locally. No documentation build was run because this change adds no docstrings, documentation, or public API.

### Links

- CI checks: https://github.com/SciML/OrdinaryDiffEq.jl/pull/4466/checks

- Original report/reproducer: https://github.com/SciML/OrdinaryDiffEq.jl/pull/4456
- Earlier interpolation fix: https://github.com/SciML/OrdinaryDiffEq.jl/pull/4411
- Reset insertion: https://github.com/SciML/OrdinaryDiffEq.jl/commit/3d9cb3ed690019ea3228209d41884639f8b48a75

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra; session: local transcript `/home/crackauc/.codex/sessions/2026/09/05/rollout-2026-09-05T05-55-03-01a070fe-35a9-7de3-8a19-e711a7c4ed0d.jsonl`).
