### PR TITLE
[bot] ImplicitDiscreteSolve: run the nonlinear solve at the integrator's tolerances

### DIFF
--- a/lib/ImplicitDiscreteSolve/Project.toml
+++ b/lib/ImplicitDiscreteSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "ImplicitDiscreteSolve"
 uuid = "3263718b-31ed-49cf-8a0f-35a466e8af96"
 authors = ["vyudu <vincent.duyuan@gmail.com>"]
-version = "2.2.1"
+version = "2.3.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/ImplicitDiscreteSolve/src/solve.jl
+++ b/lib/ImplicitDiscreteSolve/src/solve.jl
@@ -1,3 +1,26 @@
+"""
+    nlsolve_tolerances(integrator) -> NamedTuple
+
+The `abstol`/`reltol` the step's nonlinear solve should be run at, taken from the tolerances
+the integrator was initialized with.
+
+An `ImplicitDiscreteProblem` carries no tolerances of its own, so `OrdinaryDiffEqCore`
+stores `false` for one that was not supplied; that maps to `nothing`, which restores the
+nonlinear solver's own default. A per-component tolerance array is reduced to its tightest
+entry, because the nonlinear solve takes a scalar.
+"""
+function nlsolve_tolerances(integrator)
+    return (;
+        abstol = nlsolve_tolerance(integrator.opts.abstol),
+        reltol = nlsolve_tolerance(integrator.opts.reltol),
+    )
+end
+
+nlsolve_tolerance(::Nothing) = nothing
+nlsolve_tolerance(::Bool) = nothing
+nlsolve_tolerance(tol::Number) = tol
+nlsolve_tolerance(tol::AbstractArray) = isempty(tol) ? nothing : minimum(tol)
+
 # u === nothing path: nothing to step. The integrator's state is unchanged
 # and the step trivially succeeds.
 function perform_step!(
@@ -19,7 +42,7 @@ function perform_step!(integrator, cache::IDSolveCache, repeat_step = false)
     state = ImplicitDiscreteState(cache.z, p, t + dt)
 
     # nonlinear solve step
-    SciMLBase.reinit!(nlcache, cache.z; p = state)
+    SciMLBase.reinit!(nlcache, cache.z; p = state, nlsolve_tolerances(integrator)...)
     converged, znew = _solve_nonlinear!(nlcache, observer)
     if !converged
         integrator.force_stepfail = true
@@ -76,7 +99,7 @@ function _initialize_dae!(
         (; z, nlcache, observer) = integrator.cache
         z .= u
         initstate = ImplicitDiscreteState(z, p, t)
-        SciMLBase.reinit!(nlcache, u; p = initstate)
+        SciMLBase.reinit!(nlcache, u; p = initstate, nlsolve_tolerances(integrator)...)
         converged, unew = _solve_nonlinear!(nlcache, observer)
         if converged
             integrator.u .= unew

--- a/lib/ImplicitDiscreteSolve/test/runtests.jl
+++ b/lib/ImplicitDiscreteSolve/test/runtests.jl
@@ -339,6 +339,33 @@ if TEST_GROUP != "QA"
         @test length(sol.u) == 1
         @test !SciMLBase.successful_retcode(sol)
     end
+
+    @testset "Nonlinear solve runs at the integrator's tolerances" begin
+        # Terms of magnitude 1e7 put the smallest residual any `Float64` can achieve at
+        # 1.2e-9: above NonlinearSolve's default Float64 `abstol` of 3e-13, below any
+        # tolerance a caller would ask for.
+        function floored!(resid, u_next, u, p, t)
+            resid[1] = 1.0e7 * (u_next[1]^2 - 1.5) - 0.5785
+            return nothing
+        end
+
+        u0 = [sqrt(1.5)]
+        root = sqrt(1.5 + 0.5785e-7)
+
+        idprob = ImplicitDiscreteProblem(floored!, u0, (0, 0), [])
+        @test check_error(init(idprob, IDSolve())) == ReturnCode.InitialFailure
+
+        integ = init(idprob, IDSolve(); abstol = 1.0e-8)
+        @test check_error(integ) != ReturnCode.InitialFailure
+        @test integ.u[1] ≈ root
+
+        # ... and the same for a step rather than the initialization.
+        stepprob = ImplicitDiscreteProblem(floored!, u0, (0, 2), []; dt = 1.0)
+        @test !SciMLBase.successful_retcode(solve(stepprob, IDSolve(); adaptive = false))
+        sol = solve(stepprob, IDSolve(); adaptive = false, abstol = 1.0e-8)
+        @test SciMLBase.successful_retcode(sol)
+        @test sol.u[end][1] ≈ root
+    end
 end
 
 # Run QA tests (JET, Aqua)


### PR DESCRIPTION
> 🚧 **Filed by an AI agent running as @chrisrackauckas — Chris has not reviewed this PR.** Please ignore it until reviewed by @ChrisRackauckas.
> Harness: Claude Code 2.1.260 · Model: claude-opus-5[1m]
> Conversation: https://claude.ai/code/session_01UBTNFZ4A8Ciw27TmVHkpRD

## What and why

`IDSolve` never passes a tolerance into its nonlinear solve: `alg_cache` builds the cache with
`init(prob, alg.nlsolve)`, so `NewtonRaphson` always terminates against NonlinearSolve's default
Float64 `abstol = 3e-13`, whatever the caller asked `init`/`solve` for. (`alg_cache` is handed
`reltol` and ignores it; `abstol` never reaches it at all, and the cache is built before the
integrator exists.)

That default is unreachable for any residual whose terms are large: the floor is
`eps * magnitude`, so terms of magnitude 1e7 floor the residual at ~1e-9 and the Newton stalls
(`ReturnCode.Stalled`) on a problem that is solvable to any tolerance a caller would actually ask
for. Downstream this surfaces as ModelingToolkit throwing `UnsolvableCallbackError` for a
perfectly solvable symbolic affect — https://github.com/SciML/ModelingToolkit.jl/issues/5079.

This forwards the tolerances the integrator was initialized with into the nonlinear solve, at
both call sites (`perform_step!` and the `DefaultInit` path of `_initialize_dae!`). An
`ImplicitDiscreteProblem` with no tolerance supplied keeps `false` in `integrator.opts`, which
maps to `nothing` and leaves NonlinearSolve's default in place, so nothing changes unless a
tolerance is actually given.

## Verification

`ImplicitDiscreteSolve` test suite (`GROUP=Core`), aarch64 Linux, Julia 1.10.12.

**Before** (`git stash push lib/ImplicitDiscreteSolve/src/solve.jl`, new test only, rest of the
suite unchanged):

```
Nonlinear solve runs at the integrator's tolerances: Test Failed at .../test/runtests.jl:359
  Expression: check_error(integ) != ReturnCode.InitialFailure
   Evaluated: SciMLBase.ReturnCode.InitialFailure != SciMLBase.ReturnCode.InitialFailure

Nonlinear solve runs at the integrator's tolerances: Test Failed at .../test/runtests.jl:360
  Expression: integ.u[1] ≈ root
   Evaluated: 1.224744871391589 ≈ 1.2247448950087523     # unmoved from the initial guess

Nonlinear solve runs at the integrator's tolerances: Test Failed at .../test/runtests.jl:366
  Expression: SciMLBase.successful_retcode(sol)

Nonlinear solve runs at the integrator's tolerances | 2  4  6  9.0s
ERROR: Package ImplicitDiscreteSolve errored during testing
```

**After** (whole suite, unmodified except for the added testset):

```
Test Summary:  | Pass  Total   Time
Implicit Euler |    2      2  35.9s
Solver initializes |   16     16  2.7s
Reinitialize integrator |   15     15  15.3s
Constant extrapolant resets nonlinear iterate |    2      2  2.4s
Hard problem  |    1      1  2.4s
Kantorovich strict acceptance |    4      4  0.1s
Handle nothing in u0 |    2      2  5.3s
Create NonlinearLeastSquaresProblem |    3      3  9.4s
Null u0 bypasses NonlinearSolve |    3      3  0.9s
nlsolve accepts polyalgorithms and SimpleNonlinearSolve |   13     13  52.6s
InitialFailure thrown |    3      3  4.6s
Nonlinear solve runs at the integrator's tolerances |    6      6  6.4s
     Testing ImplicitDiscreteSolve tests passed
```

The regression test is the residual-floor case: terms of magnitude 1e7 make 1.2e-9 the smallest
`|residual|` any `Float64` reaches (brute-forced over the 4001 floats around the root), so the
solve stalls at `3e-13` and succeeds at `1e-8` — same iterate, only the tolerance differs.

Formatting: Runic clean on both changed files. `typos` is not installed on this machine, so the
spell check was not run locally (no British spellings or unusual words were added).

## What I did not verify

- Only the `Core` test group was run locally (`GROUP=Core`); the `QA` group (JET/Aqua) was not.
- No downstream package's suite was run against this branch; the ModelingToolkit side is
  https://github.com/SciML/ModelingToolkit.jl/pull/MTK_PR, which needs this released as 2.3.0
  before it can resolve.
- aarch64 Linux only (Jetson AGX Orin), Julia 1.10.12. Not run on x86 or 1.12.

---
🤖 Posted by an AI agent — harness: Claude Code 2.1.260 · model: claude-opus-5[1m]
Conversation: https://claude.ai/code/session_01UBTNFZ4A8Ciw27TmVHkpRD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBTNFZ4A8Ciw27TmVHkpRD
