### PR TITLE
Rebuild the linear W on every gamma dt change

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "3.11.4"
+version = "3.11.5"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -543,17 +543,13 @@ function do_newJW(integrator, alg, nlsolver, repeat_step)::NTuple{2, Bool}
     repeat_step && return false, false
     islin, _ = islinearfunction(integrator)
     if islin
-        # J is constant for a linear function, but W = J - M/(γdt) still depends
-        # on γdt: W must be rebuilt/refactorized when the step size has drifted
-        # past the cutoff, otherwise concrete-A linear solvers keep a stale
-        # factorization from the first step's (possibly tiny) dt.
+        # J is constant for a linear function, so rebuilding W = J - M/(γdt) is a
+        # refactorization with no Jacobian evaluation and there is nothing for
+        # `new_W_dt_cutoff` to amortize; a stale W only costs Newton iterations.
         isnewton(nlsolver) || return false, true
         W_iγdt = inv(nlsolver.cache.W_γdt)
         iγdt = inv(nlsolver.γ * integrator.dt)
-        cutoff = integrator.opts.adaptive && !_uses_split_W(alg, integrator.f) ?
-            get_new_W_γdt_cutoff(nlsolver) : zero(get_new_W_γdt_cutoff(nlsolver))
-        smallstepchange = abs(iγdt / W_iγdt - 1) <= cutoff
-        return false, !smallstepchange
+        return false, iγdt != W_iγdt
     end
     !integrator.opts.adaptive && return true, true # Not adaptive will always refactorize
     errorfail = OrdinaryDiffEqCore.get_EEst(integrator) > one(OrdinaryDiffEqCore.get_EEst(integrator))

--- a/lib/OrdinaryDiffEqDifferentiation/test/stale_w_linear_operator_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/stale_w_linear_operator_tests.jl
@@ -92,3 +92,19 @@ end
     end
     @test integ.u == integ_exact.u
 end
+
+@testset "adaptive linear W takes every γdt change (#4370)" begin
+    A = [-20.0 1.0; 1.0 -20.0]
+    u0 = [1.0, 0.5]
+    prob = ODEProblem(ODEFunction(MatrixOperator(A)), u0, (0.0, 1.0))
+    solve_with(cutoff) = solve(
+        prob, SDIRK2(nlsolve = NLNewton(new_W_dt_cutoff = cutoff));
+        abstol = 1.0e-8, reltol = 1.0e-8
+    )
+
+    loose = solve_with(0.2)
+    exact = solve_with(0.0)
+    @test loose.u[end] == exact.u[end]
+    @test loose.stats.nw == exact.stats.nw
+    @test loose.stats.nnonliniter == exact.stats.nnonliniter
+end


### PR DESCRIPTION
`new_W_dt_cutoff` no longer applies to the `islinearfunction` path, so `W = J - M/(γdt)` is refactorized on every step whose `γdt` differs, adaptive solves included; #4401 did this for fixed steps only.

For a linear function `J` is constant, so a rebuild is a refactorization with no Jacobian evaluation, and keeping a stale `W` buys nothing while costing Newton iterations.

On the issue's 400-point heat equation with SDIRK2 at reltol 1e-8 the default cutoff took 4844 Newton iterations and 85.0 ms against 1030 and 38.2 ms with the cutoff off; at 1e-10 it is 26340 and 454.3 ms against 4680 and 173.8 ms. Dense random operators are faster too, by 23% at N=100, 11% at N=300, 5.5% at N=600 and 3.5% at N=900, and the end states agree to the last digit.

The new test in `stale_w_linear_operator_tests.jl` solves adaptively at cutoff 0.2 and 0 and compares the end state, `nw` and `nnonliniter`; on master those runs take 30 factorizations against 455.

Closes #4370. The carried-over `η` the issue also names is not what moves the answer on the adaptive path: forcing convergence with `κ = 1e-4` and `max_iter = 30` leaves the error at 5.9e-9 against 6.1e-9.

AI Disclosure: Claude assisted with this change.
