### PR TITLE
Do not seed a retry from the previous-step interpolant

### DIFF
--- a/lib/OrdinaryDiffEqSDIRK/Project.toml
+++ b/lib/OrdinaryDiffEqSDIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqSDIRK"
 uuid = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.9.2"
+version = "2.9.3"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/lib/OrdinaryDiffEqSDIRK/src/generic_imex_perform_step.jl
+++ b/lib/OrdinaryDiffEqSDIRK/src/generic_imex_perform_step.jl
@@ -160,7 +160,10 @@ end
                 copyto!(zs[2], zs[1])
             elseif predictor == Predictor.StageExtrap
                 copyto!(zs[2], zs[1])
-            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal)
+            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal || integrator.last_stepfail)
+                # A rejected attempt overwrites `integrator.k`, so after `last_stepfail`
+                # it no longer holds the interpolation data for [tprev, t] and the
+                # previous-step interpolant cannot seed the retry.
                 fill!(zs[2], zero(eltype(u)))
             elseif predictor == Predictor.MaxOrder
                 SciMLBase.addsteps!(integrator)
@@ -252,7 +255,7 @@ end
                 copyto!(zs[3], zs[2])
             elseif predictor == Predictor.StageExtrap
                 @.. broadcast = false zs[3] = zs[2] + (zs[2] - zs[1]) * ((c[3] - c[2]) / (c[2] - c[1]))
-            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal)
+            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal || integrator.last_stepfail)
                 fill!(zs[3], zero(eltype(u)))
             elseif predictor == Predictor.MaxOrder
                 SciMLBase.addsteps!(integrator)
@@ -342,7 +345,7 @@ end
                 copyto!(zs[4], zs[3])
             elseif predictor == Predictor.StageExtrap
                 @.. broadcast = false zs[4] = zs[3] + (zs[3] - zs[2]) * ((c[4] - c[3]) / (c[3] - c[2]))
-            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal)
+            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal || integrator.last_stepfail)
                 fill!(zs[4], zero(eltype(u)))
             elseif predictor == Predictor.MaxOrder
                 SciMLBase.addsteps!(integrator)
@@ -433,7 +436,7 @@ end
                 copyto!(zs[5], zs[4])
             elseif predictor == Predictor.StageExtrap
                 @.. broadcast = false zs[5] = zs[4] + (zs[4] - zs[3]) * ((c[5] - c[4]) / (c[4] - c[3]))
-            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal)
+            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal || integrator.last_stepfail)
                 fill!(zs[5], zero(eltype(u)))
             elseif predictor == Predictor.MaxOrder
                 SciMLBase.addsteps!(integrator)
@@ -525,7 +528,7 @@ end
                 copyto!(zs[6], zs[5])
             elseif predictor == Predictor.StageExtrap
                 @.. broadcast = false zs[6] = zs[5] + (zs[5] - zs[4]) * ((c[6] - c[5]) / (c[5] - c[4]))
-            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal)
+            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal || integrator.last_stepfail)
                 fill!(zs[6], zero(eltype(u)))
             elseif predictor == Predictor.MaxOrder
                 SciMLBase.addsteps!(integrator)
@@ -618,7 +621,7 @@ end
                 copyto!(zs[7], zs[6])
             elseif predictor == Predictor.StageExtrap
                 @.. broadcast = false zs[7] = zs[6] + (zs[6] - zs[5]) * ((c[7] - c[6]) / (c[6] - c[5]))
-            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal)
+            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal || integrator.last_stepfail)
                 fill!(zs[7], zero(eltype(u)))
             elseif predictor == Predictor.MaxOrder
                 SciMLBase.addsteps!(integrator)
@@ -712,7 +715,7 @@ end
                 copyto!(zs[8], zs[7])
             elseif predictor == Predictor.StageExtrap
                 @.. broadcast = false zs[8] = zs[7] + (zs[7] - zs[6]) * ((c[8] - c[7]) / (c[7] - c[6]))
-            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal)
+            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal || integrator.last_stepfail)
                 fill!(zs[8], zero(eltype(u)))
             elseif predictor == Predictor.MaxOrder
                 SciMLBase.addsteps!(integrator)
@@ -807,7 +810,7 @@ end
                 copyto!(zs[9], zs[8])
             elseif predictor == Predictor.StageExtrap
                 @.. broadcast = false zs[9] = zs[8] + (zs[8] - zs[7]) * ((c[9] - c[8]) / (c[8] - c[7]))
-            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal)
+            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal || integrator.last_stepfail)
                 fill!(zs[9], zero(eltype(u)))
             elseif predictor == Predictor.MaxOrder
                 SciMLBase.addsteps!(integrator)
@@ -903,7 +906,7 @@ end
                 copyto!(zs[10], zs[9])
             elseif predictor == Predictor.StageExtrap
                 @.. broadcast = false zs[10] = zs[9] + (zs[9] - zs[8]) * ((c[10] - c[9]) / (c[9] - c[8]))
-            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal)
+            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal || integrator.last_stepfail)
                 fill!(zs[10], zero(eltype(u)))
             elseif predictor == Predictor.MaxOrder
                 SciMLBase.addsteps!(integrator)
@@ -1000,7 +1003,7 @@ end
                 copyto!(zs[11], zs[10])
             elseif predictor == Predictor.StageExtrap
                 @.. broadcast = false zs[11] = zs[10] + (zs[10] - zs[9]) * ((c[11] - c[10]) / (c[10] - c[9]))
-            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal)
+            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal || integrator.last_stepfail)
                 fill!(zs[11], zero(eltype(u)))
             elseif predictor == Predictor.MaxOrder
                 SciMLBase.addsteps!(integrator)
@@ -1098,7 +1101,7 @@ end
                 copyto!(zs[12], zs[11])
             elseif predictor == Predictor.StageExtrap
                 @.. broadcast = false zs[12] = zs[11] + (zs[11] - zs[10]) * ((c[12] - c[11]) / (c[11] - c[10]))
-            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal)
+            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal || integrator.last_stepfail)
                 fill!(zs[12], zero(eltype(u)))
             elseif predictor == Predictor.MaxOrder
                 SciMLBase.addsteps!(integrator)
@@ -1439,7 +1442,7 @@ end
                 z_guess = z1
             elseif predictor == Predictor.StageExtrap
                 z_guess = z1
-            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal)
+            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal || integrator.last_stepfail)
                 z_guess = zero(u)
             elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder)
                 SciMLBase.addsteps!(integrator)
@@ -1507,7 +1510,7 @@ end
                 z_guess = z2
             elseif predictor == Predictor.StageExtrap
                 z_guess = z2 + (z2 - z1) * ((c[3] - c[2]) / (c[2] - c[1]))
-            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal)
+            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal || integrator.last_stepfail)
                 z_guess = zero(u)
             elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder)
                 SciMLBase.addsteps!(integrator)
@@ -1572,7 +1575,7 @@ end
                 z_guess = z3
             elseif predictor == Predictor.StageExtrap
                 z_guess = z3 + (z3 - z2) * ((c[4] - c[3]) / (c[3] - c[2]))
-            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal)
+            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal || integrator.last_stepfail)
                 z_guess = zero(u)
             elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder)
                 SciMLBase.addsteps!(integrator)
@@ -1637,7 +1640,7 @@ end
                 z_guess = z4
             elseif predictor == Predictor.StageExtrap
                 z_guess = z4 + (z4 - z3) * ((c[5] - c[4]) / (c[4] - c[3]))
-            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal)
+            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal || integrator.last_stepfail)
                 z_guess = zero(u)
             elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder)
                 SciMLBase.addsteps!(integrator)
@@ -1702,7 +1705,7 @@ end
                 z_guess = z5
             elseif predictor == Predictor.StageExtrap
                 z_guess = z5 + (z5 - z4) * ((c[6] - c[5]) / (c[5] - c[4]))
-            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal)
+            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal || integrator.last_stepfail)
                 z_guess = zero(u)
             elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder)
                 SciMLBase.addsteps!(integrator)
@@ -1767,7 +1770,7 @@ end
                 z_guess = z6
             elseif predictor == Predictor.StageExtrap
                 z_guess = z6 + (z6 - z5) * ((c[7] - c[6]) / (c[6] - c[5]))
-            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal)
+            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal || integrator.last_stepfail)
                 z_guess = zero(u)
             elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder)
                 SciMLBase.addsteps!(integrator)
@@ -1832,7 +1835,7 @@ end
                 z_guess = z7
             elseif predictor == Predictor.StageExtrap
                 z_guess = z7 + (z7 - z6) * ((c[8] - c[7]) / (c[7] - c[6]))
-            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal)
+            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal || integrator.last_stepfail)
                 z_guess = zero(u)
             elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder)
                 SciMLBase.addsteps!(integrator)
@@ -1897,7 +1900,7 @@ end
                 z_guess = z8
             elseif predictor == Predictor.StageExtrap
                 z_guess = z8 + (z8 - z7) * ((c[9] - c[8]) / (c[8] - c[7]))
-            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal)
+            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal || integrator.last_stepfail)
                 z_guess = zero(u)
             elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder)
                 SciMLBase.addsteps!(integrator)
@@ -1962,7 +1965,7 @@ end
                 z_guess = z9
             elseif predictor == Predictor.StageExtrap
                 z_guess = z9 + (z9 - z8) * ((c[10] - c[9]) / (c[9] - c[8]))
-            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal)
+            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal || integrator.last_stepfail)
                 z_guess = zero(u)
             elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder)
                 SciMLBase.addsteps!(integrator)
@@ -2027,7 +2030,7 @@ end
                 z_guess = z10
             elseif predictor == Predictor.StageExtrap
                 z_guess = z10 + (z10 - z9) * ((c[11] - c[10]) / (c[10] - c[9]))
-            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal)
+            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal || integrator.last_stepfail)
                 z_guess = zero(u)
             elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder)
                 SciMLBase.addsteps!(integrator)
@@ -2092,7 +2095,7 @@ end
                 z_guess = z11
             elseif predictor == Predictor.StageExtrap
                 z_guess = z11 + (z11 - z10) * ((c[12] - c[11]) / (c[11] - c[10]))
-            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal)
+            elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder) && (integrator.success_iter == 0 || integrator.reeval_fsal || integrator.last_stepfail)
                 z_guess = zero(u)
             elseif predictor in (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder)
                 SciMLBase.addsteps!(integrator)

--- a/lib/OrdinaryDiffEqSDIRK/test/predictor_tests.jl
+++ b/lib/OrdinaryDiffEqSDIRK/test/predictor_tests.jl
@@ -1,4 +1,5 @@
 using OrdinaryDiffEqSDIRK
+using SciMLBase
 using Test
 
 vdp!(du, u, p, t) = (du[1] = u[2]; du[2] = 1.0e3 * (1 - u[1]^2) * u[2] - u[1]; nothing)
@@ -96,4 +97,27 @@ end
     @test ImplicitEuler(extrapolant = :linear).predictor == Predictor.Linear
     @test ImplicitEuler(extrapolant = :constant).predictor == Predictor.Trivial
     @test KenCarp4(extrapolant = :interpolant).predictor == Predictor.MaxOrder
+end
+
+@testset "interpolant predictors survive a rejected step (#4472)" begin
+    function rober!(du, u, p, t)
+        du[1] = -0.04u[1] + 1.0e4 * u[2] * u[3]
+        du[2] = 0.04u[1] - 1.0e4 * u[2] * u[3] - 3.0e7 * u[2]^2
+        du[3] = 3.0e7 * u[2]^2
+        return nothing
+    end
+    rober = ODEProblem(rober!, [1.0, 0.0, 0.0], (0.0, 1.0e5))
+    lotka! = (du, u, p, t) -> (
+        du[1] = 1.5u[1] - u[1] * u[2];
+        du[2] = -3.0u[2] + u[1] * u[2]; nothing
+    )
+    lotka = ODEProblem(lotka!, [1.0, 1.0], (0.0, 30.0))
+
+    interp_predictors = (Predictor.MaxOrder, Predictor.VariableOrder, Predictor.CutoffOrder)
+    @testset "$(nameof(M)) $p" for (M, prob) in ((KenCarp4, rober), (TRBDF2, lotka)),
+            p in interp_predictors
+
+        sol = solve(prob, M(predictor = p); abstol = 1.0e-8, reltol = 1.0e-8)
+        @test SciMLBase.successful_retcode(sol)
+    end
 end


### PR DESCRIPTION
The `MaxOrder`, `VariableOrder` and `CutoffOrder` predictors seed a stage from the previous-step interpolant built out of `integrator.k`, but a rejected attempt overwrites `k` and nothing resets it before the retry, so the seed is built from the failed attempt's data; they now fall back to the zero seed when `integrator.last_stepfail` is set, as they already do before the first step.

Across 3 problems, 12 methods and those 3 predictors, 23 of 108 configurations abort with `ReturnCode.Unstable` on master, including KenCarp3/4/5, Kvaerno3/4/5, ESDIRK437L2SA, ESDIRK547L2SA2, ESDIRK659L2SA and TRBDF2. All 23 pass here. Printing the seed across four consecutive attempts at one `t` shows `integrator.k[2]` going 0.5 to 7.6e27 to 5.1e122 to `Inf` while `uprev` and `uprev2` stay at `[1.0000004, 0.9999985]`, after which every retry seeds `NaN` and `dt` runs down to `eps`.

Over the full 288-configuration sweep with all 8 predictors, 258 results are bit-identical to master, 23 go from `Unstable` to `Success`, none regress, and 7 shift while still succeeding: Hairer4 with `MaxOrder` on ROBER drops from 19617 Newton iterations to 11983.

The regression test solves ROBER with KenCarp4 and Lotka-Volterra with TRBDF2 under all three predictors; 4 of its 6 cases fail on master.

Fixes #4472.

AI Disclosure: Claude assisted with this change.
