### PR TITLE
Release DiffEqBase 7.20.1

### DIFF
--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.20.0"
+version = "7.20.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"


### PR DESCRIPTION
Bumps `DiffEqBase` 7.20.0 -> 7.20.1 (patch).

Source files changed since 7.20.0:
- `src/solve.jl`

Commits:
- Fix StochasticDiffEqImplicit import ordering (#4408)
- Fix TauLeaping JumpProblem initialization (#4409)
- Fix dense output for the explicit multirate methods (#4233)
- Let reinit! keep the step-size controller history (#4400)
- Mark an operator Jacobian as updated when calc_W! moves it (#4354)
- Restore weighted preconditioning and tolerances for default Krylov solves (#4391)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
