### PR TITLE
Release OrdinaryDiffEqCore 4.16.1

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.16.0"
+version = "4.16.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Bumps `OrdinaryDiffEqCore` 4.16.0 -> 4.16.1 (patch).

Source files changed since 4.16.0:
- `src/integrators/integrator_interface.jl`

Commits:
- Add serial SDC solver family (OrdinaryDiffEqSDC) (#4208)
- Give each threaded complex stage its own JVP operator (#4430)
- Fix the adaptive error estimates of MRIGARKERK22a and MIS (#4232)
- Skip sparsity prep for matrix-free jac_prototype operators (#4445)
- Format differentiation tests (#4446)
- Fix SciMLBase reexport QA on Julia LTS (#4450)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
