### PR TITLE
Release OrdinaryDiffEqNonlinearSolve 2.9.5

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.9.4"
+version = "2.9.5"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"


### PR DESCRIPTION
Bumps `OrdinaryDiffEqNonlinearSolve` 2.9.4 -> 2.9.5 (patch).

Source files changed since 2.9.4:
- `src/newton.jl`
- `src/utils.jl`

Commits:
- Add serial SDC solver family (OrdinaryDiffEqSDC) (#4208)
- Give each threaded complex stage its own JVP operator (#4430)
- Fix the adaptive error estimates of MRIGARKERK22a and MIS (#4232)
- Skip sparsity prep for matrix-free jac_prototype operators (#4445)
- Format differentiation tests (#4446)
- Fix SciMLBase reexport QA on Julia LTS (#4450)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
