### PR TITLE
Release DiffEqDevTools 3.6.3

### DIFF
--- a/lib/DiffEqDevTools/Project.toml
+++ b/lib/DiffEqDevTools/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqDevTools"
 uuid = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "3.6.2"
+version = "3.6.3"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"


### PR DESCRIPTION
Bumps `DiffEqDevTools` 3.6.2 -> 3.6.3 (patch).

Source files changed since 3.6.2:
- `src/DiffEqDevTools.jl`
- `src/benchmark.jl`

Commits:
- DiffEqBase: wrap mass-matrix problems on the finite-difference promote_f path (#4459)
- Preserve the DAE step start during callback interpolation (#4466)
- Release DiffEqBase 7.20.1 (#4474)
- Release OrdinaryDiffEqCore 4.16.1 (#4475)
- Release OrdinaryDiffEqNonlinearSolve 2.9.5 (#4476)
- Run IDSolve's nonlinear solve at the integrator's tolerances (#4468)
- Build W through the allocating path for a sparse GPU Jacobian with a scalar mass matrix (#4452)
- Fix threaded stochastic work-precision isolation (#4462)
- Differentiate wrapped DAEFunctions with chunk size 1, like ODEFunctions (#4464)
- Rebuild MethodOfSteps W after history updates (#4396)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
