### PR TITLE
Release OrdinaryDiffEqDifferentiation 3.11.5

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "3.11.4"
+version = "3.11.5"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 


### PR DESCRIPTION
Bumps `OrdinaryDiffEqDifferentiation` 3.11.4 -> 3.11.5 (patch).

Source files changed since 3.11.4:
- `src/alg_utils.jl`
- `src/derivative_utils.jl`

Commits:
- Fix SciMLBase reexport QA on Julia LTS (#4450)
- Preserve conditioning in OOP no-init solves (#4438)
- Read the test group from GROUP like the CI passes it (#4447)
- Raise root GPU test timeout (#4449)
- Fix default SDE dt vector lengths (#4454)
- Bump DiffEqDevTools to 3.6.2 (#4461)
- DiffEqBase: wrap mass-matrix problems on the finite-difference promote_f path (#4459)
- Preserve the DAE step start during callback interpolation (#4466)
- Release DiffEqBase 7.20.1 (#4474)
- Release OrdinaryDiffEqCore 4.16.1 (#4475)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
