### PR TITLE
[bot-unreviewed] Treat a DAEFunction as having no mass matrix in sparse Jacobian setup

### DIFF
--- a/lib/OrdinaryDiffEqBDF/test/dae_sparse_jacobian_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/dae_sparse_jacobian_tests.jl
@@ -1,0 +1,66 @@
+using OrdinaryDiffEqBDF
+using ADTypes
+using SparseArrays
+import SciMLBase
+using Test
+
+# A `DAEFunction` is fully implicit and therefore has no `mass_matrix` field. The sparse
+# Jacobian setup shared with the ODE solvers used to read `f.mass_matrix` unconditionally,
+# so every fully implicit DAE algorithm errored on a `DAEProblem` carrying a sparse
+# `jac_prototype` (SciML/OrdinaryDiffEq.jl#1966).
+
+# Chain of `N` index-1 subsystems:
+#   x_i' = -x_i + y_i          (differential)
+#   0    =  x_i + y_i - 1      (algebraic)
+# with the closed-form solution x_i(t) = (1 - exp(-2t)) / 2, y_i(t) = 1 - x_i(t).
+const N = 8
+
+function dae_chain!(res, du, u, p, t)
+    for i in 1:N
+        res[i] = du[i] + u[i] - u[N + i]
+        res[N + i] = u[i] + u[N + i] - 1
+    end
+    return nothing
+end
+
+exact(t) = vcat(fill((1 - exp(-2t)) / 2, N), fill(1 - (1 - exp(-2t)) / 2, N))
+
+const u0 = vcat(zeros(N), ones(N))
+const du0 = vcat(ones(N), zeros(N))
+const differential_vars = vcat(trues(N), falses(N))
+const tspan = (0.0, 1.0)
+
+# Structural pattern of dF/du + γ dF/d(du).
+function chain_jac_prototype()
+    rows, cols = Int[], Int[]
+    for i in 1:N
+        append!(rows, (i, i, N + i, N + i))
+        append!(cols, (i, N + i, i, N + i))
+    end
+    return sparse(rows, cols, ones(length(rows)), 2N, 2N)
+end
+
+sparse_prob() = DAEProblem(
+    DAEFunction(dae_chain!; jac_prototype = chain_jac_prototype()),
+    du0, u0, tspan; differential_vars
+)
+dense_prob() = DAEProblem(dae_chain!, du0, u0, tspan; differential_vars)
+
+# `atol` is per-algorithm because the family spans orders: `DImplicitEuler` is first
+# order, so it cannot reach the accuracy the adaptive-order `DFBDF` does on this span.
+const CASES = (
+    ("DFBDF", DFBDF(), 1.0e-6),
+    ("DFBDF, AutoFiniteDiff", DFBDF(autodiff = AutoFiniteDiff()), 1.0e-6),
+    ("DImplicitEuler", DImplicitEuler(), 1.0e-5),
+    ("DABDF2", DABDF2(), 1.0e-6),
+)
+
+@testset "$name with sparse jac_prototype" for (name, alg, atol) in CASES
+    sparse_sol = solve(sparse_prob(), alg; abstol = 1.0e-10, reltol = 1.0e-10)
+    @test SciMLBase.successful_retcode(sparse_sol)
+    @test maximum(maximum(abs, s .- exact(t)) for (s, t) in zip(sparse_sol.u, sparse_sol.t)) < atol
+
+    # Declaring the sparsity must not change the trajectory the dense path produces.
+    dense_sol = solve(dense_prob(), alg; abstol = 1.0e-10, reltol = 1.0e-10)
+    @test sparse_sol(tspan[2]) ≈ dense_sol(tspan[2]) rtol = 1.0e-8
+end

--- a/lib/OrdinaryDiffEqBDF/test/runtests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/runtests.jl
@@ -27,6 +27,7 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "DAE derivative_discontinuity! Tests" include("dae_derivative_discontinuity_tests.jl")
     @time @safetestset "DAE Initialization Tests" include("dae_initialization_tests.jl")
     @time @safetestset "DAE Nonlinear Solve Path Tests" include("dae_nlsolve_path_tests.jl")
+    @time @safetestset "DAE Sparse Jacobian Tests" include("dae_sparse_jacobian_tests.jl")
 
     @time @safetestset "BDF Inference Tests" include("inference_tests.jl")
     @time @safetestset "BDF Convergence Tests" include("bdf_convergence_tests.jl")

--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "3.11.5"
+version = "3.11.6"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 

--- a/lib/OrdinaryDiffEqDifferentiation/src/OrdinaryDiffEqDifferentiation.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/OrdinaryDiffEqDifferentiation.jl
@@ -66,6 +66,16 @@ is_sparse_csc(::Any) = false
 concrete_mass_matrix(mm) = mm
 concrete_mass_matrix(mm::AbstractSciMLOperator) = convert(AbstractMatrix, mm)
 
+"""
+    mass_matrix_or_I(f)
+
+The mass matrix of `f`, or `I` for a function type that has none. `DAEFunction` is fully
+implicit — its residual already contains the `du` coefficients — so it carries no
+`mass_matrix` field, and the sparsity-seeding code below must treat it the same way it
+treats an ODE whose mass matrix is the identity.
+"""
+mass_matrix_or_I(f) = hasfield(typeof(f), :mass_matrix) ? f.mass_matrix : I
+
 # These will error if called without the extension, but should never be called
 # on non-sparse types due to the is_sparse checks
 function nonzeros end

--- a/lib/OrdinaryDiffEqDifferentiation/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/alg_utils.jl
@@ -122,7 +122,9 @@ function prepare_user_sparsity(ad_alg, prob)
 
     if !isnothing(sparsity) && !(ad_alg isa AutoSparse)
         if is_sparse_csc(sparsity) && !SciMLBase.has_jac(prob.f)
-            if prob.f.mass_matrix isa UniformScaling
+            mass_matrix = mass_matrix_or_I(prob.f)
+
+            if mass_matrix isa UniformScaling
                 idxs = diagind(sparsity)
                 @. @view(sparsity[idxs]) = 1
 
@@ -130,7 +132,7 @@ function prepare_user_sparsity(ad_alg, prob)
                     @. @view(jac_prototype[idxs]) = 1
                 end
             else
-                mm = concrete_mass_matrix(prob.f.mass_matrix)
+                mm = concrete_mass_matrix(mass_matrix)
                 idxs = findall(!iszero, mm)
                 for idx in idxs
                     sparsity[idx] = mm[idx]

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_wrappers.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_wrappers.jl
@@ -291,11 +291,13 @@ function build_jac_config(
         jac_prototype = f.jac_prototype
 
         if is_sparse_csc(jac_prototype)
-            if f.mass_matrix isa UniformScaling
+            mass_matrix = mass_matrix_or_I(f)
+
+            if mass_matrix isa UniformScaling
                 idxs = diagind(jac_prototype)
                 @. @view(jac_prototype[idxs]) = 1
             else
-                mm = concrete_mass_matrix(f.mass_matrix)
+                mm = concrete_mass_matrix(mass_matrix)
                 idxs = findall(!iszero, mm)
                 @. @view(jac_prototype[idxs]) = @view(mm[idxs])
             end
@@ -477,11 +479,13 @@ function sparsity_colorvec(f::F, x) where {F}
     sparsity = f.sparsity
 
     if is_sparse_csc(sparsity)
-        if f.mass_matrix isa UniformScaling
+        mass_matrix = mass_matrix_or_I(f)
+
+        if mass_matrix isa UniformScaling
             idxs = diagind(sparsity)
             @. @view(sparsity[idxs]) = 1
         else
-            mm = concrete_mass_matrix(f.mass_matrix)
+            mm = concrete_mass_matrix(mass_matrix)
             idxs = findall(!iszero, mm)
             @. @view(sparsity[idxs]) = @view(mm[idxs])
         end

--- a/lib/OrdinaryDiffEqDifferentiation/test/prepare_user_sparsity_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/prepare_user_sparsity_tests.jl
@@ -85,3 +85,19 @@ end
     @test prob.f.sparsity === Jop
     @test OrdinaryDiffEqDifferentiation.prepare_user_sparsity(ad_alg, prob) === ad_alg
 end
+
+# A `DAEFunction` is fully implicit and has no `mass_matrix` field at all; the seeding must
+# treat it like an identity mass matrix rather than reaching for the missing field
+# (SciML/OrdinaryDiffEq.jl#1966).
+@testset "DAEFunction has no mass matrix" begin
+    dae_f!(res, du, u, p, t) = (res .= du .- u; nothing)
+    jac_prototype = sparse([0.0 1.0; 1.0 0.0])
+    daef = DAEFunction(dae_f!; jac_prototype)
+    prob = DAEProblem(daef, ones(2), ones(2), (0.0, 1.0))
+
+    prepped = OrdinaryDiffEqDifferentiation.prepare_user_sparsity(ad_alg, prob)
+    @test prepped isa ADTypes.AutoSparse
+    # `DAEFunction` aliases `sparsity` to `jac_prototype`, so both gain the diagonal that
+    # the `du` coefficients of the residual contribute.
+    @test Matrix(prob.f.jac_prototype) == [1.0 1.0; 1.0 1.0]
+end


### PR DESCRIPTION
> 🚧 **UNREVIEWED — awaiting review by @ChrisRackauckas.** Opened by an AI agent running as @chrisrackauckas; Chris has not seen this change. Please ignore it until he has reviewed it.
> Harness: Claude Code 2.1.260 · Model: claude-opus-5[1m]
> Conversation: https://claude.ai/code/session_01UBTNFZ4A8Ciw27TmVHkpRD
> Triage accordingly: the analysis and the patch below were machine-generated and may be wrong or incomplete. Do not read this as Chris's own assessment.

Fixes https://github.com/SciML/OrdinaryDiffEq.jl/issues/1966.

## What changed and why

A `DAEFunction` is fully implicit — the residual already contains the `du` coefficients — so it has no `mass_matrix` field. Three sparsity-seeding sites shared with the ODE solvers read `f.mass_matrix` unconditionally, so **every** fully implicit DAE algorithm (`DFBDF`, `DImplicitEuler`, `DABDF2`, any `autodiff`) errors out before taking a step on any `DAEProblem` whose `DAEFunction` carries a sparse `jac_prototype`:

```
FieldError: type DAEFunction has no field `mass_matrix`
```

This adds `mass_matrix_or_I(f)`, which falls back to `I` for a function type that has no such field, and routes all three sites through it. A DAE then takes exactly the branch an ODE with an identity mass matrix takes: the diagonal is seeded into the pattern. That is the right seeding for a DAE too — for the usual `res[i] = du[i] - rhs_i(u)` residual form the diagonal is precisely the structural contribution of `∂F/∂(du)`, and any extra structural nonzero is a safe over-approximation for a coloring-based Jacobian.

The three sites, all load-bearing (each was verified to be the *next* failure once the previous one was fixed):

| file | function | reached by |
|---|---|---|
| `lib/OrdinaryDiffEqDifferentiation/src/alg_utils.jl:125` | `prepare_user_sparsity` | every DAE alg, in `prepare_alg`, before `init` |
| `lib/OrdinaryDiffEqDifferentiation/src/derivative_wrappers.jl:294` | `build_jac_config` | every DAE alg (this is the site in #1966's 2023 stack trace) |
| `lib/OrdinaryDiffEqDifferentiation/src/derivative_wrappers.jl:482` | `sparsity_colorvec` | the `AutoFiniteDiff` DAE path |

**Scope, measured on the reproducer below.** `DFBDF`, `DImplicitEuler` and `DABDF2` all fail identically, under `AutoForwardDiff` and `AutoFiniteDiff` alike, and under `NoInit`, `CheckInit`, `ShampineCollocationInit` and `BrownFullBasicInit` alike — the failure is in `prepare_alg`, before `init`, so the initialization algorithm never enters into it. Everything I ran — `DFBDF`/`DImplicitEuler`/`DABDF2`, `DFBDF` with `AutoFiniteDiff`, and each of the four initialization algorithms under `DFBDF` — errors before the fix and solves after it. A dense `jac_prototype` was never affected (the seeding is gated on `is_sparse_csc`), and `Sundials.IDA()` solves the same problem, so the problem itself is well posed.

Note `prepare_alg` two lines above the first site already guards this exact hazard ad hoc with `!(prob.f isa DAEFunction) && prob.f.mass_matrix isa MatrixOperator`, so the `DAEFunction`-has-no-mass-matrix case was known there but missed in the seeding helpers.

**Not a regression.** `git log -S "if f.mass_matrix isa UniformScaling"` puts the read in `build_jac_config` at 2be61a07f (2022-12-24, "Handle sparsity patterns which are specified as missing some diagonal"), first released in OrdinaryDiffEq v6.36.0; #1966 reported the resulting failure in June 2023 and it has been broken ever since. The copy in `prepare_user_sparsity` arrived later with the sparsity-prep refactor (#2662). I could **not** confirm this by running a historical release: OrdinaryDiffEq v6.35.1 and v6.36.0 no longer precompile against today's registry state on either Julia 1.10 or 1.12 (`UndefVarError: AbstractDiffEqLinearOperator` from a too-new SciMLBase), so the dating is from git history plus the age of #1966, not from a bisect.

## Reproducer

```julia
using OrdinaryDiffEqBDF, SparseArrays

function f!(res, du, u, p, t)
    res[1] = du[1] + u[1] - u[2]
    res[2] = u[1] + u[2] - 1
end

fun = DAEFunction(f!; jac_prototype = sparse([1.0 1.0; 1.0 1.0]))
prob = DAEProblem(fun, [1.0, 0.0], [0.0, 1.0], (0.0, 1.0);
                  differential_vars = [true, false])
solve(prob, DFBDF())
```

On OrdinaryDiffEqBDF v2.4.6 / OrdinaryDiffEqDifferentiation v3.11.5 / SciMLBase v3.53.0, Julia 1.12.6:

```
ERROR: FieldError: type DAEFunction has no field `mass_matrix`, available fields: `f`, `analytic`, ...
Stacktrace:
  [1] getproperty(x::DAEFunction{...}, sym::Symbol)
    @ SciMLBase ~/.julia/packages/SciMLBase/yNavo/src/scimlfunctions.jl:6079
  [2] prepare_user_sparsity(ad_alg::AutoForwardDiff{...}, prob::DAEProblem{...})
    @ OrdinaryDiffEqDifferentiation ~/.julia/packages/OrdinaryDiffEqDifferentiation/Bkesc/src/alg_utils.jl:126
  [3] prepare_alg(alg::DFBDF{...}, u0::Vector{Float64}, p::NullParameters, prob::DAEProblem{...})
    @ OrdinaryDiffEqDifferentiation ~/.julia/packages/OrdinaryDiffEqDifferentiation/Bkesc/src/alg_utils.jl:42
  [4] solve_up(...)  @ DiffEqBase
```

Removing the `jac_prototype` (or making it dense) makes the same problem solve, and `Sundials.IDA()` solves it too — the problem itself is fine.

## Tests

`lib/OrdinaryDiffEqBDF/test/dae_sparse_jacobian_tests.jl` (new, wired into `runtests.jl`'s Core group) solves an 8-subsystem index-1 chain DAE with a sparse `jac_prototype` under `DFBDF`, `DFBDF(autodiff = AutoFiniteDiff())`, `DImplicitEuler` and `DABDF2`, checking both accuracy against the closed-form solution and agreement with the same problem solved without a `jac_prototype`. `lib/OrdinaryDiffEqDifferentiation/test/prepare_user_sparsity_tests.jl` gains a unit test with a `jac_prototype` that has *no* stored diagonal, which is the case the mass-matrix seeding exists for.

### Before the fix (source reverted, tests kept)

```
Test Summary:                                                    | Pass  Error  Total   Time
prepare_user_sparsity                                            |   11      1     12  24.5s
  MatrixOperator mass matrix                                     |    2             2   2.6s
  UniformScaling mass matrix (unchanged path)                    |    2             2   0.4s
  Plain sparse mass matrix (unchanged path)                      |    2             2   0.3s
  DiagonalOperator mass matrix                                   |    2             2   0.6s
  MatrixOperator mass matrix, sparsity defaulted                 |    1             1   0.4s
  Matrix-free FunctionOperator jac_prototype skips sparsity prep |    2             2   0.7s
  DAEFunction has no mass matrix                                 |           1      1   3.3s
```
```
Test Summary:                                     | Error  Total     Time
dae sparse jacobian                               |     4      4  2m51.6s
  DFBDF with sparse jac_prototype                 |     1      1     5.1s
  DFBDF, AutoFiniteDiff with sparse jac_prototype |     1      1     0.3s
  DImplicitEuler with sparse jac_prototype        |     1      1     0.2s
  DABDF2 with sparse jac_prototype                |     1      1     0.2s
```
Every error is `FieldError: type DAEFunction has no field `mass_matrix``.

### After the fix

```
Test Summary:         | Pass  Total  Time
prepare_user_sparsity |   13     13  8.5s

Test Summary:       | Pass  Total     Time
dae sparse jacobian |   12     12  1m31.4s
```

### Full suites, on this branch (Julia 1.12.6, aarch64 Linux)

`GROUP=Core Pkg.test("OrdinaryDiffEqBDF")` — `Testing OrdinaryDiffEqBDF tests passed`:

```
DAE Convergence Tests               |   50     50   5m07.5s
DAE AD Tests                        |   40     40  24m19.2s
DAE Event Tests                     |    4      4     41.7s
DAE derivative_discontinuity! Tests |   11     11   1m05.4s
DAE Initialization Tests            |   38  (+2 pre-existing broken)  2m21.9s
DAE Nonlinear Solve Path Tests      |   16     16   1m00.3s
DAE Sparse Jacobian Tests           |   12     12   2m55.8s   <-- new
BDF Inference Tests                 |    1      1      3.8s
BDF Convergence Tests               |   84     84   7m41.9s
BDF Regression Tests                |   35     35   6m43.7s
Nordsieck BDF Tests                 |  101    101   7m02.9s
LHL Factorization Tests             |   19     19   1m39.7s
```

`GROUP=Core Pkg.test("OrdinaryDiffEqDifferentiation")` — `Testing OrdinaryDiffEqDifferentiation tests passed`, all 16 testsets green, including `prepare_user_sparsity mass matrix | 13 13` (was 11 + 1 error).

`GROUP=QA` passes for both: OrdinaryDiffEqBDF `Allocation 2/20 + 18 broken`, `JET 18/41 + 23 broken`, `Aqua 21/21`; OrdinaryDiffEqDifferentiation `JET 1/1`, `Aqua 19/19`. The broken counts are pre-existing `@test_broken`s, not introduced here.

Runic and `typos` are clean on all six changed files.


## What I did not verify

- No ModelingToolkit-generated `DAEProblem` was exercised end to end; the reproducer and the tests are hand-written `DAEFunction`s.
- No GPU path, no downstream package.
- Only aarch64 Linux, Julia 1.12.6.
- No historical bisect (see above) — the "first broken in v6.36.0" claim is from `git log -S`, not from running that release.
- `Sundials.IDA(linear_solver = :KLU)` on the reproducer fails inside Sundials with `No Jacobian constructor available for SUNMatrix type` when a sparse `jac_prototype` is given without an analytic `jac`. That is a separate Sundials-side matter and is not touched here; plain `IDA()` solves the problem.

## What a reviewer should push back on

- Seeding the diagonal for a `DAEFunction` (rather than skipping the mass-matrix seeding entirely for DAEs) is a judgement call. It is safe — extra structural nonzeros only cost coloring efficiency — and it covers the common `res[i] = du[i] - rhs_i(u)` form where `∂F/∂(du)` is diagonal on the differential variables. If the intent is that a user's DAE `jac_prototype` must already be the complete pattern of `∂F/∂u + γ ∂F/∂(du)`, the seeding could be dropped for DAEs instead.
- `prepare_alg`'s existing `!(prob.f isa DAEFunction) && ...` guard was deliberately left alone to keep the diff focused; it could be folded into `mass_matrix_or_I` in a follow-up.

---
🤖 Posted by an AI agent — harness: Claude Code 2.1.260 · model: claude-opus-5[1m]
Conversation: https://claude.ai/code/session_01UBTNFZ4A8Ciw27TmVHkpRD
