### PR TITLE
Add Friedli Exponential Runge-Kutta solver

### DIFF
--- a/docs/src/semiimplicit/ExponentialRK.md
+++ b/docs/src/semiimplicit/ExponentialRK.md
@@ -47,6 +47,7 @@ For problems `du/dt = Au + f(u,t)`, exponential methods compute the exact soluti
 ### High-order specialized methods
 
   - **`HochOst4`**: Fourth-order exponential RK with enhanced stability
+  - **`Friedli`**: Fourth-order (stiff order 3) exponential RK scheme
   - **`Exp4`**: Fourth-order EPIRK scheme
 
 ### Adaptive exponential Rosenbrock
@@ -107,6 +108,7 @@ ETDRK2
 ETDRK3
 ETDRK4
 HochOst4
+Friedli
 ```
 
 ### Adaptive Exponential Rosenbrock Methods

--- a/docs/src/semilinear/ExponentialRK.md
+++ b/docs/src/semilinear/ExponentialRK.md
@@ -44,4 +44,5 @@ ETDRK2
 ETDRK3
 ETDRK4
 HochOst4
+Friedli
 ```

--- a/lib/OrdinaryDiffEqExponentialRK/README.md
+++ b/lib/OrdinaryDiffEqExponentialRK/README.md
@@ -16,6 +16,7 @@ While completely independent and usable on its own, users wanting the full ODE s
 - `ETDRK3`
 - `ETDRK4`
 - `HochOst4`
+- `Friedli`
 - `Exp4`
 - `EPIRK4s3A`
 - `EPIRK5s3`

--- a/lib/OrdinaryDiffEqExponentialRK/src/OrdinaryDiffEqExponentialRK.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/OrdinaryDiffEqExponentialRK.jl
@@ -37,7 +37,7 @@ include("alg_utils.jl")
 include("exponential_rk_caches.jl")
 include("exponential_rk_perform_step.jl")
 
-export LawsonEuler, NorsettEuler, ETD1, ETDRK2, ETDRK3, ETDRK4, HochOst4, Exp4, EPIRK4s3A,
+export LawsonEuler, NorsettEuler, ETD1, ETDRK2, ETDRK3, ETDRK4, HochOst4, Friedli, Exp4, EPIRK4s3A,
     EPIRK4s3B,
     EPIRK5s3, EXPRB53s3, EPIRK5P1, EPIRK5P2, ETD2, Exprb32, Exprb43
 end

--- a/lib/OrdinaryDiffEqExponentialRK/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/alg_utils.jl
@@ -1,6 +1,6 @@
 function isdtchangeable(
         alg::Union{
-            LawsonEuler, NorsettEuler, ETDRK2, ETDRK3, ETDRK4, HochOst4, ETD2,
+            LawsonEuler, NorsettEuler, ETDRK2, ETDRK3, ETDRK4, HochOst4, ETD2, Friedli,
         }
     )
     return false
@@ -12,6 +12,7 @@ alg_order(alg::ETDRK2) = 2
 alg_order(alg::ETDRK3) = 3
 alg_order(alg::ETDRK4) = 4
 alg_order(alg::HochOst4) = 4
+alg_order(alg::Friedli) = 4
 alg_order(alg::Exp4) = 4
 alg_order(alg::EPIRK4s3A) = 4
 alg_order(alg::EPIRK4s3B) = 4

--- a/lib/OrdinaryDiffEqExponentialRK/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/algorithms.jl
@@ -25,6 +25,7 @@ for (Alg, Description, Ref) in [
         (:ETDRK3, "3rd order exponential-RK scheme.", REF1),
         (:ETDRK4, "4th order exponential-RK scheme (fixed timestepping)", REF1),
         (:HochOst4, "4th order exponential-RK scheme with stiff order 4.", REF1),
+        (:Friedli, "4th order (stiff order 3) exponential-RK scheme.", REF1),
     ]
     @eval begin
         @doc generic_solver_docstring(

--- a/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_caches.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_caches.jl
@@ -60,6 +60,20 @@ function expRK_operators(::HochOst4, dt, A)
     B5 = 4P[3] - 8P[4]
     return A21, A31, A32, A41, A42, A51, A52, A54, B1, B4, B5
 end
+function expRK_operators(::Friedli, dt, A)
+    P = phi(dt * A, 3)
+    Phalf = phi(dt / 2 * A, 2)
+    A21 = 0.5 * Phalf[2]
+    A31 = A21 - 0.5 * Phalf[3]
+    A32 = 0.5 * Phalf[3]
+    A41 = P[2] - 2 * P[3]
+    A42 = (-26 // 25) * P[2] + (2 // 25) * P[3]
+    A43 = (26 // 25) * P[2] + (48 // 25) * P[3]
+    B1 = P[2] - 3 * P[3] + 4 * P[4]
+    B3 = 4 * P[3] - 8 * P[4]
+    B4 = -P[3] + 4 * P[4]
+    return A21, A31, A32, A41, A42, A43, B1, B3, B4
+end
 
 # Unified constructor for constant caches
 for (Alg, Cache) in [
@@ -69,6 +83,7 @@ for (Alg, Cache) in [
         (:ETDRK3, :ETDRK3ConstantCache),
         (:ETDRK4, :ETDRK4ConstantCache),
         (:HochOst4, :HochOst4ConstantCache),
+        (:Friedli, :FriedliConstantCache),
     ]
     @eval struct $Cache{opType, FType} <: ExpRKConstantCache
         ops::opType # precomputed operators
@@ -395,6 +410,48 @@ function alg_cache(
     ) # other caches
     return HochOst4Cache(
         u, uprev, tmp, dz, rtmp, rtmp2, Au, F2, F3, F4, F5, du1, jac_config, uf,
+        J, ops, KsCache
+    )
+end
+
+@cache struct FriedliCache{uType, rateType, JCType, FType, JType, opType, KsType} <:
+    ExpRKCache
+    u::uType
+    uprev::uType
+    tmp::uType
+    dz::uType
+    rtmp::rateType
+    rtmp2::rateType
+    Au::rateType
+    F2::rateType
+    F3::rateType
+    F4::rateType
+    du1::rateType
+    jac_config::JCType
+    uf::FType
+    J::JType
+    ops::opType
+    KsCache::KsType
+end
+
+function alg_cache(
+        alg::Friedli, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{true}, verbose
+    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    tmp, dz = (zero(u) for i in 1:2)                                        # uType caches
+    rtmp, rtmp2, Au, F2, F3, F4, du1 = (zero(rate_prototype) for i in 1:7) # rateType caches
+    plist = (2, 2, 3, 2, 3, 3)
+    uf, jac_config,
+        J,
+        ops,
+        KsCache = alg_cache_expRK(
+        alg, u, uEltypeNoUnits, uprev, f, t,
+        dt, p, du1, tmp, dz, plist
+    ) # other caches
+    return FriedliCache(
+        u, uprev, tmp, dz, rtmp, rtmp2, Au, F2, F3, F4, du1, jac_config, uf,
         J, ops, KsCache
     )
 end

--- a/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_perform_step.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_perform_step.jl
@@ -749,6 +749,171 @@ function perform_step!(integrator, cache::HochOst4Cache, repeat_step = false)
     # integrator.k is automatically set due to aliasing
 end
 
+function perform_step!(integrator, cache::FriedliConstantCache, repeat_step = false)
+    (; t, dt, uprev, f, p) = integrator
+    A = isa(f, SplitFunction) ? f.f1.f : calc_J(integrator, cache) # get linear operator
+    alg = unwrap_alg(integrator, true)
+
+    Au = A * uprev
+    F1 = integrator.fsalfirst
+    halfdt = dt / 2
+    if alg.krylov
+        kwargs = (
+            m = min(alg.m, size(A, 1)), opnorm = integrator.opts.internalopnorm,
+            iop = alg.iop,
+        )
+        # Krylov on F1 (first column)
+        Ks = arnoldi(A, F1; kwargs...)
+        w1_half = phiv(halfdt, Ks, 2)
+        w1 = phiv(dt, Ks, 3)
+        U2 = uprev + halfdt * w1_half[:, 2]
+        F2 = _compute_nl(f, U2, p, t + halfdt, A) + Au
+        # Krylov on F2 (second column)
+        Ks = arnoldi(A, F2; kwargs...)
+        w2_half = phiv(halfdt, Ks, 2)
+        w2 = phiv(dt, Ks, 2)
+        U3 = uprev + halfdt * (w1_half[:, 2] - w1_half[:, 3] + w2_half[:, 3])
+        F3 = _compute_nl(f, U3, p, t + halfdt, A) + Au
+        # Krylov on F3 (third column)
+        w3 = phiv(dt, A, F3, 3; kwargs...)
+        U4 = uprev +
+            dt * (
+            w1[:, 2] - 2w1[:, 3] - (26 // 25) * w2[:, 2] + (2 // 25) * w2[:, 3] +
+                (26 // 25) * w3[:, 2] + (48 // 25) * w3[:, 3]
+        )
+        F4 = _compute_nl(f, U4, p, t + dt, A) + Au
+        if isa(f, SplitFunction)
+            integrator.stats.nf2 += 3
+        else
+            OrdinaryDiffEqCore.increment_nf!(integrator.stats, 3)
+        end
+        # Krylov on F4 (fourth column)
+        w4 = phiv(dt, A, F4, 3; kwargs...)
+        # update u
+        u = uprev +
+            dt * (
+            w1[:, 2] - 3w1[:, 3] + 4w1[:, 4] + 4w3[:, 3] - 8w3[:, 4] - w4[:, 3] +
+                4w4[:, 4]
+        )
+    else
+        A21, A31, A32, A41, A42, A43, B1, B3, B4 = cache.ops
+        # stage 1 (fsaled)
+        # stage 2
+        U2 = uprev + dt * (A21 * F1)
+        F2 = f.f2(U2, p, t + halfdt) + Au
+        # stage 3
+        U3 = uprev + dt * (A31 * F1 + A32 * F2)
+        F3 = f.f2(U3, p, t + halfdt) + Au
+        # stage 4
+        U4 = uprev + dt * (A41 * F1 + A42 * F2 + A43 * F3)
+        F4 = f.f2(U4, p, t + dt) + Au
+        integrator.stats.nf2 += 3
+        # update u
+        u = uprev + dt * (B1 * F1 + B3 * F3 + B4 * F4)
+    end
+
+    # Update integrator state
+    integrator.fsallast = f(u, p, t + dt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    integrator.k[1] = integrator.fsalfirst
+    integrator.k[2] = integrator.fsallast
+    return integrator.u = u
+end
+
+function perform_step!(integrator, cache::FriedliCache, repeat_step = false)
+    (; t, dt, uprev, u, f, p) = integrator
+    (; tmp, rtmp, rtmp2, Au, F2, F3, F4, J, KsCache) = cache
+    A = isa(f, SplitFunction) ? f.f1.f : (calc_J!(J, integrator, cache); J) # get linear operator
+    alg = unwrap_alg(integrator, true)
+
+    F1 = integrator.fsalfirst
+    mul!(Au, A, uprev)
+    halfdt = dt / 2
+    if alg.krylov
+        Ks, phiv_cache, ws = KsCache
+        w1_half, w2_half, w1, w2, w3, w4 = ws
+        kwargs = (
+            m = min(alg.m, size(A, 1)), opnorm = integrator.opts.internalopnorm,
+            iop = alg.iop,
+        )
+        # Krylov on F1 (first column)
+        arnoldi!(Ks, A, F1; kwargs...)
+        phiv!(w1_half, halfdt, Ks, 2; cache = phiv_cache)
+        phiv!(w1, dt, Ks, 3; cache = phiv_cache)
+        @muladd @.. broadcast = false @views tmp = uprev + halfdt * w1_half[:, 2] # tmp is U2
+        _compute_nl!(F2, f, tmp, p, t + halfdt, A, rtmp)
+        F2 .+= Au
+        # Krylov on F2 (second column)
+        arnoldi!(Ks, A, F2; kwargs...)
+        phiv!(w2_half, halfdt, Ks, 2; cache = phiv_cache)
+        phiv!(w2, dt, Ks, 2; cache = phiv_cache)
+        @muladd @.. broadcast = false @views tmp = uprev +
+            halfdt * (w1_half[:, 2] - w1_half[:, 3] + w2_half[:, 3]) # tmp is U3
+        _compute_nl!(F3, f, tmp, p, t + halfdt, A, rtmp)
+        F3 .+= Au
+        # Krylov on F3 (third column)
+        arnoldi!(Ks, A, F3; kwargs...)
+        phiv!(w3, dt, Ks, 3; cache = phiv_cache)
+        @muladd @.. broadcast = false @views tmp = uprev +
+            dt * (
+            w1[:, 2] - 2w1[:, 3] - (26 // 25) * w2[:, 2] + (2 // 25) * w2[:, 3] +
+                (26 // 25) * w3[:, 2] + (48 // 25) * w3[:, 3]
+        ) # tmp is U4
+        _compute_nl!(F4, f, tmp, p, t + dt, A, rtmp)
+        F4 .+= Au
+        if isa(f, SplitFunction)
+            integrator.stats.nf2 += 3
+        else
+            OrdinaryDiffEqCore.increment_nf!(integrator.stats, 3)
+        end
+        # Krylov on F4 (fourth column)
+        arnoldi!(Ks, A, F4; kwargs...)
+        phiv!(w4, dt, Ks, 3; cache = phiv_cache)
+        # update u
+        @muladd @.. broadcast = false @views rtmp = w1[:, 2] - 3w1[:, 3] + 4w1[:, 4] +
+            4w3[:, 3] - 8w3[:, 4] - w4[:, 3] +
+            4w4[:, 4]
+        @muladd @.. broadcast = false u = uprev + dt * rtmp
+    else
+        A21, A31, A32, A41, A42, A43, B1, B3, B4 = cache.ops
+        # stage 1 (fsaled)
+        # stage 2
+        mul!(rtmp, A21, F1)
+        @muladd @.. broadcast = false tmp = uprev + dt * rtmp # tmp is U2
+        f.f2(F2, tmp, p, t + halfdt)
+        F2 .+= Au
+        # stage 3
+        mul!(rtmp, A31, F1)
+        mul!(rtmp2, A32, F2)
+        rtmp .+= rtmp2
+        @muladd @.. broadcast = false tmp = uprev + dt * rtmp # tmp is U3
+        f.f2(F3, tmp, p, t + halfdt)
+        F3 .+= Au
+        # stage 4
+        mul!(rtmp, A41, F1)
+        mul!(rtmp2, A42, F2)
+        rtmp .+= rtmp2
+        mul!(rtmp2, A43, F3)
+        rtmp .+= rtmp2
+        @muladd @.. broadcast = false tmp = uprev + dt * rtmp # tmp is U4
+        f.f2(F4, tmp, p, t + dt)
+        F4 .+= Au
+        integrator.stats.nf2 += 3
+        # update u
+        mul!(rtmp, B1, F1)
+        mul!(rtmp2, B3, F3)
+        rtmp .+= rtmp2
+        mul!(rtmp2, B4, F4)
+        rtmp .+= rtmp2
+        @muladd @.. broadcast = false u = uprev + dt * rtmp
+    end
+
+    # Update integrator state
+    f(integrator.fsallast, u, p, t + dt)
+    return OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    # integrator.k is automatically set due to aliasing
+end
+
 #############################################
 # EPIRK integrators
 function perform_step!(integrator, cache::Exp4ConstantCache, repeat_step = false)

--- a/lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_convergence_tests.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_convergence_tests.jl
@@ -23,6 +23,7 @@ using SciMLOperators: MatrixOperator, ScalarOperator
             ETDRK3,
             ETDRK4,
             HochOst4,
+            Friedli,
             ETD2,
             KenCarp3,
             CFNLIRK3,
@@ -57,6 +58,7 @@ end
             ETDRK3(),
             ETDRK4(),
             HochOst4(),
+            Friedli(),
             ETD2(),
         ]
         sim = test_convergence(dts, prob, Alg)

--- a/lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_krylov_tests.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_krylov_tests.jl
@@ -45,7 +45,7 @@ let N = 20
     @testset "Classical ExpRK - High Order" begin
         dt = 0.05
         tol = 1.0e-5
-        Algs = [ETDRK3, ETDRK4, HochOst4]
+        Algs = [ETDRK3, ETDRK4, HochOst4, Friedli]
         for Alg in Algs
             sol = solve(prob, Alg(krylov = true, m = 20); dt, reltol = tol)
             sol_ref = solve(prob, Tsit5(); reltol = tol)

--- a/lib/OrdinaryDiffEqExponentialRK/test/qa/allocation_tests.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/test/qa/allocation_tests.jl
@@ -27,7 +27,7 @@ using Test
     # Solvers that require SplitODEProblem
     exp_solvers = [
         LawsonEuler(), NorsettEuler(), ETD1(), ETDRK2(), ETDRK3(), ETDRK4(),
-        HochOst4(), ETD2(),
+        HochOst4(), Friedli(), ETD2(),
     ]
 
     # Exprb methods require regular ODEProblem with full function


### PR DESCRIPTION

Implements the 4th-order **Friedli** Exponential Runge-Kutta (ExpRK) method for stiff semilinear problems $\dot{u} = Au + g(t, u)$, based on A. Friedli (1978) (*"Verallgemeinerte Runge-Kutta Verfahren zur Lösung steifer Differentialgleichungssysteme"*).

The implementation follows the established architecture in `OrdinaryDiffEqExponentialRK.jl` (closely mirroring `HochOst4`):

- **Algorithm & Exports**: Defined the `Friedli` algorithm struct in `algorithms.jl`, registered its order (`alg_order = 4`) and dt-changeability in `alg_utils.jl`, and exported `Friedli` in `OrdinaryDiffEqExponentialRK.jl`.
- **Caches**: Added `FriedliCache` (in-place) and `FriedliConstantCache` (out-of-place) in `exponential_rk_caches.jl` with pre-allocated stage buffers and phi-operator operators ($\varphi_1, \varphi_2, \varphi_3$).
- **Integrator Stepping**: Implemented `perform_step!` for both cache types in `exponential_rk_perform_step.jl` supporting both full matrix exponentials and Krylov approximations.
- **Documentation**: Registered `Friedli` in both `semiimplicit/ExponentialRK.md` and `semilinear/ExponentialRK.md`, as well as `lib/OrdinaryDiffEqExponentialRK/README.md`.

## Verification

- **Convergence tests**: Added `Friedli` to `linear_nonlinear_convergence_tests.jl`, confirming expected 4th-order convergence rates for both in-place (`iip`) and out-of-place (`oop`) problems.
- **Krylov tests**: Added `Friedli` to `linear_nonlinear_krylov_tests.jl` validating integration with Krylov subspace exponential approximations.
- **Allocation tests**: Added `Friedli` to `qa/allocation_tests.jl` to ensure zero unexpected allocations in hot loops.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

AI disclosure: Assisted by Google Antigravity.