### PR TITLE
Add MOOSE234 embedded BDF method (conflict-resolved #3746)

### DIFF
--- a/lib/OrdinaryDiffEqBDF/src/OrdinaryDiffEqBDF.jl
+++ b/lib/OrdinaryDiffEqBDF/src/OrdinaryDiffEqBDF.jl
@@ -148,6 +148,6 @@ end
 
 export ABDF2, QNDF1, QBDF1, QNDF2, QBDF2, QNDF, QBDF, FBDF,
     SBDF, SBDF2, SBDF3, SBDF4, MEBDF2, IMEXEuler, IMEXEulerARK,
-    DABDF2, DImplicitEuler, DFBDF
+    DABDF2, DImplicitEuler, DFBDF, MOOSE234
 
 end

--- a/lib/OrdinaryDiffEqBDF/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqBDF/src/alg_utils.jl
@@ -46,4 +46,12 @@ alg_order(alg::DFBDF) = 1 #dummy value
 
 isfsal(alg::DImplicitEuler) = false
 
-has_stiff_interpolation(::Union{QNDF, FBDF, DFBDF}) = true
+has_stiff_interpolation(::Union{QNDF, FBDF, DFBDF, MOOSE234}) = true
+
+alg_extrapolates(alg::MOOSE234) = true
+alg_order(alg::MOOSE234) = 2
+isfsal(alg::MOOSE234) = false
+get_current_alg_order(alg::MOOSE234, cache) = cache.order
+get_current_adaptive_order(alg::MOOSE234, cache) = cache.order
+qsteady_min_default(alg::MOOSE234) = 9 // 10
+qsteady_max_default(alg::MOOSE234) = 2 // 1

--- a/lib/OrdinaryDiffEqBDF/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqBDF/src/algorithms.jl
@@ -579,8 +579,8 @@ a single implicit solve per step.",
     step_limiter! = trivial_limiter!,
     """
 )
-struct MOOSE234{CS, AD, F, F2, P, FDT, ST, CJ, StepLimiter} <:
-    OrdinaryDiffEqNewtonAdaptiveAlgorithm{CS, AD, FDT, ST, CJ}
+struct MOOSE234{AD, F, F2, P, StepLimiter, CJ} <:
+    OrdinaryDiffEqNewtonAdaptiveAlgorithm
     linsolve::F
     nlsolve::F2
     precs::P
@@ -588,23 +588,19 @@ struct MOOSE234{CS, AD, F, F2, P, FDT, ST, CJ, StepLimiter} <:
     controller::Symbol
     step_limiter!::StepLimiter
     autodiff::AD
+    concrete_jac::CJ
 end
 
 function MOOSE234(;
-        chunk_size = Val{0}(), autodiff = AutoForwardDiff(), standardtag = Val{true}(),
-        concrete_jac = nothing, diff_type = Val{:forward}(),
+        autodiff = AutoForwardDiff(), concrete_jac = nothing,
         linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
         extrapolant = :linear, controller = :Standard, step_limiter! = trivial_limiter!
     )
-    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
+    autodiff = _fixup_ad(autodiff)
 
-    return MOOSE234{
-        _unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
-        typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
-        _unwrap_val(concrete_jac), typeof(step_limiter!),
-    }(
+    return MOOSE234(
         linsolve, nlsolve, precs, extrapolant,
-        controller, step_limiter!, AD_choice
+        controller, step_limiter!, autodiff, _unwrap_val(concrete_jac),
     )
 end
 

--- a/lib/OrdinaryDiffEqBDF/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqBDF/src/algorithms.jl
@@ -579,11 +579,10 @@ a single implicit solve per step.",
     step_limiter! = trivial_limiter!,
     """
 )
-struct MOOSE234{AD, F, F2, P, StepLimiter, CJ} <:
+struct MOOSE234{AD, F, F2, StepLimiter, CJ} <:
     OrdinaryDiffEqNewtonAdaptiveAlgorithm
     linsolve::F
     nlsolve::F2
-    precs::P
     extrapolant::Symbol
     controller::Symbol
     step_limiter!::StepLimiter
@@ -593,13 +592,13 @@ end
 
 function MOOSE234(;
         autodiff = AutoForwardDiff(), concrete_jac = nothing,
-        linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
+        linsolve = nothing, nlsolve = NLNewton(),
         extrapolant = :linear, controller = :Standard, step_limiter! = trivial_limiter!
     )
     autodiff = _fixup_ad(autodiff)
 
     return MOOSE234(
-        linsolve, nlsolve, precs, extrapolant,
+        linsolve, nlsolve, extrapolant,
         controller, step_limiter!, autodiff, _unwrap_val(concrete_jac),
     )
 end

--- a/lib/OrdinaryDiffEqBDF/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqBDF/src/algorithms.jl
@@ -13,10 +13,10 @@ function BDF_docstring(
         """ * "\n" * extra_keyword_default
 
     keyword_default_description = """
-        - `autodiff`: Uses [ADTypes.jl](https://sciml.github.io/ADTypes.jl/stable/) 
+        - `autodiff`: Uses [ADTypes.jl](https://sciml.github.io/ADTypes.jl/stable/)
             to specify whether to use automatic differentiation via
             [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl) or finite
-            differencing via [FiniteDiff.jl](https://github.com/JuliaDiff/FiniteDiff.jl). 
+            differencing via [FiniteDiff.jl](https://github.com/JuliaDiff/FiniteDiff.jl).
             Defaults to `AutoForwardDiff()` for automatic differentiation, which by default uses
             `chunksize = 0`, and thus uses the internal ForwardDiff.jl algorithm for the choice.
             To use `FiniteDiff.jl`, the `AutoFiniteDiff()` ADType can be used, which has a keyword argument
@@ -552,6 +552,63 @@ function FBDF(;
 end
 
 @truncate_stacktrace FBDF
+
+@doc BDF_docstring(
+    "A variable-stepsize, variable-order (2/3/4) implicit method based on the MOOSE234
+(Multiple Order One Solve Embedded 234) scheme of DeCaria, Guzel, Layton, and Li.
+Performs a single BDF3 nonlinear solve per step, then applies two cheap linear
+time-filter post-processing steps to produce embedded solutions at orders 2 and 4.
+This yields error estimates at three orders, enabling VSVO behavior at the cost of
+a single implicit solve per step.",
+    "MOOSE234",
+    references = """@article{decaria2018variable,
+    title={A variable stepsize, variable order family of low complexity},
+    author={DeCaria, Victor and Guzel, Abigail and Layton, William and Li, Yanghong},
+    journal={arXiv preprint arXiv:1810.06670},
+    year={2018}}""",
+    extra_keyword_description = """
+    - `nlsolve`: TBD
+    - `extrapolant`: TBD
+    - `controller`: TBD
+    - `step_limiter!`: function of the form `limiter!(u, integrator, p, t)`
+    """,
+    extra_keyword_default = """
+    nlsolve = NLNewton(),
+    extrapolant = :linear,
+    controller = :Standard,
+    step_limiter! = trivial_limiter!,
+    """
+)
+struct MOOSE234{CS, AD, F, F2, P, FDT, ST, CJ, StepLimiter} <:
+    OrdinaryDiffEqNewtonAdaptiveAlgorithm{CS, AD, FDT, ST, CJ}
+    linsolve::F
+    nlsolve::F2
+    precs::P
+    extrapolant::Symbol
+    controller::Symbol
+    step_limiter!::StepLimiter
+    autodiff::AD
+end
+
+function MOOSE234(;
+        chunk_size = Val{0}(), autodiff = AutoForwardDiff(), standardtag = Val{true}(),
+        concrete_jac = nothing, diff_type = Val{:forward}(),
+        linsolve = nothing, precs = DEFAULT_PRECS, nlsolve = NLNewton(),
+        extrapolant = :linear, controller = :Standard, step_limiter! = trivial_limiter!
+    )
+    AD_choice, chunk_size, diff_type = _process_AD_choice(autodiff, chunk_size, diff_type)
+
+    return MOOSE234{
+        _unwrap_val(chunk_size), typeof(AD_choice), typeof(linsolve),
+        typeof(nlsolve), typeof(precs), diff_type, _unwrap_val(standardtag),
+        _unwrap_val(concrete_jac), typeof(step_limiter!),
+    }(
+        linsolve, nlsolve, precs, extrapolant,
+        controller, step_limiter!, AD_choice
+    )
+end
+
+@truncate_stacktrace MOOSE234
 
 """
 QBDF1: Multistep Method

--- a/lib/OrdinaryDiffEqBDF/src/bdf_caches.jl
+++ b/lib/OrdinaryDiffEqBDF/src/bdf_caches.jl
@@ -798,3 +798,164 @@ function alg_cache(
         iters_from_event, dense, alg.step_limiter!, fd_weights, stald
     )
 end
+
+# MOOSE234 — Variable-stepsize, variable-order (2/3/4) embedded method
+# DeCaria et al., arXiv:1810.06670v1
+
+@cache mutable struct MOOSE234ConstantCache{
+        N, tsType, tType, uType, uuType,
+        EEstType, rType, wType,
+    } <:
+    OrdinaryDiffEqConstantCache
+    nlsolver::N
+    ts::tsType
+    ts_tmp::tsType
+    t_old::tType
+    u_history::uuType
+    order::Int
+    prev_order::Int
+    u_corrector::uType
+    nconsteps::Int
+    consfailcnt::Int
+    qwait::Int
+    terkm1::EEstType
+    terk::EEstType
+    terkp1::EEstType
+    r::rType
+    weights::wType
+    iters_from_event::Int
+end
+
+function alg_cache(
+        alg::MOOSE234, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{false}, verbose
+    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    γ, c = Int64(1) // 1, 1
+    nlsolver = build_nlsolver(
+        alg, u, uprev, p, t, dt, f, rate_prototype, uEltypeNoUnits,
+        uBottomEltypeNoUnits, tTypeNoUnits, γ, c, Val(false), verbose
+    )
+
+    hist_size = 6 # max_order(4) + 2
+    ts = zero(Vector{typeof(t)}(undef, hist_size))
+    ts_tmp = similar(ts)
+
+    if u isa Number
+        u_history = zeros(eltype(u), hist_size)
+        u_corrector = zeros(eltype(u), hist_size)
+    else
+        u_history = [zero(u) for _ in 1:hist_size]
+        u_corrector = [zero(u) for _ in 1:hist_size]
+    end
+
+    order = 2
+    prev_order = 2
+    terkm1 = tTypeNoUnits(1)
+    terk = tTypeNoUnits(1)
+    terkp1 = tTypeNoUnits(1)
+    r = zero(Vector{typeof(t)}(undef, hist_size))
+    weights = zero(Vector{typeof(t)}(undef, hist_size))
+    weights[1] = 1
+    nconsteps = 0
+    consfailcnt = 0
+    qwait = 4 # order + 2
+    t_old = zero(t)
+    iters_from_event = 0
+
+    return MOOSE234ConstantCache(
+        nlsolver, ts, ts_tmp, t_old, u_history, order, prev_order,
+        u_corrector, nconsteps, consfailcnt, qwait, terkm1,
+        terk, terkp1, r, weights, iters_from_event
+    )
+end
+
+@cache mutable struct MOOSE234Cache{
+        N, rateType, uNoUnitsType, tsType, tType, uType, uuType,
+        EEstType, rType, wType, StepLimiter, fdWeightsType,
+    } <:
+    BDFMutableCache
+    fsalfirst::rateType
+    nlsolver::N
+    ts::tsType
+    ts_tmp::tsType
+    t_old::tType
+    u_history::uuType
+    order::Int
+    prev_order::Int
+    u_corrector::uuType
+    u₀::uType
+    nconsteps::Int
+    consfailcnt::Int
+    qwait::Int
+    tmp::uType
+    atmp::uNoUnitsType
+    terkm1::EEstType
+    terk::EEstType
+    terkp1::EEstType
+    terk_tmp::uType
+    terkp1_tmp::uType
+    r::rType
+    weights::wType
+    equi_ts::tsType
+    iters_from_event::Int
+    dense::Vector{uType}
+    step_limiter!::StepLimiter
+    fd_weights::fdWeightsType
+end
+
+@truncate_stacktrace MOOSE234Cache 1
+
+function alg_cache(
+        alg::MOOSE234, u, rate_prototype, ::Type{uEltypeNoUnits},
+        ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
+        dt, reltol, p, calck,
+        ::Val{true}, verbose
+    ) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    γ, c = Int64(1) // 1, 1
+    fsalfirst = zero(rate_prototype)
+    nlsolver = build_nlsolver(
+        alg, u, uprev, p, t, dt, f, rate_prototype, uEltypeNoUnits,
+        uBottomEltypeNoUnits, tTypeNoUnits, γ, c, Val(true), verbose
+    )
+
+    hist_size = 6
+    ts = Vector{typeof(t)}(undef, hist_size)
+    u_history = [zero(u) for _ in 1:hist_size]
+    order = 2
+    prev_order = 2
+    u_corrector = [zero(u) for _ in 1:hist_size]
+    recursivefill!(ts, zero(t))
+    terkm1 = tTypeNoUnits(1)
+    terk = tTypeNoUnits(1)
+    terkp1 = tTypeNoUnits(1)
+    terk_tmp = similar(u)
+    terkp1_tmp = similar(u)
+    r = Vector{typeof(t)}(undef, hist_size)
+    weights = Vector{typeof(t)}(undef, hist_size)
+    recursivefill!(r, zero(t))
+    recursivefill!(weights, zero(t))
+    weights[1] = 1
+    nconsteps = 0
+    consfailcnt = 0
+    qwait = 4 # order + 2
+    t_old = zero(t)
+    atmp = similar(u, uEltypeNoUnits)
+    recursivefill!(atmp, zero(uEltypeNoUnits))
+    u₀ = similar(u)
+    equi_ts = similar(ts)
+    tmp = similar(u)
+    ts_tmp = similar(ts)
+    iters_from_event = 0
+
+    dense = [zero(u) for _ in 1:10] # 2*(max_order+1) = 2*5 = 10
+    fd_weights = zeros(typeof(t), 5, 5) # (max_order+1) × (max_order+1)
+
+    return MOOSE234Cache(
+        fsalfirst, nlsolver, ts, ts_tmp, t_old, u_history, order, prev_order,
+        u_corrector, u₀, nconsteps, consfailcnt, qwait, tmp, atmp,
+        terkm1, terk, terkp1, terk_tmp, terkp1_tmp, r, weights, equi_ts,
+        iters_from_event, dense, alg.step_limiter!, fd_weights
+    )
+end

--- a/lib/OrdinaryDiffEqBDF/src/bdf_interpolants.jl
+++ b/lib/OrdinaryDiffEqBDF/src/bdf_interpolants.jl
@@ -1,6 +1,9 @@
 ### Type unions for dispatch
 QNDF_CACHES = Union{QNDFConstantCache, QNDFCache}
-FBDF_CACHES = Union{FBDFConstantCache, FBDFCache, DFBDFConstantCache, DFBDFCache}
+FBDF_CACHES = Union{
+    FBDFConstantCache, FBDFCache, DFBDFConstantCache, DFBDFCache,
+    MOOSE234ConstantCache, MOOSE234Cache,
+}
 BDF_CACHES_WITH_INTERPOLATIONS = Union{QNDF_CACHES, FBDF_CACHES}
 
 ### Fallbacks to capture unsupported derivative orders

--- a/lib/OrdinaryDiffEqBDF/src/bdf_perform_step.jl
+++ b/lib/OrdinaryDiffEqBDF/src/bdf_perform_step.jl
@@ -1851,8 +1851,9 @@ function initialize!(integrator, cache::FBDFCache{max_order}) where {max_order}
     return integrator.derivative_discontinuity = derivative_discontinuity
 end
 
-# BDF coefficients shared by FBDF and MOOSE234 for the nonlinear solve
-const _BDF_COEFFS = SA[
+# BDF coefficients for MOOSE234's nonlinear solve (plain Matrix; this sublib
+# no longer depends on StaticArrays, and it's a const lookup table indexed by order)
+const _BDF_COEFFS = [
     1 -1 0 0 0 0;
     Int64(3) // 2 -2 Int64(1) // 2 0 0 0;
     Int64(11) // 6 -3 Int64(3) // 2 -Int64(1) // 3 0 0;

--- a/lib/OrdinaryDiffEqBDF/src/bdf_perform_step.jl
+++ b/lib/OrdinaryDiffEqBDF/src/bdf_perform_step.jl
@@ -771,6 +771,486 @@ function initialize!(integrator, cache::QNDFConstantCache{max_order}) where {max
     return nothing
 end
 
+# ============================================================================
+# MOOSE234 — Variable-stepsize, variable-order (2/3/4) embedded method
+# DeCaria et al., arXiv:1810.06670v1
+#
+# Per-step procedure:
+# 1. BDF3 solve (single nonlinear solve) → y³
+# 2. BDF3-Stab filter → y² (order 2, cheap linear combination)
+# 3. FBDF4 filter → y⁴ (order 4, cheap linear combination)
+# 4. Error estimation via embedded differences
+# 5. Output selection based on cache.order
+# ============================================================================
+
+function initialize!(integrator, cache::MOOSE234ConstantCache)
+    integrator.kshortsize = 5 # max_order(4) + 1
+    integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
+    integrator.fsalfirst = integrator.f(integrator.uprev, integrator.p, integrator.t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+
+    integrator.fsallast = zero(integrator.fsalfirst)
+    for i in 1:5
+        integrator.k[i] = zero(integrator.fsalfirst)
+    end
+
+    u_modified = integrator.u_modified
+    integrator.u_modified = true
+    reinitMOOSE!(integrator, cache)
+    return integrator.u_modified = u_modified
+end
+
+function perform_step!(integrator, cache::MOOSE234ConstantCache, repeat_step = false)
+    (; ts, u_history, order, u_corrector, nlsolver, ts_tmp) = cache
+    (; t, dt, u, f, p, uprev) = integrator
+
+    tdt = t + dt
+    reinitMOOSE!(integrator, cache)
+
+    k = order
+    # n_hist: number of valid history entries after reinitMOOSE
+    n_hist = min(cache.iters_from_event + 1, 5)
+
+    # Determine available capabilities
+    can_bdf3 = n_hist >= 3
+    can_stab_filter = n_hist >= 3
+    can_fbdf4_filter = n_hist >= 4
+
+    # BDF order for the nonlinear solve
+    bdf_order = can_bdf3 ? 3 : min(n_hist, 2)
+
+    # Clamp the active order to what's achievable with available history
+    max_avail_order = can_fbdf4_filter ? 4 : (can_stab_filter ? 3 : 2)
+    k = min(k, max_avail_order)
+
+    bdf_coeffs = _BDF_COEFFS
+
+    # === Predictor: Lagrange interpolation through history ===
+    n_pred = min(bdf_order + 1, n_hist)
+    pred_thetas = Vector{typeof(t)}(undef, n_pred)
+    if cache.iters_from_event >= 1
+        for j in 1:n_pred
+            pred_thetas[j] = (ts[j] - t) / dt
+        end
+        u₀ = _eval_lagrange_oop(one(t), pred_thetas, u_history, n_pred)
+    else
+        u₀ = u
+    end
+
+    markfirststage!(nlsolver)
+    nlsolver.z = u₀
+    mass_matrix = f.mass_matrix
+
+    # === BDF Corrector: Fixed coefficients + Lagrange interpolation ===
+    if u isa Number
+        fill!(u_corrector, zero(eltype(u)))
+    else
+        for i in eachindex(u_corrector)
+            u_corrector[i] = zero(u_corrector[i])
+        end
+    end
+    if cache.iters_from_event >= 1 && bdf_order > 1
+        for i in 1:(bdf_order - 1)
+            u_corrector[i] = _eval_lagrange_oop(
+                oftype(t, -i), pred_thetas, u_history, n_pred
+            )
+        end
+    end
+
+    if u isa Number
+        tmp = -uprev * bdf_coeffs[bdf_order, 2]
+        for i in 1:(bdf_order - 1)
+            tmp -= u_corrector[i] * bdf_coeffs[bdf_order, i + 2]
+        end
+    else
+        tmp = -uprev * bdf_coeffs[bdf_order, 2]
+        for i in 1:(bdf_order - 1)
+            tmp = @.. tmp - u_corrector[i] * bdf_coeffs[bdf_order, i + 2]
+        end
+    end
+
+    if mass_matrix === I
+        nlsolver.tmp = tmp / dt
+    else
+        nlsolver.tmp = mass_matrix * tmp / dt
+    end
+
+    β₀ = inv(bdf_coeffs[bdf_order, 1])
+    α₀ = 1
+    nlsolver.γ = β₀
+    nlsolver.α = α₀
+    nlsolver.method = COEFFICIENT_MULTISTEP
+
+    # === BDF Solve → y³ ===
+    z = nlsolve!(nlsolver, integrator, cache, repeat_step)
+    nlsolvefail(nlsolver) && return
+    y3 = z
+
+    # === Apply Filters ===
+    y2 = y3
+    y4 = y3
+
+    if can_stab_filter
+        # Build ascending time vector: [t_{n-2}, t_{n-1}, t_n, t_{n+1}]
+        n_dd = 4
+        ts_asc = Vector{typeof(t)}(undef, n_dd)
+        for i in 1:(n_dd - 1)
+            ts_asc[i] = ts[n_dd - 1 - i + 1] # ts[3], ts[2], ts[1]
+        end
+        ts_asc[n_dd] = tdt
+
+        c = backdiff(ts_asc)
+        weight_stab = bdf3stab_coeff(c, n_dd)
+
+        # δ³y = Σ c[4,i] * values[i]
+        # values = [u_history[3], u_history[2], u_history[1], y3]
+        if u isa Number
+            δ3 = c[4, n_dd] * y3
+            for i in 1:(n_dd - 1)
+                δ3 += c[4, i] * u_history[n_dd - i]
+            end
+            y2 = y3 + weight_stab * δ3
+        else
+            δ3 = @.. c[4, n_dd] * y3
+            for i in 1:(n_dd - 1)
+                δ3 = @.. δ3 + c[4, i] * u_history[n_dd - i]
+            end
+            y2 = @.. y3 + weight_stab * δ3
+        end
+    end
+
+    if can_fbdf4_filter
+        # 5 points: [t_{n-3}, t_{n-2}, t_{n-1}, t_n, t_{n+1}]
+        n_dd5 = 5
+        ts_asc5 = Vector{typeof(t)}(undef, n_dd5)
+        for i in 1:4
+            ts_asc5[i] = ts[5 - i] # ts[4], ts[3], ts[2], ts[1]
+        end
+        ts_asc5[5] = tdt
+
+        _, η4, c5 = bdf_and_filt_coeff(ts_asc5, 3)
+
+        # δ⁴y = Σ c5[5,i] * values[i]
+        # values = [u_history[4], u_history[3], u_history[2], u_history[1], y3]
+        if u isa Number
+            δ4 = c5[5, 5] * y3
+            for i in 1:4
+                δ4 += c5[5, i] * u_history[5 - i]
+            end
+            y4 = y3 - η4 * δ4
+        else
+            δ4 = @.. c5[5, 5] * y3
+            for i in 1:4
+                δ4 = @.. δ4 + c5[5, i] * u_history[5 - i]
+            end
+            y4 = @.. y3 - η4 * δ4
+        end
+    end
+
+    # === Error Estimation ===
+    if integrator.opts.adaptive
+        (; abstol, reltol, internalnorm) = integrator.opts
+
+        if can_stab_filter
+            est2 = u isa Number ? (y2 - y3) : @.. y2 - y3
+            atmp = calculate_residuals(est2, uprev, y3, abstol, reltol, internalnorm, t)
+            cache.terkm1 = internalnorm(atmp, t)
+        else
+            cache.terkm1 = zero(cache.terk)
+        end
+
+        if can_fbdf4_filter
+            est3 = u isa Number ? (y4 - y3) : @.. y4 - y3
+            atmp = calculate_residuals(est3, uprev, y3, abstol, reltol, internalnorm, t)
+            cache.terkp1 = internalnorm(atmp, t)
+        else
+            cache.terkp1 = zero(cache.terk)
+        end
+
+        # FBDF-style error for the BDF solve (predictor-corrector difference)
+        if u isa Number
+            bdf_err = y3 - u₀
+            for j in 1:min(bdf_order + 1, n_hist)
+                bdf_err *= j * dt / (tdt - ts[j])
+            end
+            bdf_lte = bdf_err * (-1 / (1 + bdf_order))
+        else
+            bdf_err = @.. y3 - u₀
+            for j in 1:min(bdf_order + 1, n_hist)
+                bdf_err = @.. bdf_err * (j * dt / (tdt - ts[j]))
+            end
+            bdf_lte = @.. bdf_err * (-1 / (1 + bdf_order))
+        end
+
+        # Select the error estimate for the current order
+        if k == 2 && can_stab_filter
+            lte = est2
+        elseif k >= 3 && can_fbdf4_filter
+            lte = est3
+        elseif k == 3 && can_stab_filter
+            lte = est2
+        else
+            lte = bdf_lte
+        end
+
+        atmp = calculate_residuals(lte, uprev, y3, abstol, reltol, internalnorm, t)
+        cache.terk = internalnorm(atmp, t)
+        integrator.EEst = cache.terk
+    end
+
+    # === Set output based on current order ===
+    if k == 4 && can_fbdf4_filter
+        u = y4
+    elseif k == 2 && can_stab_filter
+        u = y2
+    else
+        u = y3
+    end
+
+    integrator.fsallast = f(u, p, tdt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+
+    # Dense output: resample Lagrange interpolant at Chebyshev nodes
+    if integrator.opts.calck
+        n = min(bdf_order + 1, 5)
+        calck_thetas = Vector{typeof(t)}(undef, n)
+        calck_thetas[1] = one(t)
+        for j in 1:min(bdf_order, 4)
+            calck_thetas[1 + j] = (ts[j] - t) / dt
+        end
+        calck_values = Vector{typeof(u)}(undef, n)
+        calck_values[1] = u isa Number ? u : copy(u)
+        for j in 1:min(bdf_order, 4)
+            calck_values[1 + j] = u isa Number ? u_history[j] : copy(u_history[j])
+        end
+        _resample_at_chebyshev!(integrator.k, calck_values, calck_thetas, n)
+        for j in (n + 1):5
+            integrator.k[j] = zero(u)
+        end
+    end
+
+    return integrator.u = u
+end
+
+function initialize!(integrator, cache::MOOSE234Cache)
+    integrator.kshortsize = 5 # max_order(4) + 1
+
+    resize!(integrator.k, integrator.kshortsize)
+    for i in 1:5
+        integrator.k[i] = cache.dense[i]
+    end
+    integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+
+    u_modified = integrator.u_modified
+    integrator.u_modified = true
+    reinitMOOSE!(integrator, cache)
+    return integrator.u_modified = u_modified
+end
+
+function perform_step!(integrator, cache::MOOSE234Cache, repeat_step = false)
+    (;
+        ts, u_history, order, u_corrector, nlsolver, ts_tmp,
+        equi_ts, step_limiter!, u₀, tmp, atmp, terk_tmp, terkp1_tmp, dense,
+    ) = cache
+    (; t, dt, u, f, p, uprev) = integrator
+
+    tdt = t + dt
+    reinitMOOSE!(integrator, cache)
+
+    k = order
+    n_hist = min(cache.iters_from_event + 1, 5)
+
+    can_bdf3 = n_hist >= 3
+    can_stab_filter = n_hist >= 3
+    can_fbdf4_filter = n_hist >= 4
+
+    bdf_order = can_bdf3 ? 3 : min(n_hist, 2)
+    max_avail_order = can_fbdf4_filter ? 4 : (can_stab_filter ? 3 : 2)
+    k = min(k, max_avail_order)
+
+    bdf_coeffs = _BDF_COEFFS
+
+    # === Predictor: Lagrange interpolation through history ===
+    n_pred = min(bdf_order + 1, n_hist)
+    @.. broadcast = false u₀ = zero(u)
+    if cache.iters_from_event >= 1
+        for j in 1:n_pred
+            equi_ts[j] = (ts[j] - t) / dt
+        end
+        _eval_lagrange_iip!(u₀, one(t), equi_ts, u_history, n_pred)
+    else
+        @.. broadcast = false u₀ = u
+    end
+
+    markfirststage!(nlsolver)
+    @.. broadcast = false nlsolver.z = u₀
+    mass_matrix = f.mass_matrix
+
+    # === BDF Corrector: Fixed coefficients + Lagrange interpolation ===
+    for h in u_corrector
+        fill!(h, zero(eltype(h)))
+    end
+    if cache.iters_from_event >= 1 && bdf_order > 1
+        for i in 1:(bdf_order - 1)
+            _eval_lagrange_iip!(u_corrector[i], oftype(t, -i), equi_ts, u_history, n_pred)
+        end
+    end
+
+    @.. broadcast = false tmp = -uprev * bdf_coeffs[bdf_order, 2]
+    for i in 1:(bdf_order - 1)
+        @.. broadcast = false tmp -= u_corrector[i] * bdf_coeffs[bdf_order, i + 2]
+    end
+
+    invdt = inv(dt)
+    if mass_matrix === I
+        @.. broadcast = false nlsolver.tmp = tmp * invdt
+    else
+        @.. broadcast = false terkp1_tmp = tmp * invdt
+        mul!(nlsolver.tmp, mass_matrix, terkp1_tmp)
+    end
+
+    β₀ = inv(bdf_coeffs[bdf_order, 1])
+    α₀ = 1
+    nlsolver.γ = β₀
+    nlsolver.α = α₀
+    nlsolver.method = COEFFICIENT_MULTISTEP
+
+    # === BDF Solve → y³ (result in u) ===
+    z = nlsolve!(nlsolver, integrator, cache, repeat_step)
+    nlsolvefail(nlsolver) && return
+    @.. broadcast = false u = z
+
+    step_limiter!(u, integrator, p, t + dt)
+
+    # y3 is now in `u`. Store y2 in u₀, y4 in terk_tmp.
+
+    # === BDF3-Stab filter → y² ===
+    # u₀ will hold y2 (overwriting the predictor, no longer needed)
+    @.. broadcast = false u₀ = u  # default: y2 = y3
+
+    if can_stab_filter
+        n_dd = 4
+        # Build ascending time points into ts_tmp
+        for i in 1:(n_dd - 1)
+            ts_tmp[i] = ts[n_dd - 1 - i + 1]
+        end
+        ts_tmp[n_dd] = tdt
+
+        # ts_tmp[1:n_dd] is ascending
+        ts_asc_view = @view ts_tmp[1:n_dd]
+        c = backdiff(ts_asc_view)
+        weight_stab = bdf3stab_coeff(c, n_dd)
+
+        # δ³y → stored in tmp
+        @.. broadcast = false tmp = c[4, n_dd] * u
+        for i in 1:(n_dd - 1)
+            idx = n_dd - i
+            @.. broadcast = false tmp += c[4, i] * u_history[idx]
+        end
+
+        # y2 = y3 + weight_stab * δ³y → stored in u₀
+        @.. broadcast = false u₀ = u + weight_stab * tmp
+    end
+
+    # === FBDF4 filter → y⁴ ===
+    # terk_tmp will hold y4
+    @.. broadcast = false terk_tmp = u  # default: y4 = y3
+
+    if can_fbdf4_filter
+        n_dd5 = 5
+        for i in 1:4
+            ts_tmp[i] = ts[5 - i]
+        end
+        ts_tmp[5] = tdt
+
+        ts_asc5_view = @view ts_tmp[1:n_dd5]
+        _, η4, c5 = bdf_and_filt_coeff(ts_asc5_view, 3)
+
+        # δ⁴y → stored in tmp
+        @.. broadcast = false tmp = c5[5, 5] * u
+        for i in 1:4
+            idx = 5 - i
+            @.. broadcast = false tmp += c5[5, i] * u_history[idx]
+        end
+
+        # y4 = y3 - η4 * δ⁴y → stored in terk_tmp
+        @.. broadcast = false terk_tmp = u - η4 * tmp
+    end
+
+    # === Error Estimation ===
+    if integrator.opts.adaptive
+        (; abstol, reltol, internalnorm) = integrator.opts
+
+        if can_stab_filter
+            # est2 = y2 - y3 → terkp1_tmp
+            @.. broadcast = false terkp1_tmp = u₀ - u
+            calculate_residuals!(atmp, terkp1_tmp, uprev, u, abstol, reltol, internalnorm, t)
+            cache.terkm1 = internalnorm(atmp, t)
+        else
+            cache.terkm1 = zero(cache.terk)
+        end
+
+        if can_fbdf4_filter
+            # est3 = y4 - y3 → tmp
+            @.. broadcast = false tmp = terk_tmp - u
+            calculate_residuals!(atmp, tmp, uprev, u, abstol, reltol, internalnorm, t)
+            cache.terkp1 = internalnorm(atmp, t)
+        else
+            cache.terkp1 = zero(cache.terk)
+        end
+
+        # FBDF-style predictor-corrector error for startup
+        @.. broadcast = false terkp1_tmp = u - u₀
+        for j in 1:min(bdf_order + 1, n_hist)
+            factor = j * dt / (tdt - ts[j])
+            @.. broadcast = false terkp1_tmp *= factor
+        end
+        @.. broadcast = false terkp1_tmp *= (-1 / (1 + bdf_order))
+
+        # Select the error estimate based on active order
+        if k == 2 && can_stab_filter
+            @.. broadcast = false tmp = u₀ - u
+        elseif k >= 3 && can_fbdf4_filter
+            @.. broadcast = false tmp = terk_tmp - u
+        elseif k == 3 && can_stab_filter
+            @.. broadcast = false tmp = u₀ - u
+        else
+            @.. broadcast = false tmp = terkp1_tmp
+        end
+
+        calculate_residuals!(atmp, tmp, uprev, u, abstol, reltol, internalnorm, t)
+        cache.terk = internalnorm(atmp, t)
+        integrator.EEst = cache.terk
+    end
+
+    # === Set output based on current order ===
+    if k == 4 && can_fbdf4_filter
+        @.. broadcast = false u = terk_tmp
+    elseif k == 2 && can_stab_filter
+        @.. broadcast = false u = u₀
+    end
+    # else: u already has y3
+
+    # Compute fsallast — call f() directly since u may hold y2 or y4, not y3
+    f(integrator.fsallast, u, p, tdt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+
+    # Dense output: resample at Chebyshev nodes
+    if integrator.opts.calck
+        n = min(bdf_order + 1, 5)
+        equi_ts[1] = one(eltype(equi_ts))
+        for j in 1:min(bdf_order, 4)
+            equi_ts[1 + j] = (ts[j] - t) / dt
+        end
+        _resample_at_chebyshev_direct_iip!(integrator.k, u, u_history, equi_ts, n)
+        for j in (n + 1):5
+            fill!(integrator.k[j], zero(eltype(u)))
+        end
+    end
+    return nothing
+end
+
 function perform_step!(
         integrator, cache::QNDFConstantCache{max_order},
         repeat_step = false
@@ -1370,6 +1850,15 @@ function initialize!(integrator, cache::FBDFCache{max_order}) where {max_order}
     reinitFBDF!(integrator, cache)
     return integrator.derivative_discontinuity = derivative_discontinuity
 end
+
+# BDF coefficients shared by FBDF and MOOSE234 for the nonlinear solve
+const _BDF_COEFFS = SA[
+    1 -1 0 0 0 0;
+    Int64(3) // 2 -2 Int64(1) // 2 0 0 0;
+    Int64(11) // 6 -3 Int64(3) // 2 -Int64(1) // 3 0 0;
+    Int64(25) // 12 -4 3 -Int64(4) // 3 Int64(1) // 4 0;
+    Int64(137) // 60 -5 5 -Int64(10) // 3 Int64(5) // 4 -Int64(1) // 5
+]
 
 function perform_step!(
         integrator, cache::FBDFCache{max_order},

--- a/lib/OrdinaryDiffEqBDF/src/bdf_perform_step.jl
+++ b/lib/OrdinaryDiffEqBDF/src/bdf_perform_step.jl
@@ -794,10 +794,10 @@ function initialize!(integrator, cache::MOOSE234ConstantCache)
         integrator.k[i] = zero(integrator.fsalfirst)
     end
 
-    u_modified = integrator.u_modified
-    integrator.u_modified = true
+    derivative_discontinuity = integrator.derivative_discontinuity
+    integrator.derivative_discontinuity = true
     reinitMOOSE!(integrator, cache)
-    return integrator.u_modified = u_modified
+    return integrator.derivative_discontinuity = derivative_discontinuity
 end
 
 function perform_step!(integrator, cache::MOOSE234ConstantCache, repeat_step = false)
@@ -1042,10 +1042,10 @@ function initialize!(integrator, cache::MOOSE234Cache)
     integrator.f(integrator.fsalfirst, integrator.uprev, integrator.p, integrator.t)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
 
-    u_modified = integrator.u_modified
-    integrator.u_modified = true
+    derivative_discontinuity = integrator.derivative_discontinuity
+    integrator.derivative_discontinuity = true
     reinitMOOSE!(integrator, cache)
-    return integrator.u_modified = u_modified
+    return integrator.derivative_discontinuity = derivative_discontinuity
 end
 
 function perform_step!(integrator, cache::MOOSE234Cache, repeat_step = false)

--- a/lib/OrdinaryDiffEqBDF/src/bdf_perform_step.jl
+++ b/lib/OrdinaryDiffEqBDF/src/bdf_perform_step.jl
@@ -995,7 +995,7 @@ function perform_step!(integrator, cache::MOOSE234ConstantCache, repeat_step = f
 
         atmp = calculate_residuals(lte, uprev, y3, abstol, reltol, internalnorm, t)
         cache.terk = internalnorm(atmp, t)
-        integrator.EEst = cache.terk
+        OrdinaryDiffEqCore.set_EEst!(integrator, cache.terk)
     end
 
     # === Set output based on current order ===
@@ -1221,7 +1221,7 @@ function perform_step!(integrator, cache::MOOSE234Cache, repeat_step = false)
 
         calculate_residuals!(atmp, tmp, uprev, u, abstol, reltol, internalnorm, t)
         cache.terk = internalnorm(atmp, t)
-        integrator.EEst = cache.terk
+        OrdinaryDiffEqCore.set_EEst!(integrator, cache.terk)
     end
 
     # === Set output based on current order ===

--- a/lib/OrdinaryDiffEqBDF/src/bdf_utils.jl
+++ b/lib/OrdinaryDiffEqBDF/src/bdf_utils.jl
@@ -520,7 +520,7 @@ function reinitMOOSE!(integrator, cache)
     ) = cache
     (; t, dt, uprev) = integrator
 
-    if integrator.u_modified
+    if integrator.derivative_discontinuity
         order = cache.order = 2
         consfailcnt = cache.consfailcnt = cache.nconsteps = 0
         cache.qwait = 4 # order + 2

--- a/lib/OrdinaryDiffEqBDF/src/bdf_utils.jl
+++ b/lib/OrdinaryDiffEqBDF/src/bdf_utils.jl
@@ -370,6 +370,132 @@ function _resample_at_chebyshev_direct_iip!(k, u, u_history, thetas, n)
     return
 end
 
+####################################################################
+# MOOSE234 divided-difference coefficient utilities
+# DeCaria et al., arXiv:1810.06670v1, Algorithm 7.1 (BACKDIFF)
+# and BDFANDFILTCOEFF.
+####################################################################
+
+"""
+    backdiff(ts::AbstractVector{T}) where {T}
+
+Compute the divided-difference coefficient table for time points `ts` given in
+ascending order (`ts[1] < ts[2] < … < ts[n]`).
+
+Implements Algorithm 7.1 (BACKDIFF) from DeCaria et al. (arXiv:1810.06670v1).
+
+Returns an `n × n` matrix `c` where `c[q+1, i]` is the coefficient of the `i`-th
+solution value in the `q`-th order divided difference:
+
+    δ^q y = Σᵢ c[q+1, i] · yᵢ
+
+Row `c[1, :]` is the zeroth divided difference (selects the newest value `y[n]`).
+"""
+function backdiff(ts::AbstractVector{T}) where {T}
+    n = length(ts)
+    m = n - 1
+
+    # D[j, :] initialised to standard basis vector e_{n+1-j}
+    # D[1,:] selects the newest point, D[n,:] selects the oldest.
+    D = zeros(T, n, n)
+    @inbounds for j in 1:n
+        D[j, n + 1 - j] = one(T)
+    end
+
+    c = zeros(T, n, n)
+    @inbounds for i in 1:n
+        c[1, i] = D[1, i]
+    end
+
+    @inbounds for q in 1:m
+        for j in 1:(n - q)
+            denom = ts[n + 1 - j] - ts[n + 1 - j - q]
+            for i in 1:n
+                D[j, i] = (D[j, i] - D[j + 1, i]) / denom
+            end
+        end
+        for i in 1:n
+            c[q + 1, i] = D[1, i]
+        end
+    end
+
+    return c
+end
+
+"""
+    bdf_and_filt_coeff(ts::AbstractVector{T}, p::Integer) where {T}
+
+Compute variable-stepsize BDF_p coefficients and FBDF_{p+1} filter weight η^{p+1}.
+
+Implements BDFANDFILTCOEFF from DeCaria et al. (arXiv:1810.06670v1).
+Requires `length(ts) ≥ p + 2` (for MOOSE234 with `p = 3`, pass 5 ascending time
+points `[tₙ₋₃, tₙ₋₂, tₙ₋₁, tₙ, tₙ₊₁]`).
+
+# Returns
+- `α_bar::Vector{T}` — BDF coefficient vector of length `n`. `α_bar[i]` multiplies
+  the solution at `ts[i]`. The leading coefficient `α_bar[n]` corresponds to the
+  unknown; for the nonlinear solve, `γ = 1 / α_bar[n]`.
+- `η::T` — Filter weight η^{p+1} for the FBDF_{p+1} time filter.
+- `c::Matrix{T}` — Divided-difference table from [`backdiff`](@ref).
+"""
+function bdf_and_filt_coeff(ts::AbstractVector{T}, p::Integer) where {T}
+    c = backdiff(ts)
+    n = length(ts)
+    tm = ts[n]   # tₙ₊ₘ (newest time point)
+
+    # η^{p+1} = ∏ᵢ₌₁ᵖ (tm − ts[n−i])  /  Σⱼ₌₁ᵖ⁺¹ (tm − ts[n−j])⁻¹
+    num_η = one(T)
+    @inbounds for i in 1:p
+        num_η *= tm - ts[n - i]
+    end
+    den_η = zero(T)
+    @inbounds for j in 1:(p + 1)
+        den_η += one(T) / (tm - ts[n - j])
+    end
+    η = num_η / den_η
+
+    # ᾱₖ = Σⱼ₌₁ᵖ [∏ᵢ₌₁ʲ⁻¹ (tm − ts[n−i])] · c[j+1, k]
+    # for k = (n − p) : n  (only indices that BDF_p touches; earlier ones stay 0)
+    α_bar = zeros(T, n)
+    @inbounds for k in (n - p):n
+        for j in 1:p
+            prefactor = one(T)
+            for i in 1:(j - 1)
+                prefactor *= tm - ts[n - i]
+            end
+            α_bar[k] += prefactor * c[j + 1, k]
+        end
+    end
+
+    return α_bar, η, c
+end
+
+"""
+    bdf3stab_coeff(ts::AbstractVector, µ = 9/125)
+    bdf3stab_coeff(c::AbstractMatrix, n::Integer, µ = 9/125)
+
+Compute the BDF3-Stab filter weight for variable stepsizes (equation 3.16 of
+DeCaria et al., arXiv:1810.06670v1).
+
+For the filter step
+
+    y² = y³ + weight · δ³y³
+
+returns `weight = µ / c[4, n]`, where `c[4, n]` is the leading coefficient of the
+3rd divided difference and `δ³y³ = Σᵢ c[4, i] · yᵢ` (with `yₙ = y³`).
+
+Requires at least 4 time points. The parameter `µ` defaults to `9/125`, the
+G-stability-optimal constant from the paper.
+"""
+function bdf3stab_coeff(ts::AbstractVector, µ = 9 / 125)
+    c = backdiff(ts)
+    return µ / c[4, length(ts)]
+end
+
+function bdf3stab_coeff(c::AbstractMatrix, n::Integer, µ = 9 / 125)
+    return µ / c[4, n]
+end
+
 function estimate_terk!(integrator, cache, k, ::Val{max_order}) where {max_order}
     #calculate hᵏ⁻¹yᵏ⁻¹
     (; ts_tmp, terk_tmp, u_history, fd_weights) = cache
@@ -380,6 +506,75 @@ function estimate_terk!(integrator, cache, k, ::Val{max_order}) where {max_order
         @.. broadcast = false terk_tmp += fd_weights[i, k] * u_history[i - 1]
     end
     return @.. broadcast = false terk_tmp *= abs(dt^(k - 1))
+end
+
+####################################################################
+# MOOSE234 history management
+# Mirrors reinitFBDF! but with initial order 2 and qwait 4.
+####################################################################
+
+function reinitMOOSE!(integrator, cache)
+    (;
+        consfailcnt, ts, u_history, u_corrector, iters_from_event,
+        order,
+    ) = cache
+    (; t, dt, uprev) = integrator
+
+    if integrator.u_modified
+        order = cache.order = 2
+        consfailcnt = cache.consfailcnt = cache.nconsteps = 0
+        cache.qwait = 4 # order + 2
+        iters_from_event = cache.iters_from_event = 0
+
+        fill!(ts, zero(eltype(ts)))
+        for h in u_history
+            if h isa AbstractArray && ArrayInterface.ismutable(h)
+                fill!(h, zero(eltype(h)))
+            end
+        end
+        for h in u_corrector
+            if h isa AbstractArray && ArrayInterface.ismutable(h)
+                fill!(h, zero(eltype(h)))
+            end
+        end
+    end
+
+    if uprev isa AbstractArray && ArrayInterface.ismutable(uprev)
+        if iters_from_event == 0
+            ts[1] = t
+            copyto!(u_history[1], uprev)
+        elseif iters_from_event == 1 && t != ts[1]
+            ts[2] = ts[1]
+            ts[1] = t
+            copyto!(u_history[2], u_history[1])
+            copyto!(u_history[1], uprev)
+        elseif consfailcnt == 0
+            for i in (order + 2):-1:2
+                ts[i] = ts[i - 1]
+                copyto!(u_history[i], u_history[i - 1])
+            end
+            ts[1] = t
+            copyto!(u_history[1], uprev)
+        end
+    else
+        if iters_from_event == 0
+            ts[1] = t
+            u_history[1] = uprev
+        elseif iters_from_event == 1 && t != ts[1]
+            ts[2] = ts[1]
+            ts[1] = t
+            u_history[2] = u_history[1]
+            u_history[1] = uprev
+        elseif consfailcnt == 0
+            for i in (order + 2):-1:2
+                ts[i] = ts[i - 1]
+                u_history[i] = u_history[i - 1]
+            end
+            ts[1] = t
+            u_history[1] = uprev
+        end
+    end
+    return nothing
 end
 
 function estimate_terk(integrator, cache, k, ::Val{max_order}, u) where {max_order}

--- a/lib/OrdinaryDiffEqBDF/src/controllers.jl
+++ b/lib/OrdinaryDiffEqBDF/src/controllers.jl
@@ -779,7 +779,7 @@ function step_reject_controller!(integrator, ::MOOSE234)
 
     # Restart from order 2 (clear history) when stuck at minimum order
     if kₙ == 2 && integrator.cache.consfailcnt > 3
-        u_modified!(integrator, true)
+        integrator.derivative_discontinuity = true
     end
 
     integrator.dt = hₙ

--- a/lib/OrdinaryDiffEqBDF/src/controllers.jl
+++ b/lib/OrdinaryDiffEqBDF/src/controllers.jl
@@ -27,7 +27,7 @@ mutable struct BDFControllerCache{T, E, C, NLPType} <: AbstractControllerCache
 end
 
 function setup_controller_cache(
-        alg::Union{QNDF, FBDF, DFBDF}, cache, controller::BDFController, ::Type{E}, disco_probs
+        alg::Union{QNDF, FBDF, DFBDF, MOOSE234}, cache, controller::BDFController, ::Type{E}, disco_probs
     ) where {E}
     QT = _resolved_QT(controller.basic)
     basic = resolve_basic(controller.basic, alg, QT; disco_probs)
@@ -68,6 +68,10 @@ function default_controller(QT, alg::Union{QNDF, FBDF, DFBDF})
         qsteady_max = alg.qsteady_max,
     )
 end
+
+# MOOSE234's struct carries no qmax/qsteady fields, so build the delegating
+# BDFController from the trait-based defaults instead of threading alg kwargs.
+default_controller(QT, alg::MOOSE234) = BDFController(QT, alg)
 
 # QNDF
 stepsize_controller!(integrator, alg::QNDF) = nothing
@@ -591,4 +595,207 @@ function step_accept_controller!(
         cache.qwait -= 1 # countdown
     end
     return integrator.dt / q
+end
+
+# ============================================================================
+# MOOSE234 Controllers
+#
+# MOOSE234 error estimates (set in perform_step!):
+#   cache.terkm1 = |Est2| — order 2 LTE norm (from BDF3-Stab filter: y² − y³)
+#   cache.terkp1 = |Est3| — order 3 LTE norm (from FBDF4 filter: y⁴ − y³)
+#   cache.terk   = LTE norm at the current active order (used for EEst)
+#
+# Est4 (order 4 LTE) would require an extra f-eval and is not computed;
+# order-4 candidate step uses a geometric-extrapolation heuristic.
+# ============================================================================
+
+# --------------------------------------------------------------------------
+# Order selection: compute candidate stepsizes for each available order
+# (2, 3, 4) and pick the order allowing the largest next step.
+#
+#   hₖ = dt · (γ / |Estₖ|)^(1/(k+1)),   γ = 0.9
+#
+# Returns (kₙ, terk_new) where terk_new is the error norm at the chosen order.
+# --------------------------------------------------------------------------
+function choose_order_moose!(
+        integrator,
+        cache::Union{MOOSE234Cache, MOOSE234ConstantCache}
+    )
+    k = cache.order
+    dt = integrator.dt
+    n_hist = min(cache.iters_from_event + 1, 5)
+    max_avail = n_hist >= 4 ? 4 : (n_hist >= 3 ? 3 : 2)
+
+    est2 = cache.terkm1
+    est3 = cache.terkp1
+
+    # Candidate step for order 2:  h₂ = dt · (γ / est2)^(1/3)
+    if est2 > zero(est2)
+        h2 = dt * (0.9 / est2)^(1 / 3)
+    else
+        h2 = 10 * dt
+    end
+
+    # Candidate step for order 3:  h₃ = dt · (γ / est3)^(1/4)
+    if max_avail >= 3 && est3 > zero(est3)
+        h3 = dt * (0.9 / est3)^(1 / 4)
+    else
+        h3 = zero(dt)
+    end
+
+    # Candidate step for order 4: Est4 is not available, so approximate it.
+    # When errors decrease geometrically (est2 > est3), extrapolate
+    # est4 ≈ est3² / est2.
+    h4 = zero(dt)
+    if max_avail >= 4 && est2 > zero(est2) && est3 > zero(est3) && est3 < est2
+        est4_approx = est3 * est3 / est2
+        h4 = dt * (0.9 / est4_approx)^(1 / 5)
+    end
+
+    # Pick the order with the largest candidate step
+    kₙ = 2
+    hₙ = h2
+    if max_avail >= 3 && h3 > hₙ
+        kₙ = 3
+        hₙ = h3
+    end
+    if max_avail >= 4 && h4 > hₙ
+        kₙ = 4
+        hₙ = h4
+    end
+
+    # Only allow order *increase* when the qwait countdown has reached 0
+    if kₙ > k && cache.qwait > 0
+        kₙ = k
+    end
+
+    # Error norm at the chosen order (drives the stepsize formula)
+    if kₙ == 2
+        terk_new = est2
+    elseif kₙ == 3
+        terk_new = est3
+    else
+        terk_new = (est2 > zero(est2) && est3 > zero(est3) && est3 < est2) ?
+                   est3 * est3 / est2 : est3
+    end
+
+    return kₙ, terk_new
+end
+
+# --------------------------------------------------------------------------
+# Stepsize controller: run order selection, compute q = dt / dt_new
+# --------------------------------------------------------------------------
+function stepsize_controller!(integrator, alg::MOOSE234)
+    return stepsize_controller!(integrator, integrator.cache, alg)
+end
+
+function stepsize_controller!(
+        integrator,
+        cache::Union{MOOSE234Cache, MOOSE234ConstantCache},
+        alg::MOOSE234
+    )
+    cache.prev_order = cache.order
+
+    kₙ, terk = choose_order_moose!(integrator, cache)
+    if kₙ != cache.order
+        cache.nconsteps = 0
+        cache.order = kₙ
+    end
+
+    if iszero(terk)
+        q = inv(get_current_qmax(integrator, get_qmax(integrator)))
+    else
+        q = (terk / 0.9)^(1 / (kₙ + 1))
+    end
+    integrator.qold = q
+    return q
+end
+
+# --------------------------------------------------------------------------
+# Step accept controller
+# --------------------------------------------------------------------------
+function step_accept_controller!(integrator, alg::MOOSE234, q)
+    return step_accept_controller!(integrator, integrator.cache, alg, q)
+end
+
+function step_accept_controller!(
+        integrator,
+        cache::Union{MOOSE234Cache, MOOSE234ConstantCache},
+        alg::MOOSE234, q
+    )
+    cache.consfailcnt = 0
+    if q <= get_qsteady_max(integrator) && q >= get_qsteady_min(integrator)
+        q = one(q)
+    end
+    cache.nconsteps += 1
+    cache.iters_from_event += 1
+    # CVODE-style qwait countdown: order + 2 steps after an order change
+    if cache.order != cache.prev_order
+        cache.qwait = cache.order + 2
+    elseif cache.qwait > 0
+        cache.qwait -= 1
+    end
+    return integrator.dt / q
+end
+
+# --------------------------------------------------------------------------
+# Step reject controller (MOOSE234-specific, min order = 2)
+#
+# On repeated failures: drop order, halve step size.
+# On consfailcnt > 3 at min order: restart (clear history).
+# --------------------------------------------------------------------------
+function step_reject_controller!(integrator, ::MOOSE234)
+    k = integrator.cache.order
+    h = integrator.dt
+    integrator.cache.consfailcnt += 1
+    integrator.cache.nconsteps = 0
+
+    if integrator.cache.consfailcnt > 1
+        h = h / 2
+    end
+
+    # Candidate step at current order
+    expo = 1 / (k + 1)
+    z = 1.2 * integrator.EEst^expo
+    hₖ = z <= 10 ? h / z : 0.1 * h
+
+    hₙ = hₖ
+    kₙ = k
+
+    if k > 2
+        # Error at one order below:
+        #   k = 3 → order 2 error (terkm1)
+        #   k = 4 → order 3 error (terkp1)
+        est_lower = k == 4 ? integrator.cache.terkp1 : integrator.cache.terkm1
+        expo_lower = 1 / k  # 1 / ((k-1) + 1)
+        zₖ₋₁ = 1.3 * est_lower^expo_lower
+        hₖ₋₁ = zₖ₋₁ <= 10 ? h / zₖ₋₁ : 0.1 * h
+
+        if integrator.cache.consfailcnt > 2 || hₖ₋₁ > hₖ
+            hₙ = min(h, hₖ₋₁)
+            kₙ = k - 1
+        end
+    end
+
+    # Restart from order 2 (clear history) when stuck at minimum order
+    if kₙ == 2 && integrator.cache.consfailcnt > 3
+        u_modified!(integrator, true)
+    end
+
+    integrator.dt = hₙ
+    return integrator.cache.order = kₙ
+end
+
+# --------------------------------------------------------------------------
+# Post-Newton failure controller
+# --------------------------------------------------------------------------
+function post_newton_controller!(integrator, alg::MOOSE234)
+    (; cache) = integrator
+    if cache.order > 2 && cache.nlsolver.nfails >= 3
+        cache.order -= 1
+    end
+    integrator.dt = integrator.dt / get_failfactor(integrator)
+    integrator.cache.consfailcnt += 1
+    integrator.cache.nconsteps = 0
+    return nothing
 end

--- a/lib/OrdinaryDiffEqBDF/src/controllers.jl
+++ b/lib/OrdinaryDiffEqBDF/src/controllers.jl
@@ -707,7 +707,6 @@ function stepsize_controller!(
     else
         q = (terk / 0.9)^(1 / (kₙ + 1))
     end
-    integrator.qold = q
     return q
 end
 
@@ -756,7 +755,7 @@ function step_reject_controller!(integrator, ::MOOSE234)
 
     # Candidate step at current order
     expo = 1 / (k + 1)
-    z = 1.2 * integrator.EEst^expo
+    z = 1.2 * OrdinaryDiffEqCore.get_EEst(integrator)^expo
     hₖ = z <= 10 ? h / z : 0.1 * h
 
     hₙ = hₖ

--- a/lib/OrdinaryDiffEqBDF/src/interp_func.jl
+++ b/lib/OrdinaryDiffEqBDF/src/interp_func.jl
@@ -7,6 +7,7 @@ function SciMLBase.interp_summary(
             QNDFConstantCache, QNDFCache,
             FBDFConstantCache, FBDFCache,
             DFBDFConstantCache, DFBDFCache,
+            MOOSE234ConstantCache, MOOSE234Cache,
         },
     }
     return dense ? "specialized backward-difference stiffness-aware interpolation" :

--- a/lib/OrdinaryDiffEqBDF/src/stiff_addsteps.jl
+++ b/lib/OrdinaryDiffEqBDF/src/stiff_addsteps.jl
@@ -137,3 +137,62 @@ function _ode_addsteps!(
     end
     return nothing
 end
+
+####################################################################
+# MOOSE234: Rebuild Chebyshev-resampled interpolation data
+# Same approach as FBDF, using Lagrange interpolation through
+# u and u_history, resampled at fixed Chebyshev reference nodes.
+####################################################################
+
+# MOOSE234 ConstantCache: out-of-place k entries
+function _ode_addsteps!(
+        k, t, uprev, u, dt, f, p,
+        cache::MOOSE234ConstantCache,
+        always_calc_begin = false, allow_calc_end = true,
+        force_calc_end = false
+    )
+    always_calc_begin || return nothing
+    (; u_history, ts, order) = cache
+    n = order + 1
+
+    thetas = Vector{typeof(t)}(undef, n)
+    thetas[1] = one(t)
+    for j in 1:order
+        thetas[1 + j] = (ts[j] - t) / dt
+    end
+
+    values = Vector{typeof(u)}(undef, n)
+    values[1] = u isa Number ? u : copy(u)
+    for j in 1:order
+        values[1 + j] = u isa Number ? u_history[j] : copy(u_history[j])
+    end
+
+    _resample_at_chebyshev!(k, values, thetas, n)
+    for j in (n + 1):length(k)
+        k[j] = zero(u)
+    end
+    return nothing
+end
+
+# MOOSE234 Cache: in-place k entries
+function _ode_addsteps!(
+        k, t, uprev, u, dt, f, p,
+        cache::MOOSE234Cache,
+        always_calc_begin = false, allow_calc_end = true,
+        force_calc_end = false
+    )
+    always_calc_begin || return nothing
+    (; u_history, ts, order, equi_ts) = cache
+    n = order + 1
+
+    equi_ts[1] = one(eltype(equi_ts))
+    for j in 1:order
+        equi_ts[1 + j] = (ts[j] - t) / dt
+    end
+
+    _resample_at_chebyshev_direct_iip!(k, u, u_history, equi_ts, n)
+    for j in (n + 1):length(k)
+        fill!(k[j], zero(eltype(u)))
+    end
+    return nothing
+end

--- a/lib/OrdinaryDiffEqBDF/test/bdf_convergence_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/bdf_convergence_tests.jl
@@ -144,7 +144,7 @@ end
 
     sol = solve(prob, MOOSE234(), abstol = 1e-8, reltol = 1e-8)
     @test sol.retcode == ReturnCode.Success
-    @test isapprox(sol[end], exp(-1.0) .* u0, rtol = 1e-2)
+    @test isapprox(sol.u[end], exp(-1.0) .* u0, rtol = 1e-2)
 end
 
 @testset "MOOSE234 vs FBDF accuracy" begin

--- a/lib/OrdinaryDiffEqBDF/test/bdf_convergence_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/bdf_convergence_tests.jl
@@ -116,6 +116,49 @@ end
 
     #FBDF
     @test_nowarn solve(prob, FBDF())
+
+    # MOOSE234 — VSVO method, test_convergence with fixed dt is not applicable
+    @test_nowarn solve(prob, MOOSE234())
+
+    sol = solve(prob, MOOSE234(), abstol = 1e-8, reltol = 1e-8)
+    @test sol.retcode == ReturnCode.Success
+end
+
+@testset "MOOSE234 accuracy (scalar exponential)" begin
+    prob = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 1.0))
+    exact = exp(-1.0)
+
+    sol_mod = solve(prob, MOOSE234(), abstol = 1e-6, reltol = 1e-6)
+    @test isapprox(sol_mod[end], exact, rtol = 1e-4)
+
+    sol_tight = solve(prob, MOOSE234(), abstol = 1e-10, reltol = 1e-10)
+    @test isapprox(sol_tight[end], exact, rtol = 1e-6)
+
+    @test abs(sol_tight[end] - exact) < abs(sol_mod[end] - exact)
+end
+
+@testset "MOOSE234 accuracy (in-place 2D)" begin
+    fiip = (du, u, p, t) -> du .= p .* u
+    u0 = [1.0, 2.0]
+    prob = ODEProblem(fiip, u0, (0.0, 1.0), -1.0)
+
+    sol = solve(prob, MOOSE234(), abstol = 1e-8, reltol = 1e-8)
+    @test sol.retcode == ReturnCode.Success
+    @test isapprox(sol[end], exp(-1.0) .* u0, rtol = 1e-2)
+end
+
+@testset "MOOSE234 vs FBDF accuracy" begin
+    prob = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 1.0))
+    exact = exp(-1.0)
+
+    sol_moose = solve(prob, MOOSE234(), abstol = 1e-8, reltol = 1e-8)
+    sol_fbdf = solve(prob, FBDF(), abstol = 1e-8, reltol = 1e-8)
+
+    err_moose = abs(sol_moose[end] - exact)
+    err_fbdf = abs(sol_fbdf[end] - exact)
+
+    @test err_moose < 1e-6
+    @test err_fbdf < 1e-6
 end
 
 @testset "Static Array (SVector) Tests" begin
@@ -123,7 +166,7 @@ end
     u0_sv = SVector(1.0, 2.0)
     prob_sv = ODEProblem(f_oop, u0_sv, (0.0, 1.0))
 
-    for alg in (QNDF(), QNDF1(), QNDF2(), FBDF())
+    for alg in (QNDF(), QNDF1(), QNDF2(), FBDF(), MOOSE234())
         name = nameof(typeof(alg))
         @testset "$name" begin
             sol = solve(prob_sv, alg, abstol = 1.0e-8, reltol = 1.0e-8)
@@ -134,7 +177,7 @@ end
 
     # Scalar
     prob_scalar = ODEProblem(f_oop, 1.0, (0.0, 1.0))
-    for alg in (QNDF(), FBDF())
+    for alg in (QNDF(), FBDF(), MOOSE234())
         name = nameof(typeof(alg))
         @testset "$name scalar" begin
             sol = solve(prob_scalar, alg, abstol = 1.0e-8, reltol = 1.0e-8)

--- a/lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl
@@ -227,7 +227,7 @@ end
     sol = solve(prob, MOOSE234(), abstol = 1e-8, reltol = 1e-8)
     @test sol.retcode == ReturnCode.Success
     @test sol.t[end] == 1e5
-    @test isapprox(sum(sol[end]), 1.0, atol = 1e-6)
+    @test isapprox(sum(sol.u[end]), 1.0, atol = 1e-6)
 end
 
 if VERSION >= v"1.12"

--- a/lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl
@@ -143,6 +143,93 @@ if VERSION >= v"1.11"
     end
 end
 
+@testset "MOOSE234 reinit" begin
+    foop_m = (u, p, t) -> p * u
+    proboop_m = ODEProblem(foop_m, ones(2), (0.0, 10.0), -1.0)
+
+    fiip_m = (du, u, p, t) -> du .= p .* u
+    probiip_m = ODEProblem(fiip_m, ones(2), (0.0, 10.0), -1.0)
+
+    for prob in [proboop_m, probiip_m]
+        integ = init(prob, MOOSE234())
+        solve!(integ)
+        @test integ.sol.retcode == ReturnCode.Success
+        @test integ.sol.t[end] == 10.0
+
+        reinit!(integ, prob.u0)
+        solve!(integ)
+        @test integ.sol.retcode == ReturnCode.Success
+        @test integ.sol.t[end] == 10.0
+    end
+end
+
+@testset "MOOSE234 startup order progression" begin
+    prob = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 5.0))
+    integ = init(prob, MOOSE234(), dt = 0.01)
+
+    @test integ.cache.order == 2
+    @test integ.cache.iters_from_event == 0
+
+    step!(integ)
+    @test integ.cache.iters_from_event >= 1
+    @test 2 <= integ.cache.order <= 4
+
+    step!(integ)
+    @test integ.cache.iters_from_event >= 2
+
+    for _ in 1:10
+        step!(integ)
+    end
+    @test integ.cache.iters_from_event >= 4
+end
+
+@testset "MOOSE234 adaptive order switching" begin
+    prob = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 10.0))
+    integ = init(prob, MOOSE234(), dt = 0.01)
+
+    orders_seen = Set{Int}()
+    for _ in 1:200
+        step!(integ)
+        push!(orders_seen, integ.cache.order)
+        integ.sol.retcode == ReturnCode.Failure && break
+    end
+
+    @test length(orders_seen) >= 2
+    @test all(o -> 2 <= o <= 4, orders_seen)
+end
+
+@testset "MOOSE234 Van der Pol (stiff)" begin
+    function vdp!(du, u, p, t)
+        μ = p[1]
+        du[1] = u[2]
+        du[2] = μ * (1 - u[1]^2) * u[2] - u[1]
+    end
+
+    prob_mod = ODEProblem(vdp!, [2.0, 0.0], (0.0, 6.3), [100.0])
+    sol_mod = solve(prob_mod, MOOSE234(), abstol = 1e-6, reltol = 1e-6)
+    @test sol_mod.retcode == ReturnCode.Success
+    @test sol_mod.t[end] == 6.3
+
+    prob_stiff = ODEProblem(vdp!, [2.0, 0.0], (0.0, 6.3), [1000.0])
+    sol_stiff = solve(prob_stiff, MOOSE234(), abstol = 1e-4, reltol = 1e-4)
+    @test sol_stiff.retcode == ReturnCode.Success
+    @test sol_stiff.t[end] == 6.3
+end
+
+@testset "MOOSE234 ROBER stiff system" begin
+    function rober!(du, u, p, t)
+        y1, y2, y3 = u
+        du[1] = -0.04 * y1 + 1e4 * y2 * y3
+        du[2] = 0.04 * y1 - 1e4 * y2 * y3 - 3e7 * y2^2
+        du[3] = 3e7 * y2^2
+    end
+    prob = ODEProblem(rober!, [1.0, 0.0, 0.0], (0.0, 1e5))
+    sol = solve(prob, MOOSE234(), abstol = 1e-8, reltol = 1e-8)
+    @test sol.retcode == ReturnCode.Success
+    @test sol.t[end] == 1e5
+    @test isapprox(sum(sol[end]), 1.0, atol = 1e-6)
+end
+
 if VERSION >= v"1.12"
     @testset "FBDF in-place perform_step! non-allocating" begin
         integrator = init(


### PR DESCRIPTION
Brings https://github.com/SciML/OrdinaryDiffEq.jl/pull/3746 by @KeshavVenkatesh up to current master. #3746 went `CONFLICTING` and cannot be merged as-is; this branch is a real merge of `KeshavVenkatesh:moose234` into `master`, so the original commits and authorship are preserved in the history.

## Conflicts and how they were resolved

All three conflicts were additive — MOOSE234 and the newly landed `NordsieckBDF`/`DNordsieckBDF` both extend the same three places. Both sides are kept in each:

- `OrdinaryDiffEqBDF.jl` — export list now carries `MOOSE234` alongside `NordsieckBDF, DNordsieckBDF`
- `alg_utils.jl` — `has_stiff_interpolation(::Union{QNDF, FBDF, DFBDF, MOOSE234})`, plus both solvers' trait blocks
- `bdf_caches.jl` — git interleaved the two solvers' `alg_cache` boilerplate, so this file was reconstructed from each side rather than by editing conflict markers: master's file in full, plus the self-contained MOOSE234 block (cache structs and both `alg_cache` methods)

## What I verified

- Diff versus master is **+1313/-8 across the same 12 files** as #3746 — the diffstat matches exactly, so nothing was dropped in the resolution
- No conflict markers remain
- Every modified file under `lib/OrdinaryDiffEqBDF/src/` passes `Meta.parseall`

## What I did NOT verify

- **The package was not loaded or tested locally.** Resolving a dev environment for the sublibrary from this checkout failed with `Unsatisfiable requirements detected for package SciMLBase`, so `using OrdinaryDiffEqBDF` and the MOOSE234 convergence tests were never run on my machine. CI is the first real check.
- The numerical content of MOOSE234 is unreviewed by me; this PR only restores mergeability.

Because the resolution touches solver cache internals, the `bdf_caches.jl` result deserves a look before merging.

Supersedes #3746.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
