### PR TITLE
Keep DAE init from overwriting uprev during callback truncation

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.9.5"
+version = "2.9.6"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/initialize_dae.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/initialize_dae.jl
@@ -200,6 +200,8 @@ The method:
 du = (u-u0)/h
 Solve for `u`
 
+Same as BrownFullBasicInit: do not assign `integrator.uprev` here (#4485).
+
 =#
 
 function _initialize_dae!(
@@ -317,10 +319,6 @@ function _initialize_dae!(
         integrator.u .= nlsol.u
         failed = nlsol.retcode != ReturnCode.Success
     end
-    recursivecopy!(integrator.uprev, integrator.u)
-    if alg_extrapolates(integrator.alg)
-        recursivecopy!(integrator.uprev2, integrator.uprev)
-    end
 
     if failed
         @SciMLMessage(
@@ -411,10 +409,6 @@ function _initialize_dae!(
         failed = nlsol.retcode != ReturnCode.Success
     end
 
-    integrator.uprev = copy(integrator.u)
-    if alg_extrapolates(integrator.alg)
-        integrator.uprev2 = copy(integrator.uprev)
-    end
 
     if failed
         @SciMLMessage(
@@ -503,10 +497,6 @@ function _initialize_dae!(
     )
 
     integrator.u = nlsol.u
-    recursivecopy!(integrator.uprev, integrator.u)
-    if alg_extrapolates(integrator.alg)
-        recursivecopy!(integrator.uprev2, integrator.uprev)
-    end
     if nlsol.retcode != ReturnCode.Success
         @SciMLMessage(
             lazy"ShampineCollocationInit DAE initialization algorithm failed with dt=$dt. Try to adjust initdt like `ShampineCollocationInit(initdt)`.",
@@ -568,10 +558,6 @@ function _initialize_dae!(
 
     integrator.u = nlsol.u
 
-    integrator.uprev = copy(integrator.u)
-    if alg_extrapolates(integrator.alg)
-        integrator.uprev2 = copy(integrator.uprev)
-    end
     if nlsol.retcode != ReturnCode.Success
         @SciMLMessage(
             lazy"ShampineCollocationInit DAE initialization algorithm failed with dt=$dt. Try to adjust initdt like `ShampineCollocationInit(initdt)`.",
@@ -592,6 +578,11 @@ The method:
 
 Keep differential variables constant
 Solve for the algebraic variables
+
+Do not assign `integrator.uprev` here. Callback truncation reinitializes the
+right endpoint while `uprev` must still be the left endpoint of the shortened
+step (see #4466 / #4485). Initial `uprev` sync happens in `solve` via
+`update_uprev!` after `initialize_dae!`.
 
 =#
 
@@ -678,10 +669,6 @@ function _initialize_dae!(
     )
     alg_u .= nlsol.u
 
-    recursivecopy!(integrator.uprev, integrator.u)
-    if alg_extrapolates(integrator.alg)
-        recursivecopy!(integrator.uprev2, integrator.uprev)
-    end
 
     if nlsol.retcode != ReturnCode.Success
         integrator.sol = SciMLBase.solution_new_retcode(
@@ -758,10 +745,6 @@ function _initialize_dae!(
         integrator.u = u
     end
 
-    integrator.uprev = copy(integrator.u)
-    if alg_extrapolates(integrator.alg)
-        integrator.uprev2 = copy(integrator.uprev)
-    end
 
     if nlsol.retcode != ReturnCode.Success
         integrator.sol = SciMLBase.solution_new_retcode(
@@ -849,10 +832,6 @@ function _initialize_dae!(
     @. du = ifelse(differential_vars, nlsol.u, du)
     @. u = ifelse(differential_vars, u, nlsol.u)
 
-    recursivecopy!(integrator.uprev, integrator.u)
-    if alg_extrapolates(integrator.alg)
-        recursivecopy!(integrator.uprev2, integrator.uprev)
-    end
 
     if nlsol.retcode != ReturnCode.Success
         integrator.sol = SciMLBase.solution_new_retcode(
@@ -918,10 +897,6 @@ function _initialize_dae!(
         integrator.du = du
     end
 
-    integrator.uprev = copy(integrator.u)
-    if alg_extrapolates(integrator.alg)
-        integrator.uprev2 = copy(integrator.uprev)
-    end
 
     if nlsol.retcode != ReturnCode.Success
         integrator.sol = SciMLBase.solution_new_retcode(

--- a/lib/OrdinaryDiffEqRosenbrock/test/callback_truncated_interpolation.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/test/callback_truncated_interpolation.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEqRosenbrock, DiffEqBase, LinearAlgebra, Test
+using OrdinaryDiffEqRosenbrock, OrdinaryDiffEqNonlinearSolve, DiffEqBase, LinearAlgebra, Test
 
 function linear_dae!(du, u, p, t)
     du[1] = -1
@@ -57,6 +57,35 @@ end
         @test sol.u[end] ≈ exact(sol.t[end]) atol = 1.0e-4
         for t in range(0.0, sol.t[end]; length = 101)
             @test sol(t) ≈ exact(t) atol = 1.0e-2
+        end
+    end
+end
+
+# Nonlinear algebraic constraint so truncation leaves a residual that forces
+# BrownFullBasicInit to run (and previously overwrite uprev; #4485).
+@testset "BrownFullBasicInit saveat matches post-solve interpolant" begin
+    function cubic_dae!(du, u, p, t)
+        du[1] = -u[1]
+        du[2] = u[2]^3 - u[1]
+        return nothing
+    end
+    callback = ContinuousCallback(
+        (u, t, integrator) -> u[1] - 0.2, terminate!;
+        save_positions = (true, false)
+    )
+    prob = ODEProblem(
+        ODEFunction(cubic_dae!; mass_matrix), [1.0, 1.0], (0.0, 10.0);
+        callback, initializealg = BrownFullBasicInit()
+    )
+    tgrid = range(0.0, 5.0; length = 101)
+    for alg in (Rodas4(), Rodas4P(), Rodas5P())
+        sol_saveat = solve(prob, alg; saveat = tgrid)
+        sol_dense = solve(prob, alg)
+        @test sol_saveat.retcode == SciMLBase.ReturnCode.Terminated
+        @test sol_dense.retcode == SciMLBase.ReturnCode.Terminated
+        @test sol_saveat.t[end] ≈ sol_dense.t[end] atol = 1.0e-10
+        for (t, u) in zip(sol_saveat.t, sol_saveat.u)
+            @test sol_dense(t) ≈ u atol = 1.0e-8
         end
     end
 end


### PR DESCRIPTION
## Summary
- `BrownFullBasicInit` / `ShampineCollocationInit` no longer copy `u` into `uprev` after reinit, so callback-truncated `saveat` keeps the left endpoint of the shortened step (#4485; follows #4466).
- Initial `uprev` sync still happens via `update_uprev!` in `solve` after `initialize_dae!`.
- Adds a Rodas regression comparing `saveat` to post-solve dense output under `BrownFullBasicInit` + `terminate!`.

## Test plan
- [x] `lib/OrdinaryDiffEqRosenbrock/test/callback_truncated_interpolation.jl` (fixed-step, adaptive, and new BrownFullBasicInit cases)
- [x] Issue #4485 LyoPronto MRE: last-step `|saveat − post|` from ~0.44 → ~0 / overall ≲ 1e-13


Made with [Cursor](https://cursor.com)