### PR TITLE
DiffEqBase: Int64 interp_points range length for 32-bit

### DIFF
--- a/lib/DiffEqBase/src/callbacks.jl
+++ b/lib/DiffEqBase/src/callbacks.jl
@@ -433,8 +433,11 @@ function check_event_occurrence(integrator, callback, bottom_sign)
     if callback.interp_points != 0 && !isdiscrete(integrator.alg) &&
             any(iszero, event_idx)
         # Use the interpolants for safety checking
-        ts = range(integrator.tprev, stop = integrator.t,
-            length = Int64(callback.interp_points))  # Int64: avoid i686 _linspace InexactError
+        ts = range(
+            integrator.tprev,
+            stop = integrator.t,
+            length = Int64(callback.interp_points)
+        )  # Int64: avoid i686 _linspace InexactError
         for i in 2:length(ts)
             top_t = ts[i]
             event_occurred, event_idx, top_sign =

--- a/lib/DiffEqBase/src/callbacks.jl
+++ b/lib/DiffEqBase/src/callbacks.jl
@@ -433,7 +433,8 @@ function check_event_occurrence(integrator, callback, bottom_sign)
     if callback.interp_points != 0 && !isdiscrete(integrator.alg) &&
             any(iszero, event_idx)
         # Use the interpolants for safety checking
-        ts = range(integrator.tprev, stop = integrator.t, length = callback.interp_points)
+        ts = range(integrator.tprev, stop = integrator.t,
+            length = Int64(callback.interp_points))  # Int64: avoid i686 _linspace InexactError
         for i in 2:length(ts)
             top_t = ts[i]
             event_occurred, event_idx, top_sign =

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/OrdinaryDiffEqNonlinearSolve.jl
@@ -40,7 +40,6 @@ import ArrayInterface: ArrayInterface
 import LinearSolve
 import ForwardDiff: ForwardDiff
 using ForwardDiff: Dual
-using RecursiveArrayTools: recursivecopy!
 import OrdinaryDiffEqCore
 
 import SciMLOperators: islinear, AbstractSciMLOperator, MatrixOperator
@@ -57,7 +56,7 @@ using OrdinaryDiffEqCore: resize_nlsolver!, _initialize_dae!,
     Convergence,
     Divergence, NLStatus,
     MethodType, error_constant,
-    alg_extrapolates, resize_J_W!, alg_autodiff,
+    resize_J_W!, alg_autodiff,
     find_algebraic_vars_eqs
 
 import OrdinaryDiffEqCore: _initialize_dae!,


### PR DESCRIPTION
## Summary
- `lib/DiffEqBase`: `range(tprev, stop=t, length=callback.interp_points)` with `Int===Int32` hits `InexactError` in `Base._linspace` on i686.
- Forces `Int64(callback.interp_points)`.
- Unblocks JumpProcesses x86 VR-jump / gene-expr tests.

## Test plan
- [ ] DiffEqBase / ODE CI green
- [ ] JumpProcesses x86 no longer fails in `check_event_occurence` linspace

Made with [Cursor](https://cursor.com)