### PR TITLE
Add optional MOOSE time_filter to NordsieckBDF

### DIFF
--- a/lib/OrdinaryDiffEqBDF/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqBDF/src/alg_utils.jl
@@ -52,8 +52,12 @@ has_stiff_interpolation(::Union{QNDF, FBDF, DFBDF}) = true
 alg_order(alg::NordsieckBDF) = 1  # dummy: the running order lives in the cache
 alg_order(alg::DNordsieckBDF) = 1
 isadaptive(alg::DNordsieckBDF) = true
-get_current_alg_order(alg::NordsieckBDFAlgs, cache) = cache.order
-get_current_adaptive_order(alg::NordsieckBDFAlgs, cache) = cache.order
+get_current_alg_order(alg::NordsieckBDFAlgs, cache) =
+    hasproperty(cache, :filter_order) && cache.filter_order > 0 ? cache.filter_order :
+    cache.order
+get_current_adaptive_order(alg::NordsieckBDFAlgs, cache) =
+    hasproperty(cache, :filter_order) && cache.filter_order > 0 ? cache.filter_order :
+    cache.order
 has_stiff_interpolation(::NordsieckBDFAlgs) = true
 
 # The Newton increment norm is scaled by tq[2], which converts it into the units of

--- a/lib/OrdinaryDiffEqBDF/src/algorithms.jl
+++ b/lib/OrdinaryDiffEqBDF/src/algorithms.jl
@@ -825,12 +825,23 @@ end
       refactorizing is comparatively rare for it.
     - `max_order`: maximum BDF order (1–5).
     - `step_limiter!`: function of the form `limiter!(u, integrator, p, t)`.
+    - `stald`: Enable Stability Limit Detection (STALD) for BDF orders 3-5.
+      Default: `false` (matches CVODE).
+    - `time_filter`: Apply optional MOOSE time filters
+      ([DeCaria et al.](https://arxiv.org/abs/1810.06670)) after the BDF corrector,
+      using a short rolling `(t, u)` history alongside the Nordsieck array. Same
+      candidate selection as `FBDF(time_filter=true)`: order `k+1` at base orders
+      1–4, and BDF3-Stab (order 2) at order 3. The filtered solution is committed
+      into the Nordsieck array via an updated `acor`. Requires the identity mass
+      matrix. Default: `false`.
     """,
     """
     nlsolve = NLNewton(max_iter = 3),
     extrapolant = :linear,
     max_order::Val{MO} = Val{5}(),
     step_limiter! = trivial_limiter!,
+    stald = false,
+    time_filter = false,
     """
 )
 struct NordsieckBDF{MO, AD, F, F2, T, StepLimiter, CJ, QT} <:
@@ -847,6 +858,7 @@ struct NordsieckBDF{MO, AD, F, F2, T, StepLimiter, CJ, QT} <:
     qmax::QT
     qsteady_min::QT
     qsteady_max::QT
+    time_filter::Bool
 end
 
 function NordsieckBDF(;
@@ -854,12 +866,14 @@ function NordsieckBDF(;
         autodiff = AutoForwardDiff(), concrete_jac = nothing,
         linsolve = nothing, nlsolve = NLNewton(max_iter = 3), tol = nothing,
         extrapolant = :linear, step_limiter! = trivial_limiter!, stald = false,
-        qsteady_min = 1 // 1, qsteady_max = 1 // 1, qmax = 10 // 1
+        qsteady_min = 1 // 1, qsteady_max = 1 // 1, qmax = 10 // 1,
+        time_filter = false,
     ) where {MO}
     autodiff = _fixup_ad(autodiff)
     return NordsieckBDF(
         max_order, linsolve, nlsolve, tol, extrapolant, step_limiter!,
-        autodiff, _unwrap_val(concrete_jac), stald, qmax, qsteady_min, qsteady_max
+        autodiff, _unwrap_val(concrete_jac), stald, qmax, qsteady_min, qsteady_max,
+        time_filter,
     )
 end
 

--- a/lib/OrdinaryDiffEqBDF/src/bdf_caches.jl
+++ b/lib/OrdinaryDiffEqBDF/src/bdf_caches.jl
@@ -841,6 +841,7 @@ end
 # ================================================================= caches
 @cache mutable struct NordsieckBDFCache{
         MO, N, rateType, uNoUnitsType, uType, tType, coeffType, staldType, StepLimiter,
+        filtTsType, filtUHType, filtCoeffType, filtMatType,
     } <: BDFMutableCache
     fsalfirst::rateType
     nlsolver::N
@@ -850,6 +851,7 @@ end
     tempv::uType
     tmp::uType
     atmp::uNoUnitsType
+    ufilt::uType
     l::coeffType
     tau::coeffType
     tq::coeffType
@@ -872,11 +874,24 @@ end
     predicted::Bool
     stald::staldType
     step_limiter!::StepLimiter
+    time_filter::Bool
+    filter_order::Int
+    iters_from_event::Int
+    ts::filtTsType
+    u_history::filtUHType
+    bdf_coeffs::filtCoeffType
+    ts_asc::filtTsType
+    α_bar::filtTsType
+    dd_c::filtMatType
+    dd_D::filtMatType
 end
 
 @truncate_stacktrace NordsieckBDFCache 1
 
-mutable struct NordsieckBDFConstantCache{MO, N, uType, tType, coeffType, staldType} <:
+mutable struct NordsieckBDFConstantCache{
+        MO, N, uType, tType, coeffType, staldType,
+        filtTsType, filtUHType, filtCoeffType, filtMatType,
+    } <:
     OrdinaryDiffEqConstantCache
     nlsolver::N
     zn::Vector{uType}
@@ -903,16 +918,48 @@ mutable struct NordsieckBDFConstantCache{MO, N, uType, tType, coeffType, staldTy
     saved_tq5::tType
     predicted::Bool
     stald::staldType
+    time_filter::Bool
+    filter_order::Int
+    iters_from_event::Int
+    ts::filtTsType
+    u_history::filtUHType
+    bdf_coeffs::filtCoeffType
+    ts_asc::filtTsType
+    α_bar::filtTsType
+    dd_c::filtMatType
+    dd_D::filtMatType
 end
 
 # DAE caches carry `u₀` because `get_dae_uprev` uses it as the predictor the
 # correction `z` is measured against.
+
+function _nordsieck_filter_workspace(alg, u, t, ::Val{MO}) where {MO}
+    n_filt = alg.time_filter ? MO + 2 : 0
+    T = typeof(t)
+    ts = fill(T(NaN), n_filt)
+    ts_asc = fill(T(NaN), n_filt)
+    α_bar = zeros(T, n_filt)
+    dd_c = zeros(T, n_filt, n_filt)
+    dd_D = zeros(T, n_filt, n_filt)
+    bdf_coeffs = alg.time_filter ? _make_bdf_coeffs_fbdf() : Matrix{Rational{Int64}}(undef, 0, 0)
+    if u isa Number
+        u_history = alg.time_filter ? zeros(eltype(u), n_filt) : eltype(u)[]
+    else
+        u_history = [zero(u) for _ in 1:n_filt]
+    end
+    return ts, u_history, bdf_coeffs, ts_asc, α_bar, dd_c, dd_D
+end
 
 function alg_cache(
         alg::NordsieckBDF{MO}, u, rate_prototype, ::Type{uEltypeNoUnits},
         ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
         dt, reltol, p, calck, ::Val{true}, verbose
     ) where {MO, uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    alg.time_filter && f.mass_matrix !== I && throw(
+        ArgumentError(
+            "NordsieckBDF(time_filter=true) requires the identity mass matrix; use time_filter=false for mass-matrix problems."
+        )
+    )
     γ, c = one(tTypeNoUnits), one(tTypeNoUnits)
     nlsolver = build_nlsolver(
         alg, u, uprev, p, t, dt, f, rate_prototype, uEltypeNoUnits,
@@ -922,16 +969,21 @@ function alg_cache(
     coeffs() = zeros(typeof(t), MO + 3)
     tq = zeros(typeof(t), 6)
     stald = StabilityLimitDetectionState(real(uBottomEltypeNoUnits); enabled = alg.stald)
+    ts, u_history, bdf_coeffs, ts_asc, α_bar, dd_c, dd_D = _nordsieck_filter_workspace(
+        alg, u, t, Val(MO)
+    )
     return NordsieckBDFCache{
         MO, typeof(nlsolver), typeof(rate_prototype),
         typeof(similar(u, uEltypeNoUnits)), typeof(u), typeof(t),
         typeof(coeffs()), typeof(stald), typeof(alg.step_limiter!),
+        typeof(ts), typeof(u_history), typeof(bdf_coeffs), typeof(dd_c),
     }(
         zero(rate_prototype), nlsolver, zn, zero(u), zero(u), zero(u), zero(u),
-        similar(u, uEltypeNoUnits), coeffs(), coeffs(), tq,
+        similar(u, uEltypeNoUnits), zero(u), coeffs(), coeffs(), tq,
         1, 1, 2, 0, 0, 0, MO, Val(MO), MO,
         zero(t), one(t), typeof(t)(NORD_ETA_MAX_FS), one(t), zero(t), zero(t),
-        zero(t), false, stald, alg.step_limiter!
+        zero(t), false, stald, alg.step_limiter!,
+        alg.time_filter, 0, 0, ts, u_history, bdf_coeffs, ts_asc, α_bar, dd_c, dd_D
     )
 end
 
@@ -940,6 +992,11 @@ function alg_cache(
         ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, uprev2, f, t,
         dt, reltol, p, calck, ::Val{false}, verbose
     ) where {MO, uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    alg.time_filter && f.mass_matrix !== I && throw(
+        ArgumentError(
+            "NordsieckBDF(time_filter=true) requires the identity mass matrix; use time_filter=false for mass-matrix problems."
+        )
+    )
     γ, c = one(tTypeNoUnits), one(tTypeNoUnits)
     nlsolver = build_nlsolver(
         alg, u, uprev, p, t, dt, f, rate_prototype, uEltypeNoUnits,
@@ -948,12 +1005,17 @@ function alg_cache(
     zn = [zero(u) for _ in 1:(MO + 1)]
     coeffs() = zeros(typeof(t), MO + 3)
     stald = StabilityLimitDetectionState(real(uBottomEltypeNoUnits); enabled = alg.stald)
+    ts, u_history, bdf_coeffs, ts_asc, α_bar, dd_c, dd_D = _nordsieck_filter_workspace(
+        alg, u, t, Val(MO)
+    )
     return NordsieckBDFConstantCache{
         MO, typeof(nlsolver), typeof(u), typeof(t), typeof(coeffs()), typeof(stald),
+        typeof(ts), typeof(u_history), typeof(bdf_coeffs), typeof(dd_c),
     }(
         nlsolver, zn, zero(u), zero(u), coeffs(), coeffs(), zeros(typeof(t), 6),
         1, 1, 2, 0, 0, 0, MO, Val(MO), MO,
         zero(t), one(t), typeof(t)(NORD_ETA_MAX_FS), one(t), zero(t), zero(t),
-        zero(t), false, stald
+        zero(t), false, stald,
+        alg.time_filter, 0, 0, ts, u_history, bdf_coeffs, ts_asc, α_bar, dd_c, dd_D
     )
 end

--- a/lib/OrdinaryDiffEqBDF/src/bdf_perform_step.jl
+++ b/lib/OrdinaryDiffEqBDF/src/bdf_perform_step.jl
@@ -1686,6 +1686,7 @@ function perform_step!(integrator, cache::NordsieckBDFCache, repeat_step = false
     nordsieck_needs_start(integrator, cache) && nordsieck_start!(integrator, cache, iip)
 
     nordsieck_prepare!(integrator, cache, iip)
+    _nordsieck_filter_reinit_history!(integrator, cache, iip)
     nordsieck_predict!(cache, iip)
     nordsieck_set_coeffs!(cache, dt)
 
@@ -1719,8 +1720,13 @@ function perform_step!(integrator, cache::NordsieckBDFCache, repeat_step = false
         )
     end
 
-    # zn[1] is h*f(u) exactly once the corrector has converged, so fsallast is free
-    @.. broadcast = false integrator.fsallast = (zn[2] + l1 * cache.acor) / dt
+    # Free FSAL from the converged Newton residual; the MOOSE filter recomputes
+    # f whenever it moves `u`, since that identity no longer holds.
+    if cache.time_filter && _nordsieck_time_filter!(integrator, cache, cache.order)
+        @.. broadcast = false cache.acor = u - cache.ypred
+    else
+        @.. broadcast = false integrator.fsallast = (zn[2] + l1 * cache.acor) / dt
+    end
     _nordsieck_finish_fixed!(integrator, cache, iip)
     return nothing
 end
@@ -1732,6 +1738,7 @@ function perform_step!(integrator, cache::NordsieckBDFConstantCache, repeat_step
     nordsieck_needs_start(integrator, cache) && nordsieck_start!(integrator, cache, iip)
 
     nordsieck_prepare!(integrator, cache, iip)
+    _nordsieck_filter_reinit_history!(integrator, cache, iip)
     nordsieck_predict!(cache, iip)
     nordsieck_set_coeffs!(cache, dt)
 
@@ -1758,7 +1765,17 @@ function perform_step!(integrator, cache::NordsieckBDFConstantCache, repeat_step
             cache.tq[2] * _nord_wrms(integrator, cache, cache.acor, uprev, u)
         )
     end
-    integrator.fsallast = @.. (zn[2] + l1 * cache.acor) / dt
+    if cache.time_filter
+        u, fsal, moved = _nordsieck_time_filter(integrator, cache, u, cache.order)
+        if moved
+            cache.acor = @.. u - cache.ypred
+            integrator.fsallast = fsal
+        else
+            integrator.fsallast = @.. (zn[2] + l1 * cache.acor) / dt
+        end
+    else
+        integrator.fsallast = @.. (zn[2] + l1 * cache.acor) / dt
+    end
     integrator.u = u
     _nordsieck_finish_fixed!(integrator, cache, iip)
     return nothing

--- a/lib/OrdinaryDiffEqBDF/src/controllers.jl
+++ b/lib/OrdinaryDiffEqBDF/src/controllers.jl
@@ -680,8 +680,40 @@ function step_accept_controller!(integrator, alg::NordsieckBDFAlgs, q)
     cache.ncf = 0
     # dense output data: the committed Nordsieck columns about t_{n+1}
     _nordsieck_store_k!(integrator, cache, iip)
+    if hasproperty(cache, :time_filter) && cache.time_filter
+        _nordsieck_filter_push_history!(cache, integrator.t + dt, u, iip)
+    end
 
-    if cache.etamax == one(T)
+    if hasproperty(cache, :time_filter) && cache.time_filter && cache.filter_order > 0
+        # Prefer the MOOSE candidate's order and rebuild eta from its EEst.
+        fo = cache.filter_order
+        cache.etaq = inv((NORD_BIAS2 * dsm)^(one(T) / (fo + 1)) + NORD_ADDON)
+        if fo > cache.order && cache.order < cache.max_order_int && cache.qwait == 0
+            cache.qprime = cache.order + 1
+            cache.eta = cache.etaq
+            _nord_setacor!(cache, acor, iip)
+            cache.qwait = 2
+        elseif fo < cache.order && fo >= 1
+            cache.qprime = fo
+            cache.eta = min(cache.etaq, one(T))
+            cache.qwait = 2
+        elseif cache.qwait != 0
+            cache.eta = cache.etaq
+            cache.qprime = cache.order
+            nordsieck_set_eta!(cache, integrator)
+        else
+            cache.qwait = 2
+            cache.etaqm1 = nordsieck_compute_etaqm1(cache, integrator, u, uprev)
+            cache.etaqp1 = nordsieck_compute_etaqp1(cache, integrator, u, uprev, acor, dt)
+            nordsieck_choose_eta!(cache, integrator, u, uprev, acor, dt, iip)
+            # Keep a MOOSE upgrade if choose_eta didn't already pick it
+            if fo > cache.order && cache.qprime <= cache.order
+                cache.qprime = cache.order + 1
+                _nord_setacor!(cache, acor, iip)
+            end
+            nordsieck_set_eta!(cache, integrator)
+        end
+    elseif cache.etamax == one(T)
         # a failure earlier in this step forbids growth (CVODE cvPrepareNextStep)
         cache.qwait = max(cache.qwait, 2)
         cache.qprime = cache.order

--- a/lib/OrdinaryDiffEqBDF/src/nordsieck_utils.jl
+++ b/lib/OrdinaryDiffEqBDF/src/nordsieck_utils.jl
@@ -451,6 +451,15 @@ function _nordsieck_finish_fixed!(integrator, cache, iip)
     integrator.opts.adaptive && return nothing
     nordsieck_complete!(cache, integrator.dt, cache.acor, iip)
     _nordsieck_store_k!(integrator, cache, iip)
+    if hasproperty(cache, :time_filter) && cache.time_filter
+        _nordsieck_filter_push_history!(cache, integrator.t + integrator.dt, integrator.u, iip)
+        if cache.filter_order > cache.order && cache.order < cache.max_order_int
+            cache.qprime = cache.order + 1
+            _nord_setacor!(cache, cache.acor, iip)
+        elseif cache.filter_order > 0
+            cache.order = max(cache.order, cache.filter_order)
+        end
+    end
     if cache.qwait <= 0
         cache.qwait = 2
         if cache.order < cache.max_order_int
@@ -475,7 +484,9 @@ function nordsieck_start!(integrator, cache, iip::Val{true})
     @inbounds for j in 3:length(zn)
         fill!(zn[j], zero(eltype(uprev)))
     end
-    return _nordsieck_start_common!(cache, dt)
+    _nordsieck_start_common!(cache, dt)
+    _nordsieck_filter_seed_history!(integrator, cache, iip)
+    return nothing
 end
 function nordsieck_start!(integrator, cache, iip::Val{false})
     (; uprev, dt) = integrator
@@ -485,7 +496,9 @@ function nordsieck_start!(integrator, cache, iip::Val{false})
     @inbounds for j in 3:length(zn)
         zn[j] = zero(uprev)
     end
-    return _nordsieck_start_common!(cache, dt)
+    _nordsieck_start_common!(cache, dt)
+    _nordsieck_filter_seed_history!(integrator, cache, iip)
+    return nothing
 end
 function _nordsieck_start_common!(cache, dt)
     cache.order = 1
@@ -501,9 +514,246 @@ function _nordsieck_start_common!(cache, dt)
     cache.predicted = false
     stald_reset!(cache.stald)
     fill!(cache.tau, zero(eltype(cache.tau)))
+    if hasproperty(cache, :time_filter) && cache.time_filter
+        cache.filter_order = 0
+        cache.iters_from_event = 0
+        fill!(cache.ts, oftype(cache.ts[1], NaN))
+        if !isempty(cache.u_history)
+            h1 = first(cache.u_history)
+            if h1 isa Number
+                fill!(cache.u_history, zero(typeof(h1)))
+            elseif ArrayInterface.ismutable(h1)
+                for h in cache.u_history
+                    fill!(h, zero(eltype(h)))
+                end
+            end
+        end
+    end
     return nothing
 end
 
 @inline function nordsieck_needs_start(integrator, cache)
     return cache.nst == 0 || integrator.derivative_discontinuity
+end
+
+# ---------------------------------------------------------------- MOOSE time filter
+"""
+    _nordsieck_filter_reinit_history!(integrator, cache, iip)
+
+Mirror `reinitFBDF!`: keep a newest-first rolling `(t, uprev)` history so the
+MOOSE filter sees the same nodes the BDF corrector just used. Only shifts on a
+fresh attempt (`nef == ncf == 0`) so rejected retries do not duplicate nodes.
+"""
+function _nordsieck_filter_reinit_history!(integrator, cache, ::Val{true})
+    (hasproperty(cache, :time_filter) && cache.time_filter) || return nothing
+    n = length(cache.ts)
+    n == 0 && return nothing
+    (; t, uprev) = integrator
+    if integrator.derivative_discontinuity || cache.nst == 0
+        fill!(cache.ts, oftype(t, NaN))
+        cache.iters_from_event = 0
+        cache.ts[1] = t
+        copyto!(cache.u_history[1], uprev)
+        return nothing
+    end
+    if cache.iters_from_event == 0
+        cache.ts[1] = t
+        copyto!(cache.u_history[1], uprev)
+    elseif cache.iters_from_event == 1 && t != cache.ts[1]
+        cache.ts[2] = cache.ts[1]
+        cache.ts[1] = t
+        copyto!(cache.u_history[2], cache.u_history[1])
+        copyto!(cache.u_history[1], uprev)
+    elseif cache.nef == 0 && cache.ncf == 0 && t != cache.ts[1]
+        @inbounds for i in n:-1:2
+            cache.ts[i] = cache.ts[i - 1]
+            copyto!(cache.u_history[i], cache.u_history[i - 1])
+        end
+        cache.ts[1] = t
+        copyto!(cache.u_history[1], uprev)
+    end
+    return nothing
+end
+function _nordsieck_filter_reinit_history!(integrator, cache, ::Val{false})
+    (hasproperty(cache, :time_filter) && cache.time_filter) || return nothing
+    n = length(cache.ts)
+    n == 0 && return nothing
+    (; t, uprev) = integrator
+    if integrator.derivative_discontinuity || cache.nst == 0
+        fill!(cache.ts, oftype(t, NaN))
+        cache.iters_from_event = 0
+        cache.ts[1] = t
+        cache.u_history[1] = uprev
+        return nothing
+    end
+    if cache.iters_from_event == 0
+        cache.ts[1] = t
+        cache.u_history[1] = uprev
+    elseif cache.iters_from_event == 1 && t != cache.ts[1]
+        cache.ts[2] = cache.ts[1]
+        cache.ts[1] = t
+        cache.u_history[2] = cache.u_history[1]
+        cache.u_history[1] = uprev
+    elseif cache.nef == 0 && cache.ncf == 0 && t != cache.ts[1]
+        @inbounds for i in n:-1:2
+            cache.ts[i] = cache.ts[i - 1]
+            cache.u_history[i] = cache.u_history[i - 1]
+        end
+        cache.ts[1] = t
+        cache.u_history[1] = uprev
+    end
+    return nothing
+end
+
+# Keep seed helper as a thin alias used from cold start.
+_nordsieck_filter_seed_history!(integrator, cache, iip) =
+    _nordsieck_filter_reinit_history!(integrator, cache, iip)
+
+function _nordsieck_filter_push_history!(cache, t_new, u_new, iip)
+    # History is maintained at step start (FBDF-style); on accept we only
+    # advance the event counter that gates filter eligibility.
+    (hasproperty(cache, :time_filter) && cache.time_filter) || return nothing
+    cache.iters_from_event += 1
+    return nothing
+end
+
+"""
+Apply the MOOSE time filter to the corrected Nordsieck step (out-of-place).
+
+Returns `(u, fsallast, moved)`. When `moved`, `acor` must be recomputed as
+`u - ypred` so `nordsieck_complete!` commits the filtered solution.
+`fsallast === nothing` means the caller should keep the free Nordsieck FSAL.
+"""
+function _nordsieck_time_filter(integrator, cache, u_bdf, k)
+    (; ts, u_history, ts_asc, α_bar, dd_c, dd_D, bdf_coeffs) = cache
+    (; t, dt, f, p, uprev) = integrator
+    (; abstol, reltol, internalnorm, adaptive) = integrator.opts
+    max_order = cache.max_order_int
+    cache.filter_order = 0
+    k <= 4 && cache.iters_from_event >= k || return u_bdf, nothing, false
+    n = k + 2
+    @inbounds for i in 1:(n - 1)
+        isfinite(ts[i]) || return u_bdf, nothing, false
+    end
+    tdt = t + dt
+    _filt_fill_ts_asc!(ts_asc, ts, tdt, n)
+    backdiff!(dd_c, dd_D, ts_asc, n)
+    η = _fbdf_filter_weight(dd_c, ts_asc, n, k, dt, bdf_coeffs)
+    isfinite(η) || return u_bdf, nothing, false
+    δ = _filt_divided_diff(dd_c, n, n, u_bdf, u_history)
+    est = @.. broadcast = false -η * δ
+    y_hi = @.. broadcast = false u_bdf + est
+    if !adaptive
+        cache.filter_order = min(k + 1, max_order)
+        if k < max_order
+            OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+            return y_hi, f(y_hi, p, tdt), true
+        end
+        return u_bdf, nothing, false
+    end
+    err = internalnorm(
+        calculate_residuals(est, uprev, u_bdf, abstol, reltol, internalnorm, t), t
+    )
+    isfinite(err) || return u_bdf, nothing, false
+    f_hi = f(y_hi, p, tdt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    _filt_bdf_coefficients!(α_bar, dd_c, ts_asc, n, k + 1)
+    abs(α_bar[n]) < eps(typeof(η)) && return u_bdf, nothing, false
+    res = _filt_bdf_residual(α_bar, n, y_hi, u_history, f_hi)
+    est_hi = @.. broadcast = false res / α_bar[n]
+    err_hi = internalnorm(
+        calculate_residuals(est_hi, uprev, y_hi, abstol, reltol, internalnorm, t), t
+    )
+    isfinite(err_hi) || (err_hi = oftype(err, Inf))
+    y_lo = u_bdf
+    err_lo = oftype(err, Inf)
+    if k == 3
+        w = bdf3stab_coeff(dd_c, n)
+        if isfinite(w)
+            δ3 = _filt_divided_diff(dd_c, 4, n, u_bdf, u_history)
+            est_lo = @.. broadcast = false w * δ3
+            y_lo = @.. broadcast = false u_bdf + est_lo
+            err_lo = internalnorm(
+                calculate_residuals(est_lo, uprev, y_lo, abstol, reltol, internalnorm, t), t
+            )
+            isfinite(err_lo) || (err_lo = oftype(err, Inf))
+        end
+    end
+    selected = _fbdf_select_filter!(integrator, cache, k, max_order, err, err_hi, err_lo)
+    selected == k + 1 && return y_hi, f_hi, true
+    if selected < k
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+        return y_lo, f(y_lo, p, tdt), true
+    end
+    return u_bdf, nothing, false
+end
+
+"""
+In-place MOOSE filter. Returns `true` if `u` (and `fsallast`) were updated.
+"""
+function _nordsieck_time_filter!(integrator, cache, k)
+    (; ts, u_history, ts_asc, α_bar, dd_c, dd_D, atmp, bdf_coeffs) = cache
+    (; t, dt, u, f, p, uprev) = integrator
+    (; abstol, reltol, internalnorm, adaptive) = integrator.opts
+    max_order = cache.max_order_int
+    cache.filter_order = 0
+    k <= 4 && cache.iters_from_event >= k || return false
+    n = k + 2
+    @inbounds for i in 1:(n - 1)
+        isfinite(ts[i]) || return false
+    end
+    tdt = t + dt
+    y_lo = cache.ufilt
+    y_hi = cache.tempv
+    work = cache.tmp
+    _filt_fill_ts_asc!(ts_asc, ts, tdt, n)
+    backdiff!(dd_c, dd_D, ts_asc, n)
+    η = _fbdf_filter_weight(dd_c, ts_asc, n, k, dt, bdf_coeffs)
+    isfinite(η) || return false
+    _filt_divided_diff!(work, dd_c, n, n, u, u_history)
+    @.. broadcast = false work = -η * work
+    @.. broadcast = false y_hi = u + work
+    if !adaptive
+        cache.filter_order = min(k + 1, max_order)
+        k < max_order || return false
+        @.. broadcast = false u = y_hi
+        f(integrator.fsallast, u, p, tdt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+        return true
+    end
+    calculate_residuals!(atmp, work, uprev, u, abstol, reltol, internalnorm, t)
+    err = internalnorm(atmp, t)
+    isfinite(err) || return false
+    f(integrator.fsallast, y_hi, p, tdt)
+    OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+    _filt_bdf_coefficients!(α_bar, dd_c, ts_asc, n, k + 1)
+    abs(α_bar[n]) < eps(typeof(η)) && return false
+    _filt_bdf_residual!(work, α_bar, n, y_hi, u_history, integrator.fsallast)
+    @.. broadcast = false work = work / α_bar[n]
+    calculate_residuals!(atmp, work, uprev, y_hi, abstol, reltol, internalnorm, t)
+    err_hi = internalnorm(atmp, t)
+    isfinite(err_hi) || (err_hi = oftype(err, Inf))
+    err_lo = oftype(err, Inf)
+    if k == 3
+        w = bdf3stab_coeff(dd_c, n)
+        if isfinite(w)
+            _filt_divided_diff!(work, dd_c, 4, n, u, u_history)
+            @.. broadcast = false work = w * work
+            @.. broadcast = false y_lo = u + work
+            calculate_residuals!(atmp, work, uprev, y_lo, abstol, reltol, internalnorm, t)
+            err_lo = internalnorm(atmp, t)
+            isfinite(err_lo) || (err_lo = oftype(err, Inf))
+        end
+    end
+    selected = _fbdf_select_filter!(integrator, cache, k, max_order, err, err_hi, err_lo)
+    if selected == k + 1
+        @.. broadcast = false u = y_hi
+        return true
+    elseif selected < k
+        @.. broadcast = false u = y_lo
+        f(integrator.fsallast, u, p, tdt)
+        OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
+        return true
+    end
+    return false
 end

--- a/lib/OrdinaryDiffEqBDF/test/nordsieck_time_filter_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/nordsieck_time_filter_tests.jl
@@ -1,0 +1,121 @@
+using OrdinaryDiffEqBDF
+using SciMLBase
+using LinearAlgebra
+using Test
+
+exp_decay!(du, u, p, t) = (du[1] = -u[1]; nothing)
+exp_decay(u, p, t) = -u
+
+const IIP_DECAY = ODEProblem(exp_decay!, [1.0], (0.0, 10.0))
+const OOP_DECAY = ODEProblem(exp_decay, 1.0, (0.0, 10.0))
+
+function decay_error(sol, tol)
+    return maximum(
+        abs(only(u) - exp(-t)) / (tol + tol * exp(-t)) for (u, t) in zip(sol.u, sol.t)
+    )
+end
+
+@testset "NordsieckBDF time_filter defaults to off" begin
+    @test NordsieckBDF().time_filter == false
+    @test NordsieckBDF(time_filter = true).time_filter == true
+end
+
+@testset "NordsieckBDF time_filter solves accurately" begin
+    for (name, prob) in (("in-place", IIP_DECAY), ("out-of-place", OOP_DECAY))
+        @testset "$name" begin
+            for tol in (1.0e-6, 1.0e-8, 1.0e-10)
+                sol = solve(
+                    prob, NordsieckBDF(time_filter = true), abstol = tol, reltol = tol
+                )
+                @test SciMLBase.successful_retcode(sol)
+                @test decay_error(sol, tol) < 100
+            end
+        end
+    end
+end
+
+@testset "NordsieckBDF time_filter does not need more steps on a smooth problem" begin
+    for prob in (IIP_DECAY, OOP_DECAY)
+        for tol in (1.0e-6, 1.0e-8)
+            filtered = solve(
+                prob, NordsieckBDF(time_filter = true), abstol = tol, reltol = tol
+            )
+            plain = solve(prob, NordsieckBDF(), abstol = tol, reltol = tol)
+            @test SciMLBase.successful_retcode(filtered)
+            @test length(filtered.t) <= 1.15 * length(plain.t)
+        end
+    end
+end
+
+@testset "NordsieckBDF time_filter on stiff problems" begin
+    function rober!(du, u, p, t)
+        du[1] = -0.04 * u[1] + 1.0e4 * u[2] * u[3]
+        du[2] = 0.04 * u[1] - 1.0e4 * u[2] * u[3] - 3.0e7 * u[2]^2
+        du[3] = 3.0e7 * u[2]^2
+        return nothing
+    end
+    rober = ODEProblem(rober!, [1.0, 0.0, 0.0], (0.0, 1.0e5))
+
+    reference = solve(rober, NordsieckBDF(), abstol = 1.0e-12, reltol = 1.0e-12)
+    sol = solve(rober, NordsieckBDF(time_filter = true), abstol = 1.0e-8, reltol = 1.0e-8)
+    @test SciMLBase.successful_retcode(sol)
+    @test isapprox(sol.u[end], reference.u[end], rtol = 1.0e-5)
+
+    for iip in (false, true)
+        dae_f(u, p, t) = [-u[1], u[2] - u[1]^2]
+        dae_f!(du, u, p, t) = (du .= dae_f(u, p, t); nothing)
+        fun = iip ? ODEFunction(dae_f!; mass_matrix = Diagonal([1.0, 0.0])) :
+            ODEFunction(dae_f; mass_matrix = Diagonal([1.0, 0.0]))
+        dae = ODEProblem(fun, [1.0, 1.0], (0.0, 1.0))
+        @test_throws ArgumentError init(dae, NordsieckBDF(time_filter = true))
+        @test SciMLBase.successful_retcode(solve(dae, NordsieckBDF(time_filter = false)))
+    end
+end
+
+@testset "NordsieckBDF time_filter respects max_order" begin
+    for mo in (2, 3, 4, 5)
+        sol = solve(
+            IIP_DECAY, NordsieckBDF(max_order = Val(mo), time_filter = true),
+            abstol = 1.0e-6, reltol = 1.0e-6
+        )
+        @test SciMLBase.successful_retcode(sol)
+        @test decay_error(sol, 1.0e-6) < 100
+    end
+end
+
+@testset "NordsieckBDF time_filter fixed-step oscillator" begin
+    function osc!(du, u, p, t)
+        ω = p
+        du[1] = -ω * u[2]
+        du[2] = ω * u[1]
+        return nothing
+    end
+    function osc_l2(sol, ω)
+        err2 = 0.0
+        for (u, t) in zip(sol.u, sol.t)
+            err2 += sum(abs2, u .- (cos(ω * t), sin(ω * t)))
+        end
+        return sqrt(err2 / length(sol.t))
+    end
+    # Mild oscillator: filter must not spoil an already-accurate solve.
+    osc_mild = ODEProblem(osc!, [1.0, 0.0], (0.0, 2.0), 10.0)
+    plain = solve(osc_mild, NordsieckBDF(); adaptive = false, dt = 1.0e-3, dense = false)
+    filt = solve(
+        osc_mild, NordsieckBDF(time_filter = true);
+        adaptive = false, dt = 1.0e-3, dense = false
+    )
+    @test SciMLBase.successful_retcode(plain)
+    @test SciMLBase.successful_retcode(filt)
+    @test osc_l2(filt, 10.0) < 2 * osc_l2(plain, 10.0)
+
+    # Stiffer imaginary eigenvalue / larger dt: filter should improve accuracy.
+    osc_hard = ODEProblem(osc!, [1.0, 0.0], (0.0, 2.0), 100.0)
+    plain_h = solve(osc_hard, NordsieckBDF(); adaptive = false, dt = 1.0e-3, dense = false)
+    filt_h = solve(
+        osc_hard, NordsieckBDF(time_filter = true);
+        adaptive = false, dt = 1.0e-3, dense = false
+    )
+    @test SciMLBase.successful_retcode(plain_h)
+    @test SciMLBase.successful_retcode(filt_h)
+    @test osc_l2(filt_h, 100.0) <= osc_l2(plain_h, 100.0)
+end

--- a/lib/OrdinaryDiffEqBDF/test/runtests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/runtests.jl
@@ -34,6 +34,7 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "FBDF Time Filter Tests" include("fbdf_time_filter_tests.jl")
     @time @safetestset "FBDF Filter Regression Tests" include("fbdf_filter_regression_tests.jl")
     @time @safetestset "Nordsieck BDF Tests" include("nordsieck_tests.jl")
+    @time @safetestset "Nordsieck Time Filter Tests" include("nordsieck_time_filter_tests.jl")
     @time @safetestset "LHL Factorization Tests" include("lhl_factorization_tests.jl")
 end
 


### PR DESCRIPTION
## Summary
- Adds `NordsieckBDF(time_filter = true)` using the same MOOSE candidates as FBDF (order `k+1` filter + BDF3-Stab at order 3), after the Nordsieck corrector.
- Commits the filtered solution through an updated `acor` so `nordsieck_complete!` keeps the history array consistent; keeps a short rolling `(t, u)` history beside the Nordsieck array for the divided-difference filters.
- Default remains `false`. Identity mass matrix required when enabled. Tests cover accuracy, stiff problems, mass-matrix rejection, `max_order`, and fixed-step oscillatory behavior.

## Sharing / QNDF
FBDF and NordsieckBDF now share the low-level MOOSE primitives in `bdf_utils.jl` (`backdiff!`, `_filt_*`, `_fbdf_filter_weight`, `_fbdf_select_filter!`). The step wiring is method-specific: FBDF already owns `(t, u)` history, while Nordsieck needs the parallel history + `acor` commit path.

QNDF does **not** share that perform_step/controller path (it advances a backward-difference `D` array with NDF κ). Giving QNDF the same switch is reasonable for API uniformity later, but it is not a free enable — it needs its own history (or reconstruction from `D`) and the filter weight should be adapted for NDF leading coefficients rather than FBDF's fixed BDF coeffs. Adaptive benchmarks so far do not show a clear win for the filter, so I would leave QNDF for a follow-up unless we want opt-in parity now.

## Test plan
- [x] `nordsieck_time_filter_tests.jl` (iip/oop accuracy, stiff ROBER, mass-matrix rejection, max_order, fixed-step oscillator)
- [x] Existing `nordsieck_tests.jl`
- [ ] CI Core / OrdinaryDiffEqBDF
- [ ] Optional: adaptive WPD ROBER/Orego/HIRES for `NordsieckBDF` ± `time_filter` (local runs: fixed-step oscillatory helps; adaptive stiff suite is mixed / often more `nf`)


Made with [Cursor](https://cursor.com)