### PR TITLE
Release OrdinaryDiffEqBDF 2.4.7

### DIFF
--- a/lib/OrdinaryDiffEqBDF/Project.toml
+++ b/lib/OrdinaryDiffEqBDF/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqBDF"
 uuid = "6ad6398a-0878-4a85-9266-38940aa047c8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.4.6"
+version = "2.4.7"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"


### PR DESCRIPTION
Bumps `OrdinaryDiffEqBDF` 2.4.6 -> 2.4.7 (patch).

Source files changed since 2.4.6:
- `src/OrdinaryDiffEqBDF.jl`
- `src/alg_utils.jl`
- `src/algorithms.jl`
- `src/bdf_caches.jl`
- `src/bdf_perform_step.jl`
- `src/bdf_utils.jl`
- `src/controllers.jl`

Commits:
- Document the limiter keywords with their real names (#4427)
- Tighten the AdaptiveRadau Newton tolerance with the stage count (#4431)
- Fix the AitkenNeville evaluation count and array states (#4428)
- Fix crashes when a cache holds a vector of nonlinear solvers (#4345)
- Tag the AD type for adaptive exponential algorithms (#4429)
- Release 7.20.0 (#4432)
- Release 3.6.1 (#4433)
- Release 2.3.1 (#4434)
- treat AutoSparse(ForwardDiff) as ForwardDiff (#4422)
- Correct skipped sublibrary version numbers (#4435)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
