### PR TITLE
Unify companion global error estimators into GlobalErrorEstimation

### DIFF
--- a/docs/src/globalerrorcontrol/GlobalDiffEq.md
+++ b/docs/src/globalerrorcontrol/GlobalDiffEq.md
@@ -25,6 +25,17 @@ estimated global error of `sol.u[i]` at `sol.t[i]`, and
 [`SciMLBase.has_global_error`](@ref) is `true` for these algorithms.
 [`global_error_estimate`](@ref) returns `sol.global_error`.
 
+[`GlobalErrorEstimation`](@ref) wraps any adaptive solver with global error
+estimation and `gtol`-based control by integrating a defect-driven companion
+equation. Two orthogonal choices configure it: [`GlobalErrorEquation`](@ref)
+selects the companion ODE — the nonlinear [`DefectCorrection`](@ref) (no Jacobian)
+or the linearized [`ErrorTransport`](@ref) (matrix-free Jacobian-vector products) —
+and [`GlobalErrorMode`](@ref) selects how it is integrated — [`InterpolatingMode`](@ref)
+(store the dense solution, integrate the companion in a second pass) or
+[`SimultaneousMode`](@ref) (advance the companion inline over each step for `O(1)`
+extra memory and no second solve). [`global_error_estimate`](@ref)`(prob, alg)`
+exposes the standalone estimator.
+
 [`GlobalRichardson`](@ref) wraps any fixed-step method in global Richardson
 extrapolation over whole solves, interpreting `abstol` and `reltol` as global
 tolerances. It is the most robust and most expensive option.
@@ -59,4 +70,11 @@ global_error_estimate
 
 ```@docs
 GlobalRichardson
+GlobalErrorEstimation
+GlobalErrorEquation
+DefectCorrection
+ErrorTransport
+GlobalErrorMode
+InterpolatingMode
+SimultaneousMode
 ```

--- a/lib/GlobalDiffEq/Project.toml
+++ b/lib/GlobalDiffEq/Project.toml
@@ -1,12 +1,15 @@
 name = "GlobalDiffEq"
 uuid = "1d72d19b-84cc-4cb7-a099-7cbdb9ccc67c"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.4.1"
+version = "1.5.0"
 
 [deps]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
+DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
@@ -23,9 +26,12 @@ OrdinaryDiffEqCore = {path = "../OrdinaryDiffEqCore"}
 OrdinaryDiffEqTsit5 = {path = "../OrdinaryDiffEqTsit5"}
 
 [compat]
+ADTypes = "1"
 Accessors = "0.1.42"
 DiffEqBase = "7"
+DifferentiationInterface = "0.6, 0.7"
 FastBroadcast = "1.3"
+ForwardDiff = "0.10, 1"
 LinearAlgebra = "1"
 MuladdMacro = "0.2.4"
 OrdinaryDiffEqCore = "4"

--- a/lib/GlobalDiffEq/src/GlobalDiffEq.jl
+++ b/lib/GlobalDiffEq/src/GlobalDiffEq.jl
@@ -3,8 +3,9 @@ module GlobalDiffEq
 using Reexport: @reexport
 @reexport using DiffEqBase
 
-import LinearAlgebra, OrdinaryDiffEqCore, OrdinaryDiffEqTsit5,
-    RecursiveArrayTools, Richardson, SciMLBase
+import ADTypes, DifferentiationInterface, ForwardDiff, LinearAlgebra,
+    OrdinaryDiffEqCore, OrdinaryDiffEqTsit5, RecursiveArrayTools, Richardson,
+    SciMLBase
 import DiffEqBase: initialize!, calculate_residuals, calculate_residuals!
 import OrdinaryDiffEqCore: perform_step!, @cache
 import Accessors: @set
@@ -15,13 +16,17 @@ using PrecompileTools: @setup_workload, @compile_workload
 abstract type GlobalDiffEqAlgorithm <: SciMLBase.AbstractODEAlgorithm end
 
 include("richardson.jl")
+include("companion.jl")
+include("estimation.jl")
 include("glee/tableaus.jl")
 include("glee/algorithms.jl")
 include("glee/solve.jl")
 include("glee/caches.jl")
 include("glee/perform_step.jl")
 
-export GlobalRichardson
+export GlobalRichardson, GlobalErrorEstimation
+export GlobalErrorEquation, DefectCorrection, ErrorTransport
+export GlobalErrorMode, InterpolatingMode, SimultaneousMode
 export GLEE23, GLEE24, GLEE35, MM5GEE, global_error_estimate
 
 @setup_workload begin

--- a/lib/GlobalDiffEq/src/companion.jl
+++ b/lib/GlobalDiffEq/src/companion.jl
@@ -1,0 +1,333 @@
+# Shared machinery for the defect-companion global error estimator
+# ([`GlobalErrorEstimation`](@ref)). After a dense forward solve producing the
+# interpolant P(t), the global error ε(t) ≈ y(t) - P(t) is estimated by
+# integrating a companion ODE driven by the defect d(t) = f(P(t)) - P'(t) of the
+# dense output. The `equation` selects the companion ODE and the `mode` selects
+# how it is integrated (see GlobalErrorEquation / GlobalErrorMode below).
+
+_positive_finite_real(value) = value isa Real && isfinite(value) && value > 0
+
+function _validate_tolerances(abstol, reltol, name)
+    abstol isa Real && isfinite(abstol) && abstol >= 0 ||
+        throw(ArgumentError("$(name)_abstol must be a nonnegative finite real number"))
+    reltol isa Real && isfinite(reltol) && reltol >= 0 ||
+        throw(ArgumentError("$(name)_reltol must be a nonnegative finite real number"))
+    iszero(abstol) && iszero(reltol) &&
+        throw(ArgumentError("$(name)_abstol and $(name)_reltol cannot both be zero"))
+    return nothing
+end
+
+function _validate_estimation_problem(prob, name)
+    prob.u0 isa AbstractVector{<:AbstractFloat} ||
+        throw(ArgumentError("$name requires a real floating-point vector state"))
+    isempty(prob.u0) && throw(ArgumentError("$name requires a nonempty state"))
+    prob.tspan[1] < prob.tspan[2] ||
+        throw(ArgumentError("$name requires a forward-time ODEProblem"))
+    prob.f.mass_matrix == LinearAlgebra.I ||
+        throw(ArgumentError("$name currently requires the standard mass matrix"))
+    problem_kwargs = values(prob.kwargs)
+    if haskey(problem_kwargs, :callback) && problem_kwargs.callback !== nothing
+        throw(ArgumentError("$name does not currently support callbacks"))
+    end
+    return nothing
+end
+
+# The estimator differentiates the dense output (P' = interp(t, Val{1})) to form
+# the defect. A solver without genuine dense output leaves the trivial
+# Linear/Constant fallback interpolation, whose derivative does not approximate
+# the method's defect and would silently corrupt the estimate, so require real
+# dense output rather than trusting the caller.
+function _has_dense_derivative(sol)
+    return sol.dense && !(sol.interp isa Union{
+        SciMLBase.ConstantInterpolation, SciMLBase.LinearInterpolation,
+    })
+end
+
+function _validate_estimation_solution(sol, name)
+    SciMLBase.successful_retcode(sol) ||
+        throw(ErrorException("the forward solve failed with retcode $(sol.retcode)"))
+    length(sol.t) >= 2 ||
+        throw(ArgumentError("the forward solution must save at least its two endpoints"))
+    _has_dense_derivative(sol) || throw(
+        ArgumentError(
+            "$name requires a solver with dense (continuous) output that provides a " *
+                "first-derivative interpolation; the wrapped solver produced none. Use a " *
+                "dense solver (e.g. Tsit5, Vern7) and do not disable `dense`."
+        )
+    )
+    return nothing
+end
+
+# Same dense-output requirement, checked on the integrator's solution before
+# stepping in SimultaneousMode.
+function _validate_streaming_interpolation(sol, name)
+    _has_dense_derivative(sol) || throw(
+        ArgumentError(
+            "$name with SimultaneousMode requires a solver with dense (continuous) " *
+                "output that provides a first-derivative interpolation; the wrapped " *
+                "solver produced none. Use a dense solver (e.g. Tsit5, Vern7) and do " *
+                "not disable `dense`."
+        )
+    )
+    return nothing
+end
+
+"""
+    GlobalErrorEquation
+
+Which companion ODE [`GlobalErrorEstimation`](@ref) integrates for the global
+error. One of [`DefectCorrection`](@ref) or [`ErrorTransport`](@ref).
+"""
+@enum GlobalErrorEquation DefectCorrection ErrorTransport
+
+@doc """
+    DefectCorrection
+
+Integrate the nonlinear correction equation `ε' = f(P + ε, p, t) - P'(t)`,
+`ε(t₀) = 0`, where `P` is the numerical solution's dense interpolant. Requires
+no Jacobian, only extra evaluations of `f` on the perturbed argument `P + ε`.
+The "solving for the correction" technique of Zadunaisky (1976) and Dormand,
+Duckers and Prince (1984).
+""" DefectCorrection
+
+@doc """
+    ErrorTransport
+
+Integrate the linearized error-transport (first variational) equation
+`ε' = J(P, p, t) ε + d(t)`, `ε(t₀) = 0`, where `d(t) = f(P, p, t) - P'(t)` is the
+dense-output defect and `J = ∂f/∂u` is applied matrix-free as a Jacobian-vector
+product (via `autodiff`). The error-transport approach of Shampine (1986) and
+Berzins (1988). It is the first-order linearization of [`DefectCorrection`](@ref).
+""" ErrorTransport
+
+"""
+    GlobalErrorMode
+
+How [`GlobalErrorEstimation`](@ref) integrates the companion ODE. One of
+[`InterpolatingMode`](@ref) or [`SimultaneousMode`](@ref).
+"""
+@enum GlobalErrorMode InterpolatingMode SimultaneousMode
+
+@doc """
+    InterpolatingMode
+
+Run the forward solve with dense output and `save_everystep`, keep that dense
+solution, and integrate the companion ODE against its interpolant in a second
+solve. Solver-agnostic, but stores the whole dense solution (`O(n_steps)` memory)
+and runs a second solve.
+""" InterpolatingMode
+
+@doc """
+    SimultaneousMode
+
+Co-integrate the error estimate in a single forward pass: drive the forward
+integrator one accepted step at a time and, over each just-completed step,
+advance the companion ODE using that step's live dense output as the interpolant.
+Stores no dense solution (`O(1)` extra memory) and runs no second solve. Gives an
+estimate closely agreeing with [`InterpolatingMode`](@ref).
+""" SimultaneousMode
+
+# Out-of-place view of the (possibly in-place) user RHS, safe for dual numbers.
+function _oop_rhs(prob)
+    f = SciMLBase.unwrapped_f(prob.f)
+    if SciMLBase.isinplace(prob)
+        return let f = f
+            function (u, p, t)
+                du = similar(u)
+                f(du, u, p, t)
+                return du
+            end
+        end
+    else
+        return f
+    end
+end
+
+# The stored dense solution spans step nodes, where the defect jumps, so it is
+# queried with right-continuity; a live integrator is restricted to the current
+# step (continuity is both irrelevant and an unsupported keyword there), so it is
+# queried plainly.
+_interp_value(interp, t, right_continuity) =
+    right_continuity ? interp(t, continuity = :right) : interp(t)
+_interp_deriv(interp, t, right_continuity) =
+    right_continuity ? interp(t, Val{1}, continuity = :right) : interp(t, Val{1})
+
+# Nonlinear defect-correction companion RHS: ε' = f(P + ε) - P'.
+function _defect_correction_rhs(prob, interp, right_continuity)
+    foop = _oop_rhs(prob)
+    return let interp = interp, foop = foop, p = prob.p, rc = right_continuity
+        function (ε, _, t)
+            u = _interp_value(interp, t, rc)
+            du = _interp_deriv(interp, t, rc)
+            return foop(u + ε, p, t) - du
+        end
+    end
+end
+
+# Linearized error-transport companion RHS: ε' = J(P) ε + (f(P) - P'), with the
+# Jacobian applied matrix-free as a JVP through `autodiff`.
+function _error_transport_rhs(prob, interp, right_continuity, autodiff)
+    foop = _oop_rhs(prob)
+    return let interp = interp, foop = foop, p = prob.p, rc = right_continuity,
+            backend = autodiff
+
+        function (ε, _, t)
+            u = _interp_value(interp, t, rc)
+            du = _interp_deriv(interp, t, rc)
+            defect = foop(u, p, t) - du
+            jv = only(
+                DifferentiationInterface.pushforward(
+                    x -> foop(x, p, t), backend, u, (ε,)
+                )
+            )
+            return jv + defect
+        end
+    end
+end
+
+# Return `make_rhs(interp, prob, right_continuity)` selecting the companion ODE.
+function _companion_rhs_builder(equation::GlobalErrorEquation, autodiff)
+    if equation === DefectCorrection
+        return (interp, prob, rc) -> _defect_correction_rhs(prob, interp, rc)
+    else
+        return (interp, prob, rc) -> _error_transport_rhs(prob, interp, rc, autodiff)
+    end
+end
+
+const _DENSE_SOLVE_KWARGS = (;
+    dense = true,
+    save_everystep = true,
+    save_start = true,
+    save_end = true,
+    saveat = (),
+    save_idxs = nothing,
+)
+
+# Endpoint-error refinement loop: solve, estimate the endpoint global error, and
+# tighten the local tolerances until the estimate is at most gtol; then redo the
+# solve with the user's original saving options.
+function _refine_to_gtol(
+        estimator, prob, inner_alg, gtol, options, args...;
+        abstol, reltol, kwargs...
+    )
+    local_abstol = abstol
+    local_reltol = reltol
+    last_estimate = oftype(float(gtol), Inf)
+
+    for _ in 1:options.maxiters
+        last_estimate = estimator(local_abstol, local_reltol)
+        isfinite(last_estimate) ||
+            throw(ErrorException("the global error estimate is not finite"))
+
+        if last_estimate <= gtol
+            return SciMLBase.solve(
+                prob, inner_alg, args...;
+                abstol = local_abstol, reltol = local_reltol, kwargs...
+            )
+        end
+
+        tolerance_scale = min(0.5, options.safety * gtol / last_estimate)
+        local_abstol *= tolerance_scale
+        local_reltol *= tolerance_scale
+        iszero(local_abstol) && iszero(local_reltol) &&
+            throw(ErrorException("local tolerances underflowed during global error control"))
+    end
+
+    throw(
+        ErrorException(
+            "failed to meet gtol=$(gtol) after $(options.maxiters) iterations; " *
+                "last estimated global error was $(last_estimate)"
+        )
+    )
+end
+
+function _companion_options(gtol, maxiters, safety, companion_abstol, companion_reltol)
+    maxiters isa Integer && maxiters > 0 ||
+        throw(ArgumentError("maxiters must be a positive integer"))
+    safety isa Real && isfinite(safety) && 0 < safety < 1 ||
+        throw(ArgumentError("safety must be between zero and one"))
+    (gtol === nothing || _positive_finite_real(gtol)) ||
+        throw(ArgumentError("gtol must be a positive finite real number"))
+    _validate_tolerances(companion_abstol, companion_reltol, "companion")
+    return (;
+        maxiters = Int(maxiters), safety,
+        companion_abstol, companion_reltol,
+    )
+end
+
+# InterpolatingMode: dense forward solve, then integrate the companion against
+# the stored interpolant. `make_rhs(interp, prob, right_continuity)` builds the
+# companion RHS. Returns the endpoint global error 2-norm estimate.
+function _companion_error_estimate(
+        make_rhs, name, prob, inner_alg, companion_alg, args...;
+        abstol, reltol, companion_abstol, companion_reltol, kwargs...
+    )
+    haskey(kwargs, :callback) &&
+        throw(ArgumentError("$name does not currently support callbacks"))
+    _validate_estimation_problem(prob, name)
+    solve_kwargs = merge((; kwargs...), _DENSE_SOLVE_KWARGS)
+    sol = SciMLBase.solve(prob, inner_alg, args...; abstol, reltol, solve_kwargs...)
+    _validate_estimation_solution(sol, name)
+    endpoint_error = _companion_endpoint(
+        make_rhs(sol, sol.prob, true), sol, companion_alg;
+        abstol = companion_abstol, reltol = companion_reltol
+    )
+    return LinearAlgebra.norm(endpoint_error)
+end
+
+# SimultaneousMode: drive the forward integrator one accepted step at a time and
+# advance the companion across each just-completed step [tprev, t] using the
+# integrator's live interpolant, keeping no dense solution and running no second
+# solve. Returns the endpoint global error 2-norm estimate.
+function _companion_error_estimate_streaming(
+        make_rhs, name, prob, inner_alg, companion_alg, args...;
+        abstol, reltol, companion_abstol, companion_reltol, kwargs...
+    )
+    haskey(kwargs, :callback) &&
+        throw(ArgumentError("$name does not currently support callbacks"))
+    _validate_estimation_problem(prob, name)
+    integrator = SciMLBase.init(
+        prob, inner_alg, args...;
+        abstol, reltol, dense = true, save_everystep = false,
+        save_start = true, save_end = true, kwargs...
+    )
+    _validate_streaming_interpolation(integrator.sol, name)
+    ε = zero(prob.u0)
+    for _ in integrator
+        tprev, t = integrator.tprev, integrator.t
+        t > tprev || continue
+        ε = _advance_companion(
+            make_rhs(integrator, prob, false), ε, tprev, t, companion_alg;
+            abstol = companion_abstol, reltol = companion_reltol
+        )
+    end
+    SciMLBase.successful_retcode(integrator.sol) ||
+        throw(ErrorException("the forward solve failed with retcode $(integrator.sol.retcode)"))
+    return LinearAlgebra.norm(ε)
+end
+
+# Solve the companion ODE ε' = rhs(ε, t), ε(t0) = 0, over the forward solution's
+# time span and return the endpoint error estimate ε(T).
+function _companion_endpoint(rhs, sol, companion_alg; abstol, reltol)
+    return _advance_companion(
+        rhs, zero(sol.prob.u0), sol.prob.tspan[1], sol.prob.tspan[2],
+        companion_alg; abstol, reltol
+    )
+end
+
+# Advance the companion ODE ε' = rhs(ε, t) from ε(t0) = ε0 over [t0, t1] and
+# return ε(t1).
+function _advance_companion(rhs, ε0, t0, t1, companion_alg; abstol, reltol)
+    companion_prob = SciMLBase.ODEProblem{false}(rhs, ε0, (t0, t1))
+    companion_sol = SciMLBase.solve(
+        companion_prob, companion_alg;
+        abstol, reltol, dense = false, save_everystep = false,
+        save_start = false, save_end = true
+    )
+    SciMLBase.successful_retcode(companion_sol) || throw(
+        ErrorException(
+            "the companion error solve failed with retcode $(companion_sol.retcode)"
+        )
+    )
+    return companion_sol.u[end]
+end

--- a/lib/GlobalDiffEq/src/estimation.jl
+++ b/lib/GlobalDiffEq/src/estimation.jl
@@ -1,0 +1,147 @@
+"""
+    GlobalErrorEstimation(alg; equation=DefectCorrection, mode=InterpolatingMode,
+                          companion_alg=alg, autodiff=ADTypes.AutoForwardDiff(),
+                          gtol=nothing, maxiters=6, safety=0.8,
+                          companion_abstol, companion_reltol)
+
+Wrap an ODE algorithm with global error estimation and control based on a
+defect-driven companion equation. After a dense forward solve producing the
+interpolant `P(t)`, the global error `ε(t) ≈ y(t) - P(t)` is estimated by
+integrating a companion ODE driven by the dense-output defect
+`d(t) = f(P(t), p, t) - P'(t)`, with `ε(t₀) = 0`.
+
+Two orthogonal choices control the estimator:
+
+`equation` ([`GlobalErrorEquation`](@ref)) selects the companion ODE:
+
+  - [`DefectCorrection`](@ref) (default): the nonlinear correction
+    `ε' = f(P + ε, p, t) - P'(t)`, requiring no Jacobian.
+  - [`ErrorTransport`](@ref): the linearized transport `ε' = J(P, p, t) ε + d(t)`,
+    with `J = ∂f/∂u` applied matrix-free as a Jacobian-vector product through
+    `autodiff` (any `ADTypes` backend supported by DifferentiationInterface).
+    `ErrorTransport` is the first-order linearization of `DefectCorrection`.
+
+`mode` ([`GlobalErrorMode`](@ref)) selects how the companion is integrated:
+
+  - [`InterpolatingMode`](@ref) (default): run the forward solve with dense
+    output and `save_everystep`, keep it, and integrate the companion against its
+    interpolant in a second solve. Solver-agnostic but `O(n_steps)` memory.
+  - [`SimultaneousMode`](@ref): drive the forward integrator one accepted step at
+    a time and advance the companion across each step using that step's live dense
+    output, storing no dense solution (`O(1)` extra memory) and running no second
+    solve. Its estimate closely agrees with `InterpolatingMode`.
+
+Set the requested absolute endpoint error with `gtol`:
+
+```julia
+solve(prob, GlobalErrorEstimation(Tsit5(); gtol = 1.0e-6))
+```
+
+The solver then tightens local tolerances until the estimated endpoint global
+error 2-norm is at most `gtol`. Omit `gtol` when using the algorithm only with
+[`global_error_estimate`](@ref). `companion_alg` selects the solver for the
+companion equation, and `companion_abstol` / `companion_reltol` control its
+tolerances.
+
+Every combination **requires** the wrapped solver to provide a genuine dense
+first-derivative interpolation (a solver with only the trivial fallback
+interpolation is rejected). This implementation supports forward-time,
+standard-mass-matrix ODEs with real vector states and no callbacks.
+
+## References
+
+  - P. E. Zadunaisky, On the estimation of errors propagated in the numerical
+    integration of ordinary differential equations, Numerische Mathematik 27
+    (1976).
+  - J. R. Dormand, R. R. Duckers and P. J. Prince, Global error estimation with
+    Runge-Kutta methods, IMA Journal of Numerical Analysis 4 (1984).
+  - L. F. Shampine, Global error estimation with one-step methods, Computers &
+    Mathematics with Applications 12A (1986).
+  - J. Lang and J. Verwer, On global error estimation and control for initial
+    value problems, SIAM Journal on Scientific Computing 29 (2007).
+"""
+struct GlobalErrorEstimation{A, CA, AD, G, V} <: GlobalDiffEqAlgorithm
+    alg::A
+    companion_alg::CA
+    equation::GlobalErrorEquation
+    mode::GlobalErrorMode
+    autodiff::AD
+    gtol::G
+    options::V
+end
+
+function GlobalErrorEstimation(
+        alg;
+        equation = DefectCorrection,
+        mode = InterpolatingMode,
+        companion_alg = alg,
+        autodiff = ADTypes.AutoForwardDiff(),
+        gtol = nothing,
+        maxiters = 6,
+        safety = 0.8,
+        companion_abstol = gtol === nothing ? 1.0e-10 : min(gtol / 100, 1.0e-10),
+        companion_reltol = gtol === nothing ? 1.0e-8 : min(gtol / 100, 1.0e-8)
+    )
+    (equation === DefectCorrection || equation === ErrorTransport) || throw(
+        ArgumentError("`equation` must be DefectCorrection or ErrorTransport")
+    )
+    (mode === InterpolatingMode || mode === SimultaneousMode) || throw(
+        ArgumentError("`mode` must be InterpolatingMode or SimultaneousMode")
+    )
+    options = _companion_options(
+        gtol, maxiters, safety, companion_abstol, companion_reltol
+    )
+    return GlobalErrorEstimation(alg, companion_alg, equation, mode, autodiff, gtol, options)
+end
+
+SciMLBase.allows_arbitrary_number_types(::GlobalErrorEstimation) = false
+SciMLBase.allowscomplex(::GlobalErrorEstimation) = false
+SciMLBase.isautodifferentiable(::GlobalErrorEstimation) = false
+
+"""
+    global_error_estimate(prob, alg::GlobalErrorEstimation; abstol=1e-6, reltol=1e-3, kwargs...)
+
+Solve an ODE problem and estimate the 2-norm of its global error at the final
+time using the companion equation selected by `alg.equation` and integrated in
+the mode selected by `alg.mode`. `abstol` and `reltol` control the forward solve;
+`companion_abstol` and `companion_reltol` control the companion error solve.
+"""
+function global_error_estimate(
+        prob::SciMLBase.AbstractODEProblem, alg::GlobalErrorEstimation, args...;
+        abstol = 1.0e-6,
+        reltol = 1.0e-3,
+        companion_abstol = alg.options.companion_abstol,
+        companion_reltol = alg.options.companion_reltol,
+        kwargs...
+    )
+    make_rhs = _companion_rhs_builder(alg.equation, alg.autodiff)
+    estimate = alg.mode === SimultaneousMode ?
+        _companion_error_estimate_streaming : _companion_error_estimate
+    return estimate(
+        make_rhs, "GlobalErrorEstimation",
+        prob, alg.alg, alg.companion_alg, args...;
+        abstol, reltol, companion_abstol, companion_reltol, kwargs...
+    )
+end
+
+function SciMLBase.__solve(
+        prob::SciMLBase.AbstractODEProblem, alg::GlobalErrorEstimation, args...;
+        abstol = something(alg.gtol, 1.0e-6),
+        reltol = something(alg.gtol, 1.0e-3),
+        kwargs...
+    )
+    alg.gtol === nothing && throw(
+        ArgumentError("GlobalErrorEstimation requires a positive `gtol` constructor keyword")
+    )
+    _validate_tolerances(abstol, reltol, "local")
+    haskey(kwargs, :callback) &&
+        throw(ArgumentError("GlobalErrorEstimation does not currently support callbacks"))
+    estimator = (local_abstol, local_reltol) -> global_error_estimate(
+        prob, alg, args...;
+        abstol = local_abstol, reltol = local_reltol, kwargs...
+    )
+    return _refine_to_gtol(
+        estimator, prob, alg.alg, alg.gtol, alg.options, args...;
+        abstol, reltol, kwargs...
+    )
+end

--- a/lib/GlobalDiffEq/test/companion_tests.jl
+++ b/lib/GlobalDiffEq/test/companion_tests.jl
@@ -1,0 +1,104 @@
+using GlobalDiffEq, OrdinaryDiffEqTsit5, LinearAlgebra
+using Test
+import SciMLBase
+
+lv!(du, u, p, t) = (du[1] = 1.5u[1] - u[1] * u[2]; du[2] = -3.0u[2] + u[1] * u[2]; nothing)
+lv(u, p, t) = [1.5u[1] - u[1] * u[2], -3.0u[2] + u[1] * u[2]]
+const lv_tspan = (0.0, 10.0)
+
+const EQUATIONS = (DefectCorrection, ErrorTransport)
+const MODES = (InterpolatingMode, SimultaneousMode)
+
+@testset "Companion global error estimators" begin
+    prob = ODEProblem(lv!, [1.0, 1.0], lv_tspan)
+    prob_oop = ODEProblem(lv, [1.0, 1.0], lv_tspan)
+    ref = solve(prob, Tsit5(); abstol = 1.0e-13, reltol = 1.0e-13)
+
+    for equation in EQUATIONS, mode in MODES, p in (prob, prob_oop)
+        for tol in (1.0e-4, 1.0e-6)
+            alg = GlobalErrorEstimation(Tsit5(); equation, mode)
+            est = global_error_estimate(p, alg; abstol = tol, reltol = tol)
+            sol = solve(p, Tsit5(); abstol = tol, reltol = tol)
+            true_err = norm(sol.u[end] - ref.u[end])
+            @test est / true_err ≈ 1 rtol = 0.1
+        end
+    end
+end
+
+@testset "SimultaneousMode matches InterpolatingMode" begin
+    prob = ODEProblem(lv!, [1.0, 1.0], lv_tspan)
+    for equation in EQUATIONS
+        for tol in (1.0e-4, 1.0e-6)
+            interp = global_error_estimate(
+                prob, GlobalErrorEstimation(Tsit5(); equation, mode = InterpolatingMode);
+                abstol = tol, reltol = tol
+            )
+            stream = global_error_estimate(
+                prob, GlobalErrorEstimation(Tsit5(); equation, mode = SimultaneousMode);
+                abstol = tol, reltol = tol
+            )
+            # Same companion ODE; the interpolating mode integrates it in one solve
+            # over the whole span while the streaming mode restarts the companion
+            # solver at every forward step, so they agree to a few 1e-3 (negligible
+            # next to the ~10% accuracy of the estimate itself), not to machine tol.
+            @test stream ≈ interp rtol = 5.0e-3
+        end
+    end
+end
+
+@testset "Companion global error control" begin
+    prob = ODEProblem(lv!, [1.0, 1.0], lv_tspan)
+    ref = solve(prob, Tsit5(); abstol = 1.0e-13, reltol = 1.0e-13)
+    gtol = 1.0e-7
+
+    for equation in EQUATIONS, mode in MODES
+        alg = GlobalErrorEstimation(Tsit5(); equation, mode, gtol)
+        sol = solve(prob, alg; abstol = 1.0e-3, reltol = 1.0e-3)
+        @test SciMLBase.successful_retcode(sol)
+        @test norm(sol.u[end] - ref.u[end]) <= gtol
+    end
+end
+
+@testset "Companion estimator argument validation" begin
+    prob = ODEProblem(lv!, [1.0, 1.0], lv_tspan)
+    alg = GlobalErrorEstimation(Tsit5())
+
+    @test !SciMLBase.allows_arbitrary_number_types(alg)
+    @test !SciMLBase.allowscomplex(alg)
+    @test !SciMLBase.isautodifferentiable(alg)
+    @test alg.equation === DefectCorrection
+    @test alg.mode === InterpolatingMode
+    @test GlobalErrorEstimation(Tsit5(); equation = ErrorTransport).equation === ErrorTransport
+    @test GlobalErrorEstimation(Tsit5(); mode = SimultaneousMode).mode === SimultaneousMode
+    @test_throws ArgumentError GlobalErrorEstimation(Tsit5(); gtol = -1.0)
+    @test_throws ArgumentError GlobalErrorEstimation(Tsit5(); maxiters = 0)
+    @test_throws ArgumentError GlobalErrorEstimation(Tsit5(); safety = 2.0)
+    # gtol is required to solve with the wrapper
+    @test_throws ArgumentError solve(prob, alg)
+
+    callback = DiscreteCallback((u, t, integrator) -> false, integrator -> nothing)
+    callback_prob = ODEProblem(lv!, [1.0, 1.0], lv_tspan; callback)
+    @test_throws ArgumentError global_error_estimate(callback_prob, alg)
+
+    backwards_prob = ODEProblem(lv!, [1.0, 1.0], (10.0, 0.0))
+    @test_throws ArgumentError global_error_estimate(backwards_prob, alg)
+
+    # Both integration modes require a solver with genuine dense output; a solution
+    # left with the trivial linear-interpolation fallback is rejected rather than
+    # silently differentiated into a wrong defect.
+    @testset "dense-output requirement" begin
+        t = [0.0, 0.5, 1.0]
+        u = [[1.0], [0.61], [0.37]]
+        nondense = SciMLBase.build_solution(
+            prob, Tsit5(), t, u;
+            interp = SciMLBase.LinearInterpolation(t, u), dense = false,
+            retcode = SciMLBase.ReturnCode.Success
+        )
+        @test_throws ArgumentError GlobalDiffEq._validate_estimation_solution(
+            nondense, "GlobalErrorEstimation"
+        )
+        @test_throws ArgumentError GlobalDiffEq._validate_streaming_interpolation(
+            nondense, "GlobalErrorEstimation"
+        )
+    end
+end

--- a/lib/GlobalDiffEq/test/runtests.jl
+++ b/lib/GlobalDiffEq/test/runtests.jl
@@ -11,6 +11,9 @@ run_tests(;
         @safetestset "Algorithm traits forwarding" begin
             include("algorithm_traits_tests.jl")
         end
+        @safetestset "Companion error estimators" begin
+            include("companion_tests.jl")
+        end
         @safetestset "GLEE solvers" begin
             include("glee_tests.jl")
         end


### PR DESCRIPTION
> **Ignore until reviewed by @ChrisRackauckas.** Draft — not ready for merge.

## What changed and why

Unifies the two defect-companion global-error wrappers into a single algorithm.
Previously #3956 (`GlobalErrorTransport`) and #3957 (`GlobalDefectCorrection`)
added two separate structs; they share the same machinery (dense forward solve →
companion ODE driven by the defect `d(t) = f(P(t)) - P'(t)`) and differ only in
the companion equation. This PR replaces both with

```julia
GlobalErrorEstimation(alg; equation = DefectCorrection, mode = InterpolatingMode, …)
```

parameterized by two orthogonal enums:

- **`equation`** (`GlobalErrorEquation`): `DefectCorrection` — the nonlinear
  correction `ε' = f(P+ε) - P'` (no Jacobian); or `ErrorTransport` — the
  linearized transport `ε' = J(P)ε + d` (matrix-free JVP via
  DifferentiationInterface). `ErrorTransport` is the first-order linearization of
  `DefectCorrection`.
- **`mode`** (`GlobalErrorMode`): `InterpolatingMode` — store the dense solution
  and integrate the companion in a second pass (`O(n_steps)` memory); or
  `SimultaneousMode` — drive the forward integrator one step at a time and advance
  the companion across each step using that step's live dense output (`O(1)` extra
  memory, no second solve).

All 2×2 combinations are supported by one implementation. **Supersedes #3956 and
#3957** (closing both).

## Verification

Run locally from `lib/GlobalDiffEq` (Julia 1.11).

`GROUP=Core`:

```
Basic functionality        |   1      1
Algorithm traits forwarding|   3      3
Companion error estimators |  43     43
GLEE solvers               |  91     91
BigFloat support           |   2      2
     Testing GlobalDiffEq tests passed
```

The 43 companion tests cover every `equation × mode` combination for the
estimate accuracy (in-place and out-of-place, `est/true_err ≈ 1 rtol=0.1`
against a `1e-13` reference), `gtol` control (endpoint error `≤ gtol`),
`SimultaneousMode ≈ InterpolatingMode` (`rtol = 5e-3`; see note below), and
argument/dense-output validation.

`GROUP=QA` (Aqua + ExplicitImports + JET): `Testing GlobalDiffEq tests passed`.

Runic: clean.

## Note for the reviewer

- **`SimultaneousMode` vs `InterpolatingMode` agree to ~few×1e-3, not machine
  precision.** They integrate the *same* companion ODE, but the streaming mode
  restarts the companion solver at every forward step (resetting its adaptive
  controller), so the accumulated quadrature differs slightly. This is negligible
  next to the ~10% accuracy of the global-error estimate itself; the `rtol=5e-3`
  match tolerance is set from the observed difference, not to hide a bug — the
  independent `gtol` control tests confirm both modes produce correct
  error-controlling estimates.
- **Dropped public names.** `GlobalDefectCorrection` / `GlobalErrorTransport` no
  longer exist. Since neither has been released on `master` (they lived only in
  the two open PRs this supersedes), this is not a break of any shipped API.
- **New dependencies** ADTypes, DifferentiationInterface, ForwardDiff (for the
  `ErrorTransport` JVP) — all MIT/permissive, matching the host package.

## Not verified

Downstream packages, GPU paths, and allowed-to-fail CI jobs were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-4-8)
https://claude.ai/code/session_01MfUh8tgp3iBmMv9nkBqoyY
