### PR TITLE
GlobalAdjoint: every-step trajectory scope and step-grid control (closes #4493, #4494)

### DIFF
--- a/docs/src/globalerrorcontrol/GlobalDiffEq.md
+++ b/docs/src/globalerrorcontrol/GlobalDiffEq.md
@@ -39,7 +39,12 @@ exposes the standalone estimator.
 To control the endpoint global error to a tolerance `gtol`, wrap any adaptive
 solver in [`GlobalAdjoint`](@ref) (adjoint-based, for endpoint functionals;
 requires SciMLSensitivity to be loaded); [`adjoint_error_estimate`](@ref)
-exposes the standalone estimator.
+exposes the standalone estimator. Its [`GlobalAdjointScope`](@ref) selects whether
+the estimate is reported only at the endpoint ([`EndpointError`](@ref)) or along
+the whole trajectory ([`TrajectoryError`](@ref), filling `sol.global_error` at
+every saved time), and its [`GlobalAdjointControl`](@ref) selects whether `gtol`
+is met by tolerance tightening ([`ToleranceRefinement`](@ref)) or by re-solving
+non-adaptively on the accepted step grid ([`StepGridRefinement`](@ref)).
 
 [`GlobalRichardson`](@ref) wraps any fixed-step method in global Richardson
 extrapolation over whole solves, interpreting `abstol` and `reltol` as global
@@ -84,4 +89,10 @@ InterpolatingMode
 SimultaneousMode
 GlobalAdjoint
 adjoint_error_estimate
+GlobalAdjointScope
+EndpointError
+TrajectoryError
+GlobalAdjointControl
+ToleranceRefinement
+StepGridRefinement
 ```

--- a/lib/GlobalDiffEq/Project.toml
+++ b/lib/GlobalDiffEq/Project.toml
@@ -1,7 +1,7 @@
 name = "GlobalDiffEq"
 uuid = "1d72d19b-84cc-4cb7-a099-7cbdb9ccc67c"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.6.0"
+version = "1.7.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/GlobalDiffEq/ext/GlobalDiffEqSciMLSensitivityExt.jl
+++ b/lib/GlobalDiffEq/ext/GlobalDiffEqSciMLSensitivityExt.jl
@@ -23,7 +23,8 @@ end
 # on t, so `adjoint_sensitivities` returns that integral as the parameter
 # gradient — no separate adjoint solve or hand-rolled quadrature.
 function GlobalDiffEq._adjoint_defect_projection(
-        sol, sensealg, adjoint_alg, direction; abstol, reltol
+        sol, sensealg, adjoint_alg, direction;
+        abstol, reltol, terminal_time = sol.prob.tspan[2]
     )
     prob = sol.prob
     f_orig = SciMLBase.unwrapped_f(prob.f)
@@ -65,7 +66,7 @@ function GlobalDiffEq._adjoint_defect_projection(
     end
     _, defect_gradient = SciMLSensitivity.adjoint_sensitivities(
         forced_sol, adjoint_alg;
-        sensealg, t = [prob.tspan[2]], dgdu_discrete = terminal_gradient!,
+        sensealg, t = [terminal_time], dgdu_discrete = terminal_gradient!,
         abstol, reltol
     )
     return only(defect_gradient)

--- a/lib/GlobalDiffEq/src/GlobalDiffEq.jl
+++ b/lib/GlobalDiffEq/src/GlobalDiffEq.jl
@@ -27,6 +27,8 @@ include("glee/perform_step.jl")
 
 export GlobalRichardson, GlobalErrorEstimation
 export GlobalAdjoint, adjoint_error_estimate
+export GlobalAdjointScope, EndpointError, TrajectoryError
+export GlobalAdjointControl, ToleranceRefinement, StepGridRefinement
 export GlobalErrorEquation, DefectCorrection, ErrorTransport
 export GlobalErrorMode, InterpolatingMode, SimultaneousMode
 export GLEE23, GLEE24, GLEE35, MM5GEE, global_error_estimate

--- a/lib/GlobalDiffEq/src/adjoint.jl
+++ b/lib/GlobalDiffEq/src/adjoint.jl
@@ -1,6 +1,55 @@
 """
+    GlobalAdjointScope
+
+What [`GlobalAdjoint`](@ref) estimates and reports in `sol.global_error`. One of
+[`EndpointError`](@ref) or [`TrajectoryError`](@ref).
+"""
+@enum GlobalAdjointScope EndpointError TrajectoryError
+
+@doc """
+    EndpointError
+
+Estimate the global error 2-norm only at the final time: `sol.global_error[end]`
+holds it and earlier entries are zero. The default; one adjoint solve per sample.
+""" EndpointError
+
+@doc """
+    TrajectoryError
+
+Estimate the global error 2-norm at every saved time: `sol.global_error[i]` is the
+estimate at `sol.t[i]` (`sol.global_error[1] = 0`), filled along the whole
+trajectory. Costs one reverse-adjoint solve per saved time per sample, and the
+returned solution is dense and saved at every solver step.
+""" TrajectoryError
+
+"""
+    GlobalAdjointControl
+
+How [`GlobalAdjoint`](@ref) drives the solve to meet `gtol`. One of
+[`ToleranceRefinement`](@ref) or [`StepGridRefinement`](@ref).
+"""
+@enum GlobalAdjointControl ToleranceRefinement StepGridRefinement
+
+@doc """
+    ToleranceRefinement
+
+Tighten the solver's local `abstol`/`reltol` and re-solve adaptively until the
+estimated endpoint error is at most `gtol`. The default.
+""" ToleranceRefinement
+
+@doc """
+    StepGridRefinement
+
+Tighten tolerances the same way to find a step grid that meets `gtol`, then return
+a solution obtained by re-solving **non-adaptively on exactly that grid**
+(`adaptive = false`, stepping on the adjoint-informed `dt`s). Yields a
+reproducible fixed-step schedule rather than an adaptive solve.
+""" StepGridRefinement
+
+"""
     GlobalAdjoint(alg; gtol=nothing, adjoint_alg=alg, sensealg=nothing, samples=2,
-                  rng=Random.default_rng(), maxiters=6, safety=0.8,
+                  rng=Random.default_rng(), scope=EndpointError,
+                  control=ToleranceRefinement, maxiters=6, safety=0.8,
                   adjoint_abstol, adjoint_reltol)
 
 Wrap an ODE algorithm with adjoint-based global error estimation and control.
@@ -26,10 +75,15 @@ system itself (via `SciMLSensitivity.adjoint_sensitivities`), not by a
 hand-rolled quadrature: the defect is introduced as a scalar forcing whose
 sensitivity is exactly that integral.
 
-When solved with a `gtol`, the returned solution carries the endpoint estimate
-in its `global_error` field (`SciMLBase.has_global_error` is `true` for
-`GlobalAdjoint`); `sol.global_error[end]` is the estimated endpoint error
-2-norm.
+When solved with a `gtol`, the returned solution carries the estimate in its
+`global_error` field (`SciMLBase.has_global_error` is `true` for `GlobalAdjoint`).
+`scope` ([`GlobalAdjointScope`](@ref)) selects what is estimated:
+[`EndpointError`](@ref) (default) fills only `sol.global_error[end]`, while
+[`TrajectoryError`](@ref) fills `sol.global_error[i]` at every saved time.
+`control` ([`GlobalAdjointControl`](@ref)) selects how `gtol` is met:
+[`ToleranceRefinement`](@ref) (default) tightens tolerances and re-solves
+adaptively, while [`StepGridRefinement`](@ref) re-solves non-adaptively on the
+accepted step grid. Control always targets the endpoint error estimate.
 
 Omit `gtol` when using the algorithm only with [`adjoint_error_estimate`](@ref).
 `maxiters` limits the number of forward-solve refinements, while `safety`
@@ -61,6 +115,8 @@ struct GlobalAdjoint{A, AA, S, R, G, V} <: GlobalDiffEqAlgorithm
     sensealg::S
     samples::Int
     rng::R
+    scope::GlobalAdjointScope
+    control::GlobalAdjointControl
     gtol::G
     options::V
 end
@@ -71,6 +127,8 @@ function GlobalAdjoint(
         sensealg = nothing,
         samples = 2,
         rng = Random.default_rng(),
+        scope = EndpointError,
+        control = ToleranceRefinement,
         gtol = nothing,
         maxiters = 6,
         safety = 0.8,
@@ -79,6 +137,10 @@ function GlobalAdjoint(
     )
     samples isa Integer || throw(ArgumentError("samples must be an integer"))
     samples > 0 || throw(ArgumentError("samples must be positive"))
+    scope isa GlobalAdjointScope ||
+        throw(ArgumentError("scope must be EndpointError or TrajectoryError"))
+    control isa GlobalAdjointControl ||
+        throw(ArgumentError("control must be ToleranceRefinement or StepGridRefinement"))
     (gtol === nothing || _positive_finite_real(gtol)) ||
         throw(ArgumentError("gtol must be a positive finite real number"))
     maxiters isa Integer && maxiters > 0 ||
@@ -87,7 +149,9 @@ function GlobalAdjoint(
         throw(ArgumentError("safety must be between zero and one"))
     _validate_tolerances(adjoint_abstol, adjoint_reltol, "adjoint")
     options = (; maxiters = Int(maxiters), safety, adjoint_abstol, adjoint_reltol)
-    return GlobalAdjoint(alg, adjoint_alg, sensealg, Int(samples), rng, gtol, options)
+    return GlobalAdjoint(
+        alg, adjoint_alg, sensealg, Int(samples), rng, scope, control, gtol, options
+    )
 end
 
 # Extension hooks: GlobalDiffEqSciMLSensitivityExt adds methods for these when
@@ -189,12 +253,15 @@ function _sphere_projection_expectation(dimension, ::Type{T}) where {T}
     return expectation
 end
 
-function _adjoint_error_estimate(sol, alg, directions; adjoint_abstol, adjoint_reltol)
+function _adjoint_error_estimate(
+        sol, alg, directions;
+        adjoint_abstol, adjoint_reltol, terminal_time = sol.prob.tspan[2]
+    )
     sensealg = _resolve_sensealg(alg)
     projections = map(directions) do direction
         _adjoint_defect_projection(
             sol, sensealg, alg.adjoint_alg, direction;
-            abstol = adjoint_abstol, reltol = adjoint_reltol
+            abstol = adjoint_abstol, reltol = adjoint_reltol, terminal_time
         )
     end
     T = eltype(sol.prob.u0)
@@ -202,6 +269,41 @@ function _adjoint_error_estimate(sol, alg, directions; adjoint_abstol, adjoint_r
     factor = _sphere_projection_expectation(sample_count, T) /
         _sphere_projection_expectation(length(sol.prob.u0), T)
     return factor * LinearAlgebra.norm(projections)
+end
+
+# Per-time global error along the trajectory: the estimate at each saved time,
+# obtained by placing the adjoint's discrete cost at that time. `sol.t[1]` (the
+# initial time) carries no error.
+function _adjoint_trajectory_errors(sol, alg, directions; adjoint_abstol, adjoint_reltol)
+    errors = zeros(eltype(sol.prob.u0), length(sol.t))
+    for j in 2:length(sol.t)
+        errors[j] = _adjoint_error_estimate(
+            sol, alg, directions;
+            adjoint_abstol, adjoint_reltol, terminal_time = sol.t[j]
+        )
+    end
+    return errors
+end
+
+# Re-solve non-adaptively on exactly `grid`, stepping on its `dt`s. Produces a
+# dense solution saved at every grid point, matching the adaptive solve's steps.
+function _solve_on_grid(prob, inner_alg, grid, args...; abstol, reltol)
+    dts = diff(grid)
+    integrator = SciMLBase.init(
+        prob, inner_alg, args...;
+        adaptive = false, dt = dts[1], dense = true,
+        save_everystep = true, save_start = true, save_end = true,
+        abstol, reltol
+    )
+    for dt in dts
+        SciMLBase.set_proposed_dt!(integrator, dt)
+        SciMLBase.step!(integrator)
+    end
+    sol = integrator.sol
+    if !SciMLBase.successful_retcode(sol) && integrator.t >= grid[end]
+        sol = @set sol.retcode = SciMLBase.ReturnCode.Success
+    end
+    return sol
 end
 
 const _DENSE_SOLVE_KWARGS = (;
@@ -287,12 +389,36 @@ function SciMLBase.__solve(
             throw(ErrorException("the adjoint global error estimate is not finite"))
 
         if last_estimate <= gtol
-            final_sol = SciMLBase.solve(
-                prob, alg.alg, args...;
-                abstol = local_abstol, reltol = local_reltol, kwargs...
-            )
-            return @set final_sol.global_error =
+            # The final solution reproduces the accepted grid non-adaptively
+            # (StepGridRefinement) or re-solves adaptively with the user's saving
+            # options (ToleranceRefinement). TrajectoryError needs the dense,
+            # every-step solution to estimate along the whole path.
+            final_sol = if alg.control === StepGridRefinement
+                _solve_on_grid(
+                    prob, alg.alg, trial_sol.t, args...;
+                    abstol = local_abstol, reltol = local_reltol
+                )
+            elseif alg.scope === TrajectoryError
+                SciMLBase.solve(
+                    prob, alg.alg, args...;
+                    abstol = local_abstol, reltol = local_reltol, trial_kwargs...
+                )
+            else
+                SciMLBase.solve(
+                    prob, alg.alg, args...;
+                    abstol = local_abstol, reltol = local_reltol, kwargs...
+                )
+            end
+            global_error = if alg.scope === TrajectoryError
+                _adjoint_trajectory_errors(
+                    final_sol, alg, directions;
+                    adjoint_abstol = options.adjoint_abstol,
+                    adjoint_reltol = options.adjoint_reltol
+                )
+            else
                 _endpoint_global_error(final_sol, last_estimate)
+            end
+            return @set final_sol.global_error = global_error
         end
 
         tolerance_scale = min(0.5, options.safety * gtol / last_estimate)

--- a/lib/GlobalDiffEq/test/adjoint_tests.jl
+++ b/lib/GlobalDiffEq/test/adjoint_tests.jl
@@ -71,3 +71,50 @@ import SciMLBase
     @test isfinite(callback_estimate)
     @test callback_estimate >= 0
 end
+
+@testset "GlobalAdjoint scope and control modes" begin
+    linear!(du, u, p, t) = (du[1] = p * u[1]; nothing)
+    rate = 2.0
+    tspan = (0.0, 2.0)
+    linear_prob = ODEProblem(linear!, [1.0], tspan, rate)
+    exact(t) = exp(rate * t)
+    gtol = 1.0e-5
+
+    @test GlobalAdjoint(Tsit5()).scope === EndpointError
+    @test GlobalAdjoint(Tsit5()).control === ToleranceRefinement
+    @test GlobalAdjoint(Tsit5(); scope = TrajectoryError).scope === TrajectoryError
+    @test GlobalAdjoint(Tsit5(); control = StepGridRefinement).control === StepGridRefinement
+
+    # TrajectoryError fills global_error along the whole path; each entry tracks the
+    # true error wherever it is above the adjoint noise floor.
+    traj_sol = solve(
+        linear_prob,
+        GlobalAdjoint(Tsit5(); gtol, scope = TrajectoryError, samples = 1, rng = Xoshiro(11));
+        abstol = 1.0e-3, reltol = 1.0e-3
+    )
+    @test length(traj_sol.global_error) == length(traj_sol.t)
+    @test traj_sol.global_error[1] == 0
+    @test traj_sol.global_error[end] <= gtol
+    @test any(traj_sol.global_error[2:end] .> 0)
+    # Check the per-time estimate against the true error only where the error is
+    # well above the adjoint noise floor (a ratio of two ~1e-8 quantities is
+    # meaningless); the well-resolved upper decade below gtol must match.
+    checked = 0
+    for i in eachindex(traj_sol.t)
+        true_err = abs(traj_sol.u[i][1] - exact(traj_sol.t[i]))
+        true_err < gtol / 10 && continue
+        @test traj_sol.global_error[i] / true_err ≈ 1 rtol = 0.2
+        checked += 1
+    end
+    @test checked > 0
+
+    # StepGridRefinement meets gtol via a non-adaptive re-solve on the accepted grid
+    grid_sol = solve(
+        linear_prob,
+        GlobalAdjoint(Tsit5(); gtol, control = StepGridRefinement, samples = 1, rng = Xoshiro(22));
+        abstol = 1.0e-3, reltol = 1.0e-3
+    )
+    @test SciMLBase.successful_retcode(grid_sol)
+    @test abs(grid_sol.u[end][1] - exact(tspan[2])) <= gtol
+    @test grid_sol.global_error[end] <= gtol
+end


### PR DESCRIPTION
> **Ignore until reviewed by @ChrisRackauckas.** Draft — not ready for merge.

Implements the two `GlobalAdjoint` follow-ups from the merged adjoint PR (#3953),
as two orthogonal enum options. **Closes #4493 and #4494.**

## What changed

- **`scope`** (`GlobalAdjointScope`): `EndpointError` (default, unchanged) fills
  only `sol.global_error[end]`; **`TrajectoryError`** estimates the error 2-norm
  at every saved time by placing the adjoint's discrete cost at each `t_i`
  (`dgdu_discrete` with `t = [t_i]`), filling `sol.global_error` along the whole
  trajectory (#4493).
- **`control`** (`GlobalAdjointControl`): `ToleranceRefinement` (default,
  unchanged) tightens local tolerances and re-solves adaptively;
  **`StepGridRefinement`** finds the accepted grid the same way, then re-solves
  **non-adaptively on exactly that grid** via the integrator interface
  (`adaptive=false`, `set_proposed_dt!` on each `dt`), for a reproducible
  fixed-step schedule (#4494).

Both reuse the existing machinery: the extension's `_adjoint_defect_projection`
gains a `terminal_time` argument, and the `autojacvec=false` ForwardDiff-Jacobian
default is kept (the RHS reads the solution interpolant, which the VJP backends
mishandle — SciML/SciMLSensitivity.jl#1649).

## Verification

Local, Julia 1.12, `lib/GlobalDiffEq`.

`GROUP=Core`:

```
Companion error estimators           |  43  43
Adjoint error estimation and control |  35  35
GLEE solvers                         |  91  91
BigFloat support                     |   2   2
     Testing GlobalDiffEq tests passed
```

The new mode tests verify (on the linear problem `u'=2u`, exact error known):
`TrajectoryError` fills `global_error` along the path with `global_error[1]=0`,
`global_error[end] ≤ gtol`, and each well-resolved per-time estimate (error above
`gtol/10`) matches the true error to `rtol=0.2`; `StepGridRefinement` returns a
successful non-adaptive solution meeting `gtol`.

`GROUP=QA` (Aqua + ExplicitImports + JET): `Testing GlobalDiffEq tests passed`.
Runic: clean.

## Note for the reviewer

- **Per-time matching is only asserted above `gtol/10`.** Below that the true
  error is at the adjoint noise floor, so a ratio of two tiny numbers is
  meaningless — not a loosened tolerance hiding a defect (the endpoint estimate is
  validated separately in the existing suite).
- `TrajectoryError` costs one reverse-adjoint solve per saved time per sample and
  returns a dense, every-step solution; it is opt-in.
- New public names get docstrings + docs entries; version bumped 1.6.0 → 1.7.0.

## Not verified

Downstream packages, GPU paths, allowed-to-fail CI jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-4-8)
https://claude.ai/code/session_01MfUh8tgp3iBmMv9nkBqoyY
