### PR TITLE
Mark discrete time-grid search helpers as Enzyme inactive

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -63,6 +63,7 @@ DiffEqBase = "7.19"
 DiffEqDevTools = "3"
 DifferentiationInterface = "0.7.18"
 DocStringExtensions = "0.9.5"
+Enzyme = "0.13"
 EnumX = "1.0.4"
 EnzymeCore = "0.8.16"
 FastBroadcast = "1.3"
@@ -102,6 +103,7 @@ julia = "1.10"
 [extras]
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
+Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 OrdinaryDiffEqFIRK = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
@@ -112,7 +114,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DiffEqDevTools", "SafeTestsets", "SparseArrays", "Test", "Pkg", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqTsit5", "DifferentiationInterface", "SciMLTesting"]
+test = ["DiffEqDevTools", "Enzyme", "SafeTestsets", "SparseArrays", "Test", "Pkg", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqTsit5", "DifferentiationInterface", "SciMLTesting"]
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}

--- a/lib/OrdinaryDiffEqCore/src/enzyme_rules.jl
+++ b/lib/OrdinaryDiffEqCore/src/enzyme_rules.jl
@@ -45,3 +45,41 @@ function EnzymeCore.EnzymeRules.inactive_noinl(
     )
     return true
 end
+
+# Discrete time-grid index helpers have zero derivative; block inlining so
+# Enzyme treats the index as constant.
+function EnzymeCore.EnzymeRules.inactive(
+        ::typeof(_searchsortedfirst), args...
+    )
+    return true
+end
+
+function EnzymeCore.EnzymeRules.inactive(
+        ::typeof(_searchsortedlast), args...
+    )
+    return true
+end
+
+function EnzymeCore.EnzymeRules.inactive(
+        ::typeof(_ts_grid_kind), args...
+    )
+    return true
+end
+
+function EnzymeCore.EnzymeRules.inactive(
+        ::typeof(ts_hint_start), args...
+    )
+    return true
+end
+
+function EnzymeCore.EnzymeRules.inactive(
+        ::typeof(reprobe_ts_hint!), args...
+    )
+    return true
+end
+
+function EnzymeCore.EnzymeRules.inactive(
+        ::typeof(maybe_reprobe_ts_hint!), args...
+    )
+    return true
+end

--- a/lib/OrdinaryDiffEqCore/test/enzyme_interpolation_tests.jl
+++ b/lib/OrdinaryDiffEqCore/test/enzyme_interpolation_tests.jl
@@ -1,0 +1,38 @@
+using OrdinaryDiffEqCore, OrdinaryDiffEqTsit5, SciMLBase, LinearAlgebra, Enzyme, Test
+
+const TEST_A = [-0.3 1.0; -1.0 -0.3]
+function test_base!(du, u, p, t)
+    mul!(du, TEST_A, u)
+    return nothing
+end
+const TEST_REF = solve(
+    ODEProblem(test_base!, [1.0, 0.5], (0.0, 3.0)), Tsit5();
+    abstol = 1.0e-10, reltol = 1.0e-10, dense = true, save_everystep = true
+)
+
+function test_forced!(du, u, p, t)
+    mul!(du, TEST_A, u)
+    r = TEST_REF(t)
+    du[1] += p[1] * r[1]
+    du[2] += p[1] * r[2]
+    return nothing
+end
+
+@testset "Enzyme reverse through interpolant" begin
+    u = [1.0, 0.5]
+    p = [0.0]
+    t = 1.5
+    du = zeros(2)
+    bdu = [1.0, 0.0]
+    bu = zeros(2)
+    bp = zeros(1)
+    Enzyme.autodiff(
+        Enzyme.Reverse, test_forced!, Enzyme.Const,
+        Enzyme.Duplicated(du, copy(bdu)),
+        Enzyme.Duplicated(u, bu),
+        Enzyme.Duplicated(p, bp),
+        Enzyme.Const(t)
+    )
+    @test bu ≈ [-0.3, 1.0]
+    @test bp[1] ≈ TEST_REF(t)[1]
+end

--- a/lib/OrdinaryDiffEqCore/test/qa/qa.jl
+++ b/lib/OrdinaryDiffEqCore/test/qa/qa.jl
@@ -42,7 +42,7 @@ run_qa(
                 # Base / Core internals
                 Symbol("@max_methods"), :Experimental, :Typeof, :promote_op,
                 # EnzymeCore / EnzymeCore.EnzymeRules internals
-                :EnzymeRules, :inactive_noinl,
+                :EnzymeRules, :inactive_noinl, :inactive,
                 # SciMLBase internals with no public replacement yet
                 :enable_interpolation_sensitivitymode,
                 :forwarddiff_chunksize, :get_root_indp,

--- a/lib/OrdinaryDiffEqCore/test/runtests.jl
+++ b/lib/OrdinaryDiffEqCore/test/runtests.jl
@@ -47,4 +47,5 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "Interpolation Search Hint" include("interpolation_hint_tests.jl")
     @time @safetestset "Bool Equal Coercion" include("bool_equal_tests.jl")
     @time @safetestset "Instability Diagnostics" include("instability_diagnostics_tests.jl")
+    @time @safetestset "Enzyme Interpolation" include("enzyme_interpolation_tests.jl")
 end


### PR DESCRIPTION
Treat discrete time-grid search helpers as Enzyme inactive so reverse-mode through `sol(t)` no longer enters the `FindFirstFunctions` SIMD preserve region. Blocking inlining makes Enzyme see the index as constant (correct almost everywhere) and avoids the `gc_preserve` dominance abort.

> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

## Verification

Original MWE from EnzymeAD/Enzyme.jl#3565 (OrdinaryDiffEqTsit5 + Enzyme reverse through `ref(t)`):

Before (without fix, `git stash`):

```
LLVM ERROR: function failed verification (4)
[..] signal (6): Aborted
EXIT: 134
```

After (with fix):

```
Test Summary:                      | Pass  Total   Time
Enzyme reverse through interpolant |    2      2  34.9s
SUCCESS: bu=[-0.3, 1.0] bp=[0.36311947343289785] (matches analytic `du[1]` and `ref(1.5)[1]`)
```

Commands run:

```
GROUP=Core julia --project=lib/OrdinaryDiffEqCore -e 'using Pkg; Pkg.test()'
# Core Infrastructure AllocCheck, JET, Aqua + all Core testsets pass, including new Enzyme Interpolation (2 passed)

GROUP=QA julia --project=lib/OrdinaryDiffEqCore -e 'using Pkg; Pkg.test()'
# Aqua 26 passed, JET 30 passed +1 broken (pre-existing), AllocCheck passed
```

New regression test `lib/OrdinaryDiffEqCore/test/enzyme_interpolation_tests.jl` fails (process abort, `LLVM ERROR`) before and passes after.

## Not verified

- GPU group (needs hardware).
- Downstream packages / SciMLSensitivity `EnzymeVJP` path (only local MWE verified).
- `julia pre` / allowed-to-fail jobs.

## Reviewer notes

- Uses `EnzymeCore.EnzymeRules.inactive` (not `inactive_noinl`) deliberately to block inlining; `inactive_noinl` still inlines and still crashes.
- Adds `Enzyme` to `[extras]`/`test` targets for OrdinaryDiffEqCore only; no new runtime dep.
- QA allowlist adds `:inactive` alongside existing `:inactive_noinl` for `EnzymeCore.EnzymeRules` internals.

🤖 Generated with OpenCode (Muse Spark) (model: muse-spark-1.3-contributor-free)
Session: /home/crackauc/sandbox/tmp_20260911_055443_18155

Links:
- Upstream Enzyme issue with standalone reproducer: https://github.com/EnzymeAD/Enzyme.jl/issues/3565
- Narrowed reproducer comment: https://github.com/EnzymeAD/Enzyme.jl/issues/3565#issuecomment-5632216139
