### PR TITLE
ExpRK: cache ishermitian (rebase of #4305, + review fixes)

### DIFF
--- a/lib/OrdinaryDiffEqExponentialRK/Project.toml
+++ b/lib/OrdinaryDiffEqExponentialRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExponentialRK"
 uuid = "e0540318-69ee-4070-8777-9e2de6de23de"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.3.1"
+version = "2.3.2"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqExponentialRK/Project.toml
+++ b/lib/OrdinaryDiffEqExponentialRK/Project.toml
@@ -15,6 +15,7 @@ ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -28,7 +29,6 @@ OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
-SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 
 [sources]
 DiffEqBase = {path = "../DiffEqBase"}
@@ -66,4 +66,4 @@ Reexport = "1.2.2"
 SafeTestsets = "0.1.0"
 
 [targets]
-test = ["DiffEqDevTools", "Random", "SafeTestsets", "Test", "OrdinaryDiffEqTsit5", "LinearSolve", "SparseArrays", "OrdinaryDiffEqVerner", "OrdinaryDiffEqSDIRK", "Pkg", "SciMLTesting", "SciMLOperators"]
+test = ["DiffEqDevTools", "Random", "SafeTestsets", "Test", "OrdinaryDiffEqTsit5", "LinearSolve", "SparseArrays", "OrdinaryDiffEqVerner", "OrdinaryDiffEqSDIRK", "Pkg", "SciMLTesting"]

--- a/lib/OrdinaryDiffEqExponentialRK/src/OrdinaryDiffEqExponentialRK.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/OrdinaryDiffEqExponentialRK.jl
@@ -31,6 +31,7 @@ import ADTypes: AutoForwardDiff
 using Reexport: Reexport, @reexport
 @reexport using SciMLBase
 using SciMLBase: SciMLBase, SplitFunction
+using SciMLOperators: isconstant
 
 include("algorithms.jl")
 include("alg_utils.jl")

--- a/lib/OrdinaryDiffEqExponentialRK/src/OrdinaryDiffEqExponentialRK.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/OrdinaryDiffEqExponentialRK.jl
@@ -15,7 +15,7 @@ using RecursiveArrayTools: RecursiveArrayTools
 import RecursiveArrayTools: recursivecopy!
 using MuladdMacro: MuladdMacro, @muladd
 using FastBroadcast: FastBroadcast, @..
-using LinearAlgebra: axpy!, mul!
+using LinearAlgebra: axpy!, mul!, ishermitian
 import DiffEqBase
 import DiffEqBase: calculate_residuals, calculate_residuals!, initialize!
 using ExponentialUtilities: ExponentialUtilities, ExpvCache, KrylovSubspace,

--- a/lib/OrdinaryDiffEqExponentialRK/src/OrdinaryDiffEqExponentialRK.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/OrdinaryDiffEqExponentialRK.jl
@@ -31,7 +31,7 @@ import ADTypes: AutoForwardDiff
 using Reexport: Reexport, @reexport
 @reexport using SciMLBase
 using SciMLBase: SciMLBase, SplitFunction
-using SciMLOperators: isconstant
+using SciMLOperators: SciMLOperators, isconstant
 
 include("algorithms.jl")
 include("alg_utils.jl")

--- a/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_caches.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_caches.jl
@@ -112,8 +112,23 @@ Symmetry of the ExpRK linear operator, or `nothing` when it cannot safely be cac
 `ETDRK4` step. For a sparse symmetric operator that check is a full `O(nnz)` scan (it can only
 exit early on finding an asymmetry), costing roughly 10% of a Krylov build at `m = 15`.
 
-A `SplitFunction`'s linear part is fixed for the whole solve, so the answer can be computed
-once. Everything else returns `nothing`, and `arnoldi!` derives the flag itself as before.
+Caching a *value* -- "are these entries symmetric?" -- is only accurate while the entries cannot
+change, so two conditions must hold. Anything else returns `nothing` and `arnoldi!` derives the
+flag itself on every call, exactly as before:
+
+  * `f isa SplitFunction`, so `A` is the fixed linear part rather than a Jacobian that
+    `calc_J!` rebuilds every step; and
+  * `isconstant(A)`, so the operator carries no `update_func` that `update_coefficients[!]`
+    could fire to replace its entries part-way through the solve.
+
+The second condition matters because the error is asymmetric. A stale `false` merely costs
+performance -- `arnoldi!` runs full Arnoldi. A stale `true` sends it to `lanczos!`, whose
+three-term recurrence is valid only for symmetric operators, and the result is *silently wrong*.
+
+Not covered: mutating the underlying array in place through a reference held outside the solver
+without going through `update_coefficients!`. That is outside the SciMLOperators contract and is
+already unsupported here -- the `krylov = false` path precomputes `expRK_operators(alg, dt, A)`
+once at cache construction and would ignore such a change entirely.
 """
 function _cached_ishermitian(f)
     isa(f, SplitFunction) || return nothing
@@ -121,6 +136,7 @@ function _cached_ishermitian(f)
     # `MatrixOperator` rather than a bare `AbstractMatrix`, so do not require the latter --
     # just ask whether `ishermitian` is defined for it, exactly as `arnoldi!` would.
     A = f.f1.f
+    isconstant(A) || return nothing
     applicable(ishermitian, A) || return nothing
     return ishermitian(A)
 end

--- a/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_caches.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_caches.jl
@@ -103,6 +103,48 @@ for (Alg, Cache) in [
 end
 
 """
+    _cached_ishermitian(f) -> Union{Bool,Nothing}
+
+Symmetry of the ExpRK linear operator, or `nothing` when it cannot safely be cached.
+
+`arnoldi!` takes `ishermitian` as a keyword argument whose default is
+`LinearAlgebra.ishermitian(A)`, so the property is re-derived on *every* call -- five times per
+`ETDRK4` step. For a sparse symmetric operator that check is a full `O(nnz)` scan (it can only
+exit early on finding an asymmetry), costing roughly 10% of a Krylov build at `m = 15`.
+
+A `SplitFunction`'s linear part is fixed for the whole solve, so the answer can be computed
+once. Everything else returns `nothing`, and `arnoldi!` derives the flag itself as before.
+"""
+function _cached_ishermitian(f)
+    isa(f, SplitFunction) || return nothing
+    # `f.f1.f` is the same object handed to `arnoldi!` in `perform_step!`. It is usually a
+    # `MatrixOperator` rather than a bare `AbstractMatrix`, so do not require the latter --
+    # just ask whether `ishermitian` is defined for it, exactly as `arnoldi!` would.
+    A = f.f1.f
+    applicable(ishermitian, A) || return nothing
+    return ishermitian(A)
+end
+
+"""
+    _arnoldi_kwargs(alg, A, integrator, herm)
+
+Keyword bundle shared by the `arnoldi!` calls within one `perform_step!`.
+
+`herm` is the flag cached by [`_cached_ishermitian`](@ref), or `nothing` when it could not be
+cached, in which case it is derived here exactly as `arnoldi!` would have. The returned
+`NamedTuple` always has the same shape, so the call sites stay type-stable.
+"""
+@inline function _arnoldi_kwargs(alg, A, integrator, herm)
+    ish = herm === nothing ? ishermitian(A) : herm
+    return (
+        m = min(alg.m, size(A, 1)),
+        opnorm = integrator.opts.internalopnorm,
+        iop = alg.iop,
+        ishermitian = ish,
+    )
+end
+
+"""
     alg_cache_expRK(alg, u, uEltypeNoUnits, uprev, f, t, dt, p, du1, tmp, dz, plist)
 
 Construct the non-standard caches (not uType or rateType) for ExpRK integrators.
@@ -139,7 +181,7 @@ function alg_cache_expRK(
         Ks = KrylovSubspace{T}(n, m)
         phiv_cache = PhivCache(u, m, maximum(plist))
         ws = [Matrix{T}(undef, n, plist[i] + 1) for i in 1:length(plist)]
-        KsCache = (Ks, phiv_cache, ws)
+        KsCache = (Ks, phiv_cache, ws, _cached_ishermitian(f))
     else
         KsCache = nothing
         # Precompute the operators
@@ -859,7 +901,9 @@ function alg_cache_exprb(
     Ks = KrylovSubspace{T}(n, m)
     phiv_cache = PhivCache(u, m, maximum(plist))
     ws = [Matrix{T}(undef, n, plist[i] + 1) for i in 1:length(plist)]
-    KsCache = (Ks, phiv_cache, ws)
+    # `nothing`: the exponential Rosenbrock methods rebuild the Jacobian every step, so its
+    # symmetry cannot be cached across the solve. `_arnoldi_kwargs` derives it per call.
+    KsCache = (Ks, phiv_cache, ws, nothing)
     return uf, jac_config, J, KsCache
 end
 

--- a/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_caches.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_caches.jl
@@ -113,17 +113,18 @@ Symmetry of the ExpRK linear operator, or `nothing` when it cannot safely be cac
 exit early on finding an asymmetry), costing roughly 10% of a Krylov build at `m = 15`.
 
 Caching a *value* -- "are these entries symmetric?" -- is only accurate while the entries cannot
-change, so two conditions must hold. Anything else returns `nothing` and `arnoldi!` derives the
-flag itself on every call, exactly as before:
+change, and what licenses that is `isconstant(A)`, only that. Being split does not: a
+`SplitFunction`'s linear part is an operator like any other, free to depend on `u`, `p` and `t`,
+and evaluating the split right-hand side runs `update_coefficients!` on it, so its entries can
+change from one step to the next -- symmetric at `t = 0` and not afterwards, say. The
+`SplitFunction` test only picks out *which* object `A` is: `f.f1.f`, as against a Jacobian that
+`calc_J!` overwrites every step and that could never be cached at all.
 
-  * `f isa SplitFunction`, so `A` is the fixed linear part rather than a Jacobian that
-    `calc_J!` rebuilds every step; and
-  * `isconstant(A)`, so the operator carries no `update_func` that `update_coefficients[!]`
-    could fire to replace its entries part-way through the solve.
-
-The second condition matters because the error is asymmetric. A stale `false` merely costs
+The gate is conservative because the error is asymmetric. A stale `false` merely costs
 performance -- `arnoldi!` runs full Arnoldi. A stale `true` sends it to `lanczos!`, whose
 three-term recurrence is valid only for symmetric operators, and the result is *silently wrong*.
+So anything not `isconstant` returns `nothing`, and `arnoldi!` derives the flag itself on every
+call, exactly as before.
 
 Not covered: mutating the underlying array in place through a reference held outside the solver
 without going through `update_coefficients!`. That is outside the SciMLOperators contract and is
@@ -131,12 +132,12 @@ already unsupported here -- the `krylov = false` path precomputes `expRK_operato
 once at cache construction and would ignore such a change entirely.
 """
 function _cached_ishermitian(f)
+    # Not a fixedness test: it says `A` is `f.f1.f` rather than a per-step Jacobian.
     isa(f, SplitFunction) || return nothing
-    # `f.f1.f` is the same object handed to `arnoldi!` in `perform_step!`. It is usually a
-    # `MatrixOperator` rather than a bare `AbstractMatrix`, so do not require the latter --
-    # just ask whether `ishermitian` is defined for it, exactly as `arnoldi!` would.
     A = f.f1.f
     isconstant(A) || return nothing
+    # `A` is usually a `MatrixOperator` rather than a bare `AbstractMatrix`, so do not require
+    # the latter -- just ask whether `ishermitian` is defined for it, as `arnoldi!` would.
     applicable(ishermitian, A) || return nothing
     return ishermitian(A)
 end

--- a/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_perform_step.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_perform_step.jl
@@ -199,11 +199,9 @@ function perform_step!(integrator, cache::ETDRK2Cache, repeat_step = false)
         F1 = integrator.fsalfirst
         Ks, phiv_cache, ws, herm = KsCache
         w1, w2 = ws
+        kwargs = _arnoldi_kwargs(alg, A, integrator, herm)
         # Krylov for F1
-        arnoldi!(
-            Ks, A, F1; m = min(alg.m, size(A, 1)),
-            opnorm = integrator.opts.internalopnorm, iop = alg.iop
-        )
+        arnoldi!(Ks, A, F1; kwargs...)
         phiv!(w1, dt, Ks, 2; cache = phiv_cache)
         # Krylov for F2
         @muladd @.. broadcast = false tmp = uprev + dt * @view(w1[:, 2])
@@ -214,10 +212,7 @@ function perform_step!(integrator, cache::ETDRK2Cache, repeat_step = false)
             OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
         end
         F2 .+= mul!(rtmp, A, uprev)
-        arnoldi!(
-            Ks, A, F2; m = min(alg.m, size(A, 1)),
-            opnorm = integrator.opts.internalopnorm, iop = alg.iop
-        )
+        arnoldi!(Ks, A, F2; kwargs...)
         phiv!(w2, dt, Ks, 2; cache = phiv_cache)
         # Update u
         u .= uprev

--- a/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_perform_step.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_perform_step.jl
@@ -127,7 +127,7 @@ function perform_step!(integrator, cache::NorsettEulerCache, repeat_step = false
     alg = unwrap_alg(integrator, true)
 
     if alg.krylov
-        Ks, phiv_cache, ws = KsCache
+        Ks, phiv_cache, ws, herm = KsCache
         w = ws[1]
         arnoldi!(
             Ks, A, integrator.fsalfirst; m = min(alg.m, size(A, 1)),
@@ -197,7 +197,7 @@ function perform_step!(integrator, cache::ETDRK2Cache, repeat_step = false)
 
     if alg.krylov
         F1 = integrator.fsalfirst
-        Ks, phiv_cache, ws = KsCache
+        Ks, phiv_cache, ws, herm = KsCache
         w1, w2 = ws
         # Krylov for F1
         arnoldi!(
@@ -256,10 +256,7 @@ function perform_step!(integrator, cache::ETDRK3ConstantCache, repeat_step = fal
     Au = A * uprev
     F1 = integrator.fsalfirst
     if alg.krylov
-        kwargs = (
-            m = min(alg.m, size(A, 1)), opnorm = integrator.opts.internalopnorm,
-            iop = alg.iop,
-        )
+        kwargs = _arnoldi_kwargs(alg, A, integrator, nothing)
         # Krylov on F1 (first column)
         Ks = arnoldi(A, F1; kwargs...)
         w1_half = phiv(dt / 2, Ks, 1)
@@ -317,12 +314,9 @@ function perform_step!(integrator, cache::ETDRK3Cache, repeat_step = false)
     mul!(Au, A, uprev)
     halfdt = dt / 2
     if alg.krylov
-        Ks, phiv_cache, ws = KsCache
+        Ks, phiv_cache, ws, herm = KsCache
         w1_half, w1, w2, w3 = ws
-        kwargs = (
-            m = min(alg.m, size(A, 1)), opnorm = integrator.opts.internalopnorm,
-            iop = alg.iop,
-        )
+        kwargs = _arnoldi_kwargs(alg, A, integrator, herm)
         # Krylov for F1 (first column)
         arnoldi!(Ks, A, F1; kwargs...)
         phiv!(w1_half, halfdt, Ks, 1; cache = phiv_cache)
@@ -386,10 +380,7 @@ function perform_step!(integrator, cache::ETDRK4ConstantCache, repeat_step = fal
     F1 = integrator.fsalfirst
     halfdt = dt / 2
     if alg.krylov
-        kwargs = (
-            m = min(alg.m, size(A, 1)), opnorm = integrator.opts.internalopnorm,
-            iop = alg.iop,
-        )
+        kwargs = _arnoldi_kwargs(alg, A, integrator, nothing)
         # Krylov on F1 (first column)
         Ks = arnoldi(A, F1; kwargs...)
         w1_half = phiv(halfdt, Ks, 1)
@@ -457,12 +448,9 @@ function perform_step!(integrator, cache::ETDRK4Cache, repeat_step = false)
     mul!(Au, A, uprev)
     halfdt = dt / 2
     if alg.krylov
-        Ks, phiv_cache, ws = KsCache
+        Ks, phiv_cache, ws, herm = KsCache
         w1_half, w2_half, w1, w2, w3, w4 = ws
-        kwargs = (
-            m = min(alg.m, size(A, 1)), opnorm = integrator.opts.internalopnorm,
-            iop = alg.iop,
-        )
+        kwargs = _arnoldi_kwargs(alg, A, integrator, herm)
         # Krylov for F1 (first column)
         arnoldi!(Ks, A, F1; kwargs...)
         phiv!(w1_half, halfdt, Ks, 1; cache = phiv_cache)
@@ -548,10 +536,7 @@ function perform_step!(integrator, cache::HochOst4ConstantCache, repeat_step = f
     F1 = integrator.fsalfirst
     halfdt = dt / 2
     if alg.krylov
-        kwargs = (
-            m = min(alg.m, size(A, 1)), opnorm = integrator.opts.internalopnorm,
-            iop = alg.iop,
-        )
+        kwargs = _arnoldi_kwargs(alg, A, integrator, nothing)
         # Krylov on F1 (first column)
         Ks = arnoldi(A, F1; kwargs...)
         w1_half = phiv(halfdt, Ks, 3)
@@ -634,12 +619,9 @@ function perform_step!(integrator, cache::HochOst4Cache, repeat_step = false)
     mul!(Au, A, uprev)
     halfdt = dt / 2
     if alg.krylov
-        Ks, phiv_cache, ws = KsCache
+        Ks, phiv_cache, ws, herm = KsCache
         w1_half, w2_half, w3_half, w4_half, w1, w2, w3, w4, w5 = ws
-        kwargs = (
-            m = min(alg.m, size(A, 1)), opnorm = integrator.opts.internalopnorm,
-            iop = alg.iop,
-        )
+        kwargs = _arnoldi_kwargs(alg, A, integrator, herm)
         # Krylov on F1 (first column)
         arnoldi!(Ks, A, F1; kwargs...)
         phiv!(w1_half, halfdt, Ks, 3; cache = phiv_cache)
@@ -1509,7 +1491,7 @@ function perform_step!(integrator, cache::Exprb32Cache, repeat_step = false)
     alg = unwrap_alg(integrator, true)
 
     F1 = integrator.fsalfirst
-    Ks, phiv_cache, ws = KsCache
+    Ks, phiv_cache, ws, herm = KsCache
     w1, w2 = ws
     # Krylov for F1
     arnoldi!(
@@ -1555,10 +1537,7 @@ function perform_step!(integrator, cache::Exprb43ConstantCache, repeat_step = fa
 
     Au = A * uprev
     F1 = integrator.fsalfirst
-    kwargs = (
-        m = min(alg.m, size(A, 1)), opnorm = integrator.opts.internalopnorm,
-        iop = alg.iop,
-    )
+    kwargs = _arnoldi_kwargs(alg, A, integrator, nothing)
     # Krylov on F1 (first column)
     Ks = arnoldi(A, F1; kwargs...)
     w1_half = phiv(dt / 2, Ks, 1)
@@ -1605,7 +1584,7 @@ function perform_step!(integrator, cache::Exprb43Cache, repeat_step = false)
     F1 = integrator.fsalfirst
     mul!(Au, J, uprev)
     halfdt = dt / 2
-    Ks, phiv_cache, ws = KsCache
+    Ks, phiv_cache, ws, herm = KsCache
     w1_half, w1, w2, w3 = ws
     kwargs = (
         m = min(alg.m, size(J, 1)), opnorm = integrator.opts.internalopnorm,

--- a/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_perform_step.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/src/exponential_rk_perform_step.jl
@@ -129,10 +129,7 @@ function perform_step!(integrator, cache::NorsettEulerCache, repeat_step = false
     if alg.krylov
         Ks, phiv_cache, ws, herm = KsCache
         w = ws[1]
-        arnoldi!(
-            Ks, A, integrator.fsalfirst; m = min(alg.m, size(A, 1)),
-            opnorm = integrator.opts.internalopnorm, iop = alg.iop
-        )
+        arnoldi!(Ks, A, integrator.fsalfirst; _arnoldi_kwargs(alg, A, integrator, herm)...)
         phiv!(w, dt, Ks, 1; cache = phiv_cache)
         @muladd @.. broadcast = false u = uprev + dt * @view(w[:, 2])
     else
@@ -1488,21 +1485,16 @@ function perform_step!(integrator, cache::Exprb32Cache, repeat_step = false)
     F1 = integrator.fsalfirst
     Ks, phiv_cache, ws, herm = KsCache
     w1, w2 = ws
+    kwargs = _arnoldi_kwargs(alg, J, integrator, herm)
     # Krylov for F1
-    arnoldi!(
-        Ks, J, F1; m = min(alg.m, size(J, 1)), opnorm = integrator.opts.internalopnorm,
-        iop = alg.iop
-    )
+    arnoldi!(Ks, J, F1; kwargs...)
     phiv!(w1, dt, Ks, 3; cache = phiv_cache)
     # Krylov for F2
     @muladd @.. broadcast = false tmp = uprev + dt * @view(w1[:, 2])
     _compute_nl!(F2, f, tmp, p, t + dt, J, rtmp)
     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
     F2 .+= mul!(rtmp, J, uprev)
-    arnoldi!(
-        Ks, J, F2; m = min(alg.m, size(J, 1)), opnorm = integrator.opts.internalopnorm,
-        iop = alg.iop
-    )
+    arnoldi!(Ks, J, F2; kwargs...)
     phiv!(w2, dt, Ks, 3; cache = phiv_cache)
     # Update u
     u .= uprev
@@ -1581,10 +1573,7 @@ function perform_step!(integrator, cache::Exprb43Cache, repeat_step = false)
     halfdt = dt / 2
     Ks, phiv_cache, ws, herm = KsCache
     w1_half, w1, w2, w3 = ws
-    kwargs = (
-        m = min(alg.m, size(J, 1)), opnorm = integrator.opts.internalopnorm,
-        iop = alg.iop,
-    )
+    kwargs = _arnoldi_kwargs(alg, J, integrator, herm)
     # Krylov for F1
     arnoldi!(Ks, J, F1; kwargs...)
     phiv!(w1_half, halfdt, Ks, 1; cache = phiv_cache)

--- a/lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_krylov_tests.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_krylov_tests.jl
@@ -1,6 +1,6 @@
 using OrdinaryDiffEqExponentialRK, Test, Random, LinearAlgebra, SparseArrays
 using OrdinaryDiffEqTsit5
-using SciMLOperators: MatrixOperator
+using SciMLOperators: MatrixOperator, isconstant
 using SciMLBase: successful_retcode
 using OrdinaryDiffEqExponentialRK: _cached_ishermitian, _arnoldi_kwargs
 
@@ -171,6 +171,30 @@ end
     @test _cached_ishermitian(ODEProblem((du, u, p, t) -> (@. du = -u), [1.0],
         (0.0, 1.0)).f) === nothing
 
+    # An operator may be symmetric at t=0 and not afterwards. A Jacobian cannot reach here
+    # (the SplitFunction guard above sends it down the uncached path), but a SplitFunction
+    # whose linear part carries an `update_func` can have its entries replaced by
+    # `update_coefficients!`. Caching `true` there would send `arnoldi!` to `lanczos!`,
+    # whose three-term recurrence assumes symmetry -- silently wrong, not merely slow. So
+    # anything that is not `isconstant` must decline to cache and fall back per call.
+    varying = SplitODEProblem(
+        MatrixOperator(sparse(sym.f.f1.f.A);
+            update_func = (A, u, p, t) -> (B = copy(A); B[1, 2] += t; B)),
+        g!, normalize(randn(N)), (0.0, 0.1))
+
+    @test ishermitian(varying.f.f1.f) === true    # symmetric at construction ...
+    @test isconstant(varying.f.f1.f) === false    # ... but free to stop being so
+    @test _cached_ishermitian(varying.f) === nothing
+
+    # having declined, the per-call fallback must still produce the right answer
+    @test _arnoldi_kwargs(ETDRK4(krylov = true, m = 15), varying.f.f1.f,
+        (; opts = (; internalopnorm = opnorm)), nothing).ishermitian ===
+          ishermitian(varying.f.f1.f)
+
+    # and the cache must actually hold `nothing`, not a stale snapshot
+    @test init(varying, ETDRK4(krylov = true, m = 15); dt = 1.0e-3).cache.KsCache[4] ===
+          nothing
+
     # when nothing was cached, the fallback must derive the same value, with the same
     # NamedTuple shape so the call sites stay type-stable
     let A = sym.f.f1.f, integ = (; opts = (; internalopnorm = opnorm)),
@@ -182,9 +206,13 @@ end
               keys(_arnoldi_kwargs(alg, A, integ, nothing))
     end
 
-    # the flag must reach every cache. Checked per algorithm on purpose: ETDRK2 builds its
-    # `arnoldi!` keywords inline rather than via the shared bundle, so one representative
-    # method would not catch a missed call site.
+    # The flag must reach every cache. Checked per algorithm rather than on one
+    # representative, since each `perform_step!` builds its own `arnoldi!` keywords.
+    # NOTE this asserts only that the flag is STORED: `alg_cache_expRK` populates
+    # `KsCache[4]` identically for all of them, so it cannot catch a `perform_step!` that
+    # receives the flag and then ignores it. All four in-place caches route through
+    # `_arnoldi_kwargs`; a new scheme that hand-rolls its keywords would pass this and
+    # still silently re-derive `ishermitian` on every build.
     for prob in (sym, nonsym), Alg in (ETDRK2, ETDRK3, ETDRK4, HochOst4)
         cache = init(prob, Alg(krylov = true, m = 15); dt = 1.0e-3).cache
         @test cache.KsCache[4] == ishermitian(prob.f.f1.f)

--- a/lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_krylov_tests.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_krylov_tests.jl
@@ -1,6 +1,8 @@
 using OrdinaryDiffEqExponentialRK, Test, Random, LinearAlgebra, SparseArrays
 using OrdinaryDiffEqTsit5
 using SciMLOperators: MatrixOperator
+using SciMLBase: successful_retcode
+using OrdinaryDiffEqExponentialRK: _cached_ishermitian, _arnoldi_kwargs
 
 let N = 20
     Random.seed!(0)
@@ -141,4 +143,56 @@ end
     prob = ODEProblem(exp_fun, u0, (0.0, 1.0))
     sol = solve(prob, LawsonEuler(krylov = true, m = N); dt = 0.1)
     @test sol(1.0) ≈ exp_fun.analytic(u0, nothing, 1.0)
+end
+
+@testset "Cached ishermitian flag" begin
+    # `arnoldi!` takes `ishermitian` as a default keyword argument, so it re-derives the
+    # property on every call -- five times per ETDRK4 step, and for a symmetric sparse
+    # operator that is a full O(nnz) scan. A SplitFunction's linear part is fixed for the
+    # whole solve, so `alg_cache_expRK` evaluates it once and `_arnoldi_kwargs` threads it
+    # through. These problems are split, unlike the ODEProblem fixtures above.
+    Random.seed!(0)
+    N = 32
+    g!(du, u, p, t) = (@. du = u - u^3)
+    split_prob(A) = SplitODEProblem(MatrixOperator(sparse(A)), g!,
+                                    normalize(randn(N)), (0.0, 0.1))
+
+    sym = split_prob(begin                       # periodic Laplacian => symmetric
+            A = diagm(-1 => ones(N - 1), 0 => -2ones(N), 1 => ones(N - 1)) .* 50.0
+            A[1, N] = A[N, 1] = 50.0
+            A
+        end)
+    nonsym = split_prob(                         # upwind-biased => not symmetric
+        diagm(-1 => 3ones(N - 1), 0 => -4ones(N), 1 => ones(N - 1)) .* 50.0)
+
+    # the three distinct outcomes
+    @test _cached_ishermitian(sym.f) === true
+    @test _cached_ishermitian(nonsym.f) === false
+    @test _cached_ishermitian(ODEProblem((du, u, p, t) -> (@. du = -u), [1.0],
+        (0.0, 1.0)).f) === nothing
+
+    # when nothing was cached, the fallback must derive the same value, with the same
+    # NamedTuple shape so the call sites stay type-stable
+    let A = sym.f.f1.f, integ = (; opts = (; internalopnorm = opnorm)),
+        alg = ETDRK4(krylov = true, m = 15)
+
+        @test _arnoldi_kwargs(alg, A, integ, true).ishermitian ===
+              _arnoldi_kwargs(alg, A, integ, nothing).ishermitian === true
+        @test keys(_arnoldi_kwargs(alg, A, integ, true)) ===
+              keys(_arnoldi_kwargs(alg, A, integ, nothing))
+    end
+
+    # the flag must reach every cache. Checked per algorithm on purpose: ETDRK2 builds its
+    # `arnoldi!` keywords inline rather than via the shared bundle, so one representative
+    # method would not catch a missed call site.
+    for prob in (sym, nonsym), Alg in (ETDRK2, ETDRK3, ETDRK4, HochOst4)
+        cache = init(prob, Alg(krylov = true, m = 15); dt = 1.0e-3).cache
+        @test cache.KsCache[4] == ishermitian(prob.f.f1.f)
+    end
+
+    # smoke: the split path still integrates (the fixtures above are all non-split)
+    for prob in (sym, nonsym)
+        @test successful_retcode(solve(prob, ETDRK4(krylov = true, m = 15);
+            dt = 1.0e-3, save_everystep = false))
+    end
 end

--- a/lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_krylov_tests.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_krylov_tests.jl
@@ -148,9 +148,9 @@ end
 @testset "Cached ishermitian flag" begin
     # `arnoldi!` takes `ishermitian` as a default keyword argument, so it re-derives the
     # property on every call -- five times per ETDRK4 step, and for a symmetric sparse
-    # operator that is a full O(nnz) scan. A SplitFunction's linear part is fixed for the
-    # whole solve, so `alg_cache_expRK` evaluates it once and `_arnoldi_kwargs` threads it
-    # through. These problems are split, unlike the ODEProblem fixtures above.
+    # operator that is a full O(nnz) scan. A *constant* linear part holds still for the whole
+    # solve, so `alg_cache_expRK` evaluates it once and `_arnoldi_kwargs` threads it through.
+    # These problems are split, unlike the ODEProblem fixtures above.
     Random.seed!(0)
     N = 32
     g!(du, u, p, t) = (@. du = u - u^3)
@@ -194,6 +194,18 @@ end
     # and the cache must actually hold `nothing`, not a stale snapshot
     @test init(varying, ETDRK4(krylov = true, m = 15); dt = 1.0e-3).cache.KsCache[4] ===
           nothing
+
+    # The operator really does stop being symmetric part-way through the solve -- evaluating
+    # the split right-hand side runs `update_coefficients!` on it -- so a snapshot taken at
+    # t=0 would be wrong, not merely stale. What reaches `arnoldi!` has to track the operator
+    # rather than the shape of the problem.
+    let alg = ETDRK4(krylov = true, m = 15), integ = init(varying, alg; dt = 1.0e-3)
+        step!(integ)
+        step!(integ)
+        A = integ.f.f1.f
+        @test ishermitian(A) === false
+        @test _arnoldi_kwargs(alg, A, integ, integ.cache.KsCache[4]).ishermitian === false
+    end
 
     # when nothing was cached, the fallback must derive the same value, with the same
     # NamedTuple shape so the call sites stay type-stable

--- a/lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_krylov_tests.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_krylov_tests.jl
@@ -173,22 +173,31 @@ end
     Random.seed!(0)
     N = 32
     g!(du, u, p, t) = (@. du = u - u^3)
-    split_prob(A) = SplitODEProblem(MatrixOperator(sparse(A)), g!,
-                                    normalize(randn(N)), (0.0, 0.1))
+    split_prob(A) = SplitODEProblem(
+        MatrixOperator(sparse(A)), g!,
+        normalize(randn(N)), (0.0, 0.1)
+    )
 
-    sym = split_prob(begin                       # periodic Laplacian => symmetric
+    sym = split_prob(
+        begin                       # periodic Laplacian => symmetric
             A = diagm(-1 => ones(N - 1), 0 => -2ones(N), 1 => ones(N - 1)) .* 50.0
             A[1, N] = A[N, 1] = 50.0
             A
-        end)
+        end
+    )
     nonsym = split_prob(                         # upwind-biased => not symmetric
-        diagm(-1 => 3ones(N - 1), 0 => -4ones(N), 1 => ones(N - 1)) .* 50.0)
+        diagm(-1 => 3ones(N - 1), 0 => -4ones(N), 1 => ones(N - 1)) .* 50.0
+    )
 
     # the three distinct outcomes
     @test _cached_ishermitian(sym.f) === true
     @test _cached_ishermitian(nonsym.f) === false
-    @test _cached_ishermitian(ODEProblem((du, u, p, t) -> (@. du = -u), [1.0],
-        (0.0, 1.0)).f) === nothing
+    @test _cached_ishermitian(
+        ODEProblem(
+            (du, u, p, t) -> (@. du = -u), [1.0],
+            (0.0, 1.0)
+        ).f
+    ) === nothing
 
     # An operator may be symmetric at t=0 and not afterwards. A Jacobian cannot reach here
     # (the SplitFunction guard above sends it down the uncached path), but a SplitFunction
@@ -197,22 +206,27 @@ end
     # whose three-term recurrence assumes symmetry -- silently wrong, not merely slow. So
     # anything that is not `isconstant` must decline to cache and fall back per call.
     varying = SplitODEProblem(
-        MatrixOperator(sparse(sym.f.f1.f.A);
-            update_func = (A, u, p, t) -> (B = copy(A); B[1, 2] += t; B)),
-        g!, normalize(randn(N)), (0.0, 0.1))
+        MatrixOperator(
+            sparse(sym.f.f1.f.A);
+            update_func = (A, u, p, t) -> (B = copy(A); B[1, 2] += t; B)
+        ),
+        g!, normalize(randn(N)), (0.0, 0.1)
+    )
 
     @test ishermitian(varying.f.f1.f) === true    # symmetric at construction ...
     @test isconstant(varying.f.f1.f) === false    # ... but free to stop being so
     @test _cached_ishermitian(varying.f) === nothing
 
     # having declined, the per-call fallback must still produce the right answer
-    @test _arnoldi_kwargs(ETDRK4(krylov = true, m = 15), varying.f.f1.f,
-        (; opts = (; internalopnorm = opnorm)), nothing).ishermitian ===
-          ishermitian(varying.f.f1.f)
+    @test _arnoldi_kwargs(
+        ETDRK4(krylov = true, m = 15), varying.f.f1.f,
+        (; opts = (; internalopnorm = opnorm)), nothing
+    ).ishermitian ===
+        ishermitian(varying.f.f1.f)
 
     # and the cache must actually hold `nothing`, not a stale snapshot
     @test init(varying, ETDRK4(krylov = true, m = 15); dt = 1.0e-3).cache.KsCache[4] ===
-          nothing
+        nothing
 
     # The operator really does stop being symmetric part-way through the solve -- evaluating
     # the split right-hand side runs `update_coefficients!` on it -- so a snapshot taken at
@@ -229,12 +243,12 @@ end
     # when nothing was cached, the fallback must derive the same value, with the same
     # NamedTuple shape so the call sites stay type-stable
     let A = sym.f.f1.f, integ = (; opts = (; internalopnorm = opnorm)),
-        alg = ETDRK4(krylov = true, m = 15)
+            alg = ETDRK4(krylov = true, m = 15)
 
         @test _arnoldi_kwargs(alg, A, integ, true).ishermitian ===
-              _arnoldi_kwargs(alg, A, integ, nothing).ishermitian === true
+            _arnoldi_kwargs(alg, A, integ, nothing).ishermitian === true
         @test keys(_arnoldi_kwargs(alg, A, integ, true)) ===
-              keys(_arnoldi_kwargs(alg, A, integ, nothing))
+            keys(_arnoldi_kwargs(alg, A, integ, nothing))
     end
 
     # The flag must reach every cache. Checked per algorithm rather than on one
@@ -269,7 +283,11 @@ end
 
     # smoke: the split path still integrates (the fixtures above are all non-split)
     for prob in (sym, nonsym)
-        @test successful_retcode(solve(prob, ETDRK4(krylov = true, m = 15);
-            dt = 1.0e-3, save_everystep = false))
+        @test successful_retcode(
+            solve(
+                prob, ETDRK4(krylov = true, m = 15);
+                dt = 1.0e-3, save_everystep = false
+            )
+        )
     end
 end

--- a/lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_krylov_tests.jl
+++ b/lib/OrdinaryDiffEqExponentialRK/test/linear_nonlinear_krylov_tests.jl
@@ -145,6 +145,25 @@ end
     @test sol(1.0) ≈ exp_fun.analytic(u0, nothing, 1.0)
 end
 
+# Counts how often the solver asks the linear part for its symmetry. `MatrixOperator` forwards
+# `ishermitian` to the wrapped array, so this sees exactly the calls `arnoldi!` makes when it is
+# left to derive the flag itself.
+mutable struct SymmetryCounter{T} <: AbstractMatrix{T}
+    A::SparseMatrixCSC{T, Int}
+    count::Int
+end
+SymmetryCounter(A::SparseMatrixCSC{T, Int}) where {T} = SymmetryCounter{T}(A, 0)
+Base.size(C::SymmetryCounter) = size(C.A)
+Base.getindex(C::SymmetryCounter, i::Int, j::Int) = C.A[i, j]
+LinearAlgebra.mul!(y::AbstractVector, C::SymmetryCounter, x::AbstractVector) = mul!(y, C.A, x)
+function LinearAlgebra.mul!(y::AbstractVector, C::SymmetryCounter, x::AbstractVector, a, b)
+    return mul!(y, C.A, x, a, b)
+end
+function LinearAlgebra.ishermitian(C::SymmetryCounter)
+    C.count += 1
+    return ishermitian(C.A)
+end
+
 @testset "Cached ishermitian flag" begin
     # `arnoldi!` takes `ishermitian` as a default keyword argument, so it re-derives the
     # property on every call -- five times per ETDRK4 step, and for a symmetric sparse
@@ -228,6 +247,24 @@ end
     for prob in (sym, nonsym), Alg in (ETDRK2, ETDRK3, ETDRK4, HochOst4)
         cache = init(prob, Alg(krylov = true, m = 15); dt = 1.0e-3).cache
         @test cache.KsCache[4] == ishermitian(prob.f.f1.f)
+    end
+
+    # That loop asserts only that the flag is stored. This one counts what the operator is
+    # actually asked for: the symmetry check happens while the cache is built and never again,
+    # however many steps run. A `perform_step!` that drops the flag re-derives it per build.
+    for Alg in (NorsettEuler, ETDRK2, ETDRK3, ETDRK4, HochOst4)
+        counter = SymmetryCounter(sparse(sym.f.f1.f.A))
+        integ = init(
+            SplitODEProblem(MatrixOperator(counter), g!, normalize(randn(N)), (0.0, 0.1)),
+            Alg(krylov = true, m = 15); dt = 1.0e-3
+        )
+        step!(integ)
+        built = counter.count
+        for _ in 1:4
+            step!(integ)
+        end
+        @test built > 0
+        @test counter.count == built
     end
 
     # smoke: the split path still integrates (the fixtures above are all non-split)


### PR DESCRIPTION
Rebase of #4305 onto current master (`eed19e7a0`), with the review comment on
`_cached_ishermitian` addressed in commits stacked on top. @KeshavVenkatesh's two commits are
cherry-picked unchanged with authorship preserved; everything after them is new. Credit for the
optimization is his — this only rebases it and answers the review.

**Please ignore until reviewed by @ChrisRackauckas.** Supersedes https://github.com/SciML/OrdinaryDiffEq.jl/pull/4305.

## What the review comment was about

> It's not necessarily a fixed linear part in a split function, only if the operator A is constant.

Correct, and the docstring said otherwise: it justified the snapshot with "a `SplitFunction`'s
linear part is fixed for the whole solve". A split linear part is an operator like any other,
and evaluating the split right-hand side runs `update_coefficients!` on it, so a non-constant
one really does change its entries mid-solve. Measured directly on a `MatrixOperator` carrying
an `update_func`, over 5 steps of `ETDRK4(krylov = true)`:

```
after init:        ishermitian(A) = true   A[1,2]=10.0                A[2,1]=10.0
after 5 steps:     ishermitian(A) = false  A[1,2]=10.075000000000001  A[2,1]=10.0
```

That is exactly the "hermitian at t=0 because the initial point is odd, not for any t>0" case
from the earlier review comment, and `isconstant(A)` — already in the guard as of `594dcd19a` —
is the whole thing that rules it out. The `SplitFunction` test only picks out *which* object `A`
is: `f.f1.f`, as against a Jacobian `calc_J!` overwrites every step. So the code was right and
its stated reason was wrong; `74e40ab5e` fixes the reason and pins the behavior with a test.

## Commits

| | |
|---|---|
| `2210f5345`, `e0e7a407e` | @KeshavVenkatesh's, cherry-picked unchanged |
| `74e40ab5e` | correct the invariant + regression test for the mid-solve case |
| `1ae996b96` | hand the cached flag to the `arnoldi!` calls that were still missing it |
| `3beea3685` | Runic formatting (no behavior change) |
| `fe3099b28` | version 2.3.1 → 2.3.2 |
| `5edca8df9` | explicit `SciMLOperators` module import, required by the QA group |

`1ae996b96` fixes something separate that the rebase surfaced: `NorsettEulerCache` destructured
the cached flag out of `KsCache` and then called `arnoldi!` without it, so ETDRK1 kept paying for
the full `ishermitian` scan per Krylov build — the cost this PR exists to remove — and the
binding sat unused. The two `Exprb` caches destructured it and hand-rolled the same keyword
tuple; theirs is always `nothing` (a per-step Jacobian cannot be cached), so routing them
through `_arnoldi_kwargs` changes no behavior, it just drops the duplicated block and the unused
binding. Drop that commit if you would rather it went separately.

## Verification

All runs on Julia 1.12.4, `lib/OrdinaryDiffEqExponentialRK`.

**Tests, final branch state:**

```
$ GROUP=Core julia --project -e 'using Pkg; Pkg.test()'
Test Summary:                         | Pass  Broken  Total     Time
Linear-Nonlinear Krylov Methods Tests |  126       2    128  2m41.0s
Test Summary:                      | Pass  Broken  Total     Time
Linear-Nonlinear Convergence Tests |   44       2     46  5m24.7s
     Testing OrdinaryDiffEqExponentialRK tests passed

$ GROUP=QA julia --project -e 'using Pkg; Pkg.test()'
Allocation Tests |    1      17     18  5m09.5s
JET Tests        |    1              1  1m13.4s
Aqua             |   21             21  1m10.4s
     Testing OrdinaryDiffEqExponentialRK tests passed
```

The 2 broken in each group are pre-existing (`CFNLIRK3()` and friends), unchanged from master.

**Both new tests discriminate.** Dropping the `isconstant` gate — i.e. the state of the first
commit, which assumed split ⇒ fixed — fails the new mid-solve assertion, along with two of
@KeshavVenkatesh's own:

```
Cached ishermitian flag: Test Failed at linear_nonlinear_krylov_tests.jl:226
  Expression: (_arnoldi_kwargs(alg, A, integ, integ.cache.KsCache[4])).ishermitian === false
   Evaluated: true === false
Linear-Nonlinear Krylov Methods Tests |  123     3       2    128
```

Reverting only the `NorsettEuler` hunk of `1ae996b96` fails the new counter test — the operator
gets asked for its symmetry once per step instead of once per solve:

```
Cached ishermitian flag: Test Failed at linear_nonlinear_krylov_tests.jl:267
  Expression: counter.count == built
   Evaluated: 6 == 2
Linear-Nonlinear Krylov Methods Tests |  125     1       2    128
```

Both pass on the final state (126/128 above).

**End-to-end timing**, N=4096 periodic 1-D Laplacian (symmetric, sparse) as the split linear
part, `dt = 1e-2` to `t = 1`, min of 5 runs, this branch vs master:

```
ETDRK4(krylov=true, m=15)        306.5 ms  vs  334.1 ms   (-8.3%)
NorsettEuler(krylov=true, m=15)   57.9 ms  vs   63.1 ms   (-8.2%)
```

`NorsettEuler` is the one `1ae996b96` unblocks; on master's code it is unchanged by #4305.

**Format and spelling:** `runic --check` and `typos` are both clean on the sublibrary. Runic is
clean on master for these files, so `3beea3685` only reformats lines this branch added.

## Not verified

- Downstream, GPU, and `julia pre` jobs — not run locally.
- Other sublibraries and the root test suite: untouched by this branch, not run.
- `LawsonEuler` still derives `ishermitian` per step. It goes through `expv` with a two-element
  `KsCache` built by a different `alg_cache`, so it is outside the shape #4305 introduced.
  `expv` does accept the keyword, so this is reachable, just not done here.
- The out-of-place (`ConstantCache`) paths pass `_arnoldi_kwargs(alg, A, integrator, nothing)`
  and so derive the flag per call, as before. No cache exists to hold it on those paths.

## Worth pushing back on

- `isconstant` is `false` for anything that is not an `AbstractSciMLOperator`, so the cache is
  declined for linear parts that are not operators. That is deliberately conservative — a stale
  `true` routes `arnoldi!` into `lanczos!` and is silently wrong, a stale `false` only costs
  time — but it does mean the optimization is narrower than "split problems".
- The `SymmetryCounter` test helper defines `LinearAlgebra.ishermitian`/`mul!` on a test-local
  matrix type to count calls. It is the only way I found to assert that the flag actually
  reaches `arnoldi!` rather than merely being stored in the cache.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_01H8v7A5YkRi8bj8eqWR3wht
