### PR TITLE
GlobalAdjoint: defer to adjoint_sensitivities default instead of pinning an adjoint

### DIFF
--- a/lib/GlobalDiffEq/ext/GlobalDiffEqSciMLSensitivityExt.jl
+++ b/lib/GlobalDiffEq/ext/GlobalDiffEqSciMLSensitivityExt.jl
@@ -3,10 +3,6 @@ module GlobalDiffEqSciMLSensitivityExt
 import GlobalDiffEq, SciMLBase, SciMLSensitivity
 import Accessors: @set
 
-function GlobalDiffEq._default_adjoint_sensealg()
-    return SciMLSensitivity.InterpolatingAdjoint()
-end
-
 # Endpoint global-error projection along `direction`, computed entirely by the
 # adjoint system. The dual-weighted residual ∫ λ(t)ᵀ (f(P(t)) − P'(t)) dt is
 # obtained as the sensitivity of the discrete cost g = ⟨direction, u(T)⟩ to a
@@ -57,9 +53,13 @@ function GlobalDiffEq._adjoint_defect_projection(
             return nothing
         end
     end
+    # A `nothing` sensealg defers to `adjoint_sensitivities`' own default; any
+    # user-passed adjoint method is forwarded unchanged.
+    sensealg_kwargs = sensealg === nothing ? (;) : (; sensealg)
     _, defect_gradient = SciMLSensitivity.adjoint_sensitivities(
         forced_sol, adjoint_alg;
-        sensealg, t = [terminal_time], dgdu_discrete = terminal_gradient!,
+        sensealg_kwargs...,
+        t = [terminal_time], dgdu_discrete = terminal_gradient!,
         abstol, reltol
     )
     return only(defect_gradient)

--- a/lib/GlobalDiffEq/ext/GlobalDiffEqSciMLSensitivityExt.jl
+++ b/lib/GlobalDiffEq/ext/GlobalDiffEqSciMLSensitivityExt.jl
@@ -3,15 +3,8 @@ module GlobalDiffEqSciMLSensitivityExt
 import GlobalDiffEq, SciMLBase, SciMLSensitivity
 import Accessors: @set
 
-# The estimator's augmented RHS evaluates the forward interpolant `sol(t)`.
-# Differentiating that through a vector-Jacobian-product backend is unreliable:
-# ReverseDiff silently mis-evaluates the interpolant (a systematic error in the
-# quadrature-based adjoints) and Enzyme fails to compile `ode_interpolation`
-# outright. The ForwardDiff Jacobian (`autojacvec = false`) seeds the state and
-# parameter rather than time, so `sol(t)` is evaluated at a plain `t` and the
-# Jacobian is correct. See SciML/SciMLSensitivity.jl#1649.
 function GlobalDiffEq._default_adjoint_sensealg()
-    return SciMLSensitivity.InterpolatingAdjoint(autojacvec = false)
+    return SciMLSensitivity.InterpolatingAdjoint()
 end
 
 # Endpoint global-error projection along `direction`, computed entirely by the

--- a/lib/GlobalDiffEq/src/adjoint.jl
+++ b/lib/GlobalDiffEq/src/adjoint.jl
@@ -92,11 +92,8 @@ controls each local-tolerance reduction. The `adjoint_abstol` and
 
 The adjoint machinery lives in a package extension: SciMLSensitivity must be
 loaded to solve with `GlobalAdjoint`. `sensealg` selects the adjoint sensitivity
-algorithm; the default (`nothing`) resolves to `InterpolatingAdjoint` with a
-ForwardDiff Jacobian (`autojacvec = false`). A ForwardDiff Jacobian is used
-rather than a vector-Jacobian product because the estimator differentiates a
-right-hand side that reads the forward solution's dense interpolant, which the
-VJP backends mishandle (see SciML/SciMLSensitivity.jl#1649). `adjoint_alg`
+algorithm; the default (`nothing`) resolves to `InterpolatingAdjoint` with the
+default vector-Jacobian product. `adjoint_alg`
 selects the solver for the reverse-time adjoint problems.
 
 This implementation supports forward-time, standard-mass-matrix ODEs with real

--- a/lib/GlobalDiffEq/src/adjoint.jl
+++ b/lib/GlobalDiffEq/src/adjoint.jl
@@ -92,8 +92,9 @@ controls each local-tolerance reduction. The `adjoint_abstol` and
 
 The adjoint machinery lives in a package extension: SciMLSensitivity must be
 loaded to solve with `GlobalAdjoint`. `sensealg` selects the adjoint sensitivity
-algorithm; the default (`nothing`) resolves to `InterpolatingAdjoint` with the
-default vector-Jacobian product. `adjoint_alg`
+algorithm and is passed straight through to `SciMLSensitivity.adjoint_sensitivities`:
+any adjoint method works, and the default (`nothing`) defers to that function's
+own default. `adjoint_alg`
 selects the solver for the reverse-time adjoint problems.
 
 This implementation supports forward-time, standard-mass-matrix ODEs with real
@@ -151,12 +152,11 @@ function GlobalAdjoint(
     )
 end
 
-# Extension hooks: GlobalDiffEqSciMLSensitivityExt adds methods for these when
+# Extension hook: GlobalDiffEqSciMLSensitivityExt adds a method for this when
 # SciMLSensitivity is loaded.
 function _adjoint_defect_projection end
-function _default_adjoint_sensealg end
 
-_adjoint_ext_loaded() = !isempty(methods(_default_adjoint_sensealg))
+_adjoint_ext_loaded() = !isempty(methods(_adjoint_defect_projection))
 
 function _require_adjoint_ext()
     _adjoint_ext_loaded() || throw(
@@ -170,7 +170,7 @@ end
 
 function _resolve_sensealg(alg::GlobalAdjoint)
     _require_adjoint_ext()
-    return alg.sensealg === nothing ? _default_adjoint_sensealg() : alg.sensealg
+    return alg.sensealg
 end
 
 _positive_finite_real(value) = value isa Real && isfinite(value) && value > 0


### PR DESCRIPTION
Follow-up to #3953: drop the ForwardDiff-Jacobian workaround for SciML/SciMLSensitivity.jl#1649 entirely.

The estimator is adjoint-agnostic, so nothing is pinned anymore: `_default_adjoint_sensealg` is gone, a `nothing` sensealg is forwarded as omitted kwargs, and `adjoint_sensitivities` applies its own default. User-passed sensealgs flow through unchanged.

Verification (run locally):

`julia -m Runic --check` on both touched files: clean. `typos --diff`: clean.

Estimator cross-check on the linear problem (default vs explicit adjoints):

default: 0.00013241391111588064
Interp: 0.00013241391111588064 (identical — upstream default is `InterpolatingAdjoint()`)
Interp_False: 0.00013241251785696054
Quad: 0.00013244528870780053
Gauss: 0.00013213878972206228
actual: 0.00013244509132448457 (ratio default/actual 0.99976)

`lib/GlobalDiffEq/test/adjoint_tests.jl` with the new default:

Adjoint error estimation and control | 18 18 6m09.2s
GlobalAdjoint scope and control modes | 17 17 1m22.5s

Also verified on the #1649 MWE (with SciMLSensitivity#1650 + #4496 present) that explicit `ReverseDiffVJP()`, `EnzymeVJP()`, and `false` all agree with finite differences for Interp/Quad/Gauss.

Not verified:

Full GlobalDiffEq suite (only `adjoint_tests.jl` run), QA group, GPU/downstream. Pre-existing `_positive_finite_real` method-overwrite precompile warning (`companion.jl:8` vs `adjoint.jl:176`, from #4492/#3953) still present and untouched.

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [OpenCode](https://github.com/anomalyco/opencode) (model: opencode/muse-spark-1.3-contributor-free)
Session: /home/crackauc/sandbox/tmp_20260911_055415_17778 (local, no shareable URL)
