### PR TITLE
CI probe: run the full sublibrary test matrix

### DIFF
--- a/lib/DiffEqBase/src/check_error.jl
+++ b/lib/DiffEqBase/src/check_error.jl
@@ -3,7 +3,7 @@
 # `DEVerbosity` toggles that gate them are differential-equation specific, so those live
 # here, as methods of the `report_integrator_failure` hook SciMLBase calls.
 
-#cap diagnostic output to avoid OOM errors when printing large symbolic systems or user data
+# Cap diagnostic output to avoid OOM errors when printing large symbolic systems or user data
 const DIAGNOSTIC_OBJECT_CHARS = 160
 const DIAGNOSTIC_REPORT_CHARS = 4000
 

--- a/lib/OrdinaryDiffEqRosenbrockTableaus/test/runtests.jl
+++ b/lib/OrdinaryDiffEqRosenbrockTableaus/test/runtests.jl
@@ -7,7 +7,7 @@ function activate_qa_env()
 end
 
 # Run functional tests
-if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
+if TEST_GROUP in ("Core", "ALL")
     include("core_tests.jl")
 end
 

--- a/lib/StochasticDiffEqLevyArea/test/runtests.jl
+++ b/lib/StochasticDiffEqLevyArea/test/runtests.jl
@@ -7,7 +7,7 @@ function activate_qa_env()
     return activate_group_env(joinpath(@__DIR__, "qa"); parent = [dirname(@__DIR__), joinpath(@__DIR__, "..", "..", "..")])
 end
 
-if TEST_GROUP == "ALL" || TEST_GROUP == "Core"
+if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "StochasticDiffEqLevyArea tests" include("levyarea_tests.jl")
 end
 


### PR DESCRIPTION
## Summary

- OrdinaryDiffEq's sublibrary CI is diff-filtered: a `lib/<pkg>` is only tested when it changed or when an internal dependency's `src/`/`Project.toml` changed. Latent breakage in untouched sublibraries is invisible on master.
- This PR touches `lib/DiffEqBase/src` (transitively reaches 57 of 59 sublibraries) plus the two packages outside that tree (`OrdinaryDiffEqRosenbrockTableaus`, `StochasticDiffEqLevyArea`), so the Sublibrary CI runs the entire matrix.
- The changes themselves are comment/test no-ops (fix a `#cap` -> `# Cap` comment typo; normalize test-group checks). They exist only to expand the CI matrix; this PR is a probe, not a functional change.

#### Test plan
- [ ] Sublibrary CI matrix covers all 59 lib/* packages; collect the full failure list.

🤖 Generated with [Devin](https://devin.ai) (harness: Devin CLI 3000.10.21, model: SWE-2 High). Session: local Devin CLI session (no shareable URL); session db at /home/crackauc/.local/share/devin/cli/sessions.db