### PR TITLE
GlobalDiffEq: fix Julia 1.13 precompilation and InterpolatingMode companion accuracy

### DIFF
--- a/lib/GlobalDiffEq/src/adjoint.jl
+++ b/lib/GlobalDiffEq/src/adjoint.jl
@@ -176,18 +176,6 @@ function _resolve_sensealg(alg::GlobalAdjoint)
     return alg.sensealg === nothing ? _default_adjoint_sensealg() : alg.sensealg
 end
 
-_positive_finite_real(value) = value isa Real && isfinite(value) && value > 0
-
-function _validate_tolerances(abstol, reltol, name)
-    abstol isa Real && isfinite(abstol) && abstol >= 0 ||
-        throw(ArgumentError("$(name)_abstol must be a nonnegative finite real number"))
-    reltol isa Real && isfinite(reltol) && reltol >= 0 ||
-        throw(ArgumentError("$(name)_reltol must be a nonnegative finite real number"))
-    iszero(abstol) && iszero(reltol) &&
-        throw(ArgumentError("$(name)_abstol and $(name)_reltol cannot both be zero"))
-    return nothing
-end
-
 SciMLBase.allows_arbitrary_number_types(::GlobalAdjoint) = false
 SciMLBase.allowscomplex(::GlobalAdjoint) = false
 SciMLBase.isautodifferentiable(::GlobalAdjoint) = false

--- a/lib/GlobalDiffEq/src/companion.jl
+++ b/lib/GlobalDiffEq/src/companion.jl
@@ -38,9 +38,11 @@ end
 # the method's defect and would silently corrupt the estimate, so require real
 # dense output rather than trusting the caller.
 function _has_dense_derivative(sol)
-    return sol.dense && !(sol.interp isa Union{
-        SciMLBase.ConstantInterpolation, SciMLBase.LinearInterpolation,
-    })
+    return sol.dense && !(
+        sol.interp isa Union{
+            SciMLBase.ConstantInterpolation, SciMLBase.LinearInterpolation,
+        }
+    )
 end
 
 function _validate_estimation_solution(sol, name)
@@ -307,21 +309,25 @@ function _companion_error_estimate_streaming(
 end
 
 # Solve the companion ODE ε' = rhs(ε, t), ε(t0) = 0, over the forward solution's
-# time span and return the endpoint error estimate ε(T).
+# time span and return the endpoint error estimate ε(T). The defect driving the
+# companion is only piecewise smooth, with kinks at the forward step nodes, so
+# the companion solver is made to land on them; a step straddling a node would
+# smooth over the kink and underestimate the local error (this is also what
+# keeps the estimate consistent with SimultaneousMode's per-step restarts).
 function _companion_endpoint(rhs, sol, companion_alg; abstol, reltol)
     return _advance_companion(
         rhs, zero(sol.prob.u0), sol.prob.tspan[1], sol.prob.tspan[2],
-        companion_alg; abstol, reltol
+        companion_alg; abstol, reltol, tstops = sol.t
     )
 end
 
 # Advance the companion ODE ε' = rhs(ε, t) from ε(t0) = ε0 over [t0, t1] and
 # return ε(t1).
-function _advance_companion(rhs, ε0, t0, t1, companion_alg; abstol, reltol)
+function _advance_companion(rhs, ε0, t0, t1, companion_alg; abstol, reltol, tstops = ())
     companion_prob = SciMLBase.ODEProblem{false}(rhs, ε0, (t0, t1))
     companion_sol = SciMLBase.solve(
         companion_prob, companion_alg;
-        abstol, reltol, dense = false, save_everystep = false,
+        abstol, reltol, tstops, dense = false, save_everystep = false,
         save_start = false, save_end = true
     )
     SciMLBase.successful_retcode(companion_sol) || throw(


### PR DESCRIPTION
## Summary

- **Fix `GlobalDiffEq` precompilation on Julia 1.13.** `src/adjoint.jl` re-defined `_positive_finite_real` and `_validate_tolerances`, which already exist in `src/companion.jl` as shared machinery (introduced by #4495 on top of #4492). Method overwriting is a hard error during module precompilation on Julia 1.13, so the package failed to precompile, which also broke `GlobalDiffEqSciMLSensitivityExt`, Aqua's `persistent_tasks` check in the QA group, and every downstream test env that loads `GlobalDiffEq`. The duplicates in `adjoint.jl` are removed; the single definitions in `companion.jl` are kept.
- **Fix the `SimultaneousMode matches InterpolatingMode` test failure** (`lib/GlobalDiffEq/test/companion_tests.jl:44`) by making `InterpolatingMode` integrate the companion ODE accurately: the defect `d(t) = f(P) - P'` driving the companion is only piecewise smooth — it has kinks (derivative jumps) at the forward solver's step nodes. A companion step straddling a node smooths over the kink and underestimates its local error, biasing the endpoint estimate. `SimultaneousMode` implicitly avoids this by restarting the companion on every forward step. Passing the forward step nodes as `tstops` to the interpolating-mode companion solve confines each companion step to a smooth piece — the modes now agree to ~1e-6 relative (see below) and the interpolating estimate matches the converged companion integral.
- **Runic-format `src/companion.jl`** (the file failing master `format-check`); `runic --check` now passes on all of `lib/GlobalDiffEq`.

## Investigation detail (test failure was not borderline)

At the default companion tolerances (`companion_abstol=1e-10`, `companion_reltol=1e-8`) on the Lotka–Volterra test problem at `tol=1e-6`:

| companion integration | estimate (ErrorTransport) |
|---|---|
| one adaptive solve over `[t0, T]` (old InterpolatingMode) | 1.2278559e-5 |
| restarted on each forward node (SimultaneousMode) | 1.2342406e-5 |
| one solve forced to step on the nodes (`tstops`) | 1.2342414e-5 |
| converged value (restarted, companion tol 1e-12) | 1.2342380e-5 |

The live-integrator and stored-solution interpolants agree to ~1e-13, and restarting the companion on the *stored* interpolant reproduces the SimultaneousMode value exactly — so the discrepancy came entirely from the one-shot companion solve straddling defect kinks, i.e. the old InterpolatingMode value was the less accurate one. `tstops = sol.t` fixes that directly rather than loosening the test tolerance.

## Test plan

Julia 1.13.0-rc4 (what CI's `1` resolves to), `cd lib/GlobalDiffEq`, `GROUP=Core julia +1.13 --project=. -e 'using Pkg; Pkg.test()'`.

**Before** (master; identical values in CI log and local run — local run needed the precompile fix to load the package at all, companion code unchanged):

```
WARNING: Method definition _positive_finite_real(Any) in module GlobalDiffEq at .../src/companion.jl:8 overwritten at .../src/adjoint.jl:115.
ERROR: Method overwriting is not permitted during Module precompilation. Use `__precompile__(false)` to opt-out of precompilation.
...
SimultaneousMode matches InterpolatingMode: Test Failed at .../test/companion_tests.jl:44
  Expression: ≈(stream, interp, rtol = 0.005)
   Evaluated: 1.234240556040866e-5 ≈ 1.2278558976054218e-5 (rtol=0.005)
```

**After** (this branch): `GlobalDiffEq` and `GlobalDiffEq → GlobalDiffEqSciMLSensitivityExt` precompile cleanly with no method-overwrite warnings, and:

```
Test Summary:              | Pass  Total   Time
Companion error estimators |   43     43  24.7s
Test Summary:                        | Pass  Total     Time
Adjoint error estimation and control |   35     35  1m01.5s
Test Summary: | Pass  Total   Time
GLEE solvers  |   91     91  32.2s
Test Summary:    | Pass  Total  Time
BigFloat support |    2      2  7.3s
     Testing GlobalDiffEq tests passed
```

`GROUP=QA` also passes (`QA | 23 passed, 1 broken (pre-existing @test_broken) | Testing GlobalDiffEq tests passed`), and `runic --check lib/GlobalDiffEq` exits 0. Docs build not run — no docstrings or public API changed.

🤖 Generated with [Devin](https://devin.ai) (harness: Devin CLI 3000.10.21, model: SWE-2 High). Session: local Devin CLI session (no shareable URL); session db at /home/crackauc/.local/share/devin/cli/sessions.db
