### PR TITLE
Release GlobalDiffEq 1.7.1

### DIFF
--- a/lib/GlobalDiffEq/Project.toml
+++ b/lib/GlobalDiffEq/Project.toml
@@ -1,7 +1,7 @@
 name = "GlobalDiffEq"
 uuid = "1d72d19b-84cc-4cb7-a099-7cbdb9ccc67c"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.7.0"
+version = "1.7.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Bumps `GlobalDiffEq` 1.7.0 -> 1.7.1 (patch).

Source files changed since 1.7.0:
- `src/adjoint.jl`
- `ext/GlobalDiffEqSciMLSensitivityExt.jl`

Commits:
- GlobalAdjoint: defer to adjoint_sensitivities default instead of pinning an adjoint (#4498)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
