### PR TITLE
Make mass-matrix identity/zero/diagonal checks GPU-safe (fix Julia 1.13 GPU DAE scalar-indexing regression)

### DIFF
--- a/docs/src/devtools/internals/public_api.md
+++ b/docs/src/devtools/internals/public_api.md
@@ -360,6 +360,9 @@ OrdinaryDiffEqCore._ode_init
 OrdinaryDiffEqCore._initialize_dae!
 OrdinaryDiffEqCore.find_algebraic_vars_eqs
 OrdinaryDiffEqCore.get_differential_vars
+OrdinaryDiffEqCore._is_identity_massmatrix
+OrdinaryDiffEqCore._is_zero_massmatrix
+OrdinaryDiffEqCore._diff_alg_vars
 OrdinaryDiffEqCore.handle_callback_modifiers!
 OrdinaryDiffEqCore.resolve_stage_step_limiters
 OrdinaryDiffEqCore.trivial_limiter!

--- a/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
+++ b/lib/OrdinaryDiffEqCore/src/OrdinaryDiffEqCore.jl
@@ -473,6 +473,7 @@ include("precompilation_setup.jl")
             # Integrator step / cache / initialization hooks.
             :_ode_init, :_determine_initdt, :ode_determine_initdt, :_initialize_dae!,
             :find_algebraic_vars_eqs, :apply_step!, :reset_alg_dependent_opts!,
+            :_is_identity_massmatrix, :_is_zero_massmatrix, :_diff_alg_vars,
             :handle_callback_modifiers!, :resolve_basic, :resolve_stage_step_limiters,
             :fix_dt_at_bounds!, :handle_tstop!, :initialize_d_discontinuities,
             :initialize_saveat, :initialize_tstops,

--- a/lib/OrdinaryDiffEqCore/src/initdt.jl
+++ b/lib/OrdinaryDiffEqCore/src/initdt.jl
@@ -143,9 +143,9 @@ end
     =#
 
     ftmp = nothing
-    if prob.f.mass_matrix != I && (
+    if !_is_identity_massmatrix(prob.f.mass_matrix) && (
             !(prob.f isa DynamicalODEFunction) ||
-                any(mm != I for mm in prob.f.mass_matrix)
+                any(!_is_identity_massmatrix, prob.f.mass_matrix)
         )
         ftmp = zero(f₀)
         try
@@ -240,9 +240,9 @@ end
     f₁ = zero(f₀)
     f(f₁, u₁, p, t + dt₀_tdir)
 
-    if prob.f.mass_matrix != I && (
+    if !_is_identity_massmatrix(prob.f.mass_matrix) && (
             !(prob.f isa DynamicalODEFunction) ||
-                any(mm != I for mm in prob.f.mass_matrix)
+                any(!_is_identity_massmatrix, prob.f.mass_matrix)
         )
         integrator.alg.linsolve(ftmp, prob.f.mass_matrix, f₁, false)
         copyto!(f₁, ftmp)

--- a/lib/OrdinaryDiffEqCore/src/misc_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/misc_utils.jl
@@ -361,6 +361,50 @@ function find_algebraic_vars_eqs(M::SciMLOperators.AbstractSciMLOperator)
 end
 
 """
+    _is_identity_massmatrix(mm) -> Bool
+
+Whether `mm` acts as the identity matrix. Unlike `mm == I`, never scalar-indexes
+`mm`: `==(A::AbstractMatrix, ::UniformScaling)` reads `first(A)` on Julia 1.13+,
+which fails for GPU-backed mass matrices (e.g. `Diagonal{T, <:CuVector}`).
+"""
+_is_identity_massmatrix(mm::UniformScaling) = isone(mm.λ)
+_is_identity_massmatrix(mm::Diagonal) = all(isone, mm.diag)
+function _is_identity_massmatrix(mm::AbstractMatrix)
+    return ArrayInterface.fast_scalar_indexing(mm) ? mm == I :
+        _is_identity_massmatrix(Matrix(mm))
+end
+_is_identity_massmatrix(mm) = mm == I
+
+"""
+    _is_zero_massmatrix(mm) -> Bool
+
+Whether every entry of `mm` is zero. Unlike `all(isequal(0), mm)`, never
+scalar-indexes `mm`, so it accepts GPU-backed mass matrices.
+"""
+_is_zero_massmatrix(mm::Diagonal) = all(iszero, mm.diag)
+function _is_zero_massmatrix(mm::AbstractMatrix)
+    return ArrayInterface.fast_scalar_indexing(mm) ? all(isequal(0), mm) :
+        _is_zero_massmatrix(Matrix(mm))
+end
+_is_zero_massmatrix(mm) = all(isequal(0), mm)
+
+"""
+    _diff_alg_vars(mm, n) -> (diff_vars, alg_vars)
+
+Indices of the differential (nonzero diagonal entry) and algebraic (zero
+diagonal entry) variables of an `n` × `n` mass matrix. `findall` on `mm.diag`
+dispatches to a device kernel for GPU-backed diagonals, while `mm[i, i]` in a
+loop scalar-indexes.
+"""
+function _diff_alg_vars(mm::Diagonal, n)
+    return findall(!iszero, mm.diag), findall(iszero, mm.diag)
+end
+function _diff_alg_vars(mm::AbstractMatrix, n)
+    ArrayInterface.fast_scalar_indexing(mm) || return _diff_alg_vars(Matrix(mm), n)
+    return findall(i -> mm[i, i] != 0, 1:n), findall(i -> mm[i, i] == 0, 1:n)
+end
+
+"""
     isnewton(nlsolver) -> Bool
 
 Return whether the nonlinear solver `nlsolver` is a Newton-type solver (as opposed

--- a/lib/OrdinaryDiffEqCore/src/solve.jl
+++ b/lib/OrdinaryDiffEqCore/src/solve.jl
@@ -217,13 +217,13 @@ Base.@constprop :aggressive function _ode_init(
         end
 
         if prob.f isa DynamicalODEFunction && prob.f.mass_matrix isa Tuple
-            if any(mm != I for mm in prob.f.mass_matrix)
+            if any(!_is_identity_massmatrix, prob.f.mass_matrix)
                 error("This solver is not able to use mass matrices. For compatible solvers see https://docs.sciml.ai/DiffEqDocs/stable/solvers/dae_solve/")
             end
         elseif !(prob isa SciMLBase.AbstractDiscreteProblem) &&
                 !(prob isa SciMLBase.AbstractDAEProblem) &&
                 !is_mass_matrix_alg(alg) &&
-                prob.f.mass_matrix != I
+                !_is_identity_massmatrix(prob.f.mass_matrix)
             error("This solver is not able to use mass matrices. For compatible solvers see https://docs.sciml.ai/DiffEqDocs/stable/solvers/dae_solve/")
         end
     end
@@ -243,7 +243,7 @@ Base.@constprop :aggressive function _ode_init(
             # https://github.com/SciML/OrdinaryDiffEq.jl/pull/2079 fixes this for Rosenbrock23 and 32
             !only_diagonal_mass_matrix(alg) &&
             prob.f.mass_matrix isa AbstractMatrix &&
-            all(isequal(0), prob.f.mass_matrix)
+            _is_zero_massmatrix(prob.f.mass_matrix)
         # technically this should also warn for zero operators but those are hard to check for
         if (dense || !isempty(saveat))
             @SciMLMessage(
@@ -287,7 +287,7 @@ Base.@constprop :aggressive function _ode_init(
     else
         alg isa DAEAlgorithm || (
             !(prob isa SciMLBase.AbstractDiscreteProblem) &&
-                prob.f.mass_matrix != I &&
+                !_is_identity_massmatrix(prob.f.mass_matrix) &&
                 !(prob.f.mass_matrix isa Tuple) &&
                 ArrayInterface.issingular(prob.f.mass_matrix)
         )

--- a/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
+++ b/lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl
@@ -7,11 +7,11 @@ using OrdinaryDiffEqTsit5: Tsit5
 using OrdinaryDiffEqRosenbrock: Rosenbrock23, Rodas5P
 using OrdinaryDiffEqBDF: FBDF, DFBDF
 
-import OrdinaryDiffEqCore: is_mass_matrix_alg, default_autoswitch, isdefaultalg
+import OrdinaryDiffEqCore: is_mass_matrix_alg, default_autoswitch, isdefaultalg,
+    _is_identity_massmatrix
 import ADTypes: AutoFiniteDiff
 import DiffEqBase
 import LinearSolve
-using LinearAlgebra: I
 using EnumX: EnumX
 
 import SciMLBase

--- a/lib/OrdinaryDiffEqDefault/src/default_alg.jl
+++ b/lib/OrdinaryDiffEqDefault/src/default_alg.jl
@@ -158,7 +158,7 @@ function stiffchoice(reltol, len, mass_matrix)
     elseif len > SMALLSIZE
         DefaultSolverChoice.FBDF
     else
-        if reltol < LOW_TOL || mass_matrix != I
+        if reltol < LOW_TOL || !_is_identity_massmatrix(mass_matrix)
             DefaultSolverChoice.Rodas5P
         else
             DefaultSolverChoice.Rosenbrock23
@@ -173,7 +173,7 @@ function default_autoswitch(AS::AutoSwitchCache, integrator)
 
     # Choose the starting method
     if AS.current == 0
-        choice = if AS.stiffalgfirst || integrator.f.mass_matrix != I
+        choice = if AS.stiffalgfirst || !_is_identity_massmatrix(integrator.f.mass_matrix)
             stiffchoice(reltol, len, integrator.f.mass_matrix)
         else
             nonstiffchoice(reltol)
@@ -191,7 +191,7 @@ function default_autoswitch(AS::AutoSwitchCache, integrator)
         ) ?
         AS.count < 0 ? 1 : AS.count + 1 :
         AS.count > 0 ? -1 : AS.count - 1
-    if integrator.f.mass_matrix != I
+    if !_is_identity_massmatrix(integrator.f.mass_matrix)
         #don't change anything
     elseif (!AS.is_stiffalg && AS.count > AS.maxstiffstep)
         integrator.dt = dt * AS.dtfac

--- a/lib/OrdinaryDiffEqFIRK/src/OrdinaryDiffEqFIRK.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/OrdinaryDiffEqFIRK.jl
@@ -17,7 +17,8 @@ import OrdinaryDiffEqCore: unwrap_alg,
     _fixup_ad, perform_step!,
     set_discontinuity,
     Convergence, FastConvergence, NLStatus,
-    VerySlowConvergence, Divergence, get_new_W_γdt_cutoff
+    VerySlowConvergence, Divergence, get_new_W_γdt_cutoff,
+    _is_identity_massmatrix
 import SciMLBase
 import SciMLBase: alg_order, _vec, _reshape, _unwrap_val, LinearAliasSpecifier,
     UDerivativeWrapper, UJacobianWrapper, value,

--- a/lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
@@ -655,7 +655,7 @@ end
     if adaptive
         e1dt, e2dt, e3dt = e1 / dt, e2 / dt, e3 / dt
         tmp = @.. e1dt * z1 + e2dt * z2 + e3dt * z3
-        mass_matrix != I && (tmp = mass_matrix * tmp)
+        !_is_identity_massmatrix(mass_matrix) && (tmp = mass_matrix * tmp)
         utilde = @.. integrator.fsalfirst + tmp
         if alg.smooth_est
             utilde = _reshape(LU1 \ _vec(utilde), axes(u))
@@ -911,7 +911,7 @@ end
         utilde = w2
         e1dt, e2dt, e3dt = e1 / dt, e2 / dt, e3 / dt
         @.. tmp = e1dt * z1 + e2dt * z2 + e3dt * z3
-        mass_matrix != I && (mul!(w1, mass_matrix, tmp); copyto!(tmp, w1))
+        !_is_identity_massmatrix(mass_matrix) && (mul!(w1, mass_matrix, tmp); copyto!(tmp, w1))
         @.. ubuff = integrator.fsalfirst + tmp
 
         if alg.smooth_est
@@ -1218,7 +1218,7 @@ end
     if adaptive
         e1dt, e2dt, e3dt, e4dt, e5dt = e1 / dt, e2 / dt, e3 / dt, e4 / dt, e5 / dt
         tmp = @.. e1dt * z1 + e2dt * z2 + e3dt * z3 + e4dt * z4 + e5dt * z5
-        mass_matrix != I && (tmp = mass_matrix * tmp)
+        !_is_identity_massmatrix(mass_matrix) && (tmp = mass_matrix * tmp)
         utilde = @.. integrator.fsalfirst + tmp
         if alg.smooth_est
             utilde = _reshape(LU1 \ _vec(utilde), axes(u))
@@ -1597,7 +1597,7 @@ end
         utilde = w2
         e1dt, e2dt, e3dt, e4dt, e5dt = e1 / dt, e2 / dt, e3 / dt, e4 / dt, e5 / dt
         @.. tmp = e1dt * z1 + e2dt * z2 + e3dt * z3 + e4dt * z4 + e5dt * z5
-        mass_matrix != I && (mul!(w1, mass_matrix, tmp); copyto!(tmp, w1))
+        !_is_identity_massmatrix(mass_matrix) && (mul!(w1, mass_matrix, tmp); copyto!(tmp, w1))
         @.. ubuff = integrator.fsalfirst + tmp
 
         if alg.smooth_est
@@ -1867,7 +1867,7 @@ end
         for i in 1:num_stages
             tmp = @.. tmp + e[i] / dt * z[i]
         end
-        mass_matrix != I && (tmp = mass_matrix * tmp)
+        !_is_identity_massmatrix(mass_matrix) && (tmp = mass_matrix * tmp)
         #utilde = @..  1 / γ * dt * integrator.fsalfirst + tmp
         utilde = @.. integrator.fsalfirst + tmp
         if alg.smooth_est
@@ -2204,7 +2204,7 @@ end
         for i in 1:num_stages
             @.. tmp += e[i] / dt * z[i]
         end
-        mass_matrix != I && (mul!(w[1], mass_matrix, tmp); copyto!(tmp, w[1]))
+        !_is_identity_massmatrix(mass_matrix) && (mul!(w[1], mass_matrix, tmp); copyto!(tmp, w[1]))
         #@.. ubuff=1 / γ * dt * integrator.fsalfirst + tmp
         @.. ubuff = integrator.fsalfirst + tmp
 

--- a/lib/OrdinaryDiffEqRosenbrock/src/OrdinaryDiffEqRosenbrock.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/OrdinaryDiffEqRosenbrock.jl
@@ -14,7 +14,7 @@ import OrdinaryDiffEqCore: alg_adaptive_order, isWmethod, isfsal, _unwrap_val,
     _ode_addsteps!,
     DerivativeOrderNotPossibleError, _fixup_ad,
     copyat_or_push!, DifferentialVarsUndefined, resize_J_W!,
-    find_algebraic_vars_eqs
+    find_algebraic_vars_eqs, _diff_alg_vars
 using MuladdMacro: MuladdMacro, @muladd
 using FastBroadcast: FastBroadcast, @..
 using RecursiveArrayTools: RecursiveArrayTools, recursivefill!

--- a/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_caches.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_caches.jl
@@ -714,8 +714,7 @@ function alg_cache(
         diff_vars = collect(1:n)
         alg_vars = Int[]
     else
-        diff_vars = findall(i -> mass_matrix[i, i] != 0, 1:n)
-        alg_vars = findall(i -> mass_matrix[i, i] == 0, 1:n)
+        diff_vars, alg_vars = _diff_alg_vars(mass_matrix, n)
     end
     n_g = length(alg_vars)
     n_f = length(diff_vars)

--- a/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_perform_step.jl
+++ b/lib/OrdinaryDiffEqRosenbrock/src/rosenbrock_perform_step.jl
@@ -882,8 +882,7 @@ end
         diff_vars = Int[]
     else
         n = length(uprev)
-        diff_vars = findall(i -> mass_matrix[i, i] != 0, 1:n)
-        alg_vars = findall(i -> mass_matrix[i, i] == 0, 1:n)
+        diff_vars, alg_vars = _diff_alg_vars(mass_matrix, n)
         has_alg = !isempty(alg_vars)
     end
 

--- a/lib/StochasticDiffEqCore/src/StochasticDiffEqCore.jl
+++ b/lib/StochasticDiffEqCore/src/StochasticDiffEqCore.jl
@@ -51,7 +51,7 @@ using SparseArrays: SparseArrays, issparse
 using DiffEqBase: DEVerbosity
 using SciMLLogging: AbstractVerbosityPreset, Standard
 
-using LinearAlgebra: LinearAlgebra, I, mul!
+using LinearAlgebra: LinearAlgebra, mul!
 using Random: Random
 
 import ForwardDiff.Dual

--- a/lib/StochasticDiffEqCore/src/solve.jl
+++ b/lib/StochasticDiffEqCore/src/solve.jl
@@ -254,10 +254,11 @@ function _sde_init(
 
     # ── SDE-specific validation ──────────────────────────────────────────
     if typeof(prob.f) <: Tuple
-        if any(mm != I for mm in prob.f.mass_matrix)
+        if any(!OrdinaryDiffEqCore._is_identity_massmatrix, prob.f.mass_matrix)
             error("This solver is not able to use mass matrices.")
         end
-    elseif prob isa SciMLBase.AbstractRODEProblem && prob.f.mass_matrix != I &&
+    elseif prob isa SciMLBase.AbstractRODEProblem &&
+            !OrdinaryDiffEqCore._is_identity_massmatrix(prob.f.mass_matrix) &&
             !alg_mass_matrix_compatible(alg)
         error("This solver is not able to use mass matrices.")
     end

--- a/test/InterfaceV/gpu_dae_mass_matrix_tests.jl
+++ b/test/InterfaceV/gpu_dae_mass_matrix_tests.jl
@@ -1,0 +1,69 @@
+using OrdinaryDiffEq, OrdinaryDiffEqRosenbrock, OrdinaryDiffEqSDIRK,
+    OrdinaryDiffEqBDF, OrdinaryDiffEqNonlinearSolve,
+    JLArrays, LinearAlgebra, SparseArrays, Test
+import DiffEqBase
+
+#=
+Regression test for the Julia-1.13 GPU DAE regression: `==(A::AbstractMatrix,
+::UniformScaling)` reads `first(A)` on 1.13+, so `f.mass_matrix != I` in
+`_ode_init` (and `all(isequal(0), f.mass_matrix)` for non-diagonal-only
+Rosenbrock methods) scalar-indexed a GPU-backed mass matrix. `JLArray` emulates
+GPU scalar-indexing semantics on CPU, so a `Diagonal{T, <:JLArray}` mass matrix
+exercises the same code path as `cu(Diagonal(...))` on CUDA.
+
+Unlike CUDA, JLArrays does not convert `AbstractArray{Bool}` indices to integer
+indices in `to_index`/`to_indices` (CUDA.jl does `to_index(::CuArray, I) =
+findall(I)`). Emulate that rule here so `view(u, bool_mask)` in
+`BrownFullBasicInit` works the same way it does on CUDA.
+=#
+Base.to_index(::JLArray, I::AbstractArray{Bool}) = JLArray(findall(Array(I)))
+if VERSION >= v"1.11.0-DEV.1157"
+    Base.to_indices(A::JLArray, I::Tuple{AbstractArray{Bool}}) =
+        (Base.to_index(A, I[1]),)
+end
+
+@testset "GPU-emulated (JLArray) diagonal-mass-matrix DAE" begin
+    function dae!(du, u, p, t)
+        return mul!(du, p, u)
+    end
+
+    P = [
+        -1 0 0 0
+        1 -0.5 0 0
+        1 1 -1 0
+        -1 1 0 -1
+    ]
+    MASS_MATRIX = Diagonal([1, 1, 0, 0])
+    JAC_PROTOTYPE = sparse(map(x -> iszero(x) ? 0.0 : 1.0, P))
+    U0 = [1.0, 1.0, 0.5, 0.5]
+    TSPAN = (0.0, 5.0)
+
+    odef_cpu = ODEFunction{true, SciMLBase.FullSpecialize}(
+        dae!; mass_matrix = MASS_MATRIX,
+        jac_prototype = JAC_PROTOTYPE
+    )
+    prob_cpu = ODEProblem(
+        odef_cpu, U0, TSPAN, P;
+        initializealg = DiffEqBase.BrownFullBasicInit()
+    )
+
+    M_D = jl(MASS_MATRIX)
+    odef_d = ODEFunction{true, SciMLBase.FullSpecialize}(
+        dae!; mass_matrix = M_D,
+        jac_prototype = nothing
+    )
+    prob_d = ODEProblem(
+        odef_d, jl(U0), TSPAN, jl(P);
+        initializealg = DiffEqBase.BrownFullBasicInit()
+    )
+
+    for ALG in (
+            Rosenbrock23, ROS2, Rodas5P, SDIRK2, Cash4, Hairer4,
+            ABDF2, QNDF2, QBDF2, FBDF, ImplicitEuler,
+        )
+        sol_cpu = solve(prob_cpu, ALG(); maxiters = 10_000)
+        sol_d = solve(prob_d, ALG(); maxiters = 10_000)
+        @test sol_d.retcode == SciMLBase.ReturnCode.Success
+        @test Array(sol_d.u[end]) ≈ sol_cpu.u[end] atol = 1.0e-3
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,6 +85,7 @@ end
 function interface_v()
     is_APPVEYOR && return
     @time @safetestset "Interpolation Derivative Error Tests" include("InterfaceV/interpolation_derivative_error_tests.jl")
+    @time @safetestset "GPU DAE Mass Matrix Tests" include("InterfaceV/gpu_dae_mass_matrix_tests.jl")
     return @time @safetestset "GPU AutoDiff Interface Tests" include("InterfaceV/gpu_autodiff_interface_tests.jl")
 end
 


### PR DESCRIPTION
## Summary

Fixes the Julia-1.13 regression that broke every `mass = diag` case in `test/gpu/dae_tests.jl` (136 failures, all solvers × all three Jacobian variants) with `Scalar indexing is disallowed`.

**Root cause.** Julia 1.13 changed `==(A::AbstractMatrix, J::UniformScaling)` to read `first(A)` before dispatching to `iszero(A)`/`isone(A)` reductions (`LinearAlgebra/src/uniformscaling.jl`). On Julia ≤ 1.12 the same comparison called `isone(D::Diagonal)`/`iszero`, which reduce over `D.diag` as GPU kernels. So `f.mass_matrix != I` in `OrdinaryDiffEqCore._ode_init` — and every other by-value mass-matrix/identity comparison — now scalar-indexes `Diagonal{T, <:CuVector}` and throws. The upstream change is JuliaLang/LinearAlgebra.jl#1369 ("Check for elementwise equality when comparing with `UniformScaling`", commit `3537c3ae`), first released in Julia 1.13. This is a Julia-version regression, not an OrdinaryDiffEq commit: none of the recent mass-matrix/W-construction commits (`386f6c5`, `c241543`, `01e4cc6`, `4b1c5c4`) are implicated.

**Fix.** New GPU-safe helpers on OrdinaryDiffEqCore's public solver-author surface (next to `find_algebraic_vars_eqs`):

- `_is_identity_massmatrix(mm)` — `mm == I` without scalar indexing (`isone(λ)` for `UniformScaling`, `all(isone, mm.diag)` for `Diagonal`, direct `==` for fast-scalar-indexing matrices, host `Matrix` copy fallback otherwise)
- `_is_zero_massmatrix(mm)` — replaces `all(isequal(0), mm)` (same iteration problem)
- `_diff_alg_vars(mm, n)` — differential/algebraic index split replacing `findall(i -> mm[i,i] != 0, 1:n)` loops in `HybridExplicitImplicitRK`/`Tsit5DA` cache and step code

applied at every `mass_matrix != I`/`== I` site: `_ode_init` (`isdae` and the mass-matrix-alg guard), `ode_determine_initdt`, `OrdinaryDiffEqDefault` autoswitch, `StochasticDiffEqCore` validation, and `OrdinaryDiffEqFIRK` perform-step. `Diagonal`-based dispatch serves `Diagonal{T, <:CuVector}` on CUDA identically.

## Regression test

`test/InterfaceV/gpu_dae_mass_matrix_tests.jl` (registered in the `InterfaceV` group): solves the `gpu/dae_tests.jl` DAE with `Diagonal{Int64, JLArray{Int64,1}}` mass matrix + `BrownFullBasicInit` under 11 stiff solvers (Rosenbrock23, ROS2, Rodas5P, SDIRK2, Cash4, Hairer4, ABDF2, QNDF2, QBDF2, FBDF, ImplicitEuler), comparing against the CPU reference. `JLArray` enforces GPUArrays' no-scalar-indexing rules on CPU. The test also emulates CUDA.jl's `to_index(::CuArray, ::AbstractArray{Bool}) = findall(I)` rule (JLArrays lacks it) so the `view(u, bool_mask)` calls in `BrownFullBasicInit` behave as on CUDA.

## Test plan / verification

Local env has no CUDA GPU, so verification uses JLArray (GPUArrays' CPU reference backend, same scalar-indexing rules).

**Before (master @ 0f08fbdbd, Julia 1.13.0-rc4)** — new test file:

```
GPU-emulated (JLArray) diagonal-mass-matrix DAE: Error During Test
  Got exception outside of a @test
  Scalar indexing is disallowed.
  Invocation of getindex resulted in scalar indexing of a GPU array.
  ...
    [10] ==(A::Diagonal{Int64, JLArray{Int64, 1}}, J::UniformScaling{Bool})
       @ LinearAlgebra .../stdlib/v1.13/LinearAlgebra/src/uniformscaling.jl:354
    [12] _ode_init(...) @ OrdinaryDiffEqCore .../OrdinaryDiffEqCore/src/solve.jl:288
```

**After (this branch, Julia 1.13.0-rc4)** — same file:

```
Test Summary:                                   | Pass  Total     Time
GPU-emulated (JLArray) diagonal-mass-matrix DAE |   22     22  4m03.9s
```

Same script on Julia 1.10 (lts): all 11 solvers `Success` on JLArray, max `|u_end - cpu|` ≤ 1.2e-4 (Rosenbrock23: 5.7e-6).

**Caveats:** GPU (`test/gpu/dae_tests.jl`) and docs builds cannot run locally (no GPU; docs env not instantiated). The JLSparseMatrixCSC/CSR prototypes hit a JLArrays-only `CanonicalIndexError` in `GPUSparseDeviceMatrix*`, so the regression test covers `jac = none`; the CSC/CSR fixes go through the same helpers. Runic `--check` passes on all touched files; `typos` clean; ExplicitImports clean on OrdinaryDiffEqDefault/FIRK/StochasticDiffEqCore (OrdinaryDiffEqCore flags only its documented ignore-list names; the pre-existing "public API is rendered in docs" QA failure on master is unrelated).

🤖 Generated with [Devin](https://devin.ai) (harness: Devin CLI 3000.10.21, model: SWE-2 High). Session: local Devin CLI session (no shareable URL); session db at /home/crackauc/.local/share/devin/cli/sessions.db.
