### PR TITLE
Fix BDF step rejection for backward-in-time integration

### DIFF
--- a/lib/OrdinaryDiffEqBDF/src/controllers.jl
+++ b/lib/OrdinaryDiffEqBDF/src/controllers.jl
@@ -187,7 +187,10 @@ end
 
 function bdf_step_reject_controller!(integrator, cache, EEst1, error_order = cache.order)
     k = cache.order
-    h = integrator.dt
+    # dt is negative for backward-in-time integration, so all step-size
+    # selection below is done on magnitudes and the direction is restored
+    # when writing back integrator.dt.
+    h = abs(integrator.dt)
     cache.consfailcnt += 1
     cache.nconsteps = 0
 
@@ -239,7 +242,7 @@ function bdf_step_reject_controller!(integrator, cache, EEst1, error_order = cac
     if kₙ == 1 && cache.consfailcnt > 3
         derivative_discontinuity!(integrator, true)
     end
-    integrator.dt = hₙ
+    integrator.dt = integrator.tdir * hₙ
     return cache.order = kₙ
 end
 

--- a/lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl
@@ -219,3 +219,24 @@ end
     @test sol.u[end] isa ArrayPartition
     @test norm(sol.u[end] - ref.u[end]) < 1.0e-6
 end
+
+# Regression test for the backward-in-time step rejection path: for tdir < 0
+# (e.g. adjoint solves), `bdf_step_reject_controller!` must still shrink |dt|.
+# Previously `min(h, hₖ₋₁)`/`hₖ₋₁ > hₖ` compared signed (negative) step sizes,
+# picking the *larger* magnitude and letting dt hit a fixed point where
+# EEst > 1 forever, hanging the solver at maxiters.
+@testset "BDF step rejection shrinks |dt| for backward integration" begin
+    for (t0, t1) in ((0.0, 1.0), (1.0, 0.0))
+        prob = ODEProblem((u, p, t) -> -u, 1.0, (t0, t1))
+        integ = init(prob, FBDF(); abstol = 1.0e-8, reltol = 1.0e-8)
+        integ.cache.consfailcnt = 4
+        integ.cache.order = 3
+        OrdinaryDiffEqCore.set_EEst!(integ, 2.0)
+        # small k-1 estimate makes the lower-order candidate much larger
+        integ.cache.terkm1 = 0.01
+        dt0 = integ.dt
+        OrdinaryDiffEqCore.step_reject_controller!(integ, FBDF())
+        @test signbit(integ.dt) == signbit(dt0)
+        @test abs(integ.dt) <= abs(dt0) / 2
+    end
+end


### PR DESCRIPTION
## Summary

`bdf_step_reject_controller!` performs its step-size selection (`hₖ₋₁ > hₖ`, `hₙ = min(h, hₖ₋₁)`) on **signed** step sizes. For backward-in-time integration (`tdir < 0`, e.g. adjoint solves in SciMLSensitivity) `dt` is negative, so `min` picks the candidate with the *larger* magnitude. On repeated step failures the retry `dt` can converge to a fixed point where `EEst > 1` forever — the solver then burns `maxiters` in an infinite reject loop instead of shrinking the step.

This is what broke the SciMLSensitivity `downstream/test/Core3/dae_adjoint.jl` EnzymeVJP/`InterpolatingAdjoint` tests on Julia 1.13: the backward adjoint `FBDF` solve stalls at `t ≈ 0.0088` with ~10⁶ consecutive rejections at a frozen `dt = -6.09e-4`, hits `MaxIters`, and returns gradients from a truncated adjoint trajectory. The regression surfaced after #4484 moved `reinitFBDF!` ahead of the cache destructuring (the correct order), which changed the restart trajectory enough to route onto this path — the sign bug itself predates that commit and also reproduces on the released `OrdinaryDiffEqBDF` 2.4.7.

Fix: do the step-size selection on magnitudes (`h = abs(integrator.dt)`) and restore the direction with `integrator.tdir` when writing `integrator.dt`. Forward-in-time behavior is unchanged (`tdir = 1`).

## Test plan

New regression test `BDF step rejection shrinks |dt| for backward integration` in `lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl` drives the real reject controller on an `FBDF` integrator for both `tdir = ±1`, forcing `consfailcnt > 2` at order 3 with a small `terkm1`.

Before the fix (unfixed code):

```
BDF step rejection shrinks |dt| for backward integration: Test Failed
  Expression: abs(integ.dt) <= abs(dt0) / 2
   Evaluated: 3.5704529489329065e-10 <= 1.0000000000000002e-10
```

i.e. |dt| *grew* by ~1.8x on a rejected backward step. After the fix all 4 tests pass, and the downstream `dae_adjoint.jl` suite passes (44/44), including the two previously failing `EnzymeVJP` assertions:

```
dpe  = [-15.50462892, -4.7545349e-9, 2.85388009e-5]   vs fd_p  = [-15.50462891, -4.7545349e-9, 2.85388010e-5]
du0e = [3.94242063, -0.00030100]                      vs fd_u  = [3.94242063, -0.00030100]
```

Also ran `bdf_regression_tests.jl` (all pass) and `fbdf_time_filter_tests.jl` + `fbdf_filter_regression_tests.jl` (all pass).

🤖 Generated with [Devin](https://devin.ai) (harness: Devin CLI 3000.10.21, model: SWE-2 High). Session: local Devin CLI session (no shareable URL); session db at /home/crackauc/.local/share/devin/cli/sessions.db
