### PR TITLE
Release GlobalDiffEq 1.7.2

### DIFF
--- a/lib/GlobalDiffEq/Project.toml
+++ b/lib/GlobalDiffEq/Project.toml
@@ -1,7 +1,7 @@
 name = "GlobalDiffEq"
 uuid = "1d72d19b-84cc-4cb7-a099-7cbdb9ccc67c"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.7.1"
+version = "1.7.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Bumps `GlobalDiffEq` 1.7.1 -> 1.7.2 (patch).

Source files changed since 1.7.1:
- `src/adjoint.jl`
- `src/companion.jl`

Commits:
- Fix GlobalDiffEq precompilation on Julia 1.13 and companion accuracy (#4500)
- Make mass-matrix identity/zero/diagonal checks GPU-safe (#4502)
- Fix BDF step rejection for backward-in-time integration (#4503)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
