### PR TITLE
Release OrdinaryDiffEqBDF 2.4.8

### DIFF
--- a/lib/OrdinaryDiffEqBDF/Project.toml
+++ b/lib/OrdinaryDiffEqBDF/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqBDF"
 uuid = "6ad6398a-0878-4a85-9266-38940aa047c8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.4.7"
+version = "2.4.8"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"


### PR DESCRIPTION
Bumps `OrdinaryDiffEqBDF` 2.4.7 -> 2.4.8 (patch).

Source files changed since 2.4.7:
- `src/controllers.jl`

Commits:
- Unify companion global error estimators into GlobalErrorEstimation (#4492)
- Add adjoint-based global error control as a SciMLSensitivity extension (#3953)
- ExpRK: cache ishermitian (rebase of #4305, + review fixes) (#4497)
- Mark discrete time-grid search helpers as Enzyme inactive (#4496)
- GlobalAdjoint: every-step trajectory scope and step-grid control (#4495)
- GlobalAdjoint: defer to adjoint_sensitivities default instead of pinning an adjoint (#4498)
- Release GlobalDiffEq 1.7.1 (#4501)
- Fix GlobalDiffEq precompilation on Julia 1.13 and companion accuracy (#4500)
- Make mass-matrix identity/zero/diagonal checks GPU-safe (#4502)
- Fix BDF step rejection for backward-in-time integration (#4503)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
