### PR TITLE
Release OrdinaryDiffEqCore 4.17.1

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.17.0"
+version = "4.17.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Bumps `OrdinaryDiffEqCore` 4.17.0 -> 4.17.1 (patch).

Source files changed since 4.17.0:
- `src/OrdinaryDiffEqCore.jl`
- `src/enzyme_rules.jl`
- `src/initdt.jl`
- `src/misc_utils.jl`
- `src/solve.jl`

Commits:
- Precompile SDE solves through specialization levels (#4467)
- Add 32-bit InterfaceI CI lane via test_groups.toml (#4480)
- incorporate time/stab filter for larger steps in FBDF (#3878)
- Keep 32-bit CI lane hard-failing. (#4482)
- Correct and validate FBDF time and stability filters (#4484)
- Keep DAE init from overwriting uprev during callback truncation (#4486)
- DiffEqBase: Int64 interp_points range length for 32-bit (#4487)
- Release OrdinaryDiffEqBDF 2.4.7 (#4490)
- Unify companion global error estimators into GlobalErrorEstimation (#4492)
- Add adjoint-based global error control as a SciMLSensitivity extension (#3953)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
