### PR TITLE
Release OrdinaryDiffEqDefault 2.6.1

### DIFF
--- a/lib/OrdinaryDiffEqDefault/Project.toml
+++ b/lib/OrdinaryDiffEqDefault/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqDefault"
 uuid = "50262376-6c5a-4cf5-baba-aaf4f84d72d7"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.6.0"
+version = "2.6.1"
 
 [deps]
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"


### PR DESCRIPTION
Bumps `OrdinaryDiffEqDefault` 2.6.0 -> 2.6.1 (patch).

Source files changed since 2.6.0:
- `src/OrdinaryDiffEqDefault.jl`
- `src/default_alg.jl`

Commits:
- Fix definite assignment in ROCK stages (#4321)
- Correct NonlinearSolve downgrade dependency floors (#4394)
- Fix ensemble work-precision error storage (#4390)
- Add explicit benchmark tag semantics (#4402)
- fix: require cache-aware nonlinear solver in PDIRK (#4406)
- fix: accept SciML caches in nlsolve! (#4407)
- Support generic callback event storage (#4398)
- test: account for Hairer4 BLAS variation (#4410)
- Fix Rosenbrock interpolation after callback truncation (#4411)
- Fix weak Platen methods for scalar Wiener processes (#4413)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
