### PR TITLE
Release OrdinaryDiffEqFIRK 2.8.5

### DIFF
--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFIRK"
 uuid = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.8.4"
+version = "2.8.5"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"


### PR DESCRIPTION
Bumps `OrdinaryDiffEqFIRK` 2.8.4 -> 2.8.5 (patch).

Source files changed since 2.8.4:
- `src/OrdinaryDiffEqFIRK.jl`
- `src/firk_perform_step.jl`

Commits:
- Preserve conditioning in OOP no-init solves (#4438)
- Read the test group from GROUP like the CI passes it (#4447)
- Raise root GPU test timeout (#4449)
- Fix default SDE dt vector lengths (#4454)
- Bump DiffEqDevTools to 3.6.2 (#4461)
- DiffEqBase: wrap mass-matrix problems on the finite-difference promote_f path (#4459)
- Preserve the DAE step start during callback interpolation (#4466)
- Release DiffEqBase 7.20.1 (#4474)
- Release OrdinaryDiffEqCore 4.16.1 (#4475)
- Release OrdinaryDiffEqNonlinearSolve 2.9.5 (#4476)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
