### PR TITLE
Release OrdinaryDiffEqRosenbrock 2.7.2

### DIFF
--- a/lib/OrdinaryDiffEqRosenbrock/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrock/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqRosenbrock"
 uuid = "43230ef6-c299-4910-a778-202eb28ce4ce"
-version = "2.7.1"
+version = "2.7.2"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
Bumps `OrdinaryDiffEqRosenbrock` 2.7.1 -> 2.7.2 (patch).

Source files changed since 2.7.1:
- `src/OrdinaryDiffEqRosenbrock.jl`
- `src/rosenbrock_caches.jl`
- `src/rosenbrock_perform_step.jl`

Commits:
- Format clean-master drift with Runic 1.10 (#4423)
- Reformat six files for Runic 1.10 (#4424)
- Refresh FSAL derivatives after solve-level step limiters (#4035)
- Require SciMLBase 3.46 where AutoDespecialize is used (#4426)
- Document the limiter keywords with their real names (#4427)
- Tighten the AdaptiveRadau Newton tolerance with the stage count (#4431)
- Fix the AitkenNeville evaluation count and array states (#4428)
- Fix crashes when a cache holds a vector of nonlinear solvers (#4345)
- Tag the AD type for adaptive exponential algorithms (#4429)
- Release 7.20.0 (#4432)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
