### PR TITLE
Release StochasticDiffEqCore 2.2.2

### DIFF
--- a/lib/StochasticDiffEqCore/Project.toml
+++ b/lib/StochasticDiffEqCore/Project.toml
@@ -1,6 +1,6 @@
 name = "StochasticDiffEqCore"
 uuid = "19c5a474-6cd1-4a5f-be79-46dc34e54d7f"
-version = "2.2.1"
+version = "2.2.2"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Bumps `StochasticDiffEqCore` 2.2.1 -> 2.2.2 (patch).

Source files changed since 2.2.1:
- `src/StochasticDiffEqCore.jl`
- `src/solve.jl`

Commits:
- Add serial SDC solver family (OrdinaryDiffEqSDC) (#4208)
- Give each threaded complex stage its own JVP operator (#4430)
- Fix the adaptive error estimates of MRIGARKERK22a and MIS (#4232)
- Skip sparsity prep for matrix-free jac_prototype operators (#4445)
- Format differentiation tests (#4446)
- Fix SciMLBase reexport QA on Julia LTS (#4450)
- Preserve conditioning in OOP no-init solves (#4438)
- Read the test group from GROUP like the CI passes it (#4447)
- Raise root GPU test timeout (#4449)
- Fix default SDE dt vector lengths (#4454)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
