### PR TITLE
Resolve OrdinaryDiffEqDefault against the local sublibraries

### DIFF
--- a/lib/OrdinaryDiffEqDefault/Project.toml
+++ b/lib/OrdinaryDiffEqDefault/Project.toml
@@ -60,3 +60,12 @@ SafeTestsets = "0.1.0"
 
 [targets]
 test = ["Aqua", "DiffEqDevTools", "JET", "Random", "SafeTestsets", "SparseArrays", "StaticArrays", "Test", "Pkg", "SciMLTesting"]
+
+[sources]
+DiffEqBase = {path = "../DiffEqBase"}
+DiffEqDevTools = {path = "../DiffEqDevTools"}
+OrdinaryDiffEqBDF = {path = "../OrdinaryDiffEqBDF"}
+OrdinaryDiffEqCore = {path = "../OrdinaryDiffEqCore"}
+OrdinaryDiffEqRosenbrock = {path = "../OrdinaryDiffEqRosenbrock"}
+OrdinaryDiffEqTsit5 = {path = "../OrdinaryDiffEqTsit5"}
+OrdinaryDiffEqVerner = {path = "../OrdinaryDiffEqVerner"}


### PR DESCRIPTION
Draft — ignore until reviewed by @ChrisRackauckas.

**Rescoped.** This PR previously also bumped OrdinaryDiffEqCore to 4.18.0 and raised four compat floors to `"4.18"`. Both are obsolete: Core **4.17.1** is registered and does contain the new helpers, and #4525 already raised the floors of Default, FIRK, Rosenbrock and StochasticDiffEqCore to `4.17.1`. The PR is now the one piece that has not been done.

## What changed

Adds a `[sources]` block to `lib/OrdinaryDiffEqDefault/Project.toml`. One file, seven lines.

## Why

`lib/OrdinaryDiffEqDefault/Project.toml` has no `[sources]` block, unlike 44 of the 59 sublibraries. Its CI therefore resolves `OrdinaryDiffEqCore` and the other `lib/` dependencies **from the registry** rather than from the checkout, so a change to local Core is never exercised against Default before merge.

That is how #4502 shipped broken. It added `_is_identity_massmatrix` to Core and used it from Default in the same commit, and the lane that should have caught it was testing Default against an already-released Core. The root-level CI stayed green only because the root `Project.toml` `dev`s both.

The load failure itself is already fixed. This change closes the gap that let it through, so the next Core internal introduced the same way is caught before merge instead of after release.

## The entries

Every dependency of OrdinaryDiffEqDefault that lives in `lib/`: the six runtime deps and the `DiffEqDevTools` test extra, which is the same pattern the sibling sublibraries follow.

## Verification

Before, resolving `lib/OrdinaryDiffEqDefault` on master:

```
Core resolved = 4.17.1     (from the registry)
```

After, on this branch:

```
OrdinaryDiffEqRosenbrock  2.7.3     LOCAL PATH
DiffEqBase                7.21.1    LOCAL PATH
OrdinaryDiffEqCore        4.17.1    LOCAL PATH
LOADED OK  _is_identity_massmatrix(I)=true
```

The `Project.toml` re-parses cleanly with `TOML.parsefile`, all seven `[sources]` paths resolve to existing directories, and `Pkg.instantiate` reports the `lib/` dependencies as path-tracked rather than registry versions. Full test suite not re-run; no source changed.

## Follow-up not in this PR

14 other sublibraries also lack a `[sources]` block and have the same exposure. Worth a separate audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R