### PR TITLE
qa: allow JET 0.12 in OrdinaryDiffEqCore/BDF/NonlinearSolve QA envs

### DIFF
--- a/lib/OrdinaryDiffEqBDF/test/qa/Project.toml
+++ b/lib/OrdinaryDiffEqBDF/test/qa/Project.toml
@@ -14,7 +14,7 @@ path = "../../../OrdinaryDiffEqCore"
 [compat]
 AllocCheck = "0.2"
 Aqua = "0.8.11"
-JET = "0.9, 0.11"
+JET = "0.9, 0.11, 0.12"
 OrdinaryDiffEqBDF = "2"
 OrdinaryDiffEqCore = "4"
 SciMLBase = "3"

--- a/lib/OrdinaryDiffEqCore/test/qa/Project.toml
+++ b/lib/OrdinaryDiffEqCore/test/qa/Project.toml
@@ -12,7 +12,7 @@ path = "../../../DiffEqBase"
 [compat]
 Aqua = "0.8.11"
 DiffEqBase = "7"
-JET = "0.9, 0.11"
+JET = "0.9, 0.11, 0.12"
 OrdinaryDiffEqCore = "4"
 SciMLTesting = "2.4"
 julia = "1.10"

--- a/lib/OrdinaryDiffEqNonlinearSolve/test/qa/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/test/qa/Project.toml
@@ -13,7 +13,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 ADTypes = "1.16"
 Aqua = "0.8.11"
-JET = "0.9, 0.11"
+JET = "0.9, 0.11, 0.12"
 OrdinaryDiffEqBDF = "2"
 OrdinaryDiffEqCore = "4"
 OrdinaryDiffEqNonlinearSolve = "2"


### PR DESCRIPTION
## Summary

CI `Julia 1` is now Julia 1.13. The QA groups for `OrdinaryDiffEqCore`, `OrdinaryDiffEqBDF`, and `OrdinaryDiffEqNonlinearSolve` fail on 1.13 because their `test/qa/Project.toml` files pin `JET = "0.9, 0.11"`, which resolves to **JET 0.11.6**. Per [JET's compatibility docs](https://aviatesk.github.io/JET.jl/dev/): *"The latest release series, v0.12, supports full JET functionality on Julia v1.12 and v1.13 only."* JET 0.11's permissive Julia bound lets it install on 1.13, but its analyzer predates 1.13 compiler-internals changes and reports **false-positive runtime dispatch**.

This PR allows JET 0.12 in those three QA environments so they resolve to JET 0.12.1 on Julia 1.12/1.13. No production code changes — the reported dispatches are analyzer artifacts, verified by:

- The same code + same package versions pass on Julia 1.12.7 with JET 0.11.6.
- Julia's native `code_typed`/inference on the flagged call sites (e.g. the SciMLLogging-generated `DEVerbosity` keyword constructor, `DiffEqBase.init` → `init_up` → `get_concrete_problem`) returns concrete types.
- JET 0.12.1 on Julia 1.13 reports zero dispatches on identical code, while still detecting real dispatch in sanity checks.

On Julia 1.10, JET 0.11+ already requires `julia >= 1.12`, so the resolver continues to pick the 0.9 series there — unchanged behavior.

## Before / after on Julia 1.13

**Before (CI, JET 0.11.6):**

| Package | Result |
|---|---|
| OrdinaryDiffEqCore | `JET Test DEVerbosity Constructors`: 25 pass / **4 fail** (jet.jl:46,50,86,95 — `linear_verbosity`/`nonlinear_verbosity` + complex mixed constructors; dispatch on `Union{Symbol, AbstractVerbosityPreset}`) |
| OrdinaryDiffEqBDF | `JET Tests`: 1 pass / **17 fail** / 23 broken (jet.jl:48,64 — `init` dispatch through `DiffEqBase.init_up`/`get_concrete_problem`/`SciMLBase.promote_u0`, prob degrading to `Any`) |
| OrdinaryDiffEqNonlinearSolve | `JET Tests`: 1 pass / **12 fail** / 33 broken (jet.jl:70,95 — same `init` path for Rosenbrock-family solvers) |

**After (local, Julia 1.13.0, JET 0.12.1), `GROUP=QA julia --project=. -e 'import Pkg; Pkg.test()'`:**

| Package | Result |
|---|---|
| OrdinaryDiffEqCore | JET **30 pass** / 1 broken, Aqua 26/26, AllocCheck 1/1 — `tests passed` |
| OrdinaryDiffEqBDF | JET **18 pass** / 23 broken (broken are `broken=true` by design), Aqua 21/21, AllocCheck 4 pass / 18 broken — `tests passed` |
| OrdinaryDiffEqNonlinearSolve | JET **13 pass** / 33 broken, Aqua 41/41 — `tests passed` |

Local repro of a representative failure on Julia 1.13.0 + JET 0.11.6 (before): `@test_opt init(linear_prob, ABDF2(), ...)` reports runtime dispatch in `init_up` (`remake`d prob inferred as `Any`); the same call reports nothing under JET 0.12.1.

Also verified `test/qa/jet.jl` for OrdinaryDiffEqCore on **Julia 1.12.7 + JET 0.12.1**: 29/29 DEVerbosity tests pass — no regression on 1.12.

## Test plan

- [x] `GROUP=QA julia +1.13 --project=. -e 'import Pkg; Pkg.test()'` in `lib/OrdinaryDiffEqCore` — pass
- [x] `GROUP=QA julia +1.13 --project=. -e 'import Pkg; Pkg.test()'` in `lib/OrdinaryDiffEqBDF` — pass
- [x] `GROUP=QA julia +1.13 --project=. -e 'import Pkg; Pkg.test()'` in `lib/OrdinaryDiffEqNonlinearSolve` — pass
- [x] OrdinaryDiffEqCore `test/qa/jet.jl` on Julia 1.12.7 + JET 0.12.1 — pass
- [ ] Sublibrary CI on this PR should run the three QA groups on Julia 1.13 with JET 0.12.1

Note: the other ~45 sublibrary `test/qa/Project.toml`s still pin `JET = "0.9, 0.11"`; most contain no live `@test_opt` assertions, and the few that do (`OrdinaryDiffEqLowOrderRK`, `OrdinaryDiffEqStabilizedRK`, `OrdinaryDiffEqSSPRK`) can get the same bump when their diff-filtered QA jobs next run on 1.13 — each should be verified under JET 0.12 rather than blanket-bumped.

🤖 Generated with [Devin](https://devin.ai) (harness: Devin CLI 3000.10.21, model: SWE-2 High). Session: local Devin CLI session (no shareable URL); session db at /home/crackauc/.local/share/devin/cli/sessions.db