### PR TITLE
Add regression tests for issues verified fixed in recent releases

### DIFF
--- a/test/Regression_II/issue_regression_tests.jl
+++ b/test/Regression_II/issue_regression_tests.jl
@@ -1,0 +1,83 @@
+using OrdinaryDiffEq, Test, LinearAlgebra
+using OrdinaryDiffEqSDIRK, OrdinaryDiffEqFIRK, OrdinaryDiffEqRKN,
+    OrdinaryDiffEqLowOrderRK, OrdinaryDiffEqLowStorageRK, OrdinaryDiffEqLinear
+using RecursiveArrayTools, SciMLOperators
+
+@testset "remake with du0 on SecondOrderODEProblem (#2138)" begin
+    f(du, u, p, t) = 0.0
+    prob = SecondOrderODEProblem(f, 0.0, 0.0, (0.0, 1.0), [0.0, 0.0])
+    new_prob = remake(prob; u0 = 1.0, du0 = 1.0)
+    sol = solve(new_prob, DPRKN6())
+    @test sol.retcode == ReturnCode.Success
+end
+
+@testset "NamedArrayPartition with stiff implicit solvers (#2707)" begin
+    function int!(du, u, p, t)
+        du.y .= u.y .+ t / 10
+        return du.x .= u.x .+ 1.0
+    end
+    u0 = NamedArrayPartition((x = zeros(10), y = zeros(10, 10)))
+    prob = ODEProblem(int!, u0, (0.0, 2.0))
+    sol = solve(prob, Trapezoid())
+    @test sol.retcode == ReturnCode.Success
+end
+
+@testset "RDPK3Sp solvers with Float32 (#2894)" begin
+    foo(du, u, p, t) = (du .= 0.9f0 .* u)
+    prob = ODEProblem(foo, fill(0.5f0, 10), (0.0f0, 1.0f0))
+    @testset "$alg" for alg in (RDPK3Sp35(), RDPK3Sp49(), RDPK3Sp510())
+        sol = solve(prob, alg)
+        @test sol.retcode == ReturnCode.Success
+    end
+end
+
+@testset "stats.nf on SecondOrderODEProblem with implicit methods (#2537)" begin
+    function test_nf(alg)
+        f_counter = Ref(0)
+        function f(ddu, du, u, p, t)
+            f_counter[] += 1
+            ddu .= p .* u
+            return nothing
+        end
+        u0 = [1.0]
+        du0 = [0.0]
+        p = [-1.0]
+        prob = SecondOrderODEProblem(f, du0, u0, (0.0, 1.0), p)
+        sol = solve(prob, alg, save_everystep = false, dense = false)
+        return sol.stats.nf == f_counter[]
+    end
+    @testset "$alg" for alg in (RadauIIA5(), Trapezoid(), ImplicitEuler())
+        @test test_nf(alg)
+    end
+end
+
+@testset "explicit jac + jac_prototype skips AD Jacobian prep (#2671)" begin
+    f!(du, u, p, t) = (du .= u)
+    N = 10
+    jac_prototype = Matrix{Float64}(I, N, N)
+    function jac!(J, u, p, t)
+        J .= 0
+        for i in 1:N
+            J[i, i] = 1
+        end
+        return nothing
+    end
+    odef = ODEFunction(f!; jac = jac!, jac_prototype = jac_prototype)
+    prob = ODEProblem(odef, ones(N), (0.0, 1.0))
+    sol = solve(prob, Trapezoid())
+    @test sol.retcode == ReturnCode.Success
+    @test sol(1.0) ≈ exp.(ones(N)) rtol = 1.0e-2
+end
+
+@testset "MagnusGL6 with MatrixOperator (#3232)" begin
+    function update_func(A, u, p, t)
+        A[1, 1] = cos(t)
+        A[2, 1] = sin(t)
+        A[1, 2] = -sin(t)
+        return A[2, 2] = cos(t)
+    end
+    A = MatrixOperator(ones(2, 2), update_func! = update_func)
+    prob = ODEProblem(A, ones(2), (1.0, 6.0))
+    sol = solve(prob, MagnusGL6(), dt = 1 / 10)
+    @test sol.retcode == ReturnCode.Success
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -133,6 +133,7 @@ function regression_ii()
     @time @safetestset "PSOS Energy Conservation Tests" include("Regression_II/psos_and_energy_conservation.jl")
     @time @safetestset "Unrolled Tests" include("Regression_II/ode_unrolled_comparison_tests.jl")
     @time @safetestset "IIP vs OOP Tests" include("Regression_II/iipvsoop_tests.jl")
+    @time @safetestset "Issue Regression Tests" include("Regression_II/issue_regression_tests.jl")
     return @time @safetestset "Inference Tests" include("Regression_II/inference.jl")
 end
 


### PR DESCRIPTION
## Summary

Regression tests for issue MWEs that are fixed on OrdinaryDiffEq v7.x but lacked dedicated coverage. Each MWE was executed locally on Julia 1.12.4 / OrdinaryDiffEq v7.8.1 and confirmed to pass before inclusion.

- #2138: `remake` with `du0` on `SecondOrderODEProblem`
- #2707: `NamedArrayPartition` u0 with stiff implicit solvers (`Trapezoid`)
- #2894: `RDPK3Sp35/49/510` on `Float32` u0
- #2537: `stats.nf` accounting on `SecondOrderODEProblem` with implicit methods (`RadauIIA5`, `Trapezoid`, `ImplicitEuler`)
- #2671: explicit `jac` + `jac_prototype` must skip AD Jacobian preparation
- #3232: `MagnusGL6` with a `SciMLOperators.MatrixOperator` (was a `FieldError` on the `autodiff` field)

#### Test plan

- [x] New testset passes locally: `Issue Regression Tests | 11 / 11`
- [x] Ran within `GROUP=Regression_II` via `Pkg.test()` — whole group green
- [x] Runic formatted

These are regression locks for already-shipped fixes — the issues' MWEs were confirmed broken at filing time and confirmed passing on current releases before closing each issue.

🤖 Generated with Devin (harness: Devin CLI; model: SWE-2 Max). Session transcript (local): /home/crackauc/.local/share/devin/cli/summaries/history_ee18806f575d4e4c.md