### PR TITLE
OrdinaryDiffEqDefault: require OrdinaryDiffEqCore 4.17.1 (fixes registry precompile failure)

### DIFF
--- a/lib/OrdinaryDiffEqDefault/Project.toml
+++ b/lib/OrdinaryDiffEqDefault/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqDefault"
 uuid = "50262376-6c5a-4cf5-baba-aaf4f84d72d7"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.6.1"
+version = "2.6.2"
 
 [deps]
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
@@ -47,7 +47,7 @@ PrecompileTools = "1.2.1, 1.3"
 EnumX = "1.0.4"
 LinearAlgebra = "1.10"
 SciMLBase = "3.46"
-OrdinaryDiffEqCore = "4.11"
+OrdinaryDiffEqCore = "4.17.1"
 SparseArrays = "1.10"
 Preferences = "1.5.0"
 StaticArrays = "1.9.18"


### PR DESCRIPTION
> **Draft — please ignore until reviewed by @ChrisRackauckas.**

## What changed and why

`lib/OrdinaryDiffEqDefault/src/OrdinaryDiffEqDefault.jl:11` imports `_is_identity_massmatrix` from `OrdinaryDiffEqCore`, and `default_alg.jl:161` calls it. That binding was added to OrdinaryDiffEqCore in 4.17.1, by "Make mass-matrix identity/zero/diagonal checks GPU-safe" (#4502, `c44595df7`). But `lib/OrdinaryDiffEqDefault/Project.toml` declares `OrdinaryDiffEqCore = "4.11"`, so the resolver is free to pair OrdinaryDiffEqDefault 2.6.1 with an older Core, and the package then fails to precompile.

In-repo CI cannot catch this: `[sources]` points OrdinaryDiffEqDefault at `../OrdinaryDiffEqCore`, so every in-repo run gets the local 4.17.1. Only registry users hit it. `OrdinaryDiffEq` 7.8.1 declares `OrdinaryDiffEqCore = "4.15.1"`, so a real environment can and does settle on Core 4.17.0 with Default 2.6.1 — that is how I hit it, resolving ModelingToolkitBase's test environment.

This raises the declared floor to `4.17.1` so the bound matches what the code actually needs, and bumps OrdinaryDiffEqDefault to 2.6.2 so a release carries the corrected bound.

## Verification

Reproduction on Julia 1.12.7 with the registry as of 2026-09-12 — pin Core to 4.17.0, then add Default 2.6.1. The resolver accepts the pair, because the current bound permits it, and precompilation then fails:

```julia
using Pkg
Pkg.activate(mktempdir())
Pkg.add(name = "OrdinaryDiffEqCore", version = "4.17.0")
Pkg.add(name = "OrdinaryDiffEqDefault", version = "2.6.1")
```

```
OrdinaryDiffEqCore v4.17.0
OrdinaryDiffEqDefault v2.6.1
WARNING: Imported binding OrdinaryDiffEqCore._is_identity_massmatrix was undeclared at import time during import to OrdinaryDiffEqDefault.
ERROR: LoadError: UndefVarError: `_is_identity_massmatrix` not defined in `OrdinaryDiffEqDefault`
Failed to precompile OrdinaryDiffEqDefault [50262376-6c5a-4cf5-baba-aaf4f84d72d7]
```

Confirming the version boundary: `_is_identity_massmatrix` is absent from the sources of OrdinaryDiffEqCore 4.15.3, 4.16.0, 4.16.1 and 4.17.0, and present in 4.17.1. It is used by OrdinaryDiffEqDefault 2.6.1 and by no earlier Default release.

## What I did *not* verify

This is a compat-bound change only, with no code change, so I ran no test group; in-repo tests resolve Core through `[sources]` and are unaffected by the bound either way. I also did not construct a registry-side resolution test proving the new bound excludes Core 4.17.0 — `Pkg.develop` of a path package does not exercise registry resolution, so I am asserting the bound's effect from its semantics rather than from an experiment.

## For the reviewer

The floor could instead be set to whichever Core release you consider the supported minimum, as long as it is ≥ 4.17.1. I picked the exact version that introduced the binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeJYXni9MkJhPFA9yxYvfn
