### PR TITLE
Release DiffEqBase 7.21.1

### DIFF
--- a/lib/DiffEqBase/Project.toml
+++ b/lib/DiffEqBase/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "7.21.0"
+version = "7.21.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"


### PR DESCRIPTION
Bumps `DiffEqBase` 7.21.0 -> 7.21.1 (patch).

Source files changed since 7.21.0:
- `src/callbacks.jl`

Commits:
- Release OrdinaryDiffEqBDF 2.4.7 (#4490)
- Unify companion global error estimators into GlobalErrorEstimation (#4492)
- Add adjoint-based global error control as a SciMLSensitivity extension (#3953)
- ExpRK: cache ishermitian (rebase of #4305, + review fixes) (#4497)
- Mark discrete time-grid search helpers as Enzyme inactive (#4496)
- GlobalAdjoint: every-step trajectory scope and step-grid control (#4495)
- GlobalAdjoint: defer to adjoint_sensitivities default instead of pinning an adjoint (#4498)
- Release GlobalDiffEq 1.7.1 (#4501)
- Fix GlobalDiffEq precompilation on Julia 1.13 and companion accuracy (#4500)
- Make mass-matrix identity/zero/diagonal checks GPU-safe (#4502)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
