### PR TITLE
Use MassActionJump directly in stochastic tau-leaping solvers

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+JumpProcesses = "ccbc3e58-028d-4f4c-8cd5-9ae44345cda5"
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 DelayDiffEq = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
@@ -110,6 +111,7 @@ StochasticDiffEqRODE = {path = "../lib/StochasticDiffEqRODE"}
 StochasticDiffEqWeak = {path = "../lib/StochasticDiffEqWeak"}
 
 [compat]
+JumpProcesses = "9.33"
 ADTypes = "1.22"
 CommonSolve = "0.2.6"
 DelayDiffEq = "6"

--- a/docs/src/devtools/internals/public_api.md
+++ b/docs/src/devtools/internals/public_api.md
@@ -457,6 +457,7 @@ StochasticDiffEqCore.@cache
 StochasticDiffEqCore.StochasticCompositeAlgorithm
 StochasticDiffEqCore.StochasticCompositeCache
 StochasticDiffEqCore.TauLeapingDrift
+StochasticDiffEqCore.jump_noise_data
 StochasticDiffEqCore._resolve_rng
 StochasticDiffEqCore._sde_init
 StochasticDiffEqCore._z_prototype

--- a/docs/src/stochastic/Algorithms.md
+++ b/docs/src/stochastic/Algorithms.md
@@ -113,12 +113,14 @@ using JumpProcesses, StochasticDiffEqLeaping
 
 jump = MassActionJump([0.1], [[1 => 1]], [[1 => -1, 2 => 1]])
 prob = JumpProblem(DiscreteProblem([1000.0, 0.0], (0.0, 1.0)), PureLeaping(), jump)
+tau_sol = solve(prob, TauLeaping())
 sol = solve(prob, ImplicitTauLeaping(); dt = 0.01, adaptive = false)
 ```
 
 For more general propensity functions and count-based updates, these methods
-also accept `RegularJump`. Combining it with a `MassActionJump` in the same
-leaping problem is not supported. These StochasticDiffEq solvers do not provide
+also accept `RegularJump`. Combining it with a `MassActionJump` in a
+`PureLeaping` problem is not supported. `RegularJump` leaps can still run alongside
+exactly aggregated mass-action jumps when using an SSA aggregator. These StochasticDiffEq solvers do not provide
 `EnsembleGPUKernel` implementations; see JumpProcesses for its supported GPU
 leaping algorithms.
 

--- a/docs/src/stochastic/Algorithms.md
+++ b/docs/src/stochastic/Algorithms.md
@@ -98,3 +98,30 @@ StochasticDiffEqRODE.RandomEM
 StochasticDiffEqRODE.RandomHeun
 StochasticDiffEqRODE.RandomTamedEM
 ```
+
+## Mass-action tau leaping
+
+`TauLeaping`, `CaoTauLeaping`, `ImplicitTauLeaping`, and
+`ThetaTrapezoidalTauLeaping` accept a `JumpProblem` built from a `DiscreteProblem`,
+`PureLeaping()`, and a `MassActionJump`. These solvers retain the mass-action
+representation, use its stored rate constants for error control, and apply its
+stoichiometry directly. The implicit methods evaluate the mass-action drift
+without an intermediate propensity vector during nonlinear iteration.
+
+```@example massaction_leaping
+using JumpProcesses, StochasticDiffEqLeaping
+
+jump = MassActionJump([0.1], [[1 => 1]], [[1 => -1, 2 => 1]])
+prob = JumpProblem(DiscreteProblem([1000.0, 0.0], (0.0, 1.0)), PureLeaping(), jump)
+sol = solve(prob, ImplicitTauLeaping(); dt = 0.01, adaptive = false)
+```
+
+For more general propensity functions and count-based updates, these methods
+also accept `RegularJump`. Combining it with a `MassActionJump` in the same
+leaping problem is not supported. These StochasticDiffEq solvers do not provide
+`EnsembleGPUKernel` implementations; see JumpProcesses for its supported GPU
+leaping algorithms.
+
+`CaoTauLeaping` currently lacks its adaptive step-selection calculation. Use
+`dt` with `adaptive = false` for that method; use `TauLeaping` when adaptive
+steps are needed.

--- a/lib/StochasticDiffEqCore/Project.toml
+++ b/lib/StochasticDiffEqCore/Project.toml
@@ -1,6 +1,6 @@
 name = "StochasticDiffEqCore"
 uuid = "19c5a474-6cd1-4a5f-be79-46dc34e54d7f"
-version = "2.2.2"
+version = "2.3.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]

--- a/lib/StochasticDiffEqCore/src/StochasticDiffEqCore.jl
+++ b/lib/StochasticDiffEqCore/src/StochasticDiffEqCore.jl
@@ -159,7 +159,7 @@ export resize_noise!, fill_new_noise_caches!,
 export _z_prototype, concrete_prob, _resolve_rng, _sde_init
 
 # Export TauLeapingDrift for Jump subpackage
-export TauLeapingDrift
+export TauLeapingDrift, jump_noise_data
 
 # General functions
 export solve, init, solve!, step!

--- a/lib/StochasticDiffEqCore/src/solve.jl
+++ b/lib/StochasticDiffEqCore/src/solve.jl
@@ -495,42 +495,26 @@ function _sde_init(
         W = nothing
     end
 
-    # ── CompoundPoissonProcess for tau-leaping ───────────────────────────
-    if _prob isa JumpProblem && _prob.regular_jump !== nothing
-        if !isnothing(_prob.regular_jump.mark_dist) == nothing
-            error("Mark distributions are currently not supported in SimpleTauLeaping")
-        end
-
-        jump_prototype = zeros(_prob.regular_jump.numjumps)
-        c = _prob.regular_jump.c
-
-        if isinplace(_prob.regular_jump)
-            rate_constants = zeros(_prob.regular_jump.numjumps)
-            _prob.regular_jump.rate(rate_constants, u ./ u, prob.p, tspan[1])
-            P = CompoundPoissonProcess!(
-                _prob.regular_jump.rate, t, jump_prototype,
-                computerates = !alg_control_rate(alg) || !adaptive,
-                save_everystep = save_noise,
-                rng = _rng
-            )
-            alg_control_rate(alg) && adaptive &&
-                P.cache.rate(P.cache.currate, u, p, tspan[1])
-        else
-            rate_constants = _prob.regular_jump.rate(u ./ u, prob.p, tspan[1])
-            P = CompoundPoissonProcess(
-                _prob.regular_jump.rate, t, jump_prototype,
-                save_everystep = save_noise,
-                computerates = !alg_control_rate(alg) || !adaptive,
-                rng = _rng
-            )
-            alg_control_rate(alg) && adaptive &&
-                (P.cache.currate = P.cache.rate(u, p, tspan[1]))
-        end
+    jump_data = jump_noise_data(alg, _prob, u, p, t)
+    if jump_data === nothing
+        jump_prototype = c = P = rate_constants = nothing
     else
-        jump_prototype = nothing
-        c = nothing
-        P = nothing
-        rate_constants = nothing
+        (; jump_prototype, c, rate_constants, rate, iip) = jump_data
+        if iip
+            P = CompoundPoissonProcess!(
+                rate, t, jump_prototype;
+                computerates = !alg_control_rate(alg) || !adaptive,
+                save_everystep = save_noise, rng = _rng
+            )
+            alg_control_rate(alg) && adaptive && rate(P.cache.currate, u, p, t)
+        else
+            P = CompoundPoissonProcess(
+                rate, t, jump_prototype;
+                computerates = !alg_control_rate(alg) || !adaptive,
+                save_everystep = save_noise, rng = _rng
+            )
+            alg_control_rate(alg) && adaptive && (P.cache.currate = rate(u, p, t))
+        end
     end
 
     # ── dW/dZ extraction, verbose conversion, alg_cache ──────────────────
@@ -609,3 +593,34 @@ end
 
 # solve! is now provided by OrdinaryDiffEqCore (SciMLBase.solve!(::ODEIntegrator))
 # handle_dt! and initialize_callbacks! are now provided by OrdinaryDiffEqCore
+
+"""
+    jump_noise_data(alg, prob, u, p, t)
+
+Return the reaction data used to initialize a stochastic solver's Poisson noise,
+or `nothing` when no jump noise is needed. Solver packages may specialize this
+hook to preserve and exploit structured jump representations.
+
+The result is a named tuple with `jump_prototype` (one zero per reaction), `c`
+(the solver's reaction-update representation), `rate_constants` (the reaction
+scales used by error control), `rate` (a propensity callable), and `iip` (whether
+`rate` has signature `rate(out, u, p, t)` rather than `rate(u, p, t)`). The default
+handles `RegularJump`; specializations must also provide step implementations
+that understand their chosen `c` representation.
+"""
+function jump_noise_data(alg, prob, u, p, t)
+    prob isa JumpProblem || return nothing
+    rj = prob.regular_jump
+    rj === nothing && return nothing
+    isnothing(rj.mark_dist) || error("Mark distributions are not supported by this solver")
+    jump_prototype = zeros(rj.numjumps)
+    iip = isinplace(rj)
+    rate_constants = if iip
+        out = similar(jump_prototype)
+        rj.rate(out, u ./ u, p, t)
+        out
+    else
+        rj.rate(u ./ u, p, t)
+    end
+    return (; jump_prototype, c = rj.c, rate_constants, rate = rj.rate, iip)
+end

--- a/lib/StochasticDiffEqLeaping/AGENTS.md
+++ b/lib/StochasticDiffEqLeaping/AGENTS.md
@@ -1,0 +1,7 @@
+# Jump representations
+
+Keep mass-action and general `RegularJump` solver paths separate. Specialize
+`StochasticDiffEqCore.jump_noise_data` to initialize structured reaction data;
+do not normalize `MassActionJump` into `RegularJump` in the problem constructor.
+Use JumpProcesses' public mass-action operations for propensities, stoichiometric
+updates, and implicit drift evaluation.

--- a/lib/StochasticDiffEqLeaping/Project.toml
+++ b/lib/StochasticDiffEqLeaping/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEqLeaping"
 uuid = "aefaaa88-39f2-4e89-b162-d61b7e8cc81b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.1.0"
+version = "2.2.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -20,6 +20,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StochasticDiffEqCore = "19c5a474-6cd1-4a5f-be79-46dc34e54d7f"
 
 [extras]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
@@ -29,12 +30,13 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 DiffEqBase = {path = "../DiffEqBase"}
 
 [compat]
+Random = "1"
 SciMLTesting = "2.8"
 ADTypes = "1.22.0"
 DiffEqBase = "7"
 FiniteDiff = "2.27.0"
 ForwardDiff = "1.3.3"
-JumpProcesses = "9.26.0"
+JumpProcesses = "9.33"
 LinearAlgebra = "1.10"
 MuladdMacro = "0.2.4"
 OrdinaryDiffEqCore = "4"
@@ -44,13 +46,13 @@ RecursiveArrayTools = "4.2.0"
 Reexport = "1.2.2"
 SciMLBase = "3.39"
 StaticArrays = "1.9.18"
-StochasticDiffEqCore = "2"
+StochasticDiffEqCore = "2.3"
 Test = "<0.0.1, 1"
 SafeTestsets = "0.1.0"
 julia = "1.10"
 
 [targets]
-test = ["Test", "Pkg", "SafeTestsets", "SciMLTesting"]
+test = ["Random", "Test", "Pkg", "SafeTestsets", "SciMLTesting"]
 
 [sources.OrdinaryDiffEqCore]
 path = "../OrdinaryDiffEqCore"

--- a/lib/StochasticDiffEqLeaping/benchmark/README.md
+++ b/lib/StochasticDiffEqLeaping/benchmark/README.md
@@ -1,0 +1,17 @@
+Compare native mass-action solves with rate/update adapters using a fresh Julia
+process for each invocation. Use Julia 1.12 or later to report compilation time.
+From the repository root, after instantiating the
+leaping package environment:
+
+```sh
+julia --project=lib/StochasticDiffEqLeaping lib/StochasticDiffEqLeaping/benchmark/massaction.jl adapter implicit 1000
+julia --project=lib/StochasticDiffEqLeaping lib/StochasticDiffEqLeaping/benchmark/massaction.jl native implicit 1000
+```
+
+Arguments select `adapter` or `native`, `explicit` or `implicit`, and the reaction
+count. Each row reports mode, method, reactions, first-solve seconds, compilation
+seconds, median warmed-up seconds, and median allocated bytes. Warmed-up medians
+use nine solves. Repeat fresh processes to assess compilation variability.
+
+Both paths use the same mass-action operations; the adapter supplies them through
+`RegularJump` callbacks.

--- a/lib/StochasticDiffEqLeaping/benchmark/massaction.jl
+++ b/lib/StochasticDiffEqLeaping/benchmark/massaction.jl
@@ -1,0 +1,36 @@
+using JumpProcesses, StochasticDiffEqLeaping
+
+struct AdapterRates{M}
+    jump::M
+end
+(r::AdapterRates)(out, u, p, t) = massaction_rates!(out, r.jump, u)
+struct AdapterChange{M}
+    jump::M
+end
+(c::AdapterChange)(du, u, p, t, counts, mark) =
+    massaction_stoichiometry_mul!(du, c.jump, counts)
+
+function benchmark_massaction(mode, method, n)
+    @assert mode in ("native", "adapter")
+    @assert method in ("explicit", "implicit")
+    maj = MassActionJump(
+        fill(0.1, n), [[i => 1] for i in 1:n],
+        [[i => -1, mod1(i + 1, n) => 1] for i in 1:n]
+    )
+    jump = mode == "native" ? maj : RegularJump(AdapterRates(maj), AdapterChange(maj), n)
+    prob = JumpProblem(DiscreteProblem(fill(100.0, n), (0.0, 1.0)), PureLeaping(), jump)
+    alg = method == "explicit" ? TauLeaping() : ImplicitTauLeaping()
+    run() = solve(prob, alg; dt = 0.01, adaptive = false, seed = 123, save_everystep = false)
+    first = @timed run()
+    @assert successful_retcode(first.value)
+    samples = [@timed(run()) for _ in 1:9]
+    return println(
+        join(
+            (
+                mode, method, n, first.time, first.compile_time,
+                sort([s.time for s in samples])[5], sort([s.bytes for s in samples])[5],
+            ), ','
+        )
+    )
+end
+benchmark_massaction(ARGS[1], ARGS[2], parse(Int, ARGS[3]))

--- a/lib/StochasticDiffEqLeaping/src/StochasticDiffEqLeaping.jl
+++ b/lib/StochasticDiffEqLeaping/src/StochasticDiffEqLeaping.jl
@@ -35,6 +35,7 @@ import OrdinaryDiffEqNonlinearSolve
 
 include("algorithms.jl")
 include("alg_utils.jl")
+include("massaction.jl")
 include("stepsize_controllers.jl")
 include("integrator_utils.jl")
 include("caches/tau_caches.jl")

--- a/lib/StochasticDiffEqLeaping/src/algorithms.jl
+++ b/lib/StochasticDiffEqLeaping/src/algorithms.jl
@@ -40,42 +40,13 @@ end
 """
     CaoTauLeaping()
 
-**CaoTauLeaping: Cao's Adaptive Tau-Leaping Method (Jump-Diffusion)**
+Tau leaping with a controller intended for Cao's adaptive step selection.
+The adaptive step-selection calculation is currently incomplete. Use
+`solve(prob, CaoTauLeaping(); dt, adaptive = false)` for fixed steps, or
+[`TauLeaping`](@ref) for implemented adaptive stepping.
 
-Advanced tau-leaping method with adaptive tau selection and improved error control.
-
-## Method Properties
-
-  - **Problem type**: Jump-diffusion processes
-  - **Approach**: Adaptive tau selection with error control
-  - **Time stepping**: Adaptive tau based on error estimates
-  - **Accuracy**: Superior to basic tau-leaping
-
-## When to Use
-
-  - Production jump-diffusion simulations requiring reliability
-  - When adaptive tau selection is needed
-  - Problems where basic TauLeaping gives poor accuracy
-  - Chemical reaction networks requiring precise control
-
-## Algorithm Features
-
-  - Adaptive tau selection based on error estimates
-  - Better stability and accuracy than basic tau-leaping
-  - Automatic step size control
-  - More sophisticated error estimation
-
-## Tau Selection
-
-Automatically adjusts tau based on:
-
-  - Local error estimates
-  - Jump rate variations
-  - Solution stability requirements
-
-## References
-
-  - Cao, Y., Gillespie, D.T., Petzold, L.R., "Efficient step size selection for the tau-leaping method"
+Accepts mass-action kinetics or a `RegularJump` with general rate and update
+functions.
 """
 @kwdef struct CaoTauLeaping{QT} <: StochasticDiffEqJumpAdaptiveAlgorithm
     gamma::QT = 9 // 10

--- a/lib/StochasticDiffEqLeaping/src/integrator_utils.jl
+++ b/lib/StochasticDiffEqLeaping/src/integrator_utils.jl
@@ -3,6 +3,9 @@
 function OrdinaryDiffEqCore.nlsolve_f(integrator::OrdinaryDiffEqCore.ODEIntegrator{A}) where {A <: ImplicitTauLeaping}
     # Determine if the cache is in-place or constant (out-of-place) based on cache type
     cache = integrator.cache
+    if integrator.c isa JumpProcesses.MassActionJump
+        return MassActionDrift{typeof(integrator.c), cache isa ImplicitTauLeapingCache}(integrator.c)
+    end
     if cache isa ImplicitTauLeapingCache
         # In-place version - use rate cache from the integrator's cache
         rate_cache = cache.rate_at_uprev
@@ -22,6 +25,9 @@ end
 function OrdinaryDiffEqCore.nlsolve_f(integrator::OrdinaryDiffEqCore.ODEIntegrator{A}) where {A <: ThetaTrapezoidalTauLeaping}
     # Determine if the cache is in-place or constant (out-of-place) based on cache type
     cache = integrator.cache
+    if integrator.c isa JumpProcesses.MassActionJump
+        return MassActionDrift{typeof(integrator.c), cache isa ThetaTrapezoidalTauLeapingCache}(integrator.c)
+    end
     if cache isa ThetaTrapezoidalTauLeapingCache
         # In-place version - use rate cache from the integrator's cache
         rate_cache = cache.rate_at_uprev

--- a/lib/StochasticDiffEqLeaping/src/massaction.jl
+++ b/lib/StochasticDiffEqLeaping/src/massaction.jl
@@ -1,0 +1,62 @@
+struct MassActionRates{M}
+    jump::M
+end
+
+(rate::MassActionRates)(out, u, p, t) =
+    JumpProcesses.massaction_rates!(out, rate.jump, u)
+function (rate::MassActionRates)(u, p, t)
+    out = similar(rate.jump.scaled_rates, promote_type(eltype(u), eltype(rate.jump.scaled_rates)))
+    return JumpProcesses.massaction_rates!(out, rate.jump, u)
+end
+
+function StochasticDiffEqCore.jump_noise_data(
+        alg::Union{TauLeaping, CaoTauLeaping, ImplicitTauLeaping, ThetaTrapezoidalTauLeaping},
+        prob, u, p, t
+    )
+    if !(prob isa JumpProcesses.JumpProblem) ||
+            JumpProcesses.get_num_majumps(prob.massaction_jump) == 0
+        return invoke(
+            StochasticDiffEqCore.jump_noise_data,
+            Tuple{Any, Any, Any, Any, Any}, alg, prob, u, p, t
+        )
+    end
+    prob.prob isa SciMLBase.DiscreteProblem && prob.aggregator isa JumpProcesses.PureLeaping ||
+        throw(ArgumentError("Mass-action leaping requires a DiscreteProblem with PureLeaping()"))
+    prob.regular_jump === nothing || throw(
+        ArgumentError(
+            "Combining MassActionJump and RegularJump is not supported by this solver"
+        )
+    )
+    isempty(prob.constant_jumps) && isempty(prob.variable_jumps) || throw(
+        ArgumentError(
+            "Mass-action leaping requires a pure mass-action problem"
+        )
+    )
+    jump = prob.massaction_jump
+    return (;
+        jump_prototype = zero(jump.scaled_rates), c = jump,
+        rate_constants = copy(jump.scaled_rates), rate = MassActionRates(jump),
+        iip = SciMLBase.isinplace(prob),
+    )
+end
+
+leaping_change(c, args...) = c(args...)
+function leaping_change(jump::JumpProcesses.MassActionJump, du, u, p, t, counts, mark)
+    return JumpProcesses.massaction_stoichiometry_mul!(du, jump, counts)
+end
+function leaping_change(jump::JumpProcesses.MassActionJump, u, p, t, counts, mark)
+    du = similar(u)
+    JumpProcesses.massaction_stoichiometry_mul!(du, jump, counts)
+    return convert(typeof(u), du)
+end
+
+struct MassActionDrift{M, IIP}
+    jump::M
+end
+(drift::MassActionDrift{M, true})(du, u, p, t) where {M} =
+    JumpProcesses.massaction_drift!(du, drift.jump, u)
+function (drift::MassActionDrift{M, false})(u, p, t) where {M}
+    du = similar(u)
+    JumpProcesses.massaction_drift!(du, drift.jump, u)
+    return convert(typeof(u), du)
+end

--- a/lib/StochasticDiffEqLeaping/src/massaction.jl
+++ b/lib/StochasticDiffEqLeaping/src/massaction.jl
@@ -14,13 +14,14 @@ function StochasticDiffEqCore.jump_noise_data(
         prob, u, p, t
     )
     if !(prob isa JumpProcesses.JumpProblem) ||
+            !(prob.aggregator isa JumpProcesses.PureLeaping) ||
             JumpProcesses.get_num_majumps(prob.massaction_jump) == 0
         return invoke(
             StochasticDiffEqCore.jump_noise_data,
             Tuple{Any, Any, Any, Any, Any}, alg, prob, u, p, t
         )
     end
-    prob.prob isa SciMLBase.DiscreteProblem && prob.aggregator isa JumpProcesses.PureLeaping ||
+    prob.prob isa SciMLBase.DiscreteProblem ||
         throw(ArgumentError("Mass-action leaping requires a DiscreteProblem with PureLeaping()"))
     prob.regular_jump === nothing || throw(
         ArgumentError(
@@ -33,8 +34,9 @@ function StochasticDiffEqCore.jump_noise_data(
         )
     )
     jump = prob.massaction_jump
+    rate_type = promote_type(float(eltype(u)), float(eltype(jump.scaled_rates)))
     return (;
-        jump_prototype = zero(jump.scaled_rates), c = jump,
+        jump_prototype = zeros(rate_type, JumpProcesses.get_num_majumps(jump)), c = jump,
         rate_constants = copy(jump.scaled_rates), rate = MassActionRates(jump),
         iip = SciMLBase.isinplace(prob),
     )

--- a/lib/StochasticDiffEqLeaping/src/perform_step/tau_leaping.jl
+++ b/lib/StochasticDiffEqLeaping/src/perform_step/tau_leaping.jl
@@ -1,6 +1,6 @@
 @muladd function perform_step!(integrator, cache::TauLeapingConstantCache)
     (; t, dt, uprev, u, W, p, P, c) = integrator
-    tmp = c(uprev, p, t, P.dW, nothing)
+    tmp = leaping_change(c, uprev, p, t, P.dW, nothing)
     integrator.u = uprev .+ tmp
 
     if integrator.opts.adaptive
@@ -22,7 +22,7 @@ end
 @muladd function perform_step!(integrator, cache::TauLeapingCache)
     (; t, dt, uprev, u, W, p, P, c) = integrator
     (; tmp, newrate, EEstcache) = cache
-    c(tmp, uprev, p, t, P.dW, nothing)
+    leaping_change(c, tmp, uprev, p, t, P.dW, nothing)
     @.. u = uprev + tmp
 
     if integrator.opts.adaptive
@@ -46,7 +46,7 @@ end
 #
 # Implicit equation:
 #   X_{n+1} = X_n + ν*k + dt*(drift(X_{n+1}) - drift(X_n))
-# where k ~ Poisson(dt * a(X_n)) and drift(u) = ν*a(u) = c(u, p, t, rate(u, p, t), nothing)
+# where k ~ Poisson(dt * a(X_n)) and drift(u) = ν*a(u) = leaping_change(c, u, p, t, rate(u, p, t), nothing)
 #
 # Rearranged for nlsolver:
 #   X_{n+1} = tmp + z
@@ -70,9 +70,9 @@ end
 
     # Step 2: Compute explicit contributions
     # jump_contribution = ν*k
-    jump_contribution = c(uprev, p, t, poisson_counts, nothing)
+    jump_contribution = leaping_change(c, uprev, p, t, poisson_counts, nothing)
     # drift_at_uprev = ν*a(X_n)
-    drift_at_uprev = c(uprev, p, t, rate_at_uprev, nothing)
+    drift_at_uprev = leaping_change(c, uprev, p, t, rate_at_uprev, nothing)
 
     # Step 3: Set up nlsolver
     # tmp = X_n + ν*k - dt*drift(X_n)
@@ -111,10 +111,10 @@ end
     # Step 2: Compute explicit contributions
     # Use nlsolver.tmp for intermediate storage
     # First compute jump_contribution = ν*k into nlsolver.tmp
-    c(nlsolver.tmp, uprev, p, t, poisson_counts, nothing)
+    leaping_change(c, nlsolver.tmp, uprev, p, t, poisson_counts, nothing)
 
     # Compute drift at uprev: drift(X_n) = ν*a(X_n) into nlsolver.z (will be overwritten)
-    c(nlsolver.z, uprev, p, t, rate_at_uprev, nothing)
+    leaping_change(c, nlsolver.z, uprev, p, t, rate_at_uprev, nothing)
 
     # Step 3: Set up nlsolver
     # tmp = X_n + ν*k - dt*drift(X_n)
@@ -143,7 +143,7 @@ end
 #
 # Implicit equation:
 #   X_{n+1} = X_n + ν*k + θ*dt*(drift(X_{n+1}) - drift(X_n))
-# where k ~ Poisson(dt * a(X_n)) and drift(u) = ν*a(u) = c(u, p, t, rate(u, p, t), nothing)
+# where k ~ Poisson(dt * a(X_n)) and drift(u) = ν*a(u) = leaping_change(c, u, p, t, rate(u, p, t), nothing)
 #
 # Rearranged for nlsolver:
 #   X_{n+1} = tmp + θ*z
@@ -167,9 +167,9 @@ end
 
     # Step 2: Compute explicit contributions
     # jump_contribution = ν*k
-    jump_contribution = c(uprev, p, t, poisson_counts, nothing)
+    jump_contribution = leaping_change(c, uprev, p, t, poisson_counts, nothing)
     # drift_at_uprev = ν*a(X_n)
-    drift_at_uprev = c(uprev, p, t, rate_at_uprev, nothing)
+    drift_at_uprev = leaping_change(c, uprev, p, t, rate_at_uprev, nothing)
 
     # Step 3: Set up nlsolver
     # tmp = X_n + ν*k - θ*dt*drift(X_n)
@@ -208,10 +208,10 @@ end
     # Step 2: Compute explicit contributions
     # Use nlsolver.tmp for intermediate storage
     # First compute jump_contribution = ν*k into nlsolver.tmp
-    c(nlsolver.tmp, uprev, p, t, poisson_counts, nothing)
+    leaping_change(c, nlsolver.tmp, uprev, p, t, poisson_counts, nothing)
 
     # Compute drift at uprev: drift(X_n) = ν*a(X_n) into nlsolver.z (will be overwritten)
-    c(nlsolver.z, uprev, p, t, rate_at_uprev, nothing)
+    leaping_change(c, nlsolver.z, uprev, p, t, rate_at_uprev, nothing)
 
     # Step 3: Set up nlsolver
     # tmp = X_n + ν*k - θ*dt*drift(X_n)

--- a/lib/StochasticDiffEqLeaping/test/massaction.jl
+++ b/lib/StochasticDiffEqLeaping/test/massaction.jl
@@ -1,0 +1,113 @@
+using JumpProcesses, StochasticDiffEqLeaping, StochasticDiffEqCore, SciMLBase, Test, Random
+
+regular_leaping_algs = (
+    TauLeaping(), CaoTauLeaping(),
+    ImplicitTauLeaping(), ThetaTrapezoidalTauLeaping(),
+)
+
+@testset "Mass-action input for regular leaping solvers" begin
+    maj = MassActionJump(
+        [0.02, 0.1], [[1 => 2], [2 => 1]],
+        [[1 => -2, 2 => 1], [1 => 2, 2 => -1]]
+    )
+    prob = DiscreteProblem([40.0, 20.0], (0.0, 0.2))
+    function rate!(out, u, p, t)
+        out[1] = u[1] * max(u[1] - 1, 0) * 0.01
+        out[2] = 0.1 * u[2]
+        nothing
+    end
+    function change!(du, u, p, t, counts, mark)
+        du[1] = -2 * counts[1] + 2 * counts[2]
+        du[2] = counts[1] - counts[2]
+        nothing
+    end
+    rj = RegularJump(rate!, change!, 2)
+    for alg in regular_leaping_algs,
+            adaptive in (alg isa Union{TauLeaping, CaoTauLeaping} ? (false, true) : (false,))
+        @testset "$(nameof(typeof(alg))), adaptive=$adaptive" begin
+            actual = JumpProblem(prob, PureLeaping(), maj; rng = Xoshiro(123))
+            reference = JumpProblem(prob, PureLeaping(), rj; rng = Xoshiro(123))
+            opts = alg isa SimpleTauLeaping ? (; dt = 0.005, seed = 123) :
+                (; dt = 0.005, seed = 123, adaptive)
+            sol = solve(actual, alg; opts...)
+            ref = solve(reference, alg; opts...)
+            @test successful_retcode(sol)
+            @test actual.regular_jump === nothing
+            if !adaptive
+                @test sol.t == ref.t
+                @test sol.u == ref.u
+            end
+            @test all(u -> u[1] + 2u[2] ≈ 80, sol.u)
+        end
+    end
+end
+
+@testset "General regular rates remain supported" begin
+    rate!(out, u, p, t) = (out[1] = 100 * u[1] / (1 + u[1]))
+    function change!(du, u, p, t, counts, mark)
+        du[1] = -counts[1]
+        du[2] = counts[1]
+        nothing
+    end
+    jp = JumpProblem(
+        DiscreteProblem([100.0, 0.0], (0.0, 0.1)),
+        PureLeaping(), RegularJump(rate!, change!, 1)
+    )
+    for alg in regular_leaping_algs
+        opts = alg isa SimpleTauLeaping ? (; dt = 0.001, seed = 42) :
+            (; dt = 0.001, seed = 42, adaptive = false)
+        sol = solve(jp, alg; opts...)
+        @test successful_retcode(sol)
+        @test sol.u[end][2] > 0
+        @test all(u -> sum(u) ≈ 100, sol.u)
+    end
+end
+
+@testset "Native rates and implicit drift with zero populations" begin
+    maj = MassActionJump(
+        [2.0, 6.0], [Pair{Int, Int}[], [1 => 3]],
+        [[1 => 1], [1 => -3, 2 => 1]]
+    )
+    for iip in (true, false), alg in regular_leaping_algs
+        f = iip ? ((du, u, p, t) -> copyto!(du, u)) : ((u, p, t) -> u)
+        prob = DiscreteProblem{iip}(f, [5.0, 0.0], (0.0, 0.02))
+        jp = JumpProblem(prob, PureLeaping(), maj)
+        data = jump_noise_data(alg, jp, prob.u0, prob.p, 0.0)
+        @test data.c === jp.massaction_jump
+        @test data.rate_constants == [2.0, 1.0]
+        @test all(isfinite, data.rate_constants)
+        sol = solve(jp, alg; dt = 0.001, adaptive = false, seed = 123)
+        @test successful_retcode(sol)
+        @test all(u -> all(isfinite, u), sol.u)
+    end
+end
+
+@testset "Unsupported mixed jump representations" begin
+    maj = MassActionJump([0.1], [[1 => 1]], [[1 => -1]])
+    rj = RegularJump(
+        (out, u, p, t) -> (out[1] = u[1]),
+        (du, u, p, t, counts, mark) -> (du[1] = -counts[1]), 1
+    )
+    jp = JumpProblem(
+        DiscreteProblem([10.0], (0.0, 1.0)), PureLeaping(),
+        JumpSet(; massaction_jumps = maj, regular_jumps = rj)
+    )
+    for alg in regular_leaping_algs
+        @test_throws ArgumentError solve(jp, alg; dt = 0.01, adaptive = false)
+    end
+end
+
+@testset "Out-of-place general rates" begin
+    rate(u, p, t) = [100 * u[1] / (1 + u[1])]
+    change(u, p, t, counts, mark) = [-counts[1], counts[1]]
+    jp = JumpProblem(
+        DiscreteProblem([100.0, 0.0], (0.0, 0.1)), PureLeaping(),
+        RegularJump(rate, change, 1)
+    )
+    for alg in regular_leaping_algs
+        sol = solve(jp, alg; dt = 0.001, seed = 42, adaptive = false)
+        @test successful_retcode(sol)
+        @test sol.u[end][2] > 0
+        @test all(u -> sum(u) ≈ 100, sol.u)
+    end
+end

--- a/lib/StochasticDiffEqLeaping/test/massaction.jl
+++ b/lib/StochasticDiffEqLeaping/test/massaction.jl
@@ -111,3 +111,41 @@ end
         @test all(u -> sum(u) ≈ 100, sol.u)
     end
 end
+
+@testset "Exact mass-action jumps alongside regular leaps" begin
+    maj = MassActionJump([0.1], [[1 => 1]], [[1 => -1, 2 => 1]])
+    rate!(out, u, p, t) = (out[1] = 0.2 * u[1])
+    function change!(du, u, p, t, counts, mark)
+        du[1] = -counts[1]
+        du[2] = counts[1]
+    end
+    rj = RegularJump(rate!, change!, 1)
+    jp = JumpProblem(
+        DiscreteProblem([100.0, 0.0], (0.0, 0.05)), Direct(),
+        JumpSet(; massaction_jumps = maj, regular_jumps = rj)
+    )
+    for alg in regular_leaping_algs
+        data = jump_noise_data(alg, jp, jp.prob.u0, jp.prob.p, 0.0)
+        @test data.c === rj.c
+        sol = solve(jp, alg; dt = 0.001, adaptive = false, seed = 123)
+        @test successful_retcode(sol)
+        @test all(u -> sum(u) ≈ 100, sol.u)
+    end
+end
+
+@testset "Integer constants with fractional propensities" begin
+    maj = MassActionJump(
+        [2, 6], [Pair{Int, Int}[], [1 => 3]],
+        [[1 => 1], [1 => -3, 2 => 1]]
+    )
+    jp = JumpProblem(DiscreteProblem([5.5, 0.0], (0.0, 0.01)), PureLeaping(), maj)
+    for alg in regular_leaping_algs
+        data = jump_noise_data(alg, jp, jp.prob.u0, jp.prob.p, 0.0)
+        @test eltype(data.jump_prototype) <: AbstractFloat
+        rates = similar(data.jump_prototype)
+        data.rate(rates, jp.prob.u0, jp.prob.p, 0.0)
+        @test rates == [2.0, 86.625]
+        sol = solve(jp, alg; dt = 0.0001, adaptive = false, seed = 123)
+        @test successful_retcode(sol)
+    end
+end

--- a/lib/StochasticDiffEqLeaping/test/runtests.jl
+++ b/lib/StochasticDiffEqLeaping/test/runtests.jl
@@ -8,6 +8,7 @@ function activate_qa_env()
 end
 
 if TEST_GROUP == "ALL" || TEST_GROUP == "Core"
+    @time @safetestset "Native mass-action leaping" include("massaction.jl")
     @time @safetestset "Module loads and constructors" begin
         using StochasticDiffEqLeaping
         using Test


### PR DESCRIPTION
Tau-leaping solvers currently require `RegularJump` callbacks and estimate rate scales by evaluating at `u ./ u`. Add native `MassActionJump` support to `TauLeaping`, `CaoTauLeaping`, `ImplicitTauLeaping`, and `ThetaTrapezoidalTauLeaping`: retain stoichiometry, read stored constants directly, and fuse drift evaluation during implicit iteration.

The new public `StochasticDiffEqCore.jump_noise_data` hook lets each solver choose its reaction representation. General in-place/out-of-place regular jumps and exact SSA callbacks remain supported. Integer rate constants use floating propensity buffers. Documentation covers the native input and corrects the incomplete adaptive Cao selector; no GPU implementation is added.

Depends on the public mass-action operations and **JumpProcesses 9.33** from https://github.com/SciML/JumpProcesses.jl/pull/652 . Registry-only CI cannot resolve that version until it is released. Core advances to 2.3 and Leaping to 2.2 for the new public API and input support. The new documentation dependency, JumpProcesses, is MIT licensed, like this repository.

## Verification

Julia 1.12.6, with the JumpProcesses prerequisite and monorepo dependencies developed locally. Ran the existing test entry points; `Pkg.test` hit a local relative-`[sources]` resolution error before launching tests.

```sh
GROUP=Core /home/crackauc/.juliaup/bin/julia +1.12.6 --project=native-validation OrdinaryDiffEq.jl/lib/StochasticDiffEqLeaping/test/runtests.jl
GROUP=Core /home/crackauc/.juliaup/bin/julia +1.12.6 --project=native-validation OrdinaryDiffEq.jl/lib/StochasticDiffEqCore/test/runtests.jl
/home/crackauc/.juliaup/bin/julia +1.12.6 --project=native-validation OrdinaryDiffEq.jl/lib/StochasticDiffEqLeaping/test/qa/qa.jl
/home/crackauc/.juliaup/bin/julia +1.12.6 --project=native-validation OrdinaryDiffEq.jl/lib/StochasticDiffEqCore/test/qa/qa.jl
/home/crackauc/.juliaup/bin/julia +1.12.6 --project=OrdinaryDiffEq.jl/docs OrdinaryDiffEq.jl/docs/make.jl
```

```text
Native mass-action leaping     | 118  118
Module loads and constructors |   5    5
Module loads and types        |  13   13
Quality Assurance (Leaping)   |  21   21
Quality Assurance (Core)      |  21   21
[ Info: HTMLWriter: rendering HTML pages.
[ Info: Automatic `version="7.8.1"` for inventory from ../Project.toml
```

Both QA suites used their declared-compatible JET 0.11.6. Aqua's Leaping subprocess used a temporary local JumpProcesses source entry to resolve the unreleased prerequisite; it was restored before committing. Runic on changed lines, `typos` over changed files, and `git diff --check` passed. Actual GPU execution and other stochastic algorithm groups were not run.

Discriminating tests caught two errors in the initial implementation (https://github.com/SciML/OrdinaryDiffEq.jl/commit/667d58e49ae82b1f83cb227a1b62dbb61bb5111f):

```text
Exact mass-action jumps alongside regular leaps: Error During Test
ArgumentError: Mass-action leaping requires a DiscreteProblem with PureLeaping()

Test Failed: eltype(data.jump_prototype) <: AbstractFloat
Evaluated: Int64 <: AbstractFloat
```

The same cases now pass in the 118-check mass-action set, including fixed-seed trajectory equality, higher-order rates with zero populations, mixed exact/regular jumps, and fractional propensities with integer constants.

## Measurements

The committed `lib/StochasticDiffEqLeaping/benchmark/massaction.jl` compares native input with a data-backed `RegularJump` adapter using the same mass-action operations. The model is a first-order reaction ring, fixed `dt=0.01`, time span `(0,1)`, seed 123. Table entries are medians from three fresh processes per case; each process measures nine warmed-up solves on a shared machine.

| Method | Reactions | Compilation: adapter → native (s) | Warm solve: adapter → native (μs) | Allocations: adapter → native (bytes) |
|---|---:|---:|---:|---:|
| explicit | 10 | 3.621 → 3.007 | 53.7 → 56.9 | 6832 → 7056 |
| explicit | 1000 | 3.415 → 2.917 | 2492.7 → 2597.7 | 157592 → 149824 |
| implicit | 10 | 3.555 → 3.354 | 121.8 → 116.1 | 8192 → 8448 |
| implicit | 1000 | 3.917 → 3.226 | 7078.3 → 6776.6 | 206392 → 198784 |

Compilation and large-model allocation costs decreased in these cases. Warm runtime differences changed sign between repeated runs, so these measurements do not establish a general throughput improvement. Small-model allocation costs increased slightly.

## CI status

The documentation, downgrade, and inspected downstream jobs fail dependency resolution because the registry currently ends at JumpProcesses 9.32.3 while this change requires 9.33. The documentation log is https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/34685462635/job/103531578714 .

Runic and spelling also found unchanged master errors in BDF and DiffEqBase tests. Their separately validated mechanical correction is https://github.com/SciML/OrdinaryDiffEq.jl/pull/4524 . These failures are not suppressed in this branch.

Ignore this PR until reviewed by @ChrisRackauckas.

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra; local session ID: 01a070e6-21f2-7dd3-bf52-2ddaf108ac53).
