### PR TITLE
Fix baseline spelling and whitespace checks in tests

### DIFF
--- a/lib/DiffEqBase/test/modelingtoolkit/events.jl
+++ b/lib/DiffEqBase/test/modelingtoolkit/events.jl
@@ -1,7 +1,7 @@
 using ModelingToolkit, OrdinaryDiffEq, Test
 using ModelingToolkit: t_nounits as t, D_nounits as D, SymbolicContinuousCallback
 
-@testset "All simultaenous events are saved" begin
+@testset "All simultaneous events are saved" begin
     # https://github.com/SciML/ModelingToolkit.jl/issues/4870 Case 2
     @variables x(t) = 0.0
     c_up = only(@discretes c_up(t) = 0.0)

--- a/lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl
@@ -242,7 +242,7 @@ end
         @test c.order == 2
     end
 end
-  
+
 # Regression test for the backward-in-time step rejection path: for tdir < 0
 # (e.g. adjoint solves), `bdf_step_reject_controller!` must still shrink |dt|.
 # Previously `min(h, hₖ₋₁)`/`hₖ₋₁ > hₖ` compared signed (negative) step sizes,


### PR DESCRIPTION
Correct `simultaenous` to `simultaneous` in a DiffEqBase event test label and remove trailing whitespace from a blank line in the BDF regression tests. These existing spelling and formatting errors fail repository checks. No test assertions or solver code change.

The typo was introduced by https://github.com/SciML/OrdinaryDiffEq.jl/commit/7b0f4ae8bbbc2036e5f68e3426d4f491bffeeec0.

The whitespace was introduced by https://github.com/SciML/OrdinaryDiffEq.jl/commit/5cc92dd99592820104a0565f95ab2e09ca9b9ab6.

Verification on clean master `5cc92dd99592820104a0565f95ab2e09ca9b9ab6`:
```text
Before: typos lib/DiffEqBase/test/modelingtoolkit/events.jl
error: `simultaenous` should be `simultaneous`
exit 2

After: same command
exit 0

typos                          # whole repository: exit 0
julia +1.12.6 --project=/home/crackauc/.julia/environments/v1.12 -m Runic --check --lines=4:4 lib/DiffEqBase/test/modelingtoolkit/events.jl
                               # exit 0
Before: Runic --check lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl
exit 1
After: same command
exit 0

julia +1.12.6 --project=mechanical-runic-env -m Runic --check --verbose .
                               # Runic 1.10.0, all 1128 files pass, exit 0
git diff --check               # exit 0
```

Solver tests, QA, and documentation builds were not rerun for these mechanical test-file corrections.

Please ignore this PR until reviewed by @ChrisRackauckas.

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra; local session ID: 01a070e6-21f2-7dd3-bf52-2ddaf108ac53).
