### PR TITLE
Require OrdinaryDiffEqCore 4.17.1 where its new internals are used

### DIFF
--- a/lib/OrdinaryDiffEqDefault/Project.toml
+++ b/lib/OrdinaryDiffEqDefault/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqDefault"
 uuid = "50262376-6c5a-4cf5-baba-aaf4f84d72d7"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.6.1"
+version = "2.6.2"
 
 [deps]
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
@@ -47,7 +47,7 @@ PrecompileTools = "1.2.1, 1.3"
 EnumX = "1.0.4"
 LinearAlgebra = "1.10"
 SciMLBase = "3.46"
-OrdinaryDiffEqCore = "4.11"
+OrdinaryDiffEqCore = "4.17.1"
 SparseArrays = "1.10"
 Preferences = "1.5.0"
 StaticArrays = "1.9.18"

--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFIRK"
 uuid = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.8.5"
+version = "2.8.6"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
@@ -50,7 +50,7 @@ LinearSolve = "5.12"
 LinearAlgebra = "1.10"
 OrdinaryDiffEqDifferentiation = "3.11"
 SciMLBase = "3.39"
-OrdinaryDiffEqCore = "4.15.1"
+OrdinaryDiffEqCore = "4.17.1"
 GenericSchur = "0.5"
 julia = "1.10"
 ADTypes = "1.22.0"

--- a/lib/OrdinaryDiffEqRosenbrock/Project.toml
+++ b/lib/OrdinaryDiffEqRosenbrock/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqRosenbrock"
 uuid = "43230ef6-c299-4910-a778-202eb28ce4ce"
-version = "2.7.2"
+version = "2.7.3"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
 
 [deps]
@@ -48,7 +48,7 @@ LinearSolve = "5.1"
 MacroTools = "0.5.6"
 MuladdMacro = "0.2.4"
 ODEProblemLibrary = "1"
-OrdinaryDiffEqCore = "4.11"
+OrdinaryDiffEqCore = "4.17.1"
 OrdinaryDiffEqDifferentiation = "3.3"
 OrdinaryDiffEqNonlinearSolve = "2"
 OrdinaryDiffEqRosenbrockTableaus = "2.1"

--- a/lib/StochasticDiffEqCore/Project.toml
+++ b/lib/StochasticDiffEqCore/Project.toml
@@ -1,6 +1,6 @@
 name = "StochasticDiffEqCore"
 uuid = "19c5a474-6cd1-4a5f-be79-46dc34e54d7f"
-version = "2.2.2"
+version = "2.2.3"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -49,7 +49,7 @@ JumpProcesses = "9.26.0"
 LinearAlgebra = "1.10"
 Logging = "1.10"
 MuladdMacro = "0.2.4"
-OrdinaryDiffEqCore = "4"
+OrdinaryDiffEqCore = "4.17.1"
 Pkg = "1"
 Random = "<0.0.1, 1"
 RecursiveArrayTools = "4.2.0"


### PR DESCRIPTION
Fixes a load failure in the currently-published releases:

```
WARNING: Imported binding OrdinaryDiffEqCore._is_identity_massmatrix was undeclared
at import time during import to OrdinaryDiffEqDefault.
ERROR: LoadError: UndefVarError: `_is_identity_massmatrix` not defined in `OrdinaryDiffEqDefault`
```

## Cause

#4502 added `_is_identity_massmatrix`, `_is_zero_massmatrix` and `_diff_alg_vars` to OrdinaryDiffEqCore's internal surface and began using them from four sublibraries in the same commit. Those sublibraries were then released **without raising their OrdinaryDiffEqCore floor**, so the resolver is free to pair a new sublibrary with an old Core that does not define the symbols. The three names first exist in OrdinaryDiffEqCore **4.17.1**.

| package | released | old floor | internal used |
|---|---|---|---|
| `OrdinaryDiffEqDefault` | 2.6.1 | `4.11` | `_is_identity_massmatrix` |
| `OrdinaryDiffEqFIRK` | 2.8.5 | `4.15.1` | `_is_identity_massmatrix` |
| `OrdinaryDiffEqRosenbrock` | 2.7.2 | `4.11` | `_diff_alg_vars` |
| `StochasticDiffEqCore` | 2.2.2 | `4` | `_is_identity_massmatrix` |

`_is_zero_massmatrix` is used only inside Core itself, so it needs no bound.

## This PR

Raises all four floors to `OrdinaryDiffEqCore = "4.17.1"` and gives each a patch bump: 2.6.2, 2.8.6, 2.7.3, 2.2.3. Raising a compat floor is non-breaking.

Only `Project.toml` files change; no source is touched.

## Still needed after this

The four versions in the table above remain broken for anyone who resolves them. Fixing those requires a **retroactive `Compat.toml` edit in the General registry**, which is a separate pull request there and needs a registry maintainer. This PR only makes the *next* releases correct.

## Verification

Each of the four `Project.toml` files was re-parsed with `TOML.parsefile` after editing, confirming it is valid and that the `[deps]` UUID entry is intact and only the `[compat]` entry moved. No test suite was run; no code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R