### PR TITLE
Say why the linear path ignores new_W_dt_cutoff

### DIFF
--- a/lib/OrdinaryDiffEqDifferentiation/Project.toml
+++ b/lib/OrdinaryDiffEqDifferentiation/Project.toml
@@ -1,5 +1,5 @@
 name = "OrdinaryDiffEqDifferentiation"
-version = "3.11.5"
+version = "3.11.6"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
 

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -543,17 +543,13 @@ function do_newJW(integrator, alg, nlsolver, repeat_step)::NTuple{2, Bool}
     repeat_step && return false, false
     islin, _ = islinearfunction(integrator)
     if islin
-        # J is constant for a linear function, but W = J - M/(γdt) still depends
-        # on γdt: W must be rebuilt/refactorized when the step size has drifted
-        # past the cutoff, otherwise concrete-A linear solvers keep a stale
-        # factorization from the first step's (possibly tiny) dt.
+        # J is constant for a linear function, so rebuilding W = J - M/(γdt) is a
+        # refactorization with no Jacobian evaluation and there is nothing for
+        # `new_W_dt_cutoff` to amortize; a stale W only costs Newton iterations.
         isnewton(nlsolver) || return false, true
         W_iγdt = inv(nlsolver.cache.W_γdt)
         iγdt = inv(nlsolver.γ * integrator.dt)
-        cutoff = integrator.opts.adaptive && !_uses_split_W(alg, integrator.f) ?
-            get_new_W_γdt_cutoff(nlsolver) : zero(get_new_W_γdt_cutoff(nlsolver))
-        smallstepchange = abs(iγdt / W_iγdt - 1) <= cutoff
-        return false, !smallstepchange
+        return false, iγdt != W_iγdt
     end
     !integrator.opts.adaptive && return true, true # Not adaptive will always refactorize
     errorfail = OrdinaryDiffEqCore.get_EEst(integrator) > one(OrdinaryDiffEqCore.get_EEst(integrator))

--- a/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
@@ -543,9 +543,11 @@ function do_newJW(integrator, alg, nlsolver, repeat_step)::NTuple{2, Bool}
     repeat_step && return false, false
     islin, _ = islinearfunction(integrator)
     if islin
-        # J is constant for a linear function, so rebuilding W = J - M/(γdt) is a
-        # refactorization with no Jacobian evaluation and there is nothing for
-        # `new_W_dt_cutoff` to amortize; a stale W only costs Newton iterations.
+        # J never changes for a linear function, so W = J - M/(γdt) has to track γdt and
+        # the rebuild is cheap: LHL, which `defaultalg` picks for this split W, absorbs a
+        # new γdt by re-shifting the Hessenberg form in O(n²) and leaves the reduction
+        # alone. Nothing is left for `new_W_dt_cutoff` to amortize (a pinned factorization
+        # pays its O(n³) instead).
         isnewton(nlsolver) || return false, true
         W_iγdt = inv(nlsolver.cache.W_γdt)
         iγdt = inv(nlsolver.γ * integrator.dt)

--- a/lib/OrdinaryDiffEqDifferentiation/test/stale_w_linear_operator_tests.jl
+++ b/lib/OrdinaryDiffEqDifferentiation/test/stale_w_linear_operator_tests.jl
@@ -92,3 +92,19 @@ end
     end
     @test integ.u == integ_exact.u
 end
+
+@testset "adaptive linear W takes every γdt change (#4370)" begin
+    A = [-20.0 1.0; 1.0 -20.0]
+    u0 = [1.0, 0.5]
+    prob = ODEProblem(ODEFunction(MatrixOperator(A)), u0, (0.0, 1.0))
+    solve_with(cutoff) = solve(
+        prob, SDIRK2(nlsolve = NLNewton(new_W_dt_cutoff = cutoff));
+        abstol = 1.0e-8, reltol = 1.0e-8
+    )
+
+    loose = solve_with(0.2)
+    exact = solve_with(0.0)
+    @test loose.u[end] == exact.u[end]
+    @test loose.stats.nw == exact.stats.nw
+    @test loose.stats.nnonliniter == exact.stats.nnonliniter
+end


### PR DESCRIPTION
Stacks on #4470 — please ignore until reviewed by @ChrisRackauckas.

This branch is #4470 rebased onto current master, plus one commit. Review only
the second commit (`Say why the linear path ignores new_W_dt_cutoff`); the
first is #4470 unchanged. If #4470 merges first, this rebases down to the
comment and the version bump.

## What changed and why

#4470 justifies taking every γdt change on the `islin` branch of `do_newJW`
with:

> rebuilding `W = J - M/(γdt)` is a refactorization with no Jacobian evaluation
> and there is nothing for `new_W_dt_cutoff` to amortize

That is backwards. The refactorization is exactly what `new_W_dt_cutoff`
amortizes — its docstring is "relative change in `γΔt` above which `W` is
refactorized", not anything about Jacobian evaluations.

The real reason the cutoff is not worth taking on this path is the linear
solver: `defaultalg` answers `LHLFactorization` for a split `WOperator`, and
LHL absorbs a new γdt by re-shifting the Hessenberg form in O(n²) while the
O(n³) reduction stays put — cheap precisely because `J` never moves on a linear
function. The comment now says that, with the O(n³) case a reader hits by
pinning a factorization noted in parentheses.

No behavior change: comment text plus a version bump.

## Verification

The claim in the new comment, checked at runtime rather than read off the
source (I first read a stale copy of `default.jl` and got this wrong):

```
sparse N=800:  CHOICE = LHLFactorization | W.J = MatrixOperator{Float64, SparseMatrixCSC{Float64, Int64}, …} | lhl_defaultable = true
dense  N=1000: CHOICE = LHLFactorization | W.J = MatrixOperator{Float64, Matrix{Float64}, …} | lhl_defaultable = true
```

for `ODEProblem(ODEFunction(MatrixOperator(A)), u0, tspan)` under `SDIRK2`,
reading `integrator.cache.nlsolver.cache.linsolve.alg.alg` after two steps.

```
$ julia --project=@runic -m Runic --check --diff lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl
(no output, exit 0)
$ typos lib/OrdinaryDiffEqDifferentiation/src/derivative_utils.jl lib/OrdinaryDiffEqDifferentiation/Project.toml
(no output, exit 0)
```

## Version bump

3.11.5 → 3.11.6. #4470 bumps to 3.11.5, which master has since released, so
that bump collides as-is.

## What I did not verify

No failing-before/passing-after evidence, because there is no behavior change
to discriminate — the only executable change is the `version` string. The
`OrdinaryDiffEqDifferentiation` suite is running locally and I will post the
result; #4470's own CI is 184/184 green on the identical code. I did not run
QA, the docs build (no docstrings touched), GPU, or downstream.

## Worth pushing back on

The parenthetical about a pinned factorization paying O(n³) is mine, not
#4470's reasoning — drop it if you think it invites the wrong question. That
case is real (measured `nw` 49 → 602 on a dense N=300 `LUFactorization()` run)
but it is not the default path.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_01D1XiWgJ1PJFDLAWTM1583M
