### PR TITLE
Fix QNDF/QBDF accept-path step and order selection for backward solves

### DIFF
--- a/lib/OrdinaryDiffEqBDF/Project.toml
+++ b/lib/OrdinaryDiffEqBDF/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqBDF"
 uuid = "6ad6398a-0878-4a85-9266-38940aa047c8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.4.8"
+version = "2.4.9"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqBDF/src/controllers.jl
+++ b/lib/OrdinaryDiffEqBDF/src/controllers.jl
@@ -96,7 +96,10 @@ function step_accept_controller!(integrator, cache::Union{QNDFCache, QNDFConstan
         est = OrdinaryDiffEqCore.get_EEst(integrator)
         estₖ₋₁ = cache.EEst1
         estₖ₊₁ = cache.EEst2
-        h = integrator.dt
+        # Work on |dt|: the candidate step sizes below are ranked with `>` and a
+        # `0` sentinel marks "this order is not viable".  With a signed dt the
+        # sentinel wins every comparison when tdir < 0.
+        h = abs(integrator.dt)
         k = cache.order
         prefer_const_step = cache.nconsteps < cache.order + 2
         zₛ = get_gamma(integrator)
@@ -152,15 +155,16 @@ function step_accept_controller!(integrator, cache::Union{QNDFCache, QNDFConstan
             end
         end
         cache.order = kₙ
-        q = integrator.dt / hₙ
+        q = h / hₙ
 
-        if prefer_const_step && 0.6 < q < 1.2
+        hnew = if prefer_const_step && 0.6 < q < 1.2
             h
         elseif q <= get_qsteady_max(integrator) && q >= get_qsteady_min(integrator)
             h
         else
             h / q
         end
+        integrator.tdir * hnew
     end
     if is_disco
         return min((integrator.disco_checkpoint - integrator.t) / 4, new_dt)

--- a/lib/OrdinaryDiffEqBDF/test/bdf_time_reversal_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/bdf_time_reversal_tests.jl
@@ -1,0 +1,69 @@
+using OrdinaryDiffEqBDF, OrdinaryDiffEqCore, Test
+using LinearAlgebra: mul!
+
+# An ODE integrated forwards and its time-mirrored counterpart integrated
+# backwards are the same problem, so an adaptive solver must take the same steps
+# either way.  With a tspan symmetric about zero the mirror map `t -> -t` is
+# exact in IEEE arithmetic and round-to-nearest is symmetric under negation, so
+# every stage value, error estimate and Newton iterate mirrors *bitwise*: the
+# `|dt|` sequences must agree to the last bit, not merely approximately.
+#
+# `step_accept_controller!` for QNDF/QBDF ranked the order-(k-1)/k/(k+1)
+# candidate step sizes with `>` against a `0.0` sentinel meaning "this order is
+# not viable", using the signed `integrator.dt`.  For a backward solve every
+# candidate is negative, so the sentinel won every comparison: the order was
+# driven to `max_order` immediately and `|dt|` never grew.  On `u' = 1.01u` that
+# was 43 forward steps against 1075 backward.
+
+"""Accepted `|dt|` sequence of `prob` under `alg`."""
+function accepted_dts(prob, alg; kwargs...)
+    integ = init(prob, alg; save_everystep = false, kwargs...)
+    return [abs(Float64(integ.dt)) for _ in integ]
+end
+
+"""Forward and mirrored-backward `|dt|` sequences on tspan `(-T, T)`."""
+function reversal_dts(f, f!, u0, p, T, alg; inplace = false, kwargs...)
+    if inplace
+        fwd = ODEProblem(f!, copy(u0), (-T, T), p)
+        g! = (du, u, q, t) -> (f!(du, u, q, -t); du .= .-du; nothing)
+        bwd = ODEProblem(g!, copy(u0), (T, -T), p)
+    else
+        fwd = ODEProblem(f, copy(u0), (-T, T), p)
+        g = (u, q, t) -> -f(u, q, -t)
+        bwd = ODEProblem(g, copy(u0), (T, -T), p)
+    end
+    return accepted_dts(fwd, alg; kwargs...), accepted_dts(bwd, alg; kwargs...)
+end
+
+lin(u, p, t) = p[1] .* u
+lin!(du, u, p, t) = (du .= p[1] .* u; nothing)
+
+const STIFFA = [-2000.0 1.0 0.0; 1.0 -3.0 1.0; 0.0 1.0 -0.5]
+sys(u, p, t) = STIFFA * u
+sys!(du, u, p, t) = (mul!(du, STIFFA, u); nothing)
+
+const CASES = (
+    ("linear", lin, lin!, [0.5], [1.01], 0.5),
+    ("stiff linear system", sys, sys!, [1.0, 1.0, 1.0], [nothing], 1.0),
+)
+
+@testset "BDF time-reversal symmetry" begin
+    # QBDF/QBDF2 are aliases of QNDF/QNDF2, so label the algorithms explicitly
+    # rather than by type name.
+    algs = (
+        "QNDF" => QNDF(), "QNDF2" => QNDF2(),
+        "QBDF" => QBDF(), "QBDF2" => QBDF2(), "FBDF" => FBDF(),
+    )
+    for (algname, alg) in algs,
+            (name, f, f!, u0, p, T) in CASES,
+            inplace in (false, true)
+
+        fdts, bdts = reversal_dts(
+            f, f!, u0, p, T, alg;
+            inplace, abstol = 1.0e-8, reltol = 1.0e-8
+        )
+        @testset "$algname $name $(inplace ? "iip" : "oop")" begin
+            @test fdts == bdts
+        end
+    end
+end

--- a/lib/OrdinaryDiffEqBDF/test/runtests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/runtests.jl
@@ -31,6 +31,7 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "BDF Inference Tests" include("inference_tests.jl")
     @time @safetestset "BDF Convergence Tests" include("bdf_convergence_tests.jl")
     @time @safetestset "BDF Regression Tests" include("bdf_regression_tests.jl")
+    @time @safetestset "BDF Time Reversal Tests" include("bdf_time_reversal_tests.jl")
     @time @safetestset "FBDF Time Filter Tests" include("fbdf_time_filter_tests.jl")
     @time @safetestset "FBDF Filter Regression Tests" include("fbdf_filter_regression_tests.jl")
     @time @safetestset "Nordsieck BDF Tests" include("nordsieck_tests.jl")


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.** Draft.

## What changed and why

`step_accept_controller!` for `QNDF`/`QBDF` ranks the order-(k−1)/k/(k+1) candidate step sizes with `>`, against a `0.0` sentinel that means "this order is not viable" — but it did so on the **signed** `integrator.dt`. For a backward solve (`tdir < 0`) every candidate is negative, so `0.0` wins every comparison: the order is pushed to `max_order` on the first few steps and `|dt|` never grows.

This is the accept-path counterpart of the reject-path bug fixed in #4519, whose Notes section flagged exactly these two comparisons (`hₖ₋₁ > hₖ`, `hₖ₊₁ > hₙ`) as follow-up.

The fix selects on magnitudes and restores the direction when returning the proposed step.

## How it shows up

`u' = 1.01u`, `u0 = [0.5]`, on `(-0.5, 0.5)` forward versus the mirrored problem `g(u,p,t) = -f(u,p,-t)` on `(0.5, -0.5)` — the same trajectory traversed the other way. Order and step size per accepted step, on master:

```
step |  fwd |dt|          order |  bwd |dt|          order
   1 | 2.9408881482e-10     1   | 2.9408881482e-10     2
   4 | 2.9408881482e-07     1   | 3.4825622487e-09     5
  13 | 1.4334531260e-03     3   | 1.1401087663e-08     4
  25 | 2.0014541459e-02     4   | 3.6551043414e-08     5
```

Total accepted steps, master (forward / backward):

| problem | QNDF | QBDF |
|---|---|---|
| `u' = 1.01u` | 43 / 1075 | 51 / 1762 |
| Lotka–Volterra | 663 / 31205 | 667 / 53615 |
| Van der Pol μ=5 | 902 / 39006 | 909 / 122181 |

With `PIDController` on Robertson the backward run hits the 200 000-step cap.

## Verification

New file `lib/OrdinaryDiffEqBDF/test/bdf_time_reversal_tests.jl`, registered in `runtests.jl`. It uses a tspan symmetric about zero, where the mirror map `t -> -t` is exact in IEEE arithmetic and round-to-nearest is symmetric under negation, so the two solves must agree **bitwise** — the test asserts `abs.(dt_fwd) == abs.(dt_bwd)`, not `≈`.

Failing on master (fix reverted, `git stash push -- lib/OrdinaryDiffEqBDF/src/controllers.jl`):

```
Test Summary:                   | Pass  Fail  Total     Time
BDF time-reversal symmetry      |   12     8     20  1m02.3s
  QNDF linear oop               |          1      1     1.5s
  QNDF linear iip               |          1      1     0.0s
  QNDF stiff linear system oop  |          1      1     0.0s
  QNDF stiff linear system iip  |          1      1     0.0s
  QNDF2 linear oop              |    1            1     0.0s
  ...
  FBDF linear oop               |    1            1     0.0s
```

Passing with the fix:

```
Test Summary:              | Pass  Total   Time
BDF time-reversal symmetry |   20     20  59.4s
```

`FBDF` passes either way — #4519 already covers its reject path; it is included as a guard.

Full package suite on this branch (`Pkg.test("OrdinaryDiffEqBDF")`, Julia 1.10.11):

```
Some tests did not pass: 0 passed, 4 failed, 0 errored, 18 broken.
  FBDF step!(save_everystep=false) Runtime Allocation Check   (x3)
  DFBDF step!(save_everystep=false) Runtime Allocation Check  (x1)
```

Every functional testset passes. Those 4 are pre-existing `AllocCheck` failures in FBDF/DFBDF `perform_step!`, which this diff does not touch — I reproduced the identical 4 with only `lib/OrdinaryDiffEqBDF/src/controllers.jl` reverted.

## What I did **not** verify

- GPU and Downstream groups.
- Julia `pre`.
- Whether the new `|dt|` sequences are *better* for real backward workloads — the claim here is only that forward and backward now agree, which they demonstrably did not.

## Worth pushing back on

- `new_dt` is now returned as `integrator.tdir * hnew` rather than a signed `h/q`. `calc_dt_propose!` takes `abs` of it anyway, so the sign only matters for the `is_disco_step` branch, which still does `min((disco_checkpoint - t)/4, new_dt)` — that `min` on two negatives is itself direction-unsafe, but discontinuity detection is off by default and I left it alone to keep this diff minimal.
- `QNDF1`/`QBDF1` are unaffected (`max_order = 1`, so neither branch runs) and are not in the test matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m], harness: Claude Code 2.1.269)

https://claude.ai/code/session_01JQATpLKMyYX3VbPPX8qdeE
