### PR TITLE
Apply the dtmin floor to backward-in-time solves in fix_dt_at_bounds!

### DIFF
--- a/lib/OrdinaryDiffEqCore/Project.toml
+++ b/lib/OrdinaryDiffEqCore/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqCore"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "4.17.1"
+version = "4.17.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
+++ b/lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl
@@ -1249,11 +1249,11 @@ function fix_dt_at_bounds!(integrator)
     else
         integrator.dt = max(integrator.opts.dtmax, integrator.dt)
     end
-    dtmin = timedepentdtmin(integrator)
+    dtmin = timedepentdtmin(integrator)  # always positive
     if integrator.tdir > 0
         integrator.dt = max(integrator.dt, dtmin)
     else
-        integrator.dt = min(integrator.dt, dtmin)
+        integrator.dt = min(integrator.dt, -dtmin)
     end
     return nothing
 end

--- a/lib/OrdinaryDiffEqCore/test/dtmin_direction_tests.jl
+++ b/lib/OrdinaryDiffEqCore/test/dtmin_direction_tests.jl
@@ -1,0 +1,40 @@
+using OrdinaryDiffEqCore, OrdinaryDiffEqTsit5, Test
+using OrdinaryDiffEqCore: fix_dt_at_bounds!
+using OrdinaryDiffEqCore.DiffEqBase: timedepentdtmin
+
+# `fix_dt_at_bounds!` clamps |dt| into [dtmin, dtmax]. `timedepentdtmin` returns a
+# positive magnitude, so the lower clamp for a backward solve has to compare
+# against `-dtmin`; `min(integrator.dt, dtmin)` is a no-op whenever dt < 0 < dtmin,
+# which silently removed the floor for every tdir < 0 solve.
+
+@testset "dtmin direction handling" begin
+@testset "dtmin floor applies in both directions" begin
+    for (t0, t1) in ((0.0, 1.0), (1.0, 0.0))
+        prob = ODEProblem((u, p, t) -> -u, 1.0, (t0, t1))
+        integ = init(prob, Tsit5(); dtmin = 1.0e-3, force_dtmin = true)
+        dtmin = timedepentdtmin(integ)
+        integ.dt = integ.tdir * dtmin / 100 # far below the floor
+        fix_dt_at_bounds!(integ)
+        @test abs(integ.dt) >= dtmin
+        @test signbit(integ.dt) == signbit(integ.tdir)
+    end
+end
+
+# End-to-end consequence: on a tspan symmetric about zero the mirrored problem
+# `g(u, p, t) = -f(u, p, -t)` traverses the same trajectory backwards, and because
+# IEEE negation and round-to-nearest are sign-symmetric the two solves agree
+# bitwise. A floor applied in only one direction breaks that.
+@testset "time-reversal symmetry at the dtmin floor" begin
+    f = (u, p, t) -> -50.0 * u
+    g = (u, p, t) -> 50.0 * u # -f(u, p, -t) for this autonomous f
+    kw = (
+        abstol = 1.0e-12, reltol = 1.0e-12, dtmin = 1.0e-2,
+        force_dtmin = true, save_everystep = false,
+    )
+    dts(prob) = (i = init(prob, Tsit5(); kw...); [abs(Float64(i.dt)) for _ in i])
+    fwd = dts(ODEProblem(f, 1.0, (-1.0, 1.0)))
+    bwd = dts(ODEProblem(g, 1.0, (1.0, -1.0)))
+    @test !isempty(fwd)
+    @test fwd == bwd
+end
+end

--- a/lib/OrdinaryDiffEqCore/test/runtests.jl
+++ b/lib/OrdinaryDiffEqCore/test/runtests.jl
@@ -46,6 +46,7 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "Algebraic Vars Detection" include("algebraic_vars_detection_tests.jl")
     @time @safetestset "Interpolation Search Hint" include("interpolation_hint_tests.jl")
     @time @safetestset "Bool Equal Coercion" include("bool_equal_tests.jl")
+    @time @safetestset "dtmin Direction" include("dtmin_direction_tests.jl")
     @time @safetestset "Instability Diagnostics" include("instability_diagnostics_tests.jl")
     @time @safetestset "Enzyme Interpolation" include("enzyme_interpolation_tests.jl")
 end


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.** Draft.

## What changed and why

`fix_dt_at_bounds!` clamps `|dt|` into `[dtmin, dtmax]`. `timedepentdtmin` returns a **positive magnitude** (`abs(max(eps(t), dtmin))`), so the lower clamp for `tdir < 0` has to compare against `-dtmin`:

```julia
    if integrator.tdir > 0
        integrator.dt = max(integrator.dt, dtmin)
    else
-       integrator.dt = min(integrator.dt, dtmin)
+       integrator.dt = min(integrator.dt, -dtmin)
    end
```

`min(dt, dtmin)` with `dt < 0 < dtmin` always returns `dt`, so the floor was silently absent from every backward-in-time solve. #4519 flagged this as follow-up.

## How it shows up

Wherever a solve collapses toward the floor, the forward run stops shrinking at `eps(t)` and the backward run does not. Solving `u' = f(u)` forward on a tspan symmetric about zero against the mirrored problem `g(u,p,t) = -f(u,p,-t)` backward, these all agreed on every step **except the last**:

```
alg                    fwd last |dt|             bwd last |dt|
JVODE_BDF              5.55111512312578270e-17   4.30222810148347291e-18
Feagin10   (PI)        4.44089209850062616e-16   1.32950589613215397e-16
Feagin12   (PI)        4.44089209850062616e-16   1.32339903416968948e-16
CKLLSRK43_2 (PI)       8.88178419700125232e-16   2.18913078485043049e-16
```

Across a 5470-case sweep (problem × algorithm × controller × in-place) this mechanism accounted for the direction-dependence of `JVODE_Adams`, `JVODE_BDF`, `Feagin10/12/14`, `RDPK3SpFSAL35/49`, `CKLLSRK43_2`, `VCAB4`, `ImplicitEuler` and `RKG1`.

## Verification

New `lib/OrdinaryDiffEqCore/test/dtmin_direction_tests.jl`, registered in `runtests.jl`, with two testsets: a direct one that pokes `fix_dt_at_bounds!` with a sub-floor `dt` in each direction, and an end-to-end one asserting **bitwise** equality of the forward and mirrored-backward `|dt|` sequences (on a symmetric tspan the mirror `t -> -t` is exact and round-to-nearest is sign-symmetric, so `==` is the right assertion, not `≈`).

Failing on master (`git stash push -- lib/OrdinaryDiffEqCore/src/integrators/integrator_utils.jl`):

```
Test Summary:                               | Pass  Fail  Total  Time
dtmin direction handling                    |    4     2      6  4.9s
  dtmin floor applies in both directions    |    3     1      4  1.9s
  time-reversal symmetry at the dtmin floor |    1     1      2  3.0s
```

Passing with the fix:

```
Test Summary:            | Pass  Total  Time
dtmin direction handling |    6      6  3.5s
```

Full package suite on this branch (Julia 1.10.11):

```
Testing OrdinaryDiffEqCore tests passed
```

## What I did **not** verify

- GPU and Downstream groups, Julia `pre`.
- Whether any existing backward-solve result in the wild silently depended on the missing floor. This makes backward solves stop shrinking earlier than before, so a solve that previously limped below `eps(t)` will now report `dtmin` failure the same way a forward solve does — that is the intended behavior, but it is a behavior change for `tdir < 0`.

## Worth pushing back on

- The upper clamp above it relies on `dtmax` having already been sign-converted in `solve.jl` (`dtmax > 0 && tdir < 0 && (dtmax *= tdir)`); it would be more robust to clamp both bounds on magnitudes, but I kept the diff to the one defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m], harness: Claude Code 2.1.269)

https://claude.ai/code/session_01JQATpLKMyYX3VbPPX8qdeE
