### PR TITLE
Select extrapolation order on |dt| in the Hairer-Wanner controller

### DIFF
--- a/lib/OrdinaryDiffEqExtrapolation/Project.toml
+++ b/lib/OrdinaryDiffEqExtrapolation/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExtrapolation"
 uuid = "becaefa8-8ca2-5cf9-886d-c06f3d2bd2c4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.6.2"
+version = "2.6.3"
 
 [deps]
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"

--- a/lib/OrdinaryDiffEqExtrapolation/src/controllers.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/controllers.jl
@@ -336,9 +336,12 @@ function step_accept_controller!(
     win_min_old = min(n_old, n_curr) - 1 # cf. win_min in perform_step! of the last step
     tmp = win_min_old:(max(n_curr, n_old) + 1) # Index range for the new order
     fill!(dt_new, zero(eltype(dt_new)))
-    @.. broadcast = false Q = integrator.dt / Q
+    # |dt|, not dt: `work` below is compared against `sigma * work`, and every
+    # one of those inequalities flips sign if the work estimates are negative.
+    absdt = abs(integrator.dt)
+    @.. broadcast = false Q = absdt / Q
     copyto!(dt_new, win_min_old, Q, win_min_old, (max(n_curr, n_old) + 1) - win_min_old + 1)
-    @.. broadcast = false Q = integrator.dt / Q
+    @.. broadcast = false Q = absdt / Q
     dtmin = timedepentdtmin(integrator)
     fill!(work, zero(eltype(work))) # work[n] is the work for order (n-1)
     for i in tmp

--- a/lib/OrdinaryDiffEqExtrapolation/test/extrapolation_time_reversal_tests.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/extrapolation_time_reversal_tests.jl
@@ -1,0 +1,76 @@
+using OrdinaryDiffEqExtrapolation, OrdinaryDiffEqCore, Test
+
+# An ODE integrated forwards and its time-mirrored counterpart integrated
+# backwards are the same problem, so an adaptive solver must take the same steps
+# either way. With a tspan symmetric about zero the mirror map `t -> -t` is exact
+# in IEEE arithmetic and round-to-nearest is symmetric under negation, so every
+# stage value and error estimate mirrors *bitwise*: the `|dt|` sequences must
+# agree to the last bit, not merely approximately.
+#
+# The Hairer-Wanner order selector formed `dt_new[i] = integrator.dt / Q[i]` with
+# the sign kept, so `work[i] = s[i] / dt_new[i]` was negative for a backward
+# solve and every `work[a] < sigma * work[b]` comparison (sigma = 9//10 > 0) came
+# out inverted. The Deuflhard selector takes `abs` first and was unaffected.
+
+"""Accepted `|dt|` sequence of `prob` under `alg`."""
+function accepted_dts(prob, alg; kwargs...)
+    integ = init(prob, alg; save_everystep = false, kwargs...)
+    return [abs(Float64(integ.dt)) for _ in integ]
+end
+
+"""Forward and mirrored-backward `|dt|` sequences on tspan `(-T, T)`."""
+function reversal_dts(f, f!, u0, p, T, alg; inplace = false, kwargs...)
+    if inplace
+        fwd = ODEProblem(f!, copy(u0), (-T, T), p)
+        g! = (du, u, q, t) -> (f!(du, u, q, -t); du .= .-du; nothing)
+        bwd = ODEProblem(g!, copy(u0), (T, -T), p)
+    else
+        fwd = ODEProblem(f, copy(u0), (-T, T), p)
+        g = (u, q, t) -> -f(u, q, -t)
+        bwd = ODEProblem(g, copy(u0), (T, -T), p)
+    end
+    return accepted_dts(fwd, alg; kwargs...), accepted_dts(bwd, alg; kwargs...)
+end
+
+lin(u, p, t) = p[1] .* u
+lin!(du, u, p, t) = (du .= p[1] .* u; nothing)
+
+function lv(u, p, t)
+    a, b, c, d = p
+    return [a * u[1] - b * u[1] * u[2], -c * u[2] + d * u[1] * u[2]]
+end
+function lv!(du, u, p, t)
+    a, b, c, d = p
+    du[1] = a * u[1] - b * u[1] * u[2]
+    du[2] = -c * u[2] + d * u[1] * u[2]
+    return nothing
+end
+
+const CASES = (
+    ("linear", lin, lin!, [0.5], [1.01], 0.5),
+    ("lotka", lv, lv!, [1.0, 1.0], [1.5, 1.0, 3.0, 1.0], 5.0),
+)
+
+@testset "Extrapolation time-reversal symmetry" begin
+    algs = (
+        "ExtrapolationMidpointHairerWanner" => ExtrapolationMidpointHairerWanner(),
+        "ImplicitHairerWannerExtrapolation" => ImplicitHairerWannerExtrapolation(),
+        "ImplicitEulerExtrapolation" => ImplicitEulerExtrapolation(),
+        "ImplicitEulerBarycentricExtrapolation" => ImplicitEulerBarycentricExtrapolation(),
+        # Deuflhard family already selected on magnitudes; kept as a guard.
+        "ExtrapolationMidpointDeuflhard" => ExtrapolationMidpointDeuflhard(),
+        "ImplicitDeuflhardExtrapolation" => ImplicitDeuflhardExtrapolation(),
+    )
+    for (algname, alg) in algs,
+            (name, f, f!, u0, p, T) in CASES,
+            inplace in (false, true)
+
+        fdts, bdts = reversal_dts(
+            f, f!, u0, p, T, alg;
+            inplace, abstol = 1.0e-8, reltol = 1.0e-8
+        )
+        @testset "$algname $name $(inplace ? "iip" : "oop")" begin
+            @test fdts == bdts
+        end
+    end
+end

--- a/lib/OrdinaryDiffEqExtrapolation/test/runtests.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/runtests.jl
@@ -27,6 +27,7 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "Extrapolation Utility Tests" include("utils_tests.jl")
     @time @safetestset "Extrapolation Tests" include("ode_extrapolation_tests.jl")
     @time @safetestset "Extrapolation In-place Consistency Tests" include("extrapolation_inplace_consistency_tests.jl")
+    @time @safetestset "Extrapolation Time Reversal Tests" include("extrapolation_time_reversal_tests.jl")
     @time @safetestset "Threading Linear Solver Tests" include("threading_linsolve_tests.jl")
 end
 


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.** Draft.

*Rebased onto master at 57a8d33.* #4532 landed first and bumped `OrdinaryDiffEqExtrapolation` to 2.6.2, so this now bumps to 2.6.3; the `runtests.jl` conflict (both PRs register a new test file at the same anchor) is resolved by keeping both lines. With #4532 on master the in-place Deuflhard step is fixed, so the test matrix here has been **extended from out-of-place-only to both**, which doubles the number of assertions that discriminate (7 -> 14).

## What changed and why

`step_accept_controller!` for the Hairer–Wanner extrapolation family built the candidate step sizes with the sign kept:

```julia
-    @.. broadcast = false Q = integrator.dt / Q
+    absdt = abs(integrator.dt)
+    @.. broadcast = false Q = absdt / Q
```

so `work[i] = s[i] / dt_new[i]` was **negative** for a backward solve, and the order selector that follows is a chain of

```julia
if work[n_curr - 1] < sigma * work[n_curr]        # sigma = 9//10 > 0
```

Every one of those inequalities inverts when `work` is negative, so the method picks systematically the wrong order when integrating backwards. The Deuflhard family takes `abs.` of `dt_new` before forming `work` and is unaffected.

## How it shows up

Solving `u' = f(u)` forward on a tspan symmetric about zero versus the mirrored problem `g(u,p,t) = -f(u,p,-t)` backward — the same trajectory the other way. Accepted step counts on master (forward / backward):

| problem | ExtrapMidpointHW | ImplicitHW | ImplicitEuler | ImplicitEulerBarycentric |
|---|---|---|---|---|
| `u' = 1.01u` | 4 / 2 | — | 6 / 11 | 11 / 10 |
| Lotka–Volterra | 49 / 65 | 27 / 34 | 31 / 204 | 29 / 177 |
| harmonic oscillator | 32 / 161 | 110 / 104 | 53 / 769 | 743 / 641 |
| Van der Pol μ=5 | 59 / 108 | — | 42 / 326 | — |

## Verification

New `lib/OrdinaryDiffEqExtrapolation/test/extrapolation_time_reversal_tests.jl`, registered in `runtests.jl`. On a symmetric tspan the mirror `t -> -t` is exact in IEEE arithmetic and round-to-nearest is sign-symmetric, so every stage value and error estimate mirrors **bitwise** — the test asserts `abs.(dt_fwd) == abs.(dt_bwd)`, not `≈`.

Failing on master (`git checkout origin/master -- lib/OrdinaryDiffEqExtrapolation/src/controllers.jl`):

```
Test Summary:                                      | Pass  Fail  Total     Time
Extrapolation time-reversal symmetry               |   10    14     24  1m23.7s
  ExtrapolationMidpointHairerWanner linear oop     |          1      1     1.4s
  ExtrapolationMidpointHairerWanner linear iip     |          1      1     0.0s
  ExtrapolationMidpointHairerWanner lotka oop      |          1      1     0.0s
  ExtrapolationMidpointHairerWanner lotka iip      |          1      1     0.0s
  ImplicitHairerWannerExtrapolation linear oop     |    1            1     0.0s
  ImplicitHairerWannerExtrapolation linear iip     |    1            1     0.0s
  ImplicitHairerWannerExtrapolation lotka oop      |          1      1     0.0s
  ImplicitHairerWannerExtrapolation lotka iip      |          1      1     0.0s
  ImplicitEulerExtrapolation linear oop            |          1      1     0.0s
  ImplicitEulerExtrapolation linear iip            |          1      1     0.0s
  ImplicitEulerExtrapolation lotka oop             |          1      1     0.0s
  ImplicitEulerExtrapolation lotka iip             |          1      1     0.0s
  ImplicitEulerBarycentricExtrapolation linear oop |          1      1     0.0s
  ImplicitEulerBarycentricExtrapolation linear iip |          1      1     0.0s
  ImplicitEulerBarycentricExtrapolation lotka oop  |          1      1     0.0s
  ImplicitEulerBarycentricExtrapolation lotka iip  |          1      1     0.0s
  ExtrapolationMidpointDeuflhard linear oop        |    1            1     0.0s
  ... (Deuflhard rows pass either way, kept as guards)
```

Passing with the fix:

```
Test Summary:                        | Pass  Total     Time
Extrapolation time-reversal symmetry |   24     24  1m21.4s
```

Full package suite on this branch (Julia 1.10.11): every functional testset passes. Two failures remain, both pre-existing QA lint on master and untouched by this diff (it adds no imports):

```
Some tests did not pass: 17 passed, 1 failed, 1 errored, 0 broken.
  no_stale_explicit_imports: Module `OrdinaryDiffEqExtrapolation` has stale
    (unused) explicit imports for: * `Sequential`
  No unapproved public reexports: [:AutoSpecialize, :DEStats, ...]
```

## What I did **not** verify

- Multithreaded extrapolation paths (`threading = BaseThreads()/PolyesterThreads()`); the fix is in the controller, which is shared, but the tests run serial.
- CI has not run on the rebased head yet.
- GPU and Downstream groups, Julia `pre`.

## Worth pushing back on

- `step_accept_controller!` still *returns* a positive magnitude; `calc_dt_propose!` takes `abs` anyway, so it is consistent, but the two extrapolation controllers now differ from the rest of the codebase in returning an unsigned dt. Normalising that is a larger cleanup I did not attempt here.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m], harness: Claude Code 2.1.269)

https://claude.ai/code/session_01JQATpLKMyYX3VbPPX8qdeE
