### PR TITLE
Invalidate the cached factorization in the in-place Deuflhard order extension

### DIFF
--- a/lib/OrdinaryDiffEqExtrapolation/Project.toml
+++ b/lib/OrdinaryDiffEqExtrapolation/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqExtrapolation"
 uuid = "becaefa8-8ca2-5cf9-886d-c06f3d2bd2c4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.6.1"
+version = "2.6.2"
 
 [deps]
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"

--- a/lib/OrdinaryDiffEqExtrapolation/src/extrapolation_perform_step.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/src/extrapolation_perform_step.jl
@@ -1628,22 +1628,35 @@ function perform_step!(
                 @.. broadcast = false linsolve_tmps[1] = fsalfirst
 
                 linsolve = cache.linsolve[1]
-                linres = dolinsolve(
-                    integrator, linsolve; b = _vec(linsolve_tmps[1]),
-                    linu = _vec(k)
-                )
+
+                # `jacobian2W!` above overwrote W[1] in place, and the LU factors
+                # live in that same array, so the cached factorization must be
+                # invalidated by passing the new `A`.
+                if !repeat_step
+                    linres = dolinsolve(
+                        integrator, linsolve; A = W[1],
+                        b = _vec(linsolve_tmps[1]), linu = _vec(k)
+                    )
+                else
+                    linres = dolinsolve(
+                        integrator, linsolve; A = nothing,
+                        b = _vec(linsolve_tmps[1]), linu = _vec(k)
+                    )
+                end
 
                 integrator.stats.nsolve += 1
                 @.. broadcast = false u_temp1 = u_temp2 - k # Euler starting step
                 for j in 2:j_int
                     f(k, cache.u_temp1, p, t + (j - 1) * dt_int)
                     OrdinaryDiffEqCore.increment_nf!(integrator.stats, 1)
-                    @.. broadcast = false linsolve_tmps[1] = dt_int * k - (u_temp1 - u_temp2)
+                    # W is built for `dt_int`, so the residual is scaled the same
+                    # way as in the internal-discretisation loop above.
+                    @.. broadcast = false linsolve_tmps[1] = k - (u_temp1 - u_temp2) / dt_int
 
                     linsolve = cache.linsolve[1]
                     linres = dolinsolve(
-                        integrator, linsolve; b = _vec(linsolve_tmps[1]),
-                        linu = _vec(k)
+                        integrator, linsolve; A = nothing,
+                        b = _vec(linsolve_tmps[1]), linu = _vec(k)
                     )
 
                     integrator.stats.nsolve += 1

--- a/lib/OrdinaryDiffEqExtrapolation/test/extrapolation_inplace_consistency_tests.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/extrapolation_inplace_consistency_tests.jl
@@ -1,0 +1,75 @@
+using OrdinaryDiffEqExtrapolation, OrdinaryDiffEqCore, Test
+
+# The mutable and immutable code paths implement the same method, so they must
+# agree on the solution and on how much work the solve takes.
+#
+# The order-extension block of the in-place ImplicitDeuflhardExtrapolation step
+# rebuilt W with `jacobian2W!` but never handed the new matrix to the linear
+# solver, so LinearSolve kept a factorization whose storage `jacobian2W!` had
+# just overwritten; the midpoint residual in the same loop was also scaled by an
+# extra factor of `dt_int`. Both were confined to T[n_curr+1], the only entry
+# that block computes.
+
+lin(u, p, t) = p[1] .* u
+lin!(du, u, p, t) = (du .= p[1] .* u; nothing)
+
+function lv(u, p, t)
+    a, b, c, d = p
+    return [a * u[1] - b * u[1] * u[2], -c * u[2] + d * u[1] * u[2]]
+end
+function lv!(du, u, p, t)
+    a, b, c, d = p
+    du[1] = a * u[1] - b * u[1] * u[2]
+    du[2] = -c * u[2] + d * u[1] * u[2]
+    return nothing
+end
+
+const CASES = (
+    ("linear", lin, lin!, [0.5], [1.01], 0.5),
+    ("lotka", lv, lv!, [1.0, 1.0], [1.5, 1.0, 3.0, 1.0], 5.0),
+)
+
+"""Accepted `|dt|` sequence of `prob` under `alg`."""
+function accepted_dts(prob, alg; kwargs...)
+    integ = init(prob, alg; save_everystep = false, kwargs...)
+    return [abs(Float64(integ.dt)) for _ in integ]
+end
+
+@testset "Extrapolation in-place/out-of-place consistency" begin
+    algs = (
+        "ImplicitDeuflhardExtrapolation" => ImplicitDeuflhardExtrapolation(),
+        "ImplicitHairerWannerExtrapolation" => ImplicitHairerWannerExtrapolation(),
+    )
+    kw = (abstol = 1.0e-8, reltol = 1.0e-8, save_everystep = false)
+
+    @testset "same effort as out-of-place" begin
+        for (algname, alg) in algs, (name, f, f!, u0, p, T) in CASES
+            soop = solve(ODEProblem(f, copy(u0), (-T, T), p), alg; kw...)
+            siip = solve(ODEProblem(f!, copy(u0), (-T, T), p), alg; kw...)
+            @testset "$algname $name" begin
+                @test siip.stats.naccept <= 2 * soop.stats.naccept
+                @test siip.stats.nreject <= 2 * soop.stats.nreject + 4
+                @test siip.u ≈ soop.u rtol = 1.0e-5
+            end
+        end
+    end
+
+    # A corrupted solve is also not sign-symmetric (an LU has an implicit unit
+    # diagonal, so LU(-X) != -LU(X)), which cost the in-place method its
+    # time-reversal symmetry: on a tspan symmetric about zero the mirrored
+    # problem `g(u, p, t) = -f(u, p, -t)` must reproduce the forward |dt|
+    # sequence bitwise.
+    # Only the Deuflhard family here: the Hairer-Wanner order selector has its own
+    # direction bug in `step_accept_controller!`, fixed separately.
+    @testset "in-place time-reversal symmetry" begin
+        for (algname, alg) in ("ImplicitDeuflhardExtrapolation" => ImplicitDeuflhardExtrapolation(),),
+                (name, f, f!, u0, p, T) in CASES
+            fwd = ODEProblem(f!, copy(u0), (-T, T), p)
+            g! = (du, u, q, t) -> (f!(du, u, q, -t); du .= .-du; nothing)
+            bwd = ODEProblem(g!, copy(u0), (T, -T), p)
+            @testset "$algname $name" begin
+                @test accepted_dts(fwd, alg; kw...) == accepted_dts(bwd, alg; kw...)
+            end
+        end
+    end
+end

--- a/lib/OrdinaryDiffEqExtrapolation/test/runtests.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/runtests.jl
@@ -26,6 +26,7 @@ if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     end
     @time @safetestset "Extrapolation Utility Tests" include("utils_tests.jl")
     @time @safetestset "Extrapolation Tests" include("ode_extrapolation_tests.jl")
+    @time @safetestset "Extrapolation In-place Consistency Tests" include("extrapolation_inplace_consistency_tests.jl")
     @time @safetestset "Threading Linear Solver Tests" include("threading_linsolve_tests.jl")
 end
 


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.** Draft.

Independent of #4531 but touches the same package: both bump `OrdinaryDiffEqExtrapolation` from 2.6.1, so whichever merges second needs a version rebase. #4531 fixes the Hairer–Wanner *controller*; this one fixes the in-place Deuflhard *step*.

## What changed and why

The order-extension block of the **mutable** `ImplicitDeuflhardExtrapolation` step (the `while n_curr <= win_max` branch, which computes the single highest-order entry `T[n_curr+1]`) had two defects that its Hairer–Wanner sibling 1600 lines later does not:

```julia
                 jacobian2W!(W[1], integrator.f.mass_matrix, dt_int, J)
                 ...
-                linres = dolinsolve(integrator, linsolve; b = ..., linu = _vec(k))
+                if !repeat_step
+                    linres = dolinsolve(integrator, linsolve; A = W[1], b = ..., linu = _vec(k))
+                else
+                    linres = dolinsolve(integrator, linsolve; A = nothing, b = ..., linu = _vec(k))
+                end
                 ...
-                    @.. linsolve_tmps[1] = dt_int * k - (u_temp1 - u_temp2)
+                    @.. linsolve_tmps[1] = k - (u_temp1 - u_temp2) / dt_int
```

1. **`A` was never passed**, so LinearSolve kept its cached factorization. But the LU factors live in `W[1]`, which `jacobian2W!` had just overwritten with the new matrix — so the "reused factorization" was the raw matrix misread as `L`/`U`.
2. **The midpoint residual was scaled inconsistently** with the internal-discretisation loop in the same function: `dt_int * k - Δ` versus `k - Δ / dt_int`, an extra factor of `dt_int` against the same `W`.

Compare `lib/OrdinaryDiffEqExtrapolation/src/extrapolation_perform_step.jl:3236-3275` (`ImplicitHairerWannerExtrapolation`), which does both correctly.

## How it was isolated

Driving step 3 attempt-by-attempt on Lotka–Volterra, forward versus mirrored-backward. Attempts 1–3 agree bitwise; attempt 4 diverges in exactly one entry:

```
attempt 3  |dt| 8.744e-01 / 8.744e-01 eq  force_stepfail 1/1  EEst eq  Q equal: true  u diff 0.000e+00
attempt 4  |dt| 8.744e-01 / 8.744e-01 eq  force_stepfail 0/0  EEst NE  Q equal: false
   T[6] differs by 1.655e+00   fwd=[5.898, -0.361]  bwd=[4.604, 1.294]
```

`T[1..5]` come from the internal-discretisation loop and match; `T[6]` is the one the extension block computes.

The direction dependence follows from the same defect: an LU has an **implicit unit diagonal**, so `LU(-X) ≠ -LU(X)` and the corrupted solve is not sign-symmetric.

## Effect

Forward solve, Lotka–Volterra, `abstol = reltol = 1e-8`:

```
                     before              after
oop  naccept/nreject  31 / 11             31 / 11
iip  naccept/nreject  605 / 841           31 / 11
iip  nf               30045               1944
iip  n_curr sequence  5,5,5,5,5,…         5,1,2,3,4,1,2,3   (= oop)
```

Reversal, in-place, previously diverging at step 3 (`|dt|` ratio 0.9737), now bitwise identical in `dt`, `n_curr`, `n_old`, `EEst` and `u`.

## Verification

New `lib/OrdinaryDiffEqExtrapolation/test/extrapolation_inplace_consistency_tests.jl`, registered in `runtests.jl`. Two testsets: the mutable path must not take wildly more work than the immutable one and must land on the same solution, and the in-place method must be reversible in time. Effort bounds are ratios (`<= 2x`), not exact counts, so BLAS/Julia-version differences cannot make it flaky — before the fix the ratio was 19.5x.

Failing on master (`git stash push -- lib/OrdinaryDiffEqExtrapolation/src/extrapolation_perform_step.jl`):

```
Test Summary:                                   | Pass  Fail  Total   Time
Extrapolation in-place/out-of-place consistency |    9     5     14  37.8s
  same effort as out-of-place                   |    8     4     12  36.2s
    ImplicitDeuflhardExtrapolation linear       |    1     2      3   1.8s
    ImplicitDeuflhardExtrapolation lotka        |    1     2      3   0.1s
    ImplicitHairerWannerExtrapolation linear    |    3            3   0.0s
    ImplicitHairerWannerExtrapolation lotka     |    3            3   0.0s
  in-place time-reversal symmetry               |    1     1      2   1.5s
    ImplicitDeuflhardExtrapolation linear       |    1            1   0.8s
    ImplicitDeuflhardExtrapolation lotka        |          1      1   0.7s
```

Passing with the fix:

```
Test Summary:                                   | Pass  Total   Time
Extrapolation in-place/out-of-place consistency |   14     14  37.0s
```

The reversal testset covers the Deuflhard family only — `ImplicitHairerWannerExtrapolation` has its own, separate direction bug in `step_accept_controller!` (#4531), so it appears here only in the effort testset, where it passes either way as a guard.

Full package suite on this branch (Julia 1.10.11): every functional testset passes; the same two pre-existing QA lint failures as on master (`no_stale_explicit_imports` for `Sequential`, unapproved reexports), untouched by this diff.

## What I did **not** verify

- The threaded branches of the same function (`:romberg` / default sequence under `BaseThreads`/`PolyesterThreads`) have their own copies of this block; I did not audit or test them, and they may carry the same omission.
- GPU and Downstream groups, Julia `pre`.
- Whether the corrected `T[n_curr+1]` changes accuracy for the better in a convergence study — I only checked that the two code paths now agree and that the existing convergence tests still pass.

## Worth pushing back on

- Changing the residual scaling changes results for every in-place `ImplicitDeuflhardExtrapolation` user, not just backward solves. I believe the new scaling is the correct one because it is what the internal-discretisation loop and the Hairer–Wanner block both use and it brings the in-place path into agreement with out-of-place, but it deserves a second opinion.
- I did not add a convergence-order test for the corrected in-place path; the package's existing `ode_extrapolation_tests.jl` covers it and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m], harness: Claude Code 2.1.269)

https://claude.ai/code/session_01JQATpLKMyYX3VbPPX8qdeE
