### PR TITLE
Do not re-factorize a reused W in the in-place RadauIIA3 step

### DIFF
--- a/lib/OrdinaryDiffEqFIRK/Project.toml
+++ b/lib/OrdinaryDiffEqFIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqFIRK"
 uuid = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.8.5"
+version = "2.8.6"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
+++ b/lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl
@@ -407,7 +407,11 @@ end
         end
 
         @. cubuff = complex(fw1 - αdt * Mw1 + βdt * Mw2, fw2 - βdt * Mw1 - αdt * Mw2)
-        needfactor = iter == 1
+        # Only hand `A = W1` to the linear solver when W was actually rebuilt this
+        # step; otherwise W1 still holds the factorization from the previous step
+        # and re-factorizing it corrupts the solve.  Matches RadauIIA5/9 and
+        # AdaptiveRadau.
+        needfactor = iter == 1 && new_W
 
         linsolve = cache.linsolve
 

--- a/lib/OrdinaryDiffEqFIRK/test/firk_time_reversal_tests.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/firk_time_reversal_tests.jl
@@ -1,0 +1,77 @@
+using OrdinaryDiffEqFIRK, OrdinaryDiffEqCore, Test
+using LinearAlgebra: mul!
+
+# An ODE integrated forwards and its time-mirrored counterpart integrated
+# backwards are the same problem, so an adaptive solver must take the same steps
+# either way. With a tspan symmetric about zero the mirror map `t -> -t` is exact
+# in IEEE arithmetic and round-to-nearest is symmetric under negation, so every
+# stage value, Newton iterate and error estimate mirrors *bitwise*.
+#
+# `RadauIIA3Cache` used `needfactor = iter == 1`, so it handed `A = W1` to the
+# linear solver on the first Newton iteration of every step, including steps
+# where `new_W` was false and `W1` therefore still held the previous step's
+# factorization. Re-factorizing those factors corrupts the solve; because an LU
+# has an implicit unit diagonal the corruption is not sign-symmetric either.
+# RadauIIA5/RadauIIA9/AdaptiveRadau all guard with `&& new_W`.
+
+"""Accepted `|dt|` sequence of `prob` under `alg`."""
+function accepted_dts(prob, alg; kwargs...)
+    integ = init(prob, alg; save_everystep = false, kwargs...)
+    return [abs(Float64(integ.dt)) for _ in integ]
+end
+
+"""Forward and mirrored-backward `|dt|` sequences on tspan `(-T, T)`."""
+function reversal_dts(f, f!, u0, p, T, alg; inplace = false, kwargs...)
+    if inplace
+        fwd = ODEProblem(f!, copy(u0), (-T, T), p)
+        g! = (du, u, q, t) -> (f!(du, u, q, -t); du .= .-du; nothing)
+        bwd = ODEProblem(g!, copy(u0), (T, -T), p)
+    else
+        fwd = ODEProblem(f, copy(u0), (-T, T), p)
+        g = (u, q, t) -> -f(u, q, -t)
+        bwd = ODEProblem(g, copy(u0), (T, -T), p)
+    end
+    return accepted_dts(fwd, alg; kwargs...), accepted_dts(bwd, alg; kwargs...)
+end
+
+function rober(u, p, t)
+    k1, k2, k3 = p
+    y1, y2, y3 = u
+    return [-k1 * y1 + k3 * y2 * y3, k1 * y1 - k2 * y2^2 - k3 * y2 * y3, k2 * y2^2]
+end
+function rober!(du, u, p, t)
+    k1, k2, k3 = p
+    y1, y2, y3 = u
+    du[1] = -k1 * y1 + k3 * y2 * y3
+    du[2] = k1 * y1 - k2 * y2^2 - k3 * y2 * y3
+    du[3] = k2 * y2^2
+    return nothing
+end
+
+const STIFFA = [-2000.0 1.0 0.0; 1.0 -3.0 1.0; 0.0 1.0 -0.5]
+sys(u, p, t) = STIFFA * u
+sys!(du, u, p, t) = (mul!(du, STIFFA, u); nothing)
+
+const CASES = (
+    ("rober", rober, rober!, [1.0, 0.0, 0.0], [0.04, 3.0e7, 1.0e4], 50.0),
+    ("stiff linear system", sys, sys!, [1.0, 1.0, 1.0], [nothing], 1.0),
+)
+
+@testset "FIRK time-reversal symmetry" begin
+    algs = (
+        "RadauIIA3" => RadauIIA3(), "RadauIIA5" => RadauIIA5(),
+        "RadauIIA9" => RadauIIA9(), "AdaptiveRadau" => AdaptiveRadau(),
+    )
+    for (algname, alg) in algs,
+            (name, f, f!, u0, p, T) in CASES,
+            inplace in (false, true)
+
+        fdts, bdts = reversal_dts(
+            f, f!, u0, p, T, alg;
+            inplace, abstol = 1.0e-8, reltol = 1.0e-8
+        )
+        @testset "$algname $name $(inplace ? "iip" : "oop")" begin
+            @test fdts == bdts
+        end
+    end
+end

--- a/lib/OrdinaryDiffEqFIRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqFIRK/test/runtests.jl
@@ -10,6 +10,7 @@ end
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "FIRK Tests" include("ode_firk_tests.jl")
+    @time @safetestset "FIRK Time Reversal Tests" include("firk_time_reversal_tests.jl")
     @time @safetestset "FIRK Krylov Tests" include("firk_krylov_tests.jl")
     @time @safetestset "FIRK LHL Factorization Tests" include("lhl_factorization_tests.jl")
 end


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.** Draft.

## What changed and why

One word, in `RadauIIA3Cache`'s Newton loop:

```julia
-        needfactor = iter == 1
+        needfactor = iter == 1 && new_W
```

`needfactor` decides whether to hand `A = W1` to the linear solver (rebuild the factorization) or `A = nothing` (reuse it). With the bare `iter == 1`, RadauIIA3 re-factorized on the first Newton iteration of **every** step — including steps where `new_W` was false and `W1` therefore still held the *previous* step's factorization rather than a matrix. Re-factorizing LU factors corrupts the solve.

Every other FIRK cache already guards this:

| cache | line | guard |
|---|---|---|
| `RadauIIA3Cache` | 410 | `iter == 1` ← |
| `RadauIIA5Cache` | 818 | `iter == 1 && new_W` |
| `RadauIIA9Cache` | 1478 | `iter == 1 && new_W` |
| `AdaptiveRadauCache` | 2073 | `iter == 1 && new_W` |
| `GaussLegendreConstantCache` | 2546 | `iter == 1` — correct, it rebuilds `W` unconditionally |

## How it was isolated

Per-step Newton state on Robertson, in-place, forward versus the mirrored problem `g(u,p,t) = -f(u,p,-t)` backward. The divergence appears on exactly the first step that **reuses** `W` (`njacs` and `nw` unchanged from the previous step):

```
step 24  du 0.00e+00  iter 2/2  njacs 4/4  nw 28/28   <- W rebuilt
step 25  du 3.58e-14  iter 1/1  njacs 4/4  nw 28/28   <- W reused; diverges
step 26  du 2.69e-13
step 27  du 3.92e-11  |dt| 1.54722337944034095e-2 / 1.54722327636744802e-2
```

The absolute error stays small because the extrapolated predictor is usually already converged (`iter == 1`), so the bogus Newton correction is tiny — but it is wrong, and because an LU has an implicit **unit diagonal** it is not sign-symmetric, which is what cost in-place RadauIIA3 its time-reversal symmetry.

With the fix, step 27 gives `1.54721750430737159e-2` in both directions — the step sizes change, i.e. the old solve really was using a corrupted factorization.

## Verification

New `lib/OrdinaryDiffEqFIRK/test/firk_time_reversal_tests.jl`, registered in `runtests.jl`. On a tspan symmetric about zero the mirror `t -> -t` is exact in IEEE arithmetic and round-to-nearest is sign-symmetric, so every stage value and Newton iterate mirrors **bitwise** — the test asserts `abs.(dt_fwd) == abs.(dt_bwd)`, not `≈`.

Failing on master (`git stash push -- lib/OrdinaryDiffEqFIRK/src/firk_perform_step.jl`):

```
Test Summary:                           | Pass  Fail  Total     Time
FIRK time-reversal symmetry             |   14     2     16  1m26.8s
  RadauIIA3 rober oop                   |    1            1     0.0s
  RadauIIA3 rober iip                   |          1      1     1.4s
  RadauIIA3 stiff linear system oop     |    1            1     0.0s
  RadauIIA3 stiff linear system iip     |          1      1     0.0s
  RadauIIA5 rober iip                   |    1            1     0.0s
  ...
```

Passing with the fix:

```
Test Summary:               | Pass  Total     Time
FIRK time-reversal symmetry |   16     16  1m26.4s
```

Only the two in-place RadauIIA3 rows discriminate; RadauIIA5/9/AdaptiveRadau pass either way and are included as guards against the same mistake reappearing.

Full package suite on this branch (Julia 1.10.11): every functional testset passes. One failure remains, pre-existing QA lint on master and untouched by this diff (it adds no imports):

```
Some tests did not pass: 18 passed, 0 failed, 1 errored, 0 broken.
  no_stale_explicit_imports: Module `OrdinaryDiffEqFIRK` has stale (unused)
    explicit imports for: * `BaseThreads` * `PolyesterThreads` * `Sequential`
```

## What I did **not** verify

- Whether accuracy improves in a convergence study; the existing `ode_firk_tests.jl` convergence tests pass, which is all I checked. Step sizes do change for in-place RadauIIA3.
- GPU and Downstream groups, Julia `pre`.
- The Krylov/lazy-`W` path (`is_lazy_W(W1)`): it takes a different branch above and I did not exercise it here.

## Worth pushing back on

- Worth checking whether `LinearSolve` is expected to factorize dense `A` in place at all. If it always copies, then `W1` holds the previous step's *matrix* rather than its factors and the old code was merely redundant rather than wrong — but the measured change in results says it was not redundant on this path.
- `cache.W_γdt = dt` is only assigned when a **new Jacobian** is computed, not when `W` is rebuilt, so `do_newW` compares against the dt at which `J` was taken. That looks unintentional but is a separate question; I left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m], harness: Claude Code 2.1.269)

https://claude.ai/code/session_01JQATpLKMyYX3VbPPX8qdeE
