### PR TITLE
Pass Θ = 0, not the absolute time, to the AN5 startup interpolant

### DIFF
--- a/lib/OrdinaryDiffEqNordsieck/Project.toml
+++ b/lib/OrdinaryDiffEqNordsieck/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNordsieck"
 uuid = "c9986a66-5c92-4813-8696-a7ec84c806c8"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.3.0"
+version = "2.3.1"
 
 [deps]
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"

--- a/lib/OrdinaryDiffEqNordsieck/src/nordsieck_perform_step.jl
+++ b/lib/OrdinaryDiffEqNordsieck/src/nordsieck_perform_step.jl
@@ -28,15 +28,15 @@ end
         z[1] = integrator.uprev
         z[2] = integrator.k[1] * dt
         z[3] = ode_interpolant(
-            t, dt, nothing, nothing, integrator.k, tsit5tab, nothing,
+            zero(t), dt, nothing, nothing, integrator.k, tsit5tab, nothing,
             Val{2}, differential_vars
         ) * dt^2 / 2
         z[4] = ode_interpolant(
-            t, dt, nothing, nothing, integrator.k, tsit5tab, nothing,
+            zero(t), dt, nothing, nothing, integrator.k, tsit5tab, nothing,
             Val{3}, differential_vars
         ) * dt^3 / 6
         z[5] = ode_interpolant(
-            t, dt, nothing, nothing, integrator.k, tsit5tab, nothing,
+            zero(t), dt, nothing, nothing, integrator.k, tsit5tab, nothing,
             Val{4}, differential_vars
         ) * dt^4 / 24
         z[6] = zero(cache.z[6])
@@ -126,15 +126,15 @@ end
         @.. broadcast = false z[1] = integrator.uprev
         @.. broadcast = false z[2] = integrator.k[1] * dt
         ode_interpolant!(
-            z[3], t, dt, nothing, nothing, integrator.k, tsit5cache, nothing,
+            z[3], zero(t), dt, nothing, nothing, integrator.k, tsit5cache, nothing,
             Val{2}, differential_vars
         )
         ode_interpolant!(
-            z[4], t, dt, nothing, nothing, integrator.k, tsit5cache, nothing,
+            z[4], zero(t), dt, nothing, nothing, integrator.k, tsit5cache, nothing,
             Val{3}, differential_vars
         )
         ode_interpolant!(
-            z[5], t, dt, nothing, nothing, integrator.k, tsit5cache, nothing,
+            z[5], zero(t), dt, nothing, nothing, integrator.k, tsit5cache, nothing,
             Val{4}, differential_vars
         )
         @.. broadcast = false z[3] = z[3] * dt^2 / 2

--- a/lib/OrdinaryDiffEqNordsieck/test/an5_startup_tests.jl
+++ b/lib/OrdinaryDiffEqNordsieck/test/an5_startup_tests.jl
@@ -1,0 +1,58 @@
+using OrdinaryDiffEqNordsieck, OrdinaryDiffEqCore, Test
+
+# AN5 builds its Nordsieck history in one shot from a Tsit5 step, reading the
+# higher derivatives out of the Tsit5 interpolant. `ode_interpolant`'s first
+# argument is the normalised parameter Θ ∈ [0, 1], but the startup passed the
+# absolute time `t`. The vector is assembled at the *start* of the step
+# (`z[1] = uprev`, `z[2] = k[1] * dt`), so the correct value is `Θ = 0`.
+#
+# Every standard test problem starts at t = 0, where `t` happens to equal the
+# right answer, which is why this went unnoticed. Away from the origin the
+# startup derivatives are wrong, and since Θ then depends on where the interval
+# sits, the method loses both time-translation invariance and time-reversal
+# symmetry.
+
+lin(u, p, t) = p[1] .* u
+lin!(du, u, p, t) = (du .= p[1] .* u; nothing)
+
+"""Accepted `|dt|` sequence of `prob` under `alg`."""
+function accepted_dts(prob, alg; kwargs...)
+    integ = init(prob, alg; save_everystep = false, kwargs...)
+    return [abs(Float64(integ.dt)) for _ in integ]
+end
+
+@testset "AN5 startup" begin
+    kw = (abstol = 1.0e-8, reltol = 1.0e-8, save_everystep = false)
+
+    # An autonomous ODE does not care where the interval sits on the time axis.
+    @testset "time-translation invariance" begin
+        for f in (lin, lin!)
+            u0 = [0.5]
+            a = solve(ODEProblem(f, copy(u0), (0.0, 1.0), [1.01]), AN5(); kw...)
+            b = solve(ODEProblem(f, copy(u0), (100.0, 101.0), [1.01]), AN5(); kw...)
+            @test a.stats.naccept == b.stats.naccept
+            @test a.u[end] ≈ b.u[end] rtol = 1.0e-6
+        end
+    end
+
+    # On a tspan symmetric about zero the mirror map `t -> -t` is exact in IEEE
+    # arithmetic and round-to-nearest is symmetric under negation, so the
+    # mirrored problem `g(u, p, t) = -f(u, p, -t)` must reproduce the forward
+    # `|dt|` sequence bitwise.
+    @testset "time-reversal symmetry" begin
+        for inplace in (false, true)
+            if inplace
+                fwd = ODEProblem(lin!, [0.5], (-0.5, 0.5), [1.01])
+                g! = (du, u, p, t) -> (lin!(du, u, p, -t); du .= .-du; nothing)
+                bwd = ODEProblem(g!, [0.5], (0.5, -0.5), [1.01])
+            else
+                fwd = ODEProblem(lin, [0.5], (-0.5, 0.5), [1.01])
+                g = (u, p, t) -> -lin(u, p, -t)
+                bwd = ODEProblem(g, [0.5], (0.5, -0.5), [1.01])
+            end
+            @testset "$(inplace ? "iip" : "oop")" begin
+                @test accepted_dts(fwd, AN5(); kw...) == accepted_dts(bwd, AN5(); kw...)
+            end
+        end
+    end
+end

--- a/lib/OrdinaryDiffEqNordsieck/test/runtests.jl
+++ b/lib/OrdinaryDiffEqNordsieck/test/runtests.jl
@@ -10,6 +10,7 @@ end
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "Nordsieck Tests" include("nordsieck_tests.jl")
+    @time @safetestset "AN5 Startup Tests" include("an5_startup_tests.jl")
 end
 
 # Run QA tests (AllocCheck, JET, Aqua) - skip on pre-release Julia


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.** Draft.

## What changed and why

`AN5` seeds its Nordsieck vector in one shot from a `Tsit5` step, reading the higher derivatives out of the Tsit5 interpolant:

```julia
         z[3] = ode_interpolant(
-            t, dt, nothing, nothing, integrator.k, tsit5tab, nothing,
+            zero(t), dt, nothing, nothing, integrator.k, tsit5tab, nothing,
             Val{2}, differential_vars
         ) * dt^2 / 2
```

`ode_interpolant`'s first argument is the **normalised** parameter `Θ ∈ [0, 1]`, not a time. The startup passed the absolute time `t`. The vector is assembled at the *start* of the step (`z[1] = uprev`, `z[2] = k[1] * dt`), so the correct value is `Θ = 0`. Six call sites, three in the out-of-place path and three in the in-place one.

Every standard test problem starts at `t = 0`, where `t` happens to equal the right answer — which is why this has been invisible.

## Consequences away from the origin

1. **`AN5` is not time-translation invariant.** For an autonomous ODE, where the interval sits on the time axis cannot matter, but `u' = 1.01u` on `(0, 1)` and on `(100, 101)` take different numbers of steps and land on different answers.
2. **`AN5` is not reversible in time.** On a tspan symmetric about zero, against the mirrored problem `g(u,p,t) = -f(u,p,-t)`, it diverged from the forward solve at **step 2** with a relative difference of 8e-5, because Θ = −0.5 one way and +0.5 the other.

## Verification

New `lib/OrdinaryDiffEqNordsieck/test/an5_startup_tests.jl`, registered in `runtests.jl`, with a translation-invariance testset and a reversal testset (the latter asserts **bitwise** `|dt|` equality — on a symmetric tspan the mirror is exact in IEEE arithmetic and round-to-nearest is sign-symmetric).

Failing on master (`git stash push -- lib/OrdinaryDiffEqNordsieck/src/nordsieck_perform_step.jl`) — all six assertions:

```
Test Summary:                 | Fail  Total  Time
AN5 startup                   |    6      6  9.9s
  time-translation invariance |    4      4  7.6s
  time-reversal symmetry      |    2      2  2.3s
    oop                       |    1      1  1.9s
    iip                       |    1      1  0.3s
```

Passing with the fix:

```
Test Summary: | Pass  Total  Time
AN5 startup   |    6      6  8.6s
```

Full package suite on this branch (Julia 1.10.11): every functional testset passes, including the existing convergence tests that pin AN5's order at 5 —

```
Test Summary:                       | Pass  Total   Time
Nordsieck Tests                     |   24     24  29.9s
```

Two failures remain, both pre-existing `AllocCheck` failures in **JVODE** `perform_step!`, which this diff does not touch:

```
Some tests did not pass: 0 passed, 2 failed, 0 errored, 1 broken.
  OrdinaryDiffEqNordsieck.JVODE{...} perform_step! allocation check
```

## What I did **not** verify

- Whether `zero(t)` versus `one(t)` is the intended seeding point from the original derivation. I chose `zero(t)` because `z[1]`/`z[2]` are the state and scaled derivative at `uprev`/`k[1]`, and because it is the choice that makes the existing order-5 convergence tests pass — `one(t)` restores reversal symmetry (any constant does) but **breaks** those convergence tests, which is how I settled it.
- GPU and Downstream groups, Julia `pre`.

## Worth pushing back on

- `JVODE_Adams`/`JVODE_BDF` also fail time-reversal, but for an unrelated reason (the `dtmin` floor in `OrdinaryDiffEqCore.fix_dt_at_bounds!`, see the companion PR); they are not covered here.
- Separately and not addressed: `JVODE_BDF` returns `Unstable` on `u' = 1.01u` over `(-0.5, 0.5)`, aborting at `dt` below floating-point epsilon. That looks like a real defect in JVODE but is out of scope for this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m], harness: Claude Code 2.1.269)

https://claude.ai/code/session_01JQATpLKMyYX3VbPPX8qdeE
