### PR TITLE
Make the stabilized-RK step cap and eigenvalue tolerance direction-agnostic

### DIFF
--- a/lib/OrdinaryDiffEqStabilizedIRK/Project.toml
+++ b/lib/OrdinaryDiffEqStabilizedIRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqStabilizedIRK"
 uuid = "e3e12d00-db14-5390-b879-ac3dd2ef6296"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.1.2"
+version = "2.1.3"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/lib/OrdinaryDiffEqStabilizedIRK/src/irkc_utils.jl
+++ b/lib/OrdinaryDiffEqStabilizedIRK/src/irkc_utils.jl
@@ -66,7 +66,7 @@ function maxeig!(integrator, cache::OrdinaryDiffEqConstantCache)
         if integrator.alg isa IRKCAlgs # To match the constants given in the paper
             if iter >= 2 &&
                     abs(eig_prev - integrator.eigen_est) <
-                    max(integrator.eigen_est, 1.0 / integrator.opts.dtmax) * 0.01
+                    max(integrator.eigen_est, 1.0 / abs(integrator.opts.dtmax)) * 0.01
                 integrator.eigen_est *= 1.2
                 # Store the eigenvector
                 cache.zprev = z - uprev
@@ -169,7 +169,7 @@ function maxeig!(integrator, cache::OrdinaryDiffEqMutableCache)
         if integrator.alg isa IRKCAlgs # To match the constants given in the paper
             if iter >= 2 &&
                     abs(eig_prev - integrator.eigen_est) <
-                    max(integrator.eigen_est, 1.0 / integrator.opts.dtmax) * 0.01
+                    max(integrator.eigen_est, 1.0 / abs(integrator.opts.dtmax)) * 0.01
                 integrator.eigen_est *= 1.2
                 # Store the eigenvector
                 @.. broadcast = false ccache.zprev = z - uprev

--- a/lib/OrdinaryDiffEqStabilizedRK/Project.toml
+++ b/lib/OrdinaryDiffEqStabilizedRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqStabilizedRK"
 uuid = "358294b1-0aab-51c3-aafe-ad5ab194a2ad"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.6.0"
+version = "2.6.1"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqStabilizedRK/src/alg_utils.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/alg_utils.jl
@@ -33,8 +33,12 @@ fac_default_gamma(alg::Union{RKC, SERK2, TSRKC2, TSRKC3, RKMC2}) = true
 fac_default_gamma(alg::Union{RKL1, RKL2}) = true
 has_dtnew_modification(alg::Union{ROCK2, ROCK4, SERK2, ESERK4, ESERK5, RKMC2}) = true
 
+# The stability bound is a magnitude.  `min` against a signed dtnew is a no-op
+# for a backward (tdir < 0) solve, which silently removes the cap.
+_cap(dtnew, bound) = copysign(min(abs(dtnew), abs(bound)), dtnew)
+
 function dtnew_modification(integrator, alg::ROCK2, dtnew)
-    return min(
+    return _cap(
         dtnew,
         typeof(dtnew)(
             (
@@ -47,7 +51,7 @@ function dtnew_modification(integrator, alg::ROCK2, dtnew)
     )
 end
 function dtnew_modification(integrator, alg::ROCK4, dtnew)
-    return min(
+    return _cap(
         dtnew,
         typeof(dtnew)(
             (
@@ -58,21 +62,21 @@ function dtnew_modification(integrator, alg::ROCK4, dtnew)
     )
 end
 function dtnew_modification(integrator, alg::SERK2, dtnew)
-    return min(
+    return _cap(
         dtnew,
         typeof(dtnew)((0.8 * 250 * 250 / (integrator.eigen_est + 1)))
     )
 end
 function dtnew_modification(integrator, alg::ESERK4, dtnew)
-    return min(dtnew, typeof(dtnew)((0.98 * 4000 * 4000 / integrator.eigen_est)))
+    return _cap(dtnew, typeof(dtnew)((0.98 * 4000 * 4000 / integrator.eigen_est)))
 end
 function dtnew_modification(integrator, alg::ESERK5, dtnew)
-    return min(dtnew, typeof(dtnew)((0.98 * 2000 * 2000 / integrator.eigen_est)))
+    return _cap(dtnew, typeof(dtnew)((0.98 * 2000 * 2000 / integrator.eigen_est)))
 end
 function dtnew_modification(integrator, alg::RKMC2, dtnew)
     s = min(alg.max_stages, 1000)
     rho_max = 0.31 * (s + 0.83)^1.87
-    return min(dtnew, typeof(dtnew)(rho_max / integrator.eigen_est))
+    return _cap(dtnew, typeof(dtnew)(rho_max / integrator.eigen_est))
 end
 
 
@@ -96,12 +100,12 @@ has_dtnew_modification(alg::Union{RKL1, RKL2}) = true
 
 function dtnew_modification(integrator, alg::RKL1, dtnew)
     _, s = _rkl_clamp_odd_stages(alg.min_stages, alg.max_stages)
-    return min(dtnew, typeof(dtnew)((s^2 + s) / integrator.eigen_est))
+    return _cap(dtnew, typeof(dtnew)((s^2 + s) / integrator.eigen_est))
 end
 
 function dtnew_modification(integrator, alg::RKL2, dtnew)
     _, s = _rkl_clamp_odd_stages(alg.min_stages, alg.max_stages)
-    return min(dtnew, typeof(dtnew)((s^2 + s - 2) / (2 * integrator.eigen_est)))
+    return _cap(dtnew, typeof(dtnew)((s^2 + s - 2) / (2 * integrator.eigen_est)))
 end
 
 alg_order(alg::RKG1) = 1
@@ -114,10 +118,10 @@ has_dtnew_modification(alg::Union{RKG1, RKG2}) = true
 
 function dtnew_modification(integrator, alg::RKG1, dtnew)
     s = alg.max_stages
-    return min(dtnew, typeof(dtnew)(s * (s + 3) / (2 * integrator.eigen_est)))
+    return _cap(dtnew, typeof(dtnew)(s * (s + 3) / (2 * integrator.eigen_est)))
 end
 
 function dtnew_modification(integrator, alg::RKG2, dtnew)
     s = alg.max_stages
-    return min(dtnew, typeof(dtnew)((s + 4) * (s - 1) / (3 * integrator.eigen_est)))
+    return _cap(dtnew, typeof(dtnew)((s + 4) * (s - 1) / (3 * integrator.eigen_est)))
 end

--- a/lib/OrdinaryDiffEqStabilizedRK/src/rkc_utils.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/rkc_utils.jl
@@ -57,7 +57,7 @@ function maxeig!(integrator, cache::OrdinaryDiffEqConstantCache)
         if integrator.alg isa RKCAlgs # To match the constants given in the paper
             if iter >= 2 &&
                     abs(eig_prev - integrator.eigen_est) <
-                    max(integrator.eigen_est, inv(integrator.opts.dtmax)) * T(0.01)
+                    max(integrator.eigen_est, inv(abs(integrator.opts.dtmax))) * T(0.01)
                 integrator.eigen_est *= T(1.2)
                 # Store the eigenvector
                 cache.zprev = z - uprev
@@ -147,7 +147,7 @@ function maxeig!(integrator, cache::OrdinaryDiffEqMutableCache)
         if integrator.alg isa RKCAlgs # To match the constants given in the paper
             if iter >= 2 &&
                     abs(eig_prev - integrator.eigen_est) <
-                    max(integrator.eigen_est, inv(integrator.opts.dtmax)) * T(0.01)
+                    max(integrator.eigen_est, inv(abs(integrator.opts.dtmax))) * T(0.01)
                 integrator.eigen_est *= T(1.2)
                 # Store the eigenvector
                 @..  ccache.zprev = z - uprev

--- a/lib/OrdinaryDiffEqStabilizedRK/test/dtnew_cap_direction_tests.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/dtnew_cap_direction_tests.jl
@@ -1,0 +1,40 @@
+using OrdinaryDiffEqStabilizedRK, OrdinaryDiffEqCore, Test
+
+# `dtnew_modification` caps the controller's proposed step at the method's
+# stability limit. The limit is a magnitude, so `min(dtnew, bound)` silently does
+# nothing for a backward (tdir < 0) solve, where dtnew < 0 < bound: the cap was
+# applied going forwards and dropped going backwards.
+#
+# NOTE: these methods' caps are currently unreachable from `calc_dt_propose!`
+# because `OrdinaryDiffEqStabilizedRK` defines `dtnew_modification` without
+# importing it from `OrdinaryDiffEqCore`, so the generic identity method is what
+# actually runs (see the issue linked from the PR). The tests below therefore
+# call the package's own method directly.
+
+f(u, p, t) = -1000.0 .* u
+
+const CAPPED_ALGS = (
+    "ROCK2" => ROCK2(), "ROCK4" => ROCK4(), "SERK2" => SERK2(),
+    "ESERK4" => ESERK4(), "ESERK5" => ESERK5(), "RKMC2" => RKMC2(),
+    "RKL1" => RKL1(), "RKL2" => RKL2(), "RKG1" => RKG1(), "RKG2" => RKG2(),
+)
+
+@testset "stability cap is direction-agnostic" begin
+    for (algname, alg) in CAPPED_ALGS
+        @testset "$algname" begin
+            capped = map(((0.0, 1.0), (1.0, 0.0))) do tspan
+                integ = init(
+                    ODEProblem(f, [1.0], tspan), alg;
+                    abstol = 1.0e-6, reltol = 1.0e-6
+                )
+                integ.eigen_est = 1.0e10 # make the stability bound bind for every method
+                dtnew = integ.tdir * 1.0 # far above it
+                return abs(
+                    OrdinaryDiffEqStabilizedRK.dtnew_modification(integ, alg, dtnew)
+                )
+            end
+            @test capped[1] < 1.0        # the cap actually binds forward
+            @test capped[1] == capped[2] # and identically backward
+        end
+    end
+end

--- a/lib/OrdinaryDiffEqStabilizedRK/test/runtests.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/runtests.jl
@@ -22,6 +22,7 @@ end
 # Run functional tests
 if TEST_GROUP == "Core" || TEST_GROUP == "ALL"
     @time @safetestset "RKC Tests" include("rkc_tests.jl")
+    @time @safetestset "dtnew Cap Direction Tests" include("dtnew_cap_direction_tests.jl")
 end
 
 # Run QA tests (AllocCheck, JET, Aqua)


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.** Draft.

## What changed and why

Two sign bugs of the same kind, in `OrdinaryDiffEqStabilizedRK` and its sibling `OrdinaryDiffEqStabilizedIRK`.

**1. The stability-limit step cap.** `dtnew_modification` caps the controller's proposed step at the method's stability limit. The limit is a *magnitude*, so `min(dtnew, bound)` does nothing at all for a backward solve, where `dtnew < 0 < bound`:

```julia
+_cap(dtnew, bound) = copysign(min(abs(dtnew), abs(bound)), dtnew)
+
 function dtnew_modification(integrator, alg::ROCK2, dtnew)
-    return min(
+    return _cap(
```

Ten methods: ROCK2, ROCK4, SERK2, ESERK4, ESERK5, RKMC2, RKL1, RKL2, RKG1, RKG2. With `eigen_est = 1e6` and a proposed `|dt|` of 1.0, ROCK2 forward caps to 0.0324385 and backward leaves it at 1.0 — a 30× difference.

**2. The power-iteration convergence tolerance.** `maxeig!` compares against `max(eigen_est, inv(integrator.opts.dtmax))`. `dtmax` is negative for `tdir < 0`, so the floor term goes negative and the tolerance differs between the two directions, giving a different number of power iterations and hence a different spectral-radius estimate. Same one-liner in `OrdinaryDiffEqStabilizedIRK`'s `maxeig!` (`1.0 / integrator.opts.dtmax`).

## Important caveat: the cap is currently dead code

`OrdinaryDiffEqStabilizedRK` defines `dtnew_modification` **without importing it** from `OrdinaryDiffEqCore`, so it shadows rather than extends, and `calc_dt_propose!` calls Core's generic identity method. See #4535. That means:

- fix (1) has **no observable end-to-end effect today** — it makes the shadowed implementation correct so that switching the import on (a separate, reviewable behavior change) does not immediately reintroduce a direction bug;
- fix (2) *is* live, but see below.

I am not fixing the import here on purpose: enabling a dormant stability cap for ten methods changes step sizes for every user of them and deserves its own PR.

## Verification

New `lib/OrdinaryDiffEqStabilizedRK/test/dtnew_cap_direction_tests.jl`, registered in `runtests.jl`. It calls the package's own `dtnew_modification` directly (the only way to reach it, per the caveat above), with `eigen_est` set high enough that the bound binds for every method, and asserts (a) the cap actually binds forward and (b) the capped magnitude is identical backward.

Failing on master (`git stash push -- lib/OrdinaryDiffEqStabilizedRK/src/alg_utils.jl`) — one assertion per method:

```
Test Summary:                       | Pass  Fail  Total     Time
stability cap is direction-agnostic |   10    10     20  1m00.4s
  ROCK2                             |    1     1      2     4.5s
  ROCK4                             |    1     1      2     2.4s
  SERK2                             |    1     1      2     0.9s
  ESERK4                            |    1     1      2    38.6s
  ESERK5                            |    1     1      2    11.2s
  RKMC2                             |    1     1      2     0.6s
  RKL1                              |    1     1      2     0.5s
  RKL2                              |    1     1      2     0.5s
  RKG1                              |    1     1      2     0.5s
  RKG2                              |    1     1      2     0.5s
```

Passing with the fix:

```
Test Summary:                       | Pass  Total   Time
stability cap is direction-agnostic |   20     20  58.2s
```

Full package suites on this branch (Julia 1.10.11):

```
Testing OrdinaryDiffEqStabilizedRK tests passed
Testing OrdinaryDiffEqStabilizedIRK tests passed
```

## What I did **not** verify — please read

**The two `inv(dtmax)` changes have no discriminating test.** I could not surface an end-to-end difference from them. The floor only matters when `eigen_est < 1/|tspan|`; I tried `u' = 1e-3 u` over a unit-length tspan with `abstol = reltol = 1e-10` across ROCK2/ROCK4/RKC/SERK2/RKL2/RKG2, in-place and out-of-place, and every case was already bitwise reversible. I am shipping them as sign corrections that are obviously right by inspection, not as fixes to an observed failure — if you would rather they went in with a demonstration, say so and I will drop them from this PR.

Also not verified: GPU and Downstream groups, Julia `pre`; and whether the intended stability bounds are still the right ones (that question belongs with #4535).

## Worth pushing back on

- `_cap` is a new unexported one-line helper in `alg_utils.jl`. If you would prefer the `copysign(min(abs(...), ...), ...)` written out at each of the ten sites, or the helper placed elsewhere, easy to change.
- Bundling two packages in one PR: they are the identical one-line defect in sibling `maxeig!` implementations, so splitting felt like more noise than signal. Happy to split.

Related: #4535 (the cap never runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m], harness: Claude Code 2.1.269)

https://claude.ai/code/session_01JQATpLKMyYX3VbPPX8qdeE
