### PR TITLE
NordsieckBDF: rebase dense output when a callback truncates the step

### DIFF
--- a/lib/OrdinaryDiffEqBDF/src/bdf_interpolants.jl
+++ b/lib/OrdinaryDiffEqBDF/src/bdf_interpolants.jl
@@ -865,11 +865,3 @@ for (TV, m) in ((Val{1}, 1), (Val{2}, 2), (Val{3}, 3))
         return out
     end
 end
-
-# `addsteps!` is a no-op: the interpolation data is written during the step.
-function _ode_addsteps!(
-        k, t, uprev, u, dt, f, p, cache::NORDSIECK_CACHES,
-        always_calc_begin = false, allow_calc_end = true, force_calc_end = false
-    )
-    return nothing
-end

--- a/lib/OrdinaryDiffEqBDF/src/stiff_addsteps.jl
+++ b/lib/OrdinaryDiffEqBDF/src/stiff_addsteps.jl
@@ -137,3 +137,76 @@ function _ode_addsteps!(
     end
     return nothing
 end
+
+####################################################################
+# NordsieckBDF / DNordsieckBDF: rebase the Nordsieck polynomial
+#
+# k[j] = zn[j] are the columns about the endpoint of the step h = hscale:
+#     p(t) = Σ_j k[j] s^(j-1),   s = (t - (tprev + h)) / h.
+# A callback shortening the step to dt evaluates the interpolant with
+# s' = (t - (tprev + dt)) / dt, and s = a + b s' with b = dt/h, a = b - 1.
+# Rebuild from zn (not k) so repeated calls stay idempotent.
+####################################################################
+
+function _ode_addsteps!(
+        k, t, uprev, u, dt, f, p,
+        cache::Union{NordsieckBDFConstantCache, DNordsieckBDFConstantCache},
+        always_calc_begin = false, allow_calc_end = true,
+        force_calc_end = false
+    )
+    always_calc_begin || return nothing
+    (; zn, order, hscale) = cache
+    iszero(hscale) && return nothing
+    b = dt / hscale
+    a = b - one(b)
+    n = length(k)
+    # constant caches alias k[j] to zn[j]; never mutate those in place
+    for j in 1:n
+        k[j] = j - 1 <= order ? zn[j] : zero(u)
+    end
+    for i in 1:(n - 1)
+        for j in (n - 1):-1:i
+            k[j] = @.. k[j] + a * k[j + 1]
+        end
+    end
+    scale = b
+    for j in 2:n
+        k[j] = @.. scale * k[j]
+        scale *= b
+    end
+    return nothing
+end
+
+function _ode_addsteps!(
+        k, t, uprev, u, dt, f, p,
+        cache::Union{NordsieckBDFCache, DNordsieckBDFCache},
+        always_calc_begin = false, allow_calc_end = true,
+        force_calc_end = false
+    )
+    always_calc_begin || return nothing
+    (; zn, order, hscale) = cache
+    iszero(hscale) && return nothing
+    b = dt / hscale
+    a = b - one(b)
+    n = length(k)
+    for j in 1:n
+        if j - 1 <= order
+            copyto!(k[j], zn[j])
+        else
+            fill!(k[j], zero(eltype(u)))
+        end
+    end
+    for i in 1:(n - 1)
+        for j in (n - 1):-1:i
+            kj, kj1 = k[j], k[j + 1]
+            @.. broadcast = false kj = kj + a * kj1
+        end
+    end
+    scale = b
+    for j in 2:n
+        kj = k[j]
+        @.. broadcast = false kj = scale * kj
+        scale *= b
+    end
+    return nothing
+end

--- a/lib/OrdinaryDiffEqBDF/test/nordsieck_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/nordsieck_tests.jl
@@ -1,6 +1,6 @@
 using OrdinaryDiffEqBDF, OrdinaryDiffEqRosenbrock, ODEProblemLibrary
 using SciMLBase: DAEProblem, ODEProblem, ODEFunction, successful_retcode, remake,
-    DiscreteCallback
+    DiscreteCallback, ContinuousCallback, NoInit
 using OrdinaryDiffEqNonlinearSolve: NLNewton, NonlinearSolveAlg
 using LinearAlgebra, Test
 
@@ -257,4 +257,49 @@ end
     sol = solve(prob, NordsieckBDF(), abstol = 1.0e-10, reltol = 1.0e-10)
     @test successful_retcode(sol)
     @test isapprox(sol.u[end][1], 0.99, atol = 1.0e-3)
+end
+
+@testset "NordsieckBDF / DNordsieckBDF: dense output over a step truncated by a callback" begin
+    # A continuous callback shortens the accepted step. The stored Nordsieck
+    # columns must be rebased to the new endpoint, or sol(t) over that step
+    # is evaluated with the wrong centre and scaling.
+    tol = 1.0e-8
+    exact(t) = exp(-t)
+    t_ev = log(2.0)
+    function check_event_step(sol, first)
+        i = findfirst(t -> abs(t - t_ev) < 1.0e-6, sol.t)
+        t0, t1 = sol.t[i - 1], sol.t[i]
+        @test t1 - t0 > 1.0e-4                          # the step really was truncated
+        @test first(sol(t1)) ≈ first(sol.u[i]) atol = 1.0e-10
+        for τ in range(t0, t1, length = 11)[2:(end - 1)]
+            @test abs(first(sol(τ)) - exact(τ)) < 1.0e-6
+        end
+        return nothing
+    end
+
+    f_oop(u, p, t) = -u
+    f_iip(du, u, p, t) = (du[1] = -u[1]; nothing)
+    cb_oop = ContinuousCallback((u, t, integ) -> u - 0.5, integ -> nothing)
+    cb_iip = ContinuousCallback((u, t, integ) -> u[1] - 0.5, integ -> nothing)
+    sol = solve(
+        ODEProblem(f_oop, 1.0, (0.0, 3.0)), NordsieckBDF();
+        callback = cb_oop, abstol = tol, reltol = tol
+    )
+    check_event_step(sol, identity)
+    sol = solve(
+        ODEProblem(f_iip, [1.0], (0.0, 3.0)), NordsieckBDF();
+        callback = cb_iip, abstol = tol, reltol = tol
+    )
+    check_event_step(sol, first)
+
+    # u1' = -u1, 0 = u2 - u1, consistent initial data so no initialization is needed
+    dae_res!(res, du, u, p, t) = (res[1] = du[1] + u[1]; res[2] = u[2] - u[1]; nothing)
+    prob = DAEProblem(
+        dae_res!, [-1.0, -1.0], [1.0, 1.0], (0.0, 3.0); differential_vars = [true, false]
+    )
+    sol = solve(
+        prob, DNordsieckBDF();
+        callback = cb_iip, abstol = tol, reltol = tol, initializealg = NoInit()
+    )
+    check_event_step(sol, first)
 end


### PR DESCRIPTION
> **Draft. Please ignore until reviewed by @ChrisRackauckas.**

## What changed and why

`_ode_addsteps!` for the four Nordsieck caches (`NordsieckBDF`, `DNordsieckBDF`, in-place and constant) was a literal `return nothing`. When a `ContinuousCallback` locates a root inside an accepted step, `OrdinaryDiffEqCore` shortens `integrator.dt` to the root and calls `ode_addsteps!(…, always_calc_begin = true)` so the solver can rebuild `integrator.k` for the truncated interval. QNDF, FBDF and DFBDF do this in `stiff_addsteps.jl`; Nordsieck ignored it, so `k` kept the columns centred on the *original* endpoint and scaled by the *original* step while the interpolant evaluated `s = Θ - 1` with Θ computed from the truncated `dt`. Dense output over the event step was wrong by ~1e-2 at `reltol = 1e-8` and did not pass through the saved event value, for both the ODE and DAE solvers.

The fix rebuilds `k` from the committed Nordsieck array `cache.zn` (columns about `tprev + h`, `h = cache.hscale`), then re-expresses the same polynomial about the new endpoint: with `b = dt / h` and `a = b - 1`, `s = a + b s'`, which is an in-place Taylor shift by `a` followed by scaling column `j` by `b^(j-1)`. Rebuilding from `zn` rather than from `k` keeps repeated calls idempotent (a following `u_modified!` reevaluation calls `ode_addsteps!` again with the same `dt`). The constant-cache method allocates new columns because `k[j]` aliases `zn[j]` there.

No public API change. `OrdinaryDiffEqBDF` is at 2.4.9 on master, which is not yet registered, so no version bump.

## Failing before / passing after

Test added to `lib/OrdinaryDiffEqBDF/test/nordsieck_tests.jl`: `u' = -u` (scalar out-of-place and vector in-place) and the index-1 DAE `u1' = -u1, 0 = u2 - u1`, with a `ContinuousCallback` at `u = 0.5` whose affect does nothing. It checks that the event step was really truncated, that `sol(t_event)` matches the saved value, and that `sol(τ)` at interior points of the event step is within 1e-6 of `exp(-τ)`.

On unmodified `master` (75adf300c) with only the test added:

```
NordsieckBDF / DNordsieckBDF: dense output over a step truncated by a callback: Test Failed
  Expression: ≈(first(sol(t1)), first(sol.u[i]), atol = 1.0e-10)
   Evaluated: 0.48981388085931105 ≈ 0.5 (atol=1.0e-10)
NordsieckBDF / DNordsieckBDF: dense output over a step truncated by a callback: Test Failed
  Expression: abs(first(sol(τ)) - exact(τ)) < 1.0e-6
   Evaluated: 0.0010450286506006323 < 1.0e-6
…
Test Summary:                                                                  | Pass  Fail  Total   Time
NordsieckBDF / DNordsieckBDF: dense output over a step truncated by a callback |    3    30     33  23.1s
```

With this PR:

```
Test Summary:                                                                  | Pass  Total   Time
NordsieckBDF / DNordsieckBDF: dense output over a step truncated by a callback |   33     33  16.7s
```

All other testsets in `nordsieck_tests.jl` pass in both runs.

## Verification

Run from `lib/OrdinaryDiffEqBDF` on Julia 1.12.4.

`GROUP=QA julia --project -e 'using Pkg; Pkg.test()'`:

```
Test Summary:    | Pass  Broken  Total     Time
Allocation Tests |    4      18     22  5m11.9s
Test Summary: | Pass  Broken  Total     Time
JET Tests     |   18      23     41  1m17.9s
Test Summary: | Pass  Total     Time
Aqua          |   21     21  1m16.6s
     Testing OrdinaryDiffEqBDF tests passed
```
(the `Broken` entries are pre-existing markers in the QA suite; none were added.)

`GROUP=Core julia --project -e 'using Pkg; Pkg.test()'`:

```
Test Summary:         | Pass  Total     Time
DAE Convergence Tests |   50     50  1m37.7s
DAE AD Tests          |   40     40  10m23.5s
DAE Event Tests       |    4      4  11.6s
DAE derivative_discontinuity! Tests |   11     11
DAE Initialization Tests |   38  (2 broken, pre-existing)  40
DAE Nonlinear Solve Path Tests |   16     16  36.4s
BDF Inference Tests   |    1      1  2.6s
BDF Convergence Tests |   84     84  4m13.2s
BDF Regression Tests  |   49     49  4m19.8s
BDF Time Reversal Tests |   20     20  1m43.7s
FBDF Time Filter Tests |   41     41  28.0s
FBDF Filter Regression Tests |  273    273  20.2s
Nordsieck BDF Tests   |  134    134  4m27.2s
LHL Factorization Tests |   19     19  1m07.1s
     Testing OrdinaryDiffEqBDF tests passed
```

Formatting checked with Runic 1.9.0 (`--check` clean) and `typos` on the changed files.

## Not verified

- GPU group (needs hardware).
- Downstream packages (DelayDiffEq history lookups through this interpolant should now be correct over event steps, but I did not run its suite).

## Found while testing, deliberately left out of this PR

An out-of-place `DAEProblem` with any `ContinuousCallback` errors on master, independent of this change:

```
MethodError: no method matching get_tmp_cache(::ODEIntegrator{DNordsieckBDF…}, ::DNordsieckBDF…, ::DNordsieckBDFConstantCache)
  get_tmp_cache(::Any, ::OrdinaryDiffEqAlgorithm, ::OrdinaryDiffEqConstantCache)   # DAEAlgorithm is not an OrdinaryDiffEqAlgorithm
  get_tmp_cache(::Any, ::DAEAlgorithm, ::OrdinaryDiffEqMutableCache)
```

reached from `DiffEqBase.find_callback_time → get_condition → get_tmp`. The regression test here therefore covers the in-place DAE only. The missing `get_tmp_cache(::Any, ::DAEAlgorithm, ::OrdinaryDiffEqConstantCache)` method is a one-line `OrdinaryDiffEqCore` fix with its own test and will go in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Code 2.1.270, model: claude-fable-5-1)

https://claude.ai/code/session_01A1EvyhqnXh4tSeovg5e8y8
