### PR TITLE
Fix Runic formatting and typos failures on master

### DIFF
--- a/lib/DiffEqBase/test/modelingtoolkit/events.jl
+++ b/lib/DiffEqBase/test/modelingtoolkit/events.jl
@@ -1,7 +1,7 @@
 using ModelingToolkit, OrdinaryDiffEq, Test
 using ModelingToolkit: t_nounits as t, D_nounits as D, SymbolicContinuousCallback
 
-@testset "All simultaenous events are saved" begin
+@testset "All simultaneous events are saved" begin
     # https://github.com/SciML/ModelingToolkit.jl/issues/4870 Case 2
     @variables x(t) = 0.0
     c_up = only(@discretes c_up(t) = 0.0)

--- a/lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl
+++ b/lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl
@@ -242,7 +242,7 @@ end
         @test c.order == 2
     end
 end
-  
+
 # Regression test for the backward-in-time step rejection path: for tdir < 0
 # (e.g. adjoint solves), `bdf_step_reject_controller!` must still shrink |dt|.
 # Previously `min(h, hₖ₋₁)`/`hₖ₋₁ > hₖ` compared signed (negative) step sizes,

--- a/lib/OrdinaryDiffEqCore/test/dtmin_direction_tests.jl
+++ b/lib/OrdinaryDiffEqCore/test/dtmin_direction_tests.jl
@@ -8,33 +8,33 @@ using OrdinaryDiffEqCore.DiffEqBase: timedepentdtmin
 # which silently removed the floor for every tdir < 0 solve.
 
 @testset "dtmin direction handling" begin
-@testset "dtmin floor applies in both directions" begin
-    for (t0, t1) in ((0.0, 1.0), (1.0, 0.0))
-        prob = ODEProblem((u, p, t) -> -u, 1.0, (t0, t1))
-        integ = init(prob, Tsit5(); dtmin = 1.0e-3, force_dtmin = true)
-        dtmin = timedepentdtmin(integ)
-        integ.dt = integ.tdir * dtmin / 100 # far below the floor
-        fix_dt_at_bounds!(integ)
-        @test abs(integ.dt) >= dtmin
-        @test signbit(integ.dt) == signbit(integ.tdir)
+    @testset "dtmin floor applies in both directions" begin
+        for (t0, t1) in ((0.0, 1.0), (1.0, 0.0))
+            prob = ODEProblem((u, p, t) -> -u, 1.0, (t0, t1))
+            integ = init(prob, Tsit5(); dtmin = 1.0e-3, force_dtmin = true)
+            dtmin = timedepentdtmin(integ)
+            integ.dt = integ.tdir * dtmin / 100 # far below the floor
+            fix_dt_at_bounds!(integ)
+            @test abs(integ.dt) >= dtmin
+            @test signbit(integ.dt) == signbit(integ.tdir)
+        end
     end
-end
 
-# End-to-end consequence: on a tspan symmetric about zero the mirrored problem
-# `g(u, p, t) = -f(u, p, -t)` traverses the same trajectory backwards, and because
-# IEEE negation and round-to-nearest are sign-symmetric the two solves agree
-# bitwise. A floor applied in only one direction breaks that.
-@testset "time-reversal symmetry at the dtmin floor" begin
-    f = (u, p, t) -> -50.0 * u
-    g = (u, p, t) -> 50.0 * u # -f(u, p, -t) for this autonomous f
-    kw = (
-        abstol = 1.0e-12, reltol = 1.0e-12, dtmin = 1.0e-2,
-        force_dtmin = true, save_everystep = false,
-    )
-    dts(prob) = (i = init(prob, Tsit5(); kw...); [abs(Float64(i.dt)) for _ in i])
-    fwd = dts(ODEProblem(f, 1.0, (-1.0, 1.0)))
-    bwd = dts(ODEProblem(g, 1.0, (1.0, -1.0)))
-    @test !isempty(fwd)
-    @test fwd == bwd
-end
+    # End-to-end consequence: on a tspan symmetric about zero the mirrored problem
+    # `g(u, p, t) = -f(u, p, -t)` traverses the same trajectory backwards, and because
+    # IEEE negation and round-to-nearest are sign-symmetric the two solves agree
+    # bitwise. A floor applied in only one direction breaks that.
+    @testset "time-reversal symmetry at the dtmin floor" begin
+        f = (u, p, t) -> -50.0 * u
+        g = (u, p, t) -> 50.0 * u # -f(u, p, -t) for this autonomous f
+        kw = (
+            abstol = 1.0e-12, reltol = 1.0e-12, dtmin = 1.0e-2,
+            force_dtmin = true, save_everystep = false,
+        )
+        dts(prob) = (i = init(prob, Tsit5(); kw...); [abs(Float64(i.dt)) for _ in i])
+        fwd = dts(ODEProblem(f, 1.0, (-1.0, 1.0)))
+        bwd = dts(ODEProblem(g, 1.0, (1.0, -1.0)))
+        @test !isempty(fwd)
+        @test fwd == bwd
+    end
 end

--- a/lib/OrdinaryDiffEqExtrapolation/test/extrapolation_inplace_consistency_tests.jl
+++ b/lib/OrdinaryDiffEqExtrapolation/test/extrapolation_inplace_consistency_tests.jl
@@ -44,12 +44,12 @@ end
 
     @testset "same effort as out-of-place" begin
         for (algname, alg) in algs, (name, f, f!, u0, p, T) in CASES
-            soop = solve(ODEProblem(f, copy(u0), (-T, T), p), alg; kw...)
-            siip = solve(ODEProblem(f!, copy(u0), (-T, T), p), alg; kw...)
+            sol_oop = solve(ODEProblem(f, copy(u0), (-T, T), p), alg; kw...)
+            sol_iip = solve(ODEProblem(f!, copy(u0), (-T, T), p), alg; kw...)
             @testset "$algname $name" begin
-                @test siip.stats.naccept <= 2 * soop.stats.naccept
-                @test siip.stats.nreject <= 2 * soop.stats.nreject + 4
-                @test siip.u ≈ soop.u rtol = 1.0e-5
+                @test sol_iip.stats.naccept <= 2 * sol_oop.stats.naccept
+                @test sol_iip.stats.nreject <= 2 * sol_oop.stats.nreject + 4
+                @test sol_iip.u ≈ sol_oop.u rtol = 1.0e-5
             end
         end
     end


### PR DESCRIPTION
> **Draft. Please ignore until reviewed by @ChrisRackauckas.**

Mechanical only. The `Runic` and `Spell Check with Typos` checks are red on `master` (seen on https://github.com/SciML/OrdinaryDiffEq.jl/pull/4540, which touches none of these files).

- Runic 1.10.0 (the version `runic-action@v1` installs; local Runic 1.9.0 disagrees on other files, so this PR fixes only what CI's version flags): trailing whitespace in `lib/OrdinaryDiffEqBDF/test/bdf_regression_tests.jl`, re-indentation of `lib/OrdinaryDiffEqCore/test/dtmin_direction_tests.jl`.
- typos: `simultaenous` → `simultaneous` in a testset name in `lib/DiffEqBase/test/modelingtoolkit/events.jl`; the variable `soop` in `lib/OrdinaryDiffEqExtrapolation/test/extrapolation_inplace_consistency_tests.jl` renamed to `sol_oop` (and `siip` to `sol_iip` to match).

## Verification

```
$ julia --project=<Runic 1.10.0 env> -e 'using Runic; exit(Runic.main(ARGS))' -- --check .   # exit 0
$ typos .                                                                                   # clean
```

The two test files whose code changed were run via TestEnv in their sublibrary environments on Julia 1.12.4:

```
Test Summary:                                   | Pass  Total   Time
Extrapolation in-place/out-of-place consistency |   14     14  47.4s
Test Summary:            | Pass  Total  Time
dtmin direction handling |    6      6  3.6s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Code 2.1.270, model: claude-fable-5-1)

https://claude.ai/code/session_01A1EvyhqnXh4tSeovg5e8y8
