### PR TITLE
Extend OrdinaryDiffEqCore.dtnew_modification instead of shadowing it

### DIFF
--- a/lib/OrdinaryDiffEqStabilizedRK/Project.toml
+++ b/lib/OrdinaryDiffEqStabilizedRK/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqStabilizedRK"
 uuid = "358294b1-0aab-51c3-aafe-ad5ab194a2ad"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com>"]
-version = "2.6.1"
+version = "2.7.0"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/lib/OrdinaryDiffEqStabilizedRK/src/OrdinaryDiffEqStabilizedRK.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/src/OrdinaryDiffEqStabilizedRK.jl
@@ -2,7 +2,7 @@ module OrdinaryDiffEqStabilizedRK
 
 import OrdinaryDiffEqCore: alg_adaptive_order,
     gamma_default, qmax_default, alg_extrapolates,
-    fac_default_gamma, has_dtnew_modification,
+    fac_default_gamma, has_dtnew_modification, dtnew_modification,
     perform_step!, unwrap_alg,
     default_controller, PredictiveController,
     OrdinaryDiffEqMutableCache, OrdinaryDiffEqConstantCache,

--- a/lib/OrdinaryDiffEqStabilizedRK/test/dtnew_cap_direction_tests.jl
+++ b/lib/OrdinaryDiffEqStabilizedRK/test/dtnew_cap_direction_tests.jl
@@ -4,12 +4,6 @@ using OrdinaryDiffEqStabilizedRK, OrdinaryDiffEqCore, Test
 # stability limit. The limit is a magnitude, so `min(dtnew, bound)` silently does
 # nothing for a backward (tdir < 0) solve, where dtnew < 0 < bound: the cap was
 # applied going forwards and dropped going backwards.
-#
-# NOTE: these methods' caps are currently unreachable from `calc_dt_propose!`
-# because `OrdinaryDiffEqStabilizedRK` defines `dtnew_modification` without
-# importing it from `OrdinaryDiffEqCore`, so the generic identity method is what
-# actually runs (see the issue linked from the PR). The tests below therefore
-# call the package's own method directly.
 
 f(u, p, t) = -1000.0 .* u
 
@@ -35,6 +29,26 @@ const CAPPED_ALGS = (
             end
             @test capped[1] < 1.0        # the cap actually binds forward
             @test capped[1] == capped[2] # and identically backward
+        end
+    end
+end
+
+# `calc_dt_propose!` dispatches on `OrdinaryDiffEqCore.dtnew_modification`. These
+# methods are only reached if this package *extends* that function rather than
+# defining a same-named one of its own, which is easy to get wrong by leaving it
+# out of the `import` list - and silently disables every cap above.
+@testset "stability cap is reachable from OrdinaryDiffEqCore" begin
+    @test OrdinaryDiffEqCore.dtnew_modification ===
+        OrdinaryDiffEqStabilizedRK.dtnew_modification
+    for (algname, alg) in CAPPED_ALGS
+        @testset "$algname" begin
+            @test OrdinaryDiffEqCore.has_dtnew_modification(alg)
+            integ = init(
+                ODEProblem(f, [1.0], (0.0, 1.0)), alg;
+                abstol = 1.0e-6, reltol = 1.0e-6
+            )
+            integ.eigen_est = 1.0e10
+            @test abs(OrdinaryDiffEqCore.dtnew_modification(integ, alg, 1.0)) < 1.0
         end
     end
 end


### PR DESCRIPTION
Closes #4535. **Ignore until reviewed by @ChrisRackauckas.** Draft.

## What changed and why

One name added to the import list:

```julia
 import OrdinaryDiffEqCore: alg_adaptive_order,
     gamma_default, qmax_default, alg_extrapolates,
-    fac_default_gamma, has_dtnew_modification,
+    fac_default_gamma, has_dtnew_modification, dtnew_modification,
```

This package defines ten `dtnew_modification` methods — ROCK2, ROCK4, SERK2, ESERK4, ESERK5, RKMC2, RKL1, RKL2, RKG1, RKG2 — that cap the controller's proposed step at the method's stability limit. Because `dtnew_modification` was absent from the import list, those definitions created a **new** function in this namespace instead of extending Core's. `calc_dt_propose!` calls `OrdinaryDiffEqCore.dtnew_modification`, got the generic identity fallback, and the cap never ran:

```
has_dtnew_modification(ROCK2())               = true
OrdinaryDiffEqCore.dtnew_modification(...)    = 1.0        <- what calc_dt_propose! called
OrdinaryDiffEqStabilizedRK.dtnew_modification = 0.0324385  <- the intended cap
same function object? false
```

`OrdinaryDiffEqRKIP` imports it correctly, which is how the asymmetry stood out.

## How much behaviour changes: almost none

The bound is the `dt` at which the required stage count would exceed `max_stages`, and `mdeg` selection in `perform_step!` already derives from the same `abs(dt) * eigen_est`, so at default settings the cap does not bind. On a 32-point MOL heat problem, every step count, function-evaluation count, return code and error is **identical** with the cap live and dead:

```
             cap dead (master)                    cap live (this PR)
tol=1e-02 ROCK2  naccept=26   nf=140   err=8.066e-04   |  naccept=26   nf=140   err=8.066e-04
tol=1e-02 ROCK4  naccept=23   nf=198   err=3.560e-05   |  naccept=23   nf=198   err=3.560e-05
tol=1e-02 RKC    naccept=19   nf=121   err=1.560e-03   |  naccept=19   nf=121   err=1.560e-03
tol=1e-02 SERK2  naccept=16   nf=248   err=1.660e-03   |  naccept=16   nf=248   err=1.660e-03
tol=1e-02 RKL2   naccept=15   nf=149   err=2.671e-03   |  naccept=15   nf=149   err=2.671e-03
tol=1e-02 RKG2   naccept=14   nf=190   err=2.830e-03   |  naccept=14   nf=190   err=2.830e-03
tol=1e-04 ROCK2  naccept=112  nf=405   err=2.832e-05   |  naccept=112  nf=405   err=2.832e-05
tol=1e-04 ROCK4  naccept=24   nf=218   err=3.639e-06   |  naccept=24   nf=218   err=3.639e-06
tol=1e-04 RKC    naccept=51   nf=212   err=1.543e-04   |  naccept=51   nf=212   err=1.543e-04
tol=1e-04 SERK2  naccept=120  nf=1570  err=1.702e-05   |  naccept=120  nf=1570  err=1.702e-05
tol=1e-04 RKL2   naccept=86   nf=524   err=5.898e-05   |  naccept=86   nf=524   err=5.898e-05
tol=1e-04 RKG2   naccept=79   nf=572   err=6.562e-05   |  naccept=79   nf=572   err=6.562e-05
tol=1e-06 ROCK2  naccept=924  nf=2856  err=3.887e-07   |  naccept=924  nf=2856  err=3.887e-07
tol=1e-06 ROCK4  naccept=60   nf=410   err=1.469e-07   |  naccept=60   nf=410   err=1.469e-07
tol=1e-06 RKC    naccept=214  nf=573   err=8.869e-06   |  naccept=214  nf=573   err=8.869e-06
tol=1e-06 SERK2  naccept=1160 nf=15090 err=1.735e-07   |  naccept=1160 nf=15090 err=1.735e-07
tol=1e-06 RKL2   naccept=851  nf=4265  err=4.424e-07   |  naccept=851  nf=4265  err=4.424e-07
tol=1e-06 RKG2   naccept=849  nf=4271  err=4.199e-07   |  naccept=849  nf=4271  err=4.199e-07
```

With a deliberately reduced stage budget the cap does bind, and in the intended direction — exactly one row out of ten moves, and it gets *more* accurate for the same number of steps:

```
                                    cap dead                      cap live
RKG2(max_stages=20) tol=1e-2  max|dt|=3.640e-02 err=2.830e-03 | max|dt|=3.017e-02 err=1.731e-03
```

All other reduced-budget rows (ROCK2 max_stages 20 and 12, ROCK4 20, RKL2 21, RKG2 at 1e-3) are unchanged.

Reversal symmetry is unaffected: with the cap now live, 24 forward/mirrored-backward cases across ROCK2/ROCK4/RKC/SERK2/RKL2/RKG2 at two tolerances, in-place and out-of-place, are all bitwise identical — #4536 already made the capped expressions direction-safe, which is why this could be switched on without reintroducing that bug.

## Verification

Extends `dtnew_cap_direction_tests.jl` (added in #4536) with a testset asserting that Core's `dtnew_modification` *is* this package's, that `has_dtnew_modification` agrees, and that the cap binds when reached through Core. Its stale "these caps are currently unreachable" note is removed.

Failing on master (`git checkout origin/master -- lib/OrdinaryDiffEqStabilizedRK/src/OrdinaryDiffEqStabilizedRK.jl`):

```
Test Summary:                       | Pass  Total   Time
stability cap is direction-agnostic |   20     20  57.6s
Test Summary:                                      | Pass  Fail  Total  Time
stability cap is reachable from OrdinaryDiffEqCore |   10    11     21  1.3s
  ROCK2                                            |    1     1      2  0.0s
  ROCK4                                            |    1     1      2  0.0s
  ... (all ten, plus the function-identity assertion)
```

Full package suite with the fix (Julia 1.10.11):

```
Testing OrdinaryDiffEqStabilizedRK tests passed
```

Minor-bumped to 2.7.0 rather than patch, since a dormant step-size cap becoming active is a behaviour change even though I could not find a default configuration where it alters results.

## What I did **not** verify

- GPU and Downstream groups, Julia `pre`.
- `ESERK4`/`ESERK5`/`RKMC2`/`RKL1`/`RKG1` at reduced stage budgets, and `TSRKC2`/`TSRKC3` (which have no `dtnew_modification`); the measured sweep covers ROCK2/ROCK4/RKC/SERK2/RKL2/RKG2.
- Whether the stability bounds themselves are still the right constants. They date from before the cap was ever reachable, so nobody has exercised them; if any look wrong, this PR is the moment to say so.

## Worth pushing back on

- The `import` list in this module now mixes functions that are extended here with ones only called. That is already true of the list, but `dtnew_modification` is specifically the kind of name worth a comment so it does not get dropped again. Happy to add one.
- A repo-wide check would be more durable than a per-package test: every `has_dtnew_modification(alg) === true` should imply `parentmodule`-level agreement between the defining package's `dtnew_modification` and Core's. I did not attempt that here.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m], harness: Claude Code 2.1.269)

https://claude.ai/code/session_01JQATpLKMyYX3VbPPX8qdeE
