### PR TITLE
Pick the DAE initialization dt by magnitude, not signed min

### DIFF
--- a/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
+++ b/lib/OrdinaryDiffEqNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "OrdinaryDiffEqNonlinearSolve"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "Yingbo Ma <mayingbo5@gmail.com>"]
-version = "2.9.6"
+version = "2.9.7"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/OrdinaryDiffEqNonlinearSolve/src/initialize_dae.jl
+++ b/lib/OrdinaryDiffEqNonlinearSolve/src/initialize_dae.jl
@@ -221,7 +221,8 @@ function _initialize_dae!(
 
     initdt = alg.initdt
     dt = if initdt === nothing
-        integrator.dt != 0 ? min(integrator.dt / 5, dtmax) :
+        integrator.dt != 0 ?
+            copysign(min(abs(integrator.dt) / 5, abs(dtmax)), integrator.dt) :
             (prob.tspan[end] - prob.tspan[begin]) / 1000 # Haven't implemented norm reduction
     else
         initdt
@@ -345,7 +346,8 @@ function _initialize_dae!(
 
     initdt = alg.initdt
     dt = if initdt === nothing
-        integrator.dt != 0 ? min(integrator.dt / 5, dtmax) :
+        integrator.dt != 0 ?
+            copysign(min(abs(integrator.dt) / 5, abs(dtmax)), integrator.dt) :
             (prob.tspan[end] - prob.tspan[begin]) / 1000 # Haven't implemented norm reduction
     else
         initdt


### PR DESCRIPTION
Addresses part 1 of #4538. **Ignore until reviewed by @ChrisRackauckas.** Draft.

## What changed and why

```julia
-        integrator.dt != 0 ? min(integrator.dt / 5, dtmax) :
+        integrator.dt != 0 ?
+            copysign(min(abs(integrator.dt) / 5, abs(dtmax)), integrator.dt) :
             (prob.tspan[end] - prob.tspan[begin]) / 1000
```

at `initialize_dae.jl:223` and `:347`. When both operands are negative — which is every backward-in-time solve, since `dtmax` is sign-converted to match `tdir` in `solve.jl` — `min` returns the operand with the **larger** magnitude, the opposite of the forward case. With a typical automatic initial dt and `dtmax` equal to the span, forward selects `|dt|/5` (tiny) and backward selects `|dtmax|` (the whole interval).

## No demonstrated behaviour change — read this before merging

I could not produce a test that fails without this patch, and I believe the reason is that the value is dead on the default path. It is consumed only here:

```julia
    if isdefined(integrator.cache, :nlsolver) && !isnothing(alg.nlsolve)
        ...
        integrator.dt = dt
        z = nlsolve!(nlsolver, integrator, integrator.cache)
```

and `BrownFullBasicInit(; abstol = 1.0e-10, nlsolve = nothing)` defaults `nlsolve` to `nothing` (`lib/DiffEqBase/src/dae_initialization.jl:50`), so unless a user passes an explicit `nlsolve` the branch never runs. Consistent with that reading, applying the patch changes nothing measurable: mass-matrix Robertson with a deliberately inconsistent `u0 = [1.0, 0.0, 0.1]` under `BrownFullBasicInit()`, forward versus mirrored-backward, gives byte-identical results before and after —

```
                     before              after
Rodas5P   steps 78/78   u0 diff 1.110e-16   |  steps 78/78   u0 diff 1.110e-16
FBDF      steps 207/207 u0 diff 1.110e-16   |  steps 207/207 u0 diff 1.110e-16
```

So this is a sign correction shipped on the strength of inspection, not of an observed failure. **If you would rather it stayed an issue until someone can exercise the explicit-`nlsolve` path, say so and I will close it.**

(The `1.110e-16` above was my own harness bug, not a library one — I had negated the algebraic constraint row when mirroring, which a constraint should not pick up. With the mirror formulated correctly both solvers are bitwise reversible, `u0 diff 0.000e+00`. Written up in #4538.)

## Verification

- `lib/OrdinaryDiffEqBDF/test/dae_initialization_tests.jl` on this branch: passes, 0 failures. This is the file that exercises `_initialize_dae!` directly.
- Full `Pkg.test("OrdinaryDiffEqNonlinearSolve")` on this branch (Julia 1.10.11): `5 passed, 8 failed, 0 errored, 33 broken`. All 8 are JET "Solver Type Stability Tests" (ABDF2, QNDF/QNDF1/QNDF2, FBDF, DFBDF, DABDF2, DImplicitEuler, MEBDF2, Rodas4). Master gives the **identical** `5 passed, 8 failed, 0 errored, 33 broken` under `GROUP=QA`, so they are pre-existing and untouched by this diff.

No new test is added, deliberately: a test that passes with and without the patch would be worse than none.

## What I did **not** verify

- The explicit-`nlsolve` path itself (`BrownFullBasicInit(nlsolve = ...)`), which is the only place the changed expression is reachable. I did not construct a problem that goes down it.
- GPU and Downstream groups, Julia `pre`.

## Worth pushing back on

- Arguably the better fix is to stop computing `dt` at all when `alg.nlsolve === nothing`, so the dead expression cannot mislead the next reader. I kept the diff to the sign so the two sites stay comparable, but I'd take that change if you prefer it.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m], harness: Claude Code 2.1.269)

https://claude.ai/code/session_01JQATpLKMyYX3VbPPX8qdeE
